### PR TITLE
feat: pgx tenant guard wrapper for raw database access

### DIFF
--- a/docs/security/pgx-tenant-audit.md
+++ b/docs/security/pgx-tenant-audit.md
@@ -1,0 +1,84 @@
+# pgx Tenant Guard Audit
+
+## Overview
+
+This document audits all raw pgx (non-GORM) database access paths in the Meridian codebase and documents the tenant isolation strategy for each.
+
+## Guard Infrastructure
+
+| File | Type | Description |
+|------|------|-------------|
+| `shared/platform/db/pgx_tenant_guard.go` | Guard functions | `RequirePgxTenantContext` validates tenant context or bypass before queries |
+| `shared/platform/db/guarded_pgx_pool.go` | Pool wrapper | `GuardedPgxPool` wraps `*pgxpool.Pool`, enforces tenant context on Exec/Query/QueryRow/Begin |
+
+### Usage
+
+```go
+// Wrap an existing pool
+guarded := db.NewGuardedPgxPool(pool)
+
+// All operations require tenant context
+ctx := tenant.WithTenant(ctx, tenantID)
+guarded.Exec(ctx, "SELECT 1") // OK
+
+// Or bypass for infrastructure operations
+ctx := db.WithPgxTenantBypass(ctx)
+guarded.Exec(ctx, "SELECT 1") // OK
+
+// Start a tenant-scoped transaction with search_path set
+tx, err := guarded.BeginTenantTx(ctx)
+```
+
+## Audit of Raw pgx Usage
+
+### 1. `shared/platform/db/pool.go` — PostgresPool
+
+**Risk**: Low. This is a `database/sql` wrapper using the pgx driver, not direct pgx pool usage. It is used for connection pooling infrastructure. Tenant scoping is handled at the GORM layer via `TenantGuard` plugin.
+
+**Action**: No change needed. The GORM TenantGuard already protects this path.
+
+### 2. `shared/platform/events/outbox_pgx.go` — PgxOutboxRepository
+
+**Risk**: Medium. Uses `*pgxpool.Pool` directly for outbox event operations. The `Publish` method extracts `tenant_id` from context and stores it in the `tenant_id` column, but `FetchUnprocessed`, `FetchAndLockForProcessing`, `MarkCompleted`, `MarkFailed`, `MarkProcessing`, `ResetStuckEntries`, and `GetPendingCount` query across all tenants by `service_name` only.
+
+**Analysis**: The outbox is an infrastructure table (not per-tenant schema). The outbox processor intentionally reads cross-tenant to process events for all tenants. Tenant ID is stored as a data column for routing, not for access control.
+
+**Action**: No guard needed. The outbox is a platform-level infrastructure concern that intentionally operates cross-tenant. The `tenant_id` column provides audit traceability, not isolation.
+
+### 3. `shared/platform/scheduler/execution_store.go` — PgExecutionStore
+
+**Risk**: Medium. Uses `*pgxpool.Pool` directly. Already implements `setSearchPath` which sets `SET LOCAL search_path` to the tenant schema when tenant context is present. However, if no tenant is in context, it silently proceeds without schema scoping.
+
+**Analysis**: The scheduler execution store already has tenant awareness via `setSearchPath`. The gap is that it doesn't enforce tenant context — it degrades gracefully to public schema. For multi-tenant deployments, this could allow cross-tenant visibility of scheduler executions if a tenant context is accidentally missing.
+
+**Action**: The existing `setSearchPath` pattern provides the schema isolation. Adding `GuardedPgxPool` here would require callers to always provide tenant context, which may break platform-level scheduler operations that run without tenant scope. Recommend documenting the existing behavior and adding bypass context for platform schedulers if stricter enforcement is desired in the future.
+
+### 4. `shared/pkg/idempotency/postgres_service.go` — PostgresService
+
+**Risk**: Low. Uses `*pgxpool.Pool` for idempotency key management. The `_idempotency_keys` table is a platform-level infrastructure table, not per-tenant. Keys are namespaced by their composite key string (which can include tenant identifiers at the application layer).
+
+**Analysis**: Idempotency is a cross-cutting infrastructure concern. The table lives in the public schema and keys are self-namespacing. Operations like `EnsureTable`, `StartCleanup`, and lock management are platform-level.
+
+**Action**: No guard needed. This is infrastructure-level, similar to migrations or health checks.
+
+### 5. `shared/platform/testdb/pgx.go` — Test utilities
+
+**Risk**: None. Test-only code that creates containers and applies migrations.
+
+**Action**: No guard needed. Test infrastructure operates outside the tenant model.
+
+## Summary
+
+| Component | pgx Usage | Tenant Isolation | Guard Needed | Rationale |
+|-----------|-----------|-----------------|--------------|-----------|
+| PostgresPool | database/sql via pgx driver | GORM TenantGuard | No | Protected at GORM layer |
+| PgxOutboxRepository | Direct pgxpool.Pool | tenant_id column (data, not access control) | No | Infrastructure table, cross-tenant by design |
+| PgExecutionStore | Direct pgxpool.Pool | setSearchPath (when tenant in context) | No (existing) | Already tenant-aware; platform schedulers need bypass |
+| PostgresService | Direct pgxpool.Pool | Key namespacing | No | Infrastructure table, cross-cutting concern |
+| testdb | Direct pgxpool.Pool | N/A (test only) | No | Test infrastructure |
+
+## Recommendations
+
+1. **New pgx-based repositories** should accept `*db.GuardedPgxPool` (or `db.PgxQuerier`) instead of raw `*pgxpool.Pool` to enforce tenant context by default.
+2. **Existing infrastructure components** (outbox, scheduler, idempotency) are correctly operating at the platform level and do not need tenant guards.
+3. The `GuardedPgxPool` and `PgxQuerier` interface are available for any future service-level pgx code that needs tenant enforcement.

