### PR TITLE
feat: centralized NODE_TYPE_REGISTRY for graph configuration

### DIFF
--- a/frontend/src/features/manifests/components/manifest-diff-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-diff-graph.tsx
@@ -25,9 +25,9 @@ import type {
   ManifestNode,
   ManifestEdge,
   ManifestGraph,
-  ManifestNodeType,
 } from '../lib/manifest-graph-model'
 import { computeManifestDiff, type ManifestDiff } from '../lib/manifest-diff'
+import { getLayerPriority } from '../lib/node-type-registry'
 
 type DiffStatus = 'added' | 'removed' | 'modified' | 'unchanged'
 
@@ -38,12 +38,7 @@ const DIFF_COLORS: Record<DiffStatus, { border: string; bg: string }> = {
   unchanged: { border: 'var(--graph-diff-unchanged)', bg: 'color-mix(in oklch, var(--graph-diff-unchanged) 6%, transparent)' },
 }
 
-const LAYER_PRIORITY: Record<ManifestNodeType, string> = {
-  instrument: '40',
-  account_type: '30',
-  valuation_rule: '20',
-  saga: '10',
-}
+const LAYER_PRIORITY = getLayerPriority()
 
 interface DiffNodeData {
   manifestNode: ManifestNode

--- a/frontend/src/features/manifests/components/manifest-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.tsx
@@ -42,17 +42,12 @@ import {
   type ManifestNodeType,
   type ManifestGraph as ManifestGraphModel,
 } from '../lib/manifest-graph-model'
+import { NODE_TYPE_REGISTRY, getNodeThemes, getLayerPriority } from '../lib/node-type-registry'
 import type { Manifest } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
 import { useEventChain } from '../hooks/use-event-chain'
 import { EventChainPanel } from './event-chain-panel'
 
-// Theme colors per node type — uses CSS variables for dark mode support
-const NODE_THEMES: Record<ManifestNodeType, { color: string; label: string }> = {
-  instrument: { color: 'var(--graph-instrument)', label: 'Instruments' },
-  account_type: { color: 'var(--graph-account-type)', label: 'Account Types' },
-  valuation_rule: { color: 'var(--graph-valuation-rule)', label: 'Valuation Rules' },
-  saga: { color: 'var(--graph-saga)', label: 'Sagas' },
-}
+const NODE_THEMES = getNodeThemes()
 
 // Edge styles per relationship type
 const MANIFEST_EDGE_STYLES: Record<string, React.CSSProperties> = {
@@ -67,13 +62,7 @@ const EDGE_LEGEND: { label: string; color: string; dashed?: boolean }[] = [
   { label: 'Converts to', color: 'var(--graph-valuation-rule)' },
 ]
 
-// ELK layer priority: higher values are placed earlier (top in DOWN direction)
-const LAYER_PRIORITY: Record<ManifestNodeType, string> = {
-  instrument: '40',
-  account_type: '30',
-  valuation_rule: '20',
-  saga: '10',
-}
+const LAYER_PRIORITY = getLayerPriority()
 
 // Trigger type display
 function getTriggerBadge(trigger: string): { label: string; variant: string } {
@@ -288,7 +277,7 @@ async function layoutManifestGraph(
     rfEdges,
     (id, position) => {
       const mn = nodeMap.get(id)!
-      const color = NODE_THEMES[mn.type].color
+      const color = NODE_TYPE_REGISTRY[mn.type].color
       return {
         id,
         type: mn.type,

--- a/frontend/src/features/manifests/lib/node-type-registry.test.ts
+++ b/frontend/src/features/manifests/lib/node-type-registry.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import {
+  NODE_TYPE_REGISTRY,
+  getNodeThemes,
+  getLayerPriority,
+  type NodeTypeConfig,
+} from './node-type-registry'
+import type { ManifestNodeType } from './manifest-graph-model'
+
+describe('NODE_TYPE_REGISTRY', () => {
+  const ALL_TYPES: ManifestNodeType[] = [
+    'instrument',
+    'account_type',
+    'valuation_rule',
+    'saga',
+  ]
+
+  it('has entries for all current ManifestNodeType values', () => {
+    for (const type of ALL_TYPES) {
+      expect(NODE_TYPE_REGISTRY[type]).toBeDefined()
+    }
+  })
+
+  it('each entry has required fields', () => {
+    for (const type of ALL_TYPES) {
+      const config = NODE_TYPE_REGISTRY[type]
+      expect(config.color).toBeTruthy()
+      expect(config.label).toBeTruthy()
+      expect(config.layerPriority).toMatch(/^\d+$/)
+    }
+  })
+
+  it('preserves original theme colors using CSS variables', () => {
+    expect(NODE_TYPE_REGISTRY.instrument.color).toBe('var(--graph-instrument)')
+    expect(NODE_TYPE_REGISTRY.account_type.color).toBe('var(--graph-account-type)')
+    expect(NODE_TYPE_REGISTRY.valuation_rule.color).toBe('var(--graph-valuation-rule)')
+    expect(NODE_TYPE_REGISTRY.saga.color).toBe('var(--graph-saga)')
+  })
+
+  it('preserves original labels', () => {
+    expect(NODE_TYPE_REGISTRY.instrument.label).toBe('Instruments')
+    expect(NODE_TYPE_REGISTRY.account_type.label).toBe('Account Types')
+    expect(NODE_TYPE_REGISTRY.valuation_rule.label).toBe('Valuation Rules')
+    expect(NODE_TYPE_REGISTRY.saga.label).toBe('Sagas')
+  })
+
+  it('preserves original layer priorities', () => {
+    expect(NODE_TYPE_REGISTRY.instrument.layerPriority).toBe('40')
+    expect(NODE_TYPE_REGISTRY.account_type.layerPriority).toBe('30')
+    expect(NODE_TYPE_REGISTRY.valuation_rule.layerPriority).toBe('20')
+    expect(NODE_TYPE_REGISTRY.saga.layerPriority).toBe('10')
+  })
+})
+
+describe('getNodeThemes', () => {
+  it('returns a Record<ManifestNodeType, { color, label }>', () => {
+    const themes = getNodeThemes()
+    expect(themes.instrument).toEqual({
+      color: 'var(--graph-instrument)',
+      label: 'Instruments',
+    })
+    expect(themes.saga).toEqual({
+      color: 'var(--graph-saga)',
+      label: 'Sagas',
+    })
+  })
+
+  it('returns the same reference on repeated calls (memoized)', () => {
+    const a = getNodeThemes()
+    const b = getNodeThemes()
+    expect(a).toBe(b)
+  })
+})
+
+describe('getLayerPriority', () => {
+  it('returns a Record<ManifestNodeType, string>', () => {
+    const priority = getLayerPriority()
+    expect(priority.instrument).toBe('40')
+    expect(priority.account_type).toBe('30')
+    expect(priority.valuation_rule).toBe('20')
+    expect(priority.saga).toBe('10')
+  })
+
+  it('returns the same reference on repeated calls (memoized)', () => {
+    const a = getLayerPriority()
+    const b = getLayerPriority()
+    expect(a).toBe(b)
+  })
+})

--- a/frontend/src/features/manifests/lib/node-type-registry.test.ts
+++ b/frontend/src/features/manifests/lib/node-type-registry.test.ts
@@ -3,7 +3,6 @@ import {
   NODE_TYPE_REGISTRY,
   getNodeThemes,
   getLayerPriority,
-  type NodeTypeConfig,
 } from './node-type-registry'
 import type { ManifestNodeType } from './manifest-graph-model'
 

--- a/frontend/src/features/manifests/lib/node-type-registry.ts
+++ b/frontend/src/features/manifests/lib/node-type-registry.ts
@@ -1,0 +1,59 @@
+import type { ManifestNodeType } from './manifest-graph-model'
+
+export interface NodeTypeConfig {
+  /** CSS variable or color value for theming this node type */
+  color: string
+  /** Human-readable plural label (e.g. "Instruments") */
+  label: string
+  /** ELK layer priority: higher values are placed earlier (top in DOWN layout) */
+  layerPriority: string
+}
+
+/**
+ * Centralized registry for all manifest node type configuration.
+ * Single source of truth for colors, labels, and layer priorities.
+ */
+export const NODE_TYPE_REGISTRY: Record<ManifestNodeType, NodeTypeConfig> = {
+  instrument: {
+    color: 'var(--graph-instrument)',
+    label: 'Instruments',
+    layerPriority: '40',
+  },
+  account_type: {
+    color: 'var(--graph-account-type)',
+    label: 'Account Types',
+    layerPriority: '30',
+  },
+  valuation_rule: {
+    color: 'var(--graph-valuation-rule)',
+    label: 'Valuation Rules',
+    layerPriority: '20',
+  },
+  saga: {
+    color: 'var(--graph-saga)',
+    label: 'Sagas',
+    layerPriority: '10',
+  },
+}
+
+/** Derived view: { color, label } per node type, compatible with existing NODE_THEMES usage. */
+let _nodeThemes: Record<ManifestNodeType, { color: string; label: string }> | null = null
+export function getNodeThemes(): Record<ManifestNodeType, { color: string; label: string }> {
+  if (_nodeThemes) return _nodeThemes
+  _nodeThemes = {} as Record<ManifestNodeType, { color: string; label: string }>
+  for (const [type, config] of Object.entries(NODE_TYPE_REGISTRY)) {
+    _nodeThemes[type as ManifestNodeType] = { color: config.color, label: config.label }
+  }
+  return _nodeThemes
+}
+
+/** Derived view: layer priority per node type, compatible with existing LAYER_PRIORITY usage. */
+let _layerPriority: Record<ManifestNodeType, string> | null = null
+export function getLayerPriority(): Record<ManifestNodeType, string> {
+  if (_layerPriority) return _layerPriority
+  _layerPriority = {} as Record<ManifestNodeType, string>
+  for (const [type, config] of Object.entries(NODE_TYPE_REGISTRY)) {
+    _layerPriority[type as ManifestNodeType] = config.layerPriority
+  }
+  return _layerPriority
+}


### PR DESCRIPTION
## Summary

- Create `node-type-registry.ts` with `NodeTypeConfig` interface and `NODE_TYPE_REGISTRY` mapping all `ManifestNodeType` values to color, label, and layerPriority
- Export derived helpers `getNodeThemes()` and `getLayerPriority()` for backward-compatible drop-in replacement
- Migrate `manifest-graph.tsx` to use registry (removes inline `NODE_THEMES` and `LAYER_PRIORITY` constants)
- Migrate `manifest-diff-graph.tsx` to use registry (removes duplicate `LAYER_PRIORITY` constant)

**Task Master**: 046-economy-visualization-completeness.7

## Test plan

- [x] Registry unit tests (9 tests) verify all node types, colors, labels, layer priorities, and memoization
- [x] All 126 existing manifests feature tests pass unchanged
- [x] TypeScript typecheck passes
- [x] ESLint passes on all changed files