### PR TITLE
test: extend node-type-registry tests to cover all 10 ManifestNodeType values

### DIFF
--- a/frontend/src/features/manifests/lib/node-type-registry.test.ts
+++ b/frontend/src/features/manifests/lib/node-type-registry.test.ts
@@ -12,9 +12,16 @@ describe('NODE_TYPE_REGISTRY', () => {
     'account_type',
     'valuation_rule',
     'saga',
+    'payment_rail',
+    'party_type',
+    'mapping',
+    'operational_gateway',
+    'provider_connection',
+    'instruction_route',
   ]
 
-  it('has entries for all current ManifestNodeType values', () => {
+  it('has entries for all 10 ManifestNodeType values', () => {
+    expect(Object.keys(NODE_TYPE_REGISTRY)).toHaveLength(10)
     for (const type of ALL_TYPES) {
       expect(NODE_TYPE_REGISTRY[type]).toBeDefined()
     }
@@ -36,11 +43,29 @@ describe('NODE_TYPE_REGISTRY', () => {
     expect(NODE_TYPE_REGISTRY.saga.color).toBe('var(--graph-saga)')
   })
 
+  it('assigns CSS variables for new node types', () => {
+    expect(NODE_TYPE_REGISTRY.payment_rail.color).toBe('var(--graph-payment-rail)')
+    expect(NODE_TYPE_REGISTRY.party_type.color).toBe('var(--graph-party-type)')
+    expect(NODE_TYPE_REGISTRY.mapping.color).toBe('var(--graph-mapping)')
+    expect(NODE_TYPE_REGISTRY.operational_gateway.color).toBe('var(--graph-operational-gateway)')
+    expect(NODE_TYPE_REGISTRY.provider_connection.color).toBe('var(--graph-provider-connection)')
+    expect(NODE_TYPE_REGISTRY.instruction_route.color).toBe('var(--graph-instruction-route)')
+  })
+
   it('preserves original labels', () => {
     expect(NODE_TYPE_REGISTRY.instrument.label).toBe('Instruments')
     expect(NODE_TYPE_REGISTRY.account_type.label).toBe('Account Types')
     expect(NODE_TYPE_REGISTRY.valuation_rule.label).toBe('Valuation Rules')
     expect(NODE_TYPE_REGISTRY.saga.label).toBe('Sagas')
+  })
+
+  it('assigns labels for new node types', () => {
+    expect(NODE_TYPE_REGISTRY.payment_rail.label).toBe('Payment Rails')
+    expect(NODE_TYPE_REGISTRY.party_type.label).toBe('Party Types')
+    expect(NODE_TYPE_REGISTRY.mapping.label).toBe('Mappings')
+    expect(NODE_TYPE_REGISTRY.operational_gateway.label).toBe('Operational Gateway')
+    expect(NODE_TYPE_REGISTRY.provider_connection.label).toBe('Provider Connections')
+    expect(NODE_TYPE_REGISTRY.instruction_route.label).toBe('Instruction Routes')
   })
 
   it('preserves original layer priorities', () => {
@@ -49,11 +74,28 @@ describe('NODE_TYPE_REGISTRY', () => {
     expect(NODE_TYPE_REGISTRY.valuation_rule.layerPriority).toBe('20')
     expect(NODE_TYPE_REGISTRY.saga.layerPriority).toBe('10')
   })
+
+  it('assigns layer priorities for new node types', () => {
+    expect(NODE_TYPE_REGISTRY.payment_rail.layerPriority).toBe('9')
+    expect(NODE_TYPE_REGISTRY.party_type.layerPriority).toBe('8')
+    expect(NODE_TYPE_REGISTRY.mapping.layerPriority).toBe('7')
+    expect(NODE_TYPE_REGISTRY.operational_gateway.layerPriority).toBe('6')
+    expect(NODE_TYPE_REGISTRY.provider_connection.layerPriority).toBe('5')
+    expect(NODE_TYPE_REGISTRY.instruction_route.layerPriority).toBe('4')
+  })
+
+  it('layer priorities are in descending order from instrument to instruction_route', () => {
+    const priorities = ALL_TYPES.map((t) => parseInt(NODE_TYPE_REGISTRY[t].layerPriority, 10))
+    for (let i = 0; i < priorities.length - 1; i++) {
+      expect(priorities[i]).toBeGreaterThan(priorities[i + 1])
+    }
+  })
 })
 
 describe('getNodeThemes', () => {
-  it('returns a Record<ManifestNodeType, { color, label }>', () => {
+  it('returns a Record<ManifestNodeType, { color, label }> for all 10 types', () => {
     const themes = getNodeThemes()
+    expect(Object.keys(themes)).toHaveLength(10)
     expect(themes.instrument).toEqual({
       color: 'var(--graph-instrument)',
       label: 'Instruments',
@@ -61,6 +103,18 @@ describe('getNodeThemes', () => {
     expect(themes.saga).toEqual({
       color: 'var(--graph-saga)',
       label: 'Sagas',
+    })
+    expect(themes.payment_rail).toEqual({
+      color: 'var(--graph-payment-rail)',
+      label: 'Payment Rails',
+    })
+    expect(themes.operational_gateway).toEqual({
+      color: 'var(--graph-operational-gateway)',
+      label: 'Operational Gateway',
+    })
+    expect(themes.instruction_route).toEqual({
+      color: 'var(--graph-instruction-route)',
+      label: 'Instruction Routes',
     })
   })
 
@@ -72,12 +126,19 @@ describe('getNodeThemes', () => {
 })
 
 describe('getLayerPriority', () => {
-  it('returns a Record<ManifestNodeType, string>', () => {
+  it('returns a Record<ManifestNodeType, string> for all 10 types', () => {
     const priority = getLayerPriority()
+    expect(Object.keys(priority)).toHaveLength(10)
     expect(priority.instrument).toBe('40')
     expect(priority.account_type).toBe('30')
     expect(priority.valuation_rule).toBe('20')
     expect(priority.saga).toBe('10')
+    expect(priority.payment_rail).toBe('9')
+    expect(priority.party_type).toBe('8')
+    expect(priority.mapping).toBe('7')
+    expect(priority.operational_gateway).toBe('6')
+    expect(priority.provider_connection).toBe('5')
+    expect(priority.instruction_route).toBe('4')
   })
 
   it('returns the same reference on repeated calls (memoized)', () => {


### PR DESCRIPTION
## Summary

- Extends `node-type-registry.test.ts` to cover all 10 `ManifestNodeType` values (previously only tested the original 4)
- Adds explicit assertions for the 6 new types: `payment_rail`, `party_type`, `mapping`, `operational_gateway`, `provider_connection`, `instruction_route`
- Asserts registry has exactly 10 entries (regression guard against silent omissions)
- Adds layer priority ordering test to verify the full descending priority chain
- `manifest-graph-model.test.ts` already had full coverage from task 9 — no changes needed there

## Test plan

- [x] `node-type-registry.test.ts` — 13 tests passing
- [x] `manifest-graph-model.test.ts` — 35 tests passing

Closes task 046-economy-visualization-completeness.24