### PR TITLE
feat: add optimistic locking conflict UI

### DIFF
--- a/frontend/src/features/economy/components/__tests__/conflict-resolution-modal.test.tsx
+++ b/frontend/src/features/economy/components/__tests__/conflict-resolution-modal.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/test-utils'
+import { ConflictResolutionModal } from '../conflict-resolution-modal'
+import type { Manifest } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
+
+// Mock the ManifestDiffGraph to avoid ReactFlow/ELK complexity in unit tests
+vi.mock('@/features/manifests/components/manifest-diff-graph', () => ({
+  ManifestDiffGraph: ({ before, after }: { before: unknown; after: unknown }) => (
+    <div data-testid="manifest-diff-graph">
+      Diff: {JSON.stringify(before)} vs {JSON.stringify(after)}
+    </div>
+  ),
+}))
+
+vi.mock('@/features/manifests/lib/manifest-graph-model', () => ({
+  buildManifestGraph: (manifest: unknown) => ({ nodes: [], edges: [], manifest }),
+}))
+
+const userManifest = { $typeName: 'meridian.control_plane.v1.Manifest' } as unknown as Manifest
+const serverManifest = { $typeName: 'meridian.control_plane.v1.Manifest', instruments: [] } as unknown as Manifest
+
+describe('ConflictResolutionModal', () => {
+  const user = userEvent.setup()
+
+  it('renders with version conflict message when open', () => {
+    renderWithProviders(
+      <ConflictResolutionModal
+        open={true}
+        onResolve={vi.fn()}
+        userManifest={userManifest}
+        serverManifest={serverManifest}
+      />,
+    )
+
+    expect(screen.getByText('Version Conflict')).toBeInTheDocument()
+    expect(screen.getByText(/modified by another user/)).toBeInTheDocument()
+  })
+
+  it('renders the diff graph', () => {
+    renderWithProviders(
+      <ConflictResolutionModal
+        open={true}
+        onResolve={vi.fn()}
+        userManifest={userManifest}
+        serverManifest={serverManifest}
+      />,
+    )
+
+    expect(screen.getByTestId('conflict-diff-graph')).toBeInTheDocument()
+    expect(screen.getByTestId('manifest-diff-graph')).toBeInTheDocument()
+  })
+
+  it('calls onResolve with "force" when Force Apply is clicked', async () => {
+    const onResolve = vi.fn()
+    renderWithProviders(
+      <ConflictResolutionModal
+        open={true}
+        onResolve={onResolve}
+        userManifest={userManifest}
+        serverManifest={serverManifest}
+      />,
+    )
+
+    await user.click(screen.getByTestId('conflict-force'))
+    expect(onResolve).toHaveBeenCalledWith('force')
+  })
+
+  it('calls onResolve with "reload" when Reload is clicked', async () => {
+    const onResolve = vi.fn()
+    renderWithProviders(
+      <ConflictResolutionModal
+        open={true}
+        onResolve={onResolve}
+        userManifest={userManifest}
+        serverManifest={serverManifest}
+      />,
+    )
+
+    await user.click(screen.getByTestId('conflict-reload'))
+    expect(onResolve).toHaveBeenCalledWith('reload')
+  })
+
+  it('calls onResolve with "cancel" when Cancel is clicked', async () => {
+    const onResolve = vi.fn()
+    renderWithProviders(
+      <ConflictResolutionModal
+        open={true}
+        onResolve={onResolve}
+        userManifest={userManifest}
+        serverManifest={serverManifest}
+      />,
+    )
+
+    await user.click(screen.getByTestId('conflict-cancel'))
+    expect(onResolve).toHaveBeenCalledWith('cancel')
+  })
+
+  it('does not render when open is false', () => {
+    renderWithProviders(
+      <ConflictResolutionModal
+        open={false}
+        onResolve={vi.fn()}
+        userManifest={userManifest}
+        serverManifest={serverManifest}
+      />,
+    )
+
+    expect(screen.queryByText('Version Conflict')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/economy/components/__tests__/deploy-wizard.test.tsx
+++ b/frontend/src/features/economy/components/__tests__/deploy-wizard.test.tsx
@@ -81,6 +81,7 @@ function renderWizard(props: Partial<React.ComponentProps<typeof DeployWizard>> 
       manifestChanged={false}
       onLineClick={vi.fn()}
       onSuggestionApply={vi.fn()}
+      onReloadManifest={vi.fn()}
       {...props}
     />,
     { initialToken: createTenantUserToken() },
@@ -362,6 +363,7 @@ describe('DeployWizard', () => {
           manifestChanged={false}
           onLineClick={vi.fn()}
           onSuggestionApply={vi.fn()}
+          onReloadManifest={vi.fn()}
         />,
         { initialToken: createTenantUserToken() },
       )
@@ -376,6 +378,7 @@ describe('DeployWizard', () => {
           manifestChanged={true}
           onLineClick={vi.fn()}
           onSuggestionApply={vi.fn()}
+          onReloadManifest={vi.fn()}
         />,
       )
 
@@ -401,6 +404,7 @@ describe('DeployWizard', () => {
           manifestChanged={false}
           onLineClick={vi.fn()}
           onSuggestionApply={vi.fn()}
+          onReloadManifest={vi.fn()}
         />,
         { initialToken: createTenantUserToken() },
       )
@@ -416,6 +420,7 @@ describe('DeployWizard', () => {
           manifestChanged={true}
           onLineClick={vi.fn()}
           onSuggestionApply={vi.fn()}
+          onReloadManifest={vi.fn()}
         />,
       )
 
@@ -428,6 +433,7 @@ describe('DeployWizard', () => {
           manifestChanged={false}
           onLineClick={vi.fn()}
           onSuggestionApply={vi.fn()}
+          onReloadManifest={vi.fn()}
         />,
       )
       await user.click(screen.getByRole('button', { name: /re-plan/i }))

--- a/frontend/src/features/economy/components/apply-resource-modal.tsx
+++ b/frontend/src/features/economy/components/apply-resource-modal.tsx
@@ -16,8 +16,6 @@ import { manifestKeys } from '@/lib/query-keys'
 import { ApplyManifestStatus } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
 import type { ManifestNodeType } from '@/features/manifests/lib/manifest-graph-model'
 import { ResourceForm } from './resource-form'
-import { type ConflictResolution } from './conflict-resolution-modal'
-import { isVersionConflict } from '../lib/version-conflict'
 import {
   getResourceSchema,
   buildResourcePayload,
@@ -69,14 +67,10 @@ export function ApplyResourceModal({
   const [state, setState] = useState<ModalState>('editing')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
-  // Conflict resolution state
-  const [conflictOpen, setConflictOpen] = useState(false)
-
   const resetState = useCallback(() => {
     setValues(defaultValues)
     setState('editing')
     setErrorMessage(null)
-    setConflictOpen(false)
   }, [defaultValues])
 
   const handleOpenChange = useCallback(
@@ -124,11 +118,6 @@ export function ApplyResourceModal({
       }
     },
     onError: (err: unknown) => {
-      if (isVersionConflict(err)) {
-        setConflictOpen(true)
-        setState('error')
-        return
-      }
       const message =
         err instanceof Error ? err.message : 'Apply failed. Please try again.'
       setErrorMessage(message)
@@ -146,48 +135,6 @@ export function ApplyResourceModal({
     setState('applying')
     applyMutation.mutate()
   }, [applyMutation])
-
-  const handleConflictResolve = useCallback((resolution: ConflictResolution) => {
-    setConflictOpen(false)
-    switch (resolution) {
-      case 'force':
-        if (!schema) return
-        setState('applying')
-        manifestApplier.applyResource({
-          resourceType: schema.resourceType,
-          resource: {
-            case: schema.oneofCase as never,
-            value: buildResourcePayload(schema, values) as never,
-          },
-          dryRun: false,
-          appliedBy: claims?.userId ?? '',
-          expectedSequenceNumber: BigInt(0),
-        }).then((response) => {
-          void queryClient.invalidateQueries({ queryKey: manifestKeys.all })
-          if (response.status === ApplyManifestStatus.APPLIED) {
-            setState('success')
-          } else {
-            const validationMessages = response.validationErrors
-              ?.map((e) => e.message)
-              .join('; ')
-            setErrorMessage(validationMessages || response.diffSummary || 'Apply failed')
-            setState('error')
-          }
-        }).catch((err: unknown) => {
-          const message = err instanceof Error ? err.message : 'Force apply failed.'
-          setErrorMessage(message)
-          setState('error')
-        })
-        break
-      case 'reload':
-        resetState()
-        break
-      case 'cancel':
-        setErrorMessage('Apply cancelled due to version conflict.')
-        setState('error')
-        break
-    }
-  }, [schema, values, claims?.userId, manifestApplier, queryClient, resetState])
 
   if (!schema) {
     return (
@@ -244,44 +191,6 @@ export function ApplyResourceModal({
               >
                 <AlertCircle className="h-4 w-4 shrink-0" />
                 <span>{errorMessage}</span>
-              </div>
-            )}
-
-            {conflictOpen && (
-              <div
-                className="space-y-2 rounded-md border border-warning/30 bg-warning-muted p-3"
-                data-testid="apply-resource-conflict"
-              >
-                <div className="flex items-center gap-2 text-sm font-medium text-warning-foreground">
-                  <AlertCircle className="h-4 w-4 shrink-0" />
-                  Version conflict: the manifest was modified by another user.
-                </div>
-                <div className="flex gap-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => handleConflictResolve('reload')}
-                    data-testid="conflict-reload"
-                  >
-                    Reload
-                  </Button>
-                  <Button
-                    variant="destructive"
-                    size="sm"
-                    onClick={() => handleConflictResolve('force')}
-                    data-testid="conflict-force"
-                  >
-                    Force Apply
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => handleConflictResolve('cancel')}
-                    data-testid="conflict-cancel"
-                  >
-                    Cancel
-                  </Button>
-                </div>
               </div>
             )}
           </>

--- a/frontend/src/features/economy/components/apply-resource-modal.tsx
+++ b/frontend/src/features/economy/components/apply-resource-modal.tsx
@@ -16,6 +16,8 @@ import { manifestKeys } from '@/lib/query-keys'
 import { ApplyManifestStatus } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
 import type { ManifestNodeType } from '@/features/manifests/lib/manifest-graph-model'
 import { ResourceForm } from './resource-form'
+import { type ConflictResolution } from './conflict-resolution-modal'
+import { isVersionConflict } from '../lib/version-conflict'
 import {
   getResourceSchema,
   buildResourcePayload,
@@ -67,10 +69,14 @@ export function ApplyResourceModal({
   const [state, setState] = useState<ModalState>('editing')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
+  // Conflict resolution state
+  const [conflictOpen, setConflictOpen] = useState(false)
+
   const resetState = useCallback(() => {
     setValues(defaultValues)
     setState('editing')
     setErrorMessage(null)
+    setConflictOpen(false)
   }, [defaultValues])
 
   const handleOpenChange = useCallback(
@@ -118,6 +124,11 @@ export function ApplyResourceModal({
       }
     },
     onError: (err: unknown) => {
+      if (isVersionConflict(err)) {
+        setConflictOpen(true)
+        setState('error')
+        return
+      }
       const message =
         err instanceof Error ? err.message : 'Apply failed. Please try again.'
       setErrorMessage(message)
@@ -135,6 +146,48 @@ export function ApplyResourceModal({
     setState('applying')
     applyMutation.mutate()
   }, [applyMutation])
+
+  const handleConflictResolve = useCallback((resolution: ConflictResolution) => {
+    setConflictOpen(false)
+    switch (resolution) {
+      case 'force':
+        if (!schema) return
+        setState('applying')
+        manifestApplier.applyResource({
+          resourceType: schema.resourceType,
+          resource: {
+            case: schema.oneofCase as never,
+            value: buildResourcePayload(schema, values) as never,
+          },
+          dryRun: false,
+          appliedBy: claims?.userId ?? '',
+          expectedSequenceNumber: BigInt(0),
+        }).then((response) => {
+          void queryClient.invalidateQueries({ queryKey: manifestKeys.all })
+          if (response.status === ApplyManifestStatus.APPLIED) {
+            setState('success')
+          } else {
+            const validationMessages = response.validationErrors
+              ?.map((e) => e.message)
+              .join('; ')
+            setErrorMessage(validationMessages || response.diffSummary || 'Apply failed')
+            setState('error')
+          }
+        }).catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : 'Force apply failed.'
+          setErrorMessage(message)
+          setState('error')
+        })
+        break
+      case 'reload':
+        resetState()
+        break
+      case 'cancel':
+        setErrorMessage('Apply cancelled due to version conflict.')
+        setState('error')
+        break
+    }
+  }, [schema, values, claims?.userId, manifestApplier, queryClient, resetState])
 
   if (!schema) {
     return (
@@ -191,6 +244,44 @@ export function ApplyResourceModal({
               >
                 <AlertCircle className="h-4 w-4 shrink-0" />
                 <span>{errorMessage}</span>
+              </div>
+            )}
+
+            {conflictOpen && (
+              <div
+                className="space-y-2 rounded-md border border-warning/30 bg-warning-muted p-3"
+                data-testid="apply-resource-conflict"
+              >
+                <div className="flex items-center gap-2 text-sm font-medium text-warning-foreground">
+                  <AlertCircle className="h-4 w-4 shrink-0" />
+                  Version conflict: the manifest was modified by another user.
+                </div>
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleConflictResolve('reload')}
+                    data-testid="conflict-reload"
+                  >
+                    Reload
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => handleConflictResolve('force')}
+                    data-testid="conflict-force"
+                  >
+                    Force Apply
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleConflictResolve('cancel')}
+                    data-testid="conflict-cancel"
+                  >
+                    Cancel
+                  </Button>
+                </div>
               </div>
             )}
           </>

--- a/frontend/src/features/economy/components/conflict-resolution-modal.tsx
+++ b/frontend/src/features/economy/components/conflict-resolution-modal.tsx
@@ -1,0 +1,99 @@
+import { useMemo } from 'react'
+import { AlertCircle, RefreshCw, ShieldAlert } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { ManifestDiffGraph } from '@/features/manifests/components/manifest-diff-graph'
+import { buildManifestGraph } from '@/features/manifests/lib/manifest-graph-model'
+import type { Manifest } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
+
+export type ConflictResolution = 'force' | 'reload' | 'cancel'
+
+export interface ConflictResolutionModalProps {
+  open: boolean
+  onResolve: (resolution: ConflictResolution) => void
+  /** The manifest the user was trying to apply. */
+  userManifest: Manifest
+  /** The manifest currently on the server (newer version). */
+  serverManifest: Manifest
+}
+
+export function ConflictResolutionModal({
+  open,
+  onResolve,
+  userManifest,
+  serverManifest,
+}: ConflictResolutionModalProps) {
+  const userGraph = useMemo(() => buildManifestGraph(userManifest), [userManifest])
+  const serverGraph = useMemo(() => buildManifestGraph(serverManifest), [serverManifest])
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) onResolve('cancel') }}>
+      <DialogContent className="sm:max-w-3xl max-h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ShieldAlert className="h-5 w-5 text-warning-foreground" />
+            Version Conflict
+          </DialogTitle>
+          <DialogDescription>
+            The manifest has been modified by another user since you last loaded it.
+            Review the differences below and choose how to proceed.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-center gap-2 rounded-md border border-warning/30 bg-warning-muted px-3 py-2 text-sm text-warning-foreground">
+          <AlertCircle className="h-4 w-4 shrink-0" />
+          <span>
+            Your changes conflict with the current server version.
+            Forcing will overwrite the server version with your changes.
+          </span>
+        </div>
+
+        <div className="min-h-[300px] flex-1 rounded-md border" data-testid="conflict-diff-graph">
+          <ManifestDiffGraph
+            before={serverGraph}
+            after={userGraph}
+            className="h-full"
+          />
+        </div>
+
+        <DialogFooter className="flex-row gap-2 sm:justify-between">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onResolve('cancel')}
+            data-testid="conflict-cancel"
+          >
+            Cancel
+          </Button>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onResolve('reload')}
+              data-testid="conflict-reload"
+            >
+              <RefreshCw className="h-4 w-4" />
+              Reload Server Version
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => onResolve('force')}
+              data-testid="conflict-force"
+            >
+              <ShieldAlert className="h-4 w-4" />
+              Force Apply
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/features/economy/components/deploy-wizard.test.tsx
+++ b/frontend/src/features/economy/components/deploy-wizard.test.tsx
@@ -39,6 +39,7 @@ function renderWizard(props?: Partial<React.ComponentProps<typeof DeployWizard>>
       <DeployWizard
         manifest={manifest}
         manifestChanged={false}
+        onReloadManifest={vi.fn()}
         {...props}
       />
     </QueryClientProvider>,

--- a/frontend/src/features/economy/components/deploy-wizard.tsx
+++ b/frontend/src/features/economy/components/deploy-wizard.tsx
@@ -141,19 +141,19 @@ export function DeployWizard({
     onError: (err: unknown) => {
       setConfirmOpen(false)
       if (isVersionConflict(err)) {
+        setStep('error')
+        setApplyError('Version conflict detected. Loading server version…')
         // Fetch the current server manifest to show the diff
         void manifestHistory.getCurrentManifest({}).then((res) => {
           if (res.version?.manifest) {
+            setApplyError(null)
             setServerManifest(res.version.manifest)
             setConflictOpen(true)
-            setStep('error')
           } else {
             setApplyError('Version conflict detected, but the server returned no manifest.')
-            setStep('error')
           }
         }).catch(() => {
           setApplyError('Version conflict detected, but failed to fetch current version.')
-          setStep('error')
         })
         return
       }

--- a/frontend/src/features/economy/components/deploy-wizard.tsx
+++ b/frontend/src/features/economy/components/deploy-wizard.tsx
@@ -141,6 +141,9 @@ export function DeployWizard({
             setServerManifest(res.version.manifest)
             setConflictOpen(true)
             setStep('error')
+          } else {
+            setApplyError('Version conflict detected, but the server returned no manifest.')
+            setStep('error')
           }
         }).catch(() => {
           setApplyError('Version conflict detected, but failed to fetch current version.')

--- a/frontend/src/features/economy/components/deploy-wizard.tsx
+++ b/frontend/src/features/economy/components/deploy-wizard.tsx
@@ -46,7 +46,7 @@ export interface DeployWizardProps {
   /** Called when a plan run is initiated so callers can reset stale flags. */
   onPlanStart?: () => void
   /** Called when the user chooses to reload the server version after a version conflict. */
-  onReloadManifest?: (serverManifest: Manifest) => void
+  onReloadManifest: (serverManifest: Manifest) => void
 }
 
 // ── Plan hash ───────────────────────────────────────────────────────────────
@@ -173,11 +173,17 @@ export function DeployWizard({
           expectedSequenceNumber: BigInt(0),
         }).then((response) => {
           setApplyStepResults(response.stepResults ?? [])
-          const isPartial = response.status === ApplyManifestStatus.FAILED &&
-            (response.stepResults ?? []).some((s) => s.status === StepResultStatus.SUCCESS)
+          const isFailed = response.status === ApplyManifestStatus.FAILED
+          const hasAnyStepSuccess = (response.stepResults ?? []).some(
+            (s) => s.status === StepResultStatus.SUCCESS,
+          )
           void queryClient.invalidateQueries({ queryKey: manifestKeys.all })
-          if (isPartial) {
-            setApplyError('Apply completed with partial failures. Some phases did not succeed.')
+          if (isFailed) {
+            setApplyError(
+              hasAnyStepSuccess
+                ? 'Apply completed with partial failures. Some phases did not succeed.'
+                : 'Apply failed. No phases succeeded.',
+            )
             setStep('error')
           } else {
             setStep('success')
@@ -189,7 +195,7 @@ export function DeployWizard({
         })
         break
       case 'reload':
-        if (serverManifest && onReloadManifest) {
+        if (serverManifest) {
           onReloadManifest(serverManifest)
         }
         setStep('idle')

--- a/frontend/src/features/economy/components/deploy-wizard.tsx
+++ b/frontend/src/features/economy/components/deploy-wizard.tsx
@@ -121,11 +121,17 @@ export function DeployWizard({
     },
     onSuccess: (response) => {
       setApplyStepResults(response.stepResults ?? [])
-      const isPartial = response.status === ApplyManifestStatus.FAILED &&
-        (response.stepResults ?? []).some((s) => s.status === StepResultStatus.SUCCESS)
+      const isFailed = response.status === ApplyManifestStatus.FAILED
+      const hasAnyStepSuccess = (response.stepResults ?? []).some(
+        (s) => s.status === StepResultStatus.SUCCESS,
+      )
       void queryClient.invalidateQueries({ queryKey: manifestKeys.all })
-      if (isPartial) {
-        setApplyError('Apply completed with partial failures. Some phases did not succeed.')
+      if (isFailed) {
+        setApplyError(
+          hasAnyStepSuccess
+            ? 'Apply completed with partial failures. Some phases did not succeed.'
+            : 'Apply failed. No phases succeeded.',
+        )
         setStep('error')
       } else {
         setStep('success')

--- a/frontend/src/features/economy/components/deploy-wizard.tsx
+++ b/frontend/src/features/economy/components/deploy-wizard.tsx
@@ -4,6 +4,8 @@ import { AlertCircle, CheckCircle2, Loader2, TriangleAlert } from 'lucide-react'
 import { useManifestPlan } from '../hooks/use-manifest-plan'
 import { ValidationPanel } from './validation-panel'
 import { ApplyPhasesStepper } from './apply-phases-stepper'
+import { ConflictResolutionModal, type ConflictResolution } from './conflict-resolution-modal'
+import { isVersionConflict } from '../lib/version-conflict'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -43,6 +45,8 @@ export interface DeployWizardProps {
   onSuggestionApply?: (path: string, suggestion: string) => void
   /** Called when a plan run is initiated so callers can reset stale flags. */
   onPlanStart?: () => void
+  /** Called when the user chooses to reload the server version after a version conflict. */
+  onReloadManifest?: (serverManifest: Manifest) => void
 }
 
 // ── Plan hash ───────────────────────────────────────────────────────────────
@@ -60,15 +64,20 @@ export function DeployWizard({
   onLineClick,
   onSuggestionApply,
   onPlanStart,
+  onReloadManifest,
 }: DeployWizardProps) {
   const { claims } = useAuth()
-  const { manifestApplier } = useApiClients()
+  const { manifestApplier, manifestHistory } = useApiClients()
   const queryClient = useQueryClient()
 
   const [step, setStep] = useState<DeployStep>('idle')
   const [applyError, setApplyError] = useState<string | null>(null)
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [applyStepResults, setApplyStepResults] = useState<StepResult[]>([])
+
+  // Conflict resolution state
+  const [conflictOpen, setConflictOpen] = useState(false)
+  const [serverManifest, setServerManifest] = useState<Manifest | null>(null)
 
   // Track plan hash to detect manifest edits after planning
   const [planHash, setPlanHash] = useState<string | null>(null)
@@ -124,12 +133,73 @@ export function DeployWizard({
       setConfirmOpen(false)
     },
     onError: (err: unknown) => {
+      setConfirmOpen(false)
+      if (isVersionConflict(err)) {
+        // Fetch the current server manifest to show the diff
+        void manifestHistory.getCurrentManifest({}).then((res) => {
+          if (res.version?.manifest) {
+            setServerManifest(res.version.manifest)
+            setConflictOpen(true)
+            setStep('error')
+          }
+        }).catch(() => {
+          setApplyError('Version conflict detected, but failed to fetch current version.')
+          setStep('error')
+        })
+        return
+      }
       const message = err instanceof Error ? err.message : 'Apply failed. Please try again.'
       setApplyError(message)
       setStep('error')
-      setConfirmOpen(false)
     },
   })
+
+  // ── Conflict resolution ──────────────────────────────────────────────────
+
+  const handleConflictResolve = useCallback((resolution: ConflictResolution) => {
+    setConflictOpen(false)
+    switch (resolution) {
+      case 'force':
+        setStep('applying')
+        // Re-apply with force=true and expectedSequenceNumber=0 to skip the check
+        manifestApplier.applyManifest({
+          manifest,
+          dryRun: false,
+          force: true,
+          appliedBy: claims?.userId ?? '',
+          expectedSequenceNumber: BigInt(0),
+        }).then((response) => {
+          setApplyStepResults(response.stepResults ?? [])
+          const isPartial = response.status === ApplyManifestStatus.FAILED &&
+            (response.stepResults ?? []).some((s) => s.status === StepResultStatus.SUCCESS)
+          void queryClient.invalidateQueries({ queryKey: manifestKeys.all })
+          if (isPartial) {
+            setApplyError('Apply completed with partial failures. Some phases did not succeed.')
+            setStep('error')
+          } else {
+            setStep('success')
+          }
+        }).catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : 'Force apply failed.'
+          setApplyError(message)
+          setStep('error')
+        })
+        break
+      case 'reload':
+        if (serverManifest && onReloadManifest) {
+          onReloadManifest(serverManifest)
+        }
+        setStep('idle')
+        setApplyError(null)
+        setServerManifest(null)
+        break
+      case 'cancel':
+        setStep('error')
+        setApplyError('Apply cancelled due to version conflict.')
+        setServerManifest(null)
+        break
+    }
+  }, [manifest, claims?.userId, manifestApplier, queryClient, serverManifest, onReloadManifest])
 
   // ── Subtask 4: Plan hash invalidation ────────────────────────────────────
 
@@ -306,6 +376,16 @@ export function DeployWizard({
         canConfirm={isApplyAllowed}
         onConfirm={handleConfirmApply}
       />
+
+      {/* Version conflict modal */}
+      {serverManifest && (
+        <ConflictResolutionModal
+          open={conflictOpen}
+          onResolve={handleConflictResolve}
+          userManifest={manifest}
+          serverManifest={serverManifest}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/features/economy/lib/__tests__/version-conflict.test.ts
+++ b/frontend/src/features/economy/lib/__tests__/version-conflict.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { ConnectError, Code } from '@connectrpc/connect'
+import { isVersionConflict } from '../version-conflict'
+
+describe('isVersionConflict', () => {
+  it('returns true for ConnectError with Aborted code', () => {
+    const err = new ConnectError('sequence mismatch', Code.Aborted)
+    expect(isVersionConflict(err)).toBe(true)
+  })
+
+  it('returns false for ConnectError with other codes', () => {
+    expect(isVersionConflict(new ConnectError('not found', Code.NotFound))).toBe(false)
+    expect(isVersionConflict(new ConnectError('internal', Code.Internal))).toBe(false)
+    expect(isVersionConflict(new ConnectError('permission', Code.PermissionDenied))).toBe(false)
+  })
+
+  it('returns false for plain Error', () => {
+    expect(isVersionConflict(new Error('something'))).toBe(false)
+  })
+
+  it('returns false for non-error values', () => {
+    expect(isVersionConflict(null)).toBe(false)
+    expect(isVersionConflict(undefined)).toBe(false)
+    expect(isVersionConflict('string')).toBe(false)
+  })
+})

--- a/frontend/src/features/economy/lib/version-conflict.ts
+++ b/frontend/src/features/economy/lib/version-conflict.ts
@@ -1,0 +1,9 @@
+import { ConnectError, Code } from '@connectrpc/connect'
+
+/**
+ * Checks if an error is a version conflict (optimistic locking failure).
+ * The server returns gRPC ABORTED when expectedSequenceNumber doesn't match.
+ */
+export function isVersionConflict(err: unknown): boolean {
+  return err instanceof ConnectError && err.code === Code.Aborted
+}

--- a/frontend/src/features/economy/pages/economy-edit-page.tsx
+++ b/frontend/src/features/economy/pages/economy-edit-page.tsx
@@ -141,8 +141,9 @@ export function EconomyEditPage() {
     setManifestYaml(yamlStr)
     setDraftManifest(serverManifest)
     setYamlParseError(false)
+    validate(serverManifest)
     setManifestChangedSincePlan(false)
-  }, [])
+  }, [validate])
 
   return (
     <div className="flex h-full flex-col overflow-hidden">

--- a/frontend/src/features/economy/pages/economy-edit-page.tsx
+++ b/frontend/src/features/economy/pages/economy-edit-page.tsx
@@ -135,6 +135,15 @@ export function EconomyEditPage() {
     setManifestChangedSincePlan(false)
   }, [])
 
+  const handleReloadManifest = useCallback((serverManifest: Manifest) => {
+    const plainObj = JSON.parse(JSON.stringify(serverManifest)) as Record<string, unknown>
+    const yamlStr = yaml.dump(plainObj, { lineWidth: 120 })
+    setManifestYaml(yamlStr)
+    setDraftManifest(serverManifest)
+    setYamlParseError(false)
+    setManifestChangedSincePlan(false)
+  }, [])
+
   return (
     <div className="flex h-full flex-col overflow-hidden">
       {/* Breadcrumbs + title bar — always visible */}
@@ -181,6 +190,7 @@ export function EconomyEditPage() {
                   onLineClick={() => {}}
                   onSuggestionApply={() => {}}
                   onPlanStart={handlePlanStart}
+                  onReloadManifest={handleReloadManifest}
                 />
               </div>
             )}


### PR DESCRIPTION
## Summary

- Add version conflict detection and resolution UI for manifest apply operations
- When `applyManifest` or `applyResource` fails with gRPC ABORTED (sequence number mismatch), show a ConflictResolutionModal with diff visualization and three resolution options: force apply, reload server version, or cancel
- Integrate ManifestDiffGraph into the conflict modal to show visual diff between user's manifest and server's current version

## Changes

- `version-conflict.ts` -- utility to detect ConnectError with Code.Aborted
- `conflict-resolution-modal.tsx` -- modal with ManifestDiffGraph, force/reload/cancel buttons
- `deploy-wizard.tsx` -- detect version conflicts in apply mutation, fetch server manifest, show conflict modal, handle force-apply with `expectedSequenceNumber=0`
- `apply-resource-modal.tsx` -- inline conflict banner with force/reload/cancel for single-resource apply

## Test plan

- [x] Unit tests for `isVersionConflict` utility (4 tests)
- [x] Unit tests for ConflictResolutionModal rendering and callbacks (6 tests)
- [x] Existing deploy-wizard tests pass (17 tests)
- [x] Existing apply-resource-modal tests pass (10 tests)
- [x] TypeScript type checking passes
- [x] ESLint passes (0 errors)
- [x] All 195 economy feature tests pass

Task: 046-economy-visualization-completeness.22