### PR TITLE
feat: Implement ApplyResource RPC for granular manifest mutations

### DIFF
--- a/api/proto/meridian/control_plane/v1/apply_manifest_service.proto
+++ b/api/proto/meridian/control_plane/v1/apply_manifest_service.proto
@@ -6,6 +6,8 @@ import "buf/validate/validate.proto";
 import "google/api/annotations.proto";
 import "meridian/control_plane/v1/manifest.proto";
 import "meridian/control_plane/v1/manifest_history_service.proto";
+import "meridian/mapping/v1/mapping.proto";
+import "meridian/party/v1/party.proto";
 
 option go_package = "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1;controlplanev1";
 
@@ -17,6 +19,18 @@ service ApplyManifestService {
   rpc ApplyManifest(ApplyManifestRequest) returns (ApplyManifestResponse) {
     option (google.api.http) = {
       post: "/v1/manifests/apply"
+      body: "*"
+    };
+  }
+
+  // ApplyResource applies a granular mutation to a single resource within the manifest.
+  // It reads the current manifest from the database, patches the specified resource into
+  // the composite manifest, validates the full dependency graph, computes a diff, and
+  // executes only the affected phases. A new manifest version is created on success.
+  // In dry_run mode, returns the diff without applying changes.
+  rpc ApplyResource(ApplyResourceRequest) returns (ApplyResourceResponse) {
+    option (google.api.http) = {
+      post: "/v1/manifests/apply-resource"
       body: "*"
     };
   }
@@ -159,4 +173,139 @@ message ValidationError {
   // resource_id is the identifier of the specific resource that caused the error
   // (e.g., the instrument code, account type code, or saga name).
   string resource_id = 7;
+}
+
+// ManifestResourceType identifies a category of resource within the manifest.
+// Used by ApplyResource to specify which resource type is being mutated.
+enum ManifestResourceType {
+  // MANIFEST_RESOURCE_TYPE_UNSPECIFIED is the default zero value.
+  MANIFEST_RESOURCE_TYPE_UNSPECIFIED = 0;
+
+  // MANIFEST_RESOURCE_TYPE_INSTRUMENT targets an InstrumentDefinition.
+  MANIFEST_RESOURCE_TYPE_INSTRUMENT = 1;
+
+  // MANIFEST_RESOURCE_TYPE_ACCOUNT_TYPE targets an AccountTypeDefinition.
+  MANIFEST_RESOURCE_TYPE_ACCOUNT_TYPE = 2;
+
+  // MANIFEST_RESOURCE_TYPE_VALUATION_RULE targets a ValuationRule.
+  MANIFEST_RESOURCE_TYPE_VALUATION_RULE = 3;
+
+  // MANIFEST_RESOURCE_TYPE_SAGA targets a SagaDefinition.
+  MANIFEST_RESOURCE_TYPE_SAGA = 4;
+
+  // MANIFEST_RESOURCE_TYPE_PARTY_TYPE targets a PartyTypeDefinition.
+  MANIFEST_RESOURCE_TYPE_PARTY_TYPE = 5;
+
+  // MANIFEST_RESOURCE_TYPE_MAPPING targets a MappingDefinition.
+  MANIFEST_RESOURCE_TYPE_MAPPING = 6;
+
+  // MANIFEST_RESOURCE_TYPE_PROVIDER_CONNECTION targets a ProviderConnectionConfig.
+  MANIFEST_RESOURCE_TYPE_PROVIDER_CONNECTION = 7;
+
+  // MANIFEST_RESOURCE_TYPE_INSTRUCTION_ROUTE targets an InstructionRouteConfig.
+  MANIFEST_RESOURCE_TYPE_INSTRUCTION_ROUTE = 8;
+
+  // MANIFEST_RESOURCE_TYPE_MARKET_DATA_SOURCE targets a MarketDataSourceDefinition.
+  MANIFEST_RESOURCE_TYPE_MARKET_DATA_SOURCE = 9;
+
+  // MANIFEST_RESOURCE_TYPE_MARKET_DATA_SET targets a MarketDataSetDefinition.
+  MANIFEST_RESOURCE_TYPE_MARKET_DATA_SET = 10;
+
+  // MANIFEST_RESOURCE_TYPE_ORGANIZATION targets an OrganizationDefinition.
+  MANIFEST_RESOURCE_TYPE_ORGANIZATION = 11;
+
+  // MANIFEST_RESOURCE_TYPE_INTERNAL_ACCOUNT targets an InternalAccountDefinition.
+  MANIFEST_RESOURCE_TYPE_INTERNAL_ACCOUNT = 12;
+}
+
+// ApplyResourceRequest contains the resource to apply and apply options.
+// The caller specifies the resource type and provides the resource payload
+// as a oneof. The server reads the current manifest, patches the resource
+// into it, validates the full dependency graph, diffs, and executes only
+// the affected phases.
+message ApplyResourceRequest {
+  // resource_type identifies which manifest section is being mutated.
+  ManifestResourceType resource_type = 1 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // resource is the resource payload to apply. Exactly one must be set,
+  // and it must match the resource_type field.
+  oneof resource {
+    option (buf.validate.oneof).required = true;
+
+    // instrument is an InstrumentDefinition to create or update.
+    InstrumentDefinition instrument = 2;
+
+    // account_type is an AccountTypeDefinition to create or update.
+    AccountTypeDefinition account_type = 3;
+
+    // valuation_rule is a ValuationRule to create or update.
+    ValuationRule valuation_rule = 4;
+
+    // saga is a SagaDefinition to create or update.
+    SagaDefinition saga = 5;
+
+    // party_type is a PartyTypeDefinition to create or update.
+    meridian.party.v1.PartyTypeDefinition party_type = 6;
+
+    // mapping is a MappingDefinition to create or update.
+    meridian.mapping.v1.MappingDefinition mapping = 7;
+
+    // provider_connection is a ProviderConnectionConfig to create or update.
+    ProviderConnectionConfig provider_connection = 8;
+
+    // instruction_route is an InstructionRouteConfig to create or update.
+    InstructionRouteConfig instruction_route = 9;
+
+    // market_data_source is a MarketDataSourceDefinition to create or update.
+    MarketDataSourceDefinition market_data_source = 10;
+
+    // market_data_set is a MarketDataSetDefinition to create or update.
+    MarketDataSetDefinition market_data_set = 11;
+
+    // organization is an OrganizationDefinition to create or update.
+    OrganizationDefinition organization = 12;
+
+    // internal_account is an InternalAccountDefinition to create or update.
+    InternalAccountDefinition internal_account = 13;
+  }
+
+  // dry_run when true performs validation and planning without committing changes.
+  bool dry_run = 14;
+
+  // applied_by identifies who is applying this resource (e.g., user email, API key ID).
+  string applied_by = 15 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // expected_sequence_number is the sequence number the caller expects the
+  // current manifest to have. If it does not match the actual current sequence
+  // number, the apply is rejected with ABORTED status (ETag semantics).
+  // Set to 0 to skip the check (first apply or "overwrite" mode).
+  int64 expected_sequence_number = 16;
+}
+
+// ApplyResourceResponse contains the result of a single-resource application.
+message ApplyResourceResponse {
+  // status is the outcome of the apply operation.
+  ApplyManifestStatus status = 1;
+
+  // step_results contains the result of each execution step.
+  repeated StepResult step_results = 2;
+
+  // validation_errors contains structured validation errors if the manifest is invalid.
+  repeated ValidationError validation_errors = 3;
+
+  // diff_summary is a human-readable summary of changes detected.
+  string diff_summary = 4;
+
+  // sequence_number is the sequence number assigned to the new manifest version.
+  // Callers should use this value as expected_sequence_number in subsequent applies.
+  int64 sequence_number = 5;
+
+  // snapshot is the manifest version record created by this apply, if successful.
+  ManifestVersion snapshot = 6;
 }

--- a/services/control-plane/internal/applier/apply_resource.go
+++ b/services/control-plane/internal/applier/apply_resource.go
@@ -204,6 +204,11 @@ func (h *ApplyManifestHandler) applyResourceExecute(
 	// Save to version store for future diffs
 	if err := h.versionStore.Save(ctx, patchedManifest, req.GetAppliedBy()); err != nil {
 		logger.Error("failed to save manifest version to differ store", "error", err)
+		response.StepResults = append(response.StepResults, &controlplanev1.StepResult{
+			StepName: "persist_baseline",
+			Status:   controlplanev1.StepResultStatus_STEP_RESULT_STATUS_FAILED,
+			Message:  "Warning: failed to update diff baseline; future diffs may be stale",
+		})
 	}
 
 	response.Status = controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_APPLIED

--- a/services/control-plane/internal/applier/apply_resource.go
+++ b/services/control-plane/internal/applier/apply_resource.go
@@ -1,0 +1,257 @@
+package applier
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/services/control-plane/internal/manifest"
+	"github.com/meridianhub/meridian/services/control-plane/internal/planner"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ApplyResource applies a granular mutation to a single resource within the manifest.
+// It reads the current manifest from the version store, patches the specified
+// resource into it, validates the full dependency graph, computes a diff, and
+// executes only the affected phases. A new manifest version is created on success.
+func (h *ApplyManifestHandler) ApplyResource(
+	ctx context.Context,
+	req *controlplanev1.ApplyResourceRequest,
+) (*controlplanev1.ApplyResourceResponse, error) {
+	if err := validateApplyResourceRequest(req); err != nil {
+		return nil, err
+	}
+
+	logger := h.logger.With(
+		"rpc", "ApplyResource",
+		"resource_type", req.GetResourceType().String(),
+		"resource_id", resourceID(req),
+		"applied_by", req.GetAppliedBy(),
+		"dry_run", req.GetDryRun(),
+	)
+
+	// Load current manifest and produce patched version.
+	patchedManifest, currentManifest, err := h.loadAndPatch(ctx, req, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	// Run the validate -> diff -> plan -> execute pipeline on the patched manifest.
+	return h.applyPatchedManifest(ctx, req, patchedManifest, currentManifest, logger)
+}
+
+// validateApplyResourceRequest checks that the request has all required fields.
+func validateApplyResourceRequest(req *controlplanev1.ApplyResourceRequest) error {
+	if req.GetResource() == nil {
+		return status.Error(codes.InvalidArgument, "resource payload is required")
+	}
+	if req.GetAppliedBy() == "" && !req.GetDryRun() {
+		return status.Error(codes.InvalidArgument, "applied_by is required for non-dry-run applies")
+	}
+	return nil
+}
+
+// loadAndPatch reads the current manifest from the version store and patches
+// the resource from the request into it. Returns the patched manifest and the
+// current (unmodified) manifest.
+func (h *ApplyManifestHandler) loadAndPatch(
+	ctx context.Context,
+	req *controlplanev1.ApplyResourceRequest,
+	logger *slog.Logger,
+) (*controlplanev1.Manifest, *controlplanev1.Manifest, error) {
+	logger.Info("loading current manifest")
+	if h.versionStore == nil {
+		return nil, nil, status.Error(codes.FailedPrecondition, "version store not configured")
+	}
+
+	prev, err := h.versionStore.GetLatestApplied(ctx)
+	if err != nil {
+		logger.Error("failed to load current manifest", "error", err)
+		return nil, nil, status.Errorf(codes.Internal, "failed to load current manifest: %v", err)
+	}
+	if prev == nil || prev.Manifest == nil {
+		return nil, nil, status.Error(codes.FailedPrecondition, ErrNoCurrentManifest.Error())
+	}
+
+	logger.Info("patching resource into manifest")
+	patched, patchErr := patchResource(prev.Manifest, req)
+	if patchErr != nil {
+		return nil, nil, status.Errorf(codes.InvalidArgument, "resource patch failed: %v", patchErr)
+	}
+
+	return patched, prev.Manifest, nil
+}
+
+// applyPatchedManifest runs the validate -> diff -> plan -> execute pipeline
+// on a patched manifest, diffing against the current manifest. It handles
+// both dry-run and real execution modes.
+func (h *ApplyManifestHandler) applyPatchedManifest(
+	ctx context.Context,
+	req *controlplanev1.ApplyResourceRequest,
+	patchedManifest *controlplanev1.Manifest,
+	currentManifest *controlplanev1.Manifest,
+	logger *slog.Logger,
+) (*controlplanev1.ApplyResourceResponse, error) {
+	response := &controlplanev1.ApplyResourceResponse{}
+
+	// Step 1: Validate
+	logger.Info("validating patched manifest")
+	validationResult := h.validate(ctx, patchedManifest, false)
+	response.StepResults = append(response.StepResults, validationResult.stepResult)
+
+	if !validationResult.valid {
+		logger.Warn("patched manifest validation failed", "error_count", len(validationResult.errors))
+		response.Status = controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_VALIDATION_FAILED
+		response.ValidationErrors = validationResult.errors
+		return response, nil
+	}
+
+	// Step 2: Diff
+	logger.Info("diffing patched manifest against current")
+	diffResult := h.diffAgainst(ctx, currentManifest, patchedManifest)
+	response.StepResults = append(response.StepResults, diffResult.stepResult)
+	response.DiffSummary = diffResult.summary
+
+	if diffResult.err != nil {
+		logger.Error("diff failed", "error", diffResult.err)
+		response.Status = controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_FAILED
+		return response, nil //nolint:nilerr // error conveyed via response status, not gRPC error
+	}
+
+	if blocked := h.checkBlockedDeletions(diffResult.plan, false, logger); blocked != nil {
+		response.Status = controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_BLOCKED
+		response.StepResults = append(response.StepResults, blocked)
+		return response, nil
+	}
+
+	// Step 3: Plan
+	logger.Info("planning execution")
+	tenantID, _ := tenant.FromContext(ctx)
+	execPlan, planResult := h.plan(diffResult.plan, string(tenantID), patchedManifest.GetVersion(), req.GetDryRun())
+	response.StepResults = append(response.StepResults, planResult)
+
+	if execPlan == nil {
+		logger.Error("planning failed")
+		response.Status = controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_FAILED
+		return response, nil
+	}
+
+	// Step 4: Execute or dry-run
+	if req.GetDryRun() {
+		return h.applyResourceDryRun(response, execPlan, logger), nil
+	}
+
+	return h.applyResourceExecute(ctx, req, response, patchedManifest, execPlan, validationResult, logger)
+}
+
+// applyResourceDryRun adds the dry-run step result and returns the response.
+func (h *ApplyManifestHandler) applyResourceDryRun(
+	response *controlplanev1.ApplyResourceResponse,
+	execPlan *planner.ExecutionPlan,
+	logger *slog.Logger,
+) *controlplanev1.ApplyResourceResponse {
+	logger.Info("dry run - skipping execution", "planned_calls", len(execPlan.Calls))
+	response.Status = controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_DRY_RUN
+	response.StepResults = append(response.StepResults, &controlplanev1.StepResult{
+		StepName: "execute",
+		Status:   controlplanev1.StepResultStatus_STEP_RESULT_STATUS_SKIPPED,
+		Message:  fmt.Sprintf("Dry run: %d calls planned, execution skipped", len(execPlan.Calls)),
+		Details: map[string]string{
+			"plan_summary": execPlan.Summary(),
+		},
+	})
+	return response
+}
+
+// applyResourceExecute runs the executor, records history, and saves the version.
+func (h *ApplyManifestHandler) applyResourceExecute(
+	ctx context.Context,
+	req *controlplanev1.ApplyResourceRequest,
+	response *controlplanev1.ApplyResourceResponse,
+	patchedManifest *controlplanev1.Manifest,
+	execPlan *planner.ExecutionPlan,
+	validationResult validationOutput,
+	logger *slog.Logger,
+) (*controlplanev1.ApplyResourceResponse, error) {
+	logger.Info("executing resource apply")
+	execResult := h.execute(ctx, &controlplanev1.ApplyManifestRequest{
+		Manifest:  patchedManifest,
+		AppliedBy: req.GetAppliedBy(),
+	}, execPlan)
+	response.StepResults = append(response.StepResults, execResult.stepResult)
+
+	if execResult.err != nil {
+		logger.Error("execution failed", "error", execResult.err)
+		response.Status = controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_FAILED
+		return response, nil //nolint:nilerr // error conveyed via response status, not gRPC error
+	}
+
+	// Record history (creates new manifest version)
+	logger.Info("recording manifest history")
+	snapshot, seqErr := h.recordHistory(ctx, patchedManifest, req.GetAppliedBy(), execResult.jobID, manifest.ApplyStatusApplied, validationResult.graph, req.GetExpectedSequenceNumber())
+	if seqErr != nil {
+		logger.Warn("sequence number conflict during history recording", "error", seqErr)
+		return nil, status.Errorf(codes.Aborted, "%v", seqErr)
+	}
+	if snapshot != nil {
+		response.Snapshot = snapshot
+		response.SequenceNumber = snapshot.SequenceNumber
+	}
+
+	// Save to version store for future diffs
+	if err := h.versionStore.Save(ctx, patchedManifest, req.GetAppliedBy()); err != nil {
+		logger.Error("failed to save manifest version to differ store", "error", err)
+	}
+
+	response.Status = controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_APPLIED
+	logger.Info("resource applied successfully",
+		"resource_type", req.GetResourceType().String(),
+		"resource_id", resourceID(req))
+
+	tenantID, _ := tenant.FromContext(ctx)
+	h.runPostApplyHooks(ctx, string(tenantID), logger)
+
+	return response, nil
+}
+
+// diffAgainst compares a new manifest against a specific base manifest.
+// Unlike the diff() method which loads the base from the version store,
+// this takes the base explicitly — used by ApplyResource where we already
+// have the current manifest loaded.
+func (h *ApplyManifestHandler) diffAgainst(
+	ctx context.Context,
+	base *controlplanev1.Manifest,
+	newManifest *controlplanev1.Manifest,
+) diffOutput {
+	diffPlan, err := h.differ.Diff(ctx, base, newManifest)
+	if err != nil {
+		return diffOutput{
+			err: err,
+			stepResult: &controlplanev1.StepResult{
+				StepName: "diff",
+				Status:   controlplanev1.StepResultStatus_STEP_RESULT_STATUS_FAILED,
+				Message:  fmt.Sprintf("Diff failed: %s", err.Error()),
+			},
+		}
+	}
+
+	summary := diffPlan.Summary()
+	step := &controlplanev1.StepResult{
+		StepName: "diff",
+		Status:   controlplanev1.StepResultStatus_STEP_RESULT_STATUS_SUCCESS,
+		Message:  summary,
+		Details: map[string]string{
+			"has_breaking_changes": fmt.Sprintf("%t", diffPlan.HasBreakingChanges),
+			"action_count":         fmt.Sprintf("%d", len(diffPlan.Actions)),
+		},
+	}
+
+	return diffOutput{
+		plan:       diffPlan,
+		summary:    summary,
+		stepResult: step,
+	}
+}

--- a/services/control-plane/internal/applier/apply_resource_test.go
+++ b/services/control-plane/internal/applier/apply_resource_test.go
@@ -1,0 +1,593 @@
+package applier
+
+import (
+	"context"
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// --- ApplyResource unit tests ---
+
+func TestApplyResource_NilResource(t *testing.T) {
+	handler := newTestHandler(t)
+
+	resp, err := handler.ApplyResource(context.Background(), &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INSTRUMENT,
+		AppliedBy:    "test-user",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "resource payload is required")
+}
+
+func TestApplyResource_EmptyAppliedBy_NonDryRun(t *testing.T) {
+	handler := newTestHandler(t)
+
+	resp, err := handler.ApplyResource(context.Background(), &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INSTRUMENT,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: &controlplanev1.InstrumentDefinition{
+				Code: "USD",
+				Name: "US Dollar",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "USD",
+					Precision: 2,
+				},
+			},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "applied_by is required")
+}
+
+func TestApplyResource_NoVersionStore(t *testing.T) {
+	// Handler without version store should fail
+	handler := newTestHandler(t)
+
+	resp, err := handler.ApplyResource(context.Background(), &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INSTRUMENT,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: &controlplanev1.InstrumentDefinition{
+				Code: "USD",
+				Name: "US Dollar",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "USD",
+					Precision: 2,
+				},
+			},
+		},
+		AppliedBy: "test-user",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestApplyResource_NoCurrentManifest(t *testing.T) {
+	// Version store returns nil (no manifest applied yet)
+	handler := newTestHandlerWithVersionStore(t, nil)
+
+	resp, err := handler.ApplyResource(context.Background(), &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INSTRUMENT,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: &controlplanev1.InstrumentDefinition{
+				Code: "USD",
+				Name: "US Dollar",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "USD",
+					Precision: 2,
+				},
+			},
+		},
+		AppliedBy: "test-user",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	assert.Contains(t, err.Error(), "no current manifest")
+}
+
+func TestApplyResource_DryRun_AddNewInstrument(t *testing.T) {
+	// Set up handler with an existing manifest in the version store
+	existingManifest := newTestManifest()
+	handler := newTestHandlerWithVersionStore(t, existingManifest)
+
+	resp, err := handler.ApplyResource(context.Background(), &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INSTRUMENT,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: &controlplanev1.InstrumentDefinition{
+				Code: "USD",
+				Name: "US Dollar",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "USD",
+					Precision: 2,
+				},
+			},
+		},
+		DryRun: true,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.Equal(t, controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_DRY_RUN, resp.Status)
+	assert.NotEmpty(t, resp.DiffSummary)
+
+	// Should have steps: validate, diff, plan, execute (skipped)
+	require.Len(t, resp.StepResults, 4)
+	assert.Equal(t, "validate", resp.StepResults[0].StepName)
+	assert.Equal(t, controlplanev1.StepResultStatus_STEP_RESULT_STATUS_SUCCESS, resp.StepResults[0].Status)
+	assert.Equal(t, "diff", resp.StepResults[1].StepName)
+	assert.Equal(t, controlplanev1.StepResultStatus_STEP_RESULT_STATUS_SUCCESS, resp.StepResults[1].Status)
+	assert.Equal(t, "plan", resp.StepResults[2].StepName)
+	assert.Equal(t, controlplanev1.StepResultStatus_STEP_RESULT_STATUS_SUCCESS, resp.StepResults[2].Status)
+	assert.Equal(t, "execute", resp.StepResults[3].StepName)
+	assert.Equal(t, controlplanev1.StepResultStatus_STEP_RESULT_STATUS_SKIPPED, resp.StepResults[3].Status)
+}
+
+func TestApplyResource_DryRun_UpdateExistingInstrument(t *testing.T) {
+	existingManifest := newTestManifest()
+	handler := newTestHandlerWithVersionStore(t, existingManifest)
+
+	// Update the existing GBP instrument's name
+	resp, err := handler.ApplyResource(context.Background(), &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INSTRUMENT,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: &controlplanev1.InstrumentDefinition{
+				Code: "GBP",
+				Name: "Pound Sterling (updated)",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "GBP",
+					Precision: 2,
+				},
+			},
+		},
+		DryRun: true,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_DRY_RUN, resp.Status)
+	// Diff should show an update, not a create
+	assert.Contains(t, resp.DiffSummary, "update")
+}
+
+func TestApplyResource_DryRun_AllowsEmptyAppliedBy(t *testing.T) {
+	existingManifest := newTestManifest()
+	handler := newTestHandlerWithVersionStore(t, existingManifest)
+
+	resp, err := handler.ApplyResource(context.Background(), &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INSTRUMENT,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: &controlplanev1.InstrumentDefinition{
+				Code: "USD",
+				Name: "US Dollar",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "USD",
+					Precision: 2,
+				},
+			},
+		},
+		DryRun: true,
+		// AppliedBy intentionally omitted
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_DRY_RUN, resp.Status)
+}
+
+func TestApplyResource_ValidationFailure_InvalidReference(t *testing.T) {
+	existingManifest := newTestManifest()
+	handler := newTestHandlerWithVersionStore(t, existingManifest)
+
+	// Add an account type that references a non-existent instrument
+	resp, err := handler.ApplyResource(context.Background(), &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_ACCOUNT_TYPE,
+		Resource: &controlplanev1.ApplyResourceRequest_AccountType{
+			AccountType: &controlplanev1.AccountTypeDefinition{
+				Code:               "SAVINGS",
+				Name:               "Savings Account",
+				NormalBalance:      controlplanev1.NormalBalance_NORMAL_BALANCE_CREDIT,
+				AllowedInstruments: []string{"NONEXISTENT"},
+			},
+		},
+		DryRun: true,
+	})
+
+	require.NoError(t, err) // RPC succeeds, status reflects validation failure
+	require.NotNil(t, resp)
+	assert.Equal(t, controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_VALIDATION_FAILED, resp.Status)
+	assert.NotEmpty(t, resp.ValidationErrors)
+
+	foundRefError := false
+	for _, ve := range resp.ValidationErrors {
+		if ve.Code == "UNDEFINED_INSTRUMENT_REFERENCE" {
+			foundRefError = true
+		}
+	}
+	assert.True(t, foundRefError, "expected UNDEFINED_INSTRUMENT_REFERENCE validation error")
+}
+
+func TestApplyResource_NonDryRun_NoExecutor(t *testing.T) {
+	existingManifest := newTestManifest()
+	handler := newTestHandlerWithVersionStore(t, existingManifest)
+
+	resp, err := handler.ApplyResource(context.Background(), &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INSTRUMENT,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: &controlplanev1.InstrumentDefinition{
+				Code: "USD",
+				Name: "US Dollar",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "USD",
+					Precision: 2,
+				},
+			},
+		},
+		AppliedBy: "test-user",
+		DryRun:    false,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	// Without executor, execution fails
+	assert.Equal(t, controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_FAILED, resp.Status)
+}
+
+func TestApplyResource_DryRun_AddAccountType(t *testing.T) {
+	existingManifest := newTestManifest()
+	handler := newTestHandlerWithVersionStore(t, existingManifest)
+
+	resp, err := handler.ApplyResource(context.Background(), &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_ACCOUNT_TYPE,
+		Resource: &controlplanev1.ApplyResourceRequest_AccountType{
+			AccountType: &controlplanev1.AccountTypeDefinition{
+				Code:               "SAVINGS",
+				Name:               "Savings Account",
+				NormalBalance:      controlplanev1.NormalBalance_NORMAL_BALANCE_CREDIT,
+				AllowedInstruments: []string{"GBP"}, // Valid: GBP exists
+			},
+		},
+		DryRun: true,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_DRY_RUN, resp.Status)
+	assert.Contains(t, resp.DiffSummary, "create")
+}
+
+func TestApplyResource_DryRun_AddSaga(t *testing.T) {
+	existingManifest := newTestManifest()
+	handler := newTestHandlerWithVersionStore(t, existingManifest)
+
+	resp, err := handler.ApplyResource(context.Background(), &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_SAGA,
+		Resource: &controlplanev1.ApplyResourceRequest_Saga{
+			Saga: &controlplanev1.SagaDefinition{
+				Name:    "process_payment",
+				Trigger: "api:/v1/payments",
+				Script:  "def execute(ctx):\n  pass\n",
+			},
+		},
+		DryRun: true,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Saga validation may produce warnings (e.g. Starlark parse warnings)
+	// but should succeed or at least produce a meaningful result.
+	// The validation result depends on the saga validator; accept either
+	// DRY_RUN (valid) or VALIDATION_FAILED (if Starlark is strict).
+	validStatuses := []controlplanev1.ApplyManifestStatus{
+		controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_DRY_RUN,
+		controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_VALIDATION_FAILED,
+	}
+	assert.Contains(t, validStatuses, resp.Status)
+}
+
+func TestApplyResource_DryRun_AddValuationRule(t *testing.T) {
+	existingManifest := newTestManifest()
+	// Add a second instrument so the valuation rule is valid
+	existingManifest.Instruments = append(existingManifest.Instruments, &controlplanev1.InstrumentDefinition{
+		Code: "KWH",
+		Name: "Kilowatt Hour",
+		Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_COMMODITY,
+		Dimensions: &controlplanev1.InstrumentDimensions{
+			Unit:      "kWh",
+			Precision: 3,
+		},
+	})
+	handler := newTestHandlerWithVersionStore(t, existingManifest)
+
+	resp, err := handler.ApplyResource(context.Background(), &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_VALUATION_RULE,
+		Resource: &controlplanev1.ApplyResourceRequest_ValuationRule{
+			ValuationRule: &controlplanev1.ValuationRule{
+				FromInstrument: "GBP",
+				ToInstrument:   "KWH",
+				Method:         controlplanev1.ValuationMethod_VALUATION_METHOD_FIXED,
+			},
+		},
+		DryRun: true,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_DRY_RUN, resp.Status)
+}
+
+// --- Resource Patcher unit tests ---
+
+func TestPatchResource_AddNewInstrument(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INSTRUMENT,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: &controlplanev1.InstrumentDefinition{
+				Code: "USD",
+				Name: "US Dollar",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "USD",
+					Precision: 2,
+				},
+			},
+		},
+	}
+
+	patched, err := patchResource(base, req)
+	require.NoError(t, err)
+	require.Len(t, patched.Instruments, 2)
+	assert.Equal(t, "GBP", patched.Instruments[0].Code)
+	assert.Equal(t, "USD", patched.Instruments[1].Code)
+
+	// Original should not be modified
+	assert.Len(t, base.Instruments, 1)
+}
+
+func TestPatchResource_UpdateExistingInstrument(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INSTRUMENT,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: &controlplanev1.InstrumentDefinition{
+				Code: "GBP",
+				Name: "Pound Sterling (updated)",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "GBP",
+					Precision: 2,
+				},
+			},
+		},
+	}
+
+	patched, err := patchResource(base, req)
+	require.NoError(t, err)
+	require.Len(t, patched.Instruments, 1)
+	assert.Equal(t, "Pound Sterling (updated)", patched.Instruments[0].Name)
+
+	// Original should not be modified
+	assert.Equal(t, "British Pound Sterling", base.Instruments[0].Name)
+}
+
+func TestPatchResource_AddAccountType(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_ACCOUNT_TYPE,
+		Resource: &controlplanev1.ApplyResourceRequest_AccountType{
+			AccountType: &controlplanev1.AccountTypeDefinition{
+				Code:          "SAVINGS",
+				Name:          "Savings Account",
+				NormalBalance: controlplanev1.NormalBalance_NORMAL_BALANCE_CREDIT,
+			},
+		},
+	}
+
+	patched, err := patchResource(base, req)
+	require.NoError(t, err)
+	require.Len(t, patched.AccountTypes, 2)
+	assert.Equal(t, "CURRENT", patched.AccountTypes[0].Code)
+	assert.Equal(t, "SAVINGS", patched.AccountTypes[1].Code)
+}
+
+func TestPatchResource_AddSaga(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_SAGA,
+		Resource: &controlplanev1.ApplyResourceRequest_Saga{
+			Saga: &controlplanev1.SagaDefinition{
+				Name:    "test_saga",
+				Trigger: "api:/test",
+				Script:  "def execute(ctx):\n  pass\n",
+			},
+		},
+	}
+
+	patched, err := patchResource(base, req)
+	require.NoError(t, err)
+	require.Len(t, patched.Sagas, 1)
+	assert.Equal(t, "test_saga", patched.Sagas[0].Name)
+}
+
+func TestPatchResource_AddProviderConnection_InitializesGateway(t *testing.T) {
+	base := newTestManifest()
+	// base has no OperationalGateway
+	require.Nil(t, base.OperationalGateway)
+
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_PROVIDER_CONNECTION,
+		Resource: &controlplanev1.ApplyResourceRequest_ProviderConnection{
+			ProviderConnection: &controlplanev1.ProviderConnectionConfig{
+				ConnectionId: "stripe-payments",
+				ProviderName: "Stripe",
+				ProviderType: "payment_gateway",
+				Protocol:     controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_HTTPS,
+				BaseUrl:      "https://api.stripe.com",
+				Auth: &controlplanev1.AuthConfigManifest{
+					AuthConfig: &controlplanev1.AuthConfigManifest_ApiKey{
+						ApiKey: &controlplanev1.ApiKeyAuthConfig{
+							HeaderName:      "Authorization",
+							ApiKeySecretRef: "sm://stripe/api_key",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	patched, err := patchResource(base, req)
+	require.NoError(t, err)
+	require.NotNil(t, patched.OperationalGateway)
+	require.Len(t, patched.OperationalGateway.ProviderConnections, 1)
+	assert.Equal(t, "stripe-payments", patched.OperationalGateway.ProviderConnections[0].ConnectionId)
+}
+
+func TestPatchResource_AddMarketDataSource_InitializesMarketData(t *testing.T) {
+	base := newTestManifest()
+	require.Nil(t, base.MarketData)
+
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_MARKET_DATA_SOURCE,
+		Resource: &controlplanev1.ApplyResourceRequest_MarketDataSource{
+			MarketDataSource: &controlplanev1.MarketDataSourceDefinition{
+				Code:       "BLOOMBERG",
+				Name:       "Bloomberg",
+				TrustLevel: 90,
+			},
+		},
+	}
+
+	patched, err := patchResource(base, req)
+	require.NoError(t, err)
+	require.NotNil(t, patched.MarketData)
+	require.Len(t, patched.MarketData.Sources, 1)
+	assert.Equal(t, "BLOOMBERG", patched.MarketData.Sources[0].Code)
+}
+
+func TestPatchResource_AddOrganization(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_ORGANIZATION,
+		Resource: &controlplanev1.ApplyResourceRequest_Organization{
+			Organization: &controlplanev1.OrganizationDefinition{
+				Code:      "ACME_ENERGY",
+				Name:      "Acme Energy Corp",
+				PartyType: "ORGANIZATION",
+			},
+		},
+	}
+
+	patched, err := patchResource(base, req)
+	require.NoError(t, err)
+	require.Len(t, patched.Organizations, 1)
+	assert.Equal(t, "ACME_ENERGY", patched.Organizations[0].Code)
+}
+
+func TestPatchResource_AddInternalAccount(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INTERNAL_ACCOUNT,
+		Resource: &controlplanev1.ApplyResourceRequest_InternalAccount{
+			InternalAccount: &controlplanev1.InternalAccountDefinition{
+				Code:        "REVENUE_GBP",
+				AccountType: "CURRENT",
+				Instrument:  "GBP",
+				Description: "Revenue clearing account",
+			},
+		},
+	}
+
+	patched, err := patchResource(base, req)
+	require.NoError(t, err)
+	require.Len(t, patched.InternalAccounts, 1)
+	assert.Equal(t, "REVENUE_GBP", patched.InternalAccounts[0].Code)
+}
+
+func TestResourceID_AllTypes(t *testing.T) {
+	tests := []struct {
+		name   string
+		req    *controlplanev1.ApplyResourceRequest
+		wantID string
+	}{
+		{
+			name: "instrument",
+			req: &controlplanev1.ApplyResourceRequest{
+				Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+					Instrument: &controlplanev1.InstrumentDefinition{Code: "GBP"},
+				},
+			},
+			wantID: "GBP",
+		},
+		{
+			name: "account_type",
+			req: &controlplanev1.ApplyResourceRequest{
+				Resource: &controlplanev1.ApplyResourceRequest_AccountType{
+					AccountType: &controlplanev1.AccountTypeDefinition{Code: "CURRENT"},
+				},
+			},
+			wantID: "CURRENT",
+		},
+		{
+			name: "valuation_rule",
+			req: &controlplanev1.ApplyResourceRequest{
+				Resource: &controlplanev1.ApplyResourceRequest_ValuationRule{
+					ValuationRule: &controlplanev1.ValuationRule{
+						FromInstrument: "GBP",
+						ToInstrument:   "KWH",
+					},
+				},
+			},
+			wantID: "GBP->KWH",
+		},
+		{
+			name: "saga",
+			req: &controlplanev1.ApplyResourceRequest{
+				Resource: &controlplanev1.ApplyResourceRequest_Saga{
+					Saga: &controlplanev1.SagaDefinition{Name: "my_saga"},
+				},
+			},
+			wantID: "my_saga",
+		},
+		{
+			name: "organization",
+			req: &controlplanev1.ApplyResourceRequest{
+				Resource: &controlplanev1.ApplyResourceRequest_Organization{
+					Organization: &controlplanev1.OrganizationDefinition{Code: "ACME"},
+				},
+			},
+			wantID: "ACME",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resourceID(tt.req)
+			assert.Equal(t, tt.wantID, got)
+		})
+	}
+}

