### PR TITLE
fix: Propagate tenant context from JWT through gRPC metadata

### DIFF
--- a/services/mcp-server/internal/auth/auth.go
+++ b/services/mcp-server/internal/auth/auth.go
@@ -13,6 +13,8 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
 
 const (
@@ -65,7 +67,8 @@ func LoadFromEnv() (*Config, error) {
 }
 
 // UnaryInterceptor returns a gRPC UnaryClientInterceptor that injects the API
-// key as a Bearer token in the outgoing metadata of every request.
+// key as a Bearer token and propagates tenant context in the outgoing metadata
+// of every request.
 func (a *Config) UnaryInterceptor() grpc.UnaryClientInterceptor {
 	return func(
 		ctx context.Context,
@@ -76,6 +79,9 @@ func (a *Config) UnaryInterceptor() grpc.UnaryClientInterceptor {
 		opts ...grpc.CallOption,
 	) error {
 		ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+a.APIKey)
+		if tenantID, ok := tenant.FromContext(ctx); ok && !tenantID.IsEmpty() {
+			ctx = metadata.AppendToOutgoingContext(ctx, tenant.TenantIDKey, string(tenantID))
+		}
 		return invoker(ctx, method, req, reply, cc, opts...)
 	}
 }


### PR DESCRIPTION
## Summary

- Propagate tenant ID from JWT claims through gRPC outgoing metadata so backend services receive tenant context

## Problem

Follow-up to PR #1697. After MCP OAuth authentication succeeds, `BearerMiddleware` now correctly extracts `x-tenant-id` from the JWT and injects it into the Go context via `tenant.WithTenant()`. However, the gRPC client interceptor only forwarded the API key — it did not propagate tenant context as gRPC metadata. Backend services require `x-tenant-id` in gRPC metadata to scope queries, so all tool calls failed with "tenant context missing."

## Changes

| File | Change |
|------|--------|
| `services/mcp-server/internal/auth/auth.go` | Extract tenant from context and append as `x-tenant-id` gRPC metadata in `UnaryInterceptor` |

## Test plan

- [x] Auth package tests pass
- [ ] Deploy to demo and verify `meridian_instruments_list` returns data