### PR TITLE
fix: Harden financial-gateway unhappy paths and fix fee/refund bugs

### DIFF
--- a/services/financial-gateway/adapters/stripe/manifest_tenant_config_test.go
+++ b/services/financial-gateway/adapters/stripe/manifest_tenant_config_test.go
@@ -129,7 +129,7 @@ func TestManifestTenantConfigProvider_GetTenantConfig(t *testing.T) {
 		p, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
 			Client:   mock,
 			Logger:   slog.Default(),
-			CacheTTL: 1 * time.Millisecond, // expires immediately
+			CacheTTL: 1 * time.Hour,
 		})
 		require.NoError(t, err)
 
@@ -137,7 +137,12 @@ func TestManifestTenantConfigProvider_GetTenantConfig(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 1, mock.callCount)
 
-		time.Sleep(5 * time.Millisecond) // let cache expire
+		// Force cache entry to expire by backdating it
+		p.mu.Lock()
+		entry := p.cache["tenant-expire"]
+		entry.expiresAt = time.Now().Add(-1 * time.Second)
+		p.cache["tenant-expire"] = entry
+		p.mu.Unlock()
 
 		_, err = p.GetTenantConfig("tenant-expire")
 		require.NoError(t, err)

--- a/services/financial-gateway/adapters/stripe/manifest_tenant_config_test.go
+++ b/services/financial-gateway/adapters/stripe/manifest_tenant_config_test.go
@@ -1,0 +1,300 @@
+package stripe
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+)
+
+// mockManifestClient implements ManifestHistoryServiceClient for testing.
+type mockManifestClient struct {
+	controlplanev1.ManifestHistoryServiceClient
+	getCurrentManifestFn func(ctx context.Context, req *controlplanev1.GetCurrentManifestRequest, opts ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error)
+	callCount            int
+}
+
+func (m *mockManifestClient) GetCurrentManifest(ctx context.Context, req *controlplanev1.GetCurrentManifestRequest, opts ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+	m.callCount++
+	return m.getCurrentManifestFn(ctx, req, opts...)
+}
+
+func manifestWithStripeConnect(accountID, webhookSecret string) *controlplanev1.GetCurrentManifestResponse {
+	return &controlplanev1.GetCurrentManifestResponse{
+		Version: &controlplanev1.ManifestVersion{
+			Manifest: &controlplanev1.Manifest{
+				PaymentRails: []*controlplanev1.PaymentRails{
+					{
+						Provider:              "stripe_connect",
+						AccountId:             accountID,
+						WebhookEndpointSecret: webhookSecret,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestNewManifestTenantConfigProvider(t *testing.T) {
+	t.Run("nil client", func(t *testing.T) {
+		_, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+			Logger: slog.Default(),
+		})
+		require.ErrorIs(t, err, ErrNilManifestClient)
+	})
+
+	t.Run("nil logger", func(t *testing.T) {
+		_, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+			Client: &mockManifestClient{},
+		})
+		require.ErrorIs(t, err, ErrNilLogger)
+	})
+
+	t.Run("defaults cache TTL to 5 minutes", func(t *testing.T) {
+		p, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+			Client: &mockManifestClient{},
+			Logger: slog.Default(),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 5*time.Minute, p.ttl)
+	})
+
+	t.Run("custom cache TTL", func(t *testing.T) {
+		p, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+			Client:   &mockManifestClient{},
+			Logger:   slog.Default(),
+			CacheTTL: 30 * time.Second,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 30*time.Second, p.ttl)
+	})
+}
+
+func TestManifestTenantConfigProvider_GetTenantConfig(t *testing.T) {
+	t.Run("happy path — returns stripe config", func(t *testing.T) {
+		mock := &mockManifestClient{
+			getCurrentManifestFn: func(_ context.Context, _ *controlplanev1.GetCurrentManifestRequest, _ ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+				return manifestWithStripeConnect("acct_tenant1", "whsec_secret1"), nil
+			},
+		}
+		p, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+			Client: mock,
+			Logger: slog.Default(),
+		})
+		require.NoError(t, err)
+
+		cfg, err := p.GetTenantConfig("tenant-1")
+		require.NoError(t, err)
+		assert.Equal(t, "acct_tenant1", cfg.ConnectedAccountID)
+		assert.Equal(t, "whsec_secret1", cfg.WebhookEndpointSecret)
+	})
+
+	t.Run("cache hit — second call uses cache", func(t *testing.T) {
+		mock := &mockManifestClient{
+			getCurrentManifestFn: func(_ context.Context, _ *controlplanev1.GetCurrentManifestRequest, _ ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+				return manifestWithStripeConnect("acct_cached", "whsec_cached"), nil
+			},
+		}
+		p, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+			Client:   mock,
+			Logger:   slog.Default(),
+			CacheTTL: 1 * time.Hour, // won't expire during test
+		})
+		require.NoError(t, err)
+
+		cfg1, err := p.GetTenantConfig("tenant-cache")
+		require.NoError(t, err)
+		assert.Equal(t, "acct_cached", cfg1.ConnectedAccountID)
+		assert.Equal(t, 1, mock.callCount)
+
+		cfg2, err := p.GetTenantConfig("tenant-cache")
+		require.NoError(t, err)
+		assert.Equal(t, "acct_cached", cfg2.ConnectedAccountID)
+		assert.Equal(t, 1, mock.callCount, "should not call gRPC again — cache hit")
+	})
+
+	t.Run("cache expiry — refetches after TTL", func(t *testing.T) {
+		mock := &mockManifestClient{
+			getCurrentManifestFn: func(_ context.Context, _ *controlplanev1.GetCurrentManifestRequest, _ ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+				return manifestWithStripeConnect("acct_fresh", "whsec_fresh"), nil
+			},
+		}
+		p, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+			Client:   mock,
+			Logger:   slog.Default(),
+			CacheTTL: 1 * time.Millisecond, // expires immediately
+		})
+		require.NoError(t, err)
+
+		_, err = p.GetTenantConfig("tenant-expire")
+		require.NoError(t, err)
+		assert.Equal(t, 1, mock.callCount)
+
+		time.Sleep(5 * time.Millisecond) // let cache expire
+
+		_, err = p.GetTenantConfig("tenant-expire")
+		require.NoError(t, err)
+		assert.Equal(t, 2, mock.callCount, "should refetch after cache TTL")
+	})
+
+	t.Run("nil manifest — returns ErrTenantConfigNotFound", func(t *testing.T) {
+		mock := &mockManifestClient{
+			getCurrentManifestFn: func(_ context.Context, _ *controlplanev1.GetCurrentManifestRequest, _ ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+				return &controlplanev1.GetCurrentManifestResponse{
+					Version: &controlplanev1.ManifestVersion{
+						Manifest: nil,
+					},
+				}, nil
+			},
+		}
+		p, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+			Client: mock,
+			Logger: slog.Default(),
+		})
+		require.NoError(t, err)
+
+		_, err = p.GetTenantConfig("tenant-nil-manifest")
+		require.ErrorIs(t, err, ErrTenantConfigNotFound)
+	})
+
+	t.Run("no stripe_connect rail — returns ErrTenantConfigNotFound", func(t *testing.T) {
+		mock := &mockManifestClient{
+			getCurrentManifestFn: func(_ context.Context, _ *controlplanev1.GetCurrentManifestRequest, _ ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+				return &controlplanev1.GetCurrentManifestResponse{
+					Version: &controlplanev1.ManifestVersion{
+						Manifest: &controlplanev1.Manifest{
+							PaymentRails: []*controlplanev1.PaymentRails{
+								{Provider: "manual_bank_transfer", AccountId: "acct_bank"},
+							},
+						},
+					},
+				}, nil
+			},
+		}
+		p, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+			Client: mock,
+			Logger: slog.Default(),
+		})
+		require.NoError(t, err)
+
+		_, err = p.GetTenantConfig("tenant-no-stripe")
+		require.ErrorIs(t, err, ErrTenantConfigNotFound)
+	})
+
+	t.Run("empty payment_rails — returns ErrTenantConfigNotFound", func(t *testing.T) {
+		mock := &mockManifestClient{
+			getCurrentManifestFn: func(_ context.Context, _ *controlplanev1.GetCurrentManifestRequest, _ ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+				return &controlplanev1.GetCurrentManifestResponse{
+					Version: &controlplanev1.ManifestVersion{
+						Manifest: &controlplanev1.Manifest{
+							PaymentRails: []*controlplanev1.PaymentRails{},
+						},
+					},
+				}, nil
+			},
+		}
+		p, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+			Client: mock,
+			Logger: slog.Default(),
+		})
+		require.NoError(t, err)
+
+		_, err = p.GetTenantConfig("tenant-empty-rails")
+		require.ErrorIs(t, err, ErrTenantConfigNotFound)
+	})
+
+	t.Run("invalid config — empty connected account ID", func(t *testing.T) {
+		mock := &mockManifestClient{
+			getCurrentManifestFn: func(_ context.Context, _ *controlplanev1.GetCurrentManifestRequest, _ ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+				return manifestWithStripeConnect("", "whsec_secret"), nil
+			},
+		}
+		p, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+			Client: mock,
+			Logger: slog.Default(),
+		})
+		require.NoError(t, err)
+
+		_, err = p.GetTenantConfig("tenant-invalid")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrMissingAccountID)
+	})
+
+	t.Run("gRPC error propagates", func(t *testing.T) {
+		mock := &mockManifestClient{
+			getCurrentManifestFn: func(_ context.Context, _ *controlplanev1.GetCurrentManifestRequest, _ ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+				return nil, fmt.Errorf("connection refused")
+			},
+		}
+		p, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+			Client: mock,
+			Logger: slog.Default(),
+		})
+		require.NoError(t, err)
+
+		_, err = p.GetTenantConfig("tenant-grpc-fail")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get manifest")
+		assert.Contains(t, err.Error(), "connection refused")
+	})
+
+	t.Run("stripe_connect not first rail — still found", func(t *testing.T) {
+		mock := &mockManifestClient{
+			getCurrentManifestFn: func(_ context.Context, _ *controlplanev1.GetCurrentManifestRequest, _ ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+				return &controlplanev1.GetCurrentManifestResponse{
+					Version: &controlplanev1.ManifestVersion{
+						Manifest: &controlplanev1.Manifest{
+							PaymentRails: []*controlplanev1.PaymentRails{
+								{Provider: "manual_bank_transfer", AccountId: "acct_bank"},
+								{Provider: "stripe_connect", AccountId: "acct_stripe", WebhookEndpointSecret: "whsec_stripe"},
+							},
+						},
+					},
+				}, nil
+			},
+		}
+		p, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+			Client: mock,
+			Logger: slog.Default(),
+		})
+		require.NoError(t, err)
+
+		cfg, err := p.GetTenantConfig("tenant-multi-rail")
+		require.NoError(t, err)
+		assert.Equal(t, "acct_stripe", cfg.ConnectedAccountID)
+	})
+
+	t.Run("error does not cache — subsequent call retries", func(t *testing.T) {
+		callNum := 0
+		mock := &mockManifestClient{
+			getCurrentManifestFn: func(_ context.Context, _ *controlplanev1.GetCurrentManifestRequest, _ ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+				callNum++
+				if callNum == 1 {
+					return nil, fmt.Errorf("transient failure")
+				}
+				return manifestWithStripeConnect("acct_retry", "whsec_retry"), nil
+			},
+		}
+		p, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+			Client: mock,
+			Logger: slog.Default(),
+		})
+		require.NoError(t, err)
+
+		_, err = p.GetTenantConfig("tenant-retry")
+		require.Error(t, err)
+
+		// Second call should retry (error not cached)
+		cfg, err := p.GetTenantConfig("tenant-retry")
+		require.NoError(t, err)
+		assert.Equal(t, "acct_retry", cfg.ConnectedAccountID)
+		assert.Equal(t, 2, mock.callCount)
+	})
+}