--- a/services/control-plane/internal/applier/resource_patcher.go
+++ b/services/control-plane/internal/applier/resource_patcher.go
@@ -1,0 +1,282 @@
+// Package applier provides the ApplyManifest gRPC handler that orchestrates
+// manifest validation, diffing, planning, and execution.
+package applier
+
+import (
+	"errors"
+	"fmt"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+// ErrResourceTypeMismatch is returned when the resource payload does not
+// match the declared resource_type in the request.
+var ErrResourceTypeMismatch = errors.New("resource payload does not match declared resource_type")
+
+// ErrNoCurrentManifest is returned when ApplyResource is called but no
+// manifest has been applied yet (nothing to patch into).
+var ErrNoCurrentManifest = errors.New("no current manifest exists; use ApplyManifest for the initial apply")
+
+// ErrUnsupportedResourceType is returned when the resource type is not supported.
+var ErrUnsupportedResourceType = errors.New("unsupported resource type")
+
+// ErrCloneManifest is returned when proto.Clone fails to produce a *Manifest.
+var ErrCloneManifest = errors.New("failed to clone manifest")
+
+// resourceID extracts the stable identifier from the resource payload in the
+// request. Returns the code/name/key used by the differ to identify the resource.
+func resourceID(req *controlplanev1.ApplyResourceRequest) string {
+	switch v := req.GetResource().(type) {
+	case *controlplanev1.ApplyResourceRequest_Instrument:
+		return v.Instrument.GetCode()
+	case *controlplanev1.ApplyResourceRequest_AccountType:
+		return v.AccountType.GetCode()
+	case *controlplanev1.ApplyResourceRequest_ValuationRule:
+		return valRuleKey(v.ValuationRule.GetFromInstrument(), v.ValuationRule.GetToInstrument())
+	case *controlplanev1.ApplyResourceRequest_Saga:
+		return v.Saga.GetName()
+	case *controlplanev1.ApplyResourceRequest_PartyType:
+		return partyTypeKey(v.PartyType.GetTenantId(), v.PartyType.GetPartyType())
+	case *controlplanev1.ApplyResourceRequest_Mapping:
+		return mappingKey(v.Mapping.GetName(), v.Mapping.GetVersion())
+	case *controlplanev1.ApplyResourceRequest_ProviderConnection:
+		return v.ProviderConnection.GetConnectionId()
+	case *controlplanev1.ApplyResourceRequest_InstructionRoute:
+		return v.InstructionRoute.GetInstructionType()
+	case *controlplanev1.ApplyResourceRequest_MarketDataSource:
+		return v.MarketDataSource.GetCode()
+	case *controlplanev1.ApplyResourceRequest_MarketDataSet:
+		return v.MarketDataSet.GetCode()
+	case *controlplanev1.ApplyResourceRequest_Organization:
+		return v.Organization.GetCode()
+	case *controlplanev1.ApplyResourceRequest_InternalAccount:
+		return v.InternalAccount.GetCode()
+	default:
+		return ""
+	}
+}
+
+// valRuleKey produces a stable identifier for a valuation rule (from->to pair).
+// Mirrors differ.valRuleKey — kept local to avoid an import cycle.
+func valRuleKey(from, to string) string {
+	return from + "->" + to
+}
+
+// partyTypeKey produces a stable identifier for a party type definition.
+// Mirrors differ.partyTypeKey — kept local to avoid an import cycle.
+func partyTypeKey(tenantID, partyType string) string {
+	return tenantID + ":" + partyType
+}
+
+// mappingKey produces a stable identifier for a mapping definition.
+// Mirrors differ.mappingKey — kept local to avoid an import cycle.
+func mappingKey(name string, version int32) string {
+	return fmt.Sprintf("%s:%d", name, version)
+}
+
+// patchResource creates a deep copy of the base manifest and patches the
+// single resource from the request into it. If a resource with the same
+// identifier already exists, it is replaced; otherwise it is appended.
+//
+// Returns the patched manifest. The base manifest is never modified.
+func patchResource(base *controlplanev1.Manifest, req *controlplanev1.ApplyResourceRequest) (*controlplanev1.Manifest, error) {
+	// Deep-copy so the caller's base is untouched.
+	patched, ok := proto.Clone(base).(*controlplanev1.Manifest)
+	if !ok {
+		return nil, ErrCloneManifest
+	}
+
+	// resourcePatchers maps each resource type to its patching function.
+	// This avoids a monolithic switch that triggers cognitive-complexity linters.
+	patcher, exists := resourcePatchers[req.GetResourceType()]
+	if !exists {
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedResourceType, req.GetResourceType())
+	}
+	if err := patcher(patched, req); err != nil {
+		return nil, err
+	}
+	return patched, nil
+}
+
+// resourcePatcherFunc applies a single resource from the request into the manifest.
+type resourcePatcherFunc func(patched *controlplanev1.Manifest, req *controlplanev1.ApplyResourceRequest) error
+
+// resourcePatchers maps manifest resource types to their patching functions.
+var resourcePatchers = map[controlplanev1.ManifestResourceType]resourcePatcherFunc{ //nolint:exhaustive // UNSPECIFIED is rejected by proto validation
+	controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INSTRUMENT:          patchInstrument,
+	controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_ACCOUNT_TYPE:        patchAccountType,
+	controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_VALUATION_RULE:      patchValuationRule,
+	controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_SAGA:                patchSaga,
+	controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_PARTY_TYPE:          patchPartyType,
+	controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_MAPPING:             patchMapping,
+	controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_PROVIDER_CONNECTION: patchProviderConnection,
+	controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INSTRUCTION_ROUTE:   patchInstructionRoute,
+	controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_MARKET_DATA_SOURCE:  patchMarketDataSource,
+	controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_MARKET_DATA_SET:     patchMarketDataSet,
+	controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_ORGANIZATION:        patchOrganization,
+	controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INTERNAL_ACCOUNT:    patchInternalAccount,
+}
+
+func patchInstrument(patched *controlplanev1.Manifest, req *controlplanev1.ApplyResourceRequest) error {
+	inst, ok := req.GetResource().(*controlplanev1.ApplyResourceRequest_Instrument)
+	if !ok || inst.Instrument == nil {
+		return ErrResourceTypeMismatch
+	}
+	patched.Instruments = upsertInSlice(patched.Instruments, inst.Instrument,
+		func(a *controlplanev1.InstrumentDefinition) string { return a.GetCode() },
+		inst.Instrument.GetCode())
+	return nil
+}
+
+func patchAccountType(patched *controlplanev1.Manifest, req *controlplanev1.ApplyResourceRequest) error {
+	at, ok := req.GetResource().(*controlplanev1.ApplyResourceRequest_AccountType)
+	if !ok || at.AccountType == nil {
+		return ErrResourceTypeMismatch
+	}
+	patched.AccountTypes = upsertInSlice(patched.AccountTypes, at.AccountType,
+		func(a *controlplanev1.AccountTypeDefinition) string { return a.GetCode() },
+		at.AccountType.GetCode())
+	return nil
+}
+
+func patchValuationRule(patched *controlplanev1.Manifest, req *controlplanev1.ApplyResourceRequest) error {
+	vr, ok := req.GetResource().(*controlplanev1.ApplyResourceRequest_ValuationRule)
+	if !ok || vr.ValuationRule == nil {
+		return ErrResourceTypeMismatch
+	}
+	key := valRuleKey(vr.ValuationRule.GetFromInstrument(), vr.ValuationRule.GetToInstrument())
+	patched.ValuationRules = upsertInSlice(patched.ValuationRules, vr.ValuationRule,
+		func(a *controlplanev1.ValuationRule) string {
+			return valRuleKey(a.GetFromInstrument(), a.GetToInstrument())
+		}, key)
+	return nil
+}
+
+func patchSaga(patched *controlplanev1.Manifest, req *controlplanev1.ApplyResourceRequest) error {
+	s, ok := req.GetResource().(*controlplanev1.ApplyResourceRequest_Saga)
+	if !ok || s.Saga == nil {
+		return ErrResourceTypeMismatch
+	}
+	patched.Sagas = upsertInSlice(patched.Sagas, s.Saga,
+		func(a *controlplanev1.SagaDefinition) string { return a.GetName() },
+		s.Saga.GetName())
+	return nil
+}
+
+func patchPartyType(patched *controlplanev1.Manifest, req *controlplanev1.ApplyResourceRequest) error {
+	pt, ok := req.GetResource().(*controlplanev1.ApplyResourceRequest_PartyType)
+	if !ok || pt.PartyType == nil {
+		return ErrResourceTypeMismatch
+	}
+	key := partyTypeKey(pt.PartyType.GetTenantId(), pt.PartyType.GetPartyType())
+	patched.PartyTypes = upsertInSlice(patched.PartyTypes, pt.PartyType,
+		func(a *partyv1.PartyTypeDefinition) string { return partyTypeKey(a.GetTenantId(), a.GetPartyType()) },
+		key)
+	return nil
+}
+
+func patchMapping(patched *controlplanev1.Manifest, req *controlplanev1.ApplyResourceRequest) error {
+	m, ok := req.GetResource().(*controlplanev1.ApplyResourceRequest_Mapping)
+	if !ok || m.Mapping == nil {
+		return ErrResourceTypeMismatch
+	}
+	key := mappingKey(m.Mapping.GetName(), m.Mapping.GetVersion())
+	patched.Mappings = upsertInSlice(patched.Mappings, m.Mapping,
+		func(a *mappingv1.MappingDefinition) string { return mappingKey(a.GetName(), a.GetVersion()) },
+		key)
+	return nil
+}
+
+func patchProviderConnection(patched *controlplanev1.Manifest, req *controlplanev1.ApplyResourceRequest) error {
+	pc, ok := req.GetResource().(*controlplanev1.ApplyResourceRequest_ProviderConnection)
+	if !ok || pc.ProviderConnection == nil {
+		return ErrResourceTypeMismatch
+	}
+	if patched.OperationalGateway == nil {
+		patched.OperationalGateway = &controlplanev1.OperationalGatewayConfig{}
+	}
+	patched.OperationalGateway.ProviderConnections = upsertInSlice(
+		patched.OperationalGateway.ProviderConnections, pc.ProviderConnection,
+		func(a *controlplanev1.ProviderConnectionConfig) string { return a.GetConnectionId() },
+		pc.ProviderConnection.GetConnectionId())
+	return nil
+}
+
+func patchInstructionRoute(patched *controlplanev1.Manifest, req *controlplanev1.ApplyResourceRequest) error {
+	ir, ok := req.GetResource().(*controlplanev1.ApplyResourceRequest_InstructionRoute)
+	if !ok || ir.InstructionRoute == nil {
+		return ErrResourceTypeMismatch
+	}
+	if patched.OperationalGateway == nil {
+		patched.OperationalGateway = &controlplanev1.OperationalGatewayConfig{}
+	}
+	patched.OperationalGateway.InstructionRoutes = upsertInSlice(
+		patched.OperationalGateway.InstructionRoutes, ir.InstructionRoute,
+		func(a *controlplanev1.InstructionRouteConfig) string { return a.GetInstructionType() },
+		ir.InstructionRoute.GetInstructionType())
+	return nil
+}
+
+func patchMarketDataSource(patched *controlplanev1.Manifest, req *controlplanev1.ApplyResourceRequest) error {
+	mds, ok := req.GetResource().(*controlplanev1.ApplyResourceRequest_MarketDataSource)
+	if !ok || mds.MarketDataSource == nil {
+		return ErrResourceTypeMismatch
+	}
+	if patched.MarketData == nil {
+		patched.MarketData = &controlplanev1.MarketDataConfig{}
+	}
+	patched.MarketData.Sources = upsertInSlice(patched.MarketData.Sources, mds.MarketDataSource,
+		func(a *controlplanev1.MarketDataSourceDefinition) string { return a.GetCode() },
+		mds.MarketDataSource.GetCode())
+	return nil
+}
+
+func patchMarketDataSet(patched *controlplanev1.Manifest, req *controlplanev1.ApplyResourceRequest) error {
+	mds, ok := req.GetResource().(*controlplanev1.ApplyResourceRequest_MarketDataSet)
+	if !ok || mds.MarketDataSet == nil {
+		return ErrResourceTypeMismatch
+	}
+	if patched.MarketData == nil {
+		patched.MarketData = &controlplanev1.MarketDataConfig{}
+	}
+	patched.MarketData.Datasets = upsertInSlice(patched.MarketData.Datasets, mds.MarketDataSet,
+		func(a *controlplanev1.MarketDataSetDefinition) string { return a.GetCode() },
+		mds.MarketDataSet.GetCode())
+	return nil
+}
+
+func patchOrganization(patched *controlplanev1.Manifest, req *controlplanev1.ApplyResourceRequest) error {
+	org, ok := req.GetResource().(*controlplanev1.ApplyResourceRequest_Organization)
+	if !ok || org.Organization == nil {
+		return ErrResourceTypeMismatch
+	}
+	patched.Organizations = upsertInSlice(patched.Organizations, org.Organization,
+		func(a *controlplanev1.OrganizationDefinition) string { return a.GetCode() },
+		org.Organization.GetCode())
+	return nil
+}
+
+func patchInternalAccount(patched *controlplanev1.Manifest, req *controlplanev1.ApplyResourceRequest) error {
+	ia, ok := req.GetResource().(*controlplanev1.ApplyResourceRequest_InternalAccount)
+	if !ok || ia.InternalAccount == nil {
+		return ErrResourceTypeMismatch
+	}
+	patched.InternalAccounts = upsertInSlice(patched.InternalAccounts, ia.InternalAccount,
+		func(a *controlplanev1.InternalAccountDefinition) string { return a.GetCode() },
+		ia.InternalAccount.GetCode())
+	return nil
+}
+
+// upsertInSlice replaces the element with matching key, or appends if not found.
+func upsertInSlice[T any](slice []T, newElem T, keyFn func(T) string, key string) []T {
+	for i, elem := range slice {
+		if keyFn(elem) == key {
+			slice[i] = newElem
+			return slice
+		}
+	}
+	return append(slice, newElem)
+}

