### PR TITLE
fix: default AUTH_ENABLED to true in api-gateway and position-keeping

### DIFF
--- a/deploy/demo/README.md
+++ b/deploy/demo/README.md
@@ -242,7 +242,7 @@ Example values for the demo environment:
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `AUTH_ENABLED` | No | `false` | Enforce JWT validation on API routes |
+| `AUTH_ENABLED` | No | `true` | Enforce JWT validation on API routes |
 | `JWKS_URL` | Yes (when `AUTH_ENABLED=true`) | `{DEX_ISSUER}/keys` | JWKS endpoint for JWT validation |
 | `JWT_ISSUER` | No | — | Expected `iss` claim; validation skipped if empty |
 | `JWT_AUDIENCE` | No | — | Expected `aud` claim; validation skipped if empty |

--- a/services/README.md
+++ b/services/README.md
@@ -364,7 +364,7 @@ The Gateway provides a multi-tenant API gateway for authenticated access to back
 |----------|----------|-------------|
 | `BASE_DOMAIN` | Yes | Base domain for subdomain-based tenant identification |
 | `DATABASE_URL` | Yes | PostgreSQL connection string for tenant lookups |
-| `AUTH_ENABLED` | No | Enable JWT/API key authentication (default: false) |
+| `AUTH_ENABLED` | No | Enable JWT/API key authentication (default: true) |
 | `JWKS_URL` | When AUTH_ENABLED | JWKS endpoint URL for JWT validation |
 | `BACKENDS` | No | JSON array of backend route mappings |
 

--- a/services/api-gateway/README.md
+++ b/services/api-gateway/README.md
@@ -156,7 +156,7 @@ Commit the updated `cmd/meridian/descriptor.binpb` after regenerating.
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `AUTH_ENABLED` | No | `false` | Enable authentication for API routes |
+| `AUTH_ENABLED` | No | `true` | Enable authentication for API routes |
 | `JWKS_URL` | When AUTH_ENABLED=true | - | JWKS endpoint URL for JWT validation |
 | `JWKS_CACHE_TTL` | No | `24h` | How long to cache JWKS keys |
 | `JWKS_REFRESH_TTL` | No | `1h` | Background refresh interval for JWKS keys |

