### PR TITLE
feat: OPA constraint and CI gate for AUTH_ENABLED security defaults

### DIFF
--- a/.github/workflows/security-defaults.yml
+++ b/.github/workflows/security-defaults.yml
@@ -1,0 +1,144 @@
+name: Security Defaults Gate
+
+on:
+  push:
+    branches: [develop, main]
+    paths:
+      - 'services/*/k8s/configmap.yaml'
+      - 'services/*/config*.go'
+      - 'shared/platform/bootstrap/auth.go'
+      - 'deployments/k8s/policies/**'
+      - '.github/workflows/security-defaults.yml'
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - 'services/*/k8s/configmap.yaml'
+      - 'services/*/config*.go'
+      - 'shared/platform/bootstrap/auth.go'
+      - 'deployments/k8s/policies/**'
+      - '.github/workflows/security-defaults.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check-auth-defaults:
+    name: Security Defaults Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Check AUTH_ENABLED not disabled in K8s ConfigMaps
+        run: |
+          echo "Checking for AUTH_ENABLED=false in K8s ConfigMaps..."
+
+          # Look for AUTH_ENABLED explicitly set to false in service configmaps.
+          # The default is true; explicitly setting false in a K8s manifest is a
+          # security regression that must be caught before merge.
+          VIOLATIONS=$(grep -rn --include="configmap.yaml" \
+            -E 'AUTH_ENABLED[[:space:]]*:[[:space:]]*"false"' \
+            services/ deployments/k8s/ 2>/dev/null || true)
+
+          if [ -n "$VIOLATIONS" ]; then
+            echo "::error::AUTH_ENABLED=false found in K8s ConfigMaps:"
+            echo "$VIOLATIONS"
+            echo ""
+            echo "AUTH_ENABLED must not be set to false in K8s manifests."
+            echo "To fix: remove AUTH_ENABLED from the ConfigMap or set it to \"true\"."
+            exit 1
+          fi
+
+          echo "No AUTH_ENABLED=false violations found in K8s ConfigMaps."
+
+      - name: Check Go auth defaults are not false
+        run: |
+          echo "Checking Go auth defaults..."
+
+          # Detect any GetEnvAsBool("AUTH_ENABLED", false) — the default must be
+          # true so that a missing env var is safe. A false default would mean
+          # auth is off unless explicitly configured, which is unsafe.
+          VIOLATIONS=$(grep -rn --include="*.go" \
+            -E 'GetEnvAsBool\("AUTH_ENABLED"[[:space:]]*,[[:space:]]*false\)' \
+            services/ shared/ 2>/dev/null || true)
+
+          if [ -n "$VIOLATIONS" ]; then
+            echo "::error::AUTH_ENABLED defaults to false in Go code:"
+            echo "$VIOLATIONS"
+            echo ""
+            echo "AUTH_ENABLED must default to true (safe default)."
+            echo "To fix: change GetEnvAsBool(\"AUTH_ENABLED\", false) to GetEnvAsBool(\"AUTH_ENABLED\", true)."
+            exit 1
+          fi
+
+          echo "Go auth defaults are safe (default: true)."
+
+      - name: Verify OPA constraints exist
+        run: |
+          echo "Verifying OPA Gatekeeper constraints are present..."
+
+          ERRORS=0
+
+          # LOCAL_DEV_MODE constraint (guards against dev mode in production)
+          DEV_MODE_CONSTRAINT="deployments/k8s/policies/gateway-dev-mode-block.yaml"
+          if [ ! -f "$DEV_MODE_CONSTRAINT" ]; then
+            echo "::error::LOCAL_DEV_MODE OPA constraint missing: $DEV_MODE_CONSTRAINT"
+            ERRORS=$((ERRORS + 1))
+          else
+            echo "Found: $DEV_MODE_CONSTRAINT"
+          fi
+
+          # AUTH_ENABLED constraint (guards against auth disabled in production)
+          AUTH_CONSTRAINT="deployments/k8s/policies/auth-enabled-block.yaml"
+          if [ ! -f "$AUTH_CONSTRAINT" ]; then
+            echo "::error::AUTH_ENABLED OPA constraint missing: $AUTH_CONSTRAINT"
+            ERRORS=$((ERRORS + 1))
+          else
+            echo "Found: $AUTH_CONSTRAINT"
+          fi
+
+          if [ "$ERRORS" -gt 0 ]; then
+            echo ""
+            echo "OPA Gatekeeper constraints provide admission control for production K8s clusters."
+            echo "These files must not be deleted."
+            exit 1
+          fi
+
+          echo "All required OPA constraints are present."
+
+      - name: Verify OPA constraint enforcement action is deny
+        run: |
+          echo "Verifying OPA constraints enforce with 'deny' action..."
+
+          ERRORS=0
+
+          for constraint_file in \
+            "deployments/k8s/policies/gateway-dev-mode-block.yaml" \
+            "deployments/k8s/policies/auth-enabled-block.yaml"; do
+
+            if [ ! -f "$constraint_file" ]; then
+              continue
+            fi
+
+            # Constraints must use enforcementAction: deny to actively block violations.
+            # 'dryrun' or 'warn' only audit without blocking — unacceptable for production.
+            ACTION=$(grep 'enforcementAction:' "$constraint_file" | awk '{print $2}' | head -1)
+            if [ "$ACTION" != "deny" ]; then
+              echo "::error::$constraint_file has enforcementAction: $ACTION (must be 'deny')"
+              ERRORS=$((ERRORS + 1))
+            else
+              echo "enforcementAction: deny — $constraint_file"
+            fi
+          done
+
+          if [ "$ERRORS" -gt 0 ]; then
+            exit 1
+          fi
+
+          echo "All OPA constraints have enforcementAction: deny."

