### PR TITLE
feat: add tabular diff view for manifest version comparison

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -108,6 +108,9 @@ const EconomyExplorePage = lazy(() =>
 const EconomyDraftPage = lazy(() =>
   import('@/features/economy/pages/economy-draft-page').then((m) => ({ default: m.EconomyDraftPage })),
 )
+const ManifestDiffPage = lazy(() =>
+  import('@/features/manifests/pages/manifest-diff-page').then((m) => ({ default: m.ManifestDiffPage })),
+)
 
 // Market data pages (lazy-loaded: chart rendering)
 const MarketDataPage = lazy(() =>
@@ -403,6 +406,7 @@ function AppShellLayout() {
         <Route path="/economy/edit" element={<FeatureGuard feature="economy"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<EconomyEditPage />)}</Suspense></FeatureGuard>} />
         <Route path="/economy/explore" element={<FeatureGuard feature="economy"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<EconomyExplorePage />)}</Suspense></FeatureGuard>} />
         <Route path="/economy/draft" element={<FeatureGuard feature="economy"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<EconomyDraftPage />)}</Suspense></FeatureGuard>} />
+        <Route path="/economy/manifests/diff/:v1/:v2" element={<FeatureGuard feature="economy"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<ManifestDiffPage />)}</Suspense></FeatureGuard>} />
         <Route path="/mcp-config" element={<FeatureGuard feature="mcp-config"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<McpConfigPage />)}</Suspense></FeatureGuard>} />
         <Route path="/cookbook" element={<Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<CookbookPage />)}</Suspense>} />
         <Route path="/cookbook/patterns" element={guarded(<Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}><CookbookPatternsPage /></Suspense>)} />

