### PR TITLE
fix: Validate redirect URI scheme to prevent open-redirect

### DIFF
--- a/services/mcp-server/internal/auth/oauth.go
+++ b/services/mcp-server/internal/auth/oauth.go
@@ -347,6 +347,15 @@ func (h *AuthorizationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Defense-in-depth: validate the resolved redirect URI has a safe scheme.
+	// resolveClient already validates against registered URIs, but this
+	// explicit check prevents open-redirect if a malformed URI is registered.
+	if !isAllowedRedirectURI(redirectURI) {
+		h.logger.Error("unsafe redirect URI scheme", "uri", redirectURI)
+		http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
+		return
+	}
+
 	clientID := q.Get("client_id")
 
 	// Require response_type=code (only supported grant).
@@ -384,14 +393,6 @@ func (h *AuthorizationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	h.logger.Info("authorization code issued", "client_id", clientID)
 
-	// Defense-in-depth: validate the resolved redirect URI has a safe scheme.
-	// resolveClient already validates against registered URIs, but this
-	// explicit check prevents open-redirect if a malformed URI is registered.
-	if !isAllowedRedirectURI(redirectURI) {
-		h.logger.Error("unsafe redirect URI scheme", "uri", redirectURI)
-		http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
-		return
-	}
 	target, err := url.Parse(redirectURI)
 	if err != nil {
 		h.logger.Error("invalid registered redirect URI", "error", err)

--- a/services/mcp-server/internal/auth/oauth.go
+++ b/services/mcp-server/internal/auth/oauth.go
@@ -384,9 +384,14 @@ func (h *AuthorizationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	h.logger.Info("authorization code issued", "client_id", clientID)
 
-	// Build redirect URL via url.Parse using the validated redirect URI.
-	// For static clients this is the registered URI; for dynamic clients
-	// it was validated against the client's registered redirect_uris.
+	// Defense-in-depth: validate the resolved redirect URI has a safe scheme.
+	// resolveClient already validates against registered URIs, but this
+	// explicit check prevents open-redirect if a malformed URI is registered.
+	if !isAllowedRedirectURI(redirectURI) {
+		h.logger.Error("unsafe redirect URI scheme", "uri", redirectURI)
+		http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
+		return
+	}
 	target, err := url.Parse(redirectURI)
 	if err != nil {
 		h.logger.Error("invalid registered redirect URI", "error", err)

--- a/services/mcp-server/internal/auth/oauth_test.go
+++ b/services/mcp-server/internal/auth/oauth_test.go
@@ -237,6 +237,31 @@ func TestAuthorizationHandler_WrongRedirectURI_ReturnsBadRequest(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+func TestAuthorizationHandler_UnsafeRedirectScheme_ReturnsBadRequest(t *testing.T) {
+	store := newTestStore(t)
+	// Simulate a misconfigured static client with a dangerous redirect URI.
+	cfg := auth.OAuthConfig{
+		ClientID:    "meridian-mcp",
+		RedirectURI: "javascript:alert(1)",
+	}
+	handler := auth.NewAuthorizationHandler(cfg, store, nil)
+
+	_, challenge := generatePKCEPair(t)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?"+url.Values{
+		"response_type":         {"code"},
+		"client_id":             {cfg.ClientID},
+		"redirect_uri":          {cfg.RedirectURI},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+	}.Encode(), nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "invalid redirect_uri")
+}
+
 func TestAuthorizationHandler_NonGetMethod_ReturnsMethodNotAllowed(t *testing.T) {
 	store := newTestStore(t)
 	cfg := auth.OAuthConfig{

--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -562,6 +562,12 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		"tenant", flowState.TenantSlug)
 
 	// Redirect to MCP client's redirect_uri with the authorization code.
+	// Defense-in-depth: validate scheme before redirecting.
+	if !isAllowedRedirectURI(flowState.MCPRedirectURI) {
+		h.logger.Error("oidc: unsafe redirect URI scheme", "uri", flowState.MCPRedirectURI)
+		http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
+		return
+	}
 	target, err := url.Parse(flowState.MCPRedirectURI)
 	if err != nil {
 		h.logger.Error("oidc: invalid redirect URI", "error", err)

--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -529,6 +529,14 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		tenantID = resolved
 	}
 
+	// Defense-in-depth: validate redirect URI scheme before signing tokens.
+	// The URI was validated at authorize-time, but re-check before redirect.
+	if !isAllowedRedirectURI(flowState.MCPRedirectURI) {
+		h.logger.Error("oidc: unsafe redirect URI scheme", "uri", flowState.MCPRedirectURI)
+		http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
+		return
+	}
+
 	// Sign Meridian JWT with tenant context.
 	claims := map[string]interface{}{
 		"sub":         email, // Use email as subject until identity resolution is wired
@@ -562,12 +570,6 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		"tenant", flowState.TenantSlug)
 
 	// Redirect to MCP client's redirect_uri with the authorization code.
-	// Defense-in-depth: validate scheme before redirecting.
-	if !isAllowedRedirectURI(flowState.MCPRedirectURI) {
-		h.logger.Error("oidc: unsafe redirect URI scheme", "uri", flowState.MCPRedirectURI)
-		http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
-		return
-	}
 	target, err := url.Parse(flowState.MCPRedirectURI)
 	if err != nil {
 		h.logger.Error("oidc: invalid redirect URI", "error", err)

--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -716,9 +716,16 @@ func BuildTenantScopedDexURL(dexBaseURL, tenantSlug, baseDomain string) string {
 
 // isAllowedRedirectURI validates that a redirect URI is safe to redirect to.
 // HTTPS is required for production; HTTP is allowed only for localhost (development).
+// Rejects opaque or hostless forms (e.g., "https:evil.com", "https:///cb")
+// that could bypass scheme-only validation due to URL parsing differences.
 func isAllowedRedirectURI(uri string) bool {
 	parsed, err := url.Parse(uri)
 	if err != nil {
+		return false
+	}
+	// Reject opaque URIs (e.g., "https:evil.com") and empty-host URIs
+	// (e.g., "https:///cb") which browsers may resolve unexpectedly.
+	if parsed.Opaque != "" || parsed.Hostname() == "" {
 		return false
 	}
 	if parsed.Scheme == schemeHTTPS {

--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -570,20 +570,28 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		"tenant", flowState.TenantSlug)
 
 	// Redirect to MCP client's redirect_uri with the authorization code.
-	target, err := url.Parse(flowState.MCPRedirectURI)
+	redirectURL, err := buildAuthRedirect(flowState.MCPRedirectURI, mcpCode, flowState.MCPState)
 	if err != nil {
 		h.logger.Error("oidc: invalid redirect URI", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
+	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
+// buildAuthRedirect constructs the redirect URL with authorization code and optional state.
+func buildAuthRedirect(redirectURI, code, state string) (string, error) {
+	target, err := url.Parse(redirectURI)
+	if err != nil {
+		return "", err
+	}
 	params := target.Query()
-	params.Set("code", mcpCode)
-	if flowState.MCPState != "" {
-		params.Set("state", flowState.MCPState)
+	params.Set("code", code)
+	if state != "" {
+		params.Set("state", state)
 	}
 	target.RawQuery = params.Encode()
-
-	http.Redirect(w, r, target.String(), http.StatusFound)
+	return target.String(), nil
 }
 
 // exchangeDexCode exchanges a Dex authorization code for an ID token.

--- a/services/mcp-server/internal/auth/redirect_internal_test.go
+++ b/services/mcp-server/internal/auth/redirect_internal_test.go
@@ -1,0 +1,71 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsAllowedRedirectURI(t *testing.T) {
+	tests := []struct {
+		name string
+		uri  string
+		want bool
+	}{
+		// Allowed
+		{"https production", "https://app.example.com/callback", true},
+		{"http localhost", "http://localhost:8090/callback", true},
+		{"http 127.0.0.1", "http://127.0.0.1:3000/cb", true},
+		{"http ipv6 loopback", "http://[::1]:3000/cb", true},
+
+		// Rejected: wrong scheme
+		{"javascript scheme", "javascript:alert(1)", false},
+		{"data scheme", "data:text/html,<h1>evil</h1>", false},
+		{"ftp scheme", "ftp://evil.com/file", false},
+		{"no scheme", "/relative/path", false},
+
+		// Rejected: http to non-localhost
+		{"http remote host", "http://evil.com/callback", false},
+
+		// Rejected: opaque URIs (bypass via url.Parse quirks)
+		{"opaque https", "https:evil.com", false},
+		{"opaque http", "http:evil.com", false},
+
+		// Rejected: empty host
+		{"empty host https", "https:///callback", false},
+		{"empty host http", "http:///callback", false},
+
+		// Rejected: invalid URI
+		{"invalid URI", "://broken", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAllowedRedirectURI(tt.uri)
+			assert.Equal(t, tt.want, got, "isAllowedRedirectURI(%q)", tt.uri)
+		})
+	}
+}
+
+func TestBuildAuthRedirect(t *testing.T) {
+	t.Run("includes code and state", func(t *testing.T) {
+		result, err := buildAuthRedirect("https://app.example.com/callback", "abc123", "mystate")
+		assert.NoError(t, err)
+		assert.Contains(t, result, "code=abc123")
+		assert.Contains(t, result, "state=mystate")
+	})
+
+	t.Run("omits state when empty", func(t *testing.T) {
+		result, err := buildAuthRedirect("https://app.example.com/callback", "abc123", "")
+		assert.NoError(t, err)
+		assert.Contains(t, result, "code=abc123")
+		assert.NotContains(t, result, "state=")
+	})
+
+	t.Run("preserves existing query params", func(t *testing.T) {
+		result, err := buildAuthRedirect("https://app.example.com/callback?foo=bar", "abc123", "")
+		assert.NoError(t, err)
+		assert.Contains(t, result, "foo=bar")
+		assert.Contains(t, result, "code=abc123")
+	})
+}


### PR DESCRIPTION
## Summary

- Adds defense-in-depth scheme validation on redirect URIs before `http.Redirect` in both the OAuth authorization handler and OIDC callback handler
- Reuses the existing `isAllowedRedirectURI` function (only allows `https` or `http` for localhost)
- Resolves CodeQL alert #243 (Open URL redirect in `services/mcp-server/internal/auth/oauth.go`)

## Context on Dependabot alerts

The 4 open Dependabot alerts are false positives:
- **dex #15-17** (3 critical): Our pseudo-version `v0.0.0-20260303133905-11d2eeb52b42` points to dex v2.45.1, which is well past the required fix versions (v2.27.0, v2.35.0). Dependabot can't match pseudo-versions to release tags.
- **go-jose.v2 #18** (medium): No fix available. Indirect dep with no direct usage in our code (`go mod why` confirms main module doesn't need it).

## Test plan

- [x] All `services/mcp-server/internal/auth` tests pass
- [ ] CI passes
- [ ] CodeQL re-scan resolves alert #243