### PR TITLE
fix: remove continue-on-error from Trivy scanner steps in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,6 @@ jobs:
       - name: Run Trivy vulnerability scanner (filesystem)
         if: github.event_name == 'pull_request'
         uses: aquasecurity/trivy-action@0.35.0
-        continue-on-error: true
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -119,7 +118,6 @@ jobs:
       - name: Upload Trivy filesystem results to GitHub Security tab
         if: github.event_name == 'pull_request'
         uses: github/codeql-action/upload-sarif@v4
-        continue-on-error: true
         with:
           sarif_file: trivy-fs-results.sarif
 


### PR DESCRIPTION
## Summary

- Removes `continue-on-error: true` from the Trivy filesystem scan step in `build.yml` (line 112)
- Removes `continue-on-error: true` from the Trivy SARIF upload step in `build.yml` (line 122)

These flags were silently swallowing Trivy scan failures, allowing PRs with vulnerabilities to merge. The dedicated `security.yml` workflow already enforces `exit-code: '1'` for CRITICAL/HIGH findings — this change brings `build.yml` in line with that policy so security failures block PR merges.

## Changes Made

- `.github/workflows/build.yml`: Removed `continue-on-error: true` from two Trivy-related steps (filesystem scan and SARIF upload)

## Non-security steps left unchanged

All non-security steps retain their existing configuration. Only the Trivy scanner and its associated upload step were modified.

## Test Plan

- [ ] Verify workflow YAML is syntactically valid
- [ ] Confirm CI passes on this PR
- [ ] Confirm `security.yml` retains `exit-code: '1'` (no changes made to security.yml)