### PR TITLE
fix: Resolve golangci-lint and E2E failures on develop

### DIFF
--- a/frontend/e2e/economy.spec.ts
+++ b/frontend/e2e/economy.spec.ts
@@ -30,8 +30,8 @@ test.describe('Economy Overview', () => {
   })
 
   test('renders empty state or overview content', async ({ authenticatedPage: page }) => {
-    // Without a backend, the page shows either empty state (NotFound) or error state.
-    // Both are valid outcomes — the page loaded without crashing.
+    // The page can resolve to empty state (NotFound), error state, or rendered content.
+    // All are valid outcomes — the page loaded without crashing.
     const emptyState = page.getByTestId('overview-empty')
     const errorState = page.getByTestId('overview-error')
     const loadingState = page.getByTestId('overview-loading')
@@ -39,11 +39,12 @@ test.describe('Economy Overview', () => {
     // Wait for loading to complete
     await expect(loadingState).toHaveCount(0, { timeout: 15_000 })
 
-    // One of empty or error should be visible (no backend = NotFound or connection error)
+    // One of empty, error, or content (h1 heading) should be visible
     const isEmpty = await emptyState.isVisible().catch(() => false)
     const isError = await errorState.isVisible().catch(() => false)
+    const hasContent = await page.getByRole('heading', { level: 1 }).isVisible().catch(() => false)
 
-    expect(isEmpty || isError).toBe(true)
+    expect(isEmpty || isError || hasContent).toBe(true)
   })
 
   test('empty state has Configure Economy button', async ({ authenticatedPage: page }) => {
@@ -92,10 +93,12 @@ test.describe('Economy Explorer', () => {
 
     await expect(loadingState).toHaveCount(0, { timeout: 15_000 })
 
+    // One of empty, error, or content (h1 heading) should be visible
     const isEmpty = await emptyState.isVisible().catch(() => false)
     const isError = await errorState.isVisible().catch(() => false)
+    const hasContent = await page.getByRole('heading', { level: 1 }).isVisible().catch(() => false)
 
-    expect(isEmpty || isError).toBe(true)
+    expect(isEmpty || isError || hasContent).toBe(true)
   })
 
   test('shows tab triggers when manifest data is present', async ({ authenticatedPage: page }) => {
@@ -156,9 +159,12 @@ test.describe('Economy Edit', () => {
 test.describe('Economy navigation flow', () => {
   test('sidebar Economy link navigates to /economy', async ({ authenticatedPage: page }) => {
     const nav = page.getByRole('navigation', { name: 'Main navigation' })
-    // Economy is in a collapsible group — click the group label first
-    const economyGroup = nav.getByText('Economy', { exact: true })
-    await economyGroup.click()
+    // Economy is in a collapsible group — expand it if collapsed
+    const economyToggle = nav.getByRole('button', { name: /economy/i })
+    const isExpanded = await economyToggle.getAttribute('aria-expanded')
+    if (isExpanded === 'false') {
+      await economyToggle.click()
+    }
 
     const overviewLink = nav.getByRole('link', { name: 'Overview' })
     await overviewLink.click()

--- a/services/mcp-server/cmd/main.go
+++ b/services/mcp-server/cmd/main.go
@@ -29,6 +29,9 @@ var (
 	BuildDate = "unknown"
 )
 
+// errMissingJWTSigningKey is returned when OIDC is enabled but no JWT signing key is configured.
+var errMissingJWTSigningKey = errors.New("JWT_SIGNING_KEY_FILE or JWT_SIGNING_KEY must be set when MCP_DEX_ISSUER_URL is configured")
+
 func main() {
 	// Log to stderr: in stdio mode, stdout is the JSON-RPC wire protocol channel.
 	// Logging to stdout would corrupt the protocol for MCP clients.
@@ -233,7 +236,7 @@ func runHTTP(logger *slog.Logger, srv *mcp.Server) error {
 			keyFile := env.GetEnvOrDefault("JWT_SIGNING_KEY_FILE", "")
 			keyPEM := env.GetEnvOrDefault("JWT_SIGNING_KEY", "")
 			if keyFile == "" && keyPEM == "" {
-				return fmt.Errorf("JWT_SIGNING_KEY_FILE or JWT_SIGNING_KEY must be set when MCP_DEX_ISSUER_URL is configured")
+				return errMissingJWTSigningKey
 			}
 			signer, err := platformauth.NewJWTSigner(platformauth.JWTSignerConfig{
 				PrivateKeyFile: keyFile,

--- a/shared/pkg/valuation/starlark_security_test.go
+++ b/shared/pkg/valuation/starlark_security_test.go
@@ -315,7 +315,7 @@ x = 42
 // frozen dict and correctly rejects mutations.
 //
 // TODO: freeze the ctx dict in defaultStarlarkRuntime.buildScriptContext so that
-// mutations are rejected at runtime (matching forecasting behaviour).
+// mutations are rejected at runtime (matching forecasting behavior).
 func TestValuationSecurityContextImmutability(t *testing.T) {
 	t.Skip("ctx dict is not frozen in valuation runtime — script mutations succeed silently; see TODO in starlark_runtime.go")
 

--- a/shared/platform/db/tenant_isolation_integration_test.go
+++ b/shared/platform/db/tenant_isolation_integration_test.go
@@ -329,7 +329,6 @@ func TestTenantGuard_Integration_ConcurrentTenantRequests(t *testing.T) {
 		err := db.WithGormTenantTransaction(ctx, gormDB, func(tx *gorm.DB) error {
 			return tx.Table("isolation_test_entities").Find(&rows).Error
 		})
-
 		if err != nil {
 			ch <- result{tenantID: id, err: err}
 			return

--- a/shared/platform/sandbox/harden_test.go
+++ b/shared/platform/sandbox/harden_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
 )
 
 func TestHardenThread_SetsMaxSteps(t *testing.T) {
@@ -30,7 +31,7 @@ def work():
     return x
 work()
 `
-	_, err := starlark.ExecFile(smallThread, "test.star", script, nil)
+	_, err := starlark.ExecFileOptions(&syntax.FileOptions{}, smallThread, "test.star", script, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "too many steps")
 }
@@ -42,7 +43,7 @@ func TestHardenThread_AllowsSmallScripts(t *testing.T) {
 	HardenThread(thread, cfg)
 
 	script := `x = 1 + 2`
-	_, err := starlark.ExecFile(thread, "test.star", script, nil)
+	_, err := starlark.ExecFileOptions(&syntax.FileOptions{}, thread, "test.star", script, nil)
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
## Summary
- Fix 5 golangci-lint errors failing the Code Quality workflow on develop
- Fix E2E economy test failures (Shard 2/4) that fail consistently on develop

## Changes

### golangci-lint (5 issues)
- **err113**: Replace dynamic `fmt.Errorf` with sentinel `errMissingJWTSigningKey` in `services/mcp-server/cmd/main.go`
- **gofumpt**: Remove blank line before short `if` in `shared/platform/db/tenant_isolation_integration_test.go`
- **misspell**: Fix "behaviour" → "behavior" in `shared/pkg/valuation/starlark_security_test.go`
- **staticcheck SA1019**: Replace deprecated `starlark.ExecFile` with `ExecFileOptions` in `shared/platform/sandbox/harden_test.go`

### E2E Tests
- **Overview/Explorer tests**: Accept successful content render as valid outcome alongside empty/error states. The economy page can render manifest content when backend data is available, but the tests only checked for empty/error states.
- **Navigation test**: Check `aria-expanded` attribute before clicking the Economy sidebar group. The group starts expanded by default, so clicking it collapsed the group and hid the Overview link, causing a timeout.

## Not addressed (not code-actionable)
- **Deploy to Demo Droplet**: SSH authentication failure (infrastructure/secrets issue)
- **Trivy Repository Scan**: Dependency vulnerabilities (requires dependency updates)

## Test plan
- [ ] Code Quality (golangci-lint) passes
- [ ] E2E Shard 2/4 passes
- [ ] Build & Test passes (already passing on latest develop)