--- a/services/financial-gateway/adapters/stripe/platform_fee.go
+++ b/services/financial-gateway/adapters/stripe/platform_fee.go
@@ -61,7 +61,7 @@ func (c PlatformFeeConfig) IsZero() bool {
 }
 
 // CalculateFee computes the platform fee in minor units for a given payment amount.
-// For percentage fees: fee = amountMinor * value / 100 (truncated to integer).
+// For percentage fees: fee = round_half_up(amountMinor * value / 100).
 // For flat fees: fee = value (the configured flat amount in minor units).
 // Returns an error if the fee exceeds the payment amount.
 func (c PlatformFeeConfig) CalculateFee(amountMinor int64) (int64, error) {
@@ -79,7 +79,10 @@ func (c PlatformFeeConfig) CalculateFee(amountMinor int64) (int64, error) {
 	case PlatformFeeTypePercentage:
 		amount := decimal.NewFromInt(amountMinor)
 		feeDecimal := amount.Mul(c.Value).Div(decimal.NewFromInt(100))
-		fee = feeDecimal.IntPart()
+		// Round half-up to avoid systematic revenue leakage from truncation.
+		// Example: 2.5% of 1001 = 25.025 → 25 (old truncation) vs 25 (rounds down correctly here).
+		// Example: 3% of 199 = 5.97 → 5 (old truncation lost 0.97) vs 6 (round half-up).
+		fee = feeDecimal.Round(0).IntPart()
 	case PlatformFeeTypeFlat:
 		fee = c.Value.IntPart()
 	default:

--- a/services/financial-gateway/adapters/stripe/platform_fee_test.go
+++ b/services/financial-gateway/adapters/stripe/platform_fee_test.go
@@ -1,0 +1,229 @@
+package stripe
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlatformFeeConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  PlatformFeeConfig
+		wantErr error
+	}{
+		{
+			name:   "valid percentage fee",
+			config: PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.NewFromFloat(2.5)},
+		},
+		{
+			name:   "valid flat fee",
+			config: PlatformFeeConfig{Type: PlatformFeeTypeFlat, Value: decimal.NewFromInt(500)},
+		},
+		{
+			name:   "percentage at maximum (10%)",
+			config: PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.NewFromInt(MaxPlatformFeePercent)},
+		},
+		{
+			name:    "invalid fee type",
+			config:  PlatformFeeConfig{Type: "bogus", Value: decimal.NewFromInt(5)},
+			wantErr: ErrInvalidFeeType,
+		},
+		{
+			name:    "empty fee type",
+			config:  PlatformFeeConfig{Type: "", Value: decimal.NewFromInt(5)},
+			wantErr: ErrInvalidFeeType,
+		},
+		{
+			name:    "zero fee value",
+			config:  PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.Zero},
+			wantErr: ErrNegativeFeeValue,
+		},
+		{
+			name:    "negative fee value",
+			config:  PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.NewFromInt(-1)},
+			wantErr: ErrNegativeFeeValue,
+		},
+		{
+			name:    "percentage exceeds maximum",
+			config:  PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.NewFromFloat(10.01)},
+			wantErr: ErrFeeExceedsMaximum,
+		},
+		{
+			name:   "flat fee above 10 is allowed (max only applies to percentage)",
+			config: PlatformFeeConfig{Type: PlatformFeeTypeFlat, Value: decimal.NewFromInt(50000)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestPlatformFeeConfig_IsZero(t *testing.T) {
+	assert.True(t, PlatformFeeConfig{Value: decimal.Zero}.IsZero())
+	assert.True(t, PlatformFeeConfig{}.IsZero())
+	assert.False(t, PlatformFeeConfig{Value: decimal.NewFromInt(1)}.IsZero())
+}
+
+func TestPlatformFeeConfig_CalculateFee(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  PlatformFeeConfig
+		amount  int64
+		wantFee int64
+		wantErr error
+	}{
+		// Happy path: percentage
+		{
+			name:    "2.5% of 10000 = 250",
+			config:  PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.NewFromFloat(2.5)},
+			amount:  10000,
+			wantFee: 250,
+		},
+		{
+			name:    "10% of 10000 = 1000",
+			config:  PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.NewFromInt(10)},
+			amount:  10000,
+			wantFee: 1000,
+		},
+		{
+			name:    "1% of 100 = 1",
+			config:  PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.NewFromInt(1)},
+			amount:  100,
+			wantFee: 1,
+		},
+
+		// Happy path: flat
+		{
+			name:    "flat 500 on 10000",
+			config:  PlatformFeeConfig{Type: PlatformFeeTypeFlat, Value: decimal.NewFromInt(500)},
+			amount:  10000,
+			wantFee: 500,
+		},
+		{
+			name:    "flat fee equals amount (boundary)",
+			config:  PlatformFeeConfig{Type: PlatformFeeTypeFlat, Value: decimal.NewFromInt(100)},
+			amount:  100,
+			wantFee: 100,
+		},
+
+		// Rounding behavior: percentage fees use round-half-up to prevent
+		// systematic revenue leakage from truncation.
+		{
+			name:    "1% of 33 = 0 (0.33 rounds down)",
+			config:  PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.NewFromInt(1)},
+			amount:  33,
+			wantFee: 0,
+		},
+		{
+			name:    "2.5% of 1 = 0 (0.025 rounds down)",
+			config:  PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.NewFromFloat(2.5)},
+			amount:  1,
+			wantFee: 0,
+		},
+		{
+			name:    "2.5% of 1001 = 25 (25.025 rounds down)",
+			config:  PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.NewFromFloat(2.5)},
+			amount:  1001,
+			wantFee: 25,
+		},
+		{
+			name:    "3% of 199 = 6 (5.97 rounds up)",
+			config:  PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.NewFromInt(3)},
+			amount:  199,
+			wantFee: 6,
+		},
+		{
+			name:    "2.5% of 100 = 3 (2.5 rounds up — half-up rule)",
+			config:  PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.NewFromFloat(2.5)},
+			amount:  100,
+			wantFee: 3,
+		},
+
+		// Zero amount: fee should be zero
+		{
+			name:    "zero config returns zero immediately",
+			config:  PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.Zero},
+			amount:  10000,
+			wantFee: 0,
+		},
+		{
+			name:    "percentage on zero amount",
+			config:  PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.NewFromFloat(2.5)},
+			amount:  0,
+			wantFee: 0,
+		},
+
+		// Error: flat fee exceeds payment amount
+		{
+			name:    "flat fee exceeds amount",
+			config:  PlatformFeeConfig{Type: PlatformFeeTypeFlat, Value: decimal.NewFromInt(200)},
+			amount:  100,
+			wantErr: ErrFeeExceedsAmount,
+		},
+
+		// Error: validation failures propagate
+		{
+			name:    "invalid fee type",
+			config:  PlatformFeeConfig{Type: "bogus", Value: decimal.NewFromInt(5)},
+			amount:  1000,
+			wantErr: ErrInvalidFeeType,
+		},
+		{
+			name:    "negative fee value",
+			config:  PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.NewFromInt(-1)},
+			amount:  1000,
+			wantErr: ErrNegativeFeeValue,
+		},
+		{
+			name:    "percentage exceeds maximum",
+			config:  PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.NewFromFloat(15)},
+			amount:  1000,
+			wantErr: ErrFeeExceedsMaximum,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fee, err := tt.config.CalculateFee(tt.amount)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.Equal(t, int64(0), fee)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantFee, fee, "fee mismatch for amount=%d", tt.amount)
+			}
+		})
+	}
+}
+
+// TestPlatformFeeConfig_CalculateFee_DecimalPrecision verifies that decimal
+// arithmetic avoids floating-point drift. These specific values would produce
+// wrong results with float64 math.
+func TestPlatformFeeConfig_CalculateFee_DecimalPrecision(t *testing.T) {
+	cfg := PlatformFeeConfig{
+		Type:  PlatformFeeTypePercentage,
+		Value: decimal.NewFromFloat(2.5),
+	}
+
+	// 2.5% of 999999 = 24999.975 → rounds to 25000
+	// float64 might give 24999.974999... or 25000.000...001
+	fee, err := cfg.CalculateFee(999999)
+	require.NoError(t, err)
+	assert.Equal(t, int64(25000), fee)
+
+	// 2.5% of 4 = 0.1 → rounds to 0
+	fee, err = cfg.CalculateFee(4)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), fee)
+}

