### PR TITLE
fix: enforce saga step limit and remove dead MemoryWarningThreshold

### DIFF
--- a/shared/pkg/saga/runtime.go
+++ b/shared/pkg/saga/runtime.go
@@ -23,9 +23,6 @@ const (
 	// MaxLoopNestingDepth is the maximum allowed loop nesting level.
 	MaxLoopNestingDepth = 3
 
-	// MemoryWarningThreshold is the memory allocation threshold that triggers a warning.
-	MemoryWarningThreshold = 10 * 1024 * 1024 // 10MB
-
 	// MaxStepsPerExecution limits the number of steps to prevent infinite loops.
 	MaxStepsPerExecution = 1_000_000
 )
@@ -201,6 +198,9 @@ func (r *Runtime) ExecuteSagaWithInput(ctx context.Context, name string, script 
 	if execInput.ThreadSetup != nil {
 		execInput.ThreadSetup(thread)
 	}
+
+	// Enforce CPU step limit to prevent tenant scripts from exhausting compute resources.
+	thread.SetMaxExecutionSteps(MaxStepsPerExecution)
 
 	// Set up cancellation checking
 	done := make(chan struct{})

--- a/shared/pkg/saga/runtime_security_test.go
+++ b/shared/pkg/saga/runtime_security_test.go
@@ -400,6 +400,35 @@ result = compute()
 	}
 }
 
+// TestSecurityStepLimitEnforced verifies that scripts exceeding MaxStepsPerExecution
+// are terminated with a step limit error, not a timeout.
+func TestSecurityStepLimitEnforced(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	// Use a long timeout so the step limit triggers first, not the timeout.
+	runtime, err := NewRuntime(logger, WithTimeout(30*time.Second))
+	require.NoError(t, err)
+
+	// This script loops over a range large enough to exceed MaxStepsPerExecution (1,000,000).
+	// Each iteration costs multiple steps in the Starlark evaluator.
+	script := `
+def burn_steps():
+    x = 0
+    for i in range(10000000):
+        x = x + 1
+    return x
+result = burn_steps()
+`
+	ctx := context.Background()
+	_, err = runtime.ExecuteSaga(ctx, "step_limit_test", script, nil)
+	require.Error(t, err)
+	assert.True(t,
+		strings.Contains(err.Error(), "step") ||
+			strings.Contains(err.Error(), "limit") ||
+			strings.Contains(err.Error(), "cancelled") ||
+			strings.Contains(err.Error(), "execution"),
+		"expected step limit or execution error, got: %v", err)
+}
+
 // TestSecurityInputIsolation verifies input data cannot be modified across executions.
 func TestSecurityInputIsolation(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))


### PR DESCRIPTION
## Summary

- Calls `thread.SetMaxExecutionSteps(MaxStepsPerExecution)` in `ExecuteSagaWithInput()` after the `ThreadSetup` callback, matching the pattern used in `shared/pkg/valuation/starlark_runtime.go:127`
- Removes the dead `MemoryWarningThreshold = 10 * 1024 * 1024` constant, which was defined but never referenced anywhere in the codebase

## Changes Made

- `shared/pkg/saga/runtime.go`: Add `thread.SetMaxExecutionSteps(MaxStepsPerExecution)` and remove `MemoryWarningThreshold` constant
- `shared/pkg/saga/runtime_security_test.go`: Add `TestSecurityStepLimitEnforced` — verifies a script with >1M steps is terminated with an error, not allowed to run to completion

## Technical Details

`MaxStepsPerExecution = 1_000_000` was already declared at the top of `runtime.go` but the `SetMaxExecutionSteps()` call was never wired up. Without it, the Starlark thread had no step budget and would only be stopped by the context timeout (5s default), allowing a tenant script to burn CPU for up to 5 seconds per call.

With the step limit active, the thread is halted as soon as it exhausts its budget, providing a deterministic, resource-bounded termination independent of wall clock time.

## Testing

- `TestSecurityStepLimitEnforced`: TDD red/green — confirmed the test failed before the fix and passes after
- All `TestSecurity*` tests pass
- Full saga package short tests pass: `go test ./shared/pkg/saga/ -short`

## Risk Assessment

Low. The `SetMaxExecutionSteps()` call follows the identical pattern used in the valuation runtime. Existing timeout enforcement remains in place as a second line of defense. Normal saga scripts complete well under 1M steps.

## Task Master

Addresses security-audit tasks 047-security-audit.2 (Enforce Saga Step Limit) and 047-security-audit.9 (Remove Dead MemoryWarningThreshold).