### PR TITLE
refactor: extract unified sandbox package for Starlark runtimes

### DIFF
--- a/services/forecasting/starlark/runner.go
+++ b/services/forecasting/starlark/runner.go
@@ -175,7 +175,7 @@ func (r *ForecastRunner) ExecuteStrategy(ctx context.Context, input StrategyInpu
 		return nil, ErrScriptRequired
 	}
 	if err := sandbox.ValidateScript(input.Script, sandboxCfg); err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrScriptTooLarge, err)
+		return nil, fmt.Errorf("%w: size %d exceeds maximum %d bytes", ErrScriptTooLarge, len(input.Script), sandboxCfg.MaxScriptSize)
 	}
 
 	now := input.Now

--- a/services/forecasting/starlark/runner.go
+++ b/services/forecasting/starlark/runner.go
@@ -20,8 +20,8 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/sandbox"
 )
 
-// SandboxConfig is the unified sandbox configuration for forecasting scripts.
-var SandboxConfig = sandbox.ForecasterConfig()
+// sandboxCfg is the unified sandbox configuration for forecasting scripts.
+var sandboxCfg = sandbox.ForecasterConfig()
 
 // Default execution constraints.
 // These constants are retained for backward compatibility; canonical values live in sandbox.ForecasterConfig().
@@ -174,7 +174,7 @@ func (r *ForecastRunner) ExecuteStrategy(ctx context.Context, input StrategyInpu
 	if input.Script == "" {
 		return nil, ErrScriptRequired
 	}
-	if err := sandbox.ValidateScript(input.Script, SandboxConfig); err != nil {
+	if err := sandbox.ValidateScript(input.Script, sandboxCfg); err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrScriptTooLarge, err)
 	}
 
@@ -281,7 +281,7 @@ func (r *ForecastRunner) executeScript(ctx context.Context, script string, forec
 		},
 	}
 	thread.SetLocal("ctx", ctx)
-	sandbox.HardenThread(thread, SandboxConfig)
+	sandbox.HardenThread(thread, sandboxCfg)
 
 	// Execute script in a goroutine for timeout support
 	done := make(chan struct{})

--- a/services/forecasting/starlark/runner.go
+++ b/services/forecasting/starlark/runner.go
@@ -17,9 +17,14 @@ import (
 	"go.starlark.net/syntax"
 
 	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/meridianhub/meridian/shared/platform/sandbox"
 )
 
+// SandboxConfig is the unified sandbox configuration for forecasting scripts.
+var SandboxConfig = sandbox.ForecasterConfig()
+
 // Default execution constraints.
+// These constants are retained for backward compatibility; canonical values live in sandbox.ForecasterConfig().
 const (
 	DefaultTimeout       = 10 * time.Second // Reduced from 30s; 2x saga's 5s to allow observation fetching overhead
 	MaxScriptSize        = 64 * 1024        // 64KB, matching saga
@@ -169,8 +174,8 @@ func (r *ForecastRunner) ExecuteStrategy(ctx context.Context, input StrategyInpu
 	if input.Script == "" {
 		return nil, ErrScriptRequired
 	}
-	if len(input.Script) > MaxScriptSize {
-		return nil, fmt.Errorf("%w: size %d exceeds maximum %d bytes", ErrScriptTooLarge, len(input.Script), MaxScriptSize)
+	if err := sandbox.ValidateScript(input.Script, SandboxConfig); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrScriptTooLarge, err)
 	}
 
 	now := input.Now
@@ -276,7 +281,7 @@ func (r *ForecastRunner) executeScript(ctx context.Context, script string, forec
 		},
 	}
 	thread.SetLocal("ctx", ctx)
-	thread.SetMaxExecutionSteps(MaxStepsPerExecution)
+	sandbox.HardenThread(thread, SandboxConfig)
 
 	// Execute script in a goroutine for timeout support
 	done := make(chan struct{})

--- a/shared/pkg/saga/runtime.go
+++ b/shared/pkg/saga/runtime.go
@@ -14,8 +14,8 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/sandbox"
 )
 
-// SandboxConfig is the unified sandbox configuration for saga scripts.
-var SandboxConfig = sandbox.DefaultConfig()
+// sandboxCfg is the unified sandbox configuration for saga scripts.
+var sandboxCfg = sandbox.DefaultConfig()
 
 // Security constraints for Starlark runtime per PRD Section 6.1.
 // These constants are retained for backward compatibility; canonical values live in sandbox.DefaultConfig().
