### PR TITLE
feat: extend ManifestNodeType union with new resource types

### DIFF
--- a/frontend/src/features/manifests/lib/manifest-graph-model.test.ts
+++ b/frontend/src/features/manifests/lib/manifest-graph-model.test.ts
@@ -458,6 +458,258 @@ describe('buildManifestGraph', () => {
     })
   })
 
+  describe('payment rail nodes', () => {
+    it('creates a node for each payment rail', () => {
+      const manifest = createMockManifest({
+        paymentRails: [
+          { provider: 'stripe_connect', mode: 1, accountId: 'acct_ABC123456789012345', webhookEndpointSecret: 'whsec_test', platformFee: { type: 1, value: '2.5' }, payoutSchedule: 1, supportedMethods: ['card'] },
+          { provider: 'wise', mode: 2, accountId: 'acct_XYZ987654321098765', webhookEndpointSecret: 'whsec_prod', platformFee: { type: 2, value: '1.00' }, payoutSchedule: 2, supportedMethods: ['bank_transfer'] },
+        ],
+      })
+      const graph = buildManifestGraph(manifest)
+      const railNodes = graph.nodes.filter((n) => n.type === 'payment_rail')
+
+      expect(railNodes).toHaveLength(2)
+      expect(railNodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'payment_rail:stripe_connect', label: 'stripe_connect' }),
+          expect.objectContaining({ id: 'payment_rail:wise', label: 'wise' }),
+        ]),
+      )
+    })
+  })
+
+  describe('party type nodes', () => {
+    it('creates a node for each party type', () => {
+      const manifest = createMockManifest({
+        partyTypes: [
+          { id: 'pt-1', tenantId: 't-1', partyType: 'PERSON', attributeSchema: '{}' },
+          { id: 'pt-2', tenantId: 't-1', partyType: 'ORGANIZATION', attributeSchema: '{}' },
+        ],
+      })
+      const graph = buildManifestGraph(manifest)
+      const ptNodes = graph.nodes.filter((n) => n.type === 'party_type')
+
+      expect(ptNodes).toHaveLength(2)
+      expect(ptNodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'party_type:PERSON', label: 'PERSON' }),
+          expect.objectContaining({ id: 'party_type:ORGANIZATION', label: 'ORGANIZATION' }),
+        ]),
+      )
+    })
+  })
+
+  describe('mapping nodes', () => {
+    it('creates a node for each mapping definition', () => {
+      const manifest = createMockManifest({
+        mappings: [
+          { id: 'm-1', tenantId: 't-1', name: 'Stripe Webhook -> Payment Order', targetService: 'payment_order.v1' },
+          { id: 'm-2', tenantId: 't-1', name: 'KYC Response -> Party Update', targetService: 'party.v1' },
+        ],
+      })
+      const graph = buildManifestGraph(manifest)
+      const mappingNodes = graph.nodes.filter((n) => n.type === 'mapping')
+
+      expect(mappingNodes).toHaveLength(2)
+      expect(mappingNodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'mapping:Stripe Webhook -> Payment Order', label: 'Stripe Webhook -> Payment Order' }),
+          expect.objectContaining({ id: 'mapping:KYC Response -> Party Update', label: 'KYC Response -> Party Update' }),
+        ]),
+      )
+    })
+  })
+
+  describe('operational gateway nodes', () => {
+    it('creates an operational_gateway node when present', () => {
+      const manifest = createMockManifest({
+        operationalGateway: {
+          providerConnections: [],
+          instructionRoutes: [],
+          inboundRoutes: [],
+        },
+      })
+      const graph = buildManifestGraph(manifest)
+      const gwNodes = graph.nodes.filter((n) => n.type === 'operational_gateway')
+
+      expect(gwNodes).toHaveLength(1)
+      expect(gwNodes[0]).toMatchObject({
+        id: 'operational_gateway:default',
+        label: 'Operational Gateway',
+      })
+    })
+
+    it('does not create operational_gateway node when absent', () => {
+      const manifest = createMockManifest({
+        operationalGateway: undefined,
+      })
+      const graph = buildManifestGraph(manifest)
+      const gwNodes = graph.nodes.filter((n) => n.type === 'operational_gateway')
+
+      expect(gwNodes).toHaveLength(0)
+    })
+  })
+
+  describe('provider connection nodes and edges', () => {
+    it('creates a node for each provider connection', () => {
+      const manifest = createMockManifest({
+        operationalGateway: {
+          providerConnections: [
+            { connectionId: 'stripe-primary', providerName: 'Stripe', providerType: 'payment_gateway', protocol: 1, baseUrl: 'https://api.stripe.com' },
+            { connectionId: 'kyc-provider', providerName: 'Onfido', providerType: 'kyc_provider', protocol: 1, baseUrl: 'https://api.onfido.com' },
+          ],
+          instructionRoutes: [],
+          inboundRoutes: [],
+        },
+      })
+      const graph = buildManifestGraph(manifest)
+      const connNodes = graph.nodes.filter((n) => n.type === 'provider_connection')
+
+      expect(connNodes).toHaveLength(2)
+      expect(connNodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'provider_connection:stripe-primary', label: 'Stripe' }),
+          expect.objectContaining({ id: 'provider_connection:kyc-provider', label: 'Onfido' }),
+        ]),
+      )
+    })
+
+    it('creates belongs_to edges from provider connections to operational gateway', () => {
+      const manifest = createMockManifest({
+        operationalGateway: {
+          providerConnections: [
+            { connectionId: 'stripe-primary', providerName: 'Stripe', providerType: 'payment_gateway', protocol: 1, baseUrl: 'https://api.stripe.com' },
+          ],
+          instructionRoutes: [],
+          inboundRoutes: [],
+        },
+      })
+      const graph = buildManifestGraph(manifest)
+      const belongsToEdges = graph.edges.filter((e) => e.relationship === 'belongs_to')
+
+      expect(belongsToEdges).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            source: 'provider_connection:stripe-primary',
+            target: 'operational_gateway:default',
+            relationship: 'belongs_to',
+          }),
+        ]),
+      )
+    })
+  })
+
+  describe('instruction route nodes and edges', () => {
+    it('creates a node for each instruction route', () => {
+      const manifest = createMockManifest({
+        operationalGateway: {
+          providerConnections: [
+            { connectionId: 'stripe-primary', providerName: 'Stripe', providerType: 'payment_gateway', protocol: 1, baseUrl: 'https://api.stripe.com' },
+          ],
+          instructionRoutes: [
+            { instructionType: 'payment.initiate', connectionId: 'stripe-primary', fallbackConnectionId: '', outboundMappingId: 'stripe-outbound', inboundMappingId: '', httpMethod: 'POST', pathTemplate: '/v1/charges' },
+            { instructionType: 'kyc.verify', connectionId: 'stripe-primary', fallbackConnectionId: '', outboundMappingId: '', inboundMappingId: '', httpMethod: 'POST', pathTemplate: '/v1/identity' },
+          ],
+          inboundRoutes: [],
+        },
+      })
+      const graph = buildManifestGraph(manifest)
+      const routeNodes = graph.nodes.filter((n) => n.type === 'instruction_route')
+
+      expect(routeNodes).toHaveLength(2)
+      expect(routeNodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'instruction_route:payment.initiate', label: 'payment.initiate' }),
+          expect.objectContaining({ id: 'instruction_route:kyc.verify', label: 'kyc.verify' }),
+        ]),
+      )
+    })
+
+    it('creates routes_to edges from instruction routes to provider connections', () => {
+      const manifest = createMockManifest({
+        operationalGateway: {
+          providerConnections: [
+            { connectionId: 'stripe-primary', providerName: 'Stripe', providerType: 'payment_gateway', protocol: 1, baseUrl: 'https://api.stripe.com' },
+          ],
+          instructionRoutes: [
+            { instructionType: 'payment.initiate', connectionId: 'stripe-primary', fallbackConnectionId: '', outboundMappingId: '', inboundMappingId: '', httpMethod: 'POST', pathTemplate: '/v1/charges' },
+          ],
+          inboundRoutes: [],
+        },
+      })
+      const graph = buildManifestGraph(manifest)
+      const routesToEdges = graph.edges.filter((e) => e.relationship === 'routes_to')
+
+      expect(routesToEdges).toHaveLength(1)
+      expect(routesToEdges[0]).toMatchObject({
+        source: 'instruction_route:payment.initiate',
+        target: 'provider_connection:stripe-primary',
+        relationship: 'routes_to',
+      })
+    })
+
+    it('creates uses_mapping edges from instruction routes to mappings', () => {
+      const manifest = createMockManifest({
+        mappings: [
+          { id: 'm-1', tenantId: 't-1', name: 'stripe-outbound', targetService: 'payment_order.v1' },
+          { id: 'm-2', tenantId: 't-1', name: 'stripe-inbound', targetService: 'payment_order.v1' },
+        ],
+        operationalGateway: {
+          providerConnections: [
+            { connectionId: 'stripe-primary', providerName: 'Stripe', providerType: 'payment_gateway', protocol: 1, baseUrl: 'https://api.stripe.com' },
+          ],
+          instructionRoutes: [
+            { instructionType: 'payment.initiate', connectionId: 'stripe-primary', fallbackConnectionId: '', outboundMappingId: 'stripe-outbound', inboundMappingId: 'stripe-inbound', httpMethod: 'POST', pathTemplate: '/v1/charges' },
+          ],
+          inboundRoutes: [],
+        },
+      })
+      const graph = buildManifestGraph(manifest)
+      const usesMappingEdges = graph.edges.filter((e) => e.relationship === 'uses_mapping')
+
+      expect(usesMappingEdges).toHaveLength(2)
+      expect(usesMappingEdges).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            source: 'instruction_route:payment.initiate',
+            target: 'mapping:stripe-outbound',
+            relationship: 'uses_mapping',
+          }),
+          expect.objectContaining({
+            source: 'instruction_route:payment.initiate',
+            target: 'mapping:stripe-inbound',
+            relationship: 'uses_mapping',
+          }),
+        ]),
+      )
+    })
+
+    it('creates fallback_to edges when fallback connection is set', () => {
+      const manifest = createMockManifest({
+        operationalGateway: {
+          providerConnections: [
+            { connectionId: 'stripe-primary', providerName: 'Stripe', providerType: 'payment_gateway', protocol: 1, baseUrl: 'https://api.stripe.com' },
+            { connectionId: 'stripe-backup', providerName: 'Stripe Backup', providerType: 'payment_gateway', protocol: 1, baseUrl: 'https://api.stripe.com' },
+          ],
+          instructionRoutes: [
+            { instructionType: 'payment.initiate', connectionId: 'stripe-primary', fallbackConnectionId: 'stripe-backup', outboundMappingId: '', inboundMappingId: '', httpMethod: 'POST', pathTemplate: '/v1/charges' },
+          ],
+          inboundRoutes: [],
+        },
+      })
+      const graph = buildManifestGraph(manifest)
+      const fallbackEdges = graph.edges.filter((e) => e.relationship === 'fallback_to')
+
+      expect(fallbackEdges).toHaveLength(1)
+      expect(fallbackEdges[0]).toMatchObject({
+        source: 'instruction_route:payment.initiate',
+        target: 'provider_connection:stripe-backup',
+        relationship: 'fallback_to',
+      })
+    })
+  })
+
   describe('edge cases', () => {
     it('returns empty graph for empty manifest', () => {
       const manifest = createMockManifest()

--- a/frontend/src/features/manifests/lib/manifest-graph-model.ts
+++ b/frontend/src/features/manifests/lib/manifest-graph-model.ts
@@ -29,14 +29,64 @@ interface ManifestSaga {
   [key: string]: unknown
 }
 
+interface ManifestPaymentRail {
+  provider: string
+  [key: string]: unknown
+}
+
+interface ManifestPartyType {
+  partyType: string
+  [key: string]: unknown
+}
+
+interface ManifestMapping {
+  name: string
+  [key: string]: unknown
+}
+
+interface ManifestProviderConnection {
+  connectionId: string
+  providerName: string
+  [key: string]: unknown
+}
+
+interface ManifestInstructionRoute {
+  instructionType: string
+  connectionId: string
+  fallbackConnectionId?: string
+  outboundMappingId?: string
+  inboundMappingId?: string
+  [key: string]: unknown
+}
+
+interface ManifestOperationalGateway {
+  providerConnections?: ManifestProviderConnection[]
+  instructionRoutes?: ManifestInstructionRoute[]
+  [key: string]: unknown
+}
+
 interface ManifestInput {
   instruments?: ManifestInstrument[]
   accountTypes?: ManifestAccountType[]
   valuationRules?: ManifestValuationRule[]
   sagas?: ManifestSaga[]
+  paymentRails?: ManifestPaymentRail[]
+  partyTypes?: ManifestPartyType[]
+  mappings?: ManifestMapping[]
+  operationalGateway?: ManifestOperationalGateway
 }
 
-export type ManifestNodeType = 'instrument' | 'account_type' | 'valuation_rule' | 'saga'
+export type ManifestNodeType =
+  | 'instrument'
+  | 'account_type'
+  | 'valuation_rule'
+  | 'saga'
+  | 'payment_rail'
+  | 'party_type'
+  | 'mapping'
+  | 'operational_gateway'
+  | 'provider_connection'
+  | 'instruction_route'
 
 export interface SagaTriggerMetadata {
   channel: string
@@ -58,6 +108,10 @@ export type ManifestRelationship =
   | 'converts_to'
   | 'writes_to'
   | 'uses_valuation'
+  | 'belongs_to'
+  | 'routes_to'
+  | 'fallback_to'
+  | 'uses_mapping'
 
 export interface ManifestEdge {
   id: string
@@ -93,6 +147,10 @@ export function buildManifestGraph(manifest: Manifest): ManifestGraph {
   const accountTypes = m.accountTypes ?? []
   const valuationRules = m.valuationRules ?? []
   const sagas = m.sagas ?? []
+  const paymentRails = m.paymentRails ?? []
+  const partyTypes = m.partyTypes ?? []
+  const mappings = m.mappings ?? []
+  const operationalGateway = m.operationalGateway
 
   const instrumentCodes = new Set(instruments.map((i) => i.code))
 
@@ -229,6 +287,120 @@ export function buildManifestGraph(manifest: Manifest): ManifestGraph {
     }
 
     nodes.push(sagaNode)
+  }
+
+  // Payment rails
+  for (const rail of paymentRails) {
+    nodes.push({
+      id: `payment_rail:${rail.provider}`,
+      type: 'payment_rail',
+      label: rail.provider,
+      data: { ...rail },
+    })
+  }
+
+  // Party types
+  for (const pt of partyTypes) {
+    nodes.push({
+      id: `party_type:${pt.partyType}`,
+      type: 'party_type',
+      label: pt.partyType,
+      data: { ...pt },
+    })
+  }
+
+  // Mappings
+  const mappingNames = new Set<string>()
+  for (const mapping of mappings) {
+    mappingNames.add(mapping.name)
+    nodes.push({
+      id: `mapping:${mapping.name}`,
+      type: 'mapping',
+      label: mapping.name,
+      data: { ...mapping },
+    })
+  }
+
+  // Operational gateway and its children
+  if (operationalGateway) {
+    const gwNodeId = 'operational_gateway:default'
+    nodes.push({
+      id: gwNodeId,
+      type: 'operational_gateway',
+      label: 'Operational Gateway',
+      data: { ...operationalGateway },
+    })
+
+    const providerConnections = operationalGateway.providerConnections ?? []
+    const connectionIds = new Set(providerConnections.map((c) => c.connectionId))
+
+    for (const conn of providerConnections) {
+      const connNodeId = `provider_connection:${conn.connectionId}`
+      nodes.push({
+        id: connNodeId,
+        type: 'provider_connection',
+        label: conn.providerName,
+        data: { ...conn },
+      })
+
+      edges.push({
+        id: `belongs_to:${conn.connectionId}:${gwNodeId}`,
+        source: connNodeId,
+        target: gwNodeId,
+        relationship: 'belongs_to',
+      })
+    }
+
+    const instructionRoutes = operationalGateway.instructionRoutes ?? []
+    for (const route of instructionRoutes) {
+      const routeNodeId = `instruction_route:${route.instructionType}`
+      nodes.push({
+        id: routeNodeId,
+        type: 'instruction_route',
+        label: route.instructionType,
+        data: { ...route },
+      })
+
+      // routes_to: instruction route -> primary provider connection
+      if (connectionIds.has(route.connectionId)) {
+        edges.push({
+          id: `routes_to:${route.instructionType}:${route.connectionId}`,
+          source: routeNodeId,
+          target: `provider_connection:${route.connectionId}`,
+          relationship: 'routes_to',
+        })
+      }
+
+      // fallback_to: instruction route -> fallback provider connection
+      if (route.fallbackConnectionId && connectionIds.has(route.fallbackConnectionId)) {
+        edges.push({
+          id: `fallback_to:${route.instructionType}:${route.fallbackConnectionId}`,
+          source: routeNodeId,
+          target: `provider_connection:${route.fallbackConnectionId}`,
+          relationship: 'fallback_to',
+        })
+      }
+
+      // uses_mapping: instruction route -> outbound mapping
+      if (route.outboundMappingId && mappingNames.has(route.outboundMappingId)) {
+        edges.push({
+          id: `uses_mapping:${route.instructionType}:outbound:${route.outboundMappingId}`,
+          source: routeNodeId,
+          target: `mapping:${route.outboundMappingId}`,
+          relationship: 'uses_mapping',
+        })
+      }
+
+      // uses_mapping: instruction route -> inbound mapping
+      if (route.inboundMappingId && mappingNames.has(route.inboundMappingId)) {
+        edges.push({
+          id: `uses_mapping:${route.instructionType}:inbound:${route.inboundMappingId}`,
+          source: routeNodeId,
+          target: `mapping:${route.inboundMappingId}`,
+          relationship: 'uses_mapping',
+        })
+      }
+    }
   }
 
   return { nodes, edges }

--- a/frontend/src/features/manifests/lib/node-type-registry.ts
+++ b/frontend/src/features/manifests/lib/node-type-registry.ts
@@ -34,6 +34,36 @@ export const NODE_TYPE_REGISTRY: Record<ManifestNodeType, NodeTypeConfig> = {
     label: 'Sagas',
     layerPriority: '10',
   },
+  payment_rail: {
+    color: 'var(--graph-payment-rail)',
+    label: 'Payment Rails',
+    layerPriority: '9',
+  },
+  party_type: {
+    color: 'var(--graph-party-type)',
+    label: 'Party Types',
+    layerPriority: '8',
+  },
+  mapping: {
+    color: 'var(--graph-mapping)',
+    label: 'Mappings',
+    layerPriority: '7',
+  },
+  operational_gateway: {
+    color: 'var(--graph-operational-gateway)',
+    label: 'Operational Gateway',
+    layerPriority: '6',
+  },
+  provider_connection: {
+    color: 'var(--graph-provider-connection)',
+    label: 'Provider Connections',
+    layerPriority: '5',
+  },
+  instruction_route: {
+    color: 'var(--graph-instruction-route)',
+    label: 'Instruction Routes',
+    layerPriority: '4',
+  },
 }
 
 /** Derived view: { color, label } per node type, compatible with existing NODE_THEMES usage. */


### PR DESCRIPTION
## Summary

- Extends `ManifestNodeType` union from 4 types to 10, adding `payment_rail`, `party_type`, `mapping`, `operational_gateway`, `provider_connection`, and `instruction_route`
- Extends `buildManifestGraph()` to extract nodes from all manifest resource arrays (payment rails, party types, mappings, operational gateway with nested provider connections and instruction routes)
- Adds 4 new edge relationships: `belongs_to`, `routes_to`, `fallback_to`, `uses_mapping` connecting operational gateway resources
- Updates `NODE_TYPE_REGISTRY` with config for all new node types

## Test plan

- [x] 16 new unit tests covering all new node types and edge relationships
- [x] All 35 tests passing
- [x] TypeScript typecheck passes
- [x] Lint passes (0 errors)

Task: 046-economy-visualization-completeness.9