--- a/frontend/src/features/manifests/components/manifest-diff-table.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-diff-table.test.tsx
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest'
+import { screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/test-utils'
+import { createTenantUserToken } from '@/test/jwt-helpers'
+import { ManifestDiffTable, type ManifestDiffTableProps } from './manifest-diff-table'
+
+const mockActions = [
+  {
+    resourceType: 'instrument',
+    resourceCode: 'GBP',
+    action: 'CREATE',
+    description: 'New instrument added',
+    breaking: false,
+  },
+  {
+    resourceType: 'instrument',
+    resourceCode: 'USD',
+    action: 'NO_CHANGE',
+    description: '',
+    breaking: false,
+  },
+  {
+    resourceType: 'account_type',
+    resourceCode: 'SAVINGS',
+    action: 'UPDATE',
+    description: 'Updated allowed instruments',
+    breaking: false,
+  },
+  {
+    resourceType: 'saga',
+    resourceCode: 'settle_payment',
+    action: 'DELETE',
+    description: 'Saga removed',
+    breaking: true,
+  },
+] as unknown as ManifestDiffTableProps['actions']
+
+const mockSummary = {
+  totalActions: 4,
+  creates: 1,
+  updates: 1,
+  deletes: 1,
+  noChanges: 1,
+  hasBreakingChanges: true,
+}
+
+function renderComponent(props: Partial<ManifestDiffTableProps> = {}) {
+  return renderWithProviders(
+    <ManifestDiffTable actions={mockActions} summary={mockSummary} {...props} />,
+    { initialToken: createTenantUserToken() },
+  )
+}
+
+describe('ManifestDiffTable', () => {
+  it('renders all diff rows', () => {
+    renderComponent()
+
+    expect(screen.getByTestId('diff-row-GBP')).toBeInTheDocument()
+    expect(screen.getByTestId('diff-row-USD')).toBeInTheDocument()
+    expect(screen.getByTestId('diff-row-SAVINGS')).toBeInTheDocument()
+    expect(screen.getByTestId('diff-row-settle_payment')).toBeInTheDocument()
+  })
+
+  it('renders summary statistics', () => {
+    renderComponent()
+
+    const summary = screen.getByTestId('diff-summary')
+    expect(within(summary).getByText(/Total:/)).toBeInTheDocument()
+    expect(within(summary).getByText('+1 added')).toBeInTheDocument()
+    expect(within(summary).getByText('~1 modified')).toBeInTheDocument()
+    expect(within(summary).getByText('-1 removed')).toBeInTheDocument()
+    expect(within(summary).getByText('1 unchanged')).toBeInTheDocument()
+  })
+
+  it('shows breaking changes warning', () => {
+    renderComponent()
+
+    expect(screen.getByTestId('breaking-warning')).toBeInTheDocument()
+    expect(screen.getByText('Breaking changes detected')).toBeInTheDocument()
+  })
+
+  it('does not show breaking warning when no breaking changes', () => {
+    renderComponent({
+      summary: { ...mockSummary, hasBreakingChanges: false },
+    })
+
+    expect(screen.queryByTestId('breaking-warning')).not.toBeInTheDocument()
+  })
+
+  it('renders change type badges in table rows', () => {
+    renderComponent()
+
+    const gbpRow = screen.getByTestId('diff-row-GBP')
+    expect(within(gbpRow).getByText('Added')).toBeInTheDocument()
+
+    const savingsRow = screen.getByTestId('diff-row-SAVINGS')
+    expect(within(savingsRow).getByText('Modified')).toBeInTheDocument()
+
+    const sagaRow = screen.getByTestId('diff-row-settle_payment')
+    expect(within(sagaRow).getByText('Removed')).toBeInTheDocument()
+
+    const usdRow = screen.getByTestId('diff-row-USD')
+    expect(within(usdRow).getByText('Unchanged')).toBeInTheDocument()
+  })
+
+  it('renders resource codes', () => {
+    renderComponent()
+
+    expect(screen.getByText('GBP')).toBeInTheDocument()
+    expect(screen.getByText('USD')).toBeInTheDocument()
+    expect(screen.getByText('SAVINGS')).toBeInTheDocument()
+    expect(screen.getByText('settle_payment')).toBeInTheDocument()
+  })
+
+  it('marks breaking changes with Yes', () => {
+    renderComponent()
+
+    const sagaRow = screen.getByTestId('diff-row-settle_payment')
+    expect(within(sagaRow).getByText('Yes')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no actions', () => {
+    renderComponent({ actions: [] as unknown as ManifestDiffTableProps['actions'] })
+
+    expect(screen.getByTestId('empty-state')).toBeInTheDocument()
+  })
+
+  it('filters by resource type', async () => {
+    renderComponent()
+    const user = userEvent.setup()
+
+    await user.selectOptions(screen.getByTestId('resource-type-filter'), 'saga')
+
+    expect(screen.getByTestId('diff-row-settle_payment')).toBeInTheDocument()
+    expect(screen.queryByTestId('diff-row-GBP')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('diff-row-SAVINGS')).not.toBeInTheDocument()
+  })
+
+  it('filters by change type', async () => {
+    renderComponent()
+    const user = userEvent.setup()
+
+    await user.selectOptions(screen.getByTestId('change-type-filter'), 'CREATE')
+
+    expect(screen.getByTestId('diff-row-GBP')).toBeInTheDocument()
+    expect(screen.queryByTestId('diff-row-USD')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('diff-row-SAVINGS')).not.toBeInTheDocument()
+  })
+
+  it('renders without summary', () => {
+    renderComponent({ summary: undefined })
+
+    expect(screen.queryByTestId('diff-summary')).not.toBeInTheDocument()
+    expect(screen.getByTestId('manifest-diff-table')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/manifests/components/manifest-diff-table.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-diff-table.test.tsx
@@ -56,10 +56,10 @@ describe('ManifestDiffTable', () => {
   it('renders all diff rows', () => {
     renderComponent()
 
-    expect(screen.getByTestId('diff-row-GBP')).toBeInTheDocument()
-    expect(screen.getByTestId('diff-row-USD')).toBeInTheDocument()
-    expect(screen.getByTestId('diff-row-SAVINGS')).toBeInTheDocument()
-    expect(screen.getByTestId('diff-row-settle_payment')).toBeInTheDocument()
+    expect(screen.getByTestId('diff-row-instrument-GBP')).toBeInTheDocument()
+    expect(screen.getByTestId('diff-row-instrument-USD')).toBeInTheDocument()
+    expect(screen.getByTestId('diff-row-account_type-SAVINGS')).toBeInTheDocument()
+    expect(screen.getByTestId('diff-row-saga-settle_payment')).toBeInTheDocument()
   })
 
   it('renders summary statistics', () => {
@@ -91,16 +91,16 @@ describe('ManifestDiffTable', () => {
   it('renders change type badges in table rows', () => {
     renderComponent()
 
-    const gbpRow = screen.getByTestId('diff-row-GBP')
+    const gbpRow = screen.getByTestId('diff-row-instrument-GBP')
     expect(within(gbpRow).getByText('Added')).toBeInTheDocument()
 
-    const savingsRow = screen.getByTestId('diff-row-SAVINGS')
+    const savingsRow = screen.getByTestId('diff-row-account_type-SAVINGS')
     expect(within(savingsRow).getByText('Modified')).toBeInTheDocument()
 
-    const sagaRow = screen.getByTestId('diff-row-settle_payment')
+    const sagaRow = screen.getByTestId('diff-row-saga-settle_payment')
     expect(within(sagaRow).getByText('Removed')).toBeInTheDocument()
 
-    const usdRow = screen.getByTestId('diff-row-USD')
+    const usdRow = screen.getByTestId('diff-row-instrument-USD')
     expect(within(usdRow).getByText('Unchanged')).toBeInTheDocument()
   })
 
@@ -116,7 +116,7 @@ describe('ManifestDiffTable', () => {
   it('marks breaking changes with Yes', () => {
     renderComponent()
 
-    const sagaRow = screen.getByTestId('diff-row-settle_payment')
+    const sagaRow = screen.getByTestId('diff-row-saga-settle_payment')
     expect(within(sagaRow).getByText('Yes')).toBeInTheDocument()
   })
 
@@ -132,9 +132,9 @@ describe('ManifestDiffTable', () => {
 
     await user.selectOptions(screen.getByTestId('resource-type-filter'), 'saga')
 
-    expect(screen.getByTestId('diff-row-settle_payment')).toBeInTheDocument()
-    expect(screen.queryByTestId('diff-row-GBP')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('diff-row-SAVINGS')).not.toBeInTheDocument()
+    expect(screen.getByTestId('diff-row-saga-settle_payment')).toBeInTheDocument()
+    expect(screen.queryByTestId('diff-row-instrument-GBP')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('diff-row-account_type-SAVINGS')).not.toBeInTheDocument()
   })
 
   it('filters by change type', async () => {
@@ -143,9 +143,9 @@ describe('ManifestDiffTable', () => {
 
     await user.selectOptions(screen.getByTestId('change-type-filter'), 'CREATE')
 
-    expect(screen.getByTestId('diff-row-GBP')).toBeInTheDocument()
-    expect(screen.queryByTestId('diff-row-USD')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('diff-row-SAVINGS')).not.toBeInTheDocument()
+    expect(screen.getByTestId('diff-row-instrument-GBP')).toBeInTheDocument()
+    expect(screen.queryByTestId('diff-row-instrument-USD')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('diff-row-account_type-SAVINGS')).not.toBeInTheDocument()
   })
 
   it('renders without summary', () => {

--- a/frontend/src/features/manifests/components/manifest-diff-table.tsx
+++ b/frontend/src/features/manifests/components/manifest-diff-table.tsx
@@ -189,7 +189,7 @@ export function ManifestDiffTable({ actions, summary }: ManifestDiffTableProps) 
                 <tr
                   key={`${action.resourceType}-${action.resourceCode}-${idx}`}
                   className="border-b last:border-b-0 hover:bg-muted/50"
-                  data-testid={`diff-row-${action.resourceCode}`}
+                  data-testid={`diff-row-${action.resourceType}-${action.resourceCode}`}
                 >
                   {columns.map((col) => {
                     const CellFn = col.cell

--- a/frontend/src/features/manifests/components/manifest-diff-table.tsx
+++ b/frontend/src/features/manifests/components/manifest-diff-table.tsx
@@ -1,0 +1,216 @@
+import { useMemo, useState } from 'react'
+import type { ColumnDef } from '@tanstack/react-table'
+import type { DiffAction } from '@/api/gen/meridian/control_plane/v1/manifest_history_service_pb'
+import { StatusBadge } from '@/shared/status-badge'
+
+const CHANGE_LABELS: Record<string, string> = {
+  CREATE: 'Added',
+  UPDATE: 'Modified',
+  DELETE: 'Removed',
+  NO_CHANGE: 'Unchanged',
+}
+
+const columns: ColumnDef<DiffAction>[] = [
+  {
+    accessorKey: 'resourceType',
+    header: 'Resource Type',
+    cell: ({ row }) => (
+      <span className="font-medium capitalize">
+        {row.original.resourceType.replace(/_/g, ' ')}
+      </span>
+    ),
+  },
+  {
+    accessorKey: 'resourceCode',
+    header: 'Resource ID',
+    cell: ({ row }) => (
+      <code className="text-sm bg-muted px-1.5 py-0.5 rounded">
+        {row.original.resourceCode}
+      </code>
+    ),
+  },
+  {
+    accessorKey: 'action',
+    header: 'Change Type',
+    cell: ({ row }) => {
+      const label = CHANGE_LABELS[row.original.action] ?? row.original.action
+      return <StatusBadge status={label} />
+    },
+  },
+  {
+    accessorKey: 'description',
+    header: 'Description',
+    cell: ({ row }) => (
+      <span className="text-sm text-muted-foreground">
+        {row.original.description || '\u2014'}
+      </span>
+    ),
+  },
+  {
+    accessorKey: 'breaking',
+    header: 'Breaking',
+    cell: ({ row }) =>
+      row.original.breaking ? (
+        <span className="text-sm font-medium text-destructive">Yes</span>
+      ) : (
+        <span className="text-sm text-muted-foreground">No</span>
+      ),
+  },
+]
+
+export interface ManifestDiffTableProps {
+  actions: DiffAction[]
+  summary?: {
+    totalActions: number
+    creates: number
+    updates: number
+    deletes: number
+    noChanges: number
+    hasBreakingChanges: boolean
+  }
+}
+
+export function ManifestDiffTable({ actions, summary }: ManifestDiffTableProps) {
+  const [resourceTypeFilter, setResourceTypeFilter] = useState<string>('all')
+  const [changeTypeFilter, setChangeTypeFilter] = useState<string>('all')
+
+  const resourceTypes = useMemo(() => {
+    const types = new Set(actions.map((a) => a.resourceType))
+    return Array.from(types).sort()
+  }, [actions])
+
+  const changeTypes = useMemo(() => {
+    const types = new Set(actions.map((a) => a.action))
+    return Array.from(types).sort()
+  }, [actions])
+
+  const filteredActions = useMemo(() => {
+    return actions.filter((a) => {
+      if (resourceTypeFilter !== 'all' && a.resourceType !== resourceTypeFilter) return false
+      if (changeTypeFilter !== 'all' && a.action !== changeTypeFilter) return false
+      return true
+    })
+  }, [actions, resourceTypeFilter, changeTypeFilter])
+
+  return (
+    <div data-testid="manifest-diff-table">
+      {summary && (
+        <div className="flex gap-4 pb-4 text-sm" data-testid="diff-summary">
+          <span>
+            Total: <strong>{summary.totalActions}</strong>
+          </span>
+          {summary.creates > 0 && (
+            <span className="text-green-600">
+              +{summary.creates} added
+            </span>
+          )}
+          {summary.updates > 0 && (
+            <span className="text-yellow-600">
+              ~{summary.updates} modified
+            </span>
+          )}
+          {summary.deletes > 0 && (
+            <span className="text-red-600">
+              -{summary.deletes} removed
+            </span>
+          )}
+          {summary.noChanges > 0 && (
+            <span className="text-muted-foreground">
+              {summary.noChanges} unchanged
+            </span>
+          )}
+          {summary.hasBreakingChanges && (
+            <span className="font-medium text-destructive" data-testid="breaking-warning">
+              Breaking changes detected
+            </span>
+          )}
+        </div>
+      )}
+
+      <div className="flex gap-3 pb-4" data-testid="diff-filters">
+        <select
+          value={resourceTypeFilter}
+          onChange={(e) => setResourceTypeFilter(e.target.value)}
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm"
+          data-testid="resource-type-filter"
+          aria-label="Filter by resource type"
+        >
+          <option value="all">All resource types</option>
+          {resourceTypes.map((type) => (
+            <option key={type} value={type}>
+              {type.replace(/_/g, ' ')}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={changeTypeFilter}
+          onChange={(e) => setChangeTypeFilter(e.target.value)}
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm"
+          data-testid="change-type-filter"
+          aria-label="Filter by change type"
+        >
+          <option value="all">All changes</option>
+          {changeTypes.map((type) => (
+            <option key={type} value={type}>
+              {CHANGE_LABELS[type] ?? type}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="rounded-md border">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b bg-muted/50">
+              {columns.map((col) => (
+                <th
+                  key={col.accessorKey as string}
+                  className="px-4 py-3 text-left text-sm font-medium text-muted-foreground"
+                >
+                  {col.header as string}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {filteredActions.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={columns.length}
+                  className="px-4 py-8 text-center text-sm text-muted-foreground"
+                  data-testid="empty-state"
+                >
+                  No changes match the selected filters.
+                </td>
+              </tr>
+            ) : (
+              filteredActions.map((action, idx) => (
+                <tr
+                  key={`${action.resourceType}-${action.resourceCode}-${idx}`}
+                  className="border-b last:border-b-0 hover:bg-muted/50"
+                  data-testid={`diff-row-${action.resourceCode}`}
+                >
+                  {columns.map((col) => {
+                    const CellFn = col.cell
+                    return (
+                      <td key={col.accessorKey as string} className="px-4 py-3 text-sm">
+                        {typeof CellFn === 'function'
+                          ? CellFn({
+                              row: { original: action },
+                              getValue: () =>
+                                action[col.accessorKey as keyof DiffAction],
+                            } as Parameters<typeof CellFn>[0])
+                          : String(action[col.accessorKey as keyof DiffAction] ?? '')}
+                      </td>
+                    )
+                  })}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/manifests/hooks/use-manifest-diff.ts
+++ b/frontend/src/features/manifests/hooks/use-manifest-diff.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query'
+import { useApiClients } from '@/api/context'
+import { manifestKeys } from '@/lib/query-keys'
+import type {
+  DiffManifestVersionsResponse,
+} from '@/api/gen/meridian/control_plane/v1/manifest_history_service_pb'
+
+export function useManifestDiff(baseSeq: number, targetSeq: number): {
+  data: DiffManifestVersionsResponse | undefined
+  isLoading: boolean
+  error: Error | null
+} {
+  const { manifestHistory } = useApiClients()
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: manifestKeys.diff(baseSeq, targetSeq),
+    queryFn: () =>
+      manifestHistory.diffManifestVersions({
+        baseSequenceNumber: BigInt(baseSeq),
+        targetSequenceNumber: BigInt(targetSeq),
+      }),
+    enabled: targetSeq > 0,
+  })
+
+  return { data, isLoading, error: error as Error | null }
+}

--- a/frontend/src/features/manifests/pages/manifest-diff-page.tsx
+++ b/frontend/src/features/manifests/pages/manifest-diff-page.tsx
@@ -11,10 +11,19 @@ export function ManifestDiffPage() {
 
   const baseSeq = Number(v1 ?? '0')
   const targetSeq = Number(v2 ?? '0')
+  const hasValidParams =
+    Boolean(v1 && v2) &&
+    Number.isInteger(baseSeq) &&
+    Number.isInteger(targetSeq) &&
+    baseSeq >= 0 &&
+    targetSeq > 0
 
-  const { data, isLoading, error } = useManifestDiff(baseSeq, targetSeq)
+  const { data, isLoading, error } = useManifestDiff(
+    hasValidParams ? baseSeq : 0,
+    hasValidParams ? targetSeq : 0,
+  )
 
-  if (!v1 || !v2 || Number.isNaN(baseSeq) || Number.isNaN(targetSeq) || targetSeq <= 0) {
+  if (!hasValidParams) {
     return (
       <PageShell>
         <PageHeader title="Manifest Diff" />

--- a/frontend/src/features/manifests/pages/manifest-diff-page.tsx
+++ b/frontend/src/features/manifests/pages/manifest-diff-page.tsx
@@ -1,0 +1,75 @@
+import { useParams, useNavigate } from 'react-router-dom'
+import { PageShell } from '@/shared/page-shell'
+import { PageHeader } from '@/shared/page-header'
+import { Button } from '@/components/ui/button'
+import { useManifestDiff } from '../hooks/use-manifest-diff'
+import { ManifestDiffTable } from '../components/manifest-diff-table'
+
+export function ManifestDiffPage() {
+  const { v1, v2 } = useParams<{ v1: string; v2: string }>()
+  const navigate = useNavigate()
+
+  const baseSeq = Number(v1 ?? '0')
+  const targetSeq = Number(v2 ?? '0')
+
+  const { data, isLoading, error } = useManifestDiff(baseSeq, targetSeq)
+
+  if (!v1 || !v2 || Number.isNaN(baseSeq) || Number.isNaN(targetSeq) || targetSeq <= 0) {
+    return (
+      <PageShell>
+        <PageHeader title="Manifest Diff" />
+        <p className="text-muted-foreground">
+          Invalid version parameters. Please select two versions to compare.
+        </p>
+        <Button variant="outline" className="mt-4" onClick={() => navigate('/economy')}>
+          Back to Economy
+        </Button>
+      </PageShell>
+    )
+  }
+
+  return (
+    <PageShell>
+      <PageHeader
+        title={`Manifest Diff: v${baseSeq} \u2192 v${targetSeq}`}
+        actions={
+          <Button variant="outline" size="sm" onClick={() => navigate(-1)}>
+            Back
+          </Button>
+        }
+      />
+
+      {isLoading && (
+        <div className="flex items-center justify-center py-12">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-4">
+          <p className="text-sm text-destructive">
+            Failed to load diff: {error.message}
+          </p>
+        </div>
+      )}
+
+      {data && (
+        <ManifestDiffTable
+          actions={data.actions ?? []}
+          summary={
+            data.summary
+              ? {
+                  totalActions: data.summary.totalActions,
+                  creates: data.summary.creates,
+                  updates: data.summary.updates,
+                  deletes: data.summary.deletes,
+                  noChanges: data.summary.noChanges,
+                  hasBreakingChanges: data.summary.hasBreakingChanges,
+                }
+              : undefined
+          }
+        />
+      )}
+    </PageShell>
+  )
+}

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -116,6 +116,7 @@ export const manifestKeys = {
   current: () => [...manifestKeys.all, 'current'] as const,
   history: () => [...manifestKeys.all, 'history'] as const,
   version: (version: string) => [...manifestKeys.all, 'version', version] as const,
+  diff: (baseSeq: number, targetSeq: number) => [...manifestKeys.all, 'diff', baseSeq, targetSeq] as const,
 } as const
 
 export const referenceKeys = {


### PR DESCRIPTION
## Summary

- Add `ManifestDiffTable` component displaying per-resource diff actions in a tabular format with columns: Resource Type, Resource ID, Change Type, Description, Breaking
- Add filtering by resource type and change type (via native `<select>` dropdowns)
- Add diff summary bar showing counts of added/modified/removed/unchanged resources and breaking change warnings
- Add `ManifestDiffPage` at `/economy/manifests/diff/:v1/:v2` using the `DiffManifestVersions` RPC
- Add `useManifestDiff` hook wrapping the `diffManifestVersions` API call with React Query
- Add `diff` query key to `manifestKeys`
- 11 tests covering rendering, filtering, summary display, breaking change indicators, and empty state

Implements 046-economy-visualization-completeness.23

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (no new errors)
- [x] 11 new tests for ManifestDiffTable (all passing)
- [x] All 137 existing manifest feature tests still pass