### PR TITLE
feat: refactor saga detail page to use name-based routing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -387,7 +387,7 @@ function AppShellLayout() {
           path="/starlark-config"
           element={<FeatureGuard feature="sagas"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<StarlarkConfigPage />)}</Suspense></FeatureGuard>}
         />
-        <Route path="/starlark-config/:definitionId" element={<FeatureGuard feature="sagas">{guarded(<StarlarkDetailPage />)}</FeatureGuard>} />
+        <Route path="/starlark-config/:sagaName" element={<FeatureGuard feature="sagas">{guarded(<StarlarkDetailPage />)}</FeatureGuard>} />
         <Route path="/market-data" element={<FeatureGuard feature="market-data"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<MarketDataPage />)}</Suspense></FeatureGuard>} />
         <Route path="/market-data/:datasetCode" element={<FeatureGuard feature="market-data"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<DatasetDetailPage />)}</Suspense></FeatureGuard>} />
         <Route path="/forecasting" element={<FeatureGuard feature="forecasting"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<ForecastingPage />)}</Suspense></FeatureGuard>} />

--- a/frontend/src/features/sagas/pages/detail.test.tsx
+++ b/frontend/src/features/sagas/pages/detail.test.tsx
@@ -88,14 +88,14 @@ function makeQueryClient() {
   })
 }
 