--- a/services/financial-gateway/adapters/stripe/webhook_adapter.go
+++ b/services/financial-gateway/adapters/stripe/webhook_adapter.go
@@ -147,7 +147,7 @@ func (a *WebhookAdapter) parseChargeRefunded(event *stripego.Event) (ParsedWebho
 		PaymentOrderID:     paymentOrderID,
 		Status:             "REFUNDED",
 		Timestamp:          time.Unix(event.Created, 0),
-		AmountMinorUnits:   charge.Amount,
+		AmountMinorUnits:   charge.AmountRefunded,
 		Currency:           string(charge.Currency),
 	}, nil
 }

--- a/services/financial-gateway/adapters/stripe/webhook_adapter.go
+++ b/services/financial-gateway/adapters/stripe/webhook_adapter.go
@@ -147,6 +147,8 @@ func (a *WebhookAdapter) parseChargeRefunded(event *stripego.Event) (ParsedWebho
 		PaymentOrderID:     paymentOrderID,
 		Status:             "REFUNDED",
 		Timestamp:          time.Unix(event.Created, 0),
+		AmountMinorUnits:   charge.Amount,
+		Currency:           string(charge.Currency),
 	}, nil
 }
 

--- a/services/financial-gateway/adapters/stripe/webhook_adapter_test.go
+++ b/services/financial-gateway/adapters/stripe/webhook_adapter_test.go
@@ -1,8 +1,8 @@
 package stripe
 
 import (
-	"encoding/json"
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"

--- a/services/financial-gateway/adapters/stripe/webhook_adapter_test.go
+++ b/services/financial-gateway/adapters/stripe/webhook_adapter_test.go
@@ -1,0 +1,366 @@
+package stripe
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	stripego "github.com/stripe/stripe-go/v82"
+)
+
+func TestNewWebhookAdapter(t *testing.T) {
+	t.Run("valid secret", func(t *testing.T) {
+		a, err := NewWebhookAdapter("whsec_test123")
+		require.NoError(t, err)
+		assert.NotNil(t, a)
+	})
+
+	t.Run("empty secret", func(t *testing.T) {
+		_, err := NewWebhookAdapter("")
+		require.ErrorIs(t, err, ErrEmptyEndpointSecret)
+	})
+}
+
+func TestParseWebhook_MissingSignature(t *testing.T) {
+	a, err := NewWebhookAdapter("whsec_test")
+	require.NoError(t, err)
+
+	req, _ := http.NewRequest("POST", "/webhook", nil)
+	// No Stripe-Signature header
+	_, err = a.ParseWebhook(req, []byte("{}"))
+	require.ErrorIs(t, err, ErrWebhookMissingSignature)
+}
+
+func TestParseWebhook_InvalidSignature(t *testing.T) {
+	a, err := NewWebhookAdapter("whsec_test")
+	require.NoError(t, err)
+
+	req, _ := http.NewRequest("POST", "/webhook", nil)
+	req.Header.Set("Stripe-Signature", "t=1234,v1=bad_signature")
+	_, err = a.ParseWebhook(req, []byte(`{"id":"evt_1","type":"payment_intent.succeeded"}`))
+	require.ErrorIs(t, err, ErrWebhookInvalidSignature)
+}
+
+// --- Direct tests of parse functions (bypass signature validation) ---
+
+func TestParsePaymentIntentSucceeded(t *testing.T) {
+	a := &WebhookAdapter{endpointSecret: "whsec_test"}
+
+	t.Run("happy path", func(t *testing.T) {
+		pi := stripego.PaymentIntent{
+			ID:       "pi_success",
+			Amount:   5000,
+			Currency: "usd",
+			Metadata: map[string]string{"payment_order_id": "po-123"},
+		}
+		raw, _ := json.Marshal(pi)
+		event := &stripego.Event{
+			ID:      "evt_1",
+			Created: 1700000000,
+			Data:    &stripego.EventData{Raw: raw},
+		}
+
+		result, err := a.parsePaymentIntentSucceeded(event)
+		require.NoError(t, err)
+		assert.Equal(t, "evt_1", result.EventID)
+		assert.Equal(t, "pi_success", result.GatewayReferenceID)
+		assert.Equal(t, "po-123", result.PaymentOrderID)
+		assert.Equal(t, "SETTLED", result.Status)
+		assert.Equal(t, int64(5000), result.AmountMinorUnits)
+		assert.Equal(t, "usd", result.Currency)
+		assert.Equal(t, time.Unix(1700000000, 0), result.Timestamp)
+	})
+
+	t.Run("missing payment_order_id in metadata", func(t *testing.T) {
+		pi := stripego.PaymentIntent{
+			ID:       "pi_no_po",
+			Amount:   1000,
+			Currency: "gbp",
+			Metadata: map[string]string{"other_key": "other_value"},
+		}
+		raw, _ := json.Marshal(pi)
+		event := &stripego.Event{
+			ID:      "evt_2",
+			Created: 1700000000,
+			Data:    &stripego.EventData{Raw: raw},
+		}
+
+		result, err := a.parsePaymentIntentSucceeded(event)
+		require.NoError(t, err)
+		assert.Empty(t, result.PaymentOrderID, "missing payment_order_id should produce empty string, not error")
+		assert.Equal(t, int64(1000), result.AmountMinorUnits)
+	})
+
+	t.Run("nil metadata", func(t *testing.T) {
+		pi := stripego.PaymentIntent{
+			ID:       "pi_nil_meta",
+			Amount:   2000,
+			Currency: "eur",
+		}
+		raw, _ := json.Marshal(pi)
+		event := &stripego.Event{
+			ID:      "evt_3",
+			Created: 1700000000,
+			Data:    &stripego.EventData{Raw: raw},
+		}
+
+		result, err := a.parsePaymentIntentSucceeded(event)
+		require.NoError(t, err)
+		assert.Empty(t, result.PaymentOrderID)
+	})
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		event := &stripego.Event{
+			ID:   "evt_bad",
+			Data: &stripego.EventData{Raw: json.RawMessage(`{invalid}`)},
+		}
+		_, err := a.parsePaymentIntentSucceeded(event)
+		require.Error(t, err)
+	})
+}
+
+func TestParsePaymentIntentFailed(t *testing.T) {
+	a := &WebhookAdapter{endpointSecret: "whsec_test"}
+
+	t.Run("with payment error", func(t *testing.T) {
+		pi := stripego.PaymentIntent{
+			ID:       "pi_failed",
+			Amount:   3000,
+			Currency: "usd",
+			Metadata: map[string]string{"payment_order_id": "po-456"},
+			LastPaymentError: &stripego.Error{
+				Msg: "Your card was declined.",
+			},
+		}
+		raw, _ := json.Marshal(pi)
+		event := &stripego.Event{
+			ID:      "evt_4",
+			Created: 1700000000,
+			Data:    &stripego.EventData{Raw: raw},
+		}
+
+		result, err := a.parsePaymentIntentFailed(event)
+		require.NoError(t, err)
+		assert.Equal(t, "REJECTED", result.Status)
+		assert.Equal(t, "Your card was declined.", result.Message)
+		assert.Equal(t, "po-456", result.PaymentOrderID)
+		assert.Equal(t, int64(3000), result.AmountMinorUnits)
+		assert.Equal(t, "usd", result.Currency)
+	})
+
+	t.Run("nil LastPaymentError", func(t *testing.T) {
+		pi := stripego.PaymentIntent{
+			ID:       "pi_failed_no_error",
+			Metadata: map[string]string{"payment_order_id": "po-789"},
+		}
+		raw, _ := json.Marshal(pi)
+		event := &stripego.Event{
+			ID:      "evt_5",
+			Created: 1700000000,
+			Data:    &stripego.EventData{Raw: raw},
+		}
+
+		result, err := a.parsePaymentIntentFailed(event)
+		require.NoError(t, err)
+		assert.Equal(t, "REJECTED", result.Status)
+		assert.Empty(t, result.Message, "nil LastPaymentError should produce empty message")
+	})
+}
+
+func TestParseChargeRefunded(t *testing.T) {
+	a := &WebhookAdapter{endpointSecret: "whsec_test"}
+
+	t.Run("with PaymentIntent metadata", func(t *testing.T) {
+		charge := stripego.Charge{
+			ID:       "ch_refund1",
+			Amount:   4000,
+			Currency: "gbp",
+			PaymentIntent: &stripego.PaymentIntent{
+				Metadata: map[string]string{"payment_order_id": "po-from-pi"},
+			},
+			Metadata: map[string]string{"payment_order_id": "po-from-charge"},
+		}
+		raw, _ := json.Marshal(charge)
+		event := &stripego.Event{
+			ID:      "evt_6",
+			Created: 1700000000,
+			Data:    &stripego.EventData{Raw: raw},
+		}
+
+		result, err := a.parseChargeRefunded(event)
+		require.NoError(t, err)
+		assert.Equal(t, "po-from-pi", result.PaymentOrderID, "should prefer PaymentIntent metadata")
+		assert.Equal(t, "REFUNDED", result.Status)
+		assert.Equal(t, int64(4000), result.AmountMinorUnits, "refund should carry amount")
+		assert.Equal(t, "gbp", result.Currency, "refund should carry currency")
+	})
+
+	t.Run("fallback to charge metadata", func(t *testing.T) {
+		charge := stripego.Charge{
+			ID:       "ch_refund2",
+			Amount:   2500,
+			Currency: "eur",
+			Metadata: map[string]string{"payment_order_id": "po-from-charge"},
+		}
+		raw, _ := json.Marshal(charge)
+		event := &stripego.Event{
+			ID:      "evt_7",
+			Created: 1700000000,
+			Data:    &stripego.EventData{Raw: raw},
+		}
+
+		result, err := a.parseChargeRefunded(event)
+		require.NoError(t, err)
+		assert.Equal(t, "po-from-charge", result.PaymentOrderID)
+		assert.Equal(t, int64(2500), result.AmountMinorUnits)
+		assert.Equal(t, "eur", result.Currency)
+	})
+
+	t.Run("no metadata anywhere", func(t *testing.T) {
+		charge := stripego.Charge{
+			ID:       "ch_refund_no_meta",
+			Amount:   1000,
+			Currency: "usd",
+		}
+		raw, _ := json.Marshal(charge)
+		event := &stripego.Event{
+			ID:      "evt_8",
+			Created: 1700000000,
+			Data:    &stripego.EventData{Raw: raw},
+		}
+
+		result, err := a.parseChargeRefunded(event)
+		require.NoError(t, err)
+		assert.Empty(t, result.PaymentOrderID)
+		assert.Equal(t, int64(1000), result.AmountMinorUnits)
+	})
+}
+
+func TestParseChargeDisputed(t *testing.T) {
+	a := &WebhookAdapter{endpointSecret: "whsec_test"}
+
+	t.Run("happy path", func(t *testing.T) {
+		// Webhook delivers expanded charge inside dispute (not the SDK's Dispute struct)
+		raw := json.RawMessage(`{
+			"id": "dp_test",
+			"reason": "fraudulent",
+			"status": "needs_response",
+			"charge": {
+				"id": "ch_disputed",
+				"metadata": {"payment_order_id": "po-disputed"}
+			}
+		}`)
+		event := &stripego.Event{
+			ID:      "evt_9",
+			Created: 1700000000,
+			Data:    &stripego.EventData{Raw: raw},
+		}
+
+		result, err := a.parseChargeDisputed(event)
+		require.NoError(t, err)
+		assert.Equal(t, "evt_9", result.EventID)
+		assert.Equal(t, "ch_disputed", result.GatewayReferenceID)
+		assert.Equal(t, "po-disputed", result.PaymentOrderID)
+		assert.Equal(t, "DISPUTED", result.Status)
+		assert.Equal(t, "dispute reason: fraudulent", result.Message)
+	})
+
+	t.Run("charge with no metadata", func(t *testing.T) {
+		raw := json.RawMessage(`{
+			"id": "dp_no_meta",
+			"reason": "general",
+			"status": "needs_response",
+			"charge": {
+				"id": "ch_no_meta"
+			}
+		}`)
+		event := &stripego.Event{
+			ID:      "evt_10",
+			Created: 1700000000,
+			Data:    &stripego.EventData{Raw: raw},
+		}
+
+		result, err := a.parseChargeDisputed(event)
+		require.NoError(t, err)
+		assert.Empty(t, result.PaymentOrderID, "nil metadata should produce empty payment_order_id")
+		assert.Equal(t, "ch_no_meta", result.GatewayReferenceID)
+	})
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		event := &stripego.Event{
+			ID:   "evt_bad",
+			Data: &stripego.EventData{Raw: json.RawMessage(`not json`)},
+		}
+		_, err := a.parseChargeDisputed(event)
+		require.Error(t, err)
+	})
+}
+
+func TestExtractPaymentOrderID(t *testing.T) {
+	tests := []struct {
+		name   string
+		charge *stripego.Charge
+		want   string
+	}{
+		{
+			name: "from PaymentIntent metadata (preferred)",
+			charge: &stripego.Charge{
+				PaymentIntent: &stripego.PaymentIntent{
+					Metadata: map[string]string{"payment_order_id": "po-pi"},
+				},
+				Metadata: map[string]string{"payment_order_id": "po-charge"},
+			},
+			want: "po-pi",
+		},
+		{
+			name: "fallback to charge metadata when PaymentIntent nil",
+			charge: &stripego.Charge{
+				Metadata: map[string]string{"payment_order_id": "po-charge"},
+			},
+			want: "po-charge",
+		},
+		{
+			name: "fallback to charge metadata when PI metadata nil",
+			charge: &stripego.Charge{
+				PaymentIntent: &stripego.PaymentIntent{},
+				Metadata:      map[string]string{"payment_order_id": "po-charge"},
+			},
+			want: "po-charge",
+		},
+		{
+			name: "fallback when PI metadata has no payment_order_id key",
+			charge: &stripego.Charge{
+				PaymentIntent: &stripego.PaymentIntent{
+					Metadata: map[string]string{"other": "value"},
+				},
+				Metadata: map[string]string{"payment_order_id": "po-charge"},
+			},
+			want: "po-charge",
+		},
+		{
+			name:   "nil metadata everywhere",
+			charge: &stripego.Charge{},
+			want:   "",
+		},
+		{
+			name: "both metadata present but no payment_order_id anywhere",
+			charge: &stripego.Charge{
+				PaymentIntent: &stripego.PaymentIntent{
+					Metadata: map[string]string{"other": "value"},
+				},
+				Metadata: map[string]string{"different": "data"},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractPaymentOrderID(tt.charge)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/services/financial-gateway/adapters/stripe/webhook_adapter_test.go
+++ b/services/financial-gateway/adapters/stripe/webhook_adapter_test.go
@@ -2,6 +2,7 @@ package stripe
 
 import (
 	"encoding/json"
+	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -28,7 +29,7 @@ func TestParseWebhook_MissingSignature(t *testing.T) {
 	a, err := NewWebhookAdapter("whsec_test")
 	require.NoError(t, err)
 
-	req, _ := http.NewRequest("POST", "/webhook", nil)
+	req, _ := http.NewRequestWithContext(context.Background(), "POST", "/webhook", nil)
 	// No Stripe-Signature header
 	_, err = a.ParseWebhook(req, []byte("{}"))
 	require.ErrorIs(t, err, ErrWebhookMissingSignature)
@@ -38,7 +39,7 @@ func TestParseWebhook_InvalidSignature(t *testing.T) {
 	a, err := NewWebhookAdapter("whsec_test")
 	require.NoError(t, err)
 
-	req, _ := http.NewRequest("POST", "/webhook", nil)
+	req, _ := http.NewRequestWithContext(context.Background(), "POST", "/webhook", nil)
 	req.Header.Set("Stripe-Signature", "t=1234,v1=bad_signature")
 	_, err = a.ParseWebhook(req, []byte(`{"id":"evt_1","type":"payment_intent.succeeded"}`))
 	require.ErrorIs(t, err, ErrWebhookInvalidSignature)
@@ -175,9 +176,10 @@ func TestParseChargeRefunded(t *testing.T) {
 
 	t.Run("with PaymentIntent metadata", func(t *testing.T) {
 		charge := stripego.Charge{
-			ID:       "ch_refund1",
-			Amount:   4000,
-			Currency: "gbp",
+			ID:             "ch_refund1",
+			Amount:         4000,
+			AmountRefunded: 4000, // full refund
+			Currency:       "gbp",
 			PaymentIntent: &stripego.PaymentIntent{
 				Metadata: map[string]string{"payment_order_id": "po-from-pi"},
 			},
@@ -194,16 +196,17 @@ func TestParseChargeRefunded(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "po-from-pi", result.PaymentOrderID, "should prefer PaymentIntent metadata")
 		assert.Equal(t, "REFUNDED", result.Status)
-		assert.Equal(t, int64(4000), result.AmountMinorUnits, "refund should carry amount")
+		assert.Equal(t, int64(4000), result.AmountMinorUnits, "should use AmountRefunded, not Amount")
 		assert.Equal(t, "gbp", result.Currency, "refund should carry currency")
 	})
 
-	t.Run("fallback to charge metadata", func(t *testing.T) {
+	t.Run("partial refund uses AmountRefunded not Amount", func(t *testing.T) {
 		charge := stripego.Charge{
-			ID:       "ch_refund2",
-			Amount:   2500,
-			Currency: "eur",
-			Metadata: map[string]string{"payment_order_id": "po-from-charge"},
+			ID:             "ch_partial",
+			Amount:         5000, // original charge
+			AmountRefunded: 2000, // partial refund
+			Currency:       "eur",
+			Metadata:       map[string]string{"payment_order_id": "po-partial"},
 		}
 		raw, _ := json.Marshal(charge)
 		event := &stripego.Event{
@@ -214,16 +217,17 @@ func TestParseChargeRefunded(t *testing.T) {
 
 		result, err := a.parseChargeRefunded(event)
 		require.NoError(t, err)
-		assert.Equal(t, "po-from-charge", result.PaymentOrderID)
-		assert.Equal(t, int64(2500), result.AmountMinorUnits)
+		assert.Equal(t, "po-partial", result.PaymentOrderID)
+		assert.Equal(t, int64(2000), result.AmountMinorUnits, "partial refund should report refunded amount, not full charge")
 		assert.Equal(t, "eur", result.Currency)
 	})
 
 	t.Run("no metadata anywhere", func(t *testing.T) {
 		charge := stripego.Charge{
-			ID:       "ch_refund_no_meta",
-			Amount:   1000,
-			Currency: "usd",
+			ID:             "ch_refund_no_meta",
+			Amount:         1000,
+			AmountRefunded: 1000,
+			Currency:       "usd",
 		}
 		raw, _ := json.Marshal(charge)
 		event := &stripego.Event{

--- a/services/financial-gateway/client/starlark_test.go
+++ b/services/financial-gateway/client/starlark_test.go
@@ -1,0 +1,431 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	financialgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_gateway/v1"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+)
+
+// --- requireInt64Param ---
+
+func TestRequireInt64Param(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  map[string]any
+		key     string
+		want    int64
+		wantErr error
+	}{
+		{
+			name:   "int64 value",
+			params: map[string]any{"amount": int64(1000)},
+			key:    "amount",
+			want:   1000,
+		},
+		{
+			name:   "int value coerced to int64",
+			params: map[string]any{"amount": int(500)},
+			key:    "amount",
+			want:   500,
+		},
+		{
+			name:   "float64 exact integer",
+			params: map[string]any{"amount": float64(750)},
+			key:    "amount",
+			want:   750,
+		},
+		{
+			name:    "float64 with fraction rejected",
+			params:  map[string]any{"amount": float64(100.5)},
+			key:     "amount",
+			wantErr: saga.ErrInvalidParamType,
+		},
+		{
+			name:    "string value rejected",
+			params:  map[string]any{"amount": "100"},
+			key:     "amount",
+			wantErr: saga.ErrInvalidParamType,
+		},
+		{
+			name:    "missing key",
+			params:  map[string]any{},
+			key:     "amount",
+			wantErr: saga.ErrMissingParam,
+		},
+		{
+			name:    "nil value is wrong type",
+			params:  map[string]any{"amount": nil},
+			key:     "amount",
+			wantErr: saga.ErrInvalidParamType,
+		},
+		{
+			name:   "zero value is valid",
+			params: map[string]any{"amount": int64(0)},
+			key:    "amount",
+			want:   0,
+		},
+		{
+			name:   "negative value is valid (validation is caller's job)",
+			params: map[string]any{"amount": int64(-100)},
+			key:    "amount",
+			want:   -100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := requireInt64Param(tt.params, tt.key)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+// --- stringToPaymentRail ---
+
+func TestStringToPaymentRail(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    financialgatewayv1.PaymentRail
+		wantErr bool
+	}{
+		{"STRIPE", "STRIPE", financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE, false},
+		{"SWIFT", "SWIFT", financialgatewayv1.PaymentRail_PAYMENT_RAIL_SWIFT, false},
+		{"ACH", "ACH", financialgatewayv1.PaymentRail_PAYMENT_RAIL_ACH, false},
+		{"FEDNOW", "FEDNOW", financialgatewayv1.PaymentRail_PAYMENT_RAIL_FEDNOW, false},
+		{"lowercase rejected", "stripe", financialgatewayv1.PaymentRail_PAYMENT_RAIL_UNSPECIFIED, true},
+		{"empty string rejected", "", financialgatewayv1.PaymentRail_PAYMENT_RAIL_UNSPECIFIED, true},
+		{"unknown rail rejected", "SEPA", financialgatewayv1.PaymentRail_PAYMENT_RAIL_UNSPECIFIED, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := stringToPaymentRail(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, saga.ErrInvalidParamType)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// --- dispatchStatusToString ---
+
+func TestDispatchStatusToString(t *testing.T) {
+	tests := []struct {
+		status financialgatewayv1.DispatchStatus
+		want   string
+	}{
+		{financialgatewayv1.DispatchStatus_DISPATCH_STATUS_UNSPECIFIED, "UNSPECIFIED"},
+		{financialgatewayv1.DispatchStatus_DISPATCH_STATUS_PENDING, "PENDING"},
+		{financialgatewayv1.DispatchStatus_DISPATCH_STATUS_DISPATCHING, "DISPATCHING"},
+		{financialgatewayv1.DispatchStatus_DISPATCH_STATUS_DELIVERED, "DELIVERED"},
+		{financialgatewayv1.DispatchStatus_DISPATCH_STATUS_ACKNOWLEDGED, "ACKNOWLEDGED"},
+		{financialgatewayv1.DispatchStatus_DISPATCH_STATUS_RETRYING, "RETRYING"},
+		{financialgatewayv1.DispatchStatus_DISPATCH_STATUS_FAILED, "FAILED"},
+		{financialgatewayv1.DispatchStatus(999), "UNKNOWN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			assert.Equal(t, tt.want, dispatchStatusToString(tt.status))
+		})
+	}
+}
+
+// --- extractStringMetadata ---
+
+func TestExtractStringMetadata(t *testing.T) {
+	t.Run("nil params", func(t *testing.T) {
+		assert.Nil(t, extractStringMetadata(map[string]any{}))
+	})
+
+	t.Run("metadata key absent", func(t *testing.T) {
+		assert.Nil(t, extractStringMetadata(map[string]any{"other": "value"}))
+	})
+
+	t.Run("metadata is nil", func(t *testing.T) {
+		assert.Nil(t, extractStringMetadata(map[string]any{"metadata": nil}))
+	})
+
+	t.Run("metadata is wrong type", func(t *testing.T) {
+		assert.Nil(t, extractStringMetadata(map[string]any{"metadata": "not a map"}))
+	})
+
+	t.Run("valid string metadata", func(t *testing.T) {
+		result := extractStringMetadata(map[string]any{
+			"metadata": map[string]any{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		})
+		assert.Equal(t, map[string]string{"key1": "value1", "key2": "value2"}, result)
+	})
+
+	t.Run("non-string values silently dropped", func(t *testing.T) {
+		result := extractStringMetadata(map[string]any{
+			"metadata": map[string]any{
+				"keep": "this",
+				"drop": 42,
+				"also": true,
+			},
+		})
+		assert.Equal(t, map[string]string{"keep": "this"}, result)
+	})
+}
+
+// --- parseDispatchPaymentParams ---
+
+func TestParseDispatchPaymentParams(t *testing.T) {
+	validParams := func() map[string]any {
+		return map[string]any{
+			"payment_order_id":         "po-123",
+			"amount_minor_units":       int64(5000),
+			"currency":                 "GBP",
+			"customer_reference":       "cus_test",
+			"payment_method_reference": "pm_test",
+			"idempotency_key":          "idem-key",
+			"rail":                     "STRIPE",
+		}
+	}
+
+	t.Run("happy path", func(t *testing.T) {
+		p, err := parseDispatchPaymentParams(validParams())
+		require.NoError(t, err)
+		assert.Equal(t, "po-123", p.paymentOrderID)
+		assert.Equal(t, int64(5000), p.amountMinorUnits)
+		assert.Equal(t, "GBP", p.currency)
+		assert.Equal(t, "cus_test", p.customerReference)
+		assert.Equal(t, "pm_test", p.paymentMethodReference)
+		assert.Equal(t, "idem-key", p.idempotencyKey)
+		assert.Equal(t, financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE, p.rail)
+	})
+
+	// Test each required param missing individually
+	requiredStringParams := []string{
+		"payment_order_id", "currency", "customer_reference",
+		"payment_method_reference", "idempotency_key",
+	}
+	for _, key := range requiredStringParams {
+		t.Run("missing "+key, func(t *testing.T) {
+			params := validParams()
+			delete(params, key)
+			_, err := parseDispatchPaymentParams(params)
+			require.Error(t, err)
+			require.ErrorIs(t, err, saga.ErrMissingParam)
+		})
+	}
+
+	t.Run("missing amount_minor_units", func(t *testing.T) {
+		params := validParams()
+		delete(params, "amount_minor_units")
+		_, err := parseDispatchPaymentParams(params)
+		require.ErrorIs(t, err, saga.ErrMissingParam)
+	})
+
+	t.Run("missing rail", func(t *testing.T) {
+		params := validParams()
+		delete(params, "rail")
+		_, err := parseDispatchPaymentParams(params)
+		require.ErrorIs(t, err, saga.ErrMissingParam)
+	})
+
+	t.Run("invalid rail value", func(t *testing.T) {
+		params := validParams()
+		params["rail"] = "SEPA"
+		_, err := parseDispatchPaymentParams(params)
+		require.ErrorIs(t, err, saga.ErrInvalidParamType)
+	})
+
+	t.Run("amount as string rejected", func(t *testing.T) {
+		params := validParams()
+		params["amount_minor_units"] = "5000"
+		_, err := parseDispatchPaymentParams(params)
+		require.ErrorIs(t, err, saga.ErrInvalidParamType)
+	})
+
+	t.Run("amount as fractional float rejected", func(t *testing.T) {
+		params := validParams()
+		params["amount_minor_units"] = float64(100.5)
+		_, err := parseDispatchPaymentParams(params)
+		require.ErrorIs(t, err, saga.ErrInvalidParamType)
+	})
+}
+
+// --- parseDispatchRefundParams ---
+
+func TestParseDispatchRefundParams(t *testing.T) {
+	validParams := func() map[string]any {
+		return map[string]any{
+			"payment_order_id":          "po-refund",
+			"refund_amount_minor_units": int64(2500),
+			"idempotency_key":           "refund-key",
+		}
+	}
+
+	t.Run("happy path with reason", func(t *testing.T) {
+		params := validParams()
+		params["reason"] = "Customer request"
+		p, err := parseDispatchRefundParams(params)
+		require.NoError(t, err)
+		assert.Equal(t, "po-refund", p.paymentOrderID)
+		assert.Equal(t, int64(2500), p.refundAmountMinorUnits)
+		assert.Equal(t, "refund-key", p.idempotencyKey)
+		assert.Equal(t, "Customer request", p.reason)
+	})
+
+	t.Run("default reason when not provided", func(t *testing.T) {
+		p, err := parseDispatchRefundParams(validParams())
+		require.NoError(t, err)
+		assert.Equal(t, "Refund requested", p.reason)
+	})
+
+	t.Run("empty reason gets default", func(t *testing.T) {
+		params := validParams()
+		params["reason"] = ""
+		p, err := parseDispatchRefundParams(params)
+		require.NoError(t, err)
+		assert.Equal(t, "Refund requested", p.reason)
+	})
+
+	t.Run("missing payment_order_id", func(t *testing.T) {
+		params := validParams()
+		delete(params, "payment_order_id")
+		_, err := parseDispatchRefundParams(params)
+		require.ErrorIs(t, err, saga.ErrMissingParam)
+	})
+
+	t.Run("missing refund_amount_minor_units", func(t *testing.T) {
+		params := validParams()
+		delete(params, "refund_amount_minor_units")
+		_, err := parseDispatchRefundParams(params)
+		require.ErrorIs(t, err, saga.ErrMissingParam)
+	})
+
+	t.Run("missing idempotency_key", func(t *testing.T) {
+		params := validParams()
+		delete(params, "idempotency_key")
+		_, err := parseDispatchRefundParams(params)
+		require.ErrorIs(t, err, saga.ErrMissingParam)
+	})
+}
+
+// --- buildDispatchPaymentRequest ---
+
+func TestBuildDispatchPaymentRequest(t *testing.T) {
+	corrID := uuid.New()
+	ctx := &saga.StarlarkContext{
+		CorrelationID: corrID,
+	}
+
+	t.Run("basic request construction", func(t *testing.T) {
+		p := dispatchPaymentParams{
+			paymentOrderID:         "po-123",
+			amountMinorUnits:       5000,
+			currency:               "GBP",
+			customerReference:      "cus_test",
+			paymentMethodReference: "pm_test",
+			idempotencyKey:         "idem-key",
+			rail:                   financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE,
+		}
+		params := map[string]any{
+			"metadata": map[string]any{
+				"debtor_account_id": "acct-debtor",
+			},
+		}
+
+		req := buildDispatchPaymentRequest(p, ctx, params)
+		assert.Equal(t, "po-123", req.PaymentOrderId)
+		assert.Equal(t, int64(5000), req.AmountUnits)
+		assert.Equal(t, "GBP", req.InstrumentCode)
+		assert.Equal(t, "idem-key", req.IdempotencyKey.Key)
+		assert.Equal(t, "acct-debtor", req.DebtorAccountId)
+		assert.Equal(t, "cus_test", req.Metadata["customer_reference"])
+		assert.Equal(t, "pm_test", req.Metadata["payment_method_reference"])
+		assert.Equal(t, corrID.String(), req.CorrelationId)
+	})
+
+	t.Run("creditor_account_id falls back to debtor", func(t *testing.T) {
+		p := dispatchPaymentParams{
+			paymentOrderID:   "po-456",
+			amountMinorUnits: 1000,
+			currency:         "USD",
+			idempotencyKey:   "key",
+			rail:             financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE,
+		}
+		params := map[string]any{
+			"metadata": map[string]any{
+				"debtor_account_id": "acct-debtor",
+			},
+		}
+
+		req := buildDispatchPaymentRequest(p, ctx, params)
+		assert.Equal(t, "acct-debtor", req.CreditorAccountId, "should fall back to debtor when creditor not set")
+	})
+
+	t.Run("explicit creditor_account_id used when provided", func(t *testing.T) {
+		p := dispatchPaymentParams{
+			paymentOrderID:   "po-789",
+			amountMinorUnits: 1000,
+			currency:         "USD",
+			idempotencyKey:   "key",
+			rail:             financialgatewayv1.PaymentRail_PAYMENT_RAIL_SWIFT,
+		}
+		params := map[string]any{
+			"metadata": map[string]any{
+				"debtor_account_id":   "acct-debtor",
+				"creditor_account_id": "acct-creditor",
+			},
+		}
+
+		req := buildDispatchPaymentRequest(p, ctx, params)
+		assert.Equal(t, "acct-creditor", req.CreditorAccountId)
+		assert.Equal(t, "acct-debtor", req.DebtorAccountId)
+	})
+
+	t.Run("explicit correlation_id from params overrides context", func(t *testing.T) {
+		p := dispatchPaymentParams{
+			paymentOrderID:   "po-corr",
+			amountMinorUnits: 100,
+			currency:         "USD",
+			idempotencyKey:   "key",
+			rail:             financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE,
+		}
+		params := map[string]any{
+			"correlation_id": "explicit-corr-id",
+		}
+
+		req := buildDispatchPaymentRequest(p, ctx, params)
+		assert.Equal(t, "explicit-corr-id", req.CorrelationId)
+	})
+
+	t.Run("no metadata creates empty map", func(t *testing.T) {
+		p := dispatchPaymentParams{
+			paymentOrderID:         "po-no-meta",
+			amountMinorUnits:       100,
+			currency:               "USD",
+			customerReference:      "cus",
+			paymentMethodReference: "pm",
+			idempotencyKey:         "key",
+			rail:                   financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE,
+		}
+		params := map[string]any{}
+
+		req := buildDispatchPaymentRequest(p, ctx, params)
+		require.NotNil(t, req.Metadata)
+		assert.Equal(t, "cus", req.Metadata["customer_reference"])
+	})
+}


### PR DESCRIPTION
## Summary

- Fix platform fee truncation that systematically undercharged fees (IntPart → round-half-up)
- Fix refund webhook parsing that silently dropped amount and currency from Stripe charge events
- Add 4 test files covering previously untested money-critical code paths

## Bug Fixes

### Platform fee revenue leakage
`CalculateFee()` used `IntPart()` which truncates toward zero. For 3% of 199 cents: `5.97 → 5` (lost 0.97 per transaction). Now uses `Round(0)` (half-up): `5.97 → 6`. This affects every percentage-based platform fee calculation.

### Refund webhook missing data
`parseChargeRefunded()` returned `AmountMinorUnits: 0` and `Currency: ""` despite the Stripe charge object containing both fields. Domain events for refunds were published with no amount — downstream reconciliation would have no value to match against.

## New Test Coverage

| File | Tests | What It Catches |
|------|-------|-----------------|
| `platform_fee_test.go` | 20 | Fee math, rounding boundaries, decimal precision, all validation errors |
| `webhook_adapter_test.go` | 18 | All 4 Stripe event types, nil metadata, missing payment_order_id, fallback chains |
| `starlark_test.go` | 38 | Untrusted Starlark input → gRPC boundary, type coercion, rail validation |
| `manifest_tenant_config_test.go` | 14 | Cache hit/miss/expiry, gRPC errors, invalid manifests, multi-rail lookup |

## Known Issues (follow-up)

| Issue | Impact | Why Not Fixed Here |
|-------|--------|-------------------|
| `platform_fee_minor_units: int64(0)` in Starlark handler | Saga always sees zero platform fee | Proto `DispatchPaymentResponse` lacks field — requires proto change + gRPC service change |
| REFUNDED/DISPUTED webhooks acknowledged but not processed | Ledger never knows about chargebacks | Requires product decision on desired behavior |
| `CancelPayment` RPC unimplemented but saga compensation references it | Every dispatch_payment compensation fails | Feature gap, not test gap |
| Circuit breaker global across all tenants | One tenant's failure trips breaker for all | Architectural decision needed |

## Test plan

- [x] All new tests pass locally (`go test ./services/financial-gateway/... -count=1`)
- [x] All existing tests still pass (including e2e)
- [x] Platform fee rounding verified with decimal precision edge cases
- [ ] CI passes