### PR TITLE
feat: add manifest export button (YAML/JSON)

### DIFF
--- a/frontend/src/features/manifests/pages/manifest-history-table.test.tsx
+++ b/frontend/src/features/manifests/pages/manifest-history-table.test.tsx
@@ -7,6 +7,10 @@ import { createTenantUserToken } from '@/test/jwt-helpers'
 import { ManifestHistoryTable } from './manifest-history-table'
 import { ApplyStatus } from '@/api/gen/meridian/control_plane/v1/manifest_history_service_pb'
 
+// Mock URL.createObjectURL for download tests
+global.URL.createObjectURL = vi.fn(() => 'blob:mock')
+global.URL.revokeObjectURL = vi.fn()
+
 vi.mock('@/api/context', () => ({
   useApiClients: vi.fn(),
   ApiClientProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -230,6 +234,123 @@ describe('ManifestHistoryTable', () => {
 
     await waitFor(() => {
       expect(screen.queryByTestId('compare-toolbar')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Export', () => {
+    const mockManifest = {
+      version: '1.0',
+      metadata: { name: 'Test', industry: 'finance', description: 'desc' },
+      instruments: [],
+      accountTypes: [],
+      valuationRules: [],
+      sagas: [],
+      seedData: undefined,
+      paymentRails: [],
+      partyTypes: [],
+      mappings: [],
+      operationalGateway: undefined,
+    }
+
+    function mockApiClientsWithExport() {
+      vi.mocked(useApiClients).mockReturnValue({
+        manifestHistory: {
+          getCurrentManifest: vi.fn(),
+          listManifestVersions: vi.fn().mockResolvedValue({
+            versions: mockVersions,
+            totalCount: 3,
+          }),
+          getManifestVersion: vi.fn(),
+          exportManifest: vi.fn().mockResolvedValue({
+            manifest: mockManifest,
+            checksum: 'abc123',
+            sectionSources: {},
+            warnings: [],
+          }),
+        },
+      } as unknown as ReturnType<typeof useApiClients>)
+    }
+
+    it('renders export button', async () => {
+      renderComponent()
+
+      await waitFor(() => {
+        expect(screen.getByTestId('export-button')).toBeInTheDocument()
+      })
+    })
+
+    it('shows YAML and JSON format options in dropdown', async () => {
+      mockApiClientsWithExport()
+      renderComponent()
+
+      await waitFor(() => {
+        expect(screen.getByTestId('export-button')).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByTestId('export-button'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('export-yaml')).toBeInTheDocument()
+        expect(screen.getByTestId('export-json')).toBeInTheDocument()
+      })
+    })
+
+    it('calls exportManifest and triggers download for YAML format', async () => {
+      const exportManifestMock = vi.fn().mockResolvedValue({
+        manifest: mockManifest,
+        checksum: 'abc123',
+        sectionSources: {},
+        warnings: [],
+      })
+      vi.mocked(useApiClients).mockReturnValue({
+        manifestHistory: {
+          getCurrentManifest: vi.fn(),
+          listManifestVersions: vi.fn().mockResolvedValue({ versions: mockVersions, totalCount: 3 }),
+          getManifestVersion: vi.fn(),
+          exportManifest: exportManifestMock,
+        },
+      } as unknown as ReturnType<typeof useApiClients>)
+
+      renderComponent()
+
+      await waitFor(() => expect(screen.getByTestId('export-button')).toBeInTheDocument())
+      await userEvent.click(screen.getByTestId('export-button'))
+      await waitFor(() => expect(screen.getByTestId('export-yaml')).toBeInTheDocument())
+      await userEvent.click(screen.getByTestId('export-yaml'))
+
+      await waitFor(() => {
+        expect(exportManifestMock).toHaveBeenCalledWith({})
+        expect(URL.createObjectURL).toHaveBeenCalled()
+      })
+    })
+
+    it('calls exportManifest and triggers download for JSON format', async () => {
+      const exportManifestMock = vi.fn().mockResolvedValue({
+        manifest: mockManifest,
+        checksum: 'abc123',
+        sectionSources: {},
+        warnings: [],
+      })
+      vi.mocked(useApiClients).mockReturnValue({
+        manifestHistory: {
+          getCurrentManifest: vi.fn(),
+          listManifestVersions: vi.fn().mockResolvedValue({ versions: mockVersions, totalCount: 3 }),
+          getManifestVersion: vi.fn(),
+          exportManifest: exportManifestMock,
+        },
+      } as unknown as ReturnType<typeof useApiClients>)
+
+      renderComponent()
+
+      await waitFor(() => expect(screen.getByTestId('export-button')).toBeInTheDocument())
+      await userEvent.click(screen.getByTestId('export-button'))
+      await waitFor(() => expect(screen.getByTestId('export-json')).toBeInTheDocument())
+      await userEvent.click(screen.getByTestId('export-json'))
+
+      await waitFor(() => {
+        expect(exportManifestMock).toHaveBeenCalledWith({})
+        expect(URL.createObjectURL).toHaveBeenCalled()
+      })
     })
   })
 })

--- a/frontend/src/features/manifests/pages/manifest-history-table.tsx
+++ b/frontend/src/features/manifests/pages/manifest-history-table.tsx
@@ -6,12 +6,20 @@ import { StatusBadge } from '@/shared/status-badge'
 import { TimeDisplay } from '@/shared/time-display'
 import { Button } from '@/components/ui/button'
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
   DialogDescription,
 } from '@/components/ui/dialog'
+import { ChevronDown } from 'lucide-react'
+import yaml from 'js-yaml'
 import { manifestKeys } from '@/lib/query-keys'
 import type { ManifestVersion } from '@/api/gen/meridian/control_plane/v1/manifest_history_service_pb'
 import { ApplyStatus } from '@/api/gen/meridian/control_plane/v1/manifest_history_service_pb'
@@ -87,11 +95,14 @@ function buildColumns(
   ]
 }
 
+type ExportFormat = 'yaml' | 'json'
+
 export function ManifestHistoryTable() {
   const { manifestHistory } = useApiClients()
   const [selectedVersion, setSelectedVersion] = useState<ManifestVersion | null>(null)
   const [compareVersions, setCompareVersions] = useState<ManifestVersion[]>([])
   const [showDiff, setShowDiff] = useState(false)
+  const [isExporting, setIsExporting] = useState(false)
 
   const compareSet = useMemo(
     () => new Set(compareVersions.map((v) => v.id ?? v.version)),
@@ -137,6 +148,41 @@ export function ManifestHistoryTable() {
     setShowDiff(false)
   }
 
+  async function handleExport(format: ExportFormat) {
+    setIsExporting(true)
+    try {
+      const response = await manifestHistory.exportManifest({})
+      const manifest = response.manifest
+      if (!manifest) return
+
+      let content: string
+      let mimeType: string
+      let extension: string
+
+      if (format === 'yaml') {
+        content = yaml.dump(manifest, { lineWidth: 120 })
+        mimeType = 'application/x-yaml'
+        extension = 'yaml'
+      } else {
+        content = JSON.stringify(manifest, null, 2)
+        mimeType = 'application/json'
+        extension = 'json'
+      }
+
+      const version = manifest.version || 'current'
+      const filename = `manifest-v${version}.${extension}`
+      const blob = new Blob([content], { type: mimeType })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = filename
+      a.click()
+      URL.revokeObjectURL(url)
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
   const diffGraphs = useMemo(() => {
     if (!showDiff || compareVersions.length !== 2) return null
     // Sort by appliedAt so earlier version is always "before"
@@ -155,6 +201,29 @@ export function ManifestHistoryTable() {
   return (
     <>
       <div data-testid="manifest-history-table">
+        <div className="flex items-center justify-end pb-3">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={isExporting}
+                data-testid="export-button"
+              >
+                {isExporting ? 'Exporting...' : 'Export'}
+                <ChevronDown className="ml-1 h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => handleExport('yaml')} data-testid="export-yaml">
+                Export as YAML
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => handleExport('json')} data-testid="export-json">
+                Export as JSON
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
         {compareVersions.length > 0 && (
           <div className="flex items-center gap-3 pb-3" data-testid="compare-toolbar">
             <span className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- Add Export dropdown button to manifest history page header
- Calls `manifestHistory.exportManifest({})` to fetch reconstructed manifest from live service state
- Supports YAML and JSON formats via dropdown menu
- Triggers browser download with filename `manifest-v{version}.yaml` or `manifest-v{version}.json`
- Button shows "Exporting..." while request is in flight

## Changes Made
- `manifest-history-table.tsx`: Add `DropdownMenu` export button, `handleExport` function with YAML/JSON serialization, and `isExporting` state
- `manifest-history-table.test.tsx`: Add export feature tests covering button rendering, format options dropdown, and API call verification

## Technical Details
- Uses `js-yaml` (already a project dependency) for YAML serialization
- Uses `JSON.stringify` for JSON serialization (consistent with existing manifest display code)
- Export button is always visible in header; disabled during in-flight request
- Filename uses `manifest.version` field from export response

## Testing
- All 16 tests pass (`npm test`)
- TypeScript type check passes (`npm run typecheck`)
- No new lint errors (`npm run lint`)