### PR TITLE
feat: add Show All/None buttons and localStorage persistence to graph type filter

### DIFF
--- a/frontend/src/features/manifests/components/manifest-graph.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.test.tsx
@@ -176,6 +176,7 @@ function renderGraph(manifest: Manifest) {
 describe('ManifestGraph', () => {
   beforeEach(() => {
     mockNavigate.mockClear()
+    localStorage.clear()
   })
 
   describe('rendering', () => {
@@ -263,6 +264,51 @@ describe('ManifestGraph', () => {
       const flow = await screen.findByTestId('react-flow')
       // The node count should decrease (7 - 2 sagas = 5)
       expect(flow).toHaveAttribute('data-node-count', '5')
+    })
+
+    it('renders Show All and None buttons', async () => {
+      renderGraph(energyManifest)
+      expect(await screen.findByLabelText('Show all types')).toBeInTheDocument()
+      expect(screen.getByLabelText('Hide all types')).toBeInTheDocument()
+    })
+
+    it('None button hides all nodes', async () => {
+      renderGraph(energyManifest)
+      const noneButton = await screen.findByLabelText('Hide all types')
+      fireEvent.click(noneButton)
+      const flow = screen.getByTestId('react-flow')
+      expect(flow).toHaveAttribute('data-node-count', '0')
+    })
+
+    it('All button restores all nodes after hiding', async () => {
+      renderGraph(energyManifest)
+      const noneButton = await screen.findByLabelText('Hide all types')
+      fireEvent.click(noneButton)
+      const allButton = screen.getByLabelText('Show all types')
+      fireEvent.click(allButton)
+      const flow = screen.getByTestId('react-flow')
+      expect(flow).toHaveAttribute('data-node-count', '7')
+    })
+
+    it('persists visible types to localStorage when toggling', async () => {
+      renderGraph(energyManifest)
+      const sagaCheckbox = await screen.findByLabelText('Show Sagas')
+      fireEvent.click(sagaCheckbox)
+      const stored = localStorage.getItem('meridian:graph-visible-types')
+      expect(stored).not.toBeNull()
+      const parsed: unknown = JSON.parse(stored!)
+      expect(Array.isArray(parsed)).toBe(true)
+      expect((parsed as string[]).includes('saga')).toBe(false)
+    })
+
+    it('restores visible types from localStorage on mount', async () => {
+      // Pre-populate localStorage with sagas hidden
+      const allTypes = Object.keys({ instrument: 1, account_type: 1, valuation_rule: 1 })
+      localStorage.setItem('meridian:graph-visible-types', JSON.stringify(allTypes))
+      renderGraph(energyManifest)
+      const flow = await screen.findByTestId('react-flow')
+      // Only instrument, account_type, valuation_rule nodes visible (2 + 1 + 1 = 4)
+      expect(flow).toHaveAttribute('data-node-count', '4')
     })
   })
 

--- a/frontend/src/features/manifests/components/manifest-graph.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { useState } from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { ManifestGraph } from './manifest-graph'
 import type { Manifest } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
@@ -276,8 +276,8 @@ describe('ManifestGraph', () => {
       renderGraph(energyManifest)
       const noneButton = await screen.findByLabelText('Hide all types')
       fireEvent.click(noneButton)
-      const flow = screen.getByTestId('react-flow')
-      expect(flow).toHaveAttribute('data-node-count', '0')
+      const flow = await screen.findByTestId('react-flow')
+      await waitFor(() => expect(flow).toHaveAttribute('data-node-count', '0'))
     })
 
     it('All button restores all nodes after hiding', async () => {
@@ -286,8 +286,8 @@ describe('ManifestGraph', () => {
       fireEvent.click(noneButton)
       const allButton = screen.getByLabelText('Show all types')
       fireEvent.click(allButton)
-      const flow = screen.getByTestId('react-flow')
-      expect(flow).toHaveAttribute('data-node-count', '7')
+      const flow = await screen.findByTestId('react-flow')
+      await waitFor(() => expect(flow).toHaveAttribute('data-node-count', '7'))
     })
 
     it('persists visible types to localStorage when toggling', async () => {

--- a/frontend/src/features/manifests/components/manifest-graph.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.test.tsx
@@ -303,12 +303,19 @@ describe('ManifestGraph', () => {
 
     it('restores visible types from localStorage on mount', async () => {
       // Pre-populate localStorage with sagas hidden
-      const allTypes = Object.keys({ instrument: 1, account_type: 1, valuation_rule: 1 })
-      localStorage.setItem('meridian:graph-visible-types', JSON.stringify(allTypes))
+      const types = ['instrument', 'account_type', 'valuation_rule']
+      localStorage.setItem('meridian:graph-visible-types', JSON.stringify(types))
       renderGraph(energyManifest)
       const flow = await screen.findByTestId('react-flow')
       // Only instrument, account_type, valuation_rule nodes visible (2 + 1 + 1 = 4)
       expect(flow).toHaveAttribute('data-node-count', '4')
+    })
+
+    it('restores empty (hide all) state from localStorage on mount', async () => {
+      localStorage.setItem('meridian:graph-visible-types', JSON.stringify([]))
+      renderGraph(energyManifest)
+      const flow = await screen.findByTestId('react-flow')
+      await waitFor(() => expect(flow).toHaveAttribute('data-node-count', '0'))
     })
   })
 

--- a/frontend/src/features/manifests/components/manifest-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.tsx
@@ -638,7 +638,8 @@ export function ManifestGraph({ manifest, className, _fullscreen }: ManifestGrap
           const valid = (parsed as unknown[]).filter(
             (t): t is ManifestNodeType => typeof t === 'string' && allTypes.has(t),
           )
-          if (valid.length > 0) return new Set<ManifestNodeType>(valid)
+          // Respect empty array as a valid "hide all" preference
+          return new Set<ManifestNodeType>(valid)
         }
       }
     } catch {

--- a/frontend/src/features/manifests/components/manifest-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.tsx
@@ -628,9 +628,24 @@ export function ManifestGraph({ manifest, className, _fullscreen }: ManifestGrap
   const [showEventChain, setShowEventChain] = useState(false)
   const [fullscreen, setFullscreen] = useState(false)
   const [editModalOpen, setEditModalOpen] = useState(false)
-  const [visibleTypes, setVisibleTypes] = useState<Set<ManifestNodeType>>(
-    () => new Set<ManifestNodeType>(Object.keys(NODE_TYPE_REGISTRY) as ManifestNodeType[]),
-  )
+  const [visibleTypes, setVisibleTypes] = useState<Set<ManifestNodeType>>(() => {
+    try {
+      const stored = localStorage.getItem('meridian:graph-visible-types')
+      if (stored) {
+        const parsed: unknown = JSON.parse(stored)
+        if (Array.isArray(parsed)) {
+          const allTypes = new Set<string>(Object.keys(NODE_TYPE_REGISTRY))
+          const valid = (parsed as unknown[]).filter(
+            (t): t is ManifestNodeType => typeof t === 'string' && allTypes.has(t),
+          )
+          if (valid.length > 0) return new Set<ManifestNodeType>(valid)
+        }
+      }
+    } catch {
+      // ignore localStorage errors
+    }
+    return new Set<ManifestNodeType>(Object.keys(NODE_TYPE_REGISTRY) as ManifestNodeType[])
+  })
 
   const graph = useMemo(() => buildManifestGraph(manifest), [manifest])
 
@@ -794,6 +809,14 @@ export function ManifestGraph({ manifest, className, _fullscreen }: ManifestGrap
     setHoveredNode(null)
   }, [])
 
+  const persistVisibleTypes = useCallback((types: Set<ManifestNodeType>) => {
+    try {
+      localStorage.setItem('meridian:graph-visible-types', JSON.stringify([...types]))
+    } catch {
+      // ignore localStorage errors
+    }
+  }, [])
+
   const toggleType = useCallback((type: ManifestNodeType) => {
     setVisibleTypes((prev) => {
       const next = new Set(prev)
@@ -802,6 +825,7 @@ export function ManifestGraph({ manifest, className, _fullscreen }: ManifestGrap
       } else {
         next.add(type)
       }
+      persistVisibleTypes(next)
       return next
     })
     // Clear selection if the selected node's type was just hidden
@@ -809,7 +833,21 @@ export function ManifestGraph({ manifest, className, _fullscreen }: ManifestGrap
       setSelectedNode(null)
       setShowEventChain(false)
     }
-  }, [selectedManifestNode])
+  }, [selectedManifestNode, persistVisibleTypes])
+
+  const showAllTypes = useCallback(() => {
+    const all = new Set<ManifestNodeType>(Object.keys(NODE_TYPE_REGISTRY) as ManifestNodeType[])
+    setVisibleTypes(all)
+    persistVisibleTypes(all)
+  }, [persistVisibleTypes])
+
+  const hideAllTypes = useCallback(() => {
+    const empty = new Set<ManifestNodeType>()
+    setVisibleTypes(empty)
+    setSelectedNode(null)
+    setShowEventChain(false)
+    persistVisibleTypes(empty)
+  }, [persistVisibleTypes])
 
   const totalVisible = nodes.length
 
@@ -852,7 +890,28 @@ export function ManifestGraph({ manifest, className, _fullscreen }: ManifestGrap
 
       {/* Filter sidebar */}
       <div className="absolute top-3 left-3 z-10 flex flex-col gap-2 rounded-lg border bg-background/95 p-3 backdrop-blur-sm shadow-sm">
-        <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Element Types</span>
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Element Types</span>
+          <div className="flex gap-1">
+            <button
+              type="button"
+              onClick={showAllTypes}
+              className="text-[10px] text-muted-foreground hover:text-foreground transition-colors px-1"
+              aria-label="Show all types"
+            >
+              All
+            </button>
+            <span className="text-[10px] text-muted-foreground">/</span>
+            <button
+              type="button"
+              onClick={hideAllTypes}
+              className="text-[10px] text-muted-foreground hover:text-foreground transition-colors px-1"
+              aria-label="Hide all types"
+            >
+              None
+            </button>
+          </div>
+        </div>
         {(Object.keys(NODE_THEMES) as ManifestNodeType[]).map((type) => {
           const theme = NODE_THEMES[type]
           const count = nodeCountByType[type]


### PR DESCRIPTION
## Summary

- Adds **Show All / None** convenience buttons to the Element Types filter sidebar in the economy graph, allowing users to toggle all 13 node types at once
- Persists the selected visible types to `localStorage` under `meridian:graph-visible-types` so filter state survives page refreshes
- On load, if stored types include unknown/removed types, they are silently dropped; defaults to all types visible if nothing is stored

## Changes Made

- `frontend/src/features/manifests/components/manifest-graph.tsx`
  - `useState` initializer reads from `localStorage` on mount
  - Added `persistVisibleTypes` helper (wraps `localStorage.setItem` with try/catch)
  - `toggleType` now calls `persistVisibleTypes` after each toggle
  - Added `showAllTypes` and `hideAllTypes` callbacks
  - Added All / None buttons to the filter sidebar header row

## Testing

- Toggle a type off, refresh — type remains hidden
- Click None — all nodes disappear; click All — full graph restores
- Clear `localStorage`, reload — all types shown by default

## Risk Assessment

Low. Changes are isolated to client-side state management and UI. No API calls, no data model changes.