### PR TITLE
feat: add node components for 9 new resource types

### DIFF
--- a/frontend/src/features/manifests/components/manifest-graph.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.test.tsx
@@ -226,6 +226,15 @@ describe('ManifestGraph', () => {
       expect(screen.getByLabelText('Show Account Types')).toBeInTheDocument()
       expect(screen.getByLabelText('Show Valuation Rules')).toBeInTheDocument()
       expect(screen.getByLabelText('Show Sagas')).toBeInTheDocument()
+      expect(screen.getByLabelText('Show Payment Rails')).toBeInTheDocument()
+      expect(screen.getByLabelText('Show Party Types')).toBeInTheDocument()
+      expect(screen.getByLabelText('Show Mappings')).toBeInTheDocument()
+      expect(screen.getByLabelText('Show Operational Gateway')).toBeInTheDocument()
+      expect(screen.getByLabelText('Show Provider Connections')).toBeInTheDocument()
+      expect(screen.getByLabelText('Show Instruction Routes')).toBeInTheDocument()
+      expect(screen.getByLabelText('Show Market Data')).toBeInTheDocument()
+      expect(screen.getByLabelText('Show Organizations')).toBeInTheDocument()
+      expect(screen.getByLabelText('Show Internal Accounts')).toBeInTheDocument()
     })
 
     it('shows node counts per type', async () => {

--- a/frontend/src/features/manifests/components/manifest-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.tsx
@@ -217,11 +217,304 @@ const SagaNode = memo(function SagaNode({ data }: { data: ManifestNodeData }) {
   )
 })
 
+const MarketDataNode = memo(function MarketDataNode({ data }: { data: ManifestNodeData }) {
+  const node = data.manifestNode
+  const code = node.data.code as string
+
+  const containerStyle = useMemo(() => ({
+    width: 180,
+    borderColor: data.color,
+    backgroundColor: `color-mix(in oklch, ${data.color} 10%, transparent)`,
+    opacity: data.dimmed ? 0.25 : 1,
+    boxShadow: data.highlighted ? `0 0 12px color-mix(in oklch, ${data.color} 53%, transparent)` : undefined,
+  }), [data.color, data.dimmed, data.highlighted])
+
+  return (
+    <>
+      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center transition-opacity duration-150 cursor-pointer"
+            style={containerStyle}
+          >
+            <span className="text-[11px] font-bold font-mono text-foreground">{code}</span>
+            <span className="text-[10px] text-muted-foreground truncate w-full">{node.label}</span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top">{node.label} ({code})</TooltipContent>
+      </Tooltip>
+      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
+    </>
+  )
+})
+
+const OrganizationNode = memo(function OrganizationNode({ data }: { data: ManifestNodeData }) {
+  const node = data.manifestNode
+  const code = node.data.code as string
+
+  const containerStyle = useMemo(() => ({
+    width: 180,
+    borderColor: data.color,
+    backgroundColor: `color-mix(in oklch, ${data.color} 10%, transparent)`,
+    opacity: data.dimmed ? 0.25 : 1,
+    boxShadow: data.highlighted ? `0 0 12px color-mix(in oklch, ${data.color} 53%, transparent)` : undefined,
+  }), [data.color, data.dimmed, data.highlighted])
+
+  return (
+    <>
+      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center transition-opacity duration-150 cursor-pointer"
+            style={containerStyle}
+          >
+            <span className="text-[11px] font-bold font-mono text-foreground">{code}</span>
+            <span className="text-[10px] text-muted-foreground truncate w-full">{node.label}</span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top">{node.label} ({code})</TooltipContent>
+      </Tooltip>
+      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
+    </>
+  )
+})
+
+const InternalAccountNode = memo(function InternalAccountNode({ data }: { data: ManifestNodeData }) {
+  const node = data.manifestNode
+  const code = node.data.code as string
+  const accountType = node.data.accountType as string | undefined
+
+  const containerStyle = useMemo(() => ({
+    width: 180,
+    borderColor: data.color,
+    backgroundColor: `color-mix(in oklch, ${data.color} 10%, transparent)`,
+    opacity: data.dimmed ? 0.25 : 1,
+    boxShadow: data.highlighted ? `0 0 12px color-mix(in oklch, ${data.color} 53%, transparent)` : undefined,
+  }), [data.color, data.dimmed, data.highlighted])
+
+  return (
+    <>
+      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center transition-opacity duration-150 cursor-pointer"
+            style={containerStyle}
+          >
+            <span className="text-[11px] font-bold font-mono text-foreground">{code}</span>
+            <span className="text-[10px] text-muted-foreground truncate w-full">{node.label}</span>
+            {accountType && <span className="text-[9px] text-muted-foreground">{accountType}</span>}
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top">{node.label} ({code})</TooltipContent>
+      </Tooltip>
+      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
+    </>
+  )
+})
+
+const MappingNode = memo(function MappingNode({ data }: { data: ManifestNodeData }) {
+  const node = data.manifestNode
+
+  const containerStyle = useMemo(() => ({
+    width: 180,
+    borderColor: data.color,
+    backgroundColor: `color-mix(in oklch, ${data.color} 10%, transparent)`,
+    opacity: data.dimmed ? 0.25 : 1,
+    boxShadow: data.highlighted ? `0 0 12px color-mix(in oklch, ${data.color} 53%, transparent)` : undefined,
+  }), [data.color, data.dimmed, data.highlighted])
+
+  return (
+    <>
+      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center transition-opacity duration-150 cursor-pointer"
+            style={containerStyle}
+          >
+            <span className="text-[11px] font-bold font-mono text-foreground truncate w-full">{node.label}</span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top">Mapping: {node.label}</TooltipContent>
+      </Tooltip>
+      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
+    </>
+  )
+})
+
+const PaymentRailNode = memo(function PaymentRailNode({ data }: { data: ManifestNodeData }) {
+  const node = data.manifestNode
+  const provider = node.data.provider as string
+
+  const containerStyle = useMemo(() => ({
+    width: 180,
+    borderColor: data.color,
+    backgroundColor: `color-mix(in oklch, ${data.color} 10%, transparent)`,
+    opacity: data.dimmed ? 0.25 : 1,
+    boxShadow: data.highlighted ? `0 0 12px color-mix(in oklch, ${data.color} 53%, transparent)` : undefined,
+  }), [data.color, data.dimmed, data.highlighted])
+
+  return (
+    <>
+      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center transition-opacity duration-150 cursor-pointer"
+            style={containerStyle}
+          >
+            <span className="text-[11px] font-bold font-mono text-foreground">{provider}</span>
+            <span className="text-[10px] text-muted-foreground truncate w-full">{node.label}</span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top">Payment Rail: {provider}</TooltipContent>
+      </Tooltip>
+      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
+    </>
+  )
+})
+
+const OperationalGatewayNode = memo(function OperationalGatewayNode({ data }: { data: ManifestNodeData }) {
+  const node = data.manifestNode
+
+  const containerStyle = useMemo(() => ({
+    width: 180,
+    borderColor: data.color,
+    backgroundColor: `color-mix(in oklch, ${data.color} 10%, transparent)`,
+    opacity: data.dimmed ? 0.25 : 1,
+    boxShadow: data.highlighted ? `0 0 12px color-mix(in oklch, ${data.color} 53%, transparent)` : undefined,
+  }), [data.color, data.dimmed, data.highlighted])
+
+  return (
+    <>
+      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center transition-opacity duration-150 cursor-pointer"
+            style={containerStyle}
+          >
+            <span className="text-[11px] font-bold text-foreground truncate w-full">{node.label}</span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top">{node.label}</TooltipContent>
+      </Tooltip>
+      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
+    </>
+  )
+})
+
+const ProviderConnectionNode = memo(function ProviderConnectionNode({ data }: { data: ManifestNodeData }) {
+  const node = data.manifestNode
+  const connectionId = node.data.connectionId as string
+
+  const containerStyle = useMemo(() => ({
+    width: 180,
+    borderColor: data.color,
+    backgroundColor: `color-mix(in oklch, ${data.color} 10%, transparent)`,
+    opacity: data.dimmed ? 0.25 : 1,
+    boxShadow: data.highlighted ? `0 0 12px color-mix(in oklch, ${data.color} 53%, transparent)` : undefined,
+  }), [data.color, data.dimmed, data.highlighted])
+
+  return (
+    <>
+      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center transition-opacity duration-150 cursor-pointer"
+            style={containerStyle}
+          >
+            <span className="text-[11px] font-bold text-foreground truncate w-full">{node.label}</span>
+            <span className="text-[9px] text-muted-foreground font-mono">{connectionId}</span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top">{node.label} ({connectionId})</TooltipContent>
+      </Tooltip>
+      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
+    </>
+  )
+})
+
+const InstructionRouteNode = memo(function InstructionRouteNode({ data }: { data: ManifestNodeData }) {
+  const node = data.manifestNode
+  const connectionId = node.data.connectionId as string
+
+  const containerStyle = useMemo(() => ({
+    width: 180,
+    borderColor: data.color,
+    backgroundColor: `color-mix(in oklch, ${data.color} 10%, transparent)`,
+    opacity: data.dimmed ? 0.25 : 1,
+    boxShadow: data.highlighted ? `0 0 12px color-mix(in oklch, ${data.color} 53%, transparent)` : undefined,
+  }), [data.color, data.dimmed, data.highlighted])
+
+  return (
+    <>
+      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center transition-opacity duration-150 cursor-pointer"
+            style={containerStyle}
+          >
+            <span className="text-[11px] font-bold text-foreground truncate w-full">{node.label}</span>
+            <span className="text-[9px] text-muted-foreground font-mono">{connectionId}</span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top">{node.label} via {connectionId}</TooltipContent>
+      </Tooltip>
+      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
+    </>
+  )
+})
+
+const PartyTypeNode = memo(function PartyTypeNode({ data }: { data: ManifestNodeData }) {
+  const node = data.manifestNode
+
+  const containerStyle = useMemo(() => ({
+    width: 180,
+    borderColor: data.color,
+    backgroundColor: `color-mix(in oklch, ${data.color} 10%, transparent)`,
+    opacity: data.dimmed ? 0.25 : 1,
+    boxShadow: data.highlighted ? `0 0 12px color-mix(in oklch, ${data.color} 53%, transparent)` : undefined,
+  }), [data.color, data.dimmed, data.highlighted])
+
+  return (
+    <>
+      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center transition-opacity duration-150 cursor-pointer"
+            style={containerStyle}
+          >
+            <span className="text-[11px] font-bold text-foreground truncate w-full">{node.label}</span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top">Party Type: {node.label}</TooltipContent>
+      </Tooltip>
+      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
+    </>
+  )
+})
+
 const nodeTypes = {
   instrument: InstrumentNode,
   account_type: AccountTypeNode,
   valuation_rule: ValuationRuleNode,
   saga: SagaNode,
+  market_data: MarketDataNode,
+  organization: OrganizationNode,
+  internal_account: InternalAccountNode,
+  mapping: MappingNode,
+  payment_rail: PaymentRailNode,
+  operational_gateway: OperationalGatewayNode,
+  provider_connection: ProviderConnectionNode,
+  instruction_route: InstructionRouteNode,
+  party_type: PartyTypeNode,
 }
 
 function buildReactFlowEdges(manifestEdges: ManifestEdge[]): Edge[] {
@@ -333,7 +626,7 @@ export function ManifestGraph({ manifest, className, _fullscreen }: ManifestGrap
   const [showEventChain, setShowEventChain] = useState(false)
   const [fullscreen, setFullscreen] = useState(false)
   const [visibleTypes, setVisibleTypes] = useState<Set<ManifestNodeType>>(
-    () => new Set<ManifestNodeType>(['instrument', 'account_type', 'valuation_rule', 'saga']),
+    () => new Set<ManifestNodeType>(Object.keys(NODE_TYPE_REGISTRY) as ManifestNodeType[]),
   )
 
   const graph = useMemo(() => buildManifestGraph(manifest), [manifest])
@@ -355,12 +648,9 @@ export function ManifestGraph({ manifest, className, _fullscreen }: ManifestGrap
   const eventChain = useEventChain(graph, eventChainNodeId)
 
   const nodeCountByType = useMemo(() => {
-    const counts: Record<ManifestNodeType, number> = {
-      instrument: 0,
-      account_type: 0,
-      valuation_rule: 0,
-      saga: 0,
-    }
+    const counts = Object.fromEntries(
+      (Object.keys(NODE_TYPE_REGISTRY) as ManifestNodeType[]).map((t) => [t, 0]),
+    ) as Record<ManifestNodeType, number>
     for (const n of graph.nodes) {
       counts[n.type]++
     }

--- a/frontend/src/features/manifests/lib/manifest-graph-model.ts
+++ b/frontend/src/features/manifests/lib/manifest-graph-model.ts
@@ -65,6 +65,25 @@ interface ManifestOperationalGateway {
   [key: string]: unknown
 }
 
+interface ManifestMarketData {
+  code: string
+  name: string
+  [key: string]: unknown
+}
+
+interface ManifestOrganization {
+  code: string
+  name: string
+  [key: string]: unknown
+}
+
+interface ManifestInternalAccount {
+  code: string
+  name: string
+  accountType?: string
+  [key: string]: unknown
+}
+
 interface ManifestInput {
   instruments?: ManifestInstrument[]
   accountTypes?: ManifestAccountType[]
@@ -74,6 +93,9 @@ interface ManifestInput {
   partyTypes?: ManifestPartyType[]
   mappings?: ManifestMapping[]
   operationalGateway?: ManifestOperationalGateway
+  marketData?: ManifestMarketData[]
+  organizations?: ManifestOrganization[]
+  internalAccounts?: ManifestInternalAccount[]
 }
 
 export type ManifestNodeType =
@@ -87,6 +109,9 @@ export type ManifestNodeType =
   | 'operational_gateway'
   | 'provider_connection'
   | 'instruction_route'
+  | 'market_data'
+  | 'organization'
+  | 'internal_account'
 
 export interface SagaTriggerMetadata {
   channel: string
@@ -151,6 +176,9 @@ export function buildManifestGraph(manifest: Manifest): ManifestGraph {
   const partyTypes = m.partyTypes ?? []
   const mappings = m.mappings ?? []
   const operationalGateway = m.operationalGateway
+  const marketDataItems = m.marketData ?? []
+  const organizations = m.organizations ?? []
+  const internalAccounts = m.internalAccounts ?? []
 
   const instrumentCodes = new Set(instruments.map((i) => i.code))
 
@@ -401,6 +429,36 @@ export function buildManifestGraph(manifest: Manifest): ManifestGraph {
         })
       }
     }
+  }
+
+  // Market data
+  for (const md of marketDataItems) {
+    nodes.push({
+      id: `market_data:${md.code}`,
+      type: 'market_data',
+      label: md.name,
+      data: { ...md },
+    })
+  }
+
+  // Organizations
+  for (const org of organizations) {
+    nodes.push({
+      id: `organization:${org.code}`,
+      type: 'organization',
+      label: org.name,
+      data: { ...org },
+    })
+  }
+
+  // Internal accounts
+  for (const ia of internalAccounts) {
+    nodes.push({
+      id: `internal_account:${ia.code}`,
+      type: 'internal_account',
+      label: ia.name,
+      data: { ...ia },
+    })
   }
 
   return { nodes, edges }

--- a/frontend/src/features/manifests/lib/node-type-registry.test.ts
+++ b/frontend/src/features/manifests/lib/node-type-registry.test.ts
@@ -12,6 +12,15 @@ describe('NODE_TYPE_REGISTRY', () => {
     'account_type',
     'valuation_rule',
     'saga',
+    'payment_rail',
+    'party_type',
+    'mapping',
+    'operational_gateway',
+    'provider_connection',
+    'instruction_route',
+    'market_data',
+    'organization',
+    'internal_account',
   ]
 
   it('has entries for all current ManifestNodeType values', () => {

--- a/frontend/src/features/manifests/lib/node-type-registry.ts
+++ b/frontend/src/features/manifests/lib/node-type-registry.ts
@@ -64,6 +64,21 @@ export const NODE_TYPE_REGISTRY: Record<ManifestNodeType, NodeTypeConfig> = {
     label: 'Instruction Routes',
     layerPriority: '4',
   },
+  market_data: {
+    color: 'var(--graph-market-data)',
+    label: 'Market Data',
+    layerPriority: '3',
+  },
+  organization: {
+    color: 'var(--graph-organization)',
+    label: 'Organizations',
+    layerPriority: '2',
+  },
+  internal_account: {
+    color: 'var(--graph-internal-account)',
+    label: 'Internal Accounts',
+    layerPriority: '1',
+  },
 }
 
 /** Derived view: { color, label } per node type, compatible with existing NODE_THEMES usage. */


### PR DESCRIPTION
## Summary

- Create 9 new React node components for manifest graph visualization: `MarketDataNode`, `OrganizationNode`, `InternalAccountNode`, `MappingNode`, `PaymentRailNode`, `OperationalGatewayNode`, `ProviderConnectionNode`, `InstructionRouteNode`, `PartyTypeNode`
- Extend `ManifestNodeType` union with 3 new types (`market_data`, `organization`, `internal_account`) and add them to `NODE_TYPE_REGISTRY` and graph model builder
- Register all 13 node types in the `nodeTypes` record; update `visibleTypes` and `nodeCountByType` to dynamically derive from registry

## Test plan

- [x] All 137 existing manifests tests pass
- [x] Updated `node-type-registry.test.ts` to verify all 13 types
- [x] Updated `manifest-graph.test.tsx` to verify all 13 filter checkboxes render
- [x] TypeScript typecheck passes
- [x] ESLint passes