--- a/services/api-gateway/config.go
+++ b/services/api-gateway/config.go
@@ -205,7 +205,7 @@ func LoadConfig() (*Config, error) {
 // LoadAuthConfig loads authentication configuration from environment variables.
 //
 // Environment variables:
-//   - AUTH_ENABLED: Enable authentication (default: false)
+//   - AUTH_ENABLED: Enable authentication (default: true)
 //   - JWKS_URL: JWKS endpoint URL for JWT validation (defaults to DEX_ISSUER/keys when DEX_ISSUER is set)
 //   - JWKS_CACHE_TTL: Cache duration for JWKS keys (default: 24h)
 //   - JWKS_REFRESH_TTL: Background refresh interval (default: 1h)
@@ -218,7 +218,7 @@ func LoadAuthConfig() AuthConfig {
 	jwksURL, jwtIssuer := resolveAuthEndpoints()
 
 	config := AuthConfig{
-		Enabled:            env.GetEnvAsBool("AUTH_ENABLED", false),
+		Enabled:            env.GetEnvAsBool("AUTH_ENABLED", true),
 		JWKSURL:            jwksURL,
 		JWKSCacheTTL:       getEnvAsDurationOrDefault("JWKS_CACHE_TTL", 24*time.Hour),
 		JWKSRefreshTTL:     getEnvAsDurationOrDefault("JWKS_REFRESH_TTL", 1*time.Hour),

--- a/services/api-gateway/config_test.go
+++ b/services/api-gateway/config_test.go
@@ -18,6 +18,7 @@ func TestLoadConfig_Success(t *testing.T) {
 		"DATABASE_URL":   "postgres://user@localhost/db",
 		"REDIS_URL":      "redis://localhost:6379",
 		"BACKENDS":       `[{"prefix":"/v1/party","target":"party:50055"}]`,
+		"AUTH_ENABLED":   "false",
 	})
 	defer cleanup()
 
@@ -38,6 +39,7 @@ func TestLoadConfig_DefaultPort(t *testing.T) {
 	cleanup := setEnvVars(t, map[string]string{
 		"BASE_DOMAIN":  "api.example.com",
 		"DATABASE_URL": "postgres://user@localhost/db",
+		"AUTH_ENABLED": "false",
 	})
 	defer cleanup()
 
@@ -51,6 +53,7 @@ func TestLoadConfig_LocalDevModeDefaultsFalse(t *testing.T) {
 	cleanup := setEnvVars(t, map[string]string{
 		"BASE_DOMAIN":  "api.example.com",
 		"DATABASE_URL": "postgres://user@localhost/db",
+		"AUTH_ENABLED": "false",
 	})
 	defer cleanup()
 
@@ -134,6 +137,7 @@ func TestLoadConfig_EmptyBackendRoutes(t *testing.T) {
 	cleanup := setEnvVars(t, map[string]string{
 		"BASE_DOMAIN":  "api.example.com",
 		"DATABASE_URL": "postgres://user@localhost/db",
+		"AUTH_ENABLED": "false",
 	})
 	defer cleanup()
 
@@ -147,6 +151,7 @@ func TestLoadConfig_MultipleBackendRoutes(t *testing.T) {
 	cleanup := setEnvVars(t, map[string]string{
 		"BASE_DOMAIN":  "api.example.com",
 		"DATABASE_URL": "postgres://user@localhost/db",
+		"AUTH_ENABLED": "false",
 		"BACKENDS": `[
 			{"prefix":"/v1/party","target":"party:50055"},
 			{"prefix":"/v1/accounts","target":"current-account:50051"},
@@ -196,6 +201,7 @@ func TestLoadConfig_LocalDevModeVariations(t *testing.T) {
 				"BASE_DOMAIN":    "api.example.com",
 				"DATABASE_URL":   "postgres://user@localhost/db",
 				"LOCAL_DEV_MODE": tc.value,
+				"AUTH_ENABLED":   "false",
 			})
 			defer cleanup()
 
@@ -418,6 +424,7 @@ func setEnvVars(t *testing.T, vars map[string]string) func() {
 	envsToClear := []string{
 		"PORT", "BASE_DOMAIN", "LOCAL_DEV_MODE",
 		"DATABASE_URL", "REDIS_URL", "BACKENDS",
+		"AUTH_ENABLED", "JWKS_URL",
 	}
 	for _, key := range envsToClear {
 		if val, ok := os.LookupEnv(key); ok {
@@ -520,7 +527,7 @@ func TestLoadAuthConfig_Defaults(t *testing.T) {
 
 	config := LoadAuthConfig()
 
-	assert.False(t, config.Enabled)
+	assert.True(t, config.Enabled)
 	assert.Empty(t, config.JWKSURL)
 	assert.Equal(t, 24*time.Hour, config.JWKSCacheTTL)
 	assert.Equal(t, 1*time.Hour, config.JWKSRefreshTTL)
@@ -661,6 +668,7 @@ func TestLoadConfig_EventStreamDefaults(t *testing.T) {
 	cleanup := setEnvVars(t, map[string]string{
 		"BASE_DOMAIN":  "api.example.com",
 		"DATABASE_URL": "postgres://user@localhost/db",
+		"AUTH_ENABLED": "false",
 	})
 	defer cleanup()
 

--- a/services/position-keeping/app/config.go
+++ b/services/position-keeping/app/config.go
@@ -217,7 +217,7 @@ func loadRedisConfig() RedisConfig {
 
 // loadAuthConfig loads JWT authentication configuration from environment variables
 func loadAuthConfig() AuthConfig {
-	enabled := env.GetEnvAsBool("AUTH_ENABLED", false)
+	enabled := env.GetEnvAsBool("AUTH_ENABLED", true)
 
 	return AuthConfig{
 		Enabled:        enabled,

--- a/services/position-keeping/app/config_test.go
+++ b/services/position-keeping/app/config_test.go
@@ -860,6 +860,42 @@ func TestLoadConfig_AccountValidation_EnabledNoURL_ReturnsError(t *testing.T) {
 	}
 }
 
+// TestLoadConfig_AuthEnabledDefaultsTrue verifies that AUTH_ENABLED defaults to true
+// when the environment variable is not set, preventing authentication bypass.
+func TestLoadConfig_AuthEnabledDefaultsTrue(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("DATABASE_URL", "postgres://localhost:5432/testdb")
+	t.Setenv("ACCOUNT_VALIDATION_ENABLED", "false")
+	// AUTH_ENABLED intentionally not set - should default to true
+
+	config, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v, want nil", err)
+	}
+
+	if !config.Auth.Enabled {
+		t.Error("Auth.Enabled = false, want true (default must be secure)")
+	}
+}
+
+// TestLoadConfig_AuthEnabledFalseWhenExplicitlyDisabled verifies that AUTH_ENABLED=false
+// still disables auth when explicitly set (local dev scenario).
+func TestLoadConfig_AuthEnabledFalseWhenExplicitlyDisabled(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("DATABASE_URL", "postgres://localhost:5432/testdb")
+	t.Setenv("ACCOUNT_VALIDATION_ENABLED", "false")
+	t.Setenv("AUTH_ENABLED", "false")
+
+	config, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v, want nil", err)
+	}
+
+	if config.Auth.Enabled {
+		t.Error("Auth.Enabled = true, want false when AUTH_ENABLED=false")
+	}
+}
+
 // clearEnv clears environment variables used in tests
 func clearEnv(t *testing.T) {
 	t.Helper()
@@ -877,6 +913,7 @@ func clearEnv(t *testing.T) {
 		"ACCOUNT_VALIDATION_ENABLED", "CURRENT_ACCOUNT_SERVICE_URL",
 		"INTERNAL_ACCOUNT_SERVICE_URL", "ACCOUNT_VALIDATION_CACHE_TTL",
 		"ACCOUNT_VALIDATION_CONNECTION_TIMEOUT",
+		"AUTH_ENABLED",
 	}
 	for _, key := range envVars {
 		_ = os.Unsetenv(key)


### PR DESCRIPTION
## Summary

- Changes `AUTH_ENABLED` default from `false` to `true` in `services/api-gateway/config.go` and `services/position-keeping/app/config.go`
- Eliminates authentication bypass when `AUTH_ENABLED` env var is missing (e.g. incomplete deployment, missing secret)
- Aligns both services with `shared/platform/bootstrap/auth.go` which already defaults to `true`
- Updates documentation in service READMEs and deploy/demo/README.md to reflect new default

## Changes Made

- `services/api-gateway/config.go`: `GetEnvAsBool("AUTH_ENABLED", false)` → `GetEnvAsBool("AUTH_ENABLED", true)`
- `services/position-keeping/app/config.go`: same change
- `services/api-gateway/config_test.go`: Updated `TestLoadAuthConfig_Defaults` assertion to `assert.True`; added `AUTH_ENABLED=false` to tests not exercising auth to prevent JWKS validation errors; updated `setEnvVars` to clear `AUTH_ENABLED`/`JWKS_URL`
- `services/position-keeping/app/config_test.go`: Added `TestLoadConfig_AuthEnabledDefaultsTrue` and `TestLoadConfig_AuthEnabledFalseWhenExplicitlyDisabled`; added `AUTH_ENABLED` to `clearEnv`

## Technical Details

Grep of codebase confirmed only these two services had `GetEnvAsBool("AUTH_ENABLED", false)` in Go code. K8s configmaps with `AUTH_ENABLED: "false"` are explicit overrides (correct behaviour) addressed by a separate HIGH-3 task.

## Risk Assessment

- Dev environments use `.env` files with explicit `AUTH_ENABLED=false` — no dev impact
- Demo environment: `deploy/demo/.env.demo.example` already shows `AUTH_ENABLED=true` for the demo stack
- Any deployment missing `AUTH_ENABLED` will now require auth rather than silently bypass it

Addresses CRITICAL-3 from 047-security-audit PRD.