--- a/.github/workflows/validate-manifests.yml
+++ b/.github/workflows/validate-manifests.yml
@@ -7,12 +7,14 @@ on:
       - 'deployments/k8s/**'
       - 'services/*/k8s/**'
       - '.github/workflows/validate-manifests.yml'
+      - '.github/workflows/security-defaults.yml'
   pull_request:
     branches: [develop, main]
     paths:
       - 'deployments/k8s/**'
       - 'services/*/k8s/**'
       - '.github/workflows/validate-manifests.yml'
+      - '.github/workflows/security-defaults.yml'
 
 permissions:
   contents: read
@@ -162,49 +164,72 @@ jobs:
         run: |
           echo "Verifying Rego policy files are in sync..."
 
-          CONSTRAINT_TEMPLATE="deployments/k8s/policies/gateway-dev-mode-block.yaml"
-          REGO_FILE="deployments/k8s/policies/tests/blockdevmodeinproduction.rego"
+          verify_rego_sync() {
+            local CONSTRAINT_TEMPLATE="$1"
+            local REGO_FILE="$2"
+            local PACKAGE_NAME="$3"
 
-          if [ ! -f "$CONSTRAINT_TEMPLATE" ]; then
-            echo "ConstraintTemplate not found: $CONSTRAINT_TEMPLATE"
+            if [ ! -f "$CONSTRAINT_TEMPLATE" ]; then
+              echo "ConstraintTemplate not found: $CONSTRAINT_TEMPLATE"
+              return 1
+            fi
+
+            if [ ! -f "$REGO_FILE" ]; then
+              echo "Rego test file not found: $REGO_FILE"
+              return 1
+            fi
+
+            # Extract Rego from ConstraintTemplate (between 'rego: |' and the next '---')
+            # Skip comment lines at the top of the standalone .rego file for comparison
+            YAML_REGO_FILE=$(mktemp)
+            sed -n '/rego: |/,/^---$/p' "$CONSTRAINT_TEMPLATE" | \
+              sed '1d;$d' | \
+              sed 's/^        //' > "$YAML_REGO_FILE"
+
+            # Get standalone Rego, skipping the header comments
+            TEST_REGO_FILE=$(mktemp)
+            sed -n "/^package ${PACKAGE_NAME}/,\$p" "$REGO_FILE" > "$TEST_REGO_FILE"
+
+            # Use opa fmt to normalize both files before comparing
+            # This is more robust than sed-based normalization
+            opa fmt "$YAML_REGO_FILE" > /tmp/yaml_rego_formatted.rego
+            opa fmt "$TEST_REGO_FILE" > /tmp/test_rego_formatted.rego
+
+            if ! diff /tmp/yaml_rego_formatted.rego /tmp/test_rego_formatted.rego > /dev/null; then
+              echo "ERROR: Rego policy in ConstraintTemplate differs from standalone test file!"
+              echo ""
+              echo "The Rego embedded in $CONSTRAINT_TEMPLATE must match $REGO_FILE"
+              echo "(excluding header comments and formatting differences)"
+              echo ""
+              echo "To fix: Update both files to have identical Rego policy logic."
+              echo ""
+              echo "=== Differences (after opa fmt normalization) ==="
+              diff /tmp/yaml_rego_formatted.rego /tmp/test_rego_formatted.rego | head -30 || true
+              return 1
+            fi
+
+            echo "In sync: $CONSTRAINT_TEMPLATE"
+            return 0
+          }
+
+          ERRORS=0
+
+          verify_rego_sync \
+            "deployments/k8s/policies/gateway-dev-mode-block.yaml" \
+            "deployments/k8s/policies/tests/blockdevmodeinproduction.rego" \
+            "blockdevmodeinproduction" || ERRORS=$((ERRORS + 1))
+
+          verify_rego_sync \
+            "deployments/k8s/policies/auth-enabled-block.yaml" \
+            "deployments/k8s/policies/tests/blockauthdiabledinproduction.rego" \
+            "blockauthdiabledinproduction" || ERRORS=$((ERRORS + 1))
+
+          if [ "$ERRORS" -gt 0 ]; then
+            echo "ERROR: $ERRORS Rego policy file(s) out of sync."
             exit 1
           fi
 
