### PR TITLE
feat: add method-level RBAC interceptor for gRPC endpoints

### DIFF
--- a/shared/platform/auth/method_rbac_interceptor.go
+++ b/shared/platform/auth/method_rbac_interceptor.go
@@ -1,0 +1,113 @@
+package auth
+
+import (
+	"context"
+	"log/slog"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// MethodPermission defines the required permission for a gRPC method.
+// Use either AllowedRoles for direct role checks, or ResourceType+Permission
+// for permission-based checks via the existing RBAC permission matrix.
+type MethodPermission struct {
+	ResourceType ResourceType
+	Permission   Permission
+	AllowedRoles []Role
+}
+
+// MethodRBACConfig maps gRPC full method names to required permissions.
+// Fail-closed: methods NOT in the map are DENIED by default.
+type MethodRBACConfig struct {
+	Permissions   map[string]MethodPermission
+	AllowUnmapped bool // NOT RECOMMENDED -- for gradual rollout only
+}
+
+// AuditFunc is called for each RBAC decision with the method, user ID, and decision.
+type AuditFunc func(method, userID, decision string)
+
+// NewMethodRBACInterceptor creates a unary interceptor that enforces method-level RBAC.
+// Methods not in the permission map are denied (fail-closed).
+func NewMethodRBACInterceptor(cfg MethodRBACConfig) grpc.UnaryServerInterceptor {
+	return newMethodRBACInterceptor(cfg, nil)
+}
+
+// NewMethodRBACInterceptorWithAudit creates a unary interceptor with an audit callback
+// that is invoked for every RBAC decision (allowed or denied).
+func NewMethodRBACInterceptorWithAudit(cfg MethodRBACConfig, audit AuditFunc) grpc.UnaryServerInterceptor {
+	return newMethodRBACInterceptor(cfg, audit)
+}
+
+func newMethodRBACInterceptor(cfg MethodRBACConfig, audit AuditFunc) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		perm, mapped := cfg.Permissions[info.FullMethod]
+
+		// Fail-closed: unmapped methods are denied unless AllowUnmapped is set
+		if !mapped {
+			if cfg.AllowUnmapped {
+				return handler(ctx, req)
+			}
+			slog.Warn("RBAC denied unmapped method",
+				"method", info.FullMethod,
+			)
+			return nil, status.Errorf(codes.PermissionDenied,
+				"method %s is not configured in RBAC policy", info.FullMethod)
+		}
+
+		claims, ok := GetClaimsFromContext(ctx)
+		if !ok {
+			if audit != nil {
+				audit(info.FullMethod, "", "denied")
+			}
+			return nil, status.Error(codes.Unauthenticated, "missing authentication context")
+		}
+
+		userID := claims.EffectiveUserID()
+
+		if err := checkMethodPermission(claims, perm); err != nil {
+			if audit != nil {
+				audit(info.FullMethod, userID, "denied")
+			}
+			return nil, err
+		}
+
+		if audit != nil {
+			audit(info.FullMethod, userID, "allowed")
+		}
+
+		return handler(ctx, req)
+	}
+}
+
+// checkMethodPermission checks whether claims satisfy the method permission.
+// It supports two modes:
+//   - AllowedRoles: direct role membership check
+//   - ResourceType+Permission: delegates to the existing RBAC permission matrix
+func checkMethodPermission(claims *Claims, perm MethodPermission) error {
+	// If AllowedRoles is specified, use direct role check
+	if len(perm.AllowedRoles) > 0 {
+		if HasAnyRole(claims, perm.AllowedRoles...) {
+			return nil
+		}
+		return status.Error(codes.PermissionDenied, "insufficient role for method")
+	}
+
+	// Otherwise, use permission-based check via the RBAC matrix
+	if perm.ResourceType != "" && perm.Permission != "" {
+		if HasPermission(claims, perm.ResourceType, perm.Permission) {
+			return nil
+		}
+		return status.Errorf(codes.PermissionDenied,
+			"insufficient permission: requires %s on %s", perm.Permission, perm.ResourceType)
+	}
+
+	// No authorization rule defined -- deny (fail-closed)
+	return status.Error(codes.PermissionDenied, "no authorization rule defined for method")
+}

