### PR TITLE
fix: Detach context in saga failure handling to prevent cancelled-context errors

### DIFF
--- a/services/payment-order/service/payment_orchestrator_saga.go
+++ b/services/payment-order/service/payment_orchestrator_saga.go
@@ -176,8 +176,13 @@ func (o *PaymentOrchestrator) ExecutePaymentSaga(ctx context.Context, paymentOrd
 			"error", err,
 			"duration_ms", durationMs)
 
+		// Detach from the saga context (may be cancelled due to timeout) so
+		// failure recording and compensation complete successfully.
+		failCtx, failCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer failCancel()
+
 		now := time.Now()
-		o.logSagaExecution(ctx, &domain.SagaExecution{
+		o.logSagaExecution(failCtx, &domain.SagaExecution{
 			ID:             executionID,
 			PaymentOrderID: paymentOrderID,
 			SagaName:       sagaName,
@@ -191,7 +196,7 @@ func (o *PaymentOrchestrator) ExecutePaymentSaga(ctx context.Context, paymentOrd
 			CompletedAt:    &now,
 		})
 
-		if err := o.failPaymentOrder(ctx, po, fmt.Sprintf("saga execution error: %v", err), "SAGA_FAILED"); err != nil {
+		if err := o.failPaymentOrder(failCtx, po, fmt.Sprintf("saga execution error: %v", err), "SAGA_FAILED"); err != nil {
 			o.logger.Error("failed to mark payment order as failed",
 				"payment_order_id", po.ID.String(),
 				"error", err)
@@ -260,8 +265,11 @@ func (o *PaymentOrchestrator) handleStarlarkSagaResult(ctx context.Context, po *
 func (o *PaymentOrchestrator) handleSagaFailure(ctx context.Context, po *domain.PaymentOrder, result *saga.RunnerOutput) {
 	// Detach from the caller's context so failure handling succeeds even when
 	// the saga context has been cancelled (e.g. timeout). The detached context
-	// preserves values (tenant, correlation ID) but not the deadline.
-	ctx = context.WithoutCancel(ctx)
+	// preserves values (tenant, correlation ID) but removes the deadline.
+	// Add a fresh timeout to prevent indefinite hangs.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+
 	o.logger.Error("payment saga failed in Starlark execution",
 		"payment_order_id", po.ID.String(),
 		"error", result.Error,
@@ -538,11 +546,6 @@ func (o *PaymentOrchestrator) evaluateBucketID(ctx context.Context, po *domain.P
 // (e.g., UpdatePaymentOrder) should propagate this error to clients. Callers in async paths
 // (e.g., saga orchestration) may log and swallow the error.
 func (o *PaymentOrchestrator) failPaymentOrder(ctx context.Context, po *domain.PaymentOrder, reason string, errorCode string) error {
-	// Detach from the caller's context so compensation operations succeed even
-	// when the saga context has been cancelled (e.g. timeout). The detached
-	// context preserves values (tenant, correlation ID) but not the deadline.
-	ctx = context.WithoutCancel(ctx)
-
 	// Capture original status before transitioning (for event)
 	failedAtStatus := po.Status
 

--- a/services/payment-order/service/payment_orchestrator_saga.go
+++ b/services/payment-order/service/payment_orchestrator_saga.go
@@ -258,6 +258,10 @@ func (o *PaymentOrchestrator) handleStarlarkSagaResult(ctx context.Context, po *
 // handleSagaFailure processes a failed saga result, extracting partial outputs and marking
 // the payment order as failed.
 func (o *PaymentOrchestrator) handleSagaFailure(ctx context.Context, po *domain.PaymentOrder, result *saga.RunnerOutput) {
+	// Detach from the caller's context so failure handling succeeds even when
+	// the saga context has been cancelled (e.g. timeout). The detached context
+	// preserves values (tenant, correlation ID) but not the deadline.
+	ctx = context.WithoutCancel(ctx)
 	o.logger.Error("payment saga failed in Starlark execution",
 		"payment_order_id", po.ID.String(),
 		"error", result.Error,
@@ -534,6 +538,11 @@ func (o *PaymentOrchestrator) evaluateBucketID(ctx context.Context, po *domain.P
 // (e.g., UpdatePaymentOrder) should propagate this error to clients. Callers in async paths
 // (e.g., saga orchestration) may log and swallow the error.
 func (o *PaymentOrchestrator) failPaymentOrder(ctx context.Context, po *domain.PaymentOrder, reason string, errorCode string) error {
+	// Detach from the caller's context so compensation operations succeed even
+	// when the saga context has been cancelled (e.g. timeout). The detached
+	// context preserves values (tenant, correlation ID) but not the deadline.
+	ctx = context.WithoutCancel(ctx)
+
 	// Capture original status before transitioning (for event)
 	failedAtStatus := po.Status
 


### PR DESCRIPTION
## Summary

- Nightly CI failing on `TestIntegration_NetworkTimeout_DuringExecutePhase` — lien not released during compensation after saga timeout
- Root cause: `handleSagaFailure` and `failPaymentOrder` used the saga context which was already cancelled by the timeout deadline, causing all downstream operations (DB reload, lien release RPC, event publishing) to fail silently
- Fix: use `context.WithoutCancel` at the top of both methods to detach from the cancelled context while preserving tenant and correlation ID values

## Evidence

- Failing nightly run: https://github.com/meridianhub/meridian/actions/runs/23215224756
- Error: `await: condition not met within timeout` — lien `TerminateLien` never called because `FindByID` failed first with `context deadline exceeded`
- Same failure in earlier nightly run (23203157039)

## Test plan

- [x] `TestIntegration_NetworkTimeout_DuringExecutePhase` now passes locally
- [x] All 15 `TestIntegration_*` tests in payment-order service pass
- [ ] CI passes on this PR