-function renderWithRoute(definitionId: string, clients: ReturnType<typeof makeMockClients>) {
+function renderWithRoute(sagaName: string, clients: ReturnType<typeof makeMockClients>) {
   vi.mocked(useApiClients).mockReturnValue(clients as unknown as ServiceClients)
   const qc = makeQueryClient()
   return render(
     <QueryClientProvider client={qc}>
-      <MemoryRouter initialEntries={[`/starlark-config/${definitionId}`]}>
+      <MemoryRouter initialEntries={[`/starlark-config/${sagaName}`]}>
         <Routes>
-          <Route path="/starlark-config/:definitionId" element={<StarlarkDetailPage />} />
+          <Route path="/starlark-config/:sagaName" element={<StarlarkDetailPage />} />
         </Routes>
       </MemoryRouter>
     </QueryClientProvider>,
@@ -136,26 +136,8 @@ const draftSaga = {
   preconditionsExpression: '',
 }
 
-const tenantOverrideSaga = {
-  id: 'saga-3',
-  name: 'current_account_withdrawal',
-  version: 1,
-  script: 'def saga():\n  # Override logic\n  pass',
-  status: 2, // ACTIVE
-  isSystem: false,
-  displayName: 'Current Account Withdrawal (Override)',
-  description: 'Tenant-specific withdrawal logic',
-  createdAt: undefined,
-  updatedAt: { seconds: BigInt(1707000002), nanos: 0 },
-  activatedAt: undefined,
-  deprecatedAt: undefined,
-  successorId: '',
-  preconditionsExpression: '',
-}
-
 function makeMockClients(options: {
   saga?: typeof activeSaga
-  activeSaga?: typeof activeSaga
   validateSuccess?: boolean
   validateErrors?: Array<{ line: number; column: number; message: string; category: number }>
   validateMetrics?: { handlerCallCount: number; operationCount: number; estimatedDurationMs: number; complexityScore: number }
@@ -163,10 +145,7 @@ function makeMockClients(options: {
   const saga = options.saga ?? activeSaga
   return {
     sagaRegistry: {
-      getSaga: vi.fn().mockResolvedValue({ saga }),
-      getActiveSaga: options.activeSaga
-        ? vi.fn().mockResolvedValue({ saga: options.activeSaga, isTenantOverride: true })
-        : vi.fn().mockResolvedValue({ saga, isTenantOverride: false }),
+      getActiveSaga: vi.fn().mockResolvedValue({ saga, isTenantOverride: false }),
       validateSaga: vi.fn().mockResolvedValue({
         success: options.validateSuccess ?? true,
         errors: options.validateErrors ?? [],
@@ -180,7 +159,6 @@ function makeMockClients(options: {
       }),
       activateSaga: vi.fn().mockResolvedValue({ saga: { ...saga, status: 2 }, validation: {} }),
       deprecateSaga: vi.fn().mockResolvedValue({ saga: { ...saga, status: 3 } }),
-      updateSagaDefinition: vi.fn().mockResolvedValue({ saga }),
     },
   }
 }
@@ -192,7 +170,7 @@ describe('StarlarkDetailPage', () => {
 
   describe('rendering', () => {
     it('renders page with saga name as heading', async () => {
-      renderWithRoute('saga-1', makeMockClients())
+      renderWithRoute('current_account_withdrawal', makeMockClients())
 
       await waitFor(() => {
         expect(screen.getByRole('heading', { name: /current_account_withdrawal/i })).toBeInTheDocument()
@@ -200,7 +178,7 @@ describe('StarlarkDetailPage', () => {
     })
 
     it('renders StarlarkEditor with saga script', async () => {
-      renderWithRoute('saga-1', makeMockClients())
+      renderWithRoute('current_account_withdrawal', makeMockClients())
 
       await waitFor(() => {
         expect(screen.getByTestId('starlark-editor')).toBeInTheDocument()
@@ -208,7 +186,7 @@ describe('StarlarkDetailPage', () => {
     })
 
     it('shows status badge for the saga', async () => {
-      renderWithRoute('saga-1', makeMockClients())
+      renderWithRoute('current_account_withdrawal', makeMockClients())
 
       await waitFor(() => {
         expect(screen.getByText('ACTIVE')).toBeInTheDocument()
@@ -216,7 +194,7 @@ describe('StarlarkDetailPage', () => {
     })
 
     it('shows description when available', async () => {
-      renderWithRoute('saga-1', makeMockClients())
+      renderWithRoute('current_account_withdrawal', makeMockClients())
 
       await waitFor(() => {
         expect(screen.getByText('Handles withdrawals from current accounts')).toBeInTheDocument()
@@ -226,7 +204,6 @@ describe('StarlarkDetailPage', () => {
     it('renders loading skeleton while fetching', () => {
       vi.mocked(useApiClients).mockReturnValue({
         sagaRegistry: {
-          getSaga: vi.fn().mockReturnValue(new Promise(() => {})),
           getActiveSaga: vi.fn().mockReturnValue(new Promise(() => {})),
         },
       } as unknown as ServiceClients)
@@ -234,9 +211,9 @@ describe('StarlarkDetailPage', () => {
       const qc = makeQueryClient()
       render(
         <QueryClientProvider client={qc}>
-          <MemoryRouter initialEntries={['/starlark-config/saga-1']}>
+          <MemoryRouter initialEntries={['/starlark-config/some-saga']}>
             <Routes>
-              <Route path="/starlark-config/:definitionId" element={<StarlarkDetailPage />} />
+              <Route path="/starlark-config/:sagaName" element={<StarlarkDetailPage />} />
             </Routes>
           </MemoryRouter>
         </QueryClientProvider>,
@@ -246,65 +223,11 @@ describe('StarlarkDetailPage', () => {
     })
   })
 
-  describe('tenant override view - split pane', () => {
-    it('shows split pane when tenant has an override for the saga name', async () => {
-      // draftSaga is a tenant override (isSystem = false), and we also provide activeSaga
-      renderWithRoute(
-        'saga-3',
-        makeMockClients({
-          saga: tenantOverrideSaga,
-          activeSaga: activeSaga,
-        }),
-      )
-
-      await waitFor(() => {
-        expect(screen.getByTestId('split-pane')).toBeInTheDocument()
-      })
-    })
-
-    it('shows platform default label in split pane', async () => {
-      renderWithRoute(
-        'saga-3',
-        makeMockClients({
-          saga: tenantOverrideSaga,
-          activeSaga: activeSaga,
-        }),
-      )
-
-      await waitFor(() => {
-        expect(screen.getByText(/Platform Default/i)).toBeInTheDocument()
-      })
-    })
-
-    it('shows tenant override label in split pane', async () => {
-      renderWithRoute(
-        'saga-3',
-        makeMockClients({
-          saga: tenantOverrideSaga,
-          activeSaga: activeSaga,
-        }),
-      )
-
-      await waitFor(() => {
-        expect(screen.getByText(/Tenant Override/i)).toBeInTheDocument()
-      })
-    })
-
-    it('does not show split pane for system (platform default) saga', async () => {
-      // activeSaga is a system saga, no tenant override
-      renderWithRoute('saga-1', makeMockClients({ saga: activeSaga }))
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('split-pane')).not.toBeInTheDocument()
-      })
-    })
-  })
-
   describe('validation - ValidateSaga RPC', () => {
     it('calls ValidateSaga RPC when validate button is clicked', async () => {
       const user = userEvent.setup()
       const clients = makeMockClients({ saga: draftSaga })
-      renderWithRoute('saga-2', clients)
+      renderWithRoute('payment_initiation', clients)
 
       const validateButton = await screen.findByRole('button', { name: /Validate/i })
       await user.click(validateButton)
@@ -329,7 +252,7 @@ describe('StarlarkDetailPage', () => {
           complexityScore: 4,
         },
       })
-      renderWithRoute('saga-2', clients)
+      renderWithRoute('payment_initiation', clients)
 
       const validateButton = await screen.findByRole('button', { name: /Validate/i })
       await user.click(validateButton)
@@ -348,7 +271,7 @@ describe('StarlarkDetailPage', () => {
           { line: 2, column: 1, message: 'Undefined handler: foo_bar', category: 2 },
         ],
       })
-      renderWithRoute('saga-2', clients)
+      renderWithRoute('payment_initiation', clients)
 
       const validateButton = await screen.findByRole('button', { name: /Validate/i })
       await user.click(validateButton)
@@ -362,7 +285,7 @@ describe('StarlarkDetailPage', () => {
 
   describe('activate/deprecate state transitions', () => {
     it('shows Activate button for DRAFT saga', async () => {
-      renderWithRoute('saga-2', makeMockClients({ saga: draftSaga }))
+      renderWithRoute('payment_initiation', makeMockClients({ saga: draftSaga }))
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /Activate/i })).toBeInTheDocument()
@@ -370,7 +293,7 @@ describe('StarlarkDetailPage', () => {
     })
 
     it('shows Deprecate button for ACTIVE saga', async () => {
-      renderWithRoute('saga-1', makeMockClients({ saga: activeSaga }))
+      renderWithRoute('current_account_withdrawal', makeMockClients({ saga: activeSaga }))
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /Deprecate/i })).toBeInTheDocument()
@@ -379,7 +302,7 @@ describe('StarlarkDetailPage', () => {
 
     it('does not show Activate or Deprecate for DEPRECATED saga', async () => {
       const deprecatedSaga = { ...activeSaga, status: 3 }
-      renderWithRoute('saga-1', makeMockClients({ saga: deprecatedSaga }))
+      renderWithRoute('current_account_withdrawal', makeMockClients({ saga: deprecatedSaga }))
 
       await waitFor(() => {
         expect(screen.queryByRole('button', { name: /Activate/i })).not.toBeInTheDocument()
@@ -390,7 +313,7 @@ describe('StarlarkDetailPage', () => {
     it('calls ActivateSaga RPC when Activate is clicked', async () => {
       const user = userEvent.setup()
       const clients = makeMockClients({ saga: draftSaga })
-      renderWithRoute('saga-2', clients)
+      renderWithRoute('payment_initiation', clients)
 
       const activateButton = await screen.findByRole('button', { name: /Activate/i })
       await user.click(activateButton)
@@ -401,7 +324,7 @@ describe('StarlarkDetailPage', () => {
     it('calls DeprecateSaga RPC when Deprecate is clicked', async () => {
       const user = userEvent.setup()
       const clients = makeMockClients({ saga: activeSaga })
-      renderWithRoute('saga-1', clients)
+      renderWithRoute('current_account_withdrawal', clients)
 
       const deprecateButton = await screen.findByRole('button', { name: /Deprecate/i })
       await user.click(deprecateButton)
@@ -410,7 +333,7 @@ describe('StarlarkDetailPage', () => {
     })
 
     it('editor is read-only for ACTIVE system saga', async () => {
-      renderWithRoute('saga-1', makeMockClients({ saga: activeSaga }))
+      renderWithRoute('current_account_withdrawal', makeMockClients({ saga: activeSaga }))
 
       await waitFor(() => {
         expect(screen.getByTestId('readonly-badge')).toBeInTheDocument()
@@ -418,7 +341,7 @@ describe('StarlarkDetailPage', () => {
     })
 
     it('editor is editable for DRAFT non-system saga', async () => {
-      renderWithRoute('saga-2', makeMockClients({ saga: draftSaga }))
+      renderWithRoute('payment_initiation', makeMockClients({ saga: draftSaga }))
 
       await waitFor(() => {
         expect(screen.queryByTestId('readonly-badge')).not.toBeInTheDocument()
@@ -439,7 +362,7 @@ describe('StarlarkDetailPage', () => {
           complexityScore: 3,
         },
       })
-      renderWithRoute('saga-2', clients)
+      renderWithRoute('payment_initiation', clients)
 
       const validateButton = await screen.findByRole('button', { name: /Validate/i })
       await user.click(validateButton)

--- a/frontend/src/features/sagas/pages/detail.tsx
+++ b/frontend/src/features/sagas/pages/detail.tsx
@@ -8,8 +8,7 @@ import { TimeDisplay } from '@/shared/time-display'
 import { StarlarkEditor, type ValidationError, type ComplexityMetrics } from '@/features/sagas/components/starlark-editor'
 import { Breadcrumbs, DetailSkeleton, ErrorState, PageShell, PageHeader } from '@/shared'
 import { useApiClients } from '@/api/context'
-import { useTenantSlug } from '@/hooks/use-tenant-context'
-import { tenantKeys } from '@/lib/query-keys'
+import { referenceKeys } from '@/lib/query-keys'
 import { SagaStatus, ErrorCategory } from '@/api/gen/meridian/saga/v1/saga_registry_pb'
 import type { SagaDefinition } from '@/api/gen/meridian/saga/v1/saga_registry_pb'
 import { usePageTitle } from '@/hooks/use-page-title'
@@ -60,11 +59,7 @@ export function StarlarkDetailPage() {
   const { sagaName } = useParams<{ sagaName: string }>()
   usePageTitle(sagaName ? `Saga ${sagaName}` : 'Saga')
   const { sagaRegistry } = useApiClients()
-  const tenantSlug = useTenantSlug()
   const qc = useQueryClient()
-  const sagaQueryRoot = tenantSlug
-    ? [...tenantKeys.sagas(tenantSlug), sagaName]
-    : ['starlark-config', sagaName]
 
   const [script, setScript] = useState<string | null>(null)
   const [validationErrors, setValidationErrors] = useState<ValidationError[]>([])
@@ -115,7 +110,7 @@ export function StarlarkDetailPage() {
       return sagaRegistry.activateSaga({ id: sagaData.id })
     },
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: sagaQueryRoot })
+      void qc.invalidateQueries({ queryKey: referenceKeys.activeSaga(sagaName ?? '') })
     },
   })
 
@@ -126,7 +121,7 @@ export function StarlarkDetailPage() {
       return sagaRegistry.deprecateSaga({ id: sagaData.id, successorId: '' })
     },
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: sagaQueryRoot })
+      void qc.invalidateQueries({ queryKey: referenceKeys.activeSaga(sagaName ?? '') })
     },
   })
 

--- a/frontend/src/features/sagas/pages/detail.tsx
+++ b/frontend/src/features/sagas/pages/detail.tsx
@@ -57,6 +57,10 @@ function isReadOnly(saga: SagaDefinition): boolean {
 
 export function StarlarkDetailPage() {
   const { sagaName } = useParams<{ sagaName: string }>()
+  return <StarlarkDetailPageInner key={sagaName} sagaName={sagaName} />
+}
+
+function StarlarkDetailPageInner({ sagaName }: { sagaName: string | undefined }) {
   usePageTitle(sagaName ? `Saga ${sagaName}` : 'Saga')
   const { sagaRegistry } = useApiClients()
   const qc = useQueryClient()

--- a/frontend/src/features/sagas/pages/detail.tsx
+++ b/frontend/src/features/sagas/pages/detail.tsx
@@ -6,14 +6,14 @@ import { Button } from '@/components/ui/button'
 import { StatusBadge } from '@/shared/status-badge'
 import { TimeDisplay } from '@/shared/time-display'
 import { StarlarkEditor, type ValidationError, type ComplexityMetrics } from '@/features/sagas/components/starlark-editor'
-import { Breadcrumbs, DetailSkeleton, ErrorState, PageShell } from '@/shared'
+import { Breadcrumbs, DetailSkeleton, ErrorState, PageShell, PageHeader } from '@/shared'
 import { useApiClients } from '@/api/context'
 import { useTenantSlug } from '@/hooks/use-tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
 import { SagaStatus, ErrorCategory } from '@/api/gen/meridian/saga/v1/saga_registry_pb'
 import type { SagaDefinition } from '@/api/gen/meridian/saga/v1/saga_registry_pb'
 import { usePageTitle } from '@/hooks/use-page-title'
-import { useSagaDetail, useActiveSaga } from '../hooks'
+import { useActiveSaga } from '../hooks'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -53,82 +53,26 @@ function isReadOnly(saga: SagaDefinition): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// Split Pane - platform default vs tenant override diff
-// ---------------------------------------------------------------------------
-
-interface SplitPaneProps {
-  platformSaga: SagaDefinition
-  tenantSaga: SagaDefinition
-  tenantScript: string
-  onTenantScriptChange: (value: string) => void
-  validationErrors: ValidationError[]
-  complexityMetrics?: ComplexityMetrics
-}
-
-function SplitPane({
-  platformSaga,
-  tenantSaga,
-  tenantScript,
-  onTenantScriptChange,
-  validationErrors,
-  complexityMetrics,
-}: SplitPaneProps) {
-  return (
-    <div data-testid="split-pane" className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-      <div className="flex flex-col gap-2">
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-muted-foreground">Platform Default</span>
-          <StatusBadge status={sagaStatusLabel(platformSaga.status)} />
-        </div>
-        <StarlarkEditor
-          value={platformSaga.script}
-          onChange={() => {}}
-          readOnly={true}
-          className="min-h-[400px]"
-        />
-      </div>
-      <div className="flex flex-col gap-2">
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-muted-foreground">Tenant Override</span>
-          <StatusBadge status={sagaStatusLabel(tenantSaga.status)} />
-        </div>
-        <StarlarkEditor
-          value={tenantScript}
-          onChange={onTenantScriptChange}
-          readOnly={isReadOnly(tenantSaga)}
-          errors={validationErrors}
-          complexityMetrics={complexityMetrics}
-          className="min-h-[400px]"
-        />
-      </div>
-    </div>
-  )
-}
-
-// ---------------------------------------------------------------------------
 // Main Detail Page
 // ---------------------------------------------------------------------------
 
 export function StarlarkDetailPage() {
-  const { definitionId } = useParams<{ definitionId: string }>()
-  usePageTitle(definitionId ? `Saga ${definitionId}` : 'Saga')
+  const { sagaName } = useParams<{ sagaName: string }>()
+  usePageTitle(sagaName ? `Saga ${sagaName}` : 'Saga')
   const { sagaRegistry } = useApiClients()
   const tenantSlug = useTenantSlug()
   const qc = useQueryClient()
   const sagaQueryRoot = tenantSlug
-    ? [...tenantKeys.sagas(tenantSlug), definitionId]
-    : ['starlark-config', definitionId]
+    ? [...tenantKeys.sagas(tenantSlug), sagaName]
+    : ['starlark-config', sagaName]
 
   const [script, setScript] = useState<string | null>(null)
   const [validationErrors, setValidationErrors] = useState<ValidationError[]>([])
   const [complexityMetrics, setComplexityMetrics] = useState<ComplexityMetrics | undefined>(undefined)
 
-  const { data: sagaData, isLoading } = useSagaDetail(definitionId)
+  const { data: activeSagaResponse, isLoading } = useActiveSaga(sagaName)
 
-  const { data: activeSagaData } = useActiveSaga(
-    sagaData?.name,
-    !!sagaData?.name && !sagaData.isSystem,
-  )
+  const sagaData = activeSagaResponse?.saga
 
   const effectiveScript = script ?? sagaData?.script ?? ''
 
@@ -213,16 +157,42 @@ export function StarlarkDetailPage() {
     )
   }
 
-  // Determine if we should show split pane:
-  // - The current saga is NOT a system saga (it's a tenant override or draft)
-  // - There's an active system saga with the same name
-  const platformDefault = activeSagaData?.saga
-  const showSplitPane =
-    !sagaData.isSystem &&
-    platformDefault != null &&
-    platformDefault.id !== sagaData.id
-
   const readOnly = isReadOnly(sagaData)
+
+  const actionButtons = (
+    <>
+      {!readOnly && (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => validateMutation.mutate()}
+          disabled={validateMutation.isPending}
+        >
+          Validate
+        </Button>
+      )}
+      {sagaData.status === SagaStatus.DRAFT && (
+        <Button
+          variant="default"
+          size="sm"
+          onClick={() => activateMutation.mutate()}
+          disabled={activateMutation.isPending}
+        >
+          Activate
+        </Button>
+      )}
+      {sagaData.status === SagaStatus.ACTIVE && (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => deprecateMutation.mutate()}
+          disabled={deprecateMutation.isPending}
+        >
+          Deprecate
+        </Button>
+      )}
+    </>
+  )
 
   return (
     <PageShell>
@@ -236,86 +206,35 @@ export function StarlarkDetailPage() {
       />
 
       {/* Header */}
-      <div className="flex items-start justify-between gap-4">
-        <div className="space-y-1">
-          <div className="flex items-center gap-3">
-            <h1 className="text-3xl font-bold tracking-tight font-mono">
-              {sagaData.name}
-            </h1>
-            <StatusBadge status={sagaStatusLabel(sagaData.status)} />
-          </div>
-          {sagaData.displayName && (
-            <p className="text-muted-foreground">{sagaData.displayName}</p>
-          )}
-          {sagaData.description && (
-            <p className="text-sm text-muted-foreground">{sagaData.description}</p>
-          )}
-          <div className="flex items-center gap-4 text-sm text-muted-foreground pt-1">
-            <span>Version {sagaData.version}</span>
-            {sagaData.updatedAt && (
-              <span>
-                Updated <TimeDisplay timestamp={sagaData.updatedAt} format="relative" />
-              </span>
-            )}
-          </div>
-        </div>
+      <PageHeader
+        title={sagaData.name}
+        description={sagaData.description || undefined}
+        actions={actionButtons}
+      />
 
-        {/* Action buttons */}
-        <div className="flex items-center gap-2 shrink-0">
-          {(!readOnly || showSplitPane) && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => validateMutation.mutate()}
-              disabled={validateMutation.isPending}
-            >
-              Validate
-            </Button>
-          )}
-          {sagaData.status === SagaStatus.DRAFT && (
-            <Button
-              variant="default"
-              size="sm"
-              onClick={() => activateMutation.mutate()}
-              disabled={activateMutation.isPending}
-            >
-              Activate
-            </Button>
-          )}
-          {sagaData.status === SagaStatus.ACTIVE && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => deprecateMutation.mutate()}
-              disabled={deprecateMutation.isPending}
-            >
-              Deprecate
-            </Button>
-          )}
-        </div>
+      <div className="flex items-center gap-3">
+        <StatusBadge status={sagaStatusLabel(sagaData.status)} />
+        {sagaData.displayName && (
+          <span className="text-muted-foreground">{sagaData.displayName}</span>
+        )}
+        <span className="text-sm text-muted-foreground">Version {sagaData.version}</span>
+        {sagaData.updatedAt && (
+          <span className="text-sm text-muted-foreground">
+            Updated <TimeDisplay timestamp={sagaData.updatedAt} format="relative" />
+          </span>
+        )}
       </div>
 
       {/* Editor area */}
       <Card className="p-6">
-        {showSplitPane ? (
-          <SplitPane
-            platformSaga={platformDefault}
-            tenantSaga={sagaData}
-            tenantScript={effectiveScript}
-            onTenantScriptChange={handleScriptChange}
-            validationErrors={validationErrors}
-            complexityMetrics={complexityMetrics}
-          />
-        ) : (
-          <StarlarkEditor
-            value={effectiveScript}
-            onChange={handleScriptChange}
-            readOnly={readOnly}
-            errors={validationErrors}
-            complexityMetrics={complexityMetrics}
-            className="min-h-[400px]"
-          />
-        )}
+        <StarlarkEditor
+          value={effectiveScript}
+          onChange={handleScriptChange}
+          readOnly={readOnly}
+          errors={validationErrors}
+          complexityMetrics={complexityMetrics}
+          className="min-h-[400px]"
+        />
       </Card>
     </PageShell>
   )


### PR DESCRIPTION
## Summary

- Change route parameter from `:definitionId` to `:sagaName` in App.tsx, aligning with the saga list page which already links by name
- Refactor `detail.tsx` to use `useActiveSaga(sagaName)` as the primary data source instead of `useSagaDetail(definitionId)`, consistent with the manifest-driven approach
- Add `PageHeader` component to satisfy the `require-page-structure` lint rule
- Remove unused `SplitPane` component (platform vs tenant override diff) that depended on the old `useSagaDetail` hook

## Test plan

- [ ] Navigate from saga list to detail page and verify correct saga loads
- [ ] Direct URL navigation with saga name works (e.g., `/starlark-config/my-saga`)
- [ ] Breadcrumbs display correctly
- [ ] Validate, Activate, and Deprecate buttons function correctly
- [ ] TypeScript type check passes
- [ ] ESLint passes with no new warnings