--- a/shared/platform/auth/method_rbac_interceptor.go
+++ b/shared/platform/auth/method_rbac_interceptor.go
@@ -52,11 +52,25 @@ func newMethodRBACInterceptor(cfg MethodRBACConfig, audit AuditFunc) grpc.UnaryS
 		// Fail-closed: unmapped methods are denied unless AllowUnmapped is set
 		if !mapped {
 			if cfg.AllowUnmapped {
+				if audit != nil {
+					userID := ""
+					if claims, ok := GetClaimsFromContext(ctx); ok {
+						userID = claims.EffectiveUserID()
+					}
+					audit(info.FullMethod, userID, "allowed_unmapped")
+				}
 				return handler(ctx, req)
 			}
 			slog.Warn("RBAC denied unmapped method",
 				"method", info.FullMethod,
 			)
+			if audit != nil {
+				userID := ""
+				if claims, ok := GetClaimsFromContext(ctx); ok {
+					userID = claims.EffectiveUserID()
+				}
+				audit(info.FullMethod, userID, "denied_unmapped")
+			}
 			return nil, status.Errorf(codes.PermissionDenied,
 				"method %s is not configured in RBAC policy", info.FullMethod)
 		}

--- a/shared/platform/auth/method_rbac_interceptor_test.go
+++ b/shared/platform/auth/method_rbac_interceptor_test.go
@@ -1,0 +1,233 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// noopHandler is a gRPC unary handler that returns nil for testing.
+func noopHandler(_ context.Context, _ interface{}) (interface{}, error) {
+	return "ok", nil
+}
+
+func TestMethodRBACInterceptor_FailClosed_UnmappedMethod(t *testing.T) {
+	interceptor := NewMethodRBACInterceptor(MethodRBACConfig{
+		Permissions: map[string]MethodPermission{
+			"/some.Service/AllowedMethod": {AllowedRoles: []Role{RoleAdmin}},
+		},
+	})
+
+	// Put valid claims in context so we isolate the fail-closed behavior
+	claims := &Claims{Roles: []string{"admin"}}
+	ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
+
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/some.Service/UnknownMethod"}, noopHandler)
+	if err == nil {
+		t.Fatal("expected error for unmapped method, got nil")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("expected PermissionDenied, got %v", st.Code())
+	}
+}
+
+func TestMethodRBACInterceptor_CorrectRole_Passes(t *testing.T) {
+	interceptor := NewMethodRBACInterceptor(MethodRBACConfig{
+		Permissions: map[string]MethodPermission{
+			"/some.Service/GetItem": {AllowedRoles: []Role{RoleAdmin, RoleOperator}},
+		},
+	})
+
+	claims := &Claims{Roles: []string{"operator"}}
+	ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
+
+	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/some.Service/GetItem"}, noopHandler)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp != "ok" {
+		t.Errorf("expected handler response 'ok', got %v", resp)
+	}
+}
+
+func TestMethodRBACInterceptor_InsufficientRole_Denied(t *testing.T) {
+	interceptor := NewMethodRBACInterceptor(MethodRBACConfig{
+		Permissions: map[string]MethodPermission{
+			"/some.Service/AdminOnly": {AllowedRoles: []Role{RoleAdmin}},
+		},
+	})
+
+	claims := &Claims{Roles: []string{"auditor"}}
+	ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
+
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/some.Service/AdminOnly"}, noopHandler)
+	if err == nil {
+		t.Fatal("expected error for insufficient role, got nil")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("expected PermissionDenied, got %v", st.Code())
+	}
+}
+
+func TestMethodRBACInterceptor_MissingAuthContext_Unauthenticated(t *testing.T) {
+	interceptor := NewMethodRBACInterceptor(MethodRBACConfig{
+		Permissions: map[string]MethodPermission{
+			"/some.Service/GetItem": {AllowedRoles: []Role{RoleAdmin}},
+		},
+	})
+
+	// No claims in context
+	ctx := context.Background()
+
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/some.Service/GetItem"}, noopHandler)
+	if err == nil {
+		t.Fatal("expected error for missing auth context, got nil")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.Unauthenticated {
+		t.Errorf("expected Unauthenticated, got %v", st.Code())
+	}
+}
+
+func TestMethodRBACInterceptor_AllowUnmapped_PermitsUnconfiguredMethods(t *testing.T) {
+	interceptor := NewMethodRBACInterceptor(MethodRBACConfig{
+		Permissions: map[string]MethodPermission{
+			"/some.Service/GetItem": {AllowedRoles: []Role{RoleAdmin}},
+		},
+		AllowUnmapped: true,
+	})
+
+	claims := &Claims{Roles: []string{"auditor"}}
+	ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
+
+	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/some.Service/UnknownMethod"}, noopHandler)
+	if err != nil {
+		t.Fatalf("expected no error with AllowUnmapped=true, got %v", err)
+	}
+	if resp != "ok" {
+		t.Errorf("expected handler response 'ok', got %v", resp)
+	}
+}
+
+func TestMethodRBACInterceptor_PermissionBased_Passes(t *testing.T) {
+	interceptor := NewMethodRBACInterceptor(MethodRBACConfig{
+		Permissions: map[string]MethodPermission{
+			"/some.Service/ReadAccount": {
+				ResourceType: ResourceTypeAccount,
+				Permission:   PermissionRead,
+			},
+		},
+	})
+
+	// Auditor has read permission on accounts
+	claims := &Claims{Roles: []string{"auditor"}}
+	ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
+
+	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/some.Service/ReadAccount"}, noopHandler)
+	if err != nil {
+		t.Fatalf("expected no error for permission-based check, got %v", err)
+	}
+	if resp != "ok" {
+		t.Errorf("expected handler response 'ok', got %v", resp)
+	}
+}
+
+func TestMethodRBACInterceptor_PermissionBased_Denied(t *testing.T) {
+	interceptor := NewMethodRBACInterceptor(MethodRBACConfig{
+		Permissions: map[string]MethodPermission{
+			"/some.Service/WriteAccount": {
+				ResourceType: ResourceTypeAccount,
+				Permission:   PermissionWrite,
+			},
+		},
+	})
+
+	// Auditor does NOT have write permission on accounts
+	claims := &Claims{Roles: []string{"auditor"}}
+	ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
+
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/some.Service/WriteAccount"}, noopHandler)
+	if err == nil {
+		t.Fatal("expected error for permission-based denial, got nil")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("expected PermissionDenied, got %v", st.Code())
+	}
+}
+
+func TestMethodRBACInterceptor_GroupsFallback(t *testing.T) {
+	interceptor := NewMethodRBACInterceptor(MethodRBACConfig{
+		Permissions: map[string]MethodPermission{
+			"/some.Service/GetItem": {AllowedRoles: []Role{RoleAdmin}},
+		},
+	})
+
+	// Claims with Groups instead of Roles (OIDC provider like Dex)
+	claims := &Claims{Groups: []string{"admin"}}
+	ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
+
+	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/some.Service/GetItem"}, noopHandler)
+	if err != nil {
+		t.Fatalf("expected no error with groups fallback, got %v", err)
+	}
+	if resp != "ok" {
+		t.Errorf("expected handler response 'ok', got %v", resp)
+	}
+}
+
+func TestMethodRBACInterceptor_AuditLog(t *testing.T) {
+	var logged []string
+	logger := func(method, userID, decision string) {
+		logged = append(logged, method+":"+userID+":"+decision)
+	}
+
+	interceptor := NewMethodRBACInterceptorWithAudit(MethodRBACConfig{
+		Permissions: map[string]MethodPermission{
+			"/some.Service/GetItem": {AllowedRoles: []Role{RoleAdmin}},
+		},
+	}, logger)
+
+	// Successful access
+	claims := &Claims{UserID: "user-1", Roles: []string{"admin"}}
+	ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
+
+	_, _ = interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/some.Service/GetItem"}, noopHandler)
+
+	// Denied access
+	claims2 := &Claims{UserID: "user-2", Roles: []string{"auditor"}}
+	ctx2 := context.WithValue(context.Background(), ClaimsContextKey, claims2)
+
+	_, _ = interceptor(ctx2, nil, &grpc.UnaryServerInfo{FullMethod: "/some.Service/GetItem"}, noopHandler)
+
+	if len(logged) != 2 {
+		t.Fatalf("expected 2 audit log entries, got %d", len(logged))
+	}
+	if logged[0] != "/some.Service/GetItem:user-1:allowed" {
+		t.Errorf("unexpected audit log entry: %s", logged[0])
+	}
+	if logged[1] != "/some.Service/GetItem:user-2:denied" {
+		t.Errorf("unexpected audit log entry: %s", logged[1])
+	}
+}

--- a/shared/platform/auth/method_rbac_interceptor_test.go
+++ b/shared/platform/auth/method_rbac_interceptor_test.go
@@ -215,19 +215,52 @@ func TestMethodRBACInterceptor_AuditLog(t *testing.T) {
 
 	_, _ = interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/some.Service/GetItem"}, noopHandler)
 
-	// Denied access
+	// Denied access (insufficient role)
 	claims2 := &Claims{UserID: "user-2", Roles: []string{"auditor"}}
 	ctx2 := context.WithValue(context.Background(), ClaimsContextKey, claims2)
 
 	_, _ = interceptor(ctx2, nil, &grpc.UnaryServerInfo{FullMethod: "/some.Service/GetItem"}, noopHandler)
 
-	if len(logged) != 2 {
-		t.Fatalf("expected 2 audit log entries, got %d", len(logged))
+	// Denied access (unmapped method, fail-closed)
+	claims3 := &Claims{UserID: "user-3", Roles: []string{"admin"}}
+	ctx3 := context.WithValue(context.Background(), ClaimsContextKey, claims3)
+
+	_, _ = interceptor(ctx3, nil, &grpc.UnaryServerInfo{FullMethod: "/some.Service/Unknown"}, noopHandler)
+
+	if len(logged) != 3 {
+		t.Fatalf("expected 3 audit log entries, got %d: %v", len(logged), logged)
 	}
 	if logged[0] != "/some.Service/GetItem:user-1:allowed" {
 		t.Errorf("unexpected audit log entry: %s", logged[0])
 	}
 	if logged[1] != "/some.Service/GetItem:user-2:denied" {
 		t.Errorf("unexpected audit log entry: %s", logged[1])
+	}
+	if logged[2] != "/some.Service/Unknown:user-3:denied_unmapped" {
+		t.Errorf("unexpected audit log entry: %s", logged[2])
+	}
+}
+
+func TestMethodRBACInterceptor_AuditLog_AllowUnmapped(t *testing.T) {
+	var logged []string
+	logger := func(method, userID, decision string) {
+		logged = append(logged, method+":"+userID+":"+decision)
+	}
+
+	interceptor := NewMethodRBACInterceptorWithAudit(MethodRBACConfig{
+		Permissions:   map[string]MethodPermission{},
+		AllowUnmapped: true,
+	}, logger)
+
+	claims := &Claims{UserID: "user-1", Roles: []string{"admin"}}
+	ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
+
+	_, _ = interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/some.Service/Any"}, noopHandler)
+
+	if len(logged) != 1 {
+		t.Fatalf("expected 1 audit log entry, got %d: %v", len(logged), logged)
+	}
+	if logged[0] != "/some.Service/Any:user-1:allowed_unmapped" {
+		t.Errorf("unexpected audit log entry: %s", logged[0])
 	}
 }

--- a/shared/platform/auth/method_rbac_interceptor_test.go
+++ b/shared/platform/auth/method_rbac_interceptor_test.go
@@ -197,6 +197,30 @@ func TestMethodRBACInterceptor_GroupsFallback(t *testing.T) {
 	}
 }
 
+func TestMethodRBACInterceptor_PermissionBased_GroupsFallback(t *testing.T) {
+	interceptor := NewMethodRBACInterceptor(MethodRBACConfig{
+		Permissions: map[string]MethodPermission{
+			"/some.Service/ReadAccount": {
+				ResourceType: ResourceTypeAccount,
+				Permission:   PermissionRead,
+			},
+		},
+	})
+
+	// Claims with Groups instead of Roles (OIDC provider like Dex)
+	// Auditor role has read permission on accounts
+	claims := &Claims{Groups: []string{"auditor"}}
+	ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
+
+	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/some.Service/ReadAccount"}, noopHandler)
+	if err != nil {
+		t.Fatalf("expected no error for permission-based check with groups fallback, got %v", err)
+	}
+	if resp != "ok" {
+		t.Errorf("expected handler response 'ok', got %v", resp)
+	}
+}
+
 func TestMethodRBACInterceptor_AuditLog(t *testing.T) {
 	var logged []string
 	logger := func(method, userID, decision string) {

--- a/shared/platform/auth/rbac.go
+++ b/shared/platform/auth/rbac.go
@@ -200,8 +200,8 @@ func HasPermission(claims *Claims, resourceType ResourceType, permission Permiss
 		return false
 	}
 
-	// Check each role in the claims
-	for _, roleStr := range claims.Roles {
+	// Check each effective role (supports Groups fallback for OIDC providers like Dex)
+	for _, roleStr := range claims.EffectiveRoles() {
 		role := Role(roleStr)
 		if !role.IsValid() {
 			continue


### PR DESCRIPTION
## Summary

- Add `NewMethodRBACInterceptor` with fail-closed permission map pattern for enforcing method-level RBAC on gRPC endpoints
- Support both direct role-based checks (`AllowedRoles`) and permission-based checks via the existing RBAC matrix (`ResourceType` + `Permission`)
- Include `AllowUnmapped` option for gradual rollout (unmapped methods denied by default)
- Add `NewMethodRBACInterceptorWithAudit` variant with audit callback for logging RBAC decisions

## Task Master

Tag: `047-security-audit`, Task: 12 - Create Method RBAC Interceptor Framework

## Test Plan

- [x] Unmapped method returns `PermissionDenied` (fail-closed)
- [x] Method with correct role passes through
- [x] Method with insufficient role returns `PermissionDenied`
- [x] Missing auth context returns `Unauthenticated`
- [x] `AllowUnmapped=true` permits unconfigured methods
- [x] Permission-based check passes for authorized role
- [x] Permission-based check denied for unauthorized role
- [x] Groups fallback (OIDC compatibility) works correctly
- [x] Audit callback captures both allowed and denied decisions