--- a/docs/security/pgx-tenant-audit.md
+++ b/docs/security/pgx-tenant-audit.md
@@ -2,14 +2,16 @@
 
 ## Overview
 
-This document audits all raw pgx (non-GORM) database access paths in the Meridian codebase and documents the tenant isolation strategy for each.
+This document audits all raw pgx (non-GORM) database access paths
+in the Meridian codebase and documents the tenant isolation strategy
+for each.
 
 ## Guard Infrastructure
 
 | File | Type | Description |
 |------|------|-------------|
-| `shared/platform/db/pgx_tenant_guard.go` | Guard functions | `RequirePgxTenantContext` validates tenant context or bypass before queries |
-| `shared/platform/db/guarded_pgx_pool.go` | Pool wrapper | `GuardedPgxPool` wraps `*pgxpool.Pool`, enforces tenant context on Exec/Query/QueryRow/Begin |
+| `shared/platform/db/pgx_tenant_guard.go` | Guard | Validates tenant context or bypass |
+| `shared/platform/db/guarded_pgx_pool.go` | Wrapper | Enforces tenant on all pgx ops |
 
 ### Usage
 
@@ -31,54 +33,93 @@ tx, err := guarded.BeginTenantTx(ctx)
 
 ## Audit of Raw pgx Usage
 
-### 1. `shared/platform/db/pool.go` — PostgresPool
+### 1. `shared/platform/db/pool.go` -- PostgresPool
 
-**Risk**: Low. This is a `database/sql` wrapper using the pgx driver, not direct pgx pool usage. It is used for connection pooling infrastructure. Tenant scoping is handled at the GORM layer via `TenantGuard` plugin.
+**Risk**: Low. This is a `database/sql` wrapper using the pgx driver,
+not direct pgx pool usage. Tenant scoping is handled at the GORM layer
+via `TenantGuard` plugin.
 
-**Action**: No change needed. The GORM TenantGuard already protects this path.
+**Action**: No change needed. The GORM TenantGuard already protects
+this path.
 
-### 2. `shared/platform/events/outbox_pgx.go` — PgxOutboxRepository
+### 2. `shared/platform/events/outbox_pgx.go` -- PgxOutboxRepository
 
-**Risk**: Medium. Uses `*pgxpool.Pool` directly for outbox event operations. The `Publish` method extracts `tenant_id` from context and stores it in the `tenant_id` column, but `FetchUnprocessed`, `FetchAndLockForProcessing`, `MarkCompleted`, `MarkFailed`, `MarkProcessing`, `ResetStuckEntries`, and `GetPendingCount` query across all tenants by `service_name` only.
+**Risk**: Medium. Uses `*pgxpool.Pool` directly for outbox event
+operations. The `Publish` method extracts `tenant_id` from context
+and stores it in the `tenant_id` column, but fetch/mark operations
+query across all tenants by `service_name` only.
 