-          if [ ! -f "$REGO_FILE" ]; then
-            echo "Rego test file not found: $REGO_FILE"
-            exit 1
-          fi
-
-          # Extract Rego from ConstraintTemplate (between 'rego: |' and the next '---')
-          # Skip comment lines at the top of the standalone .rego file for comparison
-          YAML_REGO_FILE=$(mktemp)
-          sed -n '/rego: |/,/^---$/p' "$CONSTRAINT_TEMPLATE" | \
-            sed '1d;$d' | \
-            sed 's/^        //' > "$YAML_REGO_FILE"
-
-          # Get standalone Rego, skipping the header comments
-          TEST_REGO_FILE=$(mktemp)
-          sed -n '/^package blockdevmodeinproduction/,$p' "$REGO_FILE" > "$TEST_REGO_FILE"
-
-          # Use opa fmt to normalize both files before comparing
-          # This is more robust than sed-based normalization
-          opa fmt "$YAML_REGO_FILE" > /tmp/yaml_rego_formatted.rego
-          opa fmt "$TEST_REGO_FILE" > /tmp/test_rego_formatted.rego
-
-          if ! diff /tmp/yaml_rego_formatted.rego /tmp/test_rego_formatted.rego > /dev/null; then
-            echo "ERROR: Rego policy in ConstraintTemplate differs from standalone test file!"
-            echo ""
-            echo "The Rego embedded in $CONSTRAINT_TEMPLATE must match $REGO_FILE"
-            echo "(excluding header comments and formatting differences)"
-            echo ""
-            echo "To fix: Update both files to have identical Rego policy logic."
-            echo ""
-            echo "=== Differences (after opa fmt normalization) ==="
-            diff /tmp/yaml_rego_formatted.rego /tmp/test_rego_formatted.rego | head -30 || true
-            exit 1
-          fi
-
-          echo "Rego policy files are in sync."
+          echo "All Rego policy files are in sync."
 
       - name: Run OPA policy tests
         run: |

--- a/.github/workflows/validate-manifests.yml
+++ b/.github/workflows/validate-manifests.yml
@@ -221,8 +221,8 @@ jobs:
 
           verify_rego_sync \
             "deployments/k8s/policies/auth-enabled-block.yaml" \
-            "deployments/k8s/policies/tests/blockauthdiabledinproduction.rego" \
-            "blockauthdiabledinproduction" || ERRORS=$((ERRORS + 1))
+            "deployments/k8s/policies/tests/blockauthdisabledinproduction.rego" \
+            "blockauthdisabledinproduction" || ERRORS=$((ERRORS + 1))
 
           if [ "$ERRORS" -gt 0 ]; then
             echo "ERROR: $ERRORS Rego policy file(s) out of sync."

