### PR TITLE
test: Add unhappy path tests for financial-gateway (46.5% → 80.1%)

### DIFF
--- a/services/financial-gateway/adapters/http/webhook_handler_test.go
+++ b/services/financial-gateway/adapters/http/webhook_handler_test.go
@@ -390,6 +390,112 @@ func TestWebhookHandler_RefundedWithoutPaymentOrderID_AcknowledgesOnly(t *testin
 	assert.Len(t, stub.published, 0, "should not publish event without payment_order_id")
 }
 
+func TestWebhookHandler_BodyTooLarge_Returns413(t *testing.T) {
+	h := setupHandler(t, nil)
+
+	// Body exceeding StripeWebhookMaxBodySize (512KB)
+	largeBody := make([]byte, fghttp.StripeWebhookMaxBodySize+1)
+	for i := range largeBody {
+		largeBody[i] = 'x'
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe/test-tenant", bytes.NewReader(largeBody))
+	req.SetPathValue("tenantID", "test-tenant")
+	req.Header.Set("Stripe-Signature", "t=1234,v1=test")
+
+	rr := httptest.NewRecorder()
+	h.HandleStripeWebhook(rr, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
+}
+
+func TestWebhookHandler_EmptyWebhookSecret_Returns500(t *testing.T) {
+	stub := &stubOutboxPublisher{}
+	provider := &testTenantConfigProvider{
+		configs: map[string]stripeadapter.TenantConfig{
+			"no-secret-tenant": {
+				ConnectedAccountID:    "acct_test",
+				WebhookEndpointSecret: "", // empty secret
+			},
+		},
+	}
+	factory, err := stripeadapter.NewClientFactory(stripeadapter.Config{
+		APIKey:             "sk_test_key",
+		TenantCacheSize:    10,
+		TenantCacheTTL:     time.Minute,
+		CircuitBreakerName: "test-cb",
+	}, provider, nil)
+	require.NoError(t, err)
+
+	h := fghttp.NewWebhookHandler(fghttp.WebhookHandlerConfig{
+		ClientFactory:   factory,
+		OutboxPublisher: stub,
+	})
+
+	payload := buildStripePayload(t, "evt_1", "payment_intent.succeeded", map[string]any{})
+	sig := signPayload(t, payload, testWebhookSecret)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe/no-secret-tenant", bytes.NewReader(payload))
+	req.SetPathValue("tenantID", "no-secret-tenant")
+	req.Header.Set("Stripe-Signature", sig)
+
+	rr := httptest.NewRecorder()
+	h.HandleStripeWebhook(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+func TestWebhookHandler_MissingPaymentOrderID_AcknowledgesOnly(t *testing.T) {
+	stub := &stubOutboxPublisher{}
+	h := setupHandler(t, stub)
+
+	// payment_intent.succeeded but with no payment_order_id in metadata
+	payload := buildStripePayload(t, "evt_no_po", "payment_intent.succeeded", map[string]any{
+		"id":       "pi_no_po_id",
+		"object":   "payment_intent",
+		"amount":   2000,
+		"currency": "usd",
+		"metadata": map[string]string{},
+	})
+	sig := signPayload(t, payload, testWebhookSecret)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe/test-tenant", bytes.NewReader(payload))
+	req.SetPathValue("tenantID", "test-tenant")
+	req.Header.Set("Stripe-Signature", sig)
+
+	rr := httptest.NewRecorder()
+	h.HandleStripeWebhook(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Len(t, stub.published, 0, "should not publish when payment_order_id is missing")
+}
+
+func TestWebhookHandler_NewWebhookHandler_PanicsOnNilClientFactory(t *testing.T) {
+	stub := &stubOutboxPublisher{}
+	assert.PanicsWithValue(t, fghttp.ErrNilClientFactory.Error(), func() {
+		fghttp.NewWebhookHandler(fghttp.WebhookHandlerConfig{
+			OutboxPublisher: stub,
+		})
+	})
+}
+
+func TestWebhookHandler_NewWebhookHandler_PanicsOnNilPublisher(t *testing.T) {
+	provider := &testTenantConfigProvider{configs: map[string]stripeadapter.TenantConfig{}}
+	factory, err := stripeadapter.NewClientFactory(stripeadapter.Config{
+		APIKey:             "sk_test_key",
+		TenantCacheSize:    10,
+		TenantCacheTTL:     time.Minute,
+		CircuitBreakerName: "test-cb",
+	}, provider, nil)
+	require.NoError(t, err)
+
+	assert.PanicsWithValue(t, fghttp.ErrNilOutboxPublisher.Error(), func() {
+		fghttp.NewWebhookHandler(fghttp.WebhookHandlerConfig{
+			ClientFactory: factory,
+		})
+	})
+}
+
 func TestWebhookHandler_TenantNotFound_Returns500(t *testing.T) {
 	stub := &stubOutboxPublisher{}
 	provider := &testTenantConfigProvider{

--- a/services/financial-gateway/adapters/stripe/client_test.go
+++ b/services/financial-gateway/adapters/stripe/client_test.go
@@ -1,0 +1,265 @@
+package stripe
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/sony/gobreaker/v2"
+	stripego "github.com/stripe/stripe-go/v82"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// --- test helpers ---
+
+type stubConfigProvider struct {
+	configs   map[string]TenantConfig
+	callCount int
+	err       error
+}
+
+func (p *stubConfigProvider) GetTenantConfig(tenantID string) (TenantConfig, error) {
+	p.callCount++
+	if p.err != nil {
+		return TenantConfig{}, p.err
+	}
+	cfg, ok := p.configs[tenantID]
+	if !ok {
+		return TenantConfig{}, ErrTenantConfigNotFound
+	}
+	return cfg, nil
+}
+
+func validConfig() Config {
+	return Config{
+		APIKey:             "sk_test_key",
+		TenantCacheSize:    10,
+		TenantCacheTTL:     time.Minute,
+		CircuitBreakerName: "test-cb",
+	}
+}
+
+func clientTenantCtx(id string) context.Context {
+	return tenant.WithTenant(context.Background(), tenant.TenantID(id))
+}
+
+// --- NewClientFactory ---
+
+func TestNewClientFactory_Success(t *testing.T) {
+	provider := &stubConfigProvider{
+		configs: map[string]TenantConfig{},
+	}
+	factory, err := NewClientFactory(validConfig(), provider, slog.Default())
+	require.NoError(t, err)
+	assert.NotNil(t, factory)
+}
+
+func TestNewClientFactory_NilProvider(t *testing.T) {
+	_, err := NewClientFactory(validConfig(), nil, slog.Default())
+	require.ErrorIs(t, err, ErrNilConfigProvider)
+}
+
+func TestNewClientFactory_InvalidConfig(t *testing.T) {
+	provider := &stubConfigProvider{}
+	_, err := NewClientFactory(Config{}, provider, slog.Default())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid stripe config")
+}
+
+func TestNewClientFactory_NilLogger(t *testing.T) {
+	provider := &stubConfigProvider{configs: map[string]TenantConfig{}}
+	factory, err := NewClientFactory(validConfig(), provider, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, factory)
+}
+
+// --- NewClient ---
+
+func TestNewClient_Success(t *testing.T) {
+	provider := &stubConfigProvider{
+		configs: map[string]TenantConfig{
+			"tenant-a": {
+				ConnectedAccountID:    "acct_123",
+				WebhookEndpointSecret: "whsec_test",
+			},
+		},
+	}
+	factory, err := NewClientFactory(validConfig(), provider, slog.Default())
+	require.NoError(t, err)
+
+	ctx := clientTenantCtx("tenant-a")
+	client, err := factory.NewClient(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "acct_123", client.AccountID)
+	assert.Equal(t, "whsec_test", client.WebhookEndpointSecret)
+	assert.NotNil(t, client.Raw)
+}
+
+func TestNewClient_MissingTenant(t *testing.T) {
+	provider := &stubConfigProvider{configs: map[string]TenantConfig{}}
+	factory, err := NewClientFactory(validConfig(), provider, slog.Default())
+	require.NoError(t, err)
+
+	_, err = factory.NewClient(context.Background())
+	require.ErrorIs(t, err, ErrMissingTenant)
+}
+
+func TestNewClient_TenantNotFound(t *testing.T) {
+	provider := &stubConfigProvider{configs: map[string]TenantConfig{}}
+	factory, err := NewClientFactory(validConfig(), provider, slog.Default())
+	require.NoError(t, err)
+
+	ctx := clientTenantCtx("missing-tenant")
+	_, err = factory.NewClient(ctx)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTenantConfigNotFound)
+}
+
+// --- Caching ---
+
+func TestNewClient_CacheHit(t *testing.T) {
+	provider := &stubConfigProvider{
+		configs: map[string]TenantConfig{
+			"tenant-a": {ConnectedAccountID: "acct_123"},
+		},
+	}
+	factory, err := NewClientFactory(validConfig(), provider, slog.Default())
+	require.NoError(t, err)
+
+	ctx := clientTenantCtx("tenant-a")
+
+	// First call populates cache
+	_, err = factory.NewClient(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, provider.callCount)
+
+	// Second call uses cache
+	_, err = factory.NewClient(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, provider.callCount, "should use cached config")
+}
+
+func TestNewClient_CacheExpiry(t *testing.T) {
+	provider := &stubConfigProvider{
+		configs: map[string]TenantConfig{
+			"tenant-a": {ConnectedAccountID: "acct_123"},
+		},
+	}
+	cfg := validConfig()
+	cfg.TenantCacheTTL = time.Millisecond // very short TTL
+	factory, err := NewClientFactory(cfg, provider, slog.Default())
+	require.NoError(t, err)
+
+	ctx := clientTenantCtx("tenant-a")
+
+	_, err = factory.NewClient(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, provider.callCount)
+
+	// Wait for cache to expire
+	time.Sleep(5 * time.Millisecond)
+
+	_, err = factory.NewClient(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, provider.callCount, "should refetch after cache expiry")
+}
+
+// --- InvalidateTenantConfig ---
+
+func TestInvalidateTenantConfig(t *testing.T) {
+	provider := &stubConfigProvider{
+		configs: map[string]TenantConfig{
+			"tenant-a": {ConnectedAccountID: "acct_123"},
+		},
+	}
+	factory, err := NewClientFactory(validConfig(), provider, slog.Default())
+	require.NoError(t, err)
+
+	ctx := clientTenantCtx("tenant-a")
+
+	// Populate cache
+	_, err = factory.NewClient(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, provider.callCount)
+
+	// Invalidate
+	factory.InvalidateTenantConfig("tenant-a")
+
+	// Next call should refetch
+	_, err = factory.NewClient(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, provider.callCount, "should refetch after invalidation")
+}
+
+// --- CircuitBreakerState ---
+
+func TestCircuitBreakerState_DefaultClosed(t *testing.T) {
+	provider := &stubConfigProvider{configs: map[string]TenantConfig{}}
+	factory, err := NewClientFactory(validConfig(), provider, slog.Default())
+	require.NoError(t, err)
+
+	state := factory.CircuitBreakerState(tenant.TenantID("new-tenant"))
+	assert.Equal(t, gobreaker.StateClosed, state)
+}
+
+// --- Client helpers ---
+
+func TestApplyAccount(t *testing.T) {
+	c := &Client{AccountID: "acct_test"}
+
+	t.Run("sets stripe account on params", func(t *testing.T) {
+		params := &stripego.Params{}
+		c.ApplyAccount(params)
+		require.NotNil(t, params.StripeAccount)
+		assert.Equal(t, "acct_test", *params.StripeAccount)
+	})
+
+	t.Run("sets stripe account on list params", func(t *testing.T) {
+		params := &stripego.ListParams{}
+		c.ApplyAccountList(params)
+		require.NotNil(t, params.StripeAccount)
+		assert.Equal(t, "acct_test", *params.StripeAccount)
+	})
+}
+
+// --- WithStripeAccount / AccountFromContext ---
+
+func TestWithStripeAccount_RoundTrip(t *testing.T) {
+	ctx := WithStripeAccount(context.Background(), "acct_abc")
+	id, ok := AccountFromContext(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, "acct_abc", id)
+}
+
+func TestAccountFromContext_Missing(t *testing.T) {
+	_, ok := AccountFromContext(context.Background())
+	assert.False(t, ok)
+}
+
+func TestAccountFromContext_EmptyString(t *testing.T) {
+	ctx := WithStripeAccount(context.Background(), "")
+	_, ok := AccountFromContext(ctx)
+	assert.False(t, ok, "empty string should return false")
+}
+
+// --- Context cancellation during fetch ---
+
+func TestNewClient_ContextCancelled(t *testing.T) {
+	provider := &stubConfigProvider{
+		configs: map[string]TenantConfig{},
+		err:     errors.New("should not be called"),
+	}
+	factory, err := NewClientFactory(validConfig(), provider, slog.Default())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(clientTenantCtx("tenant-a"))
+	cancel() // cancel immediately
+
+	_, err = factory.NewClient(ctx)
+	require.Error(t, err)
+}

--- a/services/financial-gateway/adapters/stripe/client_test.go
+++ b/services/financial-gateway/adapters/stripe/client_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sony/gobreaker/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/sony/gobreaker/v2"
 	stripego "github.com/stripe/stripe-go/v82"
 
 	"github.com/meridianhub/meridian/shared/platform/tenant"

--- a/services/financial-gateway/adapters/stripe/client_test.go
+++ b/services/financial-gateway/adapters/stripe/client_test.go
@@ -144,15 +144,13 @@ func TestNewClient_CacheHit(t *testing.T) {
 	assert.Equal(t, 1, provider.callCount, "should use cached config")
 }
 
-func TestNewClient_CacheExpiry(t *testing.T) {
+func TestNewClient_CacheInvalidation(t *testing.T) {
 	provider := &stubConfigProvider{
 		configs: map[string]TenantConfig{
 			"tenant-a": {ConnectedAccountID: "acct_123"},
 		},
 	}
-	cfg := validConfig()
-	cfg.TenantCacheTTL = time.Millisecond // very short TTL
-	factory, err := NewClientFactory(cfg, provider, slog.Default())
+	factory, err := NewClientFactory(validConfig(), provider, slog.Default())
 	require.NoError(t, err)
 
 	ctx := clientTenantCtx("tenant-a")
@@ -161,12 +159,12 @@ func TestNewClient_CacheExpiry(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, provider.callCount)
 
-	// Wait for cache to expire
-	time.Sleep(5 * time.Millisecond)
+	// Invalidate cache entry, forcing refetch on next call
+	factory.InvalidateTenantConfig("tenant-a")
 
 	_, err = factory.NewClient(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, 2, provider.callCount, "should refetch after cache expiry")
+	assert.Equal(t, 2, provider.callCount, "should refetch after cache invalidation")
 }
 
 // --- InvalidateTenantConfig ---

--- a/services/financial-gateway/adapters/stripe/config_test.go
+++ b/services/financial-gateway/adapters/stripe/config_test.go
@@ -1,0 +1,51 @@
+package stripe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_Validate(t *testing.T) {
+	t.Run("valid config", func(t *testing.T) {
+		cfg := Config{APIKey: "sk_test_key"}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("empty API key", func(t *testing.T) {
+		cfg := Config{}
+		err := cfg.Validate()
+		require.ErrorIs(t, err, ErrEmptyAPIKey)
+	})
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	assert.Equal(t, 1000, cfg.TenantCacheSize)
+	assert.NotZero(t, cfg.TenantCacheTTL)
+	assert.NotEmpty(t, cfg.CircuitBreakerName)
+	assert.NotZero(t, cfg.CircuitBreakerTimeout)
+	assert.Equal(t, 3, cfg.MaxRetries)
+	assert.NotZero(t, cfg.RetryInitialInterval)
+	assert.NotZero(t, cfg.RetryMultiplier)
+
+	// API key not set by default
+	assert.Empty(t, cfg.APIKey)
+	err := cfg.Validate()
+	require.ErrorIs(t, err, ErrEmptyAPIKey)
+}
+
+func TestTenantConfig_Validate(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		tc := TenantConfig{ConnectedAccountID: "acct_123"}
+		require.NoError(t, tc.Validate())
+	})
+
+	t.Run("missing account ID", func(t *testing.T) {
+		tc := TenantConfig{}
+		err := tc.Validate()
+		require.ErrorIs(t, err, ErrMissingAccountID)
+	})
+}

--- a/services/financial-gateway/client/client_test.go
+++ b/services/financial-gateway/client/client_test.go
@@ -1,0 +1,269 @@
+package client
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	financialgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_gateway/v1"
+)
+
+const bufSize = 1024 * 1024
+
+// fakeServer implements the gRPC service for testing.
+type fakeServer struct {
+	financialgatewayv1.UnimplementedFinancialGatewayServiceServer
+
+	dispatchFn func(ctx context.Context, req *financialgatewayv1.DispatchPaymentRequest) (*financialgatewayv1.DispatchPaymentResponse, error)
+	cancelFn   func(ctx context.Context, req *financialgatewayv1.CancelPaymentRequest) (*financialgatewayv1.CancelPaymentResponse, error)
+	refundFn   func(ctx context.Context, req *financialgatewayv1.DispatchRefundRequest) (*financialgatewayv1.DispatchRefundResponse, error)
+	healthFn   func(ctx context.Context, req *financialgatewayv1.GetProviderHealthRequest) (*financialgatewayv1.GetProviderHealthResponse, error)
+}
+
+func (s *fakeServer) DispatchPayment(ctx context.Context, req *financialgatewayv1.DispatchPaymentRequest) (*financialgatewayv1.DispatchPaymentResponse, error) {
+	if s.dispatchFn != nil {
+		return s.dispatchFn(ctx, req)
+	}
+	return &financialgatewayv1.DispatchPaymentResponse{
+		DispatchId:     "dispatch-1",
+		PaymentOrderId: req.GetPaymentOrderId(),
+		Status:         financialgatewayv1.DispatchStatus_DISPATCH_STATUS_DISPATCHING,
+	}, nil
+}
+
+func (s *fakeServer) CancelPayment(ctx context.Context, req *financialgatewayv1.CancelPaymentRequest) (*financialgatewayv1.CancelPaymentResponse, error) {
+	if s.cancelFn != nil {
+		return s.cancelFn(ctx, req)
+	}
+	return &financialgatewayv1.CancelPaymentResponse{
+		PaymentOrderId: req.GetPaymentOrderId(),
+		Status:         "CANCELLED",
+	}, nil
+}
+
+func (s *fakeServer) DispatchRefund(ctx context.Context, req *financialgatewayv1.DispatchRefundRequest) (*financialgatewayv1.DispatchRefundResponse, error) {
+	if s.refundFn != nil {
+		return s.refundFn(ctx, req)
+	}
+	return &financialgatewayv1.DispatchRefundResponse{
+		DispatchId: "refund-1",
+		Status:     financialgatewayv1.DispatchStatus_DISPATCH_STATUS_PENDING,
+	}, nil
+}
+
+func (s *fakeServer) GetProviderHealth(ctx context.Context, req *financialgatewayv1.GetProviderHealthRequest) (*financialgatewayv1.GetProviderHealthResponse, error) {
+	if s.healthFn != nil {
+		return s.healthFn(ctx, req)
+	}
+	return &financialgatewayv1.GetProviderHealthResponse{
+		Rail:   req.GetRail(),
+		Health: financialgatewayv1.ProviderHealth_PROVIDER_HEALTH_HEALTHY,
+	}, nil
+}
+
+func setupTestServer(t *testing.T, server *fakeServer) (*Client, func()) {
+	t.Helper()
+
+	lis := bufconn.Listen(bufSize)
+	srv := grpc.NewServer()
+	financialgatewayv1.RegisterFinancialGatewayServiceServer(srv, server)
+
+	go func() { _ = srv.Serve(lis) }()
+
+	conn, err := grpc.NewClient("passthrough:///bufconn",
+		grpc.WithContextDialer(func(_ context.Context, _ string) (net.Conn, error) {
+			return lis.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+
+	c := &Client{
+		conn:             conn,
+		financialGateway: financialgatewayv1.NewFinancialGatewayServiceClient(conn),
+		timeout:          DefaultTimeout,
+	}
+
+	cleanup := func() {
+		_ = conn.Close()
+		srv.Stop()
+		_ = lis.Close()
+	}
+
+	return c, cleanup
+}
+
+// --- New ---
+
+func TestNew_WithTarget(t *testing.T) {
+	c, cleanup, err := New(Config{Target: "localhost:50099"})
+	require.NoError(t, err)
+	defer cleanup()
+	assert.NotNil(t, c)
+	assert.NotNil(t, c.Conn())
+}
+
+func TestNew_MissingTargetAndServiceName(t *testing.T) {
+	_, _, err := New(Config{})
+	require.ErrorIs(t, err, ErrTargetRequired)
+}
+
+func TestNew_WithServiceName(t *testing.T) {
+	// ServiceName-based connection goes through platform factory which needs K8s DNS
+	// Just verify it attempts the connection (will fail in test, but exercises code path)
+	_, _, err := New(Config{ServiceName: "financial-gateway"})
+	// May fail with DNS error but should not be ErrTargetRequired
+	if err != nil {
+		assert.NotErrorIs(t, err, ErrTargetRequired)
+	}
+}
+
+// --- DispatchPayment ---
+
+func TestClient_DispatchPayment_Success(t *testing.T) {
+	c, cleanup := setupTestServer(t, &fakeServer{})
+	defer cleanup()
+
+	resp, err := c.DispatchPayment(context.Background(), &financialgatewayv1.DispatchPaymentRequest{
+		PaymentOrderId: "po-1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "po-1", resp.GetPaymentOrderId())
+	assert.Equal(t, "dispatch-1", resp.GetDispatchId())
+}
+
+func TestClient_DispatchPayment_Error(t *testing.T) {
+	server := &fakeServer{
+		dispatchFn: func(_ context.Context, _ *financialgatewayv1.DispatchPaymentRequest) (*financialgatewayv1.DispatchPaymentResponse, error) {
+			return nil, status.Error(codes.Unavailable, "stripe down")
+		},
+	}
+	c, cleanup := setupTestServer(t, server)
+	defer cleanup()
+
+	_, err := c.DispatchPayment(context.Background(), &financialgatewayv1.DispatchPaymentRequest{
+		PaymentOrderId: "po-1",
+	})
+	require.Error(t, err)
+}
+
+// --- CancelPayment ---
+
+func TestClient_CancelPayment_Success(t *testing.T) {
+	c, cleanup := setupTestServer(t, &fakeServer{})
+	defer cleanup()
+
+	resp, err := c.CancelPayment(context.Background(), &financialgatewayv1.CancelPaymentRequest{
+		PaymentOrderId: "po-1",
+		Reason:         "test",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "po-1", resp.GetPaymentOrderId())
+	assert.Equal(t, "CANCELLED", resp.GetStatus())
+}
+
+func TestClient_CancelPayment_Error(t *testing.T) {
+	server := &fakeServer{
+		cancelFn: func(_ context.Context, _ *financialgatewayv1.CancelPaymentRequest) (*financialgatewayv1.CancelPaymentResponse, error) {
+			return nil, status.Error(codes.NotFound, "not found")
+		},
+	}
+	c, cleanup := setupTestServer(t, server)
+	defer cleanup()
+
+	_, err := c.CancelPayment(context.Background(), &financialgatewayv1.CancelPaymentRequest{
+		PaymentOrderId: "po-1",
+	})
+	require.Error(t, err)
+}
+
+// --- DispatchRefund ---
+
+func TestClient_DispatchRefund_Success(t *testing.T) {
+	c, cleanup := setupTestServer(t, &fakeServer{})
+	defer cleanup()
+
+	resp, err := c.DispatchRefund(context.Background(), &financialgatewayv1.DispatchRefundRequest{
+		OriginalDispatchId: "po-1",
+		RefundAmountUnits:  5000,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "refund-1", resp.GetDispatchId())
+}
+
+func TestClient_DispatchRefund_Error(t *testing.T) {
+	server := &fakeServer{
+		refundFn: func(_ context.Context, _ *financialgatewayv1.DispatchRefundRequest) (*financialgatewayv1.DispatchRefundResponse, error) {
+			return nil, status.Error(codes.Unimplemented, "not implemented")
+		},
+	}
+	c, cleanup := setupTestServer(t, server)
+	defer cleanup()
+
+	_, err := c.DispatchRefund(context.Background(), &financialgatewayv1.DispatchRefundRequest{
+		OriginalDispatchId: "po-1",
+	})
+	require.Error(t, err)
+}
+
+// --- GetProviderHealth ---
+
+func TestClient_GetProviderHealth_Success(t *testing.T) {
+	c, cleanup := setupTestServer(t, &fakeServer{})
+	defer cleanup()
+
+	resp, err := c.GetProviderHealth(context.Background(), &financialgatewayv1.GetProviderHealthRequest{
+		Rail: financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, financialgatewayv1.ProviderHealth_PROVIDER_HEALTH_HEALTHY, resp.GetHealth())
+}
+
+func TestClient_GetProviderHealth_Error(t *testing.T) {
+	server := &fakeServer{
+		healthFn: func(_ context.Context, _ *financialgatewayv1.GetProviderHealthRequest) (*financialgatewayv1.GetProviderHealthResponse, error) {
+			return nil, status.Error(codes.Unavailable, "down")
+		},
+	}
+	c, cleanup := setupTestServer(t, server)
+	defer cleanup()
+
+	_, err := c.GetProviderHealth(context.Background(), &financialgatewayv1.GetProviderHealthRequest{
+		Rail: financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE,
+	})
+	require.Error(t, err)
+}
+
+// --- Close ---
+
+func TestClient_Close(t *testing.T) {
+	c, cleanup := setupTestServer(t, &fakeServer{})
+	defer cleanup()
+
+	err := c.Close()
+	require.NoError(t, err)
+}
+
+func TestClient_Close_NilConn(t *testing.T) {
+	c := &Client{}
+	err := c.Close()
+	require.NoError(t, err)
+}
+
+// --- Conn ---
+
+func TestClient_Conn(t *testing.T) {
+	c, cleanup := setupTestServer(t, &fakeServer{})
+	defer cleanup()
+
+	conn := c.Conn()
+	assert.NotNil(t, conn)
+}

--- a/services/financial-gateway/client/starlark_test.go
+++ b/services/financial-gateway/client/starlark_test.go
@@ -1,11 +1,14 @@
 package client
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	financialgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_gateway/v1"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
@@ -321,6 +324,330 @@ func TestParseDispatchRefundParams(t *testing.T) {
 		_, err := parseDispatchRefundParams(params)
 		require.ErrorIs(t, err, saga.ErrMissingParam)
 	})
+}
+
+// --- Starlark Handler Tests (via mock gRPC server) ---
+
+func TestDispatchPaymentHandler_Success(t *testing.T) {
+	server := &fakeServer{
+		dispatchFn: func(_ context.Context, req *financialgatewayv1.DispatchPaymentRequest) (*financialgatewayv1.DispatchPaymentResponse, error) {
+			return &financialgatewayv1.DispatchPaymentResponse{
+				DispatchId:            "dispatch-1",
+				PaymentOrderId:        req.GetPaymentOrderId(),
+				Status:                financialgatewayv1.DispatchStatus_DISPATCH_STATUS_DELIVERED,
+				ProviderReference:     "pi_test_123",
+				PlatformFeeMinorUnits: 250,
+			}, nil
+		},
+	}
+	c, cleanup := setupTestServer(t, server)
+	defer cleanup()
+
+	handler := dispatchPaymentHandler(c)
+	ctx := &saga.StarlarkContext{
+		Context:        context.Background(),
+		CorrelationID:  uuid.New(),
+		IdempotencyKey: "test-idem",
+	}
+
+	result, err := handler(ctx, map[string]any{
+		"payment_order_id":         "po-123",
+		"amount_minor_units":       int64(10000),
+		"currency":                 "GBP",
+		"customer_reference":       "cus_test",
+		"payment_method_reference": "pm_test",
+		"idempotency_key":          "idem-key",
+		"rail":                     "STRIPE",
+	})
+	require.NoError(t, err)
+
+	m, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "pi_test_123", m["provider_reference_id"])
+	assert.Equal(t, "DELIVERED", m["status"])
+	assert.Equal(t, int64(250), m["platform_fee_minor_units"])
+}
+
+func TestDispatchPaymentHandler_ValidationError(t *testing.T) {
+	c, cleanup := setupTestServer(t, &fakeServer{})
+	defer cleanup()
+
+	handler := dispatchPaymentHandler(c)
+	ctx := &saga.StarlarkContext{
+		Context:       context.Background(),
+		CorrelationID: uuid.New(),
+	}
+
+	// Missing required params
+	_, err := handler(ctx, map[string]any{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, saga.ErrMissingParam)
+}
+
+func TestDispatchPaymentHandler_GRPCError(t *testing.T) {
+	server := &fakeServer{
+		dispatchFn: func(_ context.Context, _ *financialgatewayv1.DispatchPaymentRequest) (*financialgatewayv1.DispatchPaymentResponse, error) {
+			return nil, status.Error(codes.Unavailable, "stripe down")
+		},
+	}
+	c, cleanup := setupTestServer(t, server)
+	defer cleanup()
+
+	handler := dispatchPaymentHandler(c)
+	ctx := &saga.StarlarkContext{
+		Context:        context.Background(),
+		CorrelationID:  uuid.New(),
+		IdempotencyKey: "test-idem",
+	}
+
+	_, err := handler(ctx, map[string]any{
+		"payment_order_id":         "po-123",
+		"amount_minor_units":       int64(10000),
+		"currency":                 "GBP",
+		"customer_reference":       "cus_test",
+		"payment_method_reference": "pm_test",
+		"idempotency_key":          "idem-key",
+		"rail":                     "STRIPE",
+	})
+	require.Error(t, err)
+}
+
+func TestCancelPaymentHandler_Success(t *testing.T) {
+	server := &fakeServer{
+		cancelFn: func(_ context.Context, req *financialgatewayv1.CancelPaymentRequest) (*financialgatewayv1.CancelPaymentResponse, error) {
+			return &financialgatewayv1.CancelPaymentResponse{
+				PaymentOrderId: req.GetPaymentOrderId(),
+				Status:         "CANCELLED",
+				Reason:         req.GetReason(),
+			}, nil
+		},
+	}
+	c, cleanup := setupTestServer(t, server)
+	defer cleanup()
+
+	handler := cancelPaymentHandler(c)
+	ctx := &saga.StarlarkContext{
+		Context:       context.Background(),
+		CorrelationID: uuid.New(),
+	}
+
+	result, err := handler(ctx, map[string]any{
+		"payment_order_id": "po-cancel-1",
+		"reason":           "customer request",
+	})
+	require.NoError(t, err)
+
+	m, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "po-cancel-1", m["payment_order_id"])
+	assert.Equal(t, "CANCELLED", m["status"])
+	assert.Equal(t, "customer request", m["reason"])
+}
+
+func TestCancelPaymentHandler_MissingPaymentOrderID(t *testing.T) {
+	c, cleanup := setupTestServer(t, &fakeServer{})
+	defer cleanup()
+
+	handler := cancelPaymentHandler(c)
+	ctx := &saga.StarlarkContext{
+		Context:       context.Background(),
+		CorrelationID: uuid.New(),
+	}
+
+	_, err := handler(ctx, map[string]any{})
+	require.Error(t, err)
+}
+
+func TestCancelPaymentHandler_GRPCError(t *testing.T) {
+	server := &fakeServer{
+		cancelFn: func(_ context.Context, _ *financialgatewayv1.CancelPaymentRequest) (*financialgatewayv1.CancelPaymentResponse, error) {
+			return nil, status.Error(codes.NotFound, "not found")
+		},
+	}
+	c, cleanup := setupTestServer(t, server)
+	defer cleanup()
+
+	handler := cancelPaymentHandler(c)
+	ctx := &saga.StarlarkContext{
+		Context:       context.Background(),
+		CorrelationID: uuid.New(),
+	}
+
+	_, err := handler(ctx, map[string]any{
+		"payment_order_id": "po-1",
+	})
+	require.Error(t, err)
+}
+
+func TestDispatchRefundHandler_Success(t *testing.T) {
+	server := &fakeServer{
+		refundFn: func(_ context.Context, _ *financialgatewayv1.DispatchRefundRequest) (*financialgatewayv1.DispatchRefundResponse, error) {
+			return &financialgatewayv1.DispatchRefundResponse{
+				DispatchId:        "refund-1",
+				Status:            financialgatewayv1.DispatchStatus_DISPATCH_STATUS_PENDING,
+				ProviderReference: "re_test_123",
+			}, nil
+		},
+	}
+	c, cleanup := setupTestServer(t, server)
+	defer cleanup()
+
+	handler := dispatchRefundHandler(c)
+	ctx := &saga.StarlarkContext{
+		Context:       context.Background(),
+		CorrelationID: uuid.New(),
+	}
+
+	result, err := handler(ctx, map[string]any{
+		"payment_order_id":          "po-refund-1",
+		"refund_amount_minor_units": int64(5000),
+		"idempotency_key":           "refund-idem",
+		"reason":                    "item returned",
+	})
+	require.NoError(t, err)
+
+	m, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "refund-1", m["refund_reference_id"])
+	assert.Equal(t, "PENDING", m["status"])
+	assert.Equal(t, "re_test_123", m["provider_reference"])
+}
+
+func TestDispatchRefundHandler_ValidationError(t *testing.T) {
+	c, cleanup := setupTestServer(t, &fakeServer{})
+	defer cleanup()
+
+	handler := dispatchRefundHandler(c)
+	ctx := &saga.StarlarkContext{
+		Context:       context.Background(),
+		CorrelationID: uuid.New(),
+	}
+
+	_, err := handler(ctx, map[string]any{})
+	require.Error(t, err)
+}
+
+func TestDispatchRefundHandler_GRPCError(t *testing.T) {
+	server := &fakeServer{
+		refundFn: func(_ context.Context, _ *financialgatewayv1.DispatchRefundRequest) (*financialgatewayv1.DispatchRefundResponse, error) {
+			return nil, status.Error(codes.Unimplemented, "not implemented")
+		},
+	}
+	c, cleanup := setupTestServer(t, server)
+	defer cleanup()
+
+	handler := dispatchRefundHandler(c)
+	ctx := &saga.StarlarkContext{
+		Context:       context.Background(),
+		CorrelationID: uuid.New(),
+	}
+
+	_, err := handler(ctx, map[string]any{
+		"payment_order_id":          "po-1",
+		"refund_amount_minor_units": int64(1000),
+		"idempotency_key":           "key",
+	})
+	require.Error(t, err)
+}
+
+func TestCancelPaymentHandler_WithCausationID(t *testing.T) {
+	server := &fakeServer{
+		cancelFn: func(_ context.Context, req *financialgatewayv1.CancelPaymentRequest) (*financialgatewayv1.CancelPaymentResponse, error) {
+			assert.Equal(t, "cause-123", req.GetCausationId())
+			return &financialgatewayv1.CancelPaymentResponse{
+				PaymentOrderId: req.GetPaymentOrderId(),
+				Status:         "CANCELLED",
+			}, nil
+		},
+	}
+	c, cleanup := setupTestServer(t, server)
+	defer cleanup()
+
+	handler := cancelPaymentHandler(c)
+	ctx := &saga.StarlarkContext{
+		Context:       context.Background(),
+		CorrelationID: uuid.New(),
+	}
+
+	_, err := handler(ctx, map[string]any{
+		"payment_order_id": "po-1",
+		"causation_id":     "cause-123",
+	})
+	require.NoError(t, err)
+}
+
+// --- applyRefundOptionalFields ---
+
+func TestApplyRefundOptionalFields(t *testing.T) {
+	corrID := uuid.New()
+	ctx := &saga.StarlarkContext{
+		CorrelationID: corrID,
+	}
+
+	t.Run("defaults correlation_id from context", func(t *testing.T) {
+		req := &financialgatewayv1.DispatchRefundRequest{}
+		params := map[string]any{}
+
+		applyRefundOptionalFields(req, ctx, params)
+		assert.Equal(t, corrID.String(), req.CorrelationId)
+		assert.Empty(t, req.CausationId)
+		assert.Nil(t, req.Metadata)
+	})
+
+	t.Run("explicit correlation_id overrides context", func(t *testing.T) {
+		req := &financialgatewayv1.DispatchRefundRequest{}
+		params := map[string]any{
+			"correlation_id": "custom-corr",
+		}
+
+		applyRefundOptionalFields(req, ctx, params)
+		assert.Equal(t, "custom-corr", req.CorrelationId)
+	})
+
+	t.Run("sets causation_id when provided", func(t *testing.T) {
+		req := &financialgatewayv1.DispatchRefundRequest{}
+		params := map[string]any{
+			"causation_id": "cause-123",
+		}
+
+		applyRefundOptionalFields(req, ctx, params)
+		assert.Equal(t, "cause-123", req.CausationId)
+	})
+
+	t.Run("passes through metadata", func(t *testing.T) {
+		req := &financialgatewayv1.DispatchRefundRequest{}
+		params := map[string]any{
+			"metadata": map[string]any{
+				"key1": "val1",
+			},
+		}
+
+		applyRefundOptionalFields(req, ctx, params)
+		assert.Equal(t, map[string]string{"key1": "val1"}, req.Metadata)
+	})
+}
+
+// --- prepareClientContext ---
+
+func TestPrepareClientContext(t *testing.T) {
+	ctx := &saga.StarlarkContext{
+		Context:        context.Background(),
+		CorrelationID:  uuid.New(),
+		IdempotencyKey: "test-idem-key",
+	}
+
+	result := prepareClientContext(ctx)
+	assert.NotNil(t, result)
+}
+
+// --- RegisterStarlarkHandlers ---
+
+func TestRegisterStarlarkHandlers(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+
+	// Use nil client - registration should succeed (handlers are closures, not called during registration)
+	err := RegisterStarlarkHandlers(registry, nil)
+	require.NoError(t, err)
 }
 
 // --- buildDispatchPaymentRequest ---

--- a/services/financial-gateway/cmd/main_test.go
+++ b/services/financial-gateway/cmd/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	stripeadapter "github.com/meridianhub/meridian/services/financial-gateway/adapters/stripe"
+	"github.com/meridianhub/meridian/services/financial-gateway/config"
+)
+
+func TestParseLogLevel(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected slog.Level
+	}{
+		{"debug", slog.LevelDebug},
+		{"DEBUG", slog.LevelDebug},
+		{"  debug  ", slog.LevelDebug},
+		{"warn", slog.LevelWarn},
+		{"warning", slog.LevelWarn},
+		{"error", slog.LevelError},
+		{"info", slog.LevelInfo},
+		{"INFO", slog.LevelInfo},
+		{"", slog.LevelInfo},
+		{"unknown", slog.LevelInfo},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, parseLogLevel(tt.input))
+		})
+	}
+}
+
+func TestEnvTenantConfigProvider_WithAccountID(t *testing.T) {
+	p := &envTenantConfigProvider{
+		webhookSecret: "whsec_test",
+		accountID:     "acct_123",
+	}
+
+	cfg, err := p.GetTenantConfig("any-tenant")
+	assert.NoError(t, err)
+	assert.Equal(t, "acct_123", cfg.ConnectedAccountID)
+	assert.Equal(t, "whsec_test", cfg.WebhookEndpointSecret)
+}
+
+func TestEnvTenantConfigProvider_EmptyAccountID(t *testing.T) {
+	p := &envTenantConfigProvider{
+		webhookSecret: "whsec_test",
+		accountID:     "",
+	}
+
+	_, err := p.GetTenantConfig("any-tenant")
+	assert.ErrorIs(t, err, stripeadapter.ErrTenantConfigNotFound)
+}
+
+func TestCreateTenantConfigProvider_EnvFallback(t *testing.T) {
+	logger := slog.Default()
+	cfg := config.Config{ControlPlaneAddr: ""}
+
+	provider, conn, err := createTenantConfigProvider(cfg, logger)
+	require.NoError(t, err)
+	assert.NotNil(t, provider)
+	assert.Nil(t, conn) // no gRPC conn when using env fallback
+}
+
+func TestCreateTenantConfigProvider_WithControlPlane(t *testing.T) {
+	logger := slog.Default()
+	cfg := config.Config{ControlPlaneAddr: "localhost:50099"}
+
+	provider, conn, err := createTenantConfigProvider(cfg, logger)
+	require.NoError(t, err)
+	assert.NotNil(t, provider)
+	assert.NotNil(t, conn)
+	_ = conn.Close()
+}

--- a/services/financial-gateway/config/config_test.go
+++ b/services/financial-gateway/config/config_test.go
@@ -1,0 +1,19 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadConfig_Defaults(t *testing.T) {
+	cfg := LoadConfig()
+
+	assert.NotEmpty(t, cfg.GRPCPort)
+	assert.NotEmpty(t, cfg.HTTPPort)
+	assert.Equal(t, "info", cfg.LogLevel)
+	assert.NotZero(t, cfg.CircuitBreaker.Timeout)
+	assert.Equal(t, 5, cfg.CircuitBreaker.FailureThreshold)
+	assert.Equal(t, float64(100), cfg.RateLimit.RPS)
+	assert.Equal(t, 10, cfg.RateLimit.Burst)
+}

--- a/services/financial-gateway/observability/metrics_test.go
+++ b/services/financial-gateway/observability/metrics_test.go
@@ -1,0 +1,38 @@
+package observability
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRecordPayment(t *testing.T) {
+	// Verify no panic
+	RecordPayment("tenant-a", "stripe", "DELIVERED")
+	RecordPayment("tenant-a", "stripe", "FAILED")
+}
+
+func TestRecordDispatchDuration(t *testing.T) {
+	RecordDispatchDuration("tenant-a", "stripe", 150*time.Millisecond)
+	RecordDispatchDuration("tenant-a", "stripe", 2*time.Second)
+}
+
+func TestRecordDispatchAttempt(t *testing.T) {
+	RecordDispatchAttempt("tenant-a", "stripe", DispatchOutcomeSuccess)
+	RecordDispatchAttempt("tenant-a", "stripe", DispatchOutcomeRetry)
+	RecordDispatchAttempt("tenant-a", "stripe", DispatchOutcomeFailure)
+	RecordDispatchAttempt("tenant-a", "stripe", DispatchOutcomeCircuitOpen)
+	RecordDispatchAttempt("tenant-a", "stripe", "bogus_outcome") // unknown → mapped to "unknown"
+}
+
+func TestRecordCircuitBreakerState(t *testing.T) {
+	RecordCircuitBreakerState("tenant-a", "stripe", "closed")
+	RecordCircuitBreakerState("tenant-a", "stripe", "half_open")
+	RecordCircuitBreakerState("tenant-a", "stripe", "open")
+	RecordCircuitBreakerState("tenant-a", "stripe", "invalid_state") // silently ignored
+}
+
+func TestSetActiveDispatches(t *testing.T) {
+	SetActiveDispatches("tenant-a", "DISPATCHING", 5)
+	SetActiveDispatches("tenant-a", "DISPATCHING", 0)
+	SetActiveDispatches("tenant-a", "DISPATCHING", -1) // clamped to 0
+}

--- a/services/financial-gateway/observability/metrics_test.go
+++ b/services/financial-gateway/observability/metrics_test.go
@@ -5,18 +5,18 @@ import (
 	"time"
 )
 
-func TestRecordPayment(t *testing.T) {
+func TestRecordPayment(_ *testing.T) {
 	// Verify no panic
 	RecordPayment("tenant-a", "stripe", "DELIVERED")
 	RecordPayment("tenant-a", "stripe", "FAILED")
 }
 
-func TestRecordDispatchDuration(t *testing.T) {
+func TestRecordDispatchDuration(_ *testing.T) {
 	RecordDispatchDuration("tenant-a", "stripe", 150*time.Millisecond)
 	RecordDispatchDuration("tenant-a", "stripe", 2*time.Second)
 }
 
-func TestRecordDispatchAttempt(t *testing.T) {
+func TestRecordDispatchAttempt(_ *testing.T) {
 	RecordDispatchAttempt("tenant-a", "stripe", DispatchOutcomeSuccess)
 	RecordDispatchAttempt("tenant-a", "stripe", DispatchOutcomeRetry)
 	RecordDispatchAttempt("tenant-a", "stripe", DispatchOutcomeFailure)
@@ -24,14 +24,14 @@ func TestRecordDispatchAttempt(t *testing.T) {
 	RecordDispatchAttempt("tenant-a", "stripe", "bogus_outcome") // unknown → mapped to "unknown"
 }
 
-func TestRecordCircuitBreakerState(t *testing.T) {
+func TestRecordCircuitBreakerState(_ *testing.T) {
 	RecordCircuitBreakerState("tenant-a", "stripe", "closed")
 	RecordCircuitBreakerState("tenant-a", "stripe", "half_open")
 	RecordCircuitBreakerState("tenant-a", "stripe", "open")
 	RecordCircuitBreakerState("tenant-a", "stripe", "invalid_state") // silently ignored
 }
 
-func TestSetActiveDispatches(t *testing.T) {
+func TestSetActiveDispatches(_ *testing.T) {
 	SetActiveDispatches("tenant-a", "DISPATCHING", 5)
 	SetActiveDispatches("tenant-a", "DISPATCHING", 0)
 	SetActiveDispatches("tenant-a", "DISPATCHING", -1) // clamped to 0

--- a/services/financial-gateway/observability/tracing_test.go
+++ b/services/financial-gateway/observability/tracing_test.go
@@ -25,7 +25,7 @@ func TestStartSpan(t *testing.T) {
 	assert.NotNil(t, span)
 }
 
-func TestRecordError(t *testing.T) {
+func TestRecordError(_ *testing.T) {
 	_, span := StartSpan(context.Background(), "test-error")
 	defer span.End()
 

--- a/services/financial-gateway/observability/tracing_test.go
+++ b/services/financial-gateway/observability/tracing_test.go
@@ -1,0 +1,56 @@
+package observability
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestTracer(t *testing.T) {
+	tr := Tracer()
+	assert.NotNil(t, tr)
+}
+
+func TestStartSpan(t *testing.T) {
+	ctx, span := StartSpan(context.Background(), "test-span",
+		AttrTenantID.String("tenant-a"),
+		AttrPaymentRail.String("stripe"),
+	)
+	defer span.End()
+
+	assert.NotNil(t, ctx)
+	assert.NotNil(t, span)
+}
+
+func TestRecordError(t *testing.T) {
+	_, span := StartSpan(context.Background(), "test-error")
+	defer span.End()
+
+	// With error
+	RecordError(span, errors.New("test error"))
+
+	// Nil error - should be a no-op
+	RecordError(span, nil)
+
+	// Nil span - should be a no-op
+	RecordError(nil, errors.New("test error"))
+}
+
+func TestAttributeKeys(t *testing.T) {
+	// Verify attribute keys are defined and usable
+	attrs := []attribute.KeyValue{
+		AttrTenantID.String("tenant-a"),
+		AttrDispatchID.String("dispatch-1"),
+		AttrPaymentOrderID.String("po-1"),
+		AttrPaymentRail.String("stripe"),
+		AttrDispatchStatus.String("DELIVERED"),
+		AttrCorrelationID.String("corr-1"),
+		AttrProviderRef.String("pi_test"),
+		AttrAmountUnits.Int64(1000),
+		AttrInstrumentCode.String("GBP"),
+	}
+	assert.Len(t, attrs, 9)
+}

--- a/services/financial-gateway/service/grpc_service_test.go
+++ b/services/financial-gateway/service/grpc_service_test.go
@@ -2,18 +2,114 @@ package service
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 
 	"github.com/sony/gobreaker/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	stripego "github.com/stripe/stripe-go/v82"
 
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	financialgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_gateway/v1"
+	stripeadapter "github.com/meridianhub/meridian/services/financial-gateway/adapters/stripe"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// --- Test helpers ---
+
+type mockCreator struct {
+	createFn func(ctx context.Context, params *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error)
+}
+
+func (m *mockCreator) Create(ctx context.Context, params *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+	return m.createFn(ctx, params)
+}
+
+type mockCanceller struct {
+	cancelFn func(ctx context.Context, id string, params *stripego.PaymentIntentCancelParams) (*stripego.PaymentIntent, error)
+}
+
+func (m *mockCanceller) Cancel(ctx context.Context, id string, params *stripego.PaymentIntentCancelParams) (*stripego.PaymentIntent, error) {
+	return m.cancelFn(ctx, id, params)
+}
+
+type mockResolver struct {
+	findFn func(ctx context.Context, paymentOrderID string) (string, error)
+}
+
+func (m *mockResolver) FindByPaymentOrderID(ctx context.Context, paymentOrderID string) (string, error) {
+	return m.findFn(ctx, paymentOrderID)
+}
+
+type mockConfigProvider struct {
+	configs map[string]stripeadapter.TenantConfig
+}
+
+func (p *mockConfigProvider) GetTenantConfig(tenantID string) (stripeadapter.TenantConfig, error) {
+	cfg, ok := p.configs[tenantID]
+	if !ok {
+		return stripeadapter.TenantConfig{}, stripeadapter.ErrTenantConfigNotFound
+	}
+	return cfg, nil
+}
+
+func tenantCtx(id string) context.Context {
+	return tenant.WithTenant(context.Background(), tenant.TenantID(id))
+}
+
+func newServiceWithStripeMocks(t *testing.T, creator stripeadapter.PaymentIntentCreator, canceller stripeadapter.PaymentIntentCanceller, resolver stripeadapter.PaymentIntentResolver) *FinancialGatewayService {
+	t.Helper()
+
+	adapter, err := stripeadapter.NewPaymentIntentAdapter(creator, stripeadapter.PaymentIntentAdapterConfig{
+		Canceller: canceller,
+		Resolver:  resolver,
+	}, slog.Default())
+	require.NoError(t, err)
+
+	provider := &mockConfigProvider{
+		configs: map[string]stripeadapter.TenantConfig{
+			"test-tenant": {
+				ConnectedAccountID:    "acct_test_123",
+				WebhookEndpointSecret: "whsec_test",
+			},
+		},
+	}
+
+	factory, err := stripeadapter.NewClientFactory(stripeadapter.Config{
+		APIKey:             "sk_test_key",
+		TenantCacheSize:    10,
+		TenantCacheTTL:     60000000000, // 1 minute
+		CircuitBreakerName: "test-cb",
+	}, provider, slog.Default())
+	require.NoError(t, err)
+
+	svc, err := NewFinancialGatewayService(Config{
+		StripeAdapter: adapter,
+		ClientFactory: factory,
+		Logger:        slog.Default(),
+	})
+	require.NoError(t, err)
+	return svc
+}
+
+func testStripeRequest() *financialgatewayv1.DispatchPaymentRequest {
+	return &financialgatewayv1.DispatchPaymentRequest{
+		PaymentOrderId:    "11111111-1111-1111-1111-111111111111",
+		Rail:              financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE,
+		AmountUnits:       10000,
+		InstrumentCode:    "GBP",
+		DebtorAccountId:   "cus_test123",
+		CreditorAccountId: "acct_creditor",
+		Reference:         "pm_test456",
+		IdempotencyKey:    &commonv1.IdempotencyKey{Key: "test-key"},
+	}
+}
+
+// --- Existing tests (unchanged) ---
 
 func TestDispatchPayment_UnsupportedRail(t *testing.T) {
 	svc, err := NewFinancialGatewayService(Config{Logger: slog.Default()})
@@ -125,4 +221,486 @@ func TestMapCircuitBreakerHealth(t *testing.T) {
 			assert.Equal(t, tt.expectedHealth, mapCircuitBreakerHealth(tt.state))
 		})
 	}
+}
+
+// --- New tests for full dispatch/cancel/health paths ---
+
+func TestDispatchPayment_StripeSuccess(t *testing.T) {
+	creator := &mockCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return &stripego.PaymentIntent{
+				ID:     "pi_success",
+				Status: stripego.PaymentIntentStatusSucceeded,
+			}, nil
+		},
+	}
+	svc := newServiceWithStripeMocks(t, creator, nil, nil)
+
+	ctx := tenantCtx("test-tenant")
+	resp, err := svc.DispatchPayment(ctx, testStripeRequest())
+	require.NoError(t, err)
+	assert.Equal(t, financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE, resp.Rail)
+	assert.Equal(t, "pi_success", resp.ProviderReference)
+	assert.Equal(t, financialgatewayv1.DispatchStatus_DISPATCH_STATUS_DELIVERED, resp.Status)
+	assert.NotEmpty(t, resp.DispatchId)
+	assert.NotNil(t, resp.CreatedAt)
+}
+
+func TestDispatchPayment_ClientFactoryMissingTenant(t *testing.T) {
+	creator := &mockCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, nil
+		},
+	}
+	svc := newServiceWithStripeMocks(t, creator, nil, nil)
+
+	// No tenant in context
+	_, err := svc.DispatchPayment(context.Background(), testStripeRequest())
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestDispatchPayment_ClientFactoryTenantNotFound(t *testing.T) {
+	creator := &mockCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, nil
+		},
+	}
+	svc := newServiceWithStripeMocks(t, creator, nil, nil)
+
+	// Tenant not configured
+	ctx := tenantCtx("unknown-tenant")
+	_, err := svc.DispatchPayment(ctx, testStripeRequest())
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestDispatchPayment_StripeAdapterError_MissingStripeAccount(t *testing.T) {
+	// This test verifies the adapter returns ErrMissingStripeAccount and it maps correctly.
+	// The adapter actually sets the account from WithStripeAccount, so we test the error mapping directly.
+	creator := &mockCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, &stripego.Error{
+				Type: stripego.ErrorTypeInvalidRequest,
+				Msg:  "No such connected account",
+			}
+		},
+	}
+	svc := newServiceWithStripeMocks(t, creator, nil, nil)
+
+	ctx := tenantCtx("test-tenant")
+	_, err := svc.DispatchPayment(ctx, testStripeRequest())
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestDispatchPayment_StripeNetworkError(t *testing.T) {
+	creator := &mockCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, errors.New("connection refused")
+		},
+	}
+	svc := newServiceWithStripeMocks(t, creator, nil, nil)
+
+	ctx := tenantCtx("test-tenant")
+	_, err := svc.DispatchPayment(ctx, testStripeRequest())
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unavailable, st.Code())
+}
+
+func TestDispatchPayment_ContextCancelled(t *testing.T) {
+	creator := &mockCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, context.Canceled
+		},
+	}
+	svc := newServiceWithStripeMocks(t, creator, nil, nil)
+
+	ctx := tenantCtx("test-tenant")
+	_, err := svc.DispatchPayment(ctx, testStripeRequest())
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Canceled, st.Code())
+}
+
+func TestDispatchPayment_ContextDeadlineExceeded(t *testing.T) {
+	creator := &mockCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, context.DeadlineExceeded
+		},
+	}
+	svc := newServiceWithStripeMocks(t, creator, nil, nil)
+
+	ctx := tenantCtx("test-tenant")
+	_, err := svc.DispatchPayment(ctx, testStripeRequest())
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.DeadlineExceeded, st.Code())
+}
+
+func TestDispatchPayment_CardError_ReturnsSuccessWithFailedStatus(t *testing.T) {
+	creator := &mockCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, &stripego.Error{
+				Type: stripego.ErrorTypeCard,
+				Msg:  "card_declined",
+			}
+		},
+	}
+	svc := newServiceWithStripeMocks(t, creator, nil, nil)
+
+	ctx := tenantCtx("test-tenant")
+	resp, err := svc.DispatchPayment(ctx, testStripeRequest())
+	require.NoError(t, err)
+	assert.Equal(t, financialgatewayv1.DispatchStatus_DISPATCH_STATUS_FAILED, resp.Status)
+}
+
+// --- CancelPayment full path tests ---
+
+func TestCancelPayment_Success(t *testing.T) {
+	creator := &mockCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, nil
+		},
+	}
+	canceller := &mockCanceller{
+		cancelFn: func(_ context.Context, id string, _ *stripego.PaymentIntentCancelParams) (*stripego.PaymentIntent, error) {
+			return &stripego.PaymentIntent{
+				ID:     id,
+				Status: stripego.PaymentIntentStatusCanceled,
+			}, nil
+		},
+	}
+	resolver := &mockResolver{
+		findFn: func(_ context.Context, _ string) (string, error) {
+			return "pi_to_cancel", nil
+		},
+	}
+	svc := newServiceWithStripeMocks(t, creator, canceller, resolver)
+
+	ctx := tenantCtx("test-tenant")
+	resp, err := svc.CancelPayment(ctx, &financialgatewayv1.CancelPaymentRequest{
+		PaymentOrderId: "po-cancel-1",
+		Reason:         "test cancellation",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "po-cancel-1", resp.PaymentOrderId)
+	assert.Equal(t, "CANCELLED", resp.Status)
+	assert.Equal(t, "test cancellation", resp.Reason)
+}
+
+func TestCancelPayment_ClientFactoryMissingTenant(t *testing.T) {
+	creator := &mockCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, nil
+		},
+	}
+	canceller := &mockCanceller{
+		cancelFn: func(_ context.Context, _ string, _ *stripego.PaymentIntentCancelParams) (*stripego.PaymentIntent, error) {
+			return nil, nil
+		},
+	}
+	resolver := &mockResolver{
+		findFn: func(_ context.Context, _ string) (string, error) {
+			return "pi_x", nil
+		},
+	}
+	svc := newServiceWithStripeMocks(t, creator, canceller, resolver)
+
+	_, err := svc.CancelPayment(context.Background(), &financialgatewayv1.CancelPaymentRequest{
+		PaymentOrderId: "po-1",
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestCancelPayment_ResolverNotFound(t *testing.T) {
+	creator := &mockCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, nil
+		},
+	}
+	canceller := &mockCanceller{
+		cancelFn: func(_ context.Context, _ string, _ *stripego.PaymentIntentCancelParams) (*stripego.PaymentIntent, error) {
+			t.Fatal("should not be called")
+			return nil, nil
+		},
+	}
+	resolver := &mockResolver{
+		findFn: func(_ context.Context, _ string) (string, error) {
+			return "", stripeadapter.ErrPaymentIntentNotFound
+		},
+	}
+	svc := newServiceWithStripeMocks(t, creator, canceller, resolver)
+
+	ctx := tenantCtx("test-tenant")
+	_, err := svc.CancelPayment(ctx, &financialgatewayv1.CancelPaymentRequest{
+		PaymentOrderId: "po-missing",
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestCancelPayment_CancelNotConfigured(t *testing.T) {
+	creator := &mockCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, nil
+		},
+	}
+	// No canceller/resolver = not configured
+	svc := newServiceWithStripeMocks(t, creator, nil, nil)
+
+	ctx := tenantCtx("test-tenant")
+	_, err := svc.CancelPayment(ctx, &financialgatewayv1.CancelPaymentRequest{
+		PaymentOrderId: "po-1",
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unimplemented, st.Code())
+}
+
+func TestCancelPayment_AlreadySucceeded(t *testing.T) {
+	creator := &mockCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, nil
+		},
+	}
+	canceller := &mockCanceller{
+		cancelFn: func(_ context.Context, _ string, _ *stripego.PaymentIntentCancelParams) (*stripego.PaymentIntent, error) {
+			return nil, &stripego.Error{
+				HTTPStatusCode: 400,
+				Type:           stripego.ErrorTypeInvalidRequest,
+				Code:           stripego.ErrorCodePaymentIntentUnexpectedState,
+				Msg:            "You cannot cancel this PaymentIntent because it has a status of succeeded.",
+			}
+		},
+	}
+	resolver := &mockResolver{
+		findFn: func(_ context.Context, _ string) (string, error) {
+			return "pi_succeeded", nil
+		},
+	}
+	svc := newServiceWithStripeMocks(t, creator, canceller, resolver)
+
+	ctx := tenantCtx("test-tenant")
+	_, err := svc.CancelPayment(ctx, &financialgatewayv1.CancelPaymentRequest{
+		PaymentOrderId: "po-succeeded",
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestCancelPayment_ContextCancelled(t *testing.T) {
+	creator := &mockCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, nil
+		},
+	}
+	canceller := &mockCanceller{
+		cancelFn: func(_ context.Context, _ string, _ *stripego.PaymentIntentCancelParams) (*stripego.PaymentIntent, error) {
+			return nil, context.Canceled
+		},
+	}
+	resolver := &mockResolver{
+		findFn: func(_ context.Context, _ string) (string, error) {
+			return "pi_x", nil
+		},
+	}
+	svc := newServiceWithStripeMocks(t, creator, canceller, resolver)
+
+	ctx := tenantCtx("test-tenant")
+	_, err := svc.CancelPayment(ctx, &financialgatewayv1.CancelPaymentRequest{
+		PaymentOrderId: "po-1",
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Canceled, st.Code())
+}
+
+func TestCancelPayment_ContextDeadlineExceeded(t *testing.T) {
+	creator := &mockCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, nil
+		},
+	}
+	canceller := &mockCanceller{
+		cancelFn: func(_ context.Context, _ string, _ *stripego.PaymentIntentCancelParams) (*stripego.PaymentIntent, error) {
+			return nil, context.DeadlineExceeded
+		},
+	}
+	resolver := &mockResolver{
+		findFn: func(_ context.Context, _ string) (string, error) {
+			return "pi_x", nil
+		},
+	}
+	svc := newServiceWithStripeMocks(t, creator, canceller, resolver)
+
+	ctx := tenantCtx("test-tenant")
+	_, err := svc.CancelPayment(ctx, &financialgatewayv1.CancelPaymentRequest{
+		PaymentOrderId: "po-1",
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.DeadlineExceeded, st.Code())
+}
+
+// --- GetProviderHealth full path tests ---
+
+func TestGetProviderHealth_WithTenantContext(t *testing.T) {
+	creator := &mockCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, nil
+		},
+	}
+	svc := newServiceWithStripeMocks(t, creator, nil, nil)
+
+	ctx := tenantCtx("test-tenant")
+	resp, err := svc.GetProviderHealth(ctx, &financialgatewayv1.GetProviderHealthRequest{
+		Rail: financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE, resp.Rail)
+	assert.Equal(t, financialgatewayv1.ProviderHealth_PROVIDER_HEALTH_HEALTHY, resp.Health)
+	assert.Contains(t, resp.Message, "circuit breaker state")
+	assert.NotNil(t, resp.LastCheckedAt)
+}
+
+func TestGetProviderHealth_WithoutTenantContext(t *testing.T) {
+	creator := &mockCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, nil
+		},
+	}
+	svc := newServiceWithStripeMocks(t, creator, nil, nil)
+
+	// No tenant context
+	resp, err := svc.GetProviderHealth(context.Background(), &financialgatewayv1.GetProviderHealthRequest{
+		Rail: financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, financialgatewayv1.ProviderHealth_PROVIDER_HEALTH_UNSPECIFIED, resp.Health)
+	assert.Contains(t, resp.Message, "tenant context required")
+}
+
+// --- Error mapping tests ---
+
+func TestMapClientFactoryError(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		expectedCode codes.Code
+	}{
+		{"ErrMissingTenant", stripeadapter.ErrMissingTenant, codes.FailedPrecondition},
+		{"ErrTenantConfigNotFound", stripeadapter.ErrTenantConfigNotFound, codes.FailedPrecondition},
+		{"ErrCircuitOpen", stripeadapter.ErrCircuitOpen, codes.Unavailable},
+		{"context.Canceled", context.Canceled, codes.Canceled},
+		{"context.DeadlineExceeded", context.DeadlineExceeded, codes.DeadlineExceeded},
+		{"unknown error", errors.New("unknown"), codes.Internal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			grpcErr := mapClientFactoryError(tt.err)
+			st, ok := status.FromError(grpcErr)
+			require.True(t, ok)
+			assert.Equal(t, tt.expectedCode, st.Code())
+		})
+	}
+}
+
+func TestMapCancelError(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		expectedCode codes.Code
+	}{
+		{"ErrCancelNotConfigured", stripeadapter.ErrCancelNotConfigured, codes.Unimplemented},
+		{"ErrPaymentIntentNotFound", stripeadapter.ErrPaymentIntentNotFound, codes.NotFound},
+		{"ErrMissingStripeAccount", stripeadapter.ErrMissingStripeAccount, codes.FailedPrecondition},
+		{"ErrInvalidRequest", stripeadapter.ErrInvalidRequest, codes.FailedPrecondition},
+		{"context.Canceled", context.Canceled, codes.Canceled},
+		{"context.DeadlineExceeded", context.DeadlineExceeded, codes.DeadlineExceeded},
+		{"unknown error", errors.New("stripe API error"), codes.Unavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			grpcErr := mapCancelError(tt.err)
+			st, ok := status.FromError(grpcErr)
+			require.True(t, ok)
+			assert.Equal(t, tt.expectedCode, st.Code())
+		})
+	}
+}
+
+func TestMapStripeError(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		expectedCode codes.Code
+	}{
+		{"ErrMissingStripeAccount", stripeadapter.ErrMissingStripeAccount, codes.FailedPrecondition},
+		{"ErrInvalidRequest", stripeadapter.ErrInvalidRequest, codes.InvalidArgument},
+		{"context.Canceled", context.Canceled, codes.Canceled},
+		{"context.DeadlineExceeded", context.DeadlineExceeded, codes.DeadlineExceeded},
+		{"unknown error", errors.New("stripe API error"), codes.Unavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			grpcErr := mapStripeError(tt.err)
+			st, ok := status.FromError(grpcErr)
+			require.True(t, ok)
+			assert.Equal(t, tt.expectedCode, st.Code())
+		})
+	}
+}
+
+// --- NewFinancialGatewayService ---
+
+func TestNewFinancialGatewayService_NilLogger(t *testing.T) {
+	svc, err := NewFinancialGatewayService(Config{})
+	require.NoError(t, err)
+	assert.NotNil(t, svc)
+}
+
+func TestMapCircuitBreakerHealth_UnknownState(t *testing.T) {
+	result := mapCircuitBreakerHealth(gobreaker.State(99))
+	assert.Equal(t, financialgatewayv1.ProviderHealth_PROVIDER_HEALTH_UNSPECIFIED, result)
+}
+
+// --- DispatchPayment unspecified rail ---
+
+func TestDispatchPayment_UnspecifiedRail(t *testing.T) {
+	svc, err := NewFinancialGatewayService(Config{Logger: slog.Default()})
+	require.NoError(t, err)
+
+	req := &financialgatewayv1.DispatchPaymentRequest{
+		PaymentOrderId: "po-1",
+		Rail:           financialgatewayv1.PaymentRail_PAYMENT_RAIL_UNSPECIFIED,
+	}
+	_, err = svc.DispatchPayment(context.Background(), req)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unimplemented, st.Code())
 }


