### PR TITLE
feat: add AuditService and IdentityService to frontend proto test stubs

### DIFF
--- a/frontend/src/test/gen-stub.ts
+++ b/frontend/src/test/gen-stub.ts
@@ -29,6 +29,8 @@ export const ForecastingService = serviceStub
 export const MappingService = serviceStub
 export const ManifestHistoryService = serviceStub
 export const ApplyManifestService = serviceStub
+export const AuditService = serviceStub
+export const IdentityService = serviceStub
 
 // Enum exports (from types_pb.ts and other shared proto files)
 // Names match what Connect-ES generates from proto enums (short names without prefix).

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -31,6 +31,8 @@ function genStubPlugin(): Plugin {
     export const ForecastingService = { typeName: 'stub', methods: [] }
     export const ManifestHistoryService = { typeName: 'stub', methods: [] }
     export const ApplyManifestService = { typeName: 'stub', methods: [] }
+    export const AuditService = { typeName: 'stub', methods: [] }
+    export const IdentityService = { typeName: 'stub', methods: [] }
     export const AccountStatus = { UNSPECIFIED: 0, ACTIVE: 1, FROZEN: 2, CLOSED: 3 }
     export const TransactionStatus = { UNSPECIFIED: 0, PENDING: 1, POSTED: 2, FAILED: 3, CANCELLED: 4, REVERSED: 5 }
     export const PostingDirection = { UNSPECIFIED: 0, DEBIT: 1, CREDIT: 2 }


### PR DESCRIPTION
## Summary

- Adds `AuditService` and `IdentityService` to the `genStubPlugin` in `vitest.config.ts` and to `gen-stub.ts`
- These services are registered in `clients.ts` but were missing from the test stub module
- Verified that `buf generate` produces all expected RPCs for the control-plane service

## Context

Task 046-economy-visualization-completeness.1: Regenerate proto types for control-plane service.

The proto source files already include all new RPCs added in recent PRs:
- `ApplyResource` (PR #1695)
- `ExportManifest` (PR #1694)
- `ReconcileManifest` (PR #1696)
- `DiffManifestVersions` (PR #1687)

Frontend generation (`npm run generate`) runs at CI build time (not committed). Verified locally that generation produces correct TypeScript types for all RPCs.

## Changes Made

- `frontend/vitest.config.ts`: Added `AuditService` and `IdentityService` to the inline `genStubPlugin` stub
- `frontend/src/test/gen-stub.ts`: Added matching exports for consistency

## Testing

- `npm run generate` — succeeds, all 8 RPCs present in generated files
- `npm run typecheck` — passes with no errors
- `npm run lint` — passes (warnings are pre-existing, unrelated to this change)
- `npx vitest run` — 174 test files, 2199 tests, all passing