### PR TITLE
test: Payment-order saga failure, domain, ledger & observability tests

### DIFF
--- a/services/payment-order/adapters/persistence/billing_repository_unit_test.go
+++ b/services/payment-order/adapters/persistence/billing_repository_unit_test.go
@@ -1,0 +1,343 @@
+package persistence
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBillingRunToEntity_And_ToDomain(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	run := &domain.BillingRun{
+		ID:            uuid.New(),
+		TenantID:      "tenant-1",
+		CycleStart:    now.Add(-24 * time.Hour),
+		CycleEnd:      now,
+		Status:        domain.BillingRunStatusInitiated,
+		DunningLevel:  2,
+		FailureReason: "some failure",
+		LastRetryAt:   &now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+
+	entity := billingRunToEntity(run)
+	assert.Equal(t, run.ID, entity.ID)
+	assert.Equal(t, "tenant-1", entity.TenantID)
+	assert.Equal(t, string(domain.BillingRunStatusInitiated), entity.Status)
+	assert.Equal(t, 2, entity.DunningLevel)
+	require.NotNil(t, entity.FailureReason)
+	assert.Equal(t, "some failure", *entity.FailureReason)
+
+	back := billingRunToDomain(entity)
+	assert.Equal(t, run.ID, back.ID)
+	assert.Equal(t, run.TenantID, back.TenantID)
+	assert.Equal(t, run.Status, back.Status)
+	assert.Equal(t, run.DunningLevel, back.DunningLevel)
+	assert.Equal(t, run.FailureReason, back.FailureReason)
+}
+
+func TestBillingRunToEntity_NoFailureReason(t *testing.T) {
+	t.Parallel()
+
+	run := &domain.BillingRun{
+		ID:       uuid.New(),
+		TenantID: "tenant-1",
+		Status:   domain.BillingRunStatusCompleted,
+	}
+
+	entity := billingRunToEntity(run)
+	assert.Nil(t, entity.FailureReason)
+
+	back := billingRunToDomain(entity)
+	assert.Empty(t, back.FailureReason)
+}
+
+func TestInvoiceToEntity_And_ToDomain(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	inv := &domain.Invoice{
+		ID:            uuid.New(),
+		BillingRunID:  uuid.New(),
+		PartyID:       "party-1",
+		AccountID:     "acc-1",
+		InvoiceNumber: "INV-001",
+		PeriodStart:   now.Add(-30 * 24 * time.Hour),
+		PeriodEnd:     now,
+		LineItems: []domain.InvoiceLineItem{
+			{Description: "Usage", Quantity: decimal.NewFromInt(1), UnitPriceCents: 1000, TotalCents: 1000},
+		},
+		SubtotalCents:  1000,
+		Currency:       "GBP",
+		Status:         domain.InvoiceStatusDraft,
+		PaymentOrderID: nil,
+		CreatedAt:      now,
+	}
+
+	entity, err := invoiceToEntity(inv)
+	require.NoError(t, err)
+	assert.Equal(t, inv.ID, entity.ID)
+	assert.Equal(t, "party-1", entity.PartyID)
+	assert.Equal(t, "INV-001", entity.InvoiceNumber)
+	assert.Equal(t, int64(1000), entity.SubtotalCents)
+
+	// Verify line items are serialized as JSON
+	var items []domain.InvoiceLineItem
+	require.NoError(t, json.Unmarshal([]byte(entity.LineItems), &items))
+	assert.Len(t, items, 1)
+	assert.Equal(t, "Usage", items[0].Description)
+
+	back, err := invoiceToDomain(entity)
+	require.NoError(t, err)
+	assert.Equal(t, inv.ID, back.ID)
+	assert.Equal(t, inv.PartyID, back.PartyID)
+	assert.Len(t, back.LineItems, 1)
+	assert.Equal(t, int64(1000), back.SubtotalCents)
+}
+
+func TestInvoiceToDomain_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	entity := &InvoiceEntity{
+		ID:        uuid.New(),
+		LineItems: "not-valid-json",
+	}
+
+	_, err := invoiceToDomain(entity)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to unmarshal line items")
+}
+
+func TestIsDuplicateKeyError(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, isDuplicateKeyError(nil))
+	assert.False(t, isDuplicateKeyError(errors.New("some random error")))
+	assert.True(t, isDuplicateKeyError(errors.New("duplicate key value violates unique constraint")))
+	assert.True(t, isDuplicateKeyError(errors.New("SQLSTATE 23505: unique_violation")))
+}
+
+func TestBillingRunEntity_TableName(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "billing_run", BillingRunEntity{}.TableName())
+}
+
+func TestInvoiceEntity_TableName(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "invoice", InvoiceEntity{}.TableName())
+}
+
+func TestSagaExecutionEntity_TableName(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "saga_executions", sagaExecutionEntity{}.TableName())
+}
+
+func TestEncodeDecode_Cursor(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Nanosecond)
+	id := uuid.New()
+	cursor := Cursor{CreatedAt: now, ID: id}
+
+	encoded := EncodeCursor(cursor)
+	assert.NotEmpty(t, encoded)
+
+	decoded, err := DecodeCursor(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, id, decoded.ID)
+	assert.WithinDuration(t, now, decoded.CreatedAt, time.Microsecond)
+}
+
+func TestDecodeCursor_Empty(t *testing.T) {
+	t.Parallel()
+
+	cursor, err := DecodeCursor("")
+	require.NoError(t, err)
+	assert.Equal(t, Cursor{}, cursor)
+}
+
+func TestDecodeCursor_InvalidBase64(t *testing.T) {
+	t.Parallel()
+
+	_, err := DecodeCursor("not-valid-base64!!!")
+	assert.ErrorIs(t, err, ErrInvalidCursor)
+}
+
+func TestDecodeCursor_MalformedContent(t *testing.T) {
+	t.Parallel()
+
+	// Valid base64 but no pipe separator
+	encoded := "bm9waXBl" // "nopipe" in base64
+	_, err := DecodeCursor(encoded)
+	assert.ErrorIs(t, err, ErrInvalidCursor)
+}
+
+func TestDecodeCursor_InvalidTimestamp(t *testing.T) {
+	t.Parallel()
+
+	// base64 of "bad-time|valid-uuid"
+	import_b64 := "YmFkLXRpbWV8MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAw"
+	_, err := DecodeCursor(import_b64)
+	assert.ErrorIs(t, err, ErrInvalidCursor)
+}
+
+func TestDecodeCursor_InvalidUUID(t *testing.T) {
+	t.Parallel()
+
+	// base64 of "2023-01-01T00:00:00Z|not-a-uuid"
+	import_b64 := "MjAyMy0wMS0wMVQwMDowMDowMFp8bm90LWEtdXVpZA=="
+	_, err := DecodeCursor(import_b64)
+	assert.ErrorIs(t, err, ErrInvalidCursor)
+}
+
+// =============================================================================
+// Payment Order toEntity / toDomain mapper tests
+// =============================================================================
+
+func newTestMoney(t *testing.T, currency string, amountCents int64) domain.Money {
+	t.Helper()
+	m, err := domain.NewMoney(currency, amountCents)
+	require.NoError(t, err)
+	return m
+}
+
+func TestToEntity_WithNullableFields(t *testing.T) {
+	t.Parallel()
+
+	po := &domain.PaymentOrder{
+		ID:                  uuid.New(),
+		DebtorAccountID:     "debtor-1",
+		CreditorReference:   "cred-ref",
+		Amount:              newTestMoney(t, "GBP", 1000),
+		Status:              domain.PaymentOrderStatusCompleted,
+		LienID:              "lien-1",
+		LienExecutionStatus: domain.LienExecutionStatusSucceeded,
+		LienExecutionError:  "some error",
+		BucketID:            "bucket-42",
+		PaymentAttributes:   map[string]string{"key": "value"},
+		IdempotencyKey:      "idem-key",
+	}
+
+	entity := toEntity(po)
+	assert.Equal(t, po.ID, entity.ID)
+	assert.Equal(t, "debtor-1", entity.DebtorAccountID)
+	assert.Equal(t, int64(1000), entity.AmountCents)
+	assert.Equal(t, "GBP", entity.Currency)
+	require.NotNil(t, entity.LienExecutionStatus)
+	assert.Equal(t, string(domain.LienExecutionStatusSucceeded), *entity.LienExecutionStatus)
+	require.NotNil(t, entity.LienExecutionError)
+	assert.Equal(t, "some error", *entity.LienExecutionError)
+	require.NotNil(t, entity.BucketID)
+	assert.Equal(t, "bucket-42", *entity.BucketID)
+	require.NotNil(t, entity.PaymentAttributes)
+	assert.Contains(t, *entity.PaymentAttributes, "key")
+}
+
+func TestToEntity_WithoutNullableFields(t *testing.T) {
+	t.Parallel()
+
+	po := &domain.PaymentOrder{
+		ID:              uuid.New(),
+		DebtorAccountID: "debtor-1",
+		Amount:          newTestMoney(t, "GBP", 500),
+		Status:          domain.PaymentOrderStatusInitiated,
+	}
+
+	entity := toEntity(po)
+	assert.Nil(t, entity.LienExecutionStatus)
+	assert.Nil(t, entity.LienExecutionError)
+	assert.Nil(t, entity.BucketID)
+	assert.Nil(t, entity.PaymentAttributes)
+}
+
+func TestToDomain_WithNullableFields(t *testing.T) {
+	t.Parallel()
+
+	lienStatus := string(domain.LienExecutionStatusFailed)
+	lienErr := "connection timeout"
+	bucketID := "bucket-99"
+	attrs := `{"source":"api"}`
+
+	entity := &PaymentOrderEntity{
+		ID:                  uuid.New(),
+		DebtorAccountID:     "debtor-1",
+		CreditorReference:   "cred-ref",
+		AmountCents:         1000,
+		Currency:            "GBP",
+		Status:              "COMPLETED",
+		LienExecutionStatus: &lienStatus,
+		LienExecutionError:  &lienErr,
+		BucketID:            &bucketID,
+		PaymentAttributes:   &attrs,
+		IdempotencyKey:      "key-1",
+	}
+
+	po, err := toDomain(entity)
+	require.NoError(t, err)
+	assert.Equal(t, domain.LienExecutionStatusFailed, po.LienExecutionStatus)
+	assert.Equal(t, "connection timeout", po.LienExecutionError)
+	assert.Equal(t, "bucket-99", po.BucketID)
+	assert.Equal(t, "api", po.PaymentAttributes["source"])
+}
+
+func TestToDomain_WithoutNullableFields(t *testing.T) {
+	t.Parallel()
+
+	entity := &PaymentOrderEntity{
+		ID:              uuid.New(),
+		DebtorAccountID: "debtor-1",
+		AmountCents:     500,
+		Currency:        "GBP",
+		Status:          "INITIATED",
+		IdempotencyKey:  "key-2",
+	}
+
+	po, err := toDomain(entity)
+	require.NoError(t, err)
+	assert.Empty(t, po.LienExecutionStatus)
+	assert.Empty(t, po.LienExecutionError)
+	assert.Empty(t, po.BucketID)
+	assert.Nil(t, po.PaymentAttributes)
+}
+
+func TestToDomain_InvalidPaymentAttributes(t *testing.T) {
+	t.Parallel()
+
+	badJSON := "not-valid-json"
+	entity := &PaymentOrderEntity{
+		ID:                uuid.New(),
+		AmountCents:       100,
+		Currency:          "GBP",
+		Status:            "INITIATED",
+		PaymentAttributes: &badJSON,
+	}
+
+	_, err := toDomain(entity)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to unmarshal payment attributes")
+}
+
+func TestToDomain_InvalidCurrency(t *testing.T) {
+	t.Parallel()
+
+	entity := &PaymentOrderEntity{
+		ID:          uuid.New(),
+		AmountCents: 100,
+		Currency:    "INVALID",
+		Status:      "INITIATED",
+	}
+
+	_, err := toDomain(entity)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create payment order amount")
+}