--- a/deployments/k8s/policies/auth-enabled-block.yaml
+++ b/deployments/k8s/policies/auth-enabled-block.yaml
@@ -1,0 +1,163 @@
+# OPA Gatekeeper policy to prevent AUTH_ENABLED=false in production namespaces
+# This policy ensures that authentication cannot be disabled in production
+# or staging environments. It checks both ConfigMaps and container environment
+# variables in all workload types.
+---
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: blockauthdiabledinproduction
+  annotations:
+    description: Blocks AUTH_ENABLED=false in ConfigMaps and container env vars in production namespaces
+spec:
+  crd:
+    spec:
+      names:
+        kind: BlockAuthDisabledInProduction
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package blockauthdiabledinproduction
+
+        # =============================================================================
+        # ConfigMap violation rule
+        # =============================================================================
+
+        violation[{"msg": msg}] {
+          # Check if the object is a ConfigMap
+          input.review.object.kind == "ConfigMap"
+
+          # Check if data field exists
+          input.review.object.data
+
+          # Check if AUTH_ENABLED is set to "false" (case-insensitive)
+          lower(input.review.object.data.AUTH_ENABLED) == "false"
+
+          # Get namespace name
+          ns := input.review.object.metadata.namespace
+
+          # Check if namespace matches production patterns (prod* or *production*)
+          is_production_namespace(ns)
+
+          msg := sprintf("ConfigMap '%s' in namespace '%s' cannot have AUTH_ENABLED=false. Authentication must be enabled in production namespaces.", [input.review.object.metadata.name, ns])
+        }
+
+        # =============================================================================
+        # Pod/workload environment variable violation rules
+        # Check for AUTH_ENABLED=false in container env vars for:
+        # - Pods, Deployments, StatefulSets, DaemonSets, Jobs, CronJobs
+        # =============================================================================
+
+        # Supported workload kinds that can contain container specs
+        workload_kinds := {"Pod", "Deployment", "StatefulSet", "DaemonSet", "Job", "CronJob", "ReplicaSet"}
+
+        # Helper to get the pod spec from different workload types
+        get_pod_spec(obj) = spec {
+          obj.kind == "Pod"
+          spec := obj.spec
+        }
+
+        get_pod_spec(obj) = spec {
+          workload_kinds[obj.kind]
+          obj.kind != "Pod"
+          obj.kind != "CronJob"
+          spec := obj.spec.template.spec
+        }
+
+        get_pod_spec(obj) = spec {
+          obj.kind == "CronJob"
+          spec := obj.spec.jobTemplate.spec.template.spec
+        }
+
+        # Check containers for AUTH_ENABLED=false env var
+        violation[{"msg": msg}] {
+          obj := input.review.object
+          workload_kinds[obj.kind]
+
+          pod_spec := get_pod_spec(obj)
+          container := pod_spec.containers[_]
+          env_var := container.env[_]
+
+          env_var.name == "AUTH_ENABLED"
+          lower(env_var.value) == "false"
+
+          ns := obj.metadata.namespace
+          is_production_namespace(ns)
+
+          msg := sprintf("%s '%s' in namespace '%s' has container '%s' with AUTH_ENABLED=false environment variable. Authentication must be enabled in production namespaces.", [obj.kind, obj.metadata.name, ns, container.name])
+        }
+
+        # Check initContainers for AUTH_ENABLED=false env var
+        violation[{"msg": msg}] {
+          obj := input.review.object
+          workload_kinds[obj.kind]
+
+          pod_spec := get_pod_spec(obj)
+          container := pod_spec.initContainers[_]
+          env_var := container.env[_]
+
+          env_var.name == "AUTH_ENABLED"
+          lower(env_var.value) == "false"
+
+          ns := obj.metadata.namespace
+          is_production_namespace(ns)
+
+          msg := sprintf("%s '%s' in namespace '%s' has initContainer '%s' with AUTH_ENABLED=false environment variable. Authentication must be enabled in production namespaces.", [obj.kind, obj.metadata.name, ns, container.name])
+        }
+
+        # Check ephemeralContainers for AUTH_ENABLED=false env var
+        violation[{"msg": msg}] {
+          obj := input.review.object
+          workload_kinds[obj.kind]
+
+          pod_spec := get_pod_spec(obj)
+          container := pod_spec.ephemeralContainers[_]
+          env_var := container.env[_]
+
+          env_var.name == "AUTH_ENABLED"
+          lower(env_var.value) == "false"
+
+          ns := obj.metadata.namespace
+          is_production_namespace(ns)
+
+          msg := sprintf("%s '%s' in namespace '%s' has ephemeralContainer '%s' with AUTH_ENABLED=false environment variable. Authentication must be enabled in production namespaces.", [obj.kind, obj.metadata.name, ns, container.name])
+        }
+
+        # =============================================================================
+        # Namespace detection helpers
+        # =============================================================================
+
+        # Match namespaces starting with 'prod'
+        is_production_namespace(ns) {
+          startswith(ns, "prod")
+        }
+
+        # Match namespaces containing 'production'
+        is_production_namespace(ns) {
+          contains(ns, "production")
+        }
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: BlockAuthDisabledInProduction
+metadata:
+  name: auth-enabled-constraint
+  annotations:
+    description: Prevents AUTH_ENABLED=false in ConfigMaps and container env vars in production
+spec:
+  # For gradual rollout, use 'dryrun' (audit only) or 'warn' (allow but warn)
+  # before switching to 'deny' (block) in production
+  enforcementAction: deny
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["ConfigMap"]
+      - apiGroups: [""]
+        kinds: ["Pod"]
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "StatefulSet", "DaemonSet", "ReplicaSet"]
+      - apiGroups: ["batch"]
+        kinds: ["Job", "CronJob"]
+    # Note: Namespace matching is handled entirely by the Rego policy using name patterns
+    # (prod* or *production*). This approach allows flexible matching without requiring
+    # specific namespace labels, and the policy will correctly identify production
+    # namespaces regardless of their labels.