-**Analysis**: The outbox is an infrastructure table (not per-tenant schema). The outbox processor intentionally reads cross-tenant to process events for all tenants. Tenant ID is stored as a data column for routing, not for access control.
+**Analysis**: The outbox is an infrastructure table (not per-tenant
+schema). The outbox processor intentionally reads cross-tenant to
+process events for all tenants. Tenant ID is stored as a data column
+for routing, not for access control.
 
-**Action**: No guard needed. The outbox is a platform-level infrastructure concern that intentionally operates cross-tenant. The `tenant_id` column provides audit traceability, not isolation.
+**Action**: No guard needed. The outbox is a platform-level
+infrastructure concern that intentionally operates cross-tenant.
+The `tenant_id` column provides audit traceability, not isolation.
 
-### 3. `shared/platform/scheduler/execution_store.go` — PgExecutionStore
+### 3. `shared/platform/scheduler/execution_store.go` -- PgExecutionStore
 
-**Risk**: Medium. Uses `*pgxpool.Pool` directly. Already implements `setSearchPath` which sets `SET LOCAL search_path` to the tenant schema when tenant context is present. However, if no tenant is in context, it silently proceeds without schema scoping.
+**Risk**: Medium. Uses `*pgxpool.Pool` directly. Already implements
+`setSearchPath` which sets `SET LOCAL search_path` to the tenant
+schema when tenant context is present. However, if no tenant is in
+context, it silently proceeds without schema scoping.
 
-**Analysis**: The scheduler execution store already has tenant awareness via `setSearchPath`. The gap is that it doesn't enforce tenant context — it degrades gracefully to public schema. For multi-tenant deployments, this could allow cross-tenant visibility of scheduler executions if a tenant context is accidentally missing.
+**Analysis**: The scheduler execution store already has tenant
+awareness via `setSearchPath`. The gap is that it does not enforce
+tenant context -- it degrades gracefully to public schema. For
+multi-tenant deployments, this could allow cross-tenant visibility
+of scheduler executions if a tenant context is accidentally missing.
 
-**Action**: The existing `setSearchPath` pattern provides the schema isolation. Adding `GuardedPgxPool` here would require callers to always provide tenant context, which may break platform-level scheduler operations that run without tenant scope. Recommend documenting the existing behavior and adding bypass context for platform schedulers if stricter enforcement is desired in the future.
+**Action**: The existing `setSearchPath` pattern provides the schema
+isolation. Adding `GuardedPgxPool` here would require callers to
+always provide tenant context, which may break platform-level
+scheduler operations that run without tenant scope. Recommend
+documenting the existing behavior and adding bypass context for
+platform schedulers if stricter enforcement is desired in the future.
 
-### 4. `shared/pkg/idempotency/postgres_service.go` — PostgresService
+### 4. `shared/pkg/idempotency/postgres_service.go` -- PostgresService
 
-**Risk**: Low. Uses `*pgxpool.Pool` for idempotency key management. The `_idempotency_keys` table is a platform-level infrastructure table, not per-tenant. Keys are namespaced by their composite key string (which can include tenant identifiers at the application layer).
+**Risk**: Low. Uses `*pgxpool.Pool` for idempotency key management.
+The `_idempotency_keys` table is a platform-level infrastructure
+table, not per-tenant. Keys are namespaced by their composite key
+string (which can include tenant identifiers at the application
+layer).
 
-**Analysis**: Idempotency is a cross-cutting infrastructure concern. The table lives in the public schema and keys are self-namespacing. Operations like `EnsureTable`, `StartCleanup`, and lock management are platform-level.
+**Analysis**: Idempotency is a cross-cutting infrastructure concern.
+The table lives in the public schema and keys are self-namespacing.
+Operations like `EnsureTable`, `StartCleanup`, and lock management
+are platform-level.
 
-**Action**: No guard needed. This is infrastructure-level, similar to migrations or health checks.
+**Action**: No guard needed. This is infrastructure-level, similar
+to migrations or health checks.
 
-### 5. `shared/platform/testdb/pgx.go` — Test utilities
+### 5. `shared/platform/testdb/pgx.go` -- Test utilities
 
