### PR TITLE
feat: add PARTIAL status to manifest history table

### DIFF
--- a/frontend/src/features/manifests/pages/manifest-history-table.tsx
+++ b/frontend/src/features/manifests/pages/manifest-history-table.tsx
@@ -23,6 +23,7 @@ const APPLY_STATUS_LABEL: Record<number, string> = {
   [ApplyStatus.APPLIED]: 'APPLIED',
   [ApplyStatus.FAILED]: 'FAILED',
   [ApplyStatus.ROLLED_BACK]: 'ROLLED_BACK',
+  [ApplyStatus.PARTIAL]: 'PARTIAL',
 }
 
 function buildColumns(

--- a/frontend/src/shared/status-badge.tsx
+++ b/frontend/src/shared/status-badge.tsx
@@ -31,6 +31,7 @@ const STATUS_MAP: Record<string, StatusVariant> = {
   LOCKED: 'error',
   // Manifest apply statuses
   APPLIED: 'success',
+  PARTIAL: 'warning',
   ROLLED_BACK: 'warning',
   // Position quality ladder
   ESTIMATE: 'warning',


### PR DESCRIPTION
## Summary

- Adds `APPLY_STATUS_PARTIAL` to the `APPLY_STATUS_LABEL` mapping in `manifest-history-table.tsx`
- Registers `PARTIAL` with a `warning` variant in `status-badge.tsx`, consistent with `ROLLED_BACK`
- Regenerated frontend proto bindings to include `APPLY_STATUS_PARTIAL = 4` (the value existed in the proto definition but was missing from the generated TypeScript)

## Changes Made

- `frontend/src/features/manifests/pages/manifest-history-table.tsx`: added `[ApplyStatus.PARTIAL]: 'PARTIAL'` to `APPLY_STATUS_LABEL`
- `frontend/src/shared/status-badge.tsx`: added `PARTIAL: 'warning'` to `STATUS_MAP`

## Testing

- TypeScript typecheck passes
- All 2199 tests pass (174 test files)

## Risk Assessment

Low — additive change only; no existing status handling is modified.