### PR TITLE
fix: pin appleboy actions to commit SHAs in deploy-demo workflow

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -143,7 +143,7 @@ jobs:
           path: frontend-dist/
 
       - name: Deploy frontend via SCP
-        uses: appleboy/scp-action@v1.0.0
+        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1.0.0
         with:
           host: ${{ secrets.DROPLET_IP }}
           username: root
@@ -154,7 +154,7 @@ jobs:
           overwrite: true
 
       - name: Deploy config files via SCP
-        uses: appleboy/scp-action@v1.0.0
+        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1.0.0
         with:
           host: ${{ secrets.DROPLET_IP }}
           username: root
@@ -165,7 +165,7 @@ jobs:
           overwrite: true
 
       - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1.2.5
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
           host: ${{ secrets.DROPLET_IP }}
           username: root
@@ -178,7 +178,7 @@ jobs:
             docker image prune -f
 
       - name: Verify deployment health
-        uses: appleboy/ssh-action@v1.2.5
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
           host: ${{ secrets.DROPLET_IP }}
           username: root


### PR DESCRIPTION
## Summary

- Pins `appleboy/ssh-action@v1.2.5` to commit SHA `0ff4204d59e8e51228ff73bce53f80d53301dee2`
- Pins `appleboy/scp-action@v1.0.0` to commit SHA `ff85246acaad7bdce478db94a363cd2bf7c90345`
- Version tags retained as inline comments for maintainability

Prevents supply chain attacks where a threat actor could push malicious code to a version tag without changing the tag reference in CI workflows.

## Changes Made

`.github/workflows/deploy-demo.yml`: replaced 4 `appleboy` action references (2x `scp-action`, 2x `ssh-action`) with commit SHA pins.

## Test Plan

- [x] YAML structure preserved (4 insertions, 4 deletions — identical keys, different values)
- [ ] CI passes on push to this branch

## Risk Assessment

Low risk. This is a mechanical substitution — identical action versions, just pinned to immutable commit SHAs rather than mutable tags.