### PR TITLE
feat: add phase status indicator to manifest apply flow

### DIFF
--- a/frontend/src/features/economy/components/__tests__/apply-phases-stepper.test.tsx
+++ b/frontend/src/features/economy/components/__tests__/apply-phases-stepper.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ApplyPhasesStepper } from '../apply-phases-stepper'
+import { StepResultStatus } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
+import type { StepResult } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeStep(overrides: Partial<StepResult>): StepResult {
+  return {
+    $typeName: 'meridian.control_plane.v1.StepResult' as const,
+    stepName: 'validate',
+    status: StepResultStatus.SUCCESS,
+    message: '',
+    details: {},
+    ...overrides,
+  }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ApplyPhasesStepper', () => {
+  it('renders nothing when steps are empty and not applying', () => {
+    const { container } = render(<ApplyPhasesStepper steps={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows spinner placeholder when applying with no steps yet', () => {
+    render(<ApplyPhasesStepper steps={[]} isApplying={true} />)
+    expect(screen.getByTestId('apply-phases-stepper')).toBeInTheDocument()
+    expect(screen.getByText(/applying/i)).toBeInTheDocument()
+  })
+
+  it('renders all steps', () => {
+    const steps = [
+      makeStep({ stepName: 'validate', status: StepResultStatus.SUCCESS }),
+      makeStep({ stepName: 'plan', status: StepResultStatus.SUCCESS }),
+      makeStep({ stepName: 'execute', status: StepResultStatus.SUCCESS }),
+    ]
+    render(<ApplyPhasesStepper steps={steps} />)
+    expect(screen.getByTestId('phase-step-validate')).toBeInTheDocument()
+    expect(screen.getByTestId('phase-step-plan')).toBeInTheDocument()
+    expect(screen.getByTestId('phase-step-execute')).toBeInTheDocument()
+  })
+
+  it('formats step names for display', () => {
+    const steps = [makeStep({ stepName: 'validate' })]
+    render(<ApplyPhasesStepper steps={steps} />)
+    expect(screen.getByTestId('phase-step-validate')).toHaveTextContent('Validate')
+  })
+
+  it('shows failure message for failed steps', () => {
+    const steps = [
+      makeStep({ stepName: 'execute', status: StepResultStatus.FAILED, message: 'Connection refused' }),
+    ]
+    render(<ApplyPhasesStepper steps={steps} />)
+    expect(screen.getByText('Connection refused')).toBeInTheDocument()
+  })
+
+  it('does not show message for successful steps', () => {
+    const steps = [
+      makeStep({ stepName: 'validate', status: StepResultStatus.SUCCESS, message: 'All good' }),
+    ]
+    render(<ApplyPhasesStepper steps={steps} />)
+    expect(screen.queryByText('All good')).not.toBeInTheDocument()
+  })
+
+  describe('PARTIAL completion', () => {
+    it('shows mixed success and failure steps', () => {
+      const steps = [
+        makeStep({ stepName: 'validate', status: StepResultStatus.SUCCESS }),
+        makeStep({ stepName: 'execute', status: StepResultStatus.FAILED, message: 'Partial failure' }),
+      ]
+      render(<ApplyPhasesStepper steps={steps} />)
+      expect(screen.getByTestId('phase-step-validate')).toBeInTheDocument()
+      expect(screen.getByTestId('phase-step-execute')).toBeInTheDocument()
+      expect(screen.getByText('Partial failure')).toBeInTheDocument()
+    })
+  })
+
+  it('shows spinner on last step while applying', () => {
+    const steps = [
+      makeStep({ stepName: 'validate', status: StepResultStatus.SUCCESS }),
+      makeStep({ stepName: 'execute', status: StepResultStatus.UNSPECIFIED }),
+    ]
+    render(<ApplyPhasesStepper steps={steps} isApplying={true} />)
+    // Both steps should be in the DOM
+    expect(screen.getByTestId('phase-step-validate')).toBeInTheDocument()
+    expect(screen.getByTestId('phase-step-execute')).toBeInTheDocument()
+  })
+
+  it('shows skipped steps', () => {
+    const steps = [
+      makeStep({ stepName: 'validate', status: StepResultStatus.SUCCESS }),
+      makeStep({ stepName: 'execute', status: StepResultStatus.SKIPPED }),
+    ]
+    render(<ApplyPhasesStepper steps={steps} />)
+    expect(screen.getByTestId('phase-step-execute')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/economy/components/__tests__/deploy-wizard.test.tsx
+++ b/frontend/src/features/economy/components/__tests__/deploy-wizard.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ApplyManifestStatus, StepResultStatus } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders } from '@/test/test-utils'
@@ -433,6 +434,79 @@ describe('DeployWizard', () => {
       await waitFor(() => {
         expect(screen.getByTestId('deploy-apply-button')).not.toBeDisabled()
       })
+    })
+  })
+
+  // Subtask 5 (Task 21): Phase stepper integration
+  describe('phase stepper', () => {
+    async function planAndApplyWith(applyResponse: Record<string, unknown>) {
+      const user = userEvent.setup()
+      const plan = makePlan()
+      const planManifestAsync = vi.fn().mockResolvedValue(plan)
+      vi.mocked(useManifestPlan)
+        .mockReturnValueOnce({
+          plan: null,
+          planManifest: vi.fn(),
+          planManifestAsync,
+          isPlanning: false,
+          error: null,
+        } as unknown as ReturnType<typeof useManifestPlan>)
+        .mockReturnValue({
+          plan,
+          planManifest: vi.fn(),
+          planManifestAsync,
+          isPlanning: false,
+          error: null,
+        } as unknown as ReturnType<typeof useManifestPlan>)
+
+      const applyManifest = vi.fn().mockResolvedValue(applyResponse)
+      mockApiClients(applyManifest)
+
+      renderWizard()
+      await user.click(screen.getByRole('button', { name: /^plan$/i }))
+      await waitFor(() => screen.getByTestId('deploy-apply-button'))
+      await user.click(screen.getByTestId('deploy-apply-button'))
+      await user.click(screen.getByTestId('confirm-apply-button'))
+
+      return { user }
+    }
+
+    it('shows phase stepper after successful apply with step results', async () => {
+      await planAndApplyWith({
+        status: ApplyManifestStatus.APPLIED,
+        stepResults: [
+          { $typeName: 'meridian.control_plane.v1.StepResult', stepName: 'validate', status: StepResultStatus.SUCCESS, message: '', details: {} },
+          { $typeName: 'meridian.control_plane.v1.StepResult', stepName: 'execute', status: StepResultStatus.SUCCESS, message: '', details: {} },
+        ],
+        validationErrors: [],
+        diffSummary: '',
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('deploy-step-label')).toHaveTextContent('Applied')
+      })
+      expect(screen.getByTestId('apply-phases-stepper')).toBeInTheDocument()
+      expect(screen.getByTestId('phase-step-validate')).toBeInTheDocument()
+      expect(screen.getByTestId('phase-step-execute')).toBeInTheDocument()
+    })
+
+    it('shows phase stepper with error for PARTIAL completion', async () => {
+      await planAndApplyWith({
+        status: ApplyManifestStatus.FAILED,
+        stepResults: [
+          { $typeName: 'meridian.control_plane.v1.StepResult', stepName: 'validate', status: StepResultStatus.SUCCESS, message: '', details: {} },
+          { $typeName: 'meridian.control_plane.v1.StepResult', stepName: 'execute', status: StepResultStatus.FAILED, message: 'Resource conflict', details: {} },
+        ],
+        validationErrors: [],
+        diffSummary: '',
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('deploy-step-label')).toHaveTextContent('Failed')
+      })
+      expect(screen.getByTestId('apply-phases-stepper')).toBeInTheDocument()
+      expect(screen.getByText('Resource conflict')).toBeInTheDocument()
+      expect(screen.getByText(/partial failures/i)).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/features/economy/components/apply-phases-stepper.tsx
+++ b/frontend/src/features/economy/components/apply-phases-stepper.tsx
@@ -1,0 +1,88 @@
+import { CheckCircle2, XCircle, MinusCircle, Loader2 } from 'lucide-react'
+import { StepResultStatus } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
+import type { StepResult } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
+
+// ── Props ────────────────────────────────────────────────────────────────────
+
+export interface ApplyPhasesStepperProps {
+  /** Step results returned from the apply response. */
+  steps: StepResult[]
+  /** When true, the apply is still in progress (shows spinner on last step). */
+  isApplying?: boolean
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function stepIcon(status: StepResultStatus, isActive: boolean) {
+  if (isActive) {
+    return <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+  }
+  switch (status) {
+    case StepResultStatus.SUCCESS:
+      return <CheckCircle2 className="h-4 w-4 text-success" />
+    case StepResultStatus.FAILED:
+      return <XCircle className="h-4 w-4 text-destructive" />
+    case StepResultStatus.SKIPPED:
+      return <MinusCircle className="h-4 w-4 text-muted-foreground" />
+    default:
+      return <MinusCircle className="h-4 w-4 text-muted-foreground" />
+  }
+}
+
+function stepLabelClass(status: StepResultStatus): string {
+  switch (status) {
+    case StepResultStatus.SUCCESS:
+      return 'text-foreground'
+    case StepResultStatus.FAILED:
+      return 'text-destructive font-medium'
+    case StepResultStatus.SKIPPED:
+      return 'text-muted-foreground'
+    default:
+      return 'text-muted-foreground'
+  }
+}
+
+function formatStepName(name: string): string {
+  return name.charAt(0).toUpperCase() + name.slice(1).toLowerCase().replace(/_/g, ' ')
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export function ApplyPhasesStepper({ steps, isApplying = false }: ApplyPhasesStepperProps) {
+  if (steps.length === 0 && !isApplying) {
+    return null
+  }
+
+  return (
+    <ol
+      className="space-y-1 text-sm"
+      aria-label="Apply phases"
+      data-testid="apply-phases-stepper"
+    >
+      {steps.map((step, index) => {
+        const isLastStep = index === steps.length - 1
+        const isActive = isApplying && isLastStep
+
+        return (
+          <li key={step.stepName} className="flex items-start gap-2.5">
+            <span className="mt-0.5 shrink-0">{stepIcon(step.status, isActive)}</span>
+            <div className="min-w-0 flex-1">
+              <span className={stepLabelClass(step.status)} data-testid={`phase-step-${step.stepName}`}>
+                {formatStepName(step.stepName)}
+              </span>
+              {step.message && step.status === StepResultStatus.FAILED && (
+                <p className="mt-0.5 text-xs text-destructive/80">{step.message}</p>
+              )}
+            </div>
+          </li>
+        )
+      })}
+      {isApplying && steps.length === 0 && (
+        <li className="flex items-center gap-2.5">
+          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+          <span className="text-muted-foreground">Applying…</span>
+        </li>
+      )}
+    </ol>
+  )
+}

--- a/frontend/src/features/economy/components/deploy-wizard.tsx
+++ b/frontend/src/features/economy/components/deploy-wizard.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { AlertCircle, CheckCircle2, Loader2, TriangleAlert } from 'lucide-react'
 import { useManifestPlan } from '../hooks/use-manifest-plan'
 import { ValidationPanel } from './validation-panel'
+import { ApplyPhasesStepper } from './apply-phases-stepper'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -16,7 +17,11 @@ import { useApiClients } from '@/api/context'
 import { useAuth } from '@/contexts/auth-context'
 import { manifestKeys } from '@/lib/query-keys'
 import type { Manifest } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
-import type { ValidationError } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
+import type {
+  StepResult,
+  ValidationError,
+} from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
+import { ApplyManifestStatus } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
 import type { ManifestPlan } from '../hooks/use-manifest-plan'
 
 // ── Step state machine ──────────────────────────────────────────────────────
@@ -60,6 +65,7 @@ export function DeployWizard({
   const [step, setStep] = useState<DeployStep>('idle')
   const [applyError, setApplyError] = useState<string | null>(null)
   const [confirmOpen, setConfirmOpen] = useState(false)
+  const [applyStepResults, setApplyStepResults] = useState<StepResult[]>([])
 
   // Track plan hash to detect manifest edits after planning
   const [planHash, setPlanHash] = useState<string | null>(null)
@@ -101,9 +107,17 @@ export function DeployWizard({
         appliedBy: claims?.userId ?? '',
       })
     },
-    onSuccess: () => {
+    onSuccess: (response) => {
+      setApplyStepResults(response.stepResults ?? [])
+      const isPartial = response.status === ApplyManifestStatus.FAILED &&
+        (response.stepResults ?? []).some((s) => s.status === 1 /* SUCCESS */)
       void queryClient.invalidateQueries({ queryKey: manifestKeys.all })
-      setStep('success')
+      if (isPartial) {
+        setApplyError('Apply completed with partial failures. Some phases did not succeed.')
+        setStep('error')
+      } else {
+        setStep('success')
+      }
       setConfirmOpen(false)
     },
     onError: (err: unknown) => {
@@ -133,6 +147,7 @@ export function DeployWizard({
   const handleRetry = useCallback(() => {
     setStep('idle')
     setApplyError(null)
+    setApplyStepResults([])
   }, [])
 
   // ── Render ───────────────────────────────────────────────────────────────
@@ -193,6 +208,16 @@ export function DeployWizard({
               <span>Manifest has changed since last plan. Re-plan before applying.</span>
             </div>
           )}
+        </div>
+      )}
+
+      {/* Apply phases stepper — shown while applying or after apply completes */}
+      {(step === 'applying' || step === 'success' || (step === 'error' && applyStepResults.length > 0)) && (
+        <div className="rounded-md border bg-muted/40 px-4 py-3">
+          <ApplyPhasesStepper
+            steps={applyStepResults}
+            isApplying={step === 'applying'}
+          />
         </div>
       )}
 

--- a/frontend/src/features/economy/components/deploy-wizard.tsx
+++ b/frontend/src/features/economy/components/deploy-wizard.tsx
@@ -21,7 +21,10 @@ import type {
   StepResult,
   ValidationError,
 } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
-import { ApplyManifestStatus } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
+import {
+  ApplyManifestStatus,
+  StepResultStatus,
+} from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
 import type { ManifestPlan } from '../hooks/use-manifest-plan'
 
 // ── Step state machine ──────────────────────────────────────────────────────
@@ -110,7 +113,7 @@ export function DeployWizard({
     onSuccess: (response) => {
       setApplyStepResults(response.stepResults ?? [])
       const isPartial = response.status === ApplyManifestStatus.FAILED &&
-        (response.stepResults ?? []).some((s) => s.status === 1 /* SUCCESS */)
+        (response.stepResults ?? []).some((s) => s.status === StepResultStatus.SUCCESS)
       void queryClient.invalidateQueries({ queryKey: manifestKeys.all })
       if (isPartial) {
         setApplyError('Apply completed with partial failures. Some phases did not succeed.')


### PR DESCRIPTION
## Summary

- Creates `ApplyPhasesStepper` component that renders step-by-step progress (validate, plan, execute) using `StepResult` data from the apply response
- Integrates the stepper into `DeployWizard` — visible during apply and after completion (success or error)
- Handles PARTIAL completion: detects mixed SUCCESS/FAILED step results and transitions to error state with per-phase failure messages

## Changes Made

- `frontend/src/features/economy/components/apply-phases-stepper.tsx` — new component
- `frontend/src/features/economy/components/deploy-wizard.tsx` — capture `stepResults` from apply response, render `ApplyPhasesStepper`, detect PARTIAL status
- `frontend/src/features/economy/components/__tests__/apply-phases-stepper.test.tsx` — 9 unit tests
- `frontend/src/features/economy/components/__tests__/deploy-wizard.test.tsx` — 2 integration tests for phase stepper

## Test Plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — no new errors
- [x] All 17 deploy wizard tests pass
- [x] All 9 apply phases stepper tests pass

Closes 046-economy-visualization-completeness.21