### PR TITLE
fix: enable AUTH_ENABLED in all K8s service configmaps

### DIFF
--- a/services/control-plane/k8s/configmap.yaml
+++ b/services/control-plane/k8s/configmap.yaml
@@ -25,4 +25,4 @@ data:
   OTEL_SAMPLING_RATE: "0.1"
 
   # Authentication configuration
-  AUTH_ENABLED: "false"
+  AUTH_ENABLED: "true"

--- a/services/control-plane/k8s/configmap.yaml
+++ b/services/control-plane/k8s/configmap.yaml
@@ -26,3 +26,4 @@ data:
 
   # Authentication configuration
   AUTH_ENABLED: "true"
+  AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"

--- a/services/current-account/k8s/configmap.yaml
+++ b/services/current-account/k8s/configmap.yaml
@@ -44,5 +44,5 @@ data:
 
   # Authentication configuration
   # Set to "true" to require JWT validation on gRPC calls
-  AUTH_ENABLED: "false"
+  AUTH_ENABLED: "true"
   # AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"

--- a/services/current-account/k8s/configmap.yaml
+++ b/services/current-account/k8s/configmap.yaml
@@ -45,4 +45,4 @@ data:
   # Authentication configuration
   # Set to "true" to require JWT validation on gRPC calls
   AUTH_ENABLED: "true"
-  # AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"
+  AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"

--- a/services/financial-accounting/k8s/configmap.yaml
+++ b/services/financial-accounting/k8s/configmap.yaml
@@ -29,7 +29,7 @@ data:
 
   # Authentication configuration
   AUTH_ENABLED: "true"
-  # AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"
+  AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"
 
   # Feature flags
   FEATURE_INCOMPLETE_IMPLEMENTATION: "true"

--- a/services/financial-accounting/k8s/configmap.yaml
+++ b/services/financial-accounting/k8s/configmap.yaml
@@ -28,7 +28,7 @@ data:
   REDIS_URL: "redis://redis:6379"
 
   # Authentication configuration
-  AUTH_ENABLED: "false"
+  AUTH_ENABLED: "true"
   # AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"
 
   # Feature flags

--- a/services/forecasting/k8s/configmap.yaml
+++ b/services/forecasting/k8s/configmap.yaml
@@ -28,4 +28,4 @@ data:
   REDIS_ADDR: "redis:6379"
 
   # Authentication configuration
-  AUTH_ENABLED: "false"
+  AUTH_ENABLED: "true"

--- a/services/forecasting/k8s/configmap.yaml
+++ b/services/forecasting/k8s/configmap.yaml
@@ -29,3 +29,4 @@ data:
 
   # Authentication configuration
   AUTH_ENABLED: "true"
+  AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"

--- a/services/internal-account/k8s/configmap.yaml
+++ b/services/internal-account/k8s/configmap.yaml
@@ -29,5 +29,5 @@ data:
 
   # Authentication configuration
   # Set to "true" to require JWT validation on gRPC calls
-  AUTH_ENABLED: "false"
+  AUTH_ENABLED: "true"
   # AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"

--- a/services/internal-account/k8s/configmap.yaml
+++ b/services/internal-account/k8s/configmap.yaml
@@ -30,4 +30,4 @@ data:
   # Authentication configuration
   # Set to "true" to require JWT validation on gRPC calls
   AUTH_ENABLED: "true"
-  # AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"
+  AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"

--- a/services/market-information/k8s/configmap.yaml
+++ b/services/market-information/k8s/configmap.yaml
@@ -27,4 +27,4 @@ data:
   # Authentication configuration
   # Set to "true" to require JWT validation on gRPC calls
   AUTH_ENABLED: "true"
-  # AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"
+  AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"

--- a/services/market-information/k8s/configmap.yaml
+++ b/services/market-information/k8s/configmap.yaml
@@ -26,5 +26,5 @@ data:
 
   # Authentication configuration
   # Set to "true" to require JWT validation on gRPC calls
-  AUTH_ENABLED: "false"
+  AUTH_ENABLED: "true"
   # AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"

--- a/services/party/k8s/configmap.yaml
+++ b/services/party/k8s/configmap.yaml
@@ -26,6 +26,7 @@ data:
 
   # Authentication configuration
   AUTH_ENABLED: "true"
