### PR TITLE
fix: Remove demo mode fallback that granted platform lens to all users

### DIFF
--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -107,15 +107,6 @@ function getUserLens(claims: JWTClaims | null): 'platform' | 'tenant' {
   const isPlatformLevel =
     claims.roles.includes('platform-admin') || claims.roles.includes('super-admin')
   if (isPlatformLevel) return 'platform'
-  // In demo mode, standard OIDC tokens lack tenant and role claims.
-  // Default to 'platform' lens only on the root domain so
-  // DevTenantAutoSelector can pick a tenant. On a tenant subdomain the
-  // user is implicitly scoped to that tenant and should see tenant lens
-  // (no tenant selector dropdown).
-  if (import.meta.env.VITE_DEMO_MODE === 'true') {
-    const slug = getTenantSlugFromSubdomain(window.location.hostname)
-    if (!slug) return 'platform'
-  }
   return 'tenant'
 }
 


### PR DESCRIPTION
## Summary

- Removes the `VITE_DEMO_MODE` fallback in `getUserLens()` that defaulted all root-domain users to `platform` lens
- This was a workaround from before the identity service properly provisioned demo users with JWT claims
- Now that demo users have correct `tenantId` and `roles` in their tokens, the fallback is dead code that incorrectly exposed the tenant selector dropdown to non-admin users

## What changes

`auth-context.tsx` `getUserLens()` now determines lens purely from JWT claims:
- Has `tenantId` → tenant lens (operator users)
- Has `platform-admin` or `super-admin` role → platform lens (admin users)
- Otherwise → tenant lens

## Demo impact

| User | JWT claims | Lens | Tenant selector |
|------|-----------|------|-----------------|
| `operator@volterra.energy` | `tenantId: volterra`, `roles: [operator]` | tenant | Hidden |
| `admin@volterra.energy` | `roles: [platform-admin, super-admin, tenant-owner]` | platform | Visible |

## Test plan

- [x] All 51 existing tests pass (auth-context, header, app-shell)
- [ ] Verify on demo: operator login does not see tenant selector
- [ ] Verify on demo: admin login sees tenant selector and can switch tenants