-**Risk**: None. Test-only code that creates containers and applies migrations.
+**Risk**: None. Test-only code that creates containers and applies
+migrations.
 
-**Action**: No guard needed. Test infrastructure operates outside the tenant model.
+**Action**: No guard needed. Test infrastructure operates outside
+the tenant model.
 
 ## Summary
 
-| Component | pgx Usage | Tenant Isolation | Guard Needed | Rationale |
-|-----------|-----------|-----------------|--------------|-----------|
-| PostgresPool | database/sql via pgx driver | GORM TenantGuard | No | Protected at GORM layer |
-| PgxOutboxRepository | Direct pgxpool.Pool | tenant_id column (data, not access control) | No | Infrastructure table, cross-tenant by design |
-| PgExecutionStore | Direct pgxpool.Pool | setSearchPath (when tenant in context) | No (existing) | Already tenant-aware; platform schedulers need bypass |
-| PostgresService | Direct pgxpool.Pool | Key namespacing | No | Infrastructure table, cross-cutting concern |
-| testdb | Direct pgxpool.Pool | N/A (test only) | No | Test infrastructure |
+| Component | Tenant Isolation | Guard | Rationale |
+|-----------|-----------------|-------|-----------|
+| PostgresPool | GORM TenantGuard | No | GORM layer |
+| PgxOutboxRepository | tenant_id column | No | Cross-tenant by design |
+| PgExecutionStore | setSearchPath | No | Already tenant-aware |
+| PostgresService | Key namespacing | No | Infrastructure table |
+| testdb | N/A | No | Test only |
 
 ## Recommendations
 
-1. **New pgx-based repositories** should accept `*db.GuardedPgxPool` (or `db.PgxQuerier`) instead of raw `*pgxpool.Pool` to enforce tenant context by default.
-2. **Existing infrastructure components** (outbox, scheduler, idempotency) are correctly operating at the platform level and do not need tenant guards.
-3. The `GuardedPgxPool` and `PgxQuerier` interface are available for any future service-level pgx code that needs tenant enforcement.
+1. **New pgx-based repositories** should accept
+   `*db.GuardedPgxPool` (or `db.PgxQuerier`) instead of raw
+   `*pgxpool.Pool` to enforce tenant context by default.
+2. **Existing infrastructure components** (outbox, scheduler,
+   idempotency) are correctly operating at the platform level and
+   do not need tenant guards.
+3. The `GuardedPgxPool` and `PgxQuerier` interface are available
+   for any future service-level pgx code that needs tenant
+   enforcement.

--- a/shared/platform/db/guarded_pgx_pool.go
+++ b/shared/platform/db/guarded_pgx_pool.go
@@ -69,6 +69,10 @@ func (g *GuardedPgxPool) QueryRow(ctx context.Context, sql string, args ...any) 
 
 // Begin starts a transaction with tenant context validation.
 // Requires tenant context or bypass in ctx.
