### PR TITLE
feat: Per-tenant circuit breakers for Stripe config lookups

### DIFF
--- a/services/financial-gateway/adapters/stripe/circuit_breaker.go
+++ b/services/financial-gateway/adapters/stripe/circuit_breaker.go
@@ -31,8 +31,9 @@ func NewTenantCircuitBreakerRegistry(settings gobreaker.Settings) *TenantCircuit
 // does not yet exist. Concurrent calls for the same tenant are safe and will
 // return the same breaker instance.
 func (r *TenantCircuitBreakerRegistry) Get(tenantID tenant.TenantID) *gobreaker.CircuitBreaker[TenantConfig] {
-	if cb, ok := r.breakers.Load(tenantID); ok {
-		return cb.(*gobreaker.CircuitBreaker[TenantConfig])
+	if val, ok := r.breakers.Load(tenantID); ok {
+		cb, _ := val.(*gobreaker.CircuitBreaker[TenantConfig]) //nolint:errcheck // sync.Map only stores this type
+		return cb
 	}
 
 	// Build tenant-specific settings with per-tenant metrics on state change.
@@ -50,15 +51,17 @@ func (r *TenantCircuitBreakerRegistry) Get(tenantID tenant.TenantID) *gobreaker.
 
 	newCB := gobreaker.NewCircuitBreaker[TenantConfig](s)
 	actual, _ := r.breakers.LoadOrStore(tenantID, newCB)
-	return actual.(*gobreaker.CircuitBreaker[TenantConfig])
+	cb, _ := actual.(*gobreaker.CircuitBreaker[TenantConfig]) //nolint:errcheck // sync.Map only stores this type
+	return cb
 }
 
 // State returns the circuit breaker state for a specific tenant.
 // If no breaker exists yet for the tenant, it returns StateClosed (the default
 // initial state for a new breaker).
 func (r *TenantCircuitBreakerRegistry) State(tenantID tenant.TenantID) gobreaker.State {
-	if cb, ok := r.breakers.Load(tenantID); ok {
-		return cb.(*gobreaker.CircuitBreaker[TenantConfig]).State()
+	if val, ok := r.breakers.Load(tenantID); ok {
+		cb, _ := val.(*gobreaker.CircuitBreaker[TenantConfig]) //nolint:errcheck // sync.Map only stores this type
+		return cb.State()
 	}
 	return gobreaker.StateClosed
 }

--- a/services/financial-gateway/adapters/stripe/circuit_breaker.go
+++ b/services/financial-gateway/adapters/stripe/circuit_breaker.go
@@ -1,0 +1,78 @@
+package stripe
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/sony/gobreaker/v2"
+
+	"github.com/meridianhub/meridian/services/financial-gateway/observability"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// TenantCircuitBreakerRegistry manages per-tenant circuit breakers so that
+// one tenant's Stripe failures do not trip the breaker for other tenants.
+type TenantCircuitBreakerRegistry struct {
+	breakers sync.Map // map[tenant.TenantID]*gobreaker.CircuitBreaker[TenantConfig]
+	settings gobreaker.Settings
+}
+
+// NewTenantCircuitBreakerRegistry creates a registry that will lazily create
+// circuit breakers for each tenant using the provided settings as a template.
+// The settings.Name field is used as a prefix; each tenant breaker is named
+// "<prefix>-<tenantID>".
+func NewTenantCircuitBreakerRegistry(settings gobreaker.Settings) *TenantCircuitBreakerRegistry {
+	return &TenantCircuitBreakerRegistry{
+		settings: settings,
+	}
+}
+
+// Get returns the circuit breaker for the given tenant, creating one if it
+// does not yet exist. Concurrent calls for the same tenant are safe and will
+// return the same breaker instance.
+func (r *TenantCircuitBreakerRegistry) Get(tenantID tenant.TenantID) *gobreaker.CircuitBreaker[TenantConfig] {
+	if cb, ok := r.breakers.Load(tenantID); ok {
+		return cb.(*gobreaker.CircuitBreaker[TenantConfig])
+	}
+
+	// Build tenant-specific settings with per-tenant metrics on state change.
+	s := r.settings
+	s.Name = fmt.Sprintf("%s-%s", r.settings.Name, tenantID)
+
+	// Wrap the caller's OnStateChange (if any) to also emit per-tenant metrics.
+	parentOnStateChange := r.settings.OnStateChange
+	s.OnStateChange = func(name string, from gobreaker.State, to gobreaker.State) {
+		if parentOnStateChange != nil {
+			parentOnStateChange(name, from, to)
+		}
+		observability.RecordCircuitBreakerState(tenantID.String(), "stripe", stateLabel(to))
+	}
+
+	newCB := gobreaker.NewCircuitBreaker[TenantConfig](s)
+	actual, _ := r.breakers.LoadOrStore(tenantID, newCB)
+	return actual.(*gobreaker.CircuitBreaker[TenantConfig])
+}
+
+// State returns the circuit breaker state for a specific tenant.
+// If no breaker exists yet for the tenant, it returns StateClosed (the default
+// initial state for a new breaker).
+func (r *TenantCircuitBreakerRegistry) State(tenantID tenant.TenantID) gobreaker.State {
+	if cb, ok := r.breakers.Load(tenantID); ok {
+		return cb.(*gobreaker.CircuitBreaker[TenantConfig]).State()
+	}
+	return gobreaker.StateClosed
+}
+
+// stateLabel converts a gobreaker.State to the label used in metrics.
+func stateLabel(s gobreaker.State) string {
+	switch s {
+	case gobreaker.StateClosed:
+		return "closed"
+	case gobreaker.StateHalfOpen:
+		return "half_open"
+	case gobreaker.StateOpen:
+		return "open"
+	default:
+		return "unknown"
+	}
+}

--- a/services/financial-gateway/adapters/stripe/circuit_breaker_test.go
+++ b/services/financial-gateway/adapters/stripe/circuit_breaker_test.go
@@ -1,0 +1,171 @@
+package stripe
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sony/gobreaker/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+func TestTenantCircuitBreakerRegistry_Get_ReturnsSameInstanceForSameTenant(t *testing.T) {
+	registry := NewTenantCircuitBreakerRegistry(gobreaker.Settings{Name: "stripe"})
+
+	cb1 := registry.Get(tenant.TenantID("tenant_a"))
+	cb2 := registry.Get(tenant.TenantID("tenant_a"))
+
+	assert.Same(t, cb1, cb2, "should return the same circuit breaker for the same tenant")
+}
+
+func TestTenantCircuitBreakerRegistry_Get_ReturnsDifferentInstancesForDifferentTenants(t *testing.T) {
+	registry := NewTenantCircuitBreakerRegistry(gobreaker.Settings{Name: "stripe"})
+
+	cbA := registry.Get(tenant.TenantID("tenant_a"))
+	cbB := registry.Get(tenant.TenantID("tenant_b"))
+
+	assert.NotSame(t, cbA, cbB, "should return different circuit breakers for different tenants")
+}
+
+func TestTenantCircuitBreakerRegistry_Isolation_OneTenantFailureDoesNotAffectAnother(t *testing.T) {
+	settings := gobreaker.Settings{
+		Name: "stripe",
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= 3
+		},
+	}
+	registry := NewTenantCircuitBreakerRegistry(settings)
+
+	tenantA := tenant.TenantID("tenant_a")
+	tenantB := tenant.TenantID("tenant_b")
+
+	cbA := registry.Get(tenantA)
+	cbB := registry.Get(tenantB)
+
+	// Trip tenant A's breaker with consecutive failures.
+	simulatedErr := errors.New("stripe config provider down")
+	for range 3 {
+		_, _ = cbA.Execute(func() (TenantConfig, error) {
+			return TenantConfig{}, simulatedErr
+		})
+	}
+
+	// Tenant A should be open.
+	assert.Equal(t, gobreaker.StateOpen, cbA.State(), "tenant A breaker should be open")
+
+	// Tenant B should still be closed.
+	assert.Equal(t, gobreaker.StateClosed, cbB.State(), "tenant B breaker should remain closed")
+
+	// Tenant B can still execute successfully.
+	cfg, err := cbB.Execute(func() (TenantConfig, error) {
+		return TenantConfig{ConnectedAccountID: "acct_b"}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "acct_b", cfg.ConnectedAccountID)
+
+	// Tenant A should be blocked.
+	_, err = cbA.Execute(func() (TenantConfig, error) {
+		return TenantConfig{ConnectedAccountID: "acct_a"}, nil
+	})
+	assert.ErrorIs(t, err, gobreaker.ErrOpenState)
+}
+
+func TestTenantCircuitBreakerRegistry_State_ReturnsClosedForUnknownTenant(t *testing.T) {
+	registry := NewTenantCircuitBreakerRegistry(gobreaker.Settings{Name: "stripe"})
+
+	state := registry.State(tenant.TenantID("unknown"))
+	assert.Equal(t, gobreaker.StateClosed, state)
+}
+
+func TestTenantCircuitBreakerRegistry_State_ReflectsActualState(t *testing.T) {
+	settings := gobreaker.Settings{
+		Name: "stripe",
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= 1
+		},
+	}
+	registry := NewTenantCircuitBreakerRegistry(settings)
+
+	tid := tenant.TenantID("tenant_a")
+	cb := registry.Get(tid)
+
+	assert.Equal(t, gobreaker.StateClosed, registry.State(tid))
+
+	// Trip the breaker.
+	_, _ = cb.Execute(func() (TenantConfig, error) {
+		return TenantConfig{}, errors.New("fail")
+	})
+
+	assert.Equal(t, gobreaker.StateOpen, registry.State(tid))
+}
+
+func TestTenantCircuitBreakerRegistry_OnStateChange_CallsParentCallback(t *testing.T) {
+	var parentCalled bool
+	var parentName, parentFrom, parentTo string
+
+	settings := gobreaker.Settings{
+		Name: "stripe",
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= 1
+		},
+		OnStateChange: func(name string, from gobreaker.State, to gobreaker.State) {
+			parentCalled = true
+			parentName = name
+			parentFrom = from.String()
+			parentTo = to.String()
+		},
+	}
+	registry := NewTenantCircuitBreakerRegistry(settings)
+
+	cb := registry.Get(tenant.TenantID("tenant_a"))
+
+	// Trip the breaker to trigger state change.
+	_, _ = cb.Execute(func() (TenantConfig, error) {
+		return TenantConfig{}, errors.New("fail")
+	})
+
+	assert.True(t, parentCalled, "parent OnStateChange should be called")
+	assert.Equal(t, "stripe-tenant_a", parentName)
+	assert.Equal(t, "closed", parentFrom)
+	assert.Equal(t, "open", parentTo)
+}
+
+func TestTenantCircuitBreakerRegistry_Get_ConcurrentAccess(t *testing.T) {
+	registry := NewTenantCircuitBreakerRegistry(gobreaker.Settings{Name: "stripe"})
+	tid := tenant.TenantID("concurrent_tenant")
+
+	const goroutines = 50
+	results := make(chan *gobreaker.CircuitBreaker[TenantConfig], goroutines)
+
+	for range goroutines {
+		go func() {
+			results <- registry.Get(tid)
+		}()
+	}
+
+	var first *gobreaker.CircuitBreaker[TenantConfig]
+	for range goroutines {
+		cb := <-results
+		if first == nil {
+			first = cb
+		}
+		assert.Same(t, first, cb, "all goroutines should get the same breaker instance")
+	}
+}
+
+func TestStateLabel(t *testing.T) {
+	tests := []struct {
+		state gobreaker.State
+		want  string
+	}{
+		{gobreaker.StateClosed, "closed"},
+		{gobreaker.StateHalfOpen, "half_open"},
+		{gobreaker.StateOpen, "open"},
+		{gobreaker.State(99), "unknown"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, stateLabel(tt.state))
+	}
+}