--- a/services/payment-order/adapters/persistence/billing_repository_unit_test.go
+++ b/services/payment-order/adapters/persistence/billing_repository_unit_test.go
@@ -186,8 +186,8 @@ func TestDecodeCursor_InvalidTimestamp(t *testing.T) {
 	t.Parallel()
 
 	// base64 of "bad-time|valid-uuid"
-	import_b64 := "YmFkLXRpbWV8MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAw"
-	_, err := DecodeCursor(import_b64)
+	importB64 := "YmFkLXRpbWV8MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAw"
+	_, err := DecodeCursor(importB64)
 	assert.ErrorIs(t, err, ErrInvalidCursor)
 }
 
@@ -195,8 +195,8 @@ func TestDecodeCursor_InvalidUUID(t *testing.T) {
 	t.Parallel()
 
 	// base64 of "2023-01-01T00:00:00Z|not-a-uuid"
-	import_b64 := "MjAyMy0wMS0wMVQwMDowMDowMFp8bm90LWEtdXVpZA=="
-	_, err := DecodeCursor(import_b64)
+	importB64 := "MjAyMy0wMS0wMVQwMDowMDowMFp8bm90LWEtdXVpZA=="
+	_, err := DecodeCursor(importB64)
 	assert.ErrorIs(t, err, ErrInvalidCursor)
 }
 

--- a/services/payment-order/domain/payment_order_unhappy_test.go
+++ b/services/payment-order/domain/payment_order_unhappy_test.go
@@ -203,14 +203,7 @@ func TestFailTransition_InvalidFromTerminal(t *testing.T) {
 		t.Run(string(status), func(t *testing.T) {
 			po := &PaymentOrder{Status: status}
 			err := po.Fail("test", "TEST")
-			// Already in terminal — Fail is idempotent for FAILED, error for others
-			if status == PaymentOrderStatusFailed {
-				assert.NoError(t, err)
-			} else {
-				// These are terminal but not FAILED — should either error or be idempotent
-				// depending on implementation
-				_ = err
-			}
+			assert.Error(t, err, "Fail() should error when called on terminal status %s", status)
 		})
 	}
 }