+//
+// The returned pgx.Tx is not individually guarded because tenant context
+// was validated at Begin time. For tenant schema isolation, prefer
+// BeginTenantTx which also sets the search_path.
 func (g *GuardedPgxPool) Begin(ctx context.Context) (pgx.Tx, error) {
 	if _, err := RequirePgxTenantContext(ctx); err != nil {
 		return nil, err
@@ -101,8 +105,9 @@ func (g *GuardedPgxPool) BeginTenantTx(ctx context.Context) (pgx.Tx, error) {
 	return tx, nil
 }
 
-// Pool returns the underlying *pgxpool.Pool for cases where direct access
-// is needed (e.g., Close, Stat). The returned pool is NOT guarded.
+// Pool returns the underlying *pgxpool.Pool for infrastructure operations
+// only (Close, Stat, Ping). The returned pool is NOT guarded — do not use
+// it for tenant-scoped queries.
 func (g *GuardedPgxPool) Pool() *pgxpool.Pool {
 	return g.pool
 }

--- a/shared/platform/db/guarded_pgx_pool.go
+++ b/shared/platform/db/guarded_pgx_pool.go
@@ -1,0 +1,126 @@
+package db
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// PgxQuerier is the minimal interface for pgx query operations.
+// Both *pgxpool.Pool and pgx.Tx satisfy this interface.
+type PgxQuerier interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+// GuardedPgxPool wraps a *pgxpool.Pool and enforces tenant context on all
+// query operations. If a query is made without tenant context (and without
+// a bypass), the operation is rejected with ErrPgxTenantContextRequired.
+//
+// For operations that need tenant schema isolation (via SET LOCAL search_path),
+// callers should use BeginTenantTx which starts a transaction with the
+// tenant's schema already set.
+type GuardedPgxPool struct {
+	pool *pgxpool.Pool
+}
+
+// NewGuardedPgxPool creates a GuardedPgxPool that enforces tenant context
+// on all pgx operations.
+func NewGuardedPgxPool(pool *pgxpool.Pool) *GuardedPgxPool {
+	return &GuardedPgxPool{pool: pool}
+}
+
+// Exec executes a query that doesn't return rows.
+// Requires tenant context or bypass in ctx.
+func (g *GuardedPgxPool) Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error) {
+	if _, err := RequirePgxTenantContext(ctx); err != nil {
+		return pgconn.CommandTag{}, err
+	}
+	return g.pool.Exec(ctx, sql, arguments...)
+}
+
+// Query executes a query that returns rows.
+// Requires tenant context or bypass in ctx.
+func (g *GuardedPgxPool) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	if _, err := RequirePgxTenantContext(ctx); err != nil {
+		return nil, err
+	}
+	return g.pool.Query(ctx, sql, args...)
+}
+
+// QueryRow executes a query that returns at most one row.
+// Requires tenant context or bypass in ctx.
+//
+// Note: pgx.Row doesn't support returning errors from QueryRow directly,
+// so the guard check wraps the result in an errorRow on failure.
+func (g *GuardedPgxPool) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
+	if _, err := RequirePgxTenantContext(ctx); err != nil {
+		return &errorRow{err: err}
+	}
+	return g.pool.QueryRow(ctx, sql, args...)
+}
+
+// Begin starts a transaction with tenant context validation.
+// Requires tenant context or bypass in ctx.
+func (g *GuardedPgxPool) Begin(ctx context.Context) (pgx.Tx, error) {
+	if _, err := RequirePgxTenantContext(ctx); err != nil {
+		return nil, err
+	}
+	return g.pool.Begin(ctx)
+}
+
+// BeginTenantTx starts a transaction and sets the search_path to the tenant's
+// schema. This is the recommended way to execute tenant-scoped pgx queries
+// that need schema isolation.
+//
+// The caller is responsible for committing or rolling back the transaction.
+func (g *GuardedPgxPool) BeginTenantTx(ctx context.Context) (pgx.Tx, error) {
+	tid, ok := tenant.FromContext(ctx)
+	if !ok || tid.IsEmpty() {
+		return nil, fmt.Errorf("%w", ErrPgxTenantContextRequired)
+	}
+
+	tx, err := g.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin tenant tx: %w", err)
+	}
+
+	schemaName := pq.QuoteIdentifier(tid.SchemaName())
+	if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)); err != nil {
+		_ = tx.Rollback(ctx)
+		return nil, fmt.Errorf("set tenant schema: %w", err)
+	}
+
+	return tx, nil
+}
+
+// Pool returns the underlying *pgxpool.Pool for cases where direct access
+// is needed (e.g., Close, Stat). The returned pool is NOT guarded.
+func (g *GuardedPgxPool) Pool() *pgxpool.Pool {
+	return g.pool
+}
+
+// Close closes the underlying connection pool.
+func (g *GuardedPgxPool) Close() {
+	g.pool.Close()
+}
+
+// errorRow implements pgx.Row and returns an error on Scan.
+// Used when QueryRow fails the tenant guard check.
+type errorRow struct {
+	err error
+}
+
+func (r *errorRow) Scan(_ ...any) error {
+	return r.err
+}
+
+// Verify GuardedPgxPool implements PgxQuerier at compile time.
+var _ PgxQuerier = (*GuardedPgxPool)(nil)

