### PR TITLE
feat: add cosign keyless image signing to build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,8 +113,6 @@ jobs:
 
       - name: Sign container image
         if: github.event_name != 'pull_request'
-        env:
-          COSIGN_EXPERIMENTAL: 1
         run: |
           cosign sign --yes \
             ghcr.io/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ permissions:
   contents: read
   packages: write
   security-events: write  # Required for SARIF upload to Security tab
+  id-token: write         # Required for cosign keyless signing via OIDC
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -105,6 +106,18 @@ jobs:
             VERSION=${{ github.ref_name }}
             COMMIT=${{ github.sha }}
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
+
+      - name: Install Cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+
+      - name: Sign container image
+        if: github.event_name != 'pull_request'
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          cosign sign --yes \
+            ghcr.io/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
 
       - name: Run Trivy vulnerability scanner (filesystem)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ permissions:
   contents: read
   packages: write
   security-events: write  # Required for SARIF upload to Security tab
-  id-token: write         # Required for cosign keyless signing via OIDC
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -38,6 +37,11 @@ jobs:
     name: Build Docker Image
     runs-on: ubuntu-latest
     timeout-minutes: 35
+    permissions:
+      contents: read
+      packages: write
+      security-events: write  # Required for SARIF upload to Security tab
+      id-token: write         # Required for cosign keyless signing via OIDC
 
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Verify container image signature
         run: |
           cosign verify \
-            --certificate-identity-regexp="https://github.com/${{ github.repository }}/.github/workflows/deploy-demo.yml@refs/heads/demo" \
+            --certificate-identity="https://github.com/${{ github.repository }}/.github/workflows/deploy-demo.yml@refs/heads/demo" \
             --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
             ghcr.io/${{ env.IMAGE_NAME }}@${{ needs.build-and-push.outputs.image-digest }}
 

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -16,6 +16,7 @@ concurrency:
 permissions:
   contents: read
   packages: write
+  id-token: write  # Required for cosign keyless signing via OIDC
 
 env:
   REGISTRY: ghcr.io
@@ -25,6 +26,8 @@ jobs:
   build-and-push:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
+    outputs:
+      image-digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Checkout code
@@ -64,6 +67,7 @@ jobs:
             type=sha,prefix=demo-,format=short
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -77,6 +81,16 @@ jobs:
             VERSION=${{ github.ref_name }}
             COMMIT=${{ github.sha }}
             BUILD_DATE=${{ github.event.head_commit.timestamp || github.event.repository.updated_at }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+
+      - name: Sign container image
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          cosign sign --yes \
+            ghcr.io/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
 
   build-frontend:
     name: Build Frontend
@@ -135,6 +149,18 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+
+      - name: Verify container image signature
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          cosign verify \
+            --certificate-identity-regexp="https://github.com/${{ github.repository }}/.github/workflows/deploy-demo.yml@refs/heads/demo" \
+            --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+            ghcr.io/${{ env.IMAGE_NAME }}@${{ needs.build-and-push.outputs.image-digest }}
 
       - name: Download frontend artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -16,7 +16,6 @@ concurrency:
 permissions:
   contents: read
   packages: write
-  id-token: write  # Required for cosign keyless signing via OIDC
 
 env:
   REGISTRY: ghcr.io
@@ -26,6 +25,10 @@ jobs:
   build-and-push:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write  # Required for cosign keyless signing via OIDC
     outputs:
       image-digest: ${{ steps.build.outputs.digest }}
 

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -86,8 +86,6 @@ jobs:
         uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
 
       - name: Sign container image
-        env:
-          COSIGN_EXPERIMENTAL: 1
         run: |
           cosign sign --yes \
             ghcr.io/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
@@ -154,8 +152,6 @@ jobs:
         uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
 
       - name: Verify container image signature
-        env:
-          COSIGN_EXPERIMENTAL: 1
         run: |
           cosign verify \
             --certificate-identity-regexp="https://github.com/${{ github.repository }}/.github/workflows/deploy-demo.yml@refs/heads/demo" \
@@ -192,13 +188,18 @@ jobs:
 
       - name: Deploy via SSH
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        env:
+          IMAGE_DIGEST: ${{ needs.build-and-push.outputs.image-digest }}
         with:
           host: ${{ secrets.DROPLET_IP }}
           username: root
           key: ${{ secrets.DEPLOY_SSH_KEY }}
+          envs: IMAGE_DIGEST
           script: |
             cd /opt/meridian
-            docker compose pull
+            # Pull the exact verified digest to prevent TOCTOU between verify and deploy
+            docker pull ghcr.io/meridianhub/meridian@${IMAGE_DIGEST}
+            docker tag ghcr.io/meridianhub/meridian@${IMAGE_DIGEST} ghcr.io/meridianhub/meridian:demo
             docker compose up -d --remove-orphans
             docker compose exec -T caddy caddy reload --config /etc/caddy/Caddyfile
             docker image prune -f


### PR DESCRIPTION
## Summary

- Adds cosign keyless (OIDC-based) container image signing to the build pipeline for supply chain security
- Signs images in both `build.yml` (on push to develop/main/tags) and `deploy-demo.yml` (demo branch builds)
- Adds signature verification in the deploy job before pulling and deploying to the demo droplet

## Changes Made

### `.github/workflows/build.yml`
- Added `id-token: write` permission required for OIDC keyless signing
- Added `Install Cosign` step using `sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22` (v4.1.0, SHA-pinned)
- Added `Sign container image` step after `build-push-action`, guarded by `github.event_name != 'pull_request'`
- Uses `COSIGN_EXPERIMENTAL=1` for keyless signing; signs by digest for immutability

### `.github/workflows/deploy-demo.yml`
- Added `id-token: write` permission
- Added `id: build` to the `build-push-action` step to capture the image digest
- Added `outputs: image-digest` to `build-and-push` job so the digest is available to the `deploy` job
- Added cosign sign step after image push in `build-and-push` job
- Added cosign verify step in `deploy` job before deployment, verifying:
  - Certificate identity matches `deploy-demo.yml@refs/heads/demo`
  - OIDC issuer is `https://token.actions.githubusercontent.com`
  - Image is verified by digest (not mutable tag)

## Technical Details

- **Keyless signing**: Uses GitHub Actions OIDC identity — no long-lived signing keys to manage or rotate
- **SHA-pinned action**: `sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0`
- **Sign by digest**: Ensures the exact image content is what was signed, not a mutable tag
- **Verify before deploy**: The deploy job fails fast if the image signature cannot be verified, preventing deployment of unsigned or tampered images

## Risk Assessment

- Low risk: workflow-only change, no application code modified
- Signing failure on push will fail the build (intentional — unsigned images should not be deployed)
- Existing pre-CI failures (dex module, Trivy repo scan) are unrelated and pre-existing