--- a/services/control-plane/internal/applier/resource_patcher.go
+++ b/services/control-plane/internal/applier/resource_patcher.go
@@ -5,6 +5,7 @@ package applier
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
 	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
@@ -61,8 +62,9 @@ func resourceID(req *controlplanev1.ApplyResourceRequest) string {
 
 // valRuleKey produces a stable identifier for a valuation rule (from->to pair).
 // Mirrors differ.valRuleKey — kept local to avoid an import cycle.
+// Applies strings.ToUpper to match differ's normalization.
 func valRuleKey(from, to string) string {
-	return from + "->" + to
+	return strings.ToUpper(from) + "->" + strings.ToUpper(to)
 }
 
 // partyTypeKey produces a stable identifier for a party type definition.


### PR DESCRIPTION
## Summary

- Add `ApplyResource` RPC to `ApplyManifestService` enabling targeted single-resource mutations without full manifest reapply
- Implement resource patching logic for all 12 manifest resource types (instrument, account_type, valuation_rule, saga, party_type, mapping, provider_connection, instruction_route, market_data_source, market_data_set, organization, internal_account)
- Pipeline: load current manifest from version store, patch resource, validate full dependency graph, diff against current state, execute only affected phases, create new manifest version

## Changes Made

- **Proto**: Added `ApplyResource` RPC, `ApplyResourceRequest`/`ApplyResourceResponse` messages, `ManifestResourceType` enum to `apply_manifest_service.proto`
- **`apply_resource.go`**: Handler implementation with `loadAndPatch` -> `applyPatchedManifest` flow, reusing existing validate/diff/plan/execute pipeline
- **`resource_patcher.go`**: `patchResource()` deep-copies the base manifest and upserts the single resource; `resourceID()` extracts stable identifiers; dispatch table pattern avoids cognitive complexity
- **`apply_resource_test.go`**: 20 tests covering request validation, version store requirements, dry-run for multiple resource types, validation failure on invalid references, no-executor failure mode, and resource patching correctness

## Technical Details

- Uses `proto.Clone()` for safe deep-copy before patching (base manifest untouched)
- `diffAgainst()` method takes explicit base instead of loading from store (avoids double-load)
- Supports optimistic locking via `expected_sequence_number` (same as `ApplyManifest`)
- Post-apply hooks fire after successful resource apply (cache invalidation)
- Resource dispatch uses map-based lookup instead of monolithic switch (linter-friendly)

## Test plan

- [x] Unit tests for all request validation paths (nil resource, missing applied_by, no version store, no current manifest)
- [x] Dry-run tests for instrument, account type, saga, valuation rule resource types
- [x] Validation failure test (account type referencing non-existent instrument)
- [x] Resource patcher unit tests (add new, update existing, initialize nested configs)
- [x] `resourceID()` coverage for multiple resource types
- [x] Full applier package test suite passes
- [x] golangci-lint clean (0 issues)
- [x] Pre-commit hooks pass (gitleaks, buf lint, buf breaking, gofumpt, golangci-lint)