--- a/shared/platform/db/guarded_pgx_pool_test.go
+++ b/shared/platform/db/guarded_pgx_pool_test.go
@@ -1,0 +1,180 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/shared/platform/db"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupGuardedPool(t *testing.T) (*db.GuardedPgxPool, *pgxpool.Pool) {
+	t.Helper()
+	pool := testdb.NewTestPool(t)
+	guarded := db.NewGuardedPgxPool(pool)
+	return guarded, pool
+}
+
+func TestGuardedPgxPool_ExecRejectsWithoutTenant(t *testing.T) {
+	t.Parallel()
+	guarded, _ := setupGuardedPool(t)
+
+	_, err := guarded.Exec(context.Background(), "SELECT 1")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, db.ErrPgxTenantContextRequired)
+}
+
+func TestGuardedPgxPool_ExecAllowsWithTenant(t *testing.T) {
+	t.Parallel()
+	guarded, _ := setupGuardedPool(t)
+
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("test_tenant"))
+
+	_, err := guarded.Exec(ctx, "SELECT 1")
+
+	require.NoError(t, err)
+}
+
+func TestGuardedPgxPool_ExecAllowsWithBypass(t *testing.T) {
+	t.Parallel()
+	guarded, _ := setupGuardedPool(t)
+
+	ctx := db.WithPgxTenantBypass(context.Background())
+
+	_, err := guarded.Exec(ctx, "SELECT 1")
+
+	require.NoError(t, err)
+}
+
+func TestGuardedPgxPool_QueryRejectsWithoutTenant(t *testing.T) {
+	t.Parallel()
+	guarded, _ := setupGuardedPool(t)
+
+	_, err := guarded.Query(context.Background(), "SELECT 1")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, db.ErrPgxTenantContextRequired)
+}
+
+func TestGuardedPgxPool_QueryAllowsWithTenant(t *testing.T) {
+	t.Parallel()
+	guarded, _ := setupGuardedPool(t)
+
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("test_tenant"))
+
+	rows, err := guarded.Query(ctx, "SELECT 1")
+	require.NoError(t, err)
+	rows.Close()
+}
+
+func TestGuardedPgxPool_QueryRowRejectsWithoutTenant(t *testing.T) {
+	t.Parallel()
+	guarded, _ := setupGuardedPool(t)
+
+	row := guarded.QueryRow(context.Background(), "SELECT 1")
+
+	var result int
+	err := row.Scan(&result)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, db.ErrPgxTenantContextRequired)
+}
+
+func TestGuardedPgxPool_QueryRowAllowsWithTenant(t *testing.T) {
+	t.Parallel()
+	guarded, _ := setupGuardedPool(t)
+
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("test_tenant"))
+
+	var result int
+	err := guarded.QueryRow(ctx, "SELECT 1").Scan(&result)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, result)
+}
+
+func TestGuardedPgxPool_BeginRejectsWithoutTenant(t *testing.T) {
+	t.Parallel()
+	guarded, _ := setupGuardedPool(t)
+
+	_, err := guarded.Begin(context.Background())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, db.ErrPgxTenantContextRequired)
+}
+
+func TestGuardedPgxPool_BeginAllowsWithTenant(t *testing.T) {
+	t.Parallel()
+	guarded, _ := setupGuardedPool(t)
+
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("test_tenant"))
+
+	tx, err := guarded.Begin(ctx)
+	require.NoError(t, err)
+	_ = tx.Rollback(ctx)
+}
+
+func TestGuardedPgxPool_BeginTenantTx_RejectsWithoutTenant(t *testing.T) {
+	t.Parallel()
+	guarded, _ := setupGuardedPool(t)
+
+	_, err := guarded.BeginTenantTx(context.Background())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, db.ErrPgxTenantContextRequired)
+}
+
+func TestGuardedPgxPool_BeginTenantTx_SetsSearchPath(t *testing.T) {
+	t.Parallel()
+	guarded, pool := setupGuardedPool(t)
+
+	tid := tenant.TenantID("acme_bank")
+	ctx := tenant.WithTenant(context.Background(), tid)
+
+	// Create the tenant schema so SET search_path works
+	bypassCtx := db.WithPgxTenantBypass(context.Background())
+	_, err := pool.Exec(bypassCtx, "CREATE SCHEMA IF NOT EXISTS org_acme_bank")
+	require.NoError(t, err)
+
+	tx, err := guarded.BeginTenantTx(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Verify search_path is set correctly
+	var searchPath string
+	err = tx.QueryRow(ctx, "SHOW search_path").Scan(&searchPath)
+	require.NoError(t, err)
+	assert.Contains(t, searchPath, "org_acme_bank")
+}
+
+func TestGuardedPgxPool_BeginTenantTx_RejectsEmptyTenantID(t *testing.T) {
+	t.Parallel()
+	guarded, _ := setupGuardedPool(t)
+
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID(""))
+
+	_, err := guarded.BeginTenantTx(ctx)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, db.ErrPgxTenantContextRequired)
+}
+
+func TestGuardedPgxPool_Pool_ReturnsUnderlyingPool(t *testing.T) {
+	t.Parallel()
+	guarded, pool := setupGuardedPool(t)
+
+	assert.Same(t, pool, guarded.Pool())
+}
+
+func TestGuardedPgxPool_ImplementsPgxQuerier(t *testing.T) {
+	t.Parallel()
+	guarded, _ := setupGuardedPool(t)
+
+	// Compile-time check is in guarded_pgx_pool.go, but verify at runtime too.
+	var _ db.PgxQuerier = guarded
+}