--- a/services/payment-order/domain/payment_order_unhappy_test.go
+++ b/services/payment-order/domain/payment_order_unhappy_test.go
@@ -1,0 +1,314 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		status   PaymentOrderStatus
+		terminal bool
+	}{
+		{PaymentOrderStatusInitiated, false},
+		{PaymentOrderStatusReserved, false},
+		{PaymentOrderStatusExecuting, false},
+		{PaymentOrderStatusCompleted, true},
+		{PaymentOrderStatusFailed, true},
+		{PaymentOrderStatusCancelled, true},
+		{PaymentOrderStatusReversed, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.status), func(t *testing.T) {
+			po := &PaymentOrder{Status: tc.status}
+			assert.Equal(t, tc.terminal, po.IsTerminal())
+		})
+	}
+
+	// Unknown status — defaults to false
+	po := &PaymentOrder{Status: PaymentOrderStatus("UNKNOWN")}
+	assert.False(t, po.IsTerminal())
+}
+
+func TestSetLienExecutionPending(t *testing.T) {
+	t.Parallel()
+
+	po := &PaymentOrder{}
+	po.SetLienExecutionPending()
+
+	assert.Equal(t, LienExecutionStatusPending, po.LienExecutionStatus)
+	assert.False(t, po.UpdatedAt.IsZero())
+}
+
+func TestSetLienExecutionSucceeded(t *testing.T) {
+	t.Parallel()
+
+	po := &PaymentOrder{
+		LienExecutionStatus: LienExecutionStatusPending,
+		LienExecutionError:  "previous error",
+	}
+	po.SetLienExecutionSucceeded()
+
+	assert.Equal(t, LienExecutionStatusSucceeded, po.LienExecutionStatus)
+	assert.Empty(t, po.LienExecutionError)
+	assert.False(t, po.UpdatedAt.IsZero())
+}
+
+func TestSetLienExecutionFailed(t *testing.T) {
+	t.Parallel()
+
+	po := &PaymentOrder{}
+	po.SetLienExecutionFailed("connection timeout")
+
+	assert.Equal(t, LienExecutionStatusFailed, po.LienExecutionStatus)
+	assert.Equal(t, "connection timeout", po.LienExecutionError)
+	assert.False(t, po.UpdatedAt.IsZero())
+}
+
+func TestSetLienExecutionFailed_Truncation(t *testing.T) {
+	t.Parallel()
+
+	longErr := strings.Repeat("x", 2000)
+	po := &PaymentOrder{}
+	po.SetLienExecutionFailed(longErr)
+
+	assert.Equal(t, LienExecutionStatusFailed, po.LienExecutionStatus)
+	assert.LessOrEqual(t, len(po.LienExecutionError), maxLienExecutionErrorLength)
+	assert.True(t, strings.HasSuffix(po.LienExecutionError, "...[truncated]"))
+}
+
+func TestRequiresLienExecution(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		po       PaymentOrder
+		expected bool
+	}{
+		{
+			name:     "completed with lien, not executed",
+			po:       PaymentOrder{Status: PaymentOrderStatusCompleted, LienID: "lien-1", LienExecutionStatus: LienExecutionStatusPending},
+			expected: true,
+		},
+		{
+			name:     "completed with lien, already succeeded",
+			po:       PaymentOrder{Status: PaymentOrderStatusCompleted, LienID: "lien-1", LienExecutionStatus: LienExecutionStatusSucceeded},
+			expected: false,
+		},
+		{
+			name:     "completed with lien, failed",
+			po:       PaymentOrder{Status: PaymentOrderStatusCompleted, LienID: "lien-1", LienExecutionStatus: LienExecutionStatusFailed},
+			expected: true,
+		},
+		{
+			name:     "completed without lien",
+			po:       PaymentOrder{Status: PaymentOrderStatusCompleted, LienID: ""},
+			expected: false,
+		},
+		{
+			name:     "not completed",
+			po:       PaymentOrder{Status: PaymentOrderStatusExecuting, LienID: "lien-1"},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.po.RequiresLienExecution())
+		})
+	}
+}
+
+func TestRequiresLienRelease(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		po       PaymentOrder
+		expected bool
+	}{
+		{
+			name:     "reserved with lien",
+			po:       PaymentOrder{Status: PaymentOrderStatusReserved, LienID: "lien-1"},
+			expected: true,
+		},
+		{
+			name:     "executing with lien",
+			po:       PaymentOrder{Status: PaymentOrderStatusExecuting, LienID: "lien-1"},
+			expected: true,
+		},
+		{
+			name:     "initiated no lien",
+			po:       PaymentOrder{Status: PaymentOrderStatusInitiated, LienID: ""},
+			expected: false,
+		},
+		{
+			name:     "completed with lien",
+			po:       PaymentOrder{Status: PaymentOrderStatusCompleted, LienID: "lien-1"},
+			expected: false,
+		},
+		{
+			name:     "reserved without lien",
+			po:       PaymentOrder{Status: PaymentOrderStatusReserved, LienID: ""},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.po.RequiresLienRelease())
+		})
+	}
+}
+
+func TestCanCancel(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, (&PaymentOrder{Status: PaymentOrderStatusInitiated}).CanCancel())
+	assert.True(t, (&PaymentOrder{Status: PaymentOrderStatusReserved}).CanCancel())
+	assert.False(t, (&PaymentOrder{Status: PaymentOrderStatusExecuting}).CanCancel())
+	assert.False(t, (&PaymentOrder{Status: PaymentOrderStatusCompleted}).CanCancel())
+	assert.False(t, (&PaymentOrder{Status: PaymentOrderStatusFailed}).CanCancel())
+	assert.False(t, (&PaymentOrder{Status: PaymentOrderStatusCancelled}).CanCancel())
+	assert.False(t, (&PaymentOrder{Status: PaymentOrderStatusReversed}).CanCancel())
+}
+
+func TestCanReverse(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, (&PaymentOrder{Status: PaymentOrderStatusInitiated}).CanReverse())
+	assert.False(t, (&PaymentOrder{Status: PaymentOrderStatusReserved}).CanReverse())
+	assert.False(t, (&PaymentOrder{Status: PaymentOrderStatusExecuting}).CanReverse())
+	assert.True(t, (&PaymentOrder{Status: PaymentOrderStatusCompleted}).CanReverse())
+	assert.False(t, (&PaymentOrder{Status: PaymentOrderStatusFailed}).CanReverse())
+	assert.False(t, (&PaymentOrder{Status: PaymentOrderStatusCancelled}).CanReverse())
+	assert.False(t, (&PaymentOrder{Status: PaymentOrderStatusReversed}).CanReverse())
+}
+
+func TestFailTransition_InvalidFromTerminal(t *testing.T) {
+	t.Parallel()
+
+	terminalStatuses := []PaymentOrderStatus{
+		PaymentOrderStatusCompleted,
+		PaymentOrderStatusCancelled,
+		PaymentOrderStatusReversed,
+	}
+
+	for _, status := range terminalStatuses {
+		t.Run(string(status), func(t *testing.T) {
+			po := &PaymentOrder{Status: status}
+			err := po.Fail("test", "TEST")
+			// Already in terminal — Fail is idempotent for FAILED, error for others
+			if status == PaymentOrderStatusFailed {
+				assert.NoError(t, err)
+			} else {
+				// These are terminal but not FAILED — should either error or be idempotent
+				// depending on implementation
+				_ = err
+			}
+		})
+	}
+}
+
+func TestCancelTransition_FromReserved(t *testing.T) {
+	t.Parallel()
+
+	po := &PaymentOrder{Status: PaymentOrderStatusReserved, LienID: "lien-cancel-test"}
+	err := po.Cancel("user cancelled")
+
+	assert.NoError(t, err)
+	assert.Equal(t, PaymentOrderStatusCancelled, po.Status)
+	assert.Equal(t, "user cancelled", po.FailureReason)
+}
+
+func TestCancelTransition_FromExecuting_Fails(t *testing.T) {
+	t.Parallel()
+
+	po := &PaymentOrder{Status: PaymentOrderStatusExecuting}
+	err := po.Cancel("too late")
+
+	assert.Error(t, err)
+	assert.Equal(t, PaymentOrderStatusExecuting, po.Status)
+}
+
+func TestReverseTransition_FromNonCompleted_Fails(t *testing.T) {
+	t.Parallel()
+
+	statuses := []PaymentOrderStatus{
+		PaymentOrderStatusInitiated,
+		PaymentOrderStatusReserved,
+		PaymentOrderStatusExecuting,
+		PaymentOrderStatusFailed,
+		PaymentOrderStatusCancelled,
+	}
+
+	for _, status := range statuses {
+		t.Run(string(status), func(t *testing.T) {
+			po := &PaymentOrder{Status: status}
+			err := po.Reverse("test reason")
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestReserveTransition_FromNonInitiated_Fails(t *testing.T) {
+	t.Parallel()
+
+	statuses := []PaymentOrderStatus{
+		PaymentOrderStatusReserved,
+		PaymentOrderStatusExecuting,
+		PaymentOrderStatusCompleted,
+		PaymentOrderStatusFailed,
+	}
+
+	for _, status := range statuses {
+		t.Run(string(status), func(t *testing.T) {
+			po := &PaymentOrder{Status: status}
+			err := po.Reserve("lien-invalid")
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestExecuteTransition_FromNonReserved_Fails(t *testing.T) {
+	t.Parallel()
+
+	statuses := []PaymentOrderStatus{
+		PaymentOrderStatusInitiated,
+		PaymentOrderStatusExecuting,
+		PaymentOrderStatusCompleted,
+		PaymentOrderStatusFailed,
+	}
+
+	for _, status := range statuses {
+		t.Run(string(status), func(t *testing.T) {
+			po := &PaymentOrder{Status: status}
+			err := po.Execute("gw-ref")
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestCompleteTransition_FromNonExecuting_Fails(t *testing.T) {
+	t.Parallel()
+
+	statuses := []PaymentOrderStatus{
+		PaymentOrderStatusInitiated,
+		PaymentOrderStatusReserved,
+		PaymentOrderStatusCompleted,
+		PaymentOrderStatusFailed,
+	}
+
+	for _, status := range statuses {
+		t.Run(string(status), func(t *testing.T) {
+			po := &PaymentOrder{Status: status}
+			err := po.Complete("booking-id")
+			assert.Error(t, err)
+		})
+	}
+}

--- a/services/payment-order/observability/metrics_test.go
+++ b/services/payment-order/observability/metrics_test.go
@@ -381,3 +381,97 @@ func TestMetricsLabels(t *testing.T) {
 		})
 	}
 }
+
+// =============================================================================
+// Tests for previously uncovered metric functions
+// =============================================================================
+
+func TestSetNoopIdempotencyActive(t *testing.T) {
+	SetNoopIdempotencyActive(true)
+	count := testutil.CollectAndCount(noopIdempotencyActive)
+	if count == 0 {
+		t.Error("Expected noop idempotency active metric to be recorded")
+	}
+
+	SetNoopIdempotencyActive(false)
+	count = testutil.CollectAndCount(noopIdempotencyActive)
+	if count == 0 {
+		t.Error("Expected noop idempotency active metric to be recorded after deactivation")
+	}
+}
+
+func TestRecordServiceDegradation(t *testing.T) {
+	serviceDegradationEvents.Reset()
+
+	RecordServiceDegradation("idempotency", "noop_fallback")
+
+	count := testutil.CollectAndCount(serviceDegradationEvents)
+	if count == 0 {
+		t.Error("Expected service degradation metric to be recorded")
+	}
+}
+
+func TestRecordLienExecutionStatusUpdateExhausted(t *testing.T) {
+	RecordLienExecutionStatusUpdateExhausted()
+
+	count := testutil.CollectAndCount(lienExecutionStatusUpdateExhausted)
+	if count == 0 {
+		t.Error("Expected lien execution status update exhausted metric to be recorded")
+	}
+}
+
+func TestRecordClearingAccountCacheHit(t *testing.T) {
+	RecordClearingAccountCacheHit()
+
+	count := testutil.CollectAndCount(clearingAccountCacheHits)
+	if count == 0 {
+		t.Error("Expected clearing account cache hit metric to be recorded")
+	}
+}
+
+func TestRecordClearingAccountCacheMiss(t *testing.T) {
+	RecordClearingAccountCacheMiss()
+
+	count := testutil.CollectAndCount(clearingAccountCacheMisses)
+	if count == 0 {
+		t.Error("Expected clearing account cache miss metric to be recorded")
+	}
+}
+
+func TestRecordClearingAccountLookupDuration(t *testing.T) {
+	RecordClearingAccountLookupDuration(100 * time.Millisecond)
+
+	count := testutil.CollectAndCount(clearingAccountLookupDuration)
+	if count == 0 {
+		t.Error("Expected clearing account lookup duration metric to be recorded")
+	}
+}
+
+func TestRecordClearingAccountLookupError(t *testing.T) {
+	clearingAccountLookupErrors.Reset()
+
+	RecordClearingAccountLookupError("settlement")
+
+	count := testutil.CollectAndCount(clearingAccountLookupErrors)
+	if count == 0 {
+		t.Error("Expected clearing account lookup error metric to be recorded")
+	}
+}
+
+func TestRecordLienExecutionLockContention(t *testing.T) {
+	RecordLienExecutionLockContention()
+
+	count := testutil.CollectAndCount(lienExecutionLockContentions)
+	if count == 0 {
+		t.Error("Expected lien execution lock contention metric to be recorded")
+	}
+}
+
+func TestRecordLienExecutionLockWaitDuration(t *testing.T) {
+	RecordLienExecutionLockWaitDuration(0.5)
+
+	count := testutil.CollectAndCount(lienExecutionLockWaitDuration)
+	if count == 0 {
+		t.Error("Expected lien execution lock wait duration metric to be recorded")
+	}
+}

--- a/services/payment-order/service/grpc_coverage_test.go
+++ b/services/payment-order/service/grpc_coverage_test.go
@@ -1,0 +1,285 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/google/uuid"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
+	"github.com/meridianhub/meridian/services/payment-order/config"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"github.com/meridianhub/meridian/services/payment-order/domain/testfixtures"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// LockClient
+// =============================================================================
+
+func TestLockNotObtainedError(t *testing.T) {
+	t.Parallel()
+
+	err := LockNotObtainedError{}
+	assert.Equal(t, "lock not obtained: already held by another process", err.Error())
+
+	assert.True(t, IsLockNotObtained(LockNotObtainedError{}))
+	assert.False(t, IsLockNotObtained(errors.New("other error")))
+	assert.False(t, IsLockNotObtained(nil))
+}
+
+// =============================================================================
+// grpc_mappers — mapLienExecutionStatusToProto, safeIntToInt32, extractGatewayIDFromRef
+// =============================================================================
+
+func TestMapLienExecutionStatusToProto(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    domain.LienExecutionStatus
+		expected pb.LienExecutionStatus
+	}{
+		{domain.LienExecutionStatusUnspecified, pb.LienExecutionStatus_LIEN_EXECUTION_STATUS_UNSPECIFIED},
+		{domain.LienExecutionStatusPending, pb.LienExecutionStatus_LIEN_EXECUTION_STATUS_PENDING},
+		{domain.LienExecutionStatusSucceeded, pb.LienExecutionStatus_LIEN_EXECUTION_STATUS_SUCCEEDED},
+		{domain.LienExecutionStatusFailed, pb.LienExecutionStatus_LIEN_EXECUTION_STATUS_FAILED},
+		{domain.LienExecutionStatus("INVALID"), pb.LienExecutionStatus_LIEN_EXECUTION_STATUS_UNSPECIFIED},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.input), func(t *testing.T) {
+			assert.Equal(t, tc.expected, mapLienExecutionStatusToProto(tc.input))
+		})
+	}
+}
+
+func TestSafeIntToInt32(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, int32(0), safeIntToInt32(0))
+	assert.Equal(t, int32(42), safeIntToInt32(42))
+	assert.Equal(t, int32(-1), safeIntToInt32(-1))
+	assert.Equal(t, int32(math.MaxInt32), safeIntToInt32(math.MaxInt32))
+	assert.Equal(t, int32(math.MaxInt32), safeIntToInt32(math.MaxInt32+1)) // overflow
+	assert.Equal(t, int32(math.MinInt32), safeIntToInt32(math.MinInt32))
+	assert.Equal(t, int32(math.MinInt32), safeIntToInt32(math.MinInt32-1)) // underflow
+}
+
+func TestExtractGatewayIDFromRef_AllPatterns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"", "unknown"},
+		{"GW-abc123", "mock"},
+		{"gateway-ref-456", "mock"},
+		{"stripe-pm_1234", "stripe"},
+		{"adyen-PSP-REF", "adyen"},
+		{"STRIPE-pi_abc", "stripe"},
+		{"nodash", "nodash"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			assert.Equal(t, tc.expected, extractGatewayIDFromRef(tc.input))
+		})
+	}
+}
+
+// =============================================================================
+// CancelPaymentOrder — additional edge cases
+// =============================================================================
+
+func TestCancelPaymentOrder_InvalidID(t *testing.T) {
+	t.Parallel()
+
+	s := newTestServiceWithMocks(t)
+
+	_, err := s.CancelPaymentOrder(context.Background(), &pb.CancelPaymentOrderRequest{
+		PaymentOrderId:     "not-a-uuid",
+		CancellationReason: "test",
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid payment order ID")
+}
+
+func TestCancelPaymentOrder_NotFound(t *testing.T) {
+	t.Parallel()
+
+	s := newTestServiceWithMocks(t)
+
+	_, err := s.CancelPaymentOrder(context.Background(), &pb.CancelPaymentOrderRequest{
+		PaymentOrderId:     uuid.New().String(),
+		CancellationReason: "test",
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "payment order not found")
+}
+
+func TestCancelPaymentOrder_LienTerminationFailure_ContinuesSuccessfully(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockRepository()
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusReserved,
+		testfixtures.WithLienID("lien-fail"),
+	)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	s := newTestServiceWithMocksAndRepo(t, repo, &testMockClients{
+		terminateLienErr: errors.New("lien service down"),
+	})
+
+	resp, err := s.CancelPaymentOrder(context.Background(), &pb.CancelPaymentOrderRequest{
+		PaymentOrderId:     po.ID.String(),
+		CancellationReason: "user requested",
+		CancelledBy:        "user@example.com",
+	})
+
+	// Cancellation succeeds even if lien termination fails
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_CANCELLED, resp.PaymentOrder.Status)
+}
+
+// =============================================================================
+// Service failPaymentOrder — with ledger reversal
+// =============================================================================
+
+func TestServiceFailPaymentOrder_WithLedgerBookingID(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockRepository()
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusExecuting,
+		testfixtures.WithLienID("lien-exec"),
+		testfixtures.WithLedgerBookingID("booking-123"),
+		testfixtures.WithGatewayReferenceID("GW-ref"),
+	)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	s := newTestServiceWithMocksAndRepo(t, repo, &testMockClients{
+		hasFA: true,
+	})
+
+	err := s.failPaymentOrder(context.Background(), po, "gateway timeout", "GATEWAY_TIMEOUT")
+	require.NoError(t, err)
+
+	updated, findErr := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, findErr)
+	assert.Equal(t, domain.PaymentOrderStatusFailed, updated.Status)
+}
+
+func TestServiceFailPaymentOrder_NoLedgerBooking(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockRepository()
+	po := testfixtures.NewPaymentOrder(t)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	s := newTestServiceWithMocksAndRepo(t, repo, &testMockClients{})
+
+	err := s.failPaymentOrder(context.Background(), po, "test failure", "TEST")
+	require.NoError(t, err)
+
+	updated, findErr := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, findErr)
+	assert.Equal(t, domain.PaymentOrderStatusFailed, updated.Status)
+}
+
+// =============================================================================
+// handlePendingStatus — edge cases
+// =============================================================================
+
+func TestHandlePendingStatus_NonExecutingState(t *testing.T) {
+	t.Parallel()
+
+	s := newTestServiceWithMocks(t)
+
+	statuses := []domain.PaymentOrderStatus{
+		domain.PaymentOrderStatusInitiated,
+		domain.PaymentOrderStatusReserved,
+		domain.PaymentOrderStatusCompleted,
+		domain.PaymentOrderStatusFailed,
+	}
+
+	for _, status := range statuses {
+		t.Run(string(status), func(t *testing.T) {
+			po := &domain.PaymentOrder{Status: status}
+			err := s.handlePendingStatus(po, "gw-ref")
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "cannot process PENDING callback")
+		})
+	}
+}
+
+func TestHandlePendingStatus_ExecutingState_Success(t *testing.T) {
+	t.Parallel()
+
+	s := newTestServiceWithMocks(t)
+
+	po := &domain.PaymentOrder{
+		Status: domain.PaymentOrderStatusExecuting,
+	}
+	err := s.handlePendingStatus(po, "gw-ref")
+	assert.NoError(t, err)
+}
+
+// =============================================================================
+// publishEvent — nil publisher
+// =============================================================================
+
+func TestPublishEvent_NilPublisher(t *testing.T) {
+	t.Parallel()
+
+	s := newTestServiceWithMocks(t)
+	s.kafkaPublisher = nil
+
+	// Should not panic
+	s.publishEvent(context.Background(), "topic", "key", nil)
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+type testMockClients struct {
+	terminateLienErr error
+	hasFA            bool
+}
+
+func newTestServiceWithMocks(t *testing.T) *Service {
+	t.Helper()
+	return newTestServiceWithMocksAndRepo(t, NewMockRepository(), &testMockClients{})
+}
+
+func newTestServiceWithMocksAndRepo(t *testing.T, repo *MockRepository, clients *testMockClients) *Service {
+	t.Helper()
+
+	mockCA := &MockCurrentAccountClient{
+		terminateLienErr: clients.terminateLienErr,
+	}
+
+	var fa FinancialAccountingClient
+	if clients.hasFA {
+		fa = &MockFinancialAccountingClient{}
+	}
+
+	var gwConfig *config.GatewayAccountConfig
+	if clients.hasFA {
+		gwConfig = testGatewayAccountConfig()
+	}
+
+	orchestrator := testOrchestrator(repo, mockCA, fa, gwConfig)
+
+	s, err := NewService(repo, NewMockIdempotencyService())
+	require.NoError(t, err)
+	s.orchestrator = orchestrator
+	s.currentAccountClient = mockCA
+	s.logger = testLogger()
+	return s
+}

--- a/services/payment-order/service/ledger_coverage_test.go
+++ b/services/payment-order/service/ledger_coverage_test.go
@@ -82,12 +82,12 @@ func ledgerTestOrchestrator(t *testing.T, faClient *MockFinancialAccountingClien
 	gwConfig := testGatewayAccountConfig()
 
 	orchestrator, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
-		Logger:                   testLogger(),
-		Repo:                     repo,
+		Logger:                    testLogger(),
+		Repo:                      repo,
 		FinancialAccountingClient: faClient,
-		GatewayAccountConfig:     gwConfig,
-		CurrentAccountClient:     &MockCurrentAccountClient{},
-		PaymentGateway:           &MockPaymentGateway{},
+		GatewayAccountConfig:      gwConfig,
+		CurrentAccountClient:      &MockCurrentAccountClient{},
+		PaymentGateway:            &MockPaymentGateway{},
 	})
 	require.NoError(t, err)
 	return orchestrator

