### PR TITLE
fix: MCP OAuth token validation and tenant context injection

### DIFF
--- a/deploy/demo/docker-compose.yml
+++ b/deploy/demo/docker-compose.yml
@@ -61,6 +61,14 @@ services:
       # Per-service databases are created by init-databases.sql on first Postgres boot.
       DATABASE_URL: postgres://${POSTGRES_USER:-meridian}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the env file}@postgres:5432/${POSTGRES_DB:-meridian}?sslmode=disable
 
+      # --- JWT Signing (shared with MCP server for token interoperability) ---
+      # Both the gateway (BFF auth + JWKS endpoint) and MCP server must use the
+      # same RSA key. Without this, MCP-signed tokens fail JWKS validation because
+      # the gateway generates a random key on startup when JWT_SIGNING_KEY is empty.
+      JWT_SIGNING_KEY: ${JWT_SIGNING_KEY:-}
+      JWT_SIGNING_KEY_ID: ${JWT_SIGNING_KEY_ID:-meridian-1}
+      JWT_SIGNING_ISSUER: ${JWT_SIGNING_ISSUER:-meridian}
+
       # --- Authentication (embedded Dex OIDC server) ---
       AUTH_ENABLED: ${AUTH_ENABLED:-true}
       DEX_ISSUER: ${DEX_ISSUER:-https://${BASE_DOMAIN:-demo.meridianhub.cloud}/dex}

--- a/services/mcp-server/internal/auth/oauth.go
+++ b/services/mcp-server/internal/auth/oauth.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
 
 const (
@@ -531,6 +533,11 @@ func NewBearerMiddleware(validator BearerValidator, fallbackBaseURL string) *Bea
 }
 
 // Handler wraps an http.Handler, enforcing Bearer token authentication.
+// When the validator implements ClaimsBearerValidator (JWKS mode), the
+// authenticated tenant ID from the JWT's x-tenant-id claim is injected
+// into the request context via tenant.WithTenant. This allows downstream
+// tool handlers to make tenant-scoped gRPC calls without requiring the
+// caller to pass a tenant_id parameter explicitly.
 func (m *BearerMiddleware) Handler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token, err := extractBearerFromHeader(r)
@@ -539,7 +546,20 @@ func (m *BearerMiddleware) Handler(next http.Handler) http.Handler {
 			return
 		}
 
-		if err := m.validator.ValidateBearer(token); err != nil {
+		// If the validator supports claims extraction, use it to get tenant context.
+		if claimsValidator, ok := m.validator.(ClaimsBearerValidator); ok {
+			tenantID, validateErr := claimsValidator.ValidateBearerWithTenant(token)
+			if validateErr != nil {
+				m.logger.Debug("bearer token validation failed",
+					"error", validateErr, "path", r.URL.Path)
+				m.writeAuthRequired(w, r)
+				return
+			}
+			if tenantID != "" {
+				ctx := tenant.WithTenant(r.Context(), tenant.TenantID(tenantID))
+				r = r.WithContext(ctx)
+			}
+		} else if err := m.validator.ValidateBearer(token); err != nil {
 			m.logger.Debug("bearer token validation failed",
 				"error", err, "path", r.URL.Path)
 			m.writeAuthRequired(w, r)


### PR DESCRIPTION
## Summary

- Add `JWT_SIGNING_KEY` to the gateway container in `deploy/demo/docker-compose.yml`
- Inject authenticated tenant context from JWT into MCP tool request context

## Problem

Two issues prevented MCP tools from working after OAuth authentication:

### 1. JWT signing key mismatch (deploy config)

The gateway container was missing `JWT_SIGNING_KEY` in its environment block, causing it to generate a random RSA key on every restart. The MCP server had the key configured and signed tokens correctly, but the gateway's `/api/auth/jwks` endpoint served the random key's public component — causing bearer token validation to fail with `crypto/rsa: verification error`.

**Symptom:** Claude Code reported "Authentication successful, but server still requires authentication."

### 2. Tenant context not injected from JWT (application code)

`BearerMiddleware.Handler()` validated the JWT but discarded the claims. After successful auth, tool handlers received a request context without tenant, causing `tenant context missing` errors on every gRPC call to the backend.

**Symptom:** Tools returned `failed to list instruments: tenant context missing` despite valid authentication.

## Changes

| File | Change |
|------|--------|
| `deploy/demo/docker-compose.yml` | Add `JWT_SIGNING_KEY`, `JWT_SIGNING_KEY_ID`, `JWT_SIGNING_ISSUER` to meridian container |
| `services/mcp-server/internal/auth/oauth.go` | Extract `x-tenant-id` from JWT via `ClaimsBearerValidator` and inject into context via `tenant.WithTenant()` |

## Test plan

- [x] Deployed fix 1 to demo — JWKS modulus matches `.env` private key
- [x] Claude Code `/mcp` authentication succeeded: "Connected to meridian"
- [x] Auth package tests pass (`go test ./services/mcp-server/internal/auth/...`)
- [ ] Deploy fix 2 to demo and verify `meridian_instruments_list` returns data