--- a/services/financial-gateway/adapters/stripe/client.go
+++ b/services/financial-gateway/adapters/stripe/client.go
@@ -42,14 +42,14 @@ func (c *Client) ApplyAccountList(params *stripego.ListParams) {
 }
 
 // ClientFactory creates tenant-scoped Stripe clients with caching,
-// circuit breaker, and retry resilience.
+// per-tenant circuit breakers, and retry resilience.
 type ClientFactory struct {
 	apiKey         string
 	configProvider TenantConfigProvider
 	rawClient      *stripego.Client
 	cache          *lru.Cache[string, *cachedTenantConfig]
 	cacheTTL       time.Duration
-	cb             *gobreaker.CircuitBreaker[TenantConfig]
+	cbRegistry     *TenantCircuitBreakerRegistry
 	retryConfig    retrySettings
 	logger         *slog.Logger
 }
@@ -124,7 +124,7 @@ func NewClientFactory(cfg Config, provider TenantConfigProvider, logger *slog.Lo
 		rawClient:      stripego.NewClient(cfg.APIKey),
 		cache:          cache,
 		cacheTTL:       cfg.TenantCacheTTL,
-		cb:             gobreaker.NewCircuitBreaker[TenantConfig](cbSettings),
+		cbRegistry:     NewTenantCircuitBreakerRegistry(cbSettings),
 		retryConfig: retrySettings{
 			maxRetries:          cfg.MaxRetries,
 			initialInterval:     cfg.RetryInitialInterval,
@@ -192,9 +192,11 @@ func (f *ClientFactory) getTenantConfig(ctx context.Context, tenantID string) (T
 	return cfg, nil
 }
 
-// fetchWithResilience fetches tenant config through circuit breaker with retries.
+// fetchWithResilience fetches tenant config through a per-tenant circuit breaker with retries.
 func (f *ClientFactory) fetchWithResilience(ctx context.Context, tenantID string) (TenantConfig, error) {
 	var result TenantConfig
+
+	cb := f.cbRegistry.Get(tenant.TenantID(tenantID))
 
 	b := backoff.NewExponentialBackOff()
 	b.InitialInterval = f.retryConfig.initialInterval
@@ -216,7 +218,7 @@ func (f *ClientFactory) fetchWithResilience(ctx context.Context, tenantID string
 
 		attempt++
 
-		cfg, err := f.cb.Execute(func() (TenantConfig, error) {
+		cfg, err := cb.Execute(func() (TenantConfig, error) {
 			return f.configProvider.GetTenantConfig(tenantID)
 		})
 		if err != nil {
@@ -270,7 +272,8 @@ func (f *ClientFactory) InvalidateTenantConfig(tenantID string) {
 	f.logger.Debug("invalidated stripe config cache", "tenant_id", tenantID)
 }
 
-// CircuitBreakerState returns the current state of the circuit breaker.
-func (f *ClientFactory) CircuitBreakerState() gobreaker.State {
-	return f.cb.State()
+// CircuitBreakerState returns the circuit breaker state for a specific tenant.
+// If no breaker exists yet for the tenant, StateClosed is returned.
+func (f *ClientFactory) CircuitBreakerState(tenantID tenant.TenantID) gobreaker.State {
+	return f.cbRegistry.State(tenantID)
 }

--- a/services/financial-gateway/e2e/e2e_test.go
+++ b/services/financial-gateway/e2e/e2e_test.go
@@ -405,7 +405,9 @@ func TestGetProviderHealth_Healthy(t *testing.T) {
 
 	h := setupHarness(t, creator, defaultConfigProvider())
 
-	resp, err := h.client.GetProviderHealth(context.Background(), &financialgatewayv1.GetProviderHealthRequest{
+	// Per-tenant circuit breakers require tenant context for health checks.
+	ctx := tenantContext("tenant_e2e")
+	resp, err := h.client.GetProviderHealth(ctx, &financialgatewayv1.GetProviderHealthRequest{
 		Rail: financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE,
 	})
 	require.NoError(t, err)
@@ -413,6 +415,25 @@ func TestGetProviderHealth_Healthy(t *testing.T) {
 	assert.Equal(t, financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE, resp.Rail)
 	assert.Equal(t, financialgatewayv1.ProviderHealth_PROVIDER_HEALTH_HEALTHY, resp.Health)
 	assert.NotNil(t, resp.LastCheckedAt)
+}
+
+func TestGetProviderHealth_NoTenantContext(t *testing.T) {
+	creator := &stubPaymentIntentCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return &stripego.PaymentIntent{ID: "pi_health", Status: stripego.PaymentIntentStatusSucceeded}, nil
+		},
+	}
+
+	h := setupHarness(t, creator, defaultConfigProvider())
+
+	// Without tenant context, health check returns UNSPECIFIED.
+	resp, err := h.client.GetProviderHealth(context.Background(), &financialgatewayv1.GetProviderHealthRequest{
+		Rail: financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, financialgatewayv1.ProviderHealth_PROVIDER_HEALTH_UNSPECIFIED, resp.Health)
+	assert.Contains(t, resp.Message, "tenant context required")
 }
 
 func TestGetProviderHealth_UnsupportedRail(t *testing.T) {

--- a/services/financial-gateway/service/grpc_service.go
+++ b/services/financial-gateway/service/grpc_service.go
@@ -13,6 +13,7 @@ import (
 
 	financialgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_gateway/v1"
 	stripeadapter "github.com/meridianhub/meridian/services/financial-gateway/adapters/stripe"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -129,20 +130,22 @@ func (s *FinancialGatewayService) CancelPayment(
 }
 
 // GetProviderHealth returns the current health status of a payment rail provider.
+// When tenant context is present, returns the per-tenant circuit breaker state.
+// Without tenant context, returns UNSPECIFIED health (per-tenant breakers require tenant).
 func (s *FinancialGatewayService) GetProviderHealth(
-	_ context.Context,
+	ctx context.Context,
 	req *financialgatewayv1.GetProviderHealthRequest,
 ) (*financialgatewayv1.GetProviderHealthResponse, error) {
 	switch req.GetRail() { //nolint:exhaustive // only Stripe is supported; all others fall through to default
 	case financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE:
-		return s.getStripeHealth()
+		return s.getStripeHealth(ctx)
 	default:
 		return nil, status.Errorf(codes.Unimplemented, "health check for rail %s is not yet supported", req.GetRail())
 	}
 }
 
-// getStripeHealth reports Stripe provider health based on circuit breaker state.
-func (s *FinancialGatewayService) getStripeHealth() (*financialgatewayv1.GetProviderHealthResponse, error) {
+// getStripeHealth reports Stripe provider health based on the per-tenant circuit breaker state.
+func (s *FinancialGatewayService) getStripeHealth(ctx context.Context) (*financialgatewayv1.GetProviderHealthResponse, error) {
 	if s.stripeAdapter == nil || s.clientFactory == nil {
 		return &financialgatewayv1.GetProviderHealthResponse{
 			Rail:          financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE,
@@ -152,7 +155,17 @@ func (s *FinancialGatewayService) getStripeHealth() (*financialgatewayv1.GetProv
 		}, nil
 	}
 
-	cbState := s.clientFactory.CircuitBreakerState()
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return &financialgatewayv1.GetProviderHealthResponse{
+			Rail:          financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE,
+			Health:        financialgatewayv1.ProviderHealth_PROVIDER_HEALTH_UNSPECIFIED,
+			Message:       "tenant context required for per-tenant health check",
+			LastCheckedAt: timestamppb.Now(),
+		}, nil
+	}
+
+	cbState := s.clientFactory.CircuitBreakerState(tenantID)
 	health := mapCircuitBreakerHealth(cbState)
 
 	return &financialgatewayv1.GetProviderHealthResponse{


### PR DESCRIPTION
## Summary

- Introduces `TenantCircuitBreakerRegistry` that lazily creates per-tenant `gobreaker` instances, so one tenant's Stripe configuration failures cannot trip the circuit breaker for other tenants
- Replaces the single global circuit breaker in `ClientFactory` with the per-tenant registry
- Updates `GetProviderHealth` to return tenant-specific circuit breaker state (requires tenant context)
- Emits per-tenant Prometheus metrics on breaker state changes via existing `observability.RecordCircuitBreakerState`

## Test plan

- [x] Unit tests for `TenantCircuitBreakerRegistry`: same-instance caching, cross-tenant isolation, concurrent access safety, state reflection, parent callback delegation
- [x] E2e test updated: `TestGetProviderHealth_Healthy` now passes tenant context
- [x] New e2e test: `TestGetProviderHealth_NoTenantContext` verifies graceful UNSPECIFIED response without tenant
- [x] Existing `TestCircuitBreakerTrips` passes (per-tenant breaker trips correctly)
- [x] All financial-gateway tests green

## Task Master

Tag: `test-coverage-80`, Task: 5 — Per-Tenant Circuit Breakers