--- a/services/payment-order/service/ledger_coverage_test.go
+++ b/services/payment-order/service/ledger_coverage_test.go
@@ -1,0 +1,569 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
+	internalaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_account/v1"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"github.com/meridianhub/meridian/services/payment-order/domain/testfixtures"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// clearingMockInternalAccountClient returns a mock that provides a valid clearing account.
+func clearingMockInternalAccountClient() *mockInternalAccountClient {
+	return &mockInternalAccountClient{
+		listResponse: &internalaccountv1.ListInternalAccountsResponse{
+			Facilities: []*internalaccountv1.InternalAccountFacility{
+				{
+					AccountId:       "clearing-acc-001",
+					AccountCode:     "CLR-GBP-SETTLEMENT",
+					Name:            "GBP Settlement Clearing",
+					ClearingPurpose: internalaccountv1.ClearingPurpose_CLEARING_PURPOSE_SETTLEMENT,
+				},
+			},
+		},
+	}
+}
+
+// =============================================================================
+// extractInt64Param
+// =============================================================================
+
+func TestExtractInt64Param_Int64(t *testing.T) {
+	t.Parallel()
+	params := map[string]any{"key": int64(42)}
+	v, err := extractInt64Param(params, "key")
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), v)
+}
+
+func TestExtractInt64Param_Int(t *testing.T) {
+	t.Parallel()
+	params := map[string]any{"key": 42}
+	v, err := extractInt64Param(params, "key")
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), v)
+}
+
+func TestExtractInt64Param_Float64(t *testing.T) {
+	t.Parallel()
+	params := map[string]any{"key": float64(42.9)}
+	v, err := extractInt64Param(params, "key")
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), v)
+}
+
+func TestExtractInt64Param_MissingKey(t *testing.T) {
+	t.Parallel()
+	params := map[string]any{}
+	_, err := extractInt64Param(params, "key")
+	assert.ErrorIs(t, err, ErrParamKeyNotFound)
+}
+
+func TestExtractInt64Param_InvalidType(t *testing.T) {
+	t.Parallel()
+	params := map[string]any{"key": "not-a-number"}
+	_, err := extractInt64Param(params, "key")
+	assert.ErrorIs(t, err, ErrParamInvalidType)
+}
+
+// =============================================================================
+// PostLedgerEntriesFromParams
+// =============================================================================
+
+func ledgerTestOrchestrator(t *testing.T, faClient *MockFinancialAccountingClient) *PaymentOrchestrator {
+	t.Helper()
+	repo := NewMockRepository()
+	gwConfig := testGatewayAccountConfig()
+
+	orchestrator, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+		Logger:                   testLogger(),
+		Repo:                     repo,
+		FinancialAccountingClient: faClient,
+		GatewayAccountConfig:     gwConfig,
+		CurrentAccountClient:     &MockCurrentAccountClient{},
+		PaymentGateway:           &MockPaymentGateway{},
+	})
+	require.NoError(t, err)
+	return orchestrator
+}
+
+func TestPostLedgerEntriesFromParams_Success(t *testing.T) {
+	t.Parallel()
+
+	fa := &MockFinancialAccountingClient{}
+	o := ledgerTestOrchestrator(t, fa)
+
+	poID := uuid.New()
+	params := map[string]any{
+		"payment_order_id":     poID.String(),
+		"debtor_account_id":    "acc-123",
+		"gateway_reference_id": "GW-ref-456",
+		"amount_cents":         int64(1000),
+		"currency":             "GBP",
+		"idempotency_key":      "idem-key-1",
+	}
+
+	bookingID, err := o.PostLedgerEntriesFromParams(context.Background(), params)
+	require.NoError(t, err)
+	assert.NotEmpty(t, bookingID)
+	assert.True(t, fa.initiateCalled)
+	assert.True(t, fa.captureCalled)
+	assert.True(t, fa.updateCalled)
+}
+
+func TestPostLedgerEntriesFromParams_MissingPaymentOrderID(t *testing.T) {
+	t.Parallel()
+	fa := &MockFinancialAccountingClient{}
+	o := ledgerTestOrchestrator(t, fa)
+
+	params := map[string]any{
+		"debtor_account_id":    "acc-123",
+		"gateway_reference_id": "GW-ref",
+		"amount_cents":         int64(1000),
+		"currency":             "GBP",
+		"idempotency_key":      "key",
+	}
+
+	_, err := o.PostLedgerEntriesFromParams(context.Background(), params)
+	assert.ErrorIs(t, err, ErrMissingPaymentOrderID)
+}
+
+func TestPostLedgerEntriesFromParams_InvalidPaymentOrderID(t *testing.T) {
+	t.Parallel()
+	fa := &MockFinancialAccountingClient{}
+	o := ledgerTestOrchestrator(t, fa)
+
+	params := map[string]any{
+		"payment_order_id":     "not-a-uuid",
+		"debtor_account_id":    "acc-123",
+		"gateway_reference_id": "GW-ref",
+		"amount_cents":         int64(1000),
+		"currency":             "GBP",
+		"idempotency_key":      "key",
+	}
+
+	_, err := o.PostLedgerEntriesFromParams(context.Background(), params)
+	assert.ErrorIs(t, err, ErrMissingPaymentOrderID)
+}
+
+func TestPostLedgerEntriesFromParams_MissingDebtorAccountID(t *testing.T) {
+	t.Parallel()
+	fa := &MockFinancialAccountingClient{}
+	o := ledgerTestOrchestrator(t, fa)
+
+	params := map[string]any{
+		"payment_order_id":     uuid.New().String(),
+		"gateway_reference_id": "GW-ref",
+		"amount_cents":         int64(1000),
+		"currency":             "GBP",
+		"idempotency_key":      "key",
+	}
+
+	_, err := o.PostLedgerEntriesFromParams(context.Background(), params)
+	assert.ErrorIs(t, err, ErrMissingDebtorAccountID)
+}
+
+func TestPostLedgerEntriesFromParams_MissingGatewayReferenceID(t *testing.T) {
+	t.Parallel()
+	fa := &MockFinancialAccountingClient{}
+	o := ledgerTestOrchestrator(t, fa)
+
+	params := map[string]any{
+		"payment_order_id":  uuid.New().String(),
+		"debtor_account_id": "acc-123",
+		"amount_cents":      int64(1000),
+		"currency":          "GBP",
+		"idempotency_key":   "key",
+	}
+
+	_, err := o.PostLedgerEntriesFromParams(context.Background(), params)
+	assert.ErrorIs(t, err, ErrMissingGatewayReferenceID)
+}
+
+func TestPostLedgerEntriesFromParams_MissingAmountCents(t *testing.T) {
+	t.Parallel()
+	fa := &MockFinancialAccountingClient{}
+	o := ledgerTestOrchestrator(t, fa)
+
+	params := map[string]any{
+		"payment_order_id":     uuid.New().String(),
+		"debtor_account_id":    "acc-123",
+		"gateway_reference_id": "GW-ref",
+		"currency":             "GBP",
+		"idempotency_key":      "key",
+	}
+
+	_, err := o.PostLedgerEntriesFromParams(context.Background(), params)
+	assert.ErrorIs(t, err, ErrMissingAmountCents)
+}
+
+func TestPostLedgerEntriesFromParams_MissingCurrency(t *testing.T) {
+	t.Parallel()
+	fa := &MockFinancialAccountingClient{}
+	o := ledgerTestOrchestrator(t, fa)
+
+	params := map[string]any{
+		"payment_order_id":     uuid.New().String(),
+		"debtor_account_id":    "acc-123",
+		"gateway_reference_id": "GW-ref",
+		"amount_cents":         int64(1000),
+		"idempotency_key":      "key",
+	}
+
+	_, err := o.PostLedgerEntriesFromParams(context.Background(), params)
+	assert.ErrorIs(t, err, ErrMissingCurrency)
+}
+
+func TestPostLedgerEntriesFromParams_MissingIdempotencyKey(t *testing.T) {
+	t.Parallel()
+	fa := &MockFinancialAccountingClient{}
+	o := ledgerTestOrchestrator(t, fa)
+
+	params := map[string]any{
+		"payment_order_id":     uuid.New().String(),
+		"debtor_account_id":    "acc-123",
+		"gateway_reference_id": "GW-ref",
+		"amount_cents":         int64(1000),
+		"currency":             "GBP",
+	}
+
+	_, err := o.PostLedgerEntriesFromParams(context.Background(), params)
+	assert.ErrorIs(t, err, ErrMissingIdempotencyKey)
+}
+
+// =============================================================================
+// PostLedgerEntries — error paths
+// =============================================================================
+
+func TestPostLedgerEntries_NilGatewayAccountConfig(t *testing.T) {
+	t.Parallel()
+	fa := &MockFinancialAccountingClient{}
+
+	o, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+		Logger:                    testLogger(),
+		Repo:                      NewMockRepository(),
+		FinancialAccountingClient: fa,
+		CurrentAccountClient:      &MockCurrentAccountClient{},
+		PaymentGateway:            &MockPaymentGateway{},
+	})
+	require.NoError(t, err)
+
+	po := testfixtures.NewPaymentOrder(t)
+	_, postErr := o.PostLedgerEntries(context.Background(), po)
+	assert.ErrorIs(t, postErr, ErrGatewayAccountConfigNotSet)
+}
+
+func TestPostLedgerEntries_NilFAClient(t *testing.T) {
+	t.Parallel()
+
+	o, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+		Logger:               testLogger(),
+		Repo:                 NewMockRepository(),
+		GatewayAccountConfig: testGatewayAccountConfig(),
+		CurrentAccountClient: &MockCurrentAccountClient{},
+		PaymentGateway:       &MockPaymentGateway{},
+	})
+	require.NoError(t, err)
+
+	po := testfixtures.NewPaymentOrder(t)
+	_, postErr := o.PostLedgerEntries(context.Background(), po)
+	assert.ErrorIs(t, postErr, ErrFinancialAccountingClientNotSet)
+}
+
+func TestPostLedgerEntries_InitiateBookingLogFails(t *testing.T) {
+	t.Parallel()
+
+	fa := &MockFinancialAccountingClient{
+		initiateErr: errors.New("fa service down"),
+	}
+	o := ledgerTestOrchestrator(t, fa)
+
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusExecuting,
+		testfixtures.WithGatewayReferenceID("GW-ref-123"),
+	)
+
+	_, err := o.PostLedgerEntries(context.Background(), po)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create booking log")
+}
+
+func TestPostLedgerEntries_NilBookingLogResponse(t *testing.T) {
+	t.Parallel()
+
+	fa := &MockFinancialAccountingClient{
+		initiateResp: &financialaccountingv1.InitiateFinancialBookingLogResponse{
+			FinancialBookingLog: nil,
+		},
+	}
+	o := ledgerTestOrchestrator(t, fa)
+
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusExecuting,
+		testfixtures.WithGatewayReferenceID("GW-ref-123"),
+	)
+
+	_, err := o.PostLedgerEntries(context.Background(), po)
+	assert.ErrorIs(t, err, ErrNilBookingLogResponse)
+}
+
+func TestPostLedgerEntries_DebitPostingFails(t *testing.T) {
+	t.Parallel()
+
+	fa := &MockFinancialAccountingClient{
+		captureErr:       errors.New("debit posting failed"),
+		captureErrOnCall: 1, // fail on first capture (debit)
+	}
+	o := ledgerTestOrchestrator(t, fa)
+
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusExecuting,
+		testfixtures.WithGatewayReferenceID("GW-ref-123"),
+	)
+
+	_, err := o.PostLedgerEntries(context.Background(), po)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create debit posting")
+}
+
+func TestPostLedgerEntries_CreditPostingFails(t *testing.T) {
+	t.Parallel()
+
+	fa := &MockFinancialAccountingClient{
+		captureErr:       errors.New("credit posting failed"),
+		captureErrOnCall: 2, // fail on second capture (credit)
+	}
+	o := ledgerTestOrchestrator(t, fa)
+
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusExecuting,
+		testfixtures.WithGatewayReferenceID("GW-ref-123"),
+	)
+
+	_, err := o.PostLedgerEntries(context.Background(), po)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create credit posting")
+}
+
+func TestPostLedgerEntries_UpdateBookingLogFails(t *testing.T) {
+	t.Parallel()
+
+	fa := &MockFinancialAccountingClient{
+		updateErr: errors.New("status update failed"),
+	}
+	o := ledgerTestOrchestrator(t, fa)
+
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusExecuting,
+		testfixtures.WithGatewayReferenceID("GW-ref-123"),
+	)
+
+	_, err := o.PostLedgerEntries(context.Background(), po)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update booking log to POSTED")
+}
+
+func TestPostLedgerEntries_StandardFlowSuccess(t *testing.T) {
+	t.Parallel()
+
+	fa := &MockFinancialAccountingClient{}
+	o := ledgerTestOrchestrator(t, fa)
+
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusExecuting,
+		testfixtures.WithGatewayReferenceID("GW-ref-123"),
+	)
+
+	bookingID, err := o.PostLedgerEntries(context.Background(), po)
+	require.NoError(t, err)
+	assert.NotEmpty(t, bookingID)
+	assert.Equal(t, 2, fa.captureCallCount) // debit + credit
+	assert.True(t, fa.updateCalled)
+}
+
+// =============================================================================
+// PostLedgerEntries — clearing flow
+// =============================================================================
+
+func TestPostLedgerEntries_ClearingFlowSuccess(t *testing.T) {
+	t.Parallel()
+
+	fa := &MockFinancialAccountingClient{}
+	repo := NewMockRepository()
+	gwConfig := testGatewayAccountConfig()
+
+	// Create orchestrator with internal clearing enabled and a mock account resolver
+	o, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+		Logger:                    testLogger(),
+		Repo:                      repo,
+		FinancialAccountingClient: fa,
+		GatewayAccountConfig:      gwConfig,
+		CurrentAccountClient:      &MockCurrentAccountClient{},
+		PaymentGateway:            &MockPaymentGateway{},
+		InternalClearingEnabled:   true,
+		InternalAccountClient:     clearingMockInternalAccountClient(),
+	})
+	require.NoError(t, err)
+
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusExecuting,
+		testfixtures.WithGatewayReferenceID("GW-ref-123"),
+	)
+
+	bookingID, postErr := o.PostLedgerEntries(context.Background(), po)
+	require.NoError(t, postErr)
+	assert.NotEmpty(t, bookingID)
+	assert.Equal(t, 4, fa.captureCallCount) // debit customer + credit clearing + debit clearing + credit gateway
+	assert.True(t, fa.updateCalled)
+}
+
+func TestPostLedgerEntries_ClearingFlowCreditClearingFails(t *testing.T) {
+	t.Parallel()
+
+	fa := &MockFinancialAccountingClient{
+		captureErr:       errors.New("clearing credit failed"),
+		captureErrOnCall: 2, // second capture is the clearing credit
+	}
+	repo := NewMockRepository()
+	gwConfig := testGatewayAccountConfig()
+
+	o, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+		Logger:                    testLogger(),
+		Repo:                      repo,
+		FinancialAccountingClient: fa,
+		GatewayAccountConfig:      gwConfig,
+		CurrentAccountClient:      &MockCurrentAccountClient{},
+		PaymentGateway:            &MockPaymentGateway{},
+		InternalClearingEnabled:   true,
+		InternalAccountClient:     clearingMockInternalAccountClient(),
+	})
+	require.NoError(t, err)
+
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusExecuting,
+		testfixtures.WithGatewayReferenceID("GW-ref-123"),
+	)
+
+	_, postErr := o.PostLedgerEntries(context.Background(), po)
+	assert.Error(t, postErr)
+	assert.Contains(t, postErr.Error(), "failed to create credit posting for clearing account")
+}
+
+func TestPostLedgerEntries_ClearingFlowDebitClearingFails(t *testing.T) {
+	t.Parallel()
+
+	fa := &MockFinancialAccountingClient{
+		captureErr:       errors.New("clearing debit failed"),
+		captureErrOnCall: 3, // third capture is the clearing debit
+	}
+	repo := NewMockRepository()
+	gwConfig := testGatewayAccountConfig()
+
+	o, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+		Logger:                    testLogger(),
+		Repo:                      repo,
+		FinancialAccountingClient: fa,
+		GatewayAccountConfig:      gwConfig,
+		CurrentAccountClient:      &MockCurrentAccountClient{},
+		PaymentGateway:            &MockPaymentGateway{},
+		InternalClearingEnabled:   true,
+		InternalAccountClient:     clearingMockInternalAccountClient(),
+	})
+	require.NoError(t, err)
+
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusExecuting,
+		testfixtures.WithGatewayReferenceID("GW-ref-123"),
+	)
+
+	_, postErr := o.PostLedgerEntries(context.Background(), po)
+	assert.Error(t, postErr)
+	assert.Contains(t, postErr.Error(), "failed to create debit posting for clearing account")
+}
+
+func TestPostLedgerEntries_ClearingFlowGatewayCreditFails(t *testing.T) {
+	t.Parallel()
+
+	fa := &MockFinancialAccountingClient{
+		captureErr:       errors.New("gateway credit failed"),
+		captureErrOnCall: 4, // fourth capture is the gateway credit
+	}
+	repo := NewMockRepository()
+	gwConfig := testGatewayAccountConfig()
+
+	o, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+		Logger:                    testLogger(),
+		Repo:                      repo,
+		FinancialAccountingClient: fa,
+		GatewayAccountConfig:      gwConfig,
+		CurrentAccountClient:      &MockCurrentAccountClient{},
+		PaymentGateway:            &MockPaymentGateway{},
+		InternalClearingEnabled:   true,
+		InternalAccountClient:     clearingMockInternalAccountClient(),
+	})
+	require.NoError(t, err)
+
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusExecuting,
+		testfixtures.WithGatewayReferenceID("GW-ref-123"),
+	)
+
+	_, postErr := o.PostLedgerEntries(context.Background(), po)
+	assert.Error(t, postErr)
+	assert.Contains(t, postErr.Error(), "failed to create credit posting for gateway account")
+}
+
+func TestPostLedgerEntries_ClearingFlowUpdateFails(t *testing.T) {
+	t.Parallel()
+
+	fa := &MockFinancialAccountingClient{
+		updateErr: errors.New("update failed"),
+	}
+	repo := NewMockRepository()
+	gwConfig := testGatewayAccountConfig()
+
+	o, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+		Logger:                    testLogger(),
+		Repo:                      repo,
+		FinancialAccountingClient: fa,
+		GatewayAccountConfig:      gwConfig,
+		CurrentAccountClient:      &MockCurrentAccountClient{},
+		PaymentGateway:            &MockPaymentGateway{},
+		InternalClearingEnabled:   true,
+		InternalAccountClient:     clearingMockInternalAccountClient(),
+	})
+	require.NoError(t, err)
+
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusExecuting,
+		testfixtures.WithGatewayReferenceID("GW-ref-123"),
+	)
+
+	_, postErr := o.PostLedgerEntries(context.Background(), po)
+	assert.Error(t, postErr)
+	assert.Contains(t, postErr.Error(), "failed to update booking log to POSTED")
+}
+
+func TestPostLedgerEntries_ClearingEnabledButNoResolver(t *testing.T) {
+	t.Parallel()
+
+	fa := &MockFinancialAccountingClient{}
+
+	// Create with clearing enabled but no InternalAccountClient → no resolver
+	o, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+		Logger:                    testLogger(),
+		Repo:                      NewMockRepository(),
+		FinancialAccountingClient: fa,
+		GatewayAccountConfig:      testGatewayAccountConfig(),
+		CurrentAccountClient:      &MockCurrentAccountClient{},
+		PaymentGateway:            &MockPaymentGateway{},
+		InternalClearingEnabled:   true,
+		// No InternalAccountClient → accountResolver stays nil
+	})
+	require.NoError(t, err)
+
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusExecuting,
+		testfixtures.WithGatewayReferenceID("GW-ref-123"),
+	)
+
+	// Should fall back to standard 2-posting flow
+	bookingID, postErr := o.PostLedgerEntries(context.Background(), po)
+	require.NoError(t, postErr)
+	assert.NotEmpty(t, bookingID)
+	assert.Equal(t, 2, fa.captureCallCount) // standard flow
+}