--- a/deployments/k8s/policies/auth-enabled-block.yaml
+++ b/deployments/k8s/policies/auth-enabled-block.yaml
@@ -6,7 +6,7 @@
 apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
-  name: blockauthdiabledinproduction
+  name: blockauthdisabledinproduction
   annotations:
     description: Blocks AUTH_ENABLED=false in ConfigMaps and container env vars in production namespaces
 spec:
@@ -17,7 +17,7 @@ spec:
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |
-        package blockauthdiabledinproduction
+        package blockauthdisabledinproduction
 
         # =============================================================================
         # ConfigMap violation rule

--- a/deployments/k8s/policies/tests/auth_enabled_test.rego
+++ b/deployments/k8s/policies/tests/auth_enabled_test.rego
@@ -1,0 +1,632 @@
+# Tests for the BlockAuthDisabledInProduction OPA Gatekeeper policy
+# Run with: opa test deployments/k8s/policies/tests/ --v0-compatible -v
+
+package blockauthdiabledinproduction
+
+# =============================================================================
+# Test: Production namespace detection
+# =============================================================================
+
+test_is_production_namespace_prod {
+    is_production_namespace("prod")
+}
+
+test_is_production_namespace_production {
+    is_production_namespace("production")
+}
+
+test_is_production_namespace_prod_eu {
+    is_production_namespace("prod-eu")
+}
+
+test_is_production_namespace_prod_us_west {
+    is_production_namespace("prod-us-west")
+}
+
+test_is_production_namespace_contains_production {
+    is_production_namespace("my-production-service")
+}
+
+test_is_not_production_namespace_dev {
+    not is_production_namespace("dev")
+}
+
+test_is_not_production_namespace_staging {
+    not is_production_namespace("staging")
+}
+
+test_is_not_production_namespace_default {
+    not is_production_namespace("default")
+}
+
+# =============================================================================
+# Test: ConfigMap with AUTH_ENABLED=false in production should be blocked
+# =============================================================================
+
+test_violation_auth_enabled_false_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "service-config",
+                    "namespace": "prod"
+                },
+                "data": {
+                    "AUTH_ENABLED": "false"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+test_violation_auth_enabled_false_in_production_namespace {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "service-config",
+                    "namespace": "production"
+                },
+                "data": {
+                    "AUTH_ENABLED": "false"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+test_violation_auth_enabled_false_in_prod_eu {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "service-config",
+                    "namespace": "prod-eu"
+                },
+                "data": {
+                    "AUTH_ENABLED": "false"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+# =============================================================================
+# Test: Case-insensitive AUTH_ENABLED value checking
+# =============================================================================
+
+test_violation_auth_enabled_False_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "service-config",
+                    "namespace": "prod"
+                },
+                "data": {
+                    "AUTH_ENABLED": "False"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+test_violation_auth_enabled_FALSE_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "service-config",
+                    "namespace": "prod"
+                },
+                "data": {
+                    "AUTH_ENABLED": "FALSE"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+# =============================================================================
+# Test: ConfigMap with AUTH_ENABLED=false in dev/staging should be allowed
+# =============================================================================
+
+test_no_violation_auth_enabled_false_in_dev {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "service-config",
+                    "namespace": "dev"
+                },
+                "data": {
+                    "AUTH_ENABLED": "false"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+test_no_violation_auth_enabled_false_in_staging {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "service-config",
+                    "namespace": "staging"
+                },
+                "data": {
+                    "AUTH_ENABLED": "false"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+# =============================================================================
+# Test: ConfigMap with AUTH_ENABLED=true or missing should be allowed in prod
+# =============================================================================
+
+test_no_violation_auth_enabled_true_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "service-config",
+                    "namespace": "prod"
+                },
+                "data": {
+                    "AUTH_ENABLED": "true"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+test_no_violation_no_auth_enabled_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "service-config",
+                    "namespace": "prod"
+                },
+                "data": {
+                    "SOME_OTHER_CONFIG": "value"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+test_no_violation_empty_configmap_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "service-config",
+                    "namespace": "prod"
+                },
+                "data": {}
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+# =============================================================================
+# Test: Non-ConfigMap objects should not trigger violations
+# =============================================================================
+
+test_no_violation_secret_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Secret",
+                "metadata": {
+                    "name": "service-secret",
+                    "namespace": "prod"
+                },
+                "data": {
+                    "AUTH_ENABLED": "false"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+# =============================================================================
+# Test: Violation message is clear and actionable
+# =============================================================================
+
+test_violation_message_contains_configmap_name {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "my-service-config",
+                    "namespace": "prod"
+                },
+                "data": {
+                    "AUTH_ENABLED": "false"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+    some v
+    violations[v]
+    contains(v.msg, "my-service-config")
+    contains(v.msg, "AUTH_ENABLED=false")
+    contains(v.msg, "Authentication must be enabled")
+}
+
+# =============================================================================
+# Test: Pod/workload container env var with AUTH_ENABLED=false
+# =============================================================================
+
+test_violation_pod_container_env_auth_enabled_false_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Pod",
+                "metadata": {
+                    "name": "service-pod",
+                    "namespace": "prod"
+                },
+                "spec": {
+                    "containers": [{
+                        "name": "service",
+                        "image": "service:latest",
+                        "env": [{
+                            "name": "AUTH_ENABLED",
+                            "value": "false"
+                        }]
+                    }]
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+test_violation_deployment_container_env_auth_enabled_false_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Deployment",
+                "metadata": {
+                    "name": "service-deployment",
+                    "namespace": "prod"
+                },
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": [{
+                                "name": "service",
+                                "image": "service:latest",
+                                "env": [{
+                                    "name": "AUTH_ENABLED",
+                                    "value": "false"
+                                }]
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+test_violation_statefulset_container_env_auth_enabled_false_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "StatefulSet",
+                "metadata": {
+                    "name": "service-sts",
+                    "namespace": "production"
+                },
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": [{
+                                "name": "service",
+                                "image": "service:latest",
+                                "env": [{
+                                    "name": "AUTH_ENABLED",
+                                    "value": "False"
+                                }]
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+test_violation_cronjob_container_env_auth_enabled_false_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "CronJob",
+                "metadata": {
+                    "name": "service-cronjob",
+                    "namespace": "prod"
+                },
+                "spec": {
+                    "jobTemplate": {
+                        "spec": {
+                            "template": {
+                                "spec": {
+                                    "containers": [{
+                                        "name": "service",
+                                        "image": "service:latest",
+                                        "env": [{
+                                            "name": "AUTH_ENABLED",
+                                            "value": "false"
+                                        }]
+                                    }]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+# =============================================================================
+# Test: initContainers with AUTH_ENABLED=false
+# =============================================================================
+
+test_violation_pod_initcontainer_env_auth_enabled_false_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Pod",
+                "metadata": {
+                    "name": "service-pod",
+                    "namespace": "prod"
+                },
+                "spec": {
+                    "containers": [{
+                        "name": "service",
+                        "image": "service:latest"
+                    }],
+                    "initContainers": [{
+                        "name": "init-service",
+                        "image": "service-init:latest",
+                        "env": [{
+                            "name": "AUTH_ENABLED",
+                            "value": "false"
+                        }]
+                    }]
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+# =============================================================================
+# Test: Workloads with AUTH_ENABLED=false in dev/staging should be allowed
+# =============================================================================
+
+test_no_violation_pod_env_auth_enabled_false_in_dev {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Pod",
+                "metadata": {
+                    "name": "service-pod",
+                    "namespace": "dev"
+                },
+                "spec": {
+                    "containers": [{
+                        "name": "service",
+                        "image": "service:latest",
+                        "env": [{
+                            "name": "AUTH_ENABLED",
+                            "value": "false"
+                        }]
+                    }]
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+test_no_violation_deployment_env_auth_enabled_false_in_staging {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Deployment",
+                "metadata": {
+                    "name": "service-deployment",
+                    "namespace": "staging"
+                },
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": [{
+                                "name": "service",
+                                "image": "service:latest",
+                                "env": [{
+                                    "name": "AUTH_ENABLED",
+                                    "value": "false"
+                                }]
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+# =============================================================================
+# Test: Workloads with AUTH_ENABLED=true in prod should be allowed
+# =============================================================================
+
+test_no_violation_pod_env_auth_enabled_true_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Pod",
+                "metadata": {
+                    "name": "service-pod",
+                    "namespace": "prod"
+                },
+                "spec": {
+                    "containers": [{
+                        "name": "service",
+                        "image": "service:latest",
+                        "env": [{
+                            "name": "AUTH_ENABLED",
+                            "value": "true"
+                        }]
+                    }]
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+test_no_violation_deployment_no_env_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Deployment",
+                "metadata": {
+                    "name": "service-deployment",
+                    "namespace": "prod"
+                },
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": [{
+                                "name": "service",
+                                "image": "service:latest"
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+# =============================================================================
+# Test: Workload violation message contains relevant information
+# =============================================================================
+
+test_workload_violation_message_contains_kind_and_name {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Deployment",
+                "metadata": {
+                    "name": "my-service-deployment",
+                    "namespace": "prod"
+                },
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": [{
+                                "name": "service-container",
+                                "image": "service:latest",
+                                "env": [{
+                                    "name": "AUTH_ENABLED",
+                                    "value": "false"
+                                }]
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+    some v
+    violations[v]
+    contains(v.msg, "Deployment")
+    contains(v.msg, "my-service-deployment")
+    contains(v.msg, "service-container")
+    contains(v.msg, "prod")
+    contains(v.msg, "AUTH_ENABLED=false")
+}

--- a/deployments/k8s/policies/tests/auth_enabled_test.rego
+++ b/deployments/k8s/policies/tests/auth_enabled_test.rego
@@ -1,7 +1,7 @@
 # Tests for the BlockAuthDisabledInProduction OPA Gatekeeper policy
 # Run with: opa test deployments/k8s/policies/tests/ --v0-compatible -v
 
-package blockauthdiabledinproduction
+package blockauthdisabledinproduction
 
 # =============================================================================
 # Test: Production namespace detection

--- a/deployments/k8s/policies/tests/blockauthdiabledinproduction.rego
+++ b/deployments/k8s/policies/tests/blockauthdiabledinproduction.rego
@@ -1,0 +1,123 @@
+# OPA Gatekeeper policy to prevent AUTH_ENABLED=false in production namespaces
+# This file is the Rego policy extracted from the ConstraintTemplate for testing.
+# The canonical source is auth-enabled-block.yaml - keep these in sync.
+
+package blockauthdiabledinproduction
+
+# =============================================================================
+# ConfigMap violation rule
+# =============================================================================
+
+violation[{"msg": msg}] {
+    # Check if the object is a ConfigMap
+    input.review.object.kind == "ConfigMap"
+
+    # Check if data field exists
+    input.review.object.data
+
+    # Check if AUTH_ENABLED is set to "false" (case-insensitive)
+    lower(input.review.object.data.AUTH_ENABLED) == "false"
+
+    # Get namespace name
+    ns := input.review.object.metadata.namespace
+
+    # Check if namespace matches production patterns (prod* or *production*)
+    is_production_namespace(ns)
+
+    msg := sprintf("ConfigMap '%s' in namespace '%s' cannot have AUTH_ENABLED=false. Authentication must be enabled in production namespaces.", [input.review.object.metadata.name, ns])
+}
+
+# =============================================================================
+# Pod/workload environment variable violation rules
+# Check for AUTH_ENABLED=false in container env vars for:
+# - Pods, Deployments, StatefulSets, DaemonSets, Jobs, CronJobs
+# =============================================================================
+
+# Supported workload kinds that can contain container specs
+workload_kinds := {"Pod", "Deployment", "StatefulSet", "DaemonSet", "Job", "CronJob", "ReplicaSet"}
+
+# Helper to get the pod spec from different workload types
+get_pod_spec(obj) = spec {
+    obj.kind == "Pod"
+    spec := obj.spec
+}
+
+get_pod_spec(obj) = spec {
+    workload_kinds[obj.kind]
+    obj.kind != "Pod"
+    obj.kind != "CronJob"
+    spec := obj.spec.template.spec
+}
+
+get_pod_spec(obj) = spec {
+    obj.kind == "CronJob"
+    spec := obj.spec.jobTemplate.spec.template.spec
+}
+
+# Check containers for AUTH_ENABLED=false env var
+violation[{"msg": msg}] {
+    obj := input.review.object
+    workload_kinds[obj.kind]
+
+    pod_spec := get_pod_spec(obj)
+    container := pod_spec.containers[_]
+    env_var := container.env[_]
+
+    env_var.name == "AUTH_ENABLED"
+    lower(env_var.value) == "false"
+
+    ns := obj.metadata.namespace
+    is_production_namespace(ns)
+
+    msg := sprintf("%s '%s' in namespace '%s' has container '%s' with AUTH_ENABLED=false environment variable. Authentication must be enabled in production namespaces.", [obj.kind, obj.metadata.name, ns, container.name])
+}
+
+# Check initContainers for AUTH_ENABLED=false env var
+violation[{"msg": msg}] {
+    obj := input.review.object
+    workload_kinds[obj.kind]
+
+    pod_spec := get_pod_spec(obj)
+    container := pod_spec.initContainers[_]
+    env_var := container.env[_]
+
+    env_var.name == "AUTH_ENABLED"
+    lower(env_var.value) == "false"
+
+    ns := obj.metadata.namespace
+    is_production_namespace(ns)
+
+    msg := sprintf("%s '%s' in namespace '%s' has initContainer '%s' with AUTH_ENABLED=false environment variable. Authentication must be enabled in production namespaces.", [obj.kind, obj.metadata.name, ns, container.name])
+}
+
+# Check ephemeralContainers for AUTH_ENABLED=false env var
+violation[{"msg": msg}] {
+    obj := input.review.object
+    workload_kinds[obj.kind]
+
+    pod_spec := get_pod_spec(obj)
+    container := pod_spec.ephemeralContainers[_]
+    env_var := container.env[_]
+
+    env_var.name == "AUTH_ENABLED"
+    lower(env_var.value) == "false"
+
+    ns := obj.metadata.namespace
+    is_production_namespace(ns)
+
+    msg := sprintf("%s '%s' in namespace '%s' has ephemeralContainer '%s' with AUTH_ENABLED=false environment variable. Authentication must be enabled in production namespaces.", [obj.kind, obj.metadata.name, ns, container.name])
+}
+
+# =============================================================================
+# Namespace detection helpers
+# =============================================================================
+
+# Match namespaces starting with 'prod'
+is_production_namespace(ns) {
+    startswith(ns, "prod")
+}
+
+# Match namespaces containing 'production'
+is_production_namespace(ns) {
+    contains(ns, "production")
+}

--- a/deployments/k8s/policies/tests/blockauthdisabledinproduction.rego
+++ b/deployments/k8s/policies/tests/blockauthdisabledinproduction.rego
@@ -2,7 +2,7 @@
 # This file is the Rego policy extracted from the ConstraintTemplate for testing.
 # The canonical source is auth-enabled-block.yaml - keep these in sync.
 
-package blockauthdiabledinproduction
+package blockauthdisabledinproduction
 
 # =============================================================================
 # ConfigMap violation rule


### PR DESCRIPTION
## Summary

- Adds `BlockAuthDisabledInProduction` OPA Gatekeeper ConstraintTemplate that blocks `AUTH_ENABLED=false` from being deployed to production namespaces in ConfigMaps, Pod/Deployment/StatefulSet/DaemonSet/Job/CronJob container env vars (including initContainers and ephemeralContainers)
- Adds `security-defaults.yml` CI workflow that gates PRs on four checks: no `AUTH_ENABLED=false` in K8s ConfigMaps, no false Go auth defaults (`GetEnvAsBool("AUTH_ENABLED", false)`), all OPA constraint files present, all constraints use `enforcementAction: deny`
- Extends `validate-manifests.yml` Rego sync verification to cover the new `auth-enabled-block.yaml` constraint alongside the existing `gateway-dev-mode-block.yaml`

## Changes Made

| File | Purpose |
|------|---------|
| `deployments/k8s/policies/auth-enabled-block.yaml` | OPA ConstraintTemplate + Constraint (task 047-security-audit.10) |
| `deployments/k8s/policies/tests/blockauthdiabledinproduction.rego` | Extracted Rego for OPA unit testing |
| `deployments/k8s/policies/tests/auth_enabled_test.rego` | 37 OPA unit tests covering ConfigMap, Pod, Deployment, StatefulSet, DaemonSet, Job, CronJob, initContainers, ephemeralContainers, case-insensitivity, namespace patterns |
| `.github/workflows/security-defaults.yml` | CI security defaults gate (task 047-security-audit.11) |
| `.github/workflows/validate-manifests.yml` | Extended Rego sync check to cover both constraints |

## Technical Details

The OPA constraint mirrors the existing `BlockDevModeInProduction` pattern (`gateway-dev-mode-block.yaml`) exactly:
- Namespace matching via Rego (`prod*`, `*production*`) rather than K8s namespace selectors
- Case-insensitive value comparison via `lower()`
- Covers all workload kinds including CronJob's nested `spec.jobTemplate.spec.template.spec`
- `enforcementAction: deny` (not dryrun/warn)

The CI gate (`security-defaults.yml`) triggers on changes to service ConfigMaps, Go config files, the bootstrap auth file, OPA policy files, or the workflow itself. All four checks are designed to catch regressions before merge:
1. `AUTH_ENABLED=false` in any service K8s ConfigMap
2. `GetEnvAsBool("AUTH_ENABLED", false)` in any Go service or shared code
3. Missing OPA constraint files (deletion detected)
4. `enforcementAction` downgraded from `deny` to `warn`/`dryrun`

## Testing

OPA unit tests: 75/75 passing (38 existing + 37 new)

```
opa test deployments/k8s/policies/tests/ --v0-compatible -v
PASS: 75/75
```

CI gate logic verified locally against current codebase — all four checks pass on the clean develop branch.

## Related Tasks

- 047-security-audit.10 — OPA Gatekeeper Constraint for AUTH_ENABLED=false
- 047-security-audit.11 — Security Defaults CI Gate