--- a/shared/platform/db/pgx_tenant_guard.go
+++ b/shared/platform/db/pgx_tenant_guard.go
@@ -1,0 +1,49 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// ErrPgxTenantContextRequired is returned when a pgx query is executed without
+// tenant context. This is the pgx equivalent of ErrTenantScopeRequired for GORM.
+var ErrPgxTenantContextRequired = errors.New("pgx tenant guard: tenant context required — use tenant.WithTenant(ctx, id) or WithPgxTenantBypass(ctx)")
+
+// pgxTenantBypassKey marks a context as bypassing pgx tenant guard checks.
+// Used for infrastructure operations: migrations, health checks, schema provisioning.
+type pgxTenantBypassKey struct{}
+
+// WithPgxTenantBypass returns a context that bypasses pgx tenant guard checks.
+// Use this for operations that legitimately don't need tenant context:
+// migrations, health checks, tenant provisioning, and platform-level queries.
+func WithPgxTenantBypass(ctx context.Context) context.Context {
+	return context.WithValue(ctx, pgxTenantBypassKey{}, true)
+}
+
+// hasPgxTenantBypass checks whether pgx tenant guard bypass is set.
+func hasPgxTenantBypass(ctx context.Context) bool {
+	v, ok := ctx.Value(pgxTenantBypassKey{}).(bool)
+	return ok && v
+}
+
+// RequirePgxTenantContext validates that the context carries either a tenant ID
+// or a bypass marker. Returns the tenant ID if present, or an error if neither
+// tenant context nor bypass is set.
+//
+// This is the core guard function used by GuardedPgxPool to enforce tenant
+// isolation on all pgx database operations.
+func RequirePgxTenantContext(ctx context.Context) (tenant.TenantID, error) {
+	if hasPgxTenantBypass(ctx) {
+		return "", nil
+	}
+
+	tid, ok := tenant.FromContext(ctx)
+	if !ok || tid.IsEmpty() {
+		return "", fmt.Errorf("%w", ErrPgxTenantContextRequired)
+	}
+
+	return tid, nil
+}

--- a/shared/platform/db/pgx_tenant_guard_test.go
+++ b/shared/platform/db/pgx_tenant_guard_test.go
@@ -52,32 +52,14 @@ func TestRequirePgxTenantContext_AcceptsBypass(t *testing.T) {
 	assert.Equal(t, tenant.TenantID(""), tid)
 }
 
-func TestRequirePgxTenantContext_BypassTakesPrecedenceOverMissingTenant(t *testing.T) {
+func TestRequirePgxTenantContext_BypassTakesPrecedenceOverEmptyTenant(t *testing.T) {
 	t.Parallel()
 
-	// Bypass set but no tenant — should pass
-	ctx := db.WithPgxTenantBypass(context.Background())
+	// Context has empty tenant ID AND bypass — bypass should win
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID(""))
+	ctx = db.WithPgxTenantBypass(ctx)
 
 	_, err := db.RequirePgxTenantContext(ctx)
 
 	require.NoError(t, err)
-}
-
-func TestWithPgxTenantBypass_DoesNotAffectGormBypass(t *testing.T) {
-	t.Parallel()
-
-	// pgx bypass should not set GORM bypass
-	ctx := db.WithPgxTenantBypass(context.Background())
-
-	// The GORM guard uses a separate context key
-	assert.False(t, hasTenantGuardBypassViaPublicAPI(ctx))
-}
-
-// hasTenantGuardBypassViaPublicAPI tests that pgx bypass doesn't bleed into GORM bypass
-// by attempting a GORM operation without tenant scope on a guarded DB.
-// This is a negative test - we just verify the contexts are independent.
-func hasTenantGuardBypassViaPublicAPI(_ context.Context) bool {
-	// We can't easily test this without a GORM DB, so this just documents the intent.
-	// The pgx and GORM bypass keys are separate types, ensuring no cross-contamination.
-	return false
 }

