### PR TITLE
feat: extend double-click navigation to all new node types in manifest graph

### DIFF
--- a/frontend/src/features/manifests/components/manifest-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.tsx
@@ -743,8 +743,34 @@ export function ManifestGraph({ manifest, className, _fullscreen }: ManifestGrap
         case 'account_type':
           navigate('/reference-data/account-types')
           break
+        case 'valuation_rule':
+          navigate('/reference-data/valuation-rules')
+          break
         case 'saga':
           navigate(`/starlark-config/${mn.label}`)
+          break
+        case 'market_data': {
+          const code = mn.data.code as string | undefined
+          navigate(code ? `/market-data/${code}` : '/market-data')
+          break
+        }
+        case 'organization':
+          navigate('/reference-data/nodes')
+          break
+        case 'internal_account':
+          navigate('/internal-accounts')
+          break
+        case 'mapping':
+          navigate('/gateway-mappings')
+          break
+        case 'payment_rail':
+        case 'operational_gateway':
+        case 'provider_connection':
+        case 'instruction_route':
+          navigate('/reference-data')
+          break
+        case 'party_type':
+          navigate('/parties')
           break
       }
     },


### PR DESCRIPTION
## Summary

- Extends `onNodeDoubleClick` in `manifest-graph.tsx` to handle all 9 node types that previously had no navigation
- Types with dedicated list pages navigate directly: `valuation_rule` → `/reference-data/valuation-rules`, `market_data` → `/market-data/:code`, `organization` → `/reference-data/nodes`, `internal_account` → `/internal-accounts`, `mapping` → `/gateway-mappings`, `party_type` → `/parties`
- Types without dedicated pages fall back to the reference-data hub: `payment_rail`, `operational_gateway`, `provider_connection`, `instruction_route`

## Changes Made

- `frontend/src/features/manifests/components/manifest-graph.tsx`: Added cases for all 9 missing node types in the `onNodeDoubleClick` switch statement

## Testing

- TypeScript typecheck passes with no errors
- ESLint passes with no errors
- Navigation targets verified against available routes in `App.tsx`

## Task Master

046-economy-visualization-completeness.13