--- a/services/payment-order/service/saga_handlers_test.go
+++ b/services/payment-order/service/saga_handlers_test.go
@@ -450,6 +450,53 @@ func TestPostLedgerEntriesHandler(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "orchestrator not configured")
 	})
+
+	t.Run("succeeds with valid orchestrator", func(t *testing.T) {
+		fa := &MockFinancialAccountingClient{}
+		gwConfig := testGatewayAccountConfig()
+
+		orchestrator, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+			Logger:                    testLogger(),
+			Repo:                      NewMockRepository(),
+			FinancialAccountingClient: fa,
+			GatewayAccountConfig:      gwConfig,
+			CurrentAccountClient:      &MockCurrentAccountClient{},
+			PaymentGateway:            &MockPaymentGateway{},
+		})
+		require.NoError(t, err)
+
+		registry := saga.NewHandlerRegistry()
+		deps := &PaymentOrderHandlerDeps{
+			Orchestrator: orchestrator,
+			Logger:       testLogger(),
+		}
+		regErr := RegisterPaymentOrderHandlers(registry, deps)
+		require.NoError(t, regErr)
+
+		handler, getErr := registry.Get("payment_order.post_ledger_entries")
+		require.NoError(t, getErr)
+
+		ctx := &saga.StarlarkContext{
+			Context:         context.Background(),
+			SagaExecutionID: uuid.New(),
+			Logger:          testLogger(),
+		}
+
+		result, handlerErr := handler(ctx, map[string]any{
+			"payment_order_id":     uuid.New().String(),
+			"debtor_account_id":    "account-123",
+			"gateway_reference_id": "GW-ref-456",
+			"amount_cents":         int64(10000),
+			"currency":             "GBP",
+			"idempotency_key":      "idemp-key",
+		})
+
+		require.NoError(t, handlerErr)
+		resultMap, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.NotEmpty(t, resultMap["booking_log_id"])
+		assert.Equal(t, "POSTED", resultMap["status"])
+	})
 }
 
 // TestMustNewMoney tests the helper function.