+  AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"
 
   # KYC/AML verification - mock provider for local development
   VERIFICATION_PROVIDER: "mock"

--- a/services/party/k8s/configmap.yaml
+++ b/services/party/k8s/configmap.yaml
@@ -25,7 +25,7 @@ data:
   OTEL_SAMPLING_RATE: "0.1"
 
   # Authentication configuration
-  AUTH_ENABLED: "false"
+  AUTH_ENABLED: "true"
 
   # KYC/AML verification - mock provider for local development
   VERIFICATION_PROVIDER: "mock"

--- a/services/payment-order/k8s/configmap.yaml
+++ b/services/payment-order/k8s/configmap.yaml
@@ -29,6 +29,7 @@ data:
 
   # Authentication configuration
   AUTH_ENABLED: "true"
+  AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"
 
   # Redis configuration
   REDIS_URL: "redis://redis:6379"

--- a/services/payment-order/k8s/configmap.yaml
+++ b/services/payment-order/k8s/configmap.yaml
@@ -28,7 +28,7 @@ data:
   OTEL_SAMPLING_RATE: "0.1"
 
   # Authentication configuration
-  AUTH_ENABLED: "false"
+  AUTH_ENABLED: "true"
 
   # Redis configuration
   REDIS_URL: "redis://redis:6379"

--- a/services/reconciliation/k8s/configmap.yaml
+++ b/services/reconciliation/k8s/configmap.yaml
@@ -33,7 +33,7 @@ data:
 
   # Authentication configuration
   AUTH_ENABLED: "true"
-  # AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"
+  AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"
 
   # OpenTelemetry configuration
   OTEL_SERVICE_NAME: "reconciliation-service"

--- a/services/reconciliation/k8s/configmap.yaml
+++ b/services/reconciliation/k8s/configmap.yaml
@@ -32,7 +32,7 @@ data:
   SETTLEMENT_SCHEDULER_ENABLED: "false"
 
   # Authentication configuration
-  AUTH_ENABLED: "false"
+  AUTH_ENABLED: "true"
   # AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"
 
   # OpenTelemetry configuration

--- a/services/reference-data/k8s/configmap.yaml
+++ b/services/reference-data/k8s/configmap.yaml
@@ -25,4 +25,4 @@ data:
   OTEL_SAMPLING_RATE: "0.1"
 
   # Authentication configuration
-  AUTH_ENABLED: "false"
+  AUTH_ENABLED: "true"

--- a/services/reference-data/k8s/configmap.yaml
+++ b/services/reference-data/k8s/configmap.yaml
@@ -26,3 +26,4 @@ data:
 
   # Authentication configuration
   AUTH_ENABLED: "true"
+  AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"

--- a/services/tenant/k8s/configmap.yaml
+++ b/services/tenant/k8s/configmap.yaml
@@ -42,7 +42,7 @@ data:
 
   # Authentication configuration
   AUTH_ENABLED: "true"
-  # AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"
+  AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"
 
   # OpenTelemetry configuration
   OTEL_SERVICE_NAME: "tenant-service"

--- a/services/tenant/k8s/configmap.yaml
+++ b/services/tenant/k8s/configmap.yaml
@@ -41,7 +41,7 @@ data:
   REDIS_URL: "redis://redis:6379"
 
   # Authentication configuration
-  AUTH_ENABLED: "false"
+  AUTH_ENABLED: "true"
   # AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"
 
   # OpenTelemetry configuration


### PR DESCRIPTION
## Summary

- Set `AUTH_ENABLED: "true"` in all 11 K8s configmaps where authentication was previously disabled
- Ensures authentication enforcement is active for all services in Kubernetes deployments
- Part of security audit (047-security-audit.5)

## Services Updated

- current-account
- financial-accounting
- party
- payment-order
- reconciliation
- tenant
- control-plane
- market-information
- reference-data
- forecasting
- internal-account

**Note:** position-keeping, api-gateway, mcp-server, and event-router do not have `AUTH_ENABLED` in their configmaps (not applicable).

## Test Plan

- [x] Grep confirms zero instances of `AUTH_ENABLED: "false"` remain in any k8s configmap
- [x] All 11 configmaps now have `AUTH_ENABLED: "true"`
- [ ] Verify services start correctly with auth enabled in staging environment