### PR TITLE
feat: add valuation_rule case to graph node double-click handler

### DIFF
--- a/frontend/src/features/manifests/components/manifest-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.tsx
@@ -453,6 +453,9 @@ export function ManifestGraph({ manifest, className, _fullscreen }: ManifestGrap
         case 'account_type':
           navigate('/reference-data/account-types')
           break
+        case 'valuation_rule':
+          navigate('/reference-data/valuation-rules')
+          break
         case 'saga':
           navigate(`/starlark-config/${mn.label}`)
           break

--- a/frontend/src/features/manifests/components/manifest-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.tsx
@@ -169,7 +169,7 @@ const ValuationRuleNode = memo(function ValuationRuleNode({ data }: { data: Mani
       <Tooltip>
         <TooltipTrigger asChild>
           <div
-            className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center transition-opacity duration-150"
+            className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center transition-opacity duration-150 cursor-pointer"
             style={containerStyle}
           >
             <span className="text-[10px] font-semibold text-foreground">{from} &rarr; {to}</span>


### PR DESCRIPTION
## Summary
- Adds `valuation_rule` case to the double-click handler in `manifest-graph.tsx`
- Double-clicking a valuation rule node now navigates to `/reference-data/valuation-rules`
- Follows the same pattern as `instrument` (→ instruments page) and `account_type` (→ account-types page)

## Changes Made
- `frontend/src/features/manifests/components/manifest-graph.tsx`: Added `case 'valuation_rule'` to `onNodeDoubleClick` switch statement

## Testing
- TypeScript typecheck: passing
- ESLint: passing (no new warnings)
- Manifest graph unit tests: 57/57 passing