--- a/services/payment-order/service/saga_unhappy_path_test.go
+++ b/services/payment-order/service/saga_unhappy_path_test.go
@@ -1,0 +1,1029 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	"github.com/meridianhub/meridian/services/payment-order/adapters/gateway"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"github.com/meridianhub/meridian/services/payment-order/domain/testfixtures"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// Saga Orchestration — handleSagaFailure, handleSagaSuccess, validateSagaOutputs
+// =============================================================================
+
+func TestHandleSagaFailure_ExtractsPartialLienAndTransitionsToReserved(t *testing.T) {
+	t.Parallel()
+	orchestrator, repo, _ := sagaTestOrchestrator(t)
+
+	po := testfixtures.NewPaymentOrder(t)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	lienID := "lien-partial-" + uuid.New().String()
+	result := &saga.RunnerOutput{
+		Success: false,
+		Error:   "send_to_gateway failed",
+		StepResults: []saga.StepResult{
+			{
+				StepName: "payment_order.create_lien",
+				Success:  true,
+				Output: map[string]any{
+					"lien_id": lienID,
+				},
+			},
+			{
+				StepName: "payment_order.send_to_gateway",
+				Success:  false,
+				Error:    "gateway timeout",
+			},
+		},
+	}
+
+	orchestrator.handleStarlarkSagaResult(context.Background(), po, result)
+
+	updated, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.PaymentOrderStatusFailed, updated.Status)
+	assert.Equal(t, "SAGA_FAILED", updated.ErrorCode)
+	// The lien_id should have been set during RESERVED transition before failure
+	assert.Equal(t, lienID, updated.LienID)
+}
+
+func TestHandleSagaFailure_NoLienCreated(t *testing.T) {
+	t.Parallel()
+	orchestrator, repo, _ := sagaTestOrchestrator(t)
+
+	po := testfixtures.NewPaymentOrder(t)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	result := &saga.RunnerOutput{
+		Success: false,
+		Error:   "create_lien failed: insufficient funds",
+		StepResults: []saga.StepResult{
+			{
+				StepName: "payment_order.create_lien",
+				Success:  false,
+				Error:    "insufficient funds",
+			},
+		},
+	}
+
+	orchestrator.handleStarlarkSagaResult(context.Background(), po, result)
+
+	updated, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.PaymentOrderStatusFailed, updated.Status)
+	assert.Empty(t, updated.LienID) // No lien was created
+}
+
+func TestHandleSagaFailure_ReloadError(t *testing.T) {
+	t.Parallel()
+	orchestrator, repo, _ := sagaTestOrchestrator(t)
+
+	// Don't create the PO in repo so FindByID fails
+	po := testfixtures.NewPaymentOrder(t)
+
+	result := &saga.RunnerOutput{
+		Success: false,
+		Error:   "some failure",
+		StepResults: []saga.StepResult{
+			{StepName: "payment_order.create_lien", Success: true, Output: map[string]any{"lien_id": "lien-x"}},
+		},
+	}
+
+	// Should not panic — handles reload error gracefully
+	orchestrator.handleStarlarkSagaResult(context.Background(), po, result)
+
+	// PO was never stored, so nothing to verify in repo
+	_, err := repo.FindByID(context.Background(), po.ID)
+	assert.Error(t, err)
+}
+
+func TestHandleSagaSuccess_MissingLienID(t *testing.T) {
+	t.Parallel()
+	orchestrator, repo, _ := sagaTestOrchestrator(t)
+
+	po := testfixtures.NewPaymentOrder(t)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	result := &saga.RunnerOutput{
+		Success: true,
+		Output:  map[string]any{},
+		StepResults: []saga.StepResult{
+			{StepName: "payment_order.create_lien", Success: true, Output: map[string]any{}},
+		},
+	}
+
+	orchestrator.handleStarlarkSagaResult(context.Background(), po, result)
+
+	// Should be marked FAILED because create_lien succeeded but no lien_id in output
+	updated, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.PaymentOrderStatusFailed, updated.Status)
+	assert.Equal(t, "SAGA_OUTPUT_INVALID", updated.ErrorCode)
+}
+
+func TestHandleSagaSuccess_MissingGatewayReferenceID(t *testing.T) {
+	t.Parallel()
+	orchestrator, repo, _ := sagaTestOrchestrator(t)
+
+	po := testfixtures.NewPaymentOrder(t)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	result := &saga.RunnerOutput{
+		Success: true,
+		Output: map[string]any{
+			"lien_id": "lien-123",
+		},
+		StepResults: []saga.StepResult{
+			{StepName: "payment_order.create_lien", Success: true, Output: map[string]any{"lien_id": "lien-123"}},
+			{StepName: "payment_order.send_to_gateway", Success: true, Output: map[string]any{}},
+		},
+	}
+
+	orchestrator.handleStarlarkSagaResult(context.Background(), po, result)
+
+	// Should be marked FAILED because send_to_gateway succeeded but no gateway_reference_id
+	updated, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.PaymentOrderStatusFailed, updated.Status)
+	assert.Equal(t, "SAGA_OUTPUT_INVALID", updated.ErrorCode)
+}
+
+func TestHandleSagaSuccess_ReloadError(t *testing.T) {
+	t.Parallel()
+	orchestrator, repo, _ := sagaTestOrchestrator(t)
+
+	// PO not in repo — reload will fail
+	po := testfixtures.NewPaymentOrder(t)
+
+	result := &saga.RunnerOutput{
+		Success: true,
+		Output: map[string]any{
+			"lien_id":              "lien-123",
+			"gateway_reference_id": "gw-123",
+		},
+		StepResults: []saga.StepResult{
+			{StepName: "payment_order.create_lien", Success: true},
+			{StepName: "payment_order.send_to_gateway", Success: true},
+		},
+	}
+
+	// Should handle gracefully
+	orchestrator.handleStarlarkSagaResult(context.Background(), po, result)
+
+	_, err := repo.FindByID(context.Background(), po.ID)
+	assert.Error(t, err)
+}
+
+func TestApplyReservedTransition_NoLienID(t *testing.T) {
+	t.Parallel()
+	orchestrator, repo, _ := sagaTestOrchestrator(t)
+
+	po := testfixtures.NewPaymentOrder(t)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	orchestrator.applyReservedTransition(context.Background(), po, "", "")
+
+	updated, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.PaymentOrderStatusInitiated, updated.Status)
+}
+
+func TestApplyReservedTransition_NotInInitiatedState(t *testing.T) {
+	t.Parallel()
+	orchestrator, repo, _ := sagaTestOrchestrator(t)
+
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusReserved)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	// Should no-op — already past INITIATED
+	orchestrator.applyReservedTransition(context.Background(), po, "lien-new", "bucket-1")
+
+	updated, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.PaymentOrderStatusReserved, updated.Status)
+}
+
+func TestApplyReservedTransition_WithBucketID(t *testing.T) {
+	t.Parallel()
+	orchestrator, repo, _ := sagaTestOrchestrator(t)
+
+	po := testfixtures.NewPaymentOrder(t)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	orchestrator.applyReservedTransition(context.Background(), po, "lien-abc", "bucket-42")
+
+	updated, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.PaymentOrderStatusReserved, updated.Status)
+	assert.Equal(t, "lien-abc", updated.LienID)
+	assert.Equal(t, "bucket-42", updated.BucketID)
+}
+
+func TestApplyExecutingTransition_NoGatewayRef(t *testing.T) {
+	t.Parallel()
+	orchestrator, repo, _ := sagaTestOrchestrator(t)
+
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusReserved)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	orchestrator.applyExecutingTransition(context.Background(), po, "")
+
+	updated, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.PaymentOrderStatusReserved, updated.Status)
+}
+
+func TestApplyExecutingTransition_NotReserved(t *testing.T) {
+	t.Parallel()
+	orchestrator, repo, _ := sagaTestOrchestrator(t)
+
+	po := testfixtures.NewPaymentOrder(t) // INITIATED state
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	orchestrator.applyExecutingTransition(context.Background(), po, "gw-ref-123")
+
+	updated, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.PaymentOrderStatusInitiated, updated.Status)
+}
+
+func TestApplyExecutingTransition_Success(t *testing.T) {
+	t.Parallel()
+	orchestrator, repo, _ := sagaTestOrchestrator(t)
+
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusReserved)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	orchestrator.applyExecutingTransition(context.Background(), po, "gw-ref-456")
+
+	updated, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.PaymentOrderStatusExecuting, updated.Status)
+	assert.Equal(t, "gw-ref-456", updated.GatewayReferenceID)
+}
+
+// =============================================================================
+// Orchestrator failPaymentOrder — lien release, compensation
+// =============================================================================
+
+func TestOrchestratorFailPaymentOrder_WithLienRelease(t *testing.T) {
+	t.Parallel()
+
+	mockCA := &MockCurrentAccountClient{
+		terminateLienResp: &currentaccountv1.TerminateLienResponse{},
+	}
+
+	orchestrator, repo, _ := sagaTestOrchestrator(t, func(cfg *PaymentOrchestratorConfig) {
+		cfg.CurrentAccountClient = mockCA
+	})
+
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusReserved,
+		testfixtures.WithLienID("lien-to-release"),
+	)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	err := orchestrator.failPaymentOrder(context.Background(), po, "test failure", "TEST_ERROR")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, mockCA.terminateLienCalls)
+
+	updated, findErr := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, findErr)
+	assert.Equal(t, domain.PaymentOrderStatusFailed, updated.Status)
+}
+
+func TestOrchestratorFailPaymentOrder_NoLienRelease_Initiated(t *testing.T) {
+	t.Parallel()
+
+	mockCA := &MockCurrentAccountClient{
+		terminateLienResp: &currentaccountv1.TerminateLienResponse{},
+	}
+
+	orchestrator, repo, _ := sagaTestOrchestrator(t, func(cfg *PaymentOrchestratorConfig) {
+		cfg.CurrentAccountClient = mockCA
+	})
+
+	po := testfixtures.NewPaymentOrder(t) // INITIATED — no lien
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	err := orchestrator.failPaymentOrder(context.Background(), po, "test failure", "TEST_ERROR")
+	require.NoError(t, err)
+
+	// No lien to release
+	assert.Equal(t, 0, mockCA.terminateLienCalls)
+}
+
+func TestOrchestratorFailPaymentOrder_AlreadyFailed_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	orchestrator, repo, _ := sagaTestOrchestrator(t)
+
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusFailed)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	// Calling failPaymentOrder on already-failed PO should be idempotent
+	err := orchestrator.failPaymentOrder(context.Background(), po, "another reason", "ANOTHER_CODE")
+	require.NoError(t, err)
+}
+
+func TestOrchestratorFailPaymentOrder_TerminateLienError(t *testing.T) {
+	t.Parallel()
+
+	mockCA := &MockCurrentAccountClient{
+		terminateLienErr: errors.New("lien service unavailable"),
+	}
+
+	orchestrator, repo, _ := sagaTestOrchestrator(t, func(cfg *PaymentOrchestratorConfig) {
+		cfg.CurrentAccountClient = mockCA
+	})
+
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusReserved,
+		testfixtures.WithLienID("lien-fail-release"),
+	)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	// Should not return error — lien release failure is logged but swallowed
+	err := orchestrator.failPaymentOrder(context.Background(), po, "failure", "FAIL")
+	require.NoError(t, err)
+
+	updated, findErr := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, findErr)
+	assert.Equal(t, domain.PaymentOrderStatusFailed, updated.Status)
+}
+
+// =============================================================================
+// ExecutePaymentSaga — nil dependencies
+// =============================================================================
+
+func TestExecutePaymentSaga_NilCurrentAccountClient(t *testing.T) {
+	t.Parallel()
+
+	orchestrator, repo, _ := sagaTestOrchestrator(t, func(cfg *PaymentOrchestratorConfig) {
+		cfg.CurrentAccountClient = nil
+	})
+
+	po := testfixtures.NewPaymentOrder(t)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	output, err := orchestrator.ExecutePaymentSaga(context.Background(), po.ID, "payment_execution", po)
+
+	assert.Nil(t, output)
+	assert.ErrorIs(t, err, ErrSagaDepsNotConfigured)
+
+	updated, findErr := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, findErr)
+	assert.Equal(t, domain.PaymentOrderStatusFailed, updated.Status)
+}
+
+func TestExecutePaymentSaga_NilPaymentGateway(t *testing.T) {
+	t.Parallel()
+
+	orchestrator, repo, _ := sagaTestOrchestrator(t, func(cfg *PaymentOrchestratorConfig) {
+		cfg.PaymentGateway = nil
+	})
+
+	po := testfixtures.NewPaymentOrder(t)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	output, err := orchestrator.ExecutePaymentSaga(context.Background(), po.ID, "payment_execution", po)
+
+	assert.Nil(t, output)
+	assert.ErrorIs(t, err, ErrSagaDepsNotConfigured)
+}
+
+func TestExecutePaymentSaga_InvalidCorrelationID(t *testing.T) {
+	t.Parallel()
+
+	orchestrator, repo, sagaLogger := sagaTestOrchestrator(t)
+
+	po := testfixtures.NewPaymentOrder(t)
+	po.CorrelationID = "not-a-uuid"
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	output, err := orchestrator.ExecutePaymentSaga(context.Background(), po.ID, "payment_execution", po)
+
+	// Should succeed — generates new correlation ID
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.True(t, output.Success)
+
+	// Verify the logged execution has a valid correlation ID (not "not-a-uuid")
+	executions := sagaLogger.Executions()
+	require.GreaterOrEqual(t, len(executions), 1)
+	_, parseErr := uuid.Parse(executions[0].CorrelationID)
+	assert.NoError(t, parseErr, "should have generated a valid UUID for correlation ID")
+}
+
+func TestExecutePaymentSaga_SagaRunnerError(t *testing.T) {
+	t.Parallel()
+
+	// Division by zero in Starlark returns Success=false (not a Go error)
+	refClient := NewMockReferenceDataClient()
+	refClient.sagaScript = `
+x = 1 / 0
+output = {}
+`
+
+	orchestrator, repo, sagaLogger := sagaTestOrchestrator(t, func(cfg *PaymentOrchestratorConfig) {
+		cfg.ReferenceDataClient = refClient
+	})
+
+	po := testfixtures.NewPaymentOrder(t)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	output, err := orchestrator.ExecutePaymentSaga(context.Background(), po.ID, "payment_execution", po)
+
+	// Starlark runtime errors result in Success=false, not a Go error
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.False(t, output.Success)
+	assert.Contains(t, output.Error, "division by zero")
+
+	// Execution records should include FAILED entry
+	executions := sagaLogger.Executions()
+	require.GreaterOrEqual(t, len(executions), 2)
+	last := executions[len(executions)-1]
+	assert.Equal(t, domain.SagaExecutionStatusFailed, last.Status)
+	assert.NotEmpty(t, last.ErrorMessage)
+
+	// Payment order should be FAILED
+	updated, findErr := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, findErr)
+	assert.Equal(t, domain.PaymentOrderStatusFailed, updated.Status)
+}
+
+func TestExecutePaymentSaga_SagaExecutionLoggerError(t *testing.T) {
+	t.Parallel()
+
+	sagaLogger := NewMockSagaExecutionLogger()
+	sagaLogger.err = errors.New("persistence error")
+
+	orchestrator, repo, _ := sagaTestOrchestrator(t, func(cfg *PaymentOrchestratorConfig) {
+		cfg.SagaExecutionLogger = sagaLogger
+	})
+
+	po := testfixtures.NewPaymentOrder(t)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	// Should not fail — logger errors are logged and swallowed
+	output, err := orchestrator.ExecutePaymentSaga(context.Background(), po.ID, "payment_execution", po)
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.True(t, output.Success)
+}
+
+// =============================================================================
+// Saga Handlers — unhappy path
+// =============================================================================
+
+func TestSendToGatewayHandler_UnexpectedGatewayStatus(t *testing.T) {
+	t.Parallel()
+
+	mockGateway := &MockPaymentGateway{
+		response: gateway.PaymentResponse{
+			Status:  gateway.Status("UNKNOWN_STATUS"),
+			Message: "unexpected",
+		},
+	}
+
+	registry := saga.NewHandlerRegistry()
+	deps := &PaymentOrderHandlerDeps{
+		PaymentGateway: mockGateway,
+		Logger:         testLogger(),
+	}
+	require.NoError(t, RegisterPaymentOrderHandlers(registry, deps))
+
+	handler, err := registry.Get("payment_order.send_to_gateway")
+	require.NoError(t, err)
+
+	ctx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		Logger:          testLogger(),
+	}
+
+	_, err = handler(ctx, map[string]any{
+		"payment_order_id":   uuid.New().String(),
+		"debtor_account_id":  "debtor",
+		"creditor_reference": "creditor",
+		"amount_cents":       int64(1000),
+		"currency":           "GBP",
+		"idempotency_key":    "idemp-123",
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnexpectedGatewayStatus)
+}
+
+func TestSendToGatewayHandler_GatewayError(t *testing.T) {
+	t.Parallel()
+
+	mockGateway := &MockPaymentGateway{
+		err: errors.New("gateway unavailable"),
+	}
+
+	registry := saga.NewHandlerRegistry()
+	deps := &PaymentOrderHandlerDeps{
+		PaymentGateway: mockGateway,
+		Logger:         testLogger(),
+	}
+	require.NoError(t, RegisterPaymentOrderHandlers(registry, deps))
+
+	handler, err := registry.Get("payment_order.send_to_gateway")
+	require.NoError(t, err)
+
+	ctx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		Logger:          testLogger(),
+	}
+
+	_, err = handler(ctx, map[string]any{
+		"payment_order_id":   uuid.New().String(),
+		"debtor_account_id":  "debtor",
+		"creditor_reference": "creditor",
+		"amount_cents":       int64(1000),
+		"currency":           "GBP",
+		"idempotency_key":    "idemp-123",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to send payment")
+}
+
+func TestSendToGatewayHandler_InvalidPaymentOrderID(t *testing.T) {
+	t.Parallel()
+
+	registry := saga.NewHandlerRegistry()
+	deps := &PaymentOrderHandlerDeps{
+		PaymentGateway: &MockPaymentGateway{response: gateway.PaymentResponse{Status: gateway.StatusAccepted}},
+		Logger:         testLogger(),
+	}
+	require.NoError(t, RegisterPaymentOrderHandlers(registry, deps))
+
+	handler, err := registry.Get("payment_order.send_to_gateway")
+	require.NoError(t, err)
+
+	ctx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		Logger:          testLogger(),
+	}
+
+	_, err = handler(ctx, map[string]any{
+		"payment_order_id":   "not-a-uuid",
+		"debtor_account_id":  "debtor",
+		"creditor_reference": "creditor",
+		"amount_cents":       int64(1000),
+		"currency":           "GBP",
+		"idempotency_key":    "idemp-123",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid payment_order_id")
+}
+
+func TestSendToGatewayHandler_MissingParams(t *testing.T) {
+	t.Parallel()
+
+	registry := saga.NewHandlerRegistry()
+	deps := &PaymentOrderHandlerDeps{
+		PaymentGateway: &MockPaymentGateway{response: gateway.PaymentResponse{Status: gateway.StatusAccepted}},
+		Logger:         testLogger(),
+	}
+	require.NoError(t, RegisterPaymentOrderHandlers(registry, deps))
+
+	handler, err := registry.Get("payment_order.send_to_gateway")
+	require.NoError(t, err)
+
+	ctx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		Logger:          testLogger(),
+	}
+
+	testCases := []struct {
+		name    string
+		params  map[string]any
+		missing string
+	}{
+		{
+			name: "missing payment_order_id",
+			params: map[string]any{
+				"debtor_account_id":  "debtor",
+				"creditor_reference": "creditor",
+				"amount_cents":       int64(1000),
+				"currency":           "GBP",
+				"idempotency_key":    "idemp-123",
+			},
+			missing: "payment_order_id",
+		},
+		{
+			name: "missing debtor_account_id",
+			params: map[string]any{
+				"payment_order_id":   uuid.New().String(),
+				"creditor_reference": "creditor",
+				"amount_cents":       int64(1000),
+				"currency":           "GBP",
+				"idempotency_key":    "idemp-123",
+			},
+			missing: "debtor_account_id",
+		},
+		{
+			name: "missing amount_cents",
+			params: map[string]any{
+				"payment_order_id":   uuid.New().String(),
+				"debtor_account_id":  "debtor",
+				"creditor_reference": "creditor",
+				"currency":           "GBP",
+				"idempotency_key":    "idemp-123",
+			},
+			missing: "amount_cents",
+		},
+		{
+			name: "missing currency",
+			params: map[string]any{
+				"payment_order_id":   uuid.New().String(),
+				"debtor_account_id":  "debtor",
+				"creditor_reference": "creditor",
+				"amount_cents":       int64(1000),
+				"idempotency_key":    "idemp-123",
+			},
+			missing: "currency",
+		},
+		{
+			name: "missing idempotency_key",
+			params: map[string]any{
+				"payment_order_id":   uuid.New().String(),
+				"debtor_account_id":  "debtor",
+				"creditor_reference": "creditor",
+				"amount_cents":       int64(1000),
+				"currency":           "GBP",
+			},
+			missing: "idempotency_key",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := handler(ctx, tc.params)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.missing)
+		})
+	}
+}
+
+func TestSendToGatewayHandler_PendingStatus(t *testing.T) {
+	t.Parallel()
+
+	mockGateway := &MockPaymentGateway{
+		response: gateway.PaymentResponse{
+			GatewayReferenceID: "gw-pending-123",
+			Status:             gateway.StatusPending,
+		},
+	}
+
+	registry := saga.NewHandlerRegistry()
+	deps := &PaymentOrderHandlerDeps{
+		PaymentGateway: mockGateway,
+		Logger:         testLogger(),
+	}
+	require.NoError(t, RegisterPaymentOrderHandlers(registry, deps))
+
+	handler, err := registry.Get("payment_order.send_to_gateway")
+	require.NoError(t, err)
+
+	ctx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		Logger:          testLogger(),
+	}
+
+	result, err := handler(ctx, map[string]any{
+		"payment_order_id":   uuid.New().String(),
+		"debtor_account_id":  "debtor",
+		"creditor_reference": "creditor",
+		"amount_cents":       int64(1000),
+		"currency":           "GBP",
+		"idempotency_key":    "idemp-123",
+	})
+
+	require.NoError(t, err)
+	resultMap := result.(map[string]any)
+	assert.Equal(t, "gw-pending-123", resultMap["gateway_reference_id"])
+	assert.Equal(t, "PENDING", resultMap["gateway_status"])
+}
+
+func TestExecuteLienHandler_RetryExhaustion(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &MockCurrentAccountClient{
+		executeLienErr: errors.New("service unavailable"),
+	}
+
+	registry := saga.NewHandlerRegistry()
+	deps := &PaymentOrderHandlerDeps{
+		CurrentAccountClient: mockClient,
+		Logger:               testLogger(),
+		LienExecutionRetryConfig: &sharedclients.RetryConfig{
+			MaxRetries:          2,
+			InitialInterval:     1 * time.Millisecond,
+			MaxInterval:         5 * time.Millisecond,
+			Multiplier:          1.5,
+			RandomizationFactor: 0,
+		},
+	}
+	require.NoError(t, RegisterPaymentOrderHandlers(registry, deps))
+
+	handler, err := registry.Get("payment_order.execute_lien")
+	require.NoError(t, err)
+
+	ctx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		Logger:          testLogger(),
+	}
+
+	result, err := handler(ctx, map[string]any{
+		"lien_id": "lien-fail-123",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lien execution failed after")
+
+	// Result should still be returned with execution status
+	resultMap := result.(map[string]any)
+	execStatus := resultMap["execution_status"].(map[string]any)
+	assert.False(t, execStatus["success"].(bool))
+	assert.GreaterOrEqual(t, execStatus["attempts"], 1) // At least initial attempt
+}
+
+func TestExecuteLienHandler_MissingLienID(t *testing.T) {
+	t.Parallel()
+
+	registry := saga.NewHandlerRegistry()
+	deps := &PaymentOrderHandlerDeps{
+		CurrentAccountClient: &MockCurrentAccountClient{
+			executeLienResp: &currentaccountv1.ExecuteLienResponse{},
+		},
+		Logger: testLogger(),
+	}
+	require.NoError(t, RegisterPaymentOrderHandlers(registry, deps))
+
+	handler, err := registry.Get("payment_order.execute_lien")
+	require.NoError(t, err)
+
+	ctx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		Logger:          testLogger(),
+	}
+
+	_, err = handler(ctx, map[string]any{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lien_id")
+}
+
+func TestTerminateLienHandler_Failure(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &MockCurrentAccountClient{
+		terminateLienErr: errors.New("lien not found"),
+	}
+
+	registry := saga.NewHandlerRegistry()
+	deps := &PaymentOrderHandlerDeps{
+		CurrentAccountClient: mockClient,
+		Logger:               testLogger(),
+	}
+	require.NoError(t, RegisterPaymentOrderHandlers(registry, deps))
+
+	handler, err := registry.Get("payment_order.terminate_lien")
+	require.NoError(t, err)
+
+	ctx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		Logger:          testLogger(),
+	}
+
+	_, err = handler(ctx, map[string]any{
+		"lien_id": "lien-nonexistent",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to terminate lien")
+}
+
+func TestTerminateLienHandler_MissingLienID(t *testing.T) {
+	t.Parallel()
+
+	registry := saga.NewHandlerRegistry()
+	deps := &PaymentOrderHandlerDeps{
+		CurrentAccountClient: &MockCurrentAccountClient{
+			terminateLienResp: &currentaccountv1.TerminateLienResponse{},
+		},
+		Logger: testLogger(),
+	}
+	require.NoError(t, RegisterPaymentOrderHandlers(registry, deps))
+
+	handler, err := registry.Get("payment_order.terminate_lien")
+	require.NoError(t, err)
+
+	ctx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		Logger:          testLogger(),
+	}
+
+	_, err = handler(ctx, map[string]any{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lien_id")
+}
+
+func TestTerminateLienHandler_ClientNotConfigured(t *testing.T) {
+	t.Parallel()
+
+	registry := saga.NewHandlerRegistry()
+	deps := &PaymentOrderHandlerDeps{
+		CurrentAccountClient: nil,
+		Logger:               testLogger(),
+	}
+	require.NoError(t, RegisterPaymentOrderHandlers(registry, deps))
+
+	handler, err := registry.Get("payment_order.terminate_lien")
+	require.NoError(t, err)
+
+	ctx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		Logger:          testLogger(),
+	}
+
+	_, err = handler(ctx, map[string]any{
+		"lien_id": "lien-123",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "current account client not configured")
+}
+
+func TestTerminateLienHandler_CustomReason(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &MockCurrentAccountClient{
+		terminateLienResp: &currentaccountv1.TerminateLienResponse{},
+	}
+
+	registry := saga.NewHandlerRegistry()
+	deps := &PaymentOrderHandlerDeps{
+		CurrentAccountClient: mockClient,
+		Logger:               testLogger(),
+	}
+	require.NoError(t, RegisterPaymentOrderHandlers(registry, deps))
+
+	handler, err := registry.Get("payment_order.terminate_lien")
+	require.NoError(t, err)
+
+	ctx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		Logger:          testLogger(),
+	}
+
+	result, err := handler(ctx, map[string]any{
+		"lien_id": "lien-123",
+		"reason":  "Custom compensation reason",
+	})
+
+	require.NoError(t, err)
+	resultMap := result.(map[string]any)
+	assert.Equal(t, "TERMINATED", resultMap["status"])
+}
+
+func TestCreateLienHandler_MalformedResponse(t *testing.T) {
+	t.Parallel()
+
+	// Return a response with nil Lien
+	mockClient := &MockCurrentAccountClient{
+		initiateLienResp: &currentaccountv1.InitiateLienResponse{
+			Lien: nil,
+		},
+	}
+
+	registry := saga.NewHandlerRegistry()
+	deps := &PaymentOrderHandlerDeps{
+		CurrentAccountClient: mockClient,
+		Logger:               testLogger(),
+	}
+	require.NoError(t, RegisterPaymentOrderHandlers(registry, deps))
+
+	handler, err := registry.Get("payment_order.create_lien")
+	require.NoError(t, err)
+
+	ctx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		Logger:          testLogger(),
+	}
+
+	_, err = handler(ctx, map[string]any{
+		"account_id":       "account-123",
+		"amount_cents":     int64(10000),
+		"currency":         "GBP",
+		"payment_order_id": "po-456",
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMalformedLienResponse)
+}
+
+func TestCreateLienHandler_EmptyLienID(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &MockCurrentAccountClient{
+		initiateLienResp: &currentaccountv1.InitiateLienResponse{
+			Lien: &currentaccountv1.Lien{LienId: ""},
+		},
+	}
+
+	registry := saga.NewHandlerRegistry()
+	deps := &PaymentOrderHandlerDeps{
+		CurrentAccountClient: mockClient,
+		Logger:               testLogger(),
+	}
+	require.NoError(t, RegisterPaymentOrderHandlers(registry, deps))
+
+	handler, err := registry.Get("payment_order.create_lien")
+	require.NoError(t, err)
+
+	ctx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		Logger:          testLogger(),
+	}
+
+	_, err = handler(ctx, map[string]any{
+		"account_id":       "account-123",
+		"amount_cents":     int64(10000),
+		"currency":         "GBP",
+		"payment_order_id": "po-456",
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMalformedLienResponse)
+}
+
+// =============================================================================
+// Parameter extraction helpers — additional coverage
+// =============================================================================
+
+func TestGetStringParamOrDefault(t *testing.T) {
+	t.Parallel()
+
+	params := map[string]any{
+		"key1":    "value1",
+		"numeric": 42,
+	}
+
+	assert.Equal(t, "value1", getStringParamOrDefault(params, "key1", "default"))
+	assert.Equal(t, "default", getStringParamOrDefault(params, "missing", "default"))
+	assert.Equal(t, "default", getStringParamOrDefault(params, "numeric", "default"))
+}
+
+func TestGetMapParamOrEmpty_NonStringValues(t *testing.T) {
+	t.Parallel()
+
+	params := map[string]any{
+		"mixed_map": map[string]any{
+			"str_val": "hello",
+			"int_val": 123, // non-string value — should be skipped
+		},
+	}
+
+	result := getMapParamOrEmpty(params, "mixed_map")
+	assert.Equal(t, "hello", result["str_val"])
+	_, hasIntVal := result["int_val"]
+	assert.False(t, hasIntVal, "non-string values should be excluded")
+}
+
+func TestRequireInt64Param_MissingKey(t *testing.T) {
+	t.Parallel()
+
+	params := map[string]any{}
+	_, err := requireInt64Param(params, "missing")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, saga.ErrMissingParam)
+}

--- a/services/payment-order/service/saga_unhappy_path_test.go
+++ b/services/payment-order/service/saga_unhappy_path_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/meridianhub/meridian/services/payment-order/adapters/gateway"
 	"github.com/meridianhub/meridian/services/payment-order/domain"
 	"github.com/meridianhub/meridian/services/payment-order/domain/testfixtures"
-	"github.com/meridianhub/meridian/shared/pkg/saga"
 	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
## Summary

- Increase payment-order test coverage from ~68% to ~73%
- Add saga orchestration unhappy path tests (failure handling, compensation, partial outputs)
- Add domain state machine tests (IsTerminal, CanCancel, CanReverse, all invalid transitions)
- Add ledger posting tests (standard + clearing flow, all error paths, PostLedgerEntriesFromParams)
- Add observability metric tests (clearing account, lock contention, noop idempotency)
- Add persistence mapper tests (toEntity/toDomain with nullable fields, cursor encode/decode)
- Add gRPC lifecycle edge case tests (CancelPaymentOrder, failPaymentOrder, handlePendingStatus)

## Coverage changes

| Package | Before | After |
|---------|--------|-------|
| domain | ~85% | 100% |
| service | ~76% | 82% |
| observability | ~69% | 100% |
| persistence | ~34% | 51% |
| **Total** | **~68%** | **~73%** |

## Remaining coverage gaps

The gap to 80% is dominated by infrastructure-dependent code:
- `adapters/persistence` CRUD methods (require CockroachDB testcontainer)
- `adapters/messaging` Kafka consumer/publisher (require Kafka)
- `adapters/lock` Redis lock client (requires Redis)
- `cmd/main.go` startup/wiring code

## Test plan

- [x] All new tests pass locally (`go test ./services/payment-order/... -count=1`)
- [x] No modifications to production code
- [x] Tests use existing mock infrastructure (MockRepository, MockCurrentAccountClient, etc.)