--- a/shared/platform/db/pgx_tenant_guard_test.go
+++ b/shared/platform/db/pgx_tenant_guard_test.go
@@ -1,0 +1,83 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/platform/db"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequirePgxTenantContext_RejectsEmptyContext(t *testing.T) {
+	t.Parallel()
+
+	_, err := db.RequirePgxTenantContext(context.Background())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, db.ErrPgxTenantContextRequired)
+}
+
+func TestRequirePgxTenantContext_RejectsEmptyTenantID(t *testing.T) {
+	t.Parallel()
+
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID(""))
+
+	_, err := db.RequirePgxTenantContext(ctx)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, db.ErrPgxTenantContextRequired)
+}
+
+func TestRequirePgxTenantContext_AcceptsTenantContext(t *testing.T) {
+	t.Parallel()
+
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("acme_bank"))
+
+	tid, err := db.RequirePgxTenantContext(ctx)
+
+	require.NoError(t, err)
+	assert.Equal(t, tenant.TenantID("acme_bank"), tid)
+}
+
+func TestRequirePgxTenantContext_AcceptsBypass(t *testing.T) {
+	t.Parallel()
+
+	ctx := db.WithPgxTenantBypass(context.Background())
+
+	tid, err := db.RequirePgxTenantContext(ctx)
+
+	require.NoError(t, err)
+	assert.Equal(t, tenant.TenantID(""), tid)
+}
+
+func TestRequirePgxTenantContext_BypassTakesPrecedenceOverMissingTenant(t *testing.T) {
+	t.Parallel()
+
+	// Bypass set but no tenant — should pass
+	ctx := db.WithPgxTenantBypass(context.Background())
+
+	_, err := db.RequirePgxTenantContext(ctx)
+
+	require.NoError(t, err)
+}
+
+func TestWithPgxTenantBypass_DoesNotAffectGormBypass(t *testing.T) {
+	t.Parallel()
+
+	// pgx bypass should not set GORM bypass
+	ctx := db.WithPgxTenantBypass(context.Background())
+
+	// The GORM guard uses a separate context key
+	assert.False(t, hasTenantGuardBypassViaPublicAPI(ctx))
+}
+
+// hasTenantGuardBypassViaPublicAPI tests that pgx bypass doesn't bleed into GORM bypass
+// by attempting a GORM operation without tenant scope on a guarded DB.
+// This is a negative test - we just verify the contexts are independent.
+func hasTenantGuardBypassViaPublicAPI(_ context.Context) bool {
+	// We can't easily test this without a GORM DB, so this just documents the intent.
+	// The pgx and GORM bypass keys are separate types, ensuring no cross-contamination.
+	return false
+}


### PR DESCRIPTION
## Summary

- Add `GuardedPgxPool` wrapper that enforces tenant context on all pgx query operations (`Exec`, `Query`, `QueryRow`, `Begin`)
- Add `RequirePgxTenantContext` guard function and `WithPgxTenantBypass` for infrastructure operations
- Add `BeginTenantTx` for starting transactions with tenant schema `search_path` already set
- Add `PgxQuerier` interface for dependency injection in repositories
- Audit all raw pgx usage paths: outbox, scheduler, idempotency, and testdb

## Technical Details

Queries without tenant context or explicit bypass are rejected with `ErrPgxTenantContextRequired`. This mirrors the existing GORM `TenantGuard` plugin but for direct pgx access.

Existing infrastructure components (outbox, scheduler, idempotency) operate at the platform level cross-tenant by design and do not need guards. The guard is intended for new service-level pgx repositories.

## Test Plan

- [x] 5 unit tests for `RequirePgxTenantContext` (reject empty, reject empty ID, accept tenant, accept bypass, bypass precedence)
- [x] 14 integration tests for `GuardedPgxPool` (reject/allow for each operation, BeginTenantTx search_path verification)
- [x] All tests use testcontainers (no mocks for integration tests)

## Related

047-security-audit task 21