### PR TITLE
feat: use SkipImmutabilityChecks for create-mode manifest validation in MCP server

### DIFF
--- a/services/mcp-server/internal/tools/economy.go
+++ b/services/mcp-server/internal/tools/economy.go
@@ -167,12 +167,13 @@ func handleManifestValidate(ctx context.Context, client ManifestApplier, params 
 	}
 
 	// Validate mode parameter.
-	var forceSkipImmutability bool
+	var skipImmutabilityChecks bool
 	switch p.Mode {
 	case "", "create":
 		// Create mode: schema-only validation, skip tenant state comparison.
-		// TODO: Replace Force with SkipImmutabilityChecks once proto field is added (task 2).
-		forceSkipImmutability = true
+		// SkipImmutabilityChecks bypasses immutability enforcement so a new manifest
+		// can be validated without comparing against any existing tenant state.
+		skipImmutabilityChecks = true
 	case "amend":
 		if p.TenantID == "" {
 			return map[string]interface{}{
@@ -205,10 +206,10 @@ func handleManifestValidate(ctx context.Context, client ManifestApplier, params 
 	}
 
 	resp, err := client.ApplyManifest(ctx, &controlplanev1.ApplyManifestRequest{
-		Manifest:  manifest,
-		DryRun:    true,
-		Force:     forceSkipImmutability,
-		AppliedBy: "mcp-server-validate",
+		Manifest:               manifest,
+		DryRun:                 true,
+		SkipImmutabilityChecks: skipImmutabilityChecks,
+		AppliedBy:              "mcp-server-validate",
 	})
 	if err != nil {
 		formatted := mcperrors.FormatGRPCError(err)

--- a/services/mcp-server/internal/tools/economy_test.go
+++ b/services/mcp-server/internal/tools/economy_test.go
@@ -292,10 +292,9 @@ func TestManifestValidate_CreateModeSkipsImmutabilityChecks(t *testing.T) {
 	if capturedReq == nil {
 		t.Fatal("expected ApplyManifest to be called")
 	}
-	// Create mode should set Force=true to skip immutability/tenant-comparison checks
-	// TODO: Replace Force with SkipImmutabilityChecks once proto field is added (task 2)
-	if !capturedReq.Force {
-		t.Error("expected Force=true in create mode to skip immutability checks")
+	// Create mode should set SkipImmutabilityChecks=true to skip tenant-comparison checks
+	if !capturedReq.SkipImmutabilityChecks {
+		t.Error("expected SkipImmutabilityChecks=true in create mode to skip immutability checks")
 	}
 }
 
@@ -328,9 +327,9 @@ func TestManifestValidate_AmendModeWithTenantID(t *testing.T) {
 	if capturedReq == nil {
 		t.Fatal("expected ApplyManifest to be called")
 	}
-	// Amend mode should NOT set Force (immutability checks apply)
-	if capturedReq.Force {
-		t.Error("expected Force=false in amend mode")
+	// Amend mode should NOT set SkipImmutabilityChecks (immutability checks apply)
+	if capturedReq.SkipImmutabilityChecks {
+		t.Error("expected SkipImmutabilityChecks=false in amend mode")
 	}
 	// Verify tenant context was propagated
 	tenantID, ok := tenant.FromContext(capturedCtx)

--- a/services/mcp-server/internal/tools/tenant_isolation_test.go
+++ b/services/mcp-server/internal/tools/tenant_isolation_test.go
@@ -53,9 +53,9 @@ func TestManifestValidate_YAMLInput_AmendMode_PropagatesTenantContext(t *testing
 		t.Errorf("expected tenant_id=acme-corp, got %q", tenantID)
 	}
 
-	// Verify amend mode does NOT set Force (immutability checks apply)
-	if capturedReq.Force {
-		t.Error("expected Force=false in amend mode with YAML input")
+	// Verify amend mode does NOT set SkipImmutabilityChecks (immutability checks apply)
+	if capturedReq.SkipImmutabilityChecks {
+		t.Error("expected SkipImmutabilityChecks=false in amend mode with YAML input")
 	}
 
 	// Verify the manifest was parsed from YAML correctly
@@ -94,8 +94,8 @@ func TestManifestValidate_YAMLInput_CreateMode_SkipsImmutabilityChecks(t *testin
 	}
 
 	// Create mode should skip immutability checks
-	if !capturedReq.Force {
-		t.Error("expected Force=true in create mode with YAML input")
+	if !capturedReq.SkipImmutabilityChecks {
+		t.Error("expected SkipImmutabilityChecks=true in create mode with YAML input")
 	}
 
 	// Create mode should NOT inject tenant context


### PR DESCRIPTION
## Summary

- The `Force` field in `ApplyManifestRequest` is for 'apply anyway despite breaking changes' semantics (optimistic concurrency override)
- The `SkipImmutabilityChecks` field (proto field 5) is the correct field for create-mode dry-run validation, where the caller wants to validate a manifest without comparing against existing tenant state
- Migrates the MCP server `meridian_manifest_validate` tool to use `SkipImmutabilityChecks` instead of `Force` in create mode, resolving the TODO comment in `economy.go`

## Changes Made

- `services/mcp-server/internal/tools/economy.go`: Replace `Force` with `SkipImmutabilityChecks` in `ApplyManifestRequest` for create-mode validation; remove TODO comment
- `services/mcp-server/internal/tools/economy_test.go`: Update assertions to check `SkipImmutabilityChecks` instead of `Force`
- `services/mcp-server/internal/tools/tenant_isolation_test.go`: Update assertions to check `SkipImmutabilityChecks` instead of `Force`

## Testing

- All MCP server tool tests pass: `go test ./services/mcp-server/internal/tools/...`
- Frontend typecheck passes: `npm run typecheck`
- All 2208 frontend unit tests pass

## Task Master

046-economy-visualization-completeness.2