@@ -206,7 +206,7 @@ func (r *Runtime) ExecuteSagaWithInput(ctx context.Context, name string, script 
 	}
 
 	// Enforce CPU step limit to prevent tenant scripts from exhausting compute resources.
-	sandbox.HardenThread(thread, SandboxConfig)
+	sandbox.HardenThread(thread, sandboxCfg)
 
 	// Set up cancellation checking
 	done := make(chan struct{})

--- a/shared/pkg/saga/runtime.go
+++ b/shared/pkg/saga/runtime.go
@@ -10,9 +10,15 @@ import (
 
 	"github.com/google/uuid"
 	"go.starlark.net/starlark"
+
+	"github.com/meridianhub/meridian/shared/platform/sandbox"
 )
 
+// SandboxConfig is the unified sandbox configuration for saga scripts.
+var SandboxConfig = sandbox.DefaultConfig()
+
 // Security constraints for Starlark runtime per PRD Section 6.1.
+// These constants are retained for backward compatibility; canonical values live in sandbox.DefaultConfig().
 const (
 	// DefaultTimeout is the maximum execution time for a saga script.
 	DefaultTimeout = 5 * time.Second
@@ -200,7 +206,7 @@ func (r *Runtime) ExecuteSagaWithInput(ctx context.Context, name string, script 
 	}
 
 	// Enforce CPU step limit to prevent tenant scripts from exhausting compute resources.
-	thread.SetMaxExecutionSteps(MaxStepsPerExecution)
+	sandbox.HardenThread(thread, SandboxConfig)
 
 	// Set up cancellation checking
 	done := make(chan struct{})

--- a/shared/pkg/saga/runtime.go
+++ b/shared/pkg/saga/runtime.go
@@ -140,6 +140,11 @@ func (r *Runtime) ExecuteSaga(ctx context.Context, name string, script string, i
 //   - Party scope resolution happens BEFORE the first user step (synthetic step -1)
 //   - Resolution failures cause the saga to fail before any user steps execute
 func (r *Runtime) ExecuteSagaWithInput(ctx context.Context, name string, script string, execInput ExecutionInput) (*ExecutionResult, error) {
+	// Validate script size before any execution.
+	if err := sandbox.ValidateScript(script, sandboxCfg); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrScriptTooLarge, err)
+	}
+
 	// Apply timeout to context
 	ctx, cancel := context.WithTimeout(ctx, r.timeout)
 	defer cancel()

--- a/shared/pkg/saga/runtime.go
+++ b/shared/pkg/saga/runtime.go
@@ -142,7 +142,7 @@ func (r *Runtime) ExecuteSaga(ctx context.Context, name string, script string, i
 func (r *Runtime) ExecuteSagaWithInput(ctx context.Context, name string, script string, execInput ExecutionInput) (*ExecutionResult, error) {
 	// Validate script size before any execution.
 	if err := sandbox.ValidateScript(script, sandboxCfg); err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrScriptTooLarge, err)
+		return nil, fmt.Errorf("%w: %d bytes exceeds %d", ErrScriptTooLarge, len(script), sandboxCfg.MaxScriptSize)
 	}
 
 	// Apply timeout to context

--- a/shared/pkg/valuation/starlark_runtime.go
+++ b/shared/pkg/valuation/starlark_runtime.go
@@ -7,12 +7,17 @@ import (
 	"time"
 
 	"github.com/meridianhub/meridian/shared/pkg/valuation/internal/builtins"
+	"github.com/meridianhub/meridian/shared/platform/sandbox"
 	"github.com/shopspring/decimal"
 	"go.starlark.net/starlark"
 	"go.starlark.net/syntax"
 )
 
+// SandboxConfig is the unified sandbox configuration for valuation scripts.
+var SandboxConfig = sandbox.ValuationConfig()
+
 // Starlark security constraints.
+// These constants are retained for backward compatibility; canonical values live in sandbox.ValuationConfig().
 const (
 	// DefaultStarlarkTimeout is the maximum execution time for a valuation script.
 	DefaultStarlarkTimeout = 5 * time.Second
@@ -87,9 +92,9 @@ func NewStarlarkRuntime(cfg StarlarkRuntimeConfig) StarlarkRuntime {
 //   - valued_amount: numeric value
 //   - instrument: string instrument code (e.g., "GBP", "USD")
 func (r *defaultStarlarkRuntime) Execute(ctx context.Context, script string, req *Request) (*Response, error) {
-	// Validate script size
-	if len(script) > MaxStarlarkScriptSize {
-		return nil, fmt.Errorf("%w: %d bytes exceeds %d", ErrStarlarkScriptTooLarge, len(script), MaxStarlarkScriptSize)
+	// Validate script size using unified sandbox config.
+	if err := sandbox.ValidateScript(script, SandboxConfig); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrStarlarkScriptTooLarge, err)
 	}
 
 	// Apply timeout
@@ -122,9 +127,8 @@ func (r *defaultStarlarkRuntime) Execute(ctx context.Context, script string, req
 		}
 	}()
 
-	// Set maximum execution steps (5 million steps ≈ 5s on typical hardware)
-	const maxSteps = 5_000_000
-	thread.SetMaxExecutionSteps(maxSteps)
+	// Apply sandbox security constraints (step limits) from unified config.
+	sandbox.HardenThread(thread, SandboxConfig)
 
 	// Build predeclared variables: builtins + script context
 	predeclared := make(starlark.StringDict, len(r.builtins)+1)

--- a/shared/pkg/valuation/starlark_runtime.go
+++ b/shared/pkg/valuation/starlark_runtime.go
@@ -13,8 +13,8 @@ import (
 	"go.starlark.net/syntax"
 )
 
-// SandboxConfig is the unified sandbox configuration for valuation scripts.
-var SandboxConfig = sandbox.ValuationConfig()
+// sandboxCfg is the unified sandbox configuration for valuation scripts.
+var sandboxCfg = sandbox.ValuationConfig()
 
 // Starlark security constraints.
 // These constants are retained for backward compatibility; canonical values live in sandbox.ValuationConfig().
@@ -93,7 +93,7 @@ func NewStarlarkRuntime(cfg StarlarkRuntimeConfig) StarlarkRuntime {
 //   - instrument: string instrument code (e.g., "GBP", "USD")
 func (r *defaultStarlarkRuntime) Execute(ctx context.Context, script string, req *Request) (*Response, error) {
 	// Validate script size using unified sandbox config.
-	if err := sandbox.ValidateScript(script, SandboxConfig); err != nil {
+	if err := sandbox.ValidateScript(script, sandboxCfg); err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrStarlarkScriptTooLarge, err)
 	}
 
@@ -128,7 +128,7 @@ func (r *defaultStarlarkRuntime) Execute(ctx context.Context, script string, req
 	}()
 
 	// Apply sandbox security constraints (step limits) from unified config.
-	sandbox.HardenThread(thread, SandboxConfig)
+	sandbox.HardenThread(thread, sandboxCfg)
 
 	// Build predeclared variables: builtins + script context
 	predeclared := make(starlark.StringDict, len(r.builtins)+1)

--- a/shared/pkg/valuation/starlark_runtime.go
+++ b/shared/pkg/valuation/starlark_runtime.go
@@ -94,7 +94,7 @@ func NewStarlarkRuntime(cfg StarlarkRuntimeConfig) StarlarkRuntime {
 func (r *defaultStarlarkRuntime) Execute(ctx context.Context, script string, req *Request) (*Response, error) {
 	// Validate script size using unified sandbox config.
 	if err := sandbox.ValidateScript(script, sandboxCfg); err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrStarlarkScriptTooLarge, err)
+		return nil, fmt.Errorf("%w: %d bytes exceeds %d", ErrStarlarkScriptTooLarge, len(script), sandboxCfg.MaxScriptSize)
 	}
 
 	// Apply timeout

--- a/shared/platform/sandbox/config.go
+++ b/shared/platform/sandbox/config.go
@@ -1,0 +1,48 @@
+// Package sandbox provides unified Starlark sandbox security configuration
+// and thread hardening for all Meridian runtimes (saga, valuation, forecasting).
+package sandbox
+
+import "time"
+
+// Config holds security constraints for a Starlark sandbox.
+type Config struct {
+	// Timeout is the maximum execution time for a script.
+	Timeout time.Duration
+
+	// MaxScriptSize is the maximum allowed script size in bytes.
+	MaxScriptSize int
+
+	// MaxStepsPerExecution limits the number of Starlark interpreter steps
+	// to prevent infinite loops and resource exhaustion.
+	MaxStepsPerExecution uint64
+}
+
+// DefaultConfig returns the standard sandbox configuration used by the saga runtime.
+// Timeout=5s, MaxScriptSize=64KB, MaxSteps=1M.
+func DefaultConfig() Config {
+	return Config{
+		Timeout:              5 * time.Second,
+		MaxScriptSize:        64 * 1024,
+		MaxStepsPerExecution: 1_000_000,
+	}
+}
+
+// ValuationConfig returns the sandbox configuration for valuation scripts.
+// Timeout=5s, MaxScriptSize=64KB, MaxSteps=5M.
+func ValuationConfig() Config {
+	return Config{
+		Timeout:              5 * time.Second,
+		MaxScriptSize:        64 * 1024,
+		MaxStepsPerExecution: 5_000_000,
+	}
+}
+
+// ForecasterConfig returns the sandbox configuration for forecasting scripts.
+// Timeout=10s, MaxScriptSize=64KB, MaxSteps=1M.
+func ForecasterConfig() Config {
+	return Config{
+		Timeout:              10 * time.Second,
+		MaxScriptSize:        64 * 1024,
+		MaxStepsPerExecution: 1_000_000,
+	}
+}

--- a/shared/platform/sandbox/config.go
+++ b/shared/platform/sandbox/config.go
@@ -7,6 +7,9 @@ import "time"
 // Config holds security constraints for a Starlark sandbox.
 type Config struct {
 	// Timeout is the maximum execution time for a script.
+	// Note: HardenThread does not apply this value; each runtime manages
+	// timeouts independently via context.WithTimeout. This field is provided
+	// so callers have a single config struct for all sandbox parameters.
 	Timeout time.Duration
 
 	// MaxScriptSize is the maximum allowed script size in bytes.

--- a/shared/platform/sandbox/config_test.go
+++ b/shared/platform/sandbox/config_test.go
@@ -1,0 +1,40 @@
+package sandbox
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	assert.Equal(t, 5*time.Second, cfg.Timeout)
+	assert.Equal(t, 64*1024, cfg.MaxScriptSize)
+	assert.Equal(t, uint64(1_000_000), cfg.MaxStepsPerExecution)
+}
+
+func TestValuationConfig(t *testing.T) {
+	cfg := ValuationConfig()
+
+	assert.Equal(t, 5*time.Second, cfg.Timeout)
+	assert.Equal(t, 64*1024, cfg.MaxScriptSize)
+	assert.Equal(t, uint64(5_000_000), cfg.MaxStepsPerExecution)
+}
+
+func TestForecasterConfig(t *testing.T) {
+	cfg := ForecasterConfig()
+
+	assert.Equal(t, 10*time.Second, cfg.Timeout)
+	assert.Equal(t, 64*1024, cfg.MaxScriptSize)
+	assert.Equal(t, uint64(1_000_000), cfg.MaxStepsPerExecution)
+}
+
+func TestConfigsShareScriptSize(t *testing.T) {
+	// All configs should use the same script size limit (64KB).
+	configs := []Config{DefaultConfig(), ValuationConfig(), ForecasterConfig()}
+	for _, cfg := range configs {
+		assert.Equal(t, 64*1024, cfg.MaxScriptSize)
+	}
+}

--- a/shared/platform/sandbox/harden.go
+++ b/shared/platform/sandbox/harden.go
@@ -1,0 +1,10 @@
+package sandbox
+
+import "go.starlark.net/starlark"
+
+// HardenThread applies security constraints from the given Config to a
+// Starlark thread. This sets the maximum execution steps to prevent
+// runaway scripts from exhausting compute resources.
+func HardenThread(thread *starlark.Thread, cfg Config) {
+	thread.SetMaxExecutionSteps(cfg.MaxStepsPerExecution)
+}

--- a/shared/platform/sandbox/harden_test.go
+++ b/shared/platform/sandbox/harden_test.go
@@ -1,0 +1,54 @@
+package sandbox
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.starlark.net/starlark"
+)
+
+func TestHardenThread_SetsMaxSteps(t *testing.T) {
+	thread := &starlark.Thread{Name: "test"}
+	cfg := DefaultConfig()
+
+	HardenThread(thread, cfg)
+
+	// Verify the step limit is enforced by running a script that exceeds it.
+	// A simple loop that does cfg.MaxStepsPerExecution+1 iterations should fail.
+	// We use a small config to make the test fast.
+	smallCfg := Config{MaxStepsPerExecution: 100}
+	smallThread := &starlark.Thread{Name: "small-test"}
+	HardenThread(smallThread, smallCfg)
+
+	// Execute a tight loop inside a function — should exceed 100 steps and error.
+	script := `
+def work():
+    x = 0
+    for i in range(1000):
+        x = x + 1
+    return x
+work()
+`
+	_, err := starlark.ExecFile(smallThread, "test.star", script, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too many steps")
+}
+
+func TestHardenThread_AllowsSmallScripts(t *testing.T) {
+	thread := &starlark.Thread{Name: "test"}
+	cfg := DefaultConfig() // 1M steps — plenty for a small script
+
+	HardenThread(thread, cfg)
+
+	script := `x = 1 + 2`
+	_, err := starlark.ExecFile(thread, "test.star", script, nil)
+	assert.NoError(t, err)
+}
+
+func TestHardenThread_ValuationStepsHigherThanDefault(t *testing.T) {
+	// Valuation config allows more steps than the default.
+	defCfg := DefaultConfig()
+	valCfg := ValuationConfig()
+	assert.Greater(t, valCfg.MaxStepsPerExecution, defCfg.MaxStepsPerExecution)
+}

--- a/shared/platform/sandbox/validate.go
+++ b/shared/platform/sandbox/validate.go
@@ -1,0 +1,17 @@
+package sandbox
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrScriptTooLarge is returned when a script exceeds the configured MaxScriptSize.
+var ErrScriptTooLarge = errors.New("script exceeds maximum size")
+
+// ValidateScript checks that the script does not exceed the configured size limit.
+func ValidateScript(script string, cfg Config) error {
+	if len(script) > cfg.MaxScriptSize {
+		return fmt.Errorf("%w: %d bytes exceeds %d", ErrScriptTooLarge, len(script), cfg.MaxScriptSize)
+	}
+	return nil
+}

--- a/shared/platform/sandbox/validate_test.go
+++ b/shared/platform/sandbox/validate_test.go
@@ -1,0 +1,41 @@
+package sandbox
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateScript_WithinLimit(t *testing.T) {
+	cfg := DefaultConfig()
+	script := "x = 1"
+
+	err := ValidateScript(script, cfg)
+	assert.NoError(t, err)
+}
+
+func TestValidateScript_ExactlyAtLimit(t *testing.T) {
+	cfg := Config{MaxScriptSize: 10}
+	script := strings.Repeat("x", 10)
+
+	err := ValidateScript(script, cfg)
+	assert.NoError(t, err)
+}
+
+func TestValidateScript_ExceedsLimit(t *testing.T) {
+	cfg := Config{MaxScriptSize: 10}
+	script := strings.Repeat("x", 11)
+
+	err := ValidateScript(script, cfg)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrScriptTooLarge)
+	assert.Contains(t, err.Error(), "11 bytes exceeds 10")
+}
+
+func TestValidateScript_EmptyScript(t *testing.T) {
+	cfg := DefaultConfig()
+	err := ValidateScript("", cfg)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

- Create `shared/platform/sandbox/` package centralizing Starlark sandbox security constants (`Config`, `HardenThread()`, `ValidateScript()`) that were duplicated across three runtimes
- Refactor saga, valuation, and forecasting runtimes to use the unified sandbox package
- Provide preset configs: `DefaultConfig()` (saga), `ValuationConfig()`, `ForecasterConfig()`

## Details

Three runtimes duplicated sandbox constants:

| Runtime | Timeout | MaxScriptSize | MaxSteps |
|---------|---------|---------------|----------|
| Saga | 5s | 64KB | 1M |
| Valuation | 5s | 64KB | 5M (hardcoded inline) |
| Forecasting | 10s | 64KB | 1M |

Now all three delegate to `sandbox.HardenThread(thread, cfg)` and `sandbox.ValidateScript(script, cfg)`. Backward-compatible constants retained in each package.

## Test plan

- [x] New unit tests for `sandbox` package (config, harden, validate)
- [x] Existing saga runtime tests pass
- [x] Existing valuation tests pass
- [x] Existing forecasting starlark tests pass