### PR TITLE
fix: harden forecasting Starlark runtime security controls

### DIFF
--- a/services/forecasting/starlark/runner.go
+++ b/services/forecasting/starlark/runner.go
@@ -21,7 +21,9 @@ import (
 
 // Default execution constraints.
 const (
-	DefaultTimeout = 30 * time.Second
+	DefaultTimeout       = 10 * time.Second // Reduced from 30s to match saga/valuation security posture
+	MaxScriptSize        = 64 * 1024        // 64KB, matching saga
+	MaxStepsPerExecution = 1_000_000        // Matching saga
 )
 
 // Runner errors.
@@ -34,6 +36,7 @@ var (
 	ErrTimestampOutOfRange = errors.New("forecast point timestamp is outside the horizon")
 	ErrNonMonotonic        = errors.New("forecast point timestamps must be monotonically increasing")
 	ErrGranularityMismatch = errors.New("forecast point timestamp is not aligned to granularity")
+	ErrScriptTooLarge      = errors.New("script exceeds maximum size")
 	ErrValidation          = errors.New("script validation error")
 	ErrInvalidInput        = errors.New("invalid strategy input")
 )
@@ -166,6 +169,9 @@ func (r *ForecastRunner) ExecuteStrategy(ctx context.Context, input StrategyInpu
 	if input.Script == "" {
 		return nil, ErrScriptRequired
 	}
+	if len(input.Script) > MaxScriptSize {
+		return nil, fmt.Errorf("%w: size %d exceeds maximum %d bytes", ErrScriptTooLarge, len(input.Script), MaxScriptSize)
+	}
 
 	now := input.Now
 	if now.IsZero() {
@@ -270,6 +276,7 @@ func (r *ForecastRunner) executeScript(ctx context.Context, script string, forec
 		},
 	}
 	thread.SetLocal("ctx", ctx)
+	thread.SetMaxExecutionSteps(MaxStepsPerExecution)
 
 	// Execute script in a goroutine for timeout support
 	done := make(chan struct{})

--- a/services/forecasting/starlark/runner.go
+++ b/services/forecasting/starlark/runner.go
@@ -21,7 +21,7 @@ import (
 
 // Default execution constraints.
 const (
-	DefaultTimeout       = 10 * time.Second // Reduced from 30s to match saga/valuation security posture
+	DefaultTimeout       = 10 * time.Second // Reduced from 30s; 2x saga's 5s to allow observation fetching overhead
 	MaxScriptSize        = 64 * 1024        // 64KB, matching saga
 	MaxStepsPerExecution = 1_000_000        // Matching saga
 )

--- a/services/forecasting/starlark/runner_test.go
+++ b/services/forecasting/starlark/runner_test.go
@@ -874,7 +874,15 @@ func TestExecuteStrategy_ScriptSizeLimit(t *testing.T) {
 func TestExecuteStrategy_StepLimitEnforced(t *testing.T) {
 	mis := &mockMISClient{observations: map[string][]Observation{}}
 	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
-	runner := newTestRunner(t, mis, ref)
+
+	// Use a long timeout so the step limit fires before the timeout
+	runner, err := NewForecastRunner(ForecastRunnerConfig{
+		MISClient: mis,
+		RefData:   ref,
+		Timeout:   30 * time.Second,
+		Logger:    newTestLogger(),
+	})
+	require.NoError(t, err)
 
 	// Script with a loop that exceeds MaxStepsPerExecution (1M steps)
 	script := `
@@ -885,7 +893,7 @@ def compute_forecast(ctx):
     return []
 `
 
-	_, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+	_, err = runner.ExecuteStrategy(context.Background(), StrategyInput{
 		Script:            script,
 		InputDatasetCodes: []string{},
 		OutputDatasetCode: "TEST",
@@ -895,13 +903,9 @@ def compute_forecast(ctx):
 	})
 
 	require.Error(t, err)
-	// Step limit exceeded produces either a timeout or execution error
-	assert.True(t,
-		strings.Contains(err.Error(), "too many steps") ||
-			strings.Contains(err.Error(), "exceeded") ||
-			errors.Is(err, saga.ErrExecution) ||
-			errors.Is(err, saga.ErrTimeout),
-		"expected step limit or execution error, got: %v", err)
+	assert.ErrorIs(t, err, saga.ErrExecution)
+	assert.NotErrorIs(t, err, saga.ErrTimeout)
+	assert.Contains(t, err.Error(), "too many steps")
 }
 
 func TestDefaultTimeout_Is10Seconds(t *testing.T) {

--- a/services/forecasting/starlark/runner_test.go
+++ b/services/forecasting/starlark/runner_test.go
@@ -846,6 +846,68 @@ func TestForecastContextToStarlark(t *testing.T) {
 	assert.Equal(t, starlarklib.String(now.Format(time.RFC3339)), nowVal)
 }
 
+// --- Security hardening tests ---
+
+func TestExecuteStrategy_ScriptSizeLimit(t *testing.T) {
+	mis := &mockMISClient{observations: map[string][]Observation{}}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	// Create a script that exceeds MaxScriptSize (64KB)
+	largeScript := "def compute_forecast(ctx):\n    return []\n" + strings.Repeat("# padding\n", 7000)
+	require.Greater(t, len(largeScript), MaxScriptSize, "test script must exceed MaxScriptSize")
+
+	_, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            largeScript,
+		InputDatasetCodes: []string{},
+		OutputDatasetCode: "TEST",
+		HorizonHours:      1,
+		GranularityHours:  1,
+		Now:               baseTime(),
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrScriptTooLarge)
+	assert.Contains(t, err.Error(), "exceeds maximum")
+}
+
+func TestExecuteStrategy_StepLimitEnforced(t *testing.T) {
+	mis := &mockMISClient{observations: map[string][]Observation{}}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	// Script with a loop that exceeds MaxStepsPerExecution (1M steps)
+	script := `
+def compute_forecast(ctx):
+    result = 0
+    for i in range(2000000):
+        result = result + i
+    return []
+`
+
+	_, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{},
+		OutputDatasetCode: "TEST",
+		HorizonHours:      1,
+		GranularityHours:  1,
+		Now:               baseTime(),
+	})
+
+	require.Error(t, err)
+	// Step limit exceeded produces either a timeout or execution error
+	assert.True(t,
+		strings.Contains(err.Error(), "too many steps") ||
+			strings.Contains(err.Error(), "exceeded") ||
+			errors.Is(err, saga.ErrExecution) ||
+			errors.Is(err, saga.ErrTimeout),
+		"expected step limit or execution error, got: %v", err)
+}
+
+func TestDefaultTimeout_Is10Seconds(t *testing.T) {
+	assert.Equal(t, 10*time.Second, DefaultTimeout, "DefaultTimeout should be 10s")
+}
+
 func TestForecastContextToStarlark_NilReferenceData(t *testing.T) {
 	fc := &ForecastContext{
 		Observations:  map[string][]Observation{},


### PR DESCRIPTION
## Summary

Hardens the forecasting Starlark runtime to match the security controls already present in saga and valuation runtimes. Closes HIGH-2 from the 047-security-audit PRD.

- Reduce `DefaultTimeout` from 30s to 10s (6x longer than saga was unjustified)
- Add `MaxScriptSize` (64KB) with pre-execution validation and `ErrScriptTooLarge` sentinel
- Add `MaxStepsPerExecution` (1M) via `SetMaxExecutionSteps` on the Starlark thread
- Three new tests covering script size limit, step limit enforcement, and default timeout value

## Changes

- `services/forecasting/starlark/runner.go` - Added constants, size check in `ExecuteStrategy`, step limit in `executeScript`
- `services/forecasting/starlark/runner_test.go` - Added `TestExecuteStrategy_ScriptSizeLimit`, `TestExecuteStrategy_StepLimitEnforced`, `TestDefaultTimeout_Is10Seconds`

## Test plan

- [x] Script exceeding 64KB fails with `ErrScriptTooLarge`
- [x] Script with >1M steps fails with step limit error
- [x] Default timeout constant is 10s
- [x] All 27 existing + new tests pass (full regression)