### PR TITLE
fix: scale demo docker-compose CPU limits for 1-CPU droplet

### DIFF
--- a/deploy/demo/docker-compose.yml
+++ b/deploy/demo/docker-compose.yml
@@ -42,11 +42,11 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '2'
-          memory: 2G
+          cpus: '1'
+          memory: 1G
         reservations:
-          cpus: '0.5'
-          memory: 512M
+          cpus: '0.25'
+          memory: 256M
     # Not exposed to host — accessed only by meridian on the internal network
 
   # Dex OIDC is embedded in the meridian binary (no sidecar container needed).
@@ -123,11 +123,11 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '4'
-          memory: 4G
-        reservations:
           cpus: '1'
-          memory: 1G
+          memory: 2G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
     # Note: The meridian image uses gcr.io/distroless/static-debian12 (no shell,
     # no wget), so a CMD-SHELL healthcheck cannot run. Health is monitored via
     # the gRPC health check service on port 50051. Caddy uses service_started


### PR DESCRIPTION
## Summary

- Reduces postgres CPU limit from 2 → 1 and meridian from 4 → 1 in `deploy/demo/docker-compose.yml`
- The demo droplet has 1 CPU; Docker rejects `cpus` limits exceeding the host count, which broke container recreation after #1743

## Changes Made

| Service | Before (limit/reservation) | After |
|---------|---------------------------|-------|
| postgres | 2 / 0.5 CPU, 2G / 512M | 1 / 0.25 CPU, 1G / 256M |
| meridian | 4 / 1 CPU, 4G / 1G | 1 / 0.5 CPU, 2G / 512M |
| mcp-server | 1 / 0.25 (unchanged) | 1 / 0.25 (unchanged) |
| caddy | 1 / 0.25 (unchanged) | 1 / 0.25 (unchanged) |

## Test plan

- [x] Manually verified on droplet: `docker compose up -d --force-recreate` succeeds
- [x] Health check passing at https://demo.meridianhub.cloud/healthz