### PR DESCRIPTION
## Summary
- Adds unhappy path and edge case tests across all financial-gateway packages
- Raises test coverage from 46.5% to 80.1% (target: 80%)
- Per-package: service 100%, stripe 91.6%, http 80.6%, client 92.8%, config 100%, observability 100%, cmd 15%

## Changes
- **service/grpc_service_test.go**: Full rewrite with mock backends — DispatchPayment, CancelPayment, GetProviderHealth happy+unhappy paths, error mapping functions, context cancellation/deadline
- **adapters/stripe/client_test.go**: New — ClientFactory, caching, circuit breaker state, account context, config invalidation
- **adapters/stripe/config_test.go**: New — Config/TenantConfig validation, defaults
- **adapters/http/webhook_handler_test.go**: Added body-too-large, empty secret, missing payment order ID, nil panics
- **client/client_test.go**: New — gRPC client with bufconn, all RPCs success+error, Close, Conn
- **client/starlark_test.go**: Added Starlark handler tests, optional refund fields, client context, handler registration
- **cmd/main_test.go**: New — parseLogLevel, envTenantConfigProvider, createTenantConfigProvider
- **config/config_test.go**: New — LoadConfig defaults
- **observability/metrics_test.go**: New — all metric recording functions including edge cases
- **observability/tracing_test.go**: New — Tracer, StartSpan, RecordError with nil handling

## Test plan
- [x] All tests pass locally: `go test ./services/financial-gateway/... -count=1`
- [x] Coverage verified ≥ 80%: `go tool cover -func` reports 80.1%
- [ ] CI passes