### PR TITLE
feat: add ApplyResource modal for single-resource updates

### DIFF
--- a/frontend/src/features/economy/components/__tests__/apply-resource-modal.test.tsx
+++ b/frontend/src/features/economy/components/__tests__/apply-resource-modal.test.tsx
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/test-utils'
+import { createTenantUserToken } from '@/test/jwt-helpers'
+import { ApplyManifestStatus } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
+import { ApplyResourceModal } from '../apply-resource-modal'
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(),
+  ApiClientProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+import { useApiClients } from '@/api/context'
+
+function mockApiClients(applyResource = vi.fn().mockResolvedValue({
+  status: ApplyManifestStatus.APPLIED,
+  stepResults: [],
+  validationErrors: [],
+  diffSummary: '',
+  sequenceNumber: BigInt(1),
+})) {
+  vi.mocked(useApiClients).mockReturnValue({
+    manifestApplier: { applyResource },
+  } as unknown as ReturnType<typeof useApiClients>)
+  return { applyResource }
+}
+
+describe('ApplyResourceModal', () => {
+  const user = userEvent.setup()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders form fields for instrument type', () => {
+    mockApiClients()
+    renderWithProviders(
+      <ApplyResourceModal
+        open={true}
+        onOpenChange={vi.fn()}
+        nodeType="instrument"
+      />,
+      { initialToken: createTenantUserToken() },
+    )
+
+    expect(screen.getByLabelText('Code')).toBeInTheDocument()
+    expect(screen.getByLabelText('Name')).toBeInTheDocument()
+    expect(screen.getByLabelText('Type')).toBeInTheDocument()
+    expect(screen.getByLabelText('Unit')).toBeInTheDocument()
+    expect(screen.getByLabelText('Precision')).toBeInTheDocument()
+  })
+
+  it('renders form fields for account_type', () => {
+    mockApiClients()
+    renderWithProviders(
+      <ApplyResourceModal
+        open={true}
+        onOpenChange={vi.fn()}
+        nodeType="account_type"
+      />,
+      { initialToken: createTenantUserToken() },
+    )
+
+    expect(screen.getByLabelText('Code')).toBeInTheDocument()
+    expect(screen.getByLabelText('Normal Balance')).toBeInTheDocument()
+    expect(screen.getByLabelText('Allowed Instruments')).toBeInTheDocument()
+  })
+
+  it('shows unsupported message for operational_gateway', () => {
+    mockApiClients()
+    renderWithProviders(
+      <ApplyResourceModal
+        open={true}
+        onOpenChange={vi.fn()}
+        nodeType="operational_gateway"
+      />,
+      { initialToken: createTenantUserToken() },
+    )
+
+    expect(screen.getByText(/not supported/i)).toBeInTheDocument()
+  })
+
+  it('disables Apply when required fields are empty', () => {
+    mockApiClients()
+    renderWithProviders(
+      <ApplyResourceModal
+        open={true}
+        onOpenChange={vi.fn()}
+        nodeType="instrument"
+      />,
+      { initialToken: createTenantUserToken() },
+    )
+
+    const applyBtn = screen.getByTestId('apply-resource-submit')
+    expect(applyBtn).toBeDisabled()
+  })
+
+  it('enables Apply when required fields are filled', async () => {
+    mockApiClients()
+    renderWithProviders(
+      <ApplyResourceModal
+        open={true}
+        onOpenChange={vi.fn()}
+        nodeType="instrument"
+      />,
+      { initialToken: createTenantUserToken() },
+    )
+
+    await user.type(screen.getByLabelText('Code'), 'GBP')
+    await user.type(screen.getByLabelText('Name'), 'British Pound')
+    await user.selectOptions(screen.getByLabelText('Type'), '1')
+
+    const applyBtn = screen.getByTestId('apply-resource-submit')
+    expect(applyBtn).toBeEnabled()
+  })
+
+  it('calls applyResource with correct payload on submit', async () => {
+    const { applyResource } = mockApiClients()
+    renderWithProviders(
+      <ApplyResourceModal
+        open={true}
+        onOpenChange={vi.fn()}
+        nodeType="instrument"
+      />,
+      { initialToken: createTenantUserToken() },
+    )
+
+    await user.type(screen.getByLabelText('Code'), 'GBP')
+    await user.type(screen.getByLabelText('Name'), 'British Pound')
+    await user.selectOptions(screen.getByLabelText('Type'), '1')
+    await user.click(screen.getByTestId('apply-resource-submit'))
+
+    await waitFor(() => {
+      expect(applyResource).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resourceType: 1,
+          dryRun: false,
+          resource: expect.objectContaining({
+            case: 'instrument',
+          }),
+        }),
+      )
+    })
+  })
+
+  it('shows success message after apply', async () => {
+    mockApiClients()
+    renderWithProviders(
+      <ApplyResourceModal
+        open={true}
+        onOpenChange={vi.fn()}
+        nodeType="instrument"
+      />,
+      { initialToken: createTenantUserToken() },
+    )
+
+    await user.type(screen.getByLabelText('Code'), 'GBP')
+    await user.type(screen.getByLabelText('Name'), 'British Pound')
+    await user.selectOptions(screen.getByLabelText('Type'), '1')
+    await user.click(screen.getByTestId('apply-resource-submit'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('apply-resource-success')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error message on failure', async () => {
+    mockApiClients(
+      vi.fn().mockRejectedValue(new Error('Network error')),
+    )
+    renderWithProviders(
+      <ApplyResourceModal
+        open={true}
+        onOpenChange={vi.fn()}
+        nodeType="instrument"
+      />,
+      { initialToken: createTenantUserToken() },
+    )
+
+    await user.type(screen.getByLabelText('Code'), 'GBP')
+    await user.type(screen.getByLabelText('Name'), 'British Pound')
+    await user.selectOptions(screen.getByLabelText('Type'), '1')
+    await user.click(screen.getByTestId('apply-resource-submit'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('apply-resource-error')).toBeInTheDocument()
+      expect(screen.getByText('Network error')).toBeInTheDocument()
+    })
+  })
+
+  it('pre-fills form when initialData is provided', () => {
+    mockApiClients()
+    renderWithProviders(
+      <ApplyResourceModal
+        open={true}
+        onOpenChange={vi.fn()}
+        nodeType="instrument"
+        initialData={{
+          code: 'GBP',
+          name: 'British Pound',
+          type: 1,
+          dimensions: { unit: 'GBP', precision: 2 },
+        }}
+      />,
+      { initialToken: createTenantUserToken() },
+    )
+
+    expect(screen.getByLabelText('Code')).toHaveValue('GBP')
+    expect(screen.getByLabelText('Name')).toHaveValue('British Pound')
+    expect(screen.getByLabelText('Unit')).toHaveValue('GBP')
+    expect(screen.getByLabelText('Precision')).toHaveValue(2)
+  })
+
+  it('shows validation error from server response', async () => {
+    mockApiClients(
+      vi.fn().mockResolvedValue({
+        status: ApplyManifestStatus.VALIDATION_FAILED,
+        stepResults: [],
+        validationErrors: [
+          {
+            severity: 'ERROR',
+            path: 'instruments[0].code',
+            code: 'DUPLICATE',
+            message: 'Instrument code already exists',
+            suggestion: '',
+            resourceType: 'instrument',
+            resourceId: 'GBP',
+          },
+        ],
+        diffSummary: '',
+        sequenceNumber: BigInt(0),
+      }),
+    )
+
+    renderWithProviders(
+      <ApplyResourceModal
+        open={true}
+        onOpenChange={vi.fn()}
+        nodeType="instrument"
+      />,
+      { initialToken: createTenantUserToken() },
+    )
+
+    await user.type(screen.getByLabelText('Code'), 'GBP')
+    await user.type(screen.getByLabelText('Name'), 'British Pound')
+    await user.selectOptions(screen.getByLabelText('Type'), '1')
+    await user.click(screen.getByTestId('apply-resource-submit'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('apply-resource-error')).toBeInTheDocument()
+      expect(screen.getByText('Instrument code already exists')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/features/economy/components/apply-resource-modal.tsx
+++ b/frontend/src/features/economy/components/apply-resource-modal.tsx
@@ -1,0 +1,228 @@
+import { useState, useCallback, useMemo } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { AlertCircle, CheckCircle2, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { useApiClients } from '@/api/context'
+import { useAuth } from '@/contexts/auth-context'
+import { manifestKeys } from '@/lib/query-keys'
+import { ApplyManifestStatus } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
+import type { ManifestNodeType } from '@/features/manifests/lib/manifest-graph-model'
+import { ResourceForm } from './resource-form'
+import {
+  getResourceSchema,
+  buildResourcePayload,
+  extractFormValues,
+  type ResourceSchema,
+} from '../lib/resource-schema-registry'
+
+type ModalState = 'editing' | 'applying' | 'success' | 'error'
+
+export interface ApplyResourceModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  nodeType: ManifestNodeType
+  initialData?: Record<string, unknown>
+}
+
+function validateRequiredFields(
+  schema: ResourceSchema,
+  values: Record<string, string>,
+): string[] {
+  const missing: string[] = []
+  for (const field of schema.fields) {
+    if (field.required && !values[field.name]?.trim()) {
+      missing.push(field.label)
+    }
+  }
+  return missing
+}
+
+export function ApplyResourceModal({
+  open,
+  onOpenChange,
+  nodeType,
+  initialData,
+}: ApplyResourceModalProps) {
+  const { claims } = useAuth()
+  const { manifestApplier } = useApiClients()
+  const queryClient = useQueryClient()
+
+  const schema = getResourceSchema(nodeType)
+
+  const defaultValues = useMemo(() => {
+    if (!schema) return {}
+    if (initialData) return extractFormValues(schema, initialData)
+    return {}
+  }, [schema, initialData])
+
+  const [values, setValues] = useState<Record<string, string>>(defaultValues)
+  const [state, setState] = useState<ModalState>('editing')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const resetState = useCallback(() => {
+    setValues(defaultValues)
+    setState('editing')
+    setErrorMessage(null)
+  }, [defaultValues])
+
+  const handleOpenChange = useCallback(
+    (isOpen: boolean) => {
+      if (!isOpen) {
+        resetState()
+      }
+      onOpenChange(isOpen)
+    },
+    [onOpenChange, resetState],
+  )
+
+  const applyMutation = useMutation({
+    mutationFn: async () => {
+      if (!schema) throw new Error('No schema for this resource type')
+
+      const payload = buildResourcePayload(schema, values)
+
+      return manifestApplier.applyResource({
+        resourceType: schema.resourceType,
+        resource: {
+          case: schema.oneofCase as never,
+          value: payload as never,
+        },
+        dryRun: false,
+        appliedBy: claims?.userId ?? '',
+        expectedSequenceNumber: BigInt(0),
+      })
+    },
+    onSuccess: (response) => {
+      void queryClient.invalidateQueries({ queryKey: manifestKeys.all })
+
+      if (
+        response.status === ApplyManifestStatus.APPLIED
+      ) {
+        setState('success')
+      } else {
+        const validationMessages = response.validationErrors
+          ?.map((e) => e.message)
+          .join('; ')
+        setErrorMessage(
+          validationMessages || response.diffSummary || 'Apply failed',
+        )
+        setState('error')
+      }
+    },
+    onError: (err: unknown) => {
+      const message =
+        err instanceof Error ? err.message : 'Apply failed. Please try again.'
+      setErrorMessage(message)
+      setState('error')
+    },
+  })
+
+  const missingFields = schema ? validateRequiredFields(schema, values) : []
+  const canApply =
+    state === 'editing' &&
+    missingFields.length === 0 &&
+    Boolean(claims?.userId)
+
+  const handleApply = useCallback(() => {
+    setState('applying')
+    applyMutation.mutate()
+  }, [applyMutation])
+
+  if (!schema) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Resource</DialogTitle>
+            <DialogDescription>
+              Editing is not supported for this resource type.
+            </DialogDescription>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
+    )
+  }
+
+  const isEditing = initialData !== undefined
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {isEditing ? `Edit ${schema.label}` : `Add ${schema.label}`}
+          </DialogTitle>
+          <DialogDescription>
+            {isEditing
+              ? `Update this ${schema.label.toLowerCase()} and apply changes to the live economy.`
+              : `Create a new ${schema.label.toLowerCase()} and apply it to the live economy.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        {state === 'success' ? (
+          <div
+            className="flex items-center gap-2 rounded-md border border-success/30 bg-success-muted px-3 py-2 text-sm text-success-foreground"
+            data-testid="apply-resource-success"
+          >
+            <CheckCircle2 className="h-4 w-4 shrink-0" />
+            <span>{schema.label} applied successfully.</span>
+          </div>
+        ) : (
+          <>
+            <ResourceForm
+              schema={schema}
+              values={values}
+              onChange={setValues}
+              disabled={state === 'applying'}
+            />
+
+            {state === 'error' && errorMessage && (
+              <div
+                className="flex items-center gap-2 rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+                data-testid="apply-resource-error"
+              >
+                <AlertCircle className="h-4 w-4 shrink-0" />
+                <span>{errorMessage}</span>
+              </div>
+            )}
+          </>
+        )}
+
+        <DialogFooter showCloseButton={state !== 'applying'}>
+          {state === 'success' ? (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleOpenChange(false)}
+            >
+              Close
+            </Button>
+          ) : (
+            <Button
+              onClick={handleApply}
+              disabled={!canApply || state === 'applying'}
+              data-testid="apply-resource-submit"
+            >
+              {state === 'applying' ? (
+                <>
+                  <Loader2 className="animate-spin" />
+                  Applying...
+                </>
+              ) : (
+                'Apply'
+              )}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/features/economy/components/resource-form.tsx
+++ b/frontend/src/features/economy/components/resource-form.tsx
@@ -1,0 +1,85 @@
+import { useCallback } from 'react'
+import { Input } from '@/components/ui/input'
+import type { FieldDefinition, ResourceSchema } from '../lib/resource-schema-registry'
+
+interface ResourceFormProps {
+  schema: ResourceSchema
+  values: Record<string, string>
+  onChange: (values: Record<string, string>) => void
+  disabled?: boolean
+}
+
+function FieldInput({
+  field,
+  value,
+  onChange,
+  disabled,
+}: {
+  field: FieldDefinition
+  value: string
+  onChange: (value: string) => void
+  disabled?: boolean
+}) {
+  if (field.type === 'select' && field.options) {
+    return (
+      <select
+        id={`resource-field-${field.name}`}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        className="border-input bg-transparent h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:opacity-50"
+        aria-label={field.label}
+      >
+        <option value="">Select {field.label}</option>
+        {field.options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    )
+  }
+
+  return (
+    <Input
+      id={`resource-field-${field.name}`}
+      type={field.type === 'number' ? 'number' : 'text'}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={field.placeholder}
+      disabled={disabled}
+      aria-label={field.label}
+    />
+  )
+}
+
+export function ResourceForm({ schema, values, onChange, disabled }: ResourceFormProps) {
+  const handleFieldChange = useCallback(
+    (fieldName: string, fieldValue: string) => {
+      onChange({ ...values, [fieldName]: fieldValue })
+    },
+    [values, onChange],
+  )
+
+  return (
+    <div className="space-y-4" data-testid="resource-form">
+      {schema.fields.map((field) => (
+        <div key={field.name} className="space-y-1.5">
+          <label
+            htmlFor={`resource-field-${field.name}`}
+            className="text-sm font-medium text-foreground"
+          >
+            {field.label}
+            {field.required && <span className="text-destructive ml-0.5">*</span>}
+          </label>
+          <FieldInput
+            field={field}
+            value={values[field.name] ?? ''}
+            onChange={(v) => handleFieldChange(field.name, v)}
+            disabled={disabled}
+          />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/features/economy/lib/resource-schema-registry.test.ts
+++ b/frontend/src/features/economy/lib/resource-schema-registry.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest'
+import { ManifestResourceType } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
+import { InstrumentType, NormalBalance } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
+import {
+  RESOURCE_SCHEMAS,
+  getResourceSchema,
+  buildResourcePayload,
+  extractFormValues,
+} from './resource-schema-registry'
+
+describe('resource-schema-registry', () => {
+  describe('RESOURCE_SCHEMAS', () => {
+    it('has a schema for each supported resource type', () => {
+      expect(RESOURCE_SCHEMAS.instrument).toBeDefined()
+      expect(RESOURCE_SCHEMAS.account_type).toBeDefined()
+      expect(RESOURCE_SCHEMAS.valuation_rule).toBeDefined()
+      expect(RESOURCE_SCHEMAS.saga).toBeDefined()
+      expect(RESOURCE_SCHEMAS.party_type).toBeDefined()
+      expect(RESOURCE_SCHEMAS.mapping).toBeDefined()
+      expect(RESOURCE_SCHEMAS.organization).toBeDefined()
+      expect(RESOURCE_SCHEMAS.internal_account).toBeDefined()
+    })
+
+    it('maps instrument schema to correct resource type and oneof case', () => {
+      const schema = RESOURCE_SCHEMAS.instrument
+      expect(schema.resourceType).toBe(ManifestResourceType.INSTRUMENT)
+      expect(schema.oneofCase).toBe('instrument')
+      expect(schema.identifierField).toBe('code')
+    })
+
+    it('maps account_type schema to correct resource type and oneof case', () => {
+      const schema = RESOURCE_SCHEMAS.account_type
+      expect(schema.resourceType).toBe(ManifestResourceType.ACCOUNT_TYPE)
+      expect(schema.oneofCase).toBe('accountType')
+    })
+
+    it('has required fields marked correctly', () => {
+      const schema = RESOURCE_SCHEMAS.instrument
+      const codeField = schema.fields.find((f) => f.name === 'code')
+      expect(codeField?.required).toBe(true)
+      const unitField = schema.fields.find((f) => f.name === 'unit')
+      expect(unitField?.required).toBeFalsy()
+    })
+  })
+
+  describe('getResourceSchema', () => {
+    it('returns schema for known types', () => {
+      expect(getResourceSchema('instrument')).toBe(RESOURCE_SCHEMAS.instrument)
+      expect(getResourceSchema('account_type')).toBe(RESOURCE_SCHEMAS.account_type)
+    })
+
+    it('returns undefined for unsupported types', () => {
+      expect(getResourceSchema('operational_gateway')).toBeUndefined()
+      expect(getResourceSchema('provider_connection')).toBeUndefined()
+    })
+  })
+
+  describe('buildResourcePayload', () => {
+    it('builds a flat resource payload', () => {
+      const schema = RESOURCE_SCHEMAS.valuation_rule
+      const values = {
+        fromInstrument: 'KWH',
+        toInstrument: 'GBP',
+        method: '1',
+        source: 'ecb_fx_daily',
+      }
+      const payload = buildResourcePayload(schema, values)
+      expect(payload).toEqual({
+        fromInstrument: 'KWH',
+        toInstrument: 'GBP',
+        method: 1,
+        source: 'ecb_fx_daily',
+      })
+    })
+
+    it('nests fields with nested property', () => {
+      const schema = RESOURCE_SCHEMAS.instrument
+      const values = {
+        code: 'GBP',
+        name: 'British Pound',
+        type: String(InstrumentType.FIAT),
+        unit: 'GBP',
+        precision: '2',
+      }
+      const payload = buildResourcePayload(schema, values)
+      expect(payload.code).toBe('GBP')
+      expect(payload.dimensions).toEqual({ unit: 'GBP', precision: 2 })
+    })
+
+    it('skips empty values', () => {
+      const schema = RESOURCE_SCHEMAS.instrument
+      const values = {
+        code: 'GBP',
+        name: 'British Pound',
+        type: String(InstrumentType.FIAT),
+        unit: '',
+        precision: '',
+      }
+      const payload = buildResourcePayload(schema, values)
+      expect(payload.dimensions).toBeUndefined()
+    })
+
+    it('splits multitext into array', () => {
+      const schema = RESOURCE_SCHEMAS.account_type
+      const values = {
+        code: 'CURRENT',
+        name: 'Current Account',
+        normalBalance: String(NormalBalance.DEBIT),
+        allowedInstruments: 'GBP, USD, EUR',
+      }
+      const payload = buildResourcePayload(schema, values)
+      expect(payload.allowedInstruments).toEqual(['GBP', 'USD', 'EUR'])
+    })
+  })
+
+  describe('extractFormValues', () => {
+    it('extracts flat values to strings', () => {
+      const schema = RESOURCE_SCHEMAS.valuation_rule
+      const data = {
+        fromInstrument: 'KWH',
+        toInstrument: 'GBP',
+        method: 1,
+        source: 'ecb_fx_daily',
+      }
+      const values = extractFormValues(schema, data)
+      expect(values.fromInstrument).toBe('KWH')
+      expect(values.method).toBe('1')
+    })
+
+    it('extracts nested values', () => {
+      const schema = RESOURCE_SCHEMAS.instrument
+      const data = {
+        code: 'GBP',
+        name: 'British Pound',
+        type: InstrumentType.FIAT,
+        dimensions: { unit: 'GBP', precision: 2 },
+      }
+      const values = extractFormValues(schema, data)
+      expect(values.unit).toBe('GBP')
+      expect(values.precision).toBe('2')
+    })
+
+    it('converts arrays to comma-separated strings', () => {
+      const schema = RESOURCE_SCHEMAS.account_type
+      const data = {
+        code: 'CURRENT',
+        name: 'Current Account',
+        normalBalance: NormalBalance.DEBIT,
+        allowedInstruments: ['GBP', 'USD'],
+      }
+      const values = extractFormValues(schema, data)
+      expect(values.allowedInstruments).toBe('GBP, USD')
+    })
+
+    it('returns empty strings for missing values', () => {
+      const schema = RESOURCE_SCHEMAS.instrument
+      const data = { code: 'GBP' }
+      const values = extractFormValues(schema, data)
+      expect(values.name).toBe('')
+      expect(values.unit).toBe('')
+    })
+  })
+})

--- a/frontend/src/features/economy/lib/resource-schema-registry.ts
+++ b/frontend/src/features/economy/lib/resource-schema-registry.ts
@@ -1,0 +1,205 @@
+import {
+  ManifestResourceType,
+} from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
+import {
+  InstrumentType,
+  NormalBalance,
+  ValuationMethod,
+} from '@/api/gen/meridian/control_plane/v1/manifest_pb'
+import type { ManifestNodeType } from '@/features/manifests/lib/manifest-graph-model'
+
+export type FieldType = 'text' | 'number' | 'select' | 'multitext'
+
+export interface SelectOption {
+  value: string | number
+  label: string
+}
+
+export interface FieldDefinition {
+  name: string
+  label: string
+  type: FieldType
+  required?: boolean
+  placeholder?: string
+  options?: SelectOption[]
+  nested?: string
+}
+
+export interface ResourceSchema {
+  resourceType: ManifestResourceType
+  oneofCase: string
+  label: string
+  identifierField: string
+  fields: FieldDefinition[]
+}
+
+const INSTRUMENT_TYPE_OPTIONS: SelectOption[] = [
+  { value: InstrumentType.FIAT, label: 'Fiat' },
+  { value: InstrumentType.COMMODITY, label: 'Commodity' },
+  { value: InstrumentType.VOUCHER, label: 'Voucher' },
+]
+
+const NORMAL_BALANCE_OPTIONS: SelectOption[] = [
+  { value: NormalBalance.DEBIT, label: 'Debit' },
+  { value: NormalBalance.CREDIT, label: 'Credit' },
+]
+
+const VALUATION_METHOD_OPTIONS: SelectOption[] = [
+  { value: ValuationMethod.SPOT_RATE, label: 'Spot Rate' },
+  { value: ValuationMethod.FIXED, label: 'Fixed' },
+]
+
+export const RESOURCE_SCHEMAS: Record<string, ResourceSchema> = {
+  instrument: {
+    resourceType: ManifestResourceType.INSTRUMENT,
+    oneofCase: 'instrument',
+    label: 'Instrument',
+    identifierField: 'code',
+    fields: [
+      { name: 'code', label: 'Code', type: 'text', required: true, placeholder: 'e.g. GBP' },
+      { name: 'name', label: 'Name', type: 'text', required: true, placeholder: 'e.g. British Pound Sterling' },
+      { name: 'type', label: 'Type', type: 'select', required: true, options: INSTRUMENT_TYPE_OPTIONS },
+      { name: 'unit', label: 'Unit', type: 'text', placeholder: 'e.g. GBP', nested: 'dimensions' },
+      { name: 'precision', label: 'Precision', type: 'number', placeholder: '2', nested: 'dimensions' },
+    ],
+  },
+  account_type: {
+    resourceType: ManifestResourceType.ACCOUNT_TYPE,
+    oneofCase: 'accountType',
+    label: 'Account Type',
+    identifierField: 'code',
+    fields: [
+      { name: 'code', label: 'Code', type: 'text', required: true, placeholder: 'e.g. CURRENT' },
+      { name: 'name', label: 'Name', type: 'text', required: true, placeholder: 'e.g. Current Account' },
+      { name: 'normalBalance', label: 'Normal Balance', type: 'select', required: true, options: NORMAL_BALANCE_OPTIONS },
+      { name: 'allowedInstruments', label: 'Allowed Instruments', type: 'multitext', placeholder: 'Comma-separated codes' },
+    ],
+  },
+  valuation_rule: {
+    resourceType: ManifestResourceType.VALUATION_RULE,
+    oneofCase: 'valuationRule',
+    label: 'Valuation Rule',
+    identifierField: 'fromInstrument',
+    fields: [
+      { name: 'fromInstrument', label: 'From Instrument', type: 'text', required: true, placeholder: 'e.g. KWH' },
+      { name: 'toInstrument', label: 'To Instrument', type: 'text', required: true, placeholder: 'e.g. GBP' },
+      { name: 'method', label: 'Method', type: 'select', required: true, options: VALUATION_METHOD_OPTIONS },
+      { name: 'source', label: 'Source', type: 'text', placeholder: 'e.g. ecb_fx_daily' },
+    ],
+  },
+  saga: {
+    resourceType: ManifestResourceType.SAGA,
+    oneofCase: 'saga',
+    label: 'Saga',
+    identifierField: 'name',
+    fields: [
+      { name: 'name', label: 'Name', type: 'text', required: true, placeholder: 'e.g. process_settlement' },
+      { name: 'trigger', label: 'Trigger', type: 'text', required: true, placeholder: 'e.g. event:position-keeping.transaction-captured.v1' },
+      { name: 'script', label: 'Script', type: 'text', required: true, placeholder: 'Starlark script' },
+    ],
+  },
+  party_type: {
+    resourceType: ManifestResourceType.PARTY_TYPE,
+    oneofCase: 'partyType',
+    label: 'Party Type',
+    identifierField: 'partyType',
+    fields: [
+      { name: 'partyType', label: 'Party Type', type: 'text', required: true, placeholder: 'e.g. CUSTOMER' },
+    ],
+  },
+  mapping: {
+    resourceType: ManifestResourceType.MAPPING,
+    oneofCase: 'mapping',
+    label: 'Mapping',
+    identifierField: 'name',
+    fields: [
+      { name: 'name', label: 'Name', type: 'text', required: true, placeholder: 'e.g. stripe_payment_inbound' },
+      { name: 'targetService', label: 'Target Service', type: 'text', placeholder: 'e.g. meridian.payment_order.v1.PaymentOrderService' },
+      { name: 'targetRpc', label: 'Target RPC', type: 'text', placeholder: 'e.g. InitiatePaymentOrder' },
+    ],
+  },
+  organization: {
+    resourceType: ManifestResourceType.ORGANIZATION,
+    oneofCase: 'organization',
+    label: 'Organization',
+    identifierField: 'code',
+    fields: [
+      { name: 'code', label: 'Code', type: 'text', required: true, placeholder: 'e.g. ACME_CORP' },
+      { name: 'name', label: 'Name', type: 'text', required: true, placeholder: 'e.g. Acme Corporation' },
+    ],
+  },
+  internal_account: {
+    resourceType: ManifestResourceType.INTERNAL_ACCOUNT,
+    oneofCase: 'internalAccount',
+    label: 'Internal Account',
+    identifierField: 'code',
+    fields: [
+      { name: 'code', label: 'Code', type: 'text', required: true, placeholder: 'e.g. OPERATING_GBP' },
+      { name: 'accountType', label: 'Account Type', type: 'text', required: true, placeholder: 'e.g. CURRENT' },
+      { name: 'instrument', label: 'Instrument', type: 'text', required: true, placeholder: 'e.g. GBP' },
+      { name: 'description', label: 'Description', type: 'text', placeholder: 'Optional description' },
+    ],
+  },
+}
+
+export function getResourceSchema(nodeType: ManifestNodeType): ResourceSchema | undefined {
+  return RESOURCE_SCHEMAS[nodeType]
+}
+
+export function buildResourcePayload(
+  schema: ResourceSchema,
+  formValues: Record<string, string>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+
+  for (const field of schema.fields) {
+    const rawValue = formValues[field.name]
+    if (rawValue === undefined || rawValue === '') continue
+
+    let value: unknown = rawValue
+    if (field.type === 'number') {
+      value = parseInt(rawValue, 10)
+    } else if (field.type === 'select') {
+      value = parseInt(rawValue, 10)
+    } else if (field.type === 'multitext') {
+      value = rawValue.split(',').map((s) => s.trim()).filter(Boolean)
+    }
+
+    if (field.nested) {
+      const nested = (result[field.nested] ?? {}) as Record<string, unknown>
+      nested[field.name] = value
+      result[field.nested] = nested
+    } else {
+      result[field.name] = value
+    }
+  }
+
+  return result
+}
+
+export function extractFormValues(
+  schema: ResourceSchema,
+  data: Record<string, unknown>,
+): Record<string, string> {
+  const values: Record<string, string> = {}
+
+  for (const field of schema.fields) {
+    let rawValue: unknown
+    if (field.nested) {
+      const nested = data[field.nested] as Record<string, unknown> | undefined
+      rawValue = nested?.[field.name]
+    } else {
+      rawValue = data[field.name]
+    }
+
+    if (rawValue === undefined || rawValue === null) {
+      values[field.name] = ''
+    } else if (Array.isArray(rawValue)) {
+      values[field.name] = rawValue.join(', ')
+    } else {
+      values[field.name] = String(rawValue)
+    }
+  }
+
+  return values
+}

--- a/frontend/src/features/manifests/components/manifest-graph.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.test.tsx
@@ -13,6 +13,10 @@ vi.mock('@/api/clients', () => ({
   createServiceClients: vi.fn(() => ({})),
 }))
 
+vi.mock('@/features/economy/components/apply-resource-modal', () => ({
+  ApplyResourceModal: () => null,
+}))
+
 vi.mock('@/components/ui/tooltip', () => ({
   TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,

--- a/frontend/src/features/manifests/components/manifest-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.tsx
@@ -670,6 +670,7 @@ export function ManifestGraph({ manifest, className, _fullscreen }: ManifestGrap
 
       {selectedManifestNode && canEditResource && (
         <ApplyResourceModal
+          key={selectedManifestNode.id}
           open={editModalOpen}
           onOpenChange={setEditModalOpen}
           nodeType={selectedManifestNode.type}

--- a/frontend/src/features/manifests/components/manifest-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.tsx
@@ -15,7 +15,7 @@ import {
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import { useNavigate } from 'react-router-dom'
-import { Maximize2, X } from 'lucide-react'
+import { Maximize2, Pencil, X } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -46,6 +46,8 @@ import { NODE_TYPE_REGISTRY, getNodeThemes, getLayerPriority } from '../lib/node
 import type { Manifest } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
 import { useEventChain } from '../hooks/use-event-chain'
 import { EventChainPanel } from './event-chain-panel'
+import { ApplyResourceModal } from '@/features/economy/components/apply-resource-modal'
+import { getResourceSchema } from '@/features/economy/lib/resource-schema-registry'
 
 const NODE_THEMES = getNodeThemes()
 
@@ -332,6 +334,7 @@ export function ManifestGraph({ manifest, className, _fullscreen }: ManifestGrap
   const [selectedNode, setSelectedNode] = useState<string | null>(null)
   const [showEventChain, setShowEventChain] = useState(false)
   const [fullscreen, setFullscreen] = useState(false)
+  const [editModalOpen, setEditModalOpen] = useState(false)
   const [visibleTypes, setVisibleTypes] = useState<Set<ManifestNodeType>>(
     () => new Set<ManifestNodeType>(['instrument', 'account_type', 'valuation_rule', 'saga']),
   )
@@ -350,6 +353,7 @@ export function ManifestGraph({ manifest, className, _fullscreen }: ManifestGrap
   )
 
   const canShowEventChain = selectedManifestNode?.type === 'instrument' || selectedManifestNode?.type === 'account_type'
+  const canEditResource = selectedManifestNode ? getResourceSchema(selectedManifestNode.type) !== undefined : false
 
   const eventChainNodeId = showEventChain ? effectiveSelectedNode : null
   const eventChain = useEventChain(graph, eventChainNodeId)
@@ -574,6 +578,18 @@ export function ManifestGraph({ manifest, className, _fullscreen }: ManifestGrap
           <span className="text-xs font-medium text-foreground px-1">
             {selectedManifestNode.label}
           </span>
+          {canEditResource && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="text-xs h-7"
+              onClick={() => setEditModalOpen(true)}
+              data-testid="edit-resource-button"
+            >
+              <Pencil className="h-3 w-3 mr-1" />
+              Edit
+            </Button>
+          )}
           {canShowEventChain && (
             <Button
               size="sm"
@@ -650,6 +666,15 @@ export function ManifestGraph({ manifest, className, _fullscreen }: ManifestGrap
             </div>
           </DialogContent>
         </Dialog>
+      )}
+
+      {selectedManifestNode && canEditResource && (
+        <ApplyResourceModal
+          open={editModalOpen}
+          onOpenChange={setEditModalOpen}
+          nodeType={selectedManifestNode.type}
+          initialData={selectedManifestNode.data}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

- Add resource type schema registry mapping manifest node types to form field definitions with validation, enum options, and nested field support (8 resource types)
- Implement `ResourceForm` component for dynamic form rendering based on schema definitions
- Create `ApplyResourceModal` that renders the appropriate form per resource type, calls the `ApplyResource` RPC, and handles success/error/validation states
- Integrate Edit button into the manifest graph node selection toolbar for supported resource types

## Test plan

- [x] Schema registry unit tests (14 tests) - payload building, form value extraction, multitext splitting, nested fields
- [x] Modal integration tests (10 tests) - form rendering, validation, submit flow, success/error states, pre-filled data
- [x] Typecheck passes
- [x] Lint passes
- [x] All economy feature tests pass (185 tests)