### PR TITLE
test: Add unhappy path tests for operational-gateway service

### DIFF
--- a/services/operational-gateway/adapters/persistence/entity_test.go
+++ b/services/operational-gateway/adapters/persistence/entity_test.go
@@ -1,0 +1,266 @@
+package persistence
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ========== JSONB Value/Scan ==========
+
+func TestJSONB_Value_NilMap(t *testing.T) {
+	var j JSONB
+	v, err := j.Value()
+	require.NoError(t, err)
+	assert.Equal(t, "{}", v)
+}
+
+func TestJSONB_Value_NonNilMap(t *testing.T) {
+	j := JSONB{"key": "value"}
+	v, err := j.Value()
+	require.NoError(t, err)
+	assert.Contains(t, v, "key")
+}
+
+func TestJSONB_Scan_Nil(t *testing.T) {
+	var j JSONB
+	require.NoError(t, j.Scan(nil))
+	assert.Nil(t, j)
+}
+
+func TestJSONB_Scan_Bytes(t *testing.T) {
+	var j JSONB
+	require.NoError(t, j.Scan([]byte(`{"a":"b"}`)))
+	assert.Equal(t, "b", j["a"])
+}
+
+func TestJSONB_Scan_String(t *testing.T) {
+	var j JSONB
+	require.NoError(t, j.Scan(`{"x":1}`))
+	assert.Equal(t, float64(1), j["x"])
+}
+
+func TestJSONB_Scan_UnsupportedType(t *testing.T) {
+	var j JSONB
+	err := j.Scan(42)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidJSONScan)
+}
+
+// ========== JSONBString Value/Scan ==========
+
+func TestJSONBString_Value_NilMap(t *testing.T) {
+	var j JSONBString
+	v, err := j.Value()
+	require.NoError(t, err)
+	assert.Nil(t, v)
+}
+
+func TestJSONBString_Value_NonNilMap(t *testing.T) {
+	j := JSONBString{"key": "value"}
+	v, err := j.Value()
+	require.NoError(t, err)
+	assert.Contains(t, v, "key")
+}
+
+func TestJSONBString_Scan_Nil(t *testing.T) {
+	var j JSONBString
+	require.NoError(t, j.Scan(nil))
+	assert.Nil(t, j)
+}
+
+func TestJSONBString_Scan_Bytes(t *testing.T) {
+	var j JSONBString
+	require.NoError(t, j.Scan([]byte(`{"a":"b"}`)))
+	assert.Equal(t, "b", j["a"])
+}
+
+func TestJSONBString_Scan_String(t *testing.T) {
+	var j JSONBString
+	require.NoError(t, j.Scan(`{"x":"y"}`))
+	assert.Equal(t, "y", j["x"])
+}
+
+func TestJSONBString_Scan_UnsupportedType(t *testing.T) {
+	var j JSONBString
+	err := j.Scan(42)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidJSONScan)
+}
+
+// ========== priorityToInt / intToPriority ==========
+
+func TestPriorityToInt_AllValues(t *testing.T) {
+	tests := []struct {
+		priority string
+		expected int16
+	}{
+		{"LOW", 1},
+		{"NORMAL", 2},
+		{"HIGH", 3},
+		{"CRITICAL", 4},
+		{"BOGUS", 2}, // default to NORMAL
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.priority, func(t *testing.T) {
+			assert.Equal(t, tt.expected, priorityToInt(tt.priority))
+		})
+	}
+}
+
+func TestIntToPriority_AllValues(t *testing.T) {
+	tests := []struct {
+		input    int16
+		expected string
+	}{
+		{1, "LOW"},
+		{2, "NORMAL"},
+		{3, "HIGH"},
+		{4, "CRITICAL"},
+		{99, "NORMAL"}, // default to NORMAL
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, intToPriority(tt.input))
+		})
+	}
+}
+
+// ========== nullableString / derefString ==========
+
+func TestNullableString_Empty(t *testing.T) {
+	assert.Nil(t, nullableString(""))
+}
+
+func TestNullableString_NonEmpty(t *testing.T) {
+	p := nullableString("hello")
+	require.NotNil(t, p)
+	assert.Equal(t, "hello", *p)
+}
+
+func TestDerefString_Nil(t *testing.T) {
+	assert.Equal(t, "", derefString(nil))
+}
+
+func TestDerefString_NonNil(t *testing.T) {
+	s := "hello"
+	assert.Equal(t, "hello", derefString(&s))
+}
+
+// ========== TableName ==========
+
+func TestInstructionEntity_TableName(t *testing.T) {
+	assert.Equal(t, "instructions", InstructionEntity{}.TableName())
+}
+
+func TestInstructionAttemptEntity_TableName(t *testing.T) {
+	assert.Equal(t, "instruction_attempts", InstructionAttemptEntity{}.TableName())
+}
+
+func TestConnectionEntity_TableName(t *testing.T) {
+	assert.Equal(t, "provider_connections", ConnectionEntity{}.TableName())
+}
+
+// ========== AuthConfigJSON Value/Scan ==========
+
+func TestAuthConfigJSON_Value(t *testing.T) {
+	a := AuthConfigJSON{AuthType: "api_key", HeaderName: "X-Key", SecretRef: "ref"}
+	v, err := a.Value()
+	require.NoError(t, err)
+	assert.Contains(t, v, "api_key")
+}
+
+func TestAuthConfigJSON_Scan_Nil(t *testing.T) {
+	var a AuthConfigJSON
+	require.NoError(t, a.Scan(nil))
+}
+
+func TestAuthConfigJSON_Scan_Bytes(t *testing.T) {
+	var a AuthConfigJSON
+	require.NoError(t, a.Scan([]byte(`{"auth_type":"basic","username":"u"}`)))
+	assert.Equal(t, "basic", a.AuthType)
+	assert.Equal(t, "u", a.Username)
+}
+
+func TestAuthConfigJSON_Scan_String(t *testing.T) {
+	var a AuthConfigJSON
+	require.NoError(t, a.Scan(`{"auth_type":"oauth2","token_url":"https://t"}`))
+	assert.Equal(t, "oauth2", a.AuthType)
+	assert.Equal(t, "https://t", a.TokenURL)
+}
+
+func TestAuthConfigJSON_Scan_UnsupportedType(t *testing.T) {
+	var a AuthConfigJSON
+	err := a.Scan(42)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidJSONScan)
+}
+
+// ========== RetryPolicyJSON Value/Scan ==========
+
+func TestRetryPolicyJSON_Value(t *testing.T) {
+	r := RetryPolicyJSON{MaxAttempts: 3, BackoffMultiplier: 2.0}
+	v, err := r.Value()
+	require.NoError(t, err)
+	assert.Contains(t, v, "max_attempts")
+}
+
+func TestRetryPolicyJSON_Scan_Nil(t *testing.T) {
+	var r RetryPolicyJSON
+	require.NoError(t, r.Scan(nil))
+}
+
+func TestRetryPolicyJSON_Scan_Bytes(t *testing.T) {
+	var r RetryPolicyJSON
+	require.NoError(t, r.Scan([]byte(`{"max_attempts":5}`)))
+	assert.Equal(t, 5, r.MaxAttempts)
+}
+
+func TestRetryPolicyJSON_Scan_String(t *testing.T) {
+	var r RetryPolicyJSON
+	require.NoError(t, r.Scan(`{"backoff_multiplier":3.0}`))
+	assert.Equal(t, 3.0, r.BackoffMultiplier)
+}
+
+func TestRetryPolicyJSON_Scan_UnsupportedType(t *testing.T) {
+	var r RetryPolicyJSON
+	err := r.Scan(42)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidJSONScan)
+}
+
+// ========== RateLimitJSON Value/Scan ==========
+
+func TestRateLimitJSON_Value(t *testing.T) {
+	r := RateLimitJSON{RequestsPerSecond: 100, BurstSize: 50}
+	v, err := r.Value()
+	require.NoError(t, err)
+	assert.Contains(t, v, "requests_per_second")
+}
+
+func TestRateLimitJSON_Scan_Nil(t *testing.T) {
+	var r RateLimitJSON
+	require.NoError(t, r.Scan(nil))
+}
+
+func TestRateLimitJSON_Scan_Bytes(t *testing.T) {
+	var r RateLimitJSON
+	require.NoError(t, r.Scan([]byte(`{"requests_per_second":100}`)))
+	assert.Equal(t, 100.0, r.RequestsPerSecond)
+}
+
+func TestRateLimitJSON_Scan_String(t *testing.T) {
+	var r RateLimitJSON
+	require.NoError(t, r.Scan(`{"burst_size":50}`))
+	assert.Equal(t, 50, r.BurstSize)
+}
+
+func TestRateLimitJSON_Scan_UnsupportedType(t *testing.T) {
+	var r RateLimitJSON
+	err := r.Scan(42)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidJSONScan)
+}

--- a/services/operational-gateway/adapters/persistence/mappers_test.go
+++ b/services/operational-gateway/adapters/persistence/mappers_test.go
@@ -1,0 +1,236 @@
+package persistence
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ========== authConfigToJSON / authConfigFromJSON roundtrip ==========
+
+func TestAuthConfigRoundtrip_APIKey(t *testing.T) {
+	auth := &domain.APIKeyAuth{HeaderName: "X-Key", SecretRef: "ref"}
+	j, err := authConfigToJSON(auth)
+	require.NoError(t, err)
+	assert.Equal(t, "api_key", j.AuthType)
+
+	back, err := authConfigFromJSON(j)
+	require.NoError(t, err)
+	apiKey, ok := back.(*domain.APIKeyAuth)
+	require.True(t, ok)
+	assert.Equal(t, "X-Key", apiKey.HeaderName)
+}
+
+func TestAuthConfigRoundtrip_Basic(t *testing.T) {
+	auth := &domain.BasicAuth{Username: "user", PasswordRef: "pass"}
+	j, err := authConfigToJSON(auth)
+	require.NoError(t, err)
+	assert.Equal(t, "basic", j.AuthType)
+
+	back, err := authConfigFromJSON(j)
+	require.NoError(t, err)
+	basic, ok := back.(*domain.BasicAuth)
+	require.True(t, ok)
+	assert.Equal(t, "user", basic.Username)
+}
+
+func TestAuthConfigRoundtrip_OAuth2(t *testing.T) {
+	auth := &domain.OAuth2Auth{
+		TokenURL:        "https://auth.example.com/token",
+		ClientID:        "c1",
+		ClientSecretRef: "cs",
+		Scopes:          []string{"read"},
+	}
+	j, err := authConfigToJSON(auth)
+	require.NoError(t, err)
+	assert.Equal(t, "oauth2", j.AuthType)
+
+	back, err := authConfigFromJSON(j)
+	require.NoError(t, err)
+	oauth, ok := back.(*domain.OAuth2Auth)
+	require.True(t, ok)
+	assert.Equal(t, "https://auth.example.com/token", oauth.TokenURL)
+}
+
+func TestAuthConfigRoundtrip_HMAC(t *testing.T) {
+	auth := &domain.HMACAuth{Algorithm: "SHA256", SecretRef: "ref", SignatureHeader: "X-Sig"}
+	j, err := authConfigToJSON(auth)
+	require.NoError(t, err)
+	assert.Equal(t, "hmac", j.AuthType)
+
+	back, err := authConfigFromJSON(j)
+	require.NoError(t, err)
+	hmac, ok := back.(*domain.HMACAuth)
+	require.True(t, ok)
+	assert.Equal(t, "SHA256", hmac.Algorithm)
+}
+
+func TestAuthConfigRoundtrip_MTLS(t *testing.T) {
+	auth := &domain.MTLSAuth{ClientCertRef: "cert", ClientKeyRef: "key", CACertRef: "ca"}
+	j, err := authConfigToJSON(auth)
+	require.NoError(t, err)
+	assert.Equal(t, "mtls", j.AuthType)
+
+	back, err := authConfigFromJSON(j)
+	require.NoError(t, err)
+	mtls, ok := back.(*domain.MTLSAuth)
+	require.True(t, ok)
+	assert.Equal(t, "cert", mtls.ClientCertRef)
+}
+
+func TestAuthConfigToJSON_UnknownType(t *testing.T) {
+	_, err := authConfigToJSON(nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnknownAuthConfigType)
+}
+
+func TestAuthConfigFromJSON_UnknownType(t *testing.T) {
+	_, err := authConfigFromJSON(AuthConfigJSON{AuthType: "bogus"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnknownAuthType)
+}
+
+// ========== healthStatusForDB / healthStatusFromDB ==========
+
+func TestHealthStatusForDB_AllStatuses(t *testing.T) {
+	tests := []struct {
+		domain   domain.HealthStatus
+		expected string
+	}{
+		{domain.HealthStatusUnknown, "UNKNOWN"},
+		{domain.HealthStatusHealthy, "HEALTHY"},
+		{domain.HealthStatusDegraded, "DEGRADED"},
+		{domain.HealthStatusUnhealthy, "UNHEALTHY"},
+		{"BOGUS", "UNKNOWN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.domain), func(t *testing.T) {
+			assert.Equal(t, tt.expected, healthStatusForDB(tt.domain))
+		})
+	}
+}
+
+func TestHealthStatusFromDB_AllStatuses(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected domain.HealthStatus
+	}{
+		{"HEALTHY", domain.HealthStatusHealthy},
+		{"DEGRADED", domain.HealthStatusDegraded},
+		{"UNHEALTHY", domain.HealthStatusUnhealthy},
+		{"UNKNOWN", domain.HealthStatusUnknown},
+		{"BOGUS", domain.HealthStatusUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, healthStatusFromDB(tt.input))
+		})
+	}
+}
+
+// ========== instructionToEntity / instructionFromEntity roundtrip ==========
+
+func TestInstructionEntityRoundtrip(t *testing.T) {
+	tid := uuid.New()
+	connID := uuid.New().String()
+	inst, err := domain.NewInstruction(tid, "device.command", connID, map[string]any{"k": "v"},
+		domain.WithPriority(domain.PriorityHigh),
+		domain.WithCorrelationID("corr-1"),
+		domain.WithCausationID("cause-1"),
+		domain.WithMetadata(map[string]string{"env": "test"}),
+	)
+	require.NoError(t, err)
+	inst.ID = uuid.New()
+
+	entity, err := instructionToEntity(inst, "idem-key")
+	require.NoError(t, err)
+	assert.Equal(t, inst.ID, entity.ID)
+	assert.Equal(t, "idem-key", entity.IdempotencyKey)
+	assert.Equal(t, int16(3), entity.Priority) // HIGH = 3
+
+	back, err := instructionFromEntity(entity, nil)
+	require.NoError(t, err)
+	assert.Equal(t, inst.ID, back.ID)
+	assert.Equal(t, inst.InstructionType, back.InstructionType)
+	assert.Equal(t, domain.PriorityHigh, back.Priority)
+	assert.Equal(t, "corr-1", back.CorrelationID)
+	assert.Equal(t, "cause-1", back.CausationID)
+}
+
+func TestInstructionFromEntity_WithAttempts(t *testing.T) {
+	entity := &InstructionEntity{
+		ID:                   uuid.New(),
+		TenantID:             uuid.New(),
+		InstructionType:      "test.cmd",
+		ProviderConnectionID: uuid.New(),
+		Payload:              JSONB{"k": "v"},
+		Priority:             2,
+		Status:               "PENDING",
+		MaxAttempts:          3,
+		Version:              1,
+		CreatedAt:            time.Now(),
+		UpdatedAt:            time.Now(),
+	}
+	attempts := []InstructionAttemptEntity{
+		{
+			AttemptNumber: 1,
+			DispatchedAt:  time.Now(),
+			ErrorMessage:  nullableString("timeout"),
+		},
+	}
+	back, err := instructionFromEntity(entity, attempts)
+	require.NoError(t, err)
+	assert.Len(t, back.Attempts, 1)
+	assert.Equal(t, "timeout", back.Attempts[0].FailureReason)
+}
+
+func TestInstructionFromEntity_WithMetadata(t *testing.T) {
+	entity := &InstructionEntity{
+		ID:                   uuid.New(),
+		TenantID:             uuid.New(),
+		InstructionType:      "test.cmd",
+		ProviderConnectionID: uuid.New(),
+		Payload:              JSONB{"k": "v"},
+		Metadata:             JSONB{"env": "prod"},
+		Priority:             2,
+		Status:               "PENDING",
+		Version:              1,
+		CreatedAt:            time.Now(),
+		UpdatedAt:            time.Now(),
+	}
+	back, err := instructionFromEntity(entity, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "prod", back.Metadata["env"])
+}
+
+// ========== connectionToEntity / connectionFromEntity roundtrip ==========
+
+func TestConnectionEntityRoundtrip(t *testing.T) {
+	tid := uuid.New().String()
+	conn, err := domain.NewProviderConnection(
+		tid, "Onfido", "kyc_provider", domain.ProtocolHTTPS,
+		"https://api.onfido.com",
+		&domain.APIKeyAuth{HeaderName: "X-API-Key", SecretRef: "key"},
+		domain.RetryPolicy{MaxAttempts: 3, InitialBackoff: 1 * time.Second, MaxBackoff: 60 * time.Second, BackoffMultiplier: 2.0},
+		domain.RateLimitConfig{RequestsPerSecond: 100, BurstSize: 50},
+	)
+	require.NoError(t, err)
+
+	entity, err := connectionToEntity(conn)
+	require.NoError(t, err)
+	assert.Equal(t, "Onfido", entity.ProviderName)
+	assert.Equal(t, "HTTPS", entity.Protocol)
+
+	back, err := connectionFromEntity(entity)
+	require.NoError(t, err)
+	assert.Equal(t, "Onfido", back.ProviderName)
+	assert.Equal(t, domain.ProtocolHTTPS, back.Protocol)
+	assert.Equal(t, 3, back.RetryPolicy.MaxAttempts)
+	assert.Equal(t, 100.0, back.RateLimitConfig.RequestsPerSecond)
+}

--- a/services/operational-gateway/adapters/persistence/mappers_test.go
+++ b/services/operational-gateway/adapters/persistence/mappers_test.go
@@ -23,6 +23,7 @@ func TestAuthConfigRoundtrip_APIKey(t *testing.T) {
 	apiKey, ok := back.(*domain.APIKeyAuth)
 	require.True(t, ok)
 	assert.Equal(t, "X-Key", apiKey.HeaderName)
+	assert.Equal(t, "ref", apiKey.SecretRef)
 }
 
 func TestAuthConfigRoundtrip_Basic(t *testing.T) {
@@ -36,6 +37,7 @@ func TestAuthConfigRoundtrip_Basic(t *testing.T) {
 	basic, ok := back.(*domain.BasicAuth)
 	require.True(t, ok)
 	assert.Equal(t, "user", basic.Username)
+	assert.Equal(t, "pass", basic.PasswordRef)
 }
 
 func TestAuthConfigRoundtrip_OAuth2(t *testing.T) {
@@ -54,6 +56,9 @@ func TestAuthConfigRoundtrip_OAuth2(t *testing.T) {
 	oauth, ok := back.(*domain.OAuth2Auth)
 	require.True(t, ok)
 	assert.Equal(t, "https://auth.example.com/token", oauth.TokenURL)
+	assert.Equal(t, "c1", oauth.ClientID)
+	assert.Equal(t, "cs", oauth.ClientSecretRef)
+	assert.Equal(t, []string{"read"}, oauth.Scopes)
 }
 
 func TestAuthConfigRoundtrip_HMAC(t *testing.T) {
@@ -67,6 +72,8 @@ func TestAuthConfigRoundtrip_HMAC(t *testing.T) {
 	hmac, ok := back.(*domain.HMACAuth)
 	require.True(t, ok)
 	assert.Equal(t, "SHA256", hmac.Algorithm)
+	assert.Equal(t, "ref", hmac.SecretRef)
+	assert.Equal(t, "X-Sig", hmac.SignatureHeader)
 }
 
 func TestAuthConfigRoundtrip_MTLS(t *testing.T) {
@@ -80,6 +87,8 @@ func TestAuthConfigRoundtrip_MTLS(t *testing.T) {
 	mtls, ok := back.(*domain.MTLSAuth)
 	require.True(t, ok)
 	assert.Equal(t, "cert", mtls.ClientCertRef)
+	assert.Equal(t, "key", mtls.ClientKeyRef)
+	assert.Equal(t, "ca", mtls.CACertRef)
 }
 
 func TestAuthConfigToJSON_UnknownType(t *testing.T) {

--- a/services/operational-gateway/client/client_test.go
+++ b/services/operational-gateway/client/client_test.go
@@ -1,0 +1,94 @@
+package client
+
+import (
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func TestNew_WithTarget(t *testing.T) {
+	c, cleanup, err := New(Config{
+		Target: "localhost:50051",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	require.NotNil(t, cleanup)
+	assert.NotNil(t, c.conn)
+	assert.NotNil(t, c.operationalGateway)
+	assert.Equal(t, DefaultTimeout, c.timeout)
+	cleanup()
+}
+
+func TestNew_WithTargetAndCustomDialOptions(t *testing.T) {
+	c, cleanup, err := New(Config{
+		Target: "localhost:50051",
+		DialOptions: []grpc.DialOption{
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	cleanup()
+}
+
+func TestNew_WithCustomTimeout(t *testing.T) {
+	c, cleanup, err := New(Config{
+		Target:  "localhost:50051",
+		Timeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 5*time.Second, c.timeout)
+	cleanup()
+}
+
+func TestNew_WithResilience(t *testing.T) {
+	c, cleanup, err := New(Config{
+		Target: "localhost:50051",
+		Resilience: &clients.ResilientClientConfig{
+			MaxRetries: 3,
+		},
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, c.resilient)
+	cleanup()
+}
+
+func TestNew_NoTargetOrServiceName(t *testing.T) {
+	_, _, err := New(Config{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTargetRequired)
+}
+
+func TestClose_Success(t *testing.T) {
+	c, _, err := New(Config{Target: "localhost:50051"})
+	require.NoError(t, err)
+	assert.NoError(t, c.Close())
+}
+
+func TestClose_NilConn(t *testing.T) {
+	c := &Client{}
+	assert.NoError(t, c.Close())
+}
+
+func TestConn_ReturnsConnection(t *testing.T) {
+	c, cleanup, err := New(Config{Target: "localhost:50051"})
+	require.NoError(t, err)
+	defer cleanup()
+
+	conn := c.Conn()
+	assert.NotNil(t, conn)
+	assert.Equal(t, c.conn, conn)
+}
+
+func TestDefaults_Applied(t *testing.T) {
+	c, cleanup, err := New(Config{Target: "localhost:50051"})
+	require.NoError(t, err)
+	defer cleanup()
+
+	assert.Equal(t, DefaultTimeout, c.timeout)
+}

--- a/services/operational-gateway/client/starlark_helpers_test.go
+++ b/services/operational-gateway/client/starlark_helpers_test.go
@@ -1,0 +1,109 @@
+package client
+
+import (
+	"testing"
+
+	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ========== stringToPriority ==========
+
+func TestStringToPriority_ValidValues(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected opgatewayv1.Priority
+	}{
+		{"LOW", opgatewayv1.Priority_PRIORITY_LOW},
+		{"NORMAL", opgatewayv1.Priority_PRIORITY_NORMAL},
+		{"HIGH", opgatewayv1.Priority_PRIORITY_HIGH},
+		{"CRITICAL", opgatewayv1.Priority_PRIORITY_CRITICAL},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result, err := stringToPriority(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestStringToPriority_Invalid(t *testing.T) {
+	_, err := stringToPriority("BOGUS")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not valid")
+}
+
+func TestStringToPriority_Empty(t *testing.T) {
+	_, err := stringToPriority("")
+	require.Error(t, err)
+}
+
+func TestStringToPriority_LowerCase(t *testing.T) {
+	_, err := stringToPriority("low")
+	require.Error(t, err)
+}
+
+// ========== instructionStatusToString ==========
+
+func TestInstructionStatusToString_AllStatuses(t *testing.T) {
+	tests := []struct {
+		status   opgatewayv1.InstructionStatus
+		expected string
+	}{
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_UNSPECIFIED, "UNKNOWN"},
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_PENDING, "PENDING"},
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_DISPATCHING, "DISPATCHING"},
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_DELIVERED, "DELIVERED"},
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_ACKNOWLEDGED, "ACKNOWLEDGED"},
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_RETRYING, "RETRYING"},
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_FAILED, "FAILED"},
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_EXPIRED, "EXPIRED"},
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_CANCELLED, "CANCELLED"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, instructionStatusToString(tt.status))
+		})
+	}
+}
+
+func TestInstructionStatusToString_Unrecognized(t *testing.T) {
+	assert.Equal(t, "UNKNOWN", instructionStatusToString(opgatewayv1.InstructionStatus(999)))
+}
+
+// ========== optionalStringParam ==========
+
+func TestOptionalStringParam_Present(t *testing.T) {
+	params := map[string]any{"key": "value"}
+	result, exists, err := optionalStringParam(params, "key")
+	require.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, "value", result)
+}
+
+func TestOptionalStringParam_Missing(t *testing.T) {
+	params := map[string]any{}
+	result, exists, err := optionalStringParam(params, "key")
+	require.NoError(t, err)
+	assert.False(t, exists)
+	assert.Equal(t, "", result)
+}
+
+func TestOptionalStringParam_WrongType(t *testing.T) {
+	params := map[string]any{"key": 42}
+	_, exists, err := optionalStringParam(params, "key")
+	assert.True(t, exists)
+	assert.Error(t, err)
+}
+
+func TestOptionalStringParam_NilValue(t *testing.T) {
+	params := map[string]any{"key": nil}
+	result, exists, err := optionalStringParam(params, "key")
+	require.NoError(t, err)
+	assert.False(t, exists)
+	assert.Equal(t, "", result)
+}

--- a/services/operational-gateway/observability/tracing_test.go
+++ b/services/operational-gateway/observability/tracing_test.go
@@ -43,23 +43,25 @@ func TestStartSpan_WithMultipleAttributes(t *testing.T) {
 }
 
 func TestRecordError_NilError(t *testing.T) {
-	_, span := StartSpan(context.Background(), "test")
-	defer span.End()
-	// Should not panic.
-	RecordError(span, nil)
+	assert.NotPanics(t, func() {
+		_, span := StartSpan(context.Background(), "test")
+		defer span.End()
+		RecordError(span, nil)
+	})
 }
 
 func TestRecordError_NilSpan(t *testing.T) {
-	// Should not panic.
-	RecordError(nil, errors.New("test error"))
+	assert.NotPanics(t, func() {
+		RecordError(nil, errors.New("test error"))
+	})
 }
 
 func TestRecordError_WithError(t *testing.T) {
-	// Use a recording span to verify error is recorded.
-	_, span := StartSpan(context.Background(), "error-span")
-	defer span.End()
-	RecordError(span, errors.New("test error"))
-	// Verify span is still valid (no panic).
+	assert.NotPanics(t, func() {
+		_, span := StartSpan(context.Background(), "error-span")
+		defer span.End()
+		RecordError(span, errors.New("test error"))
+	})
 }
 
 func TestRecordError_SetsErrorStatus(t *testing.T) {

--- a/services/operational-gateway/observability/tracing_test.go
+++ b/services/operational-gateway/observability/tracing_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 )
@@ -94,14 +93,10 @@ func TestAttributeKeys_AreDistinct(t *testing.T) {
 	}
 }
 
-// Verify the trace package codes constant is accessible.
-func TestCodes_ErrorConstant(t *testing.T) {
-	assert.Equal(t, codes.Error, codes.Error)
-}
-
-// Verify SpanKindInternal is used.
-func TestStartSpan_UsesInternalKind(t *testing.T) {
-	t.Helper()
-	// StartSpan uses trace.SpanKindInternal; verify it compiles.
-	assert.NotNil(t, trace.SpanKindInternal)
+func TestStartSpan_ProducesValidSpanContext(t *testing.T) {
+	ctx, span := StartSpan(context.Background(), "valid-span")
+	defer span.End()
+	// Verify span is embedded in the returned context.
+	spanFromCtx := trace.SpanFromContext(ctx)
+	assert.Equal(t, span, spanFromCtx)
 }

--- a/services/operational-gateway/observability/tracing_test.go
+++ b/services/operational-gateway/observability/tracing_test.go
@@ -7,10 +7,27 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
-	"go.opentelemetry.io/otel/trace/noop"
 )
+
+// setupTestTracer installs a recording tracer provider and returns the span recorder.
+// It restores the original provider when the test finishes.
+func setupTestTracer(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+	})
+	return sr
+}
 
 func TestTracer_ReturnsNonNil(t *testing.T) {
 	tr := Tracer()
@@ -18,6 +35,8 @@ func TestTracer_ReturnsNonNil(t *testing.T) {
 }
 
 func TestStartSpan_CreatesSpan(t *testing.T) {
+	sr := setupTestTracer(t)
+
 	ctx, span := StartSpan(context.Background(), "test-span",
 		AttrTenantID.String("tenant-1"),
 		AttrInstructionID.String("inst-1"),
@@ -25,9 +44,20 @@ func TestStartSpan_CreatesSpan(t *testing.T) {
 	require.NotNil(t, span)
 	require.NotNil(t, ctx)
 	span.End()
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "test-span", spans[0].Name())
+	assert.Equal(t, trace.SpanKindInternal, spans[0].SpanKind())
+
+	attrs := spans[0].Attributes()
+	assert.Contains(t, attrs, AttrTenantID.String("tenant-1"))
+	assert.Contains(t, attrs, AttrInstructionID.String("inst-1"))
 }
 
 func TestStartSpan_WithMultipleAttributes(t *testing.T) {
+	sr := setupTestTracer(t)
+
 	attrs := []attribute.KeyValue{
 		AttrInstructionType.String("kyc.verify"),
 		AttrProviderName.String("Onfido"),
@@ -35,18 +65,29 @@ func TestStartSpan_WithMultipleAttributes(t *testing.T) {
 		AttrMaxAttempts.Int(3),
 		AttrBatchSize.Int(10),
 	}
-	ctx, span := StartSpan(context.Background(), "multi-attr-span", attrs...)
-	require.NotNil(t, span)
-	require.NotNil(t, ctx)
+	_, span := StartSpan(context.Background(), "multi-attr-span", attrs...)
 	span.End()
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	recorded := spans[0].Attributes()
+	for _, a := range attrs {
+		assert.Contains(t, recorded, a)
+	}
 }
 
 func TestRecordError_NilError(t *testing.T) {
-	assert.NotPanics(t, func() {
-		_, span := StartSpan(context.Background(), "test")
-		defer span.End()
-		RecordError(span, nil)
-	})
+	sr := setupTestTracer(t)
+
+	_, span := StartSpan(context.Background(), "test")
+	RecordError(span, nil)
+	span.End()
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	// Nil error should not set error status.
+	assert.Equal(t, codes.Unset, spans[0].Status().Code)
+	assert.Empty(t, spans[0].Events())
 }
 
 func TestRecordError_NilSpan(t *testing.T) {
@@ -56,21 +97,18 @@ func TestRecordError_NilSpan(t *testing.T) {
 }
 
 func TestRecordError_WithError(t *testing.T) {
-	assert.NotPanics(t, func() {
-		_, span := StartSpan(context.Background(), "error-span")
-		defer span.End()
-		RecordError(span, errors.New("test error"))
-	})
-}
+	sr := setupTestTracer(t)
 
-func TestRecordError_SetsErrorStatus(t *testing.T) {
-	// Use noop tracer to verify no panic; status is set internally.
-	assert.NotPanics(t, func() {
-		tracer := noop.NewTracerProvider().Tracer("test")
-		_, span := tracer.Start(context.Background(), "test-op")
-		RecordError(span, errors.New("something went wrong"))
-		span.End()
-	})
+	_, span := StartSpan(context.Background(), "error-span")
+	RecordError(span, errors.New("something broke"))
+	span.End()
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	assert.Equal(t, codes.Error, spans[0].Status().Code)
+	assert.Equal(t, "error", spans[0].Status().Description)
+	require.NotEmpty(t, spans[0].Events())
+	assert.Equal(t, "exception", spans[0].Events()[0].Name)
 }
 
 func TestAttributeKeys_AreDistinct(t *testing.T) {
@@ -94,9 +132,16 @@ func TestAttributeKeys_AreDistinct(t *testing.T) {
 }
 
 func TestStartSpan_ProducesValidSpanContext(t *testing.T) {
+	sr := setupTestTracer(t)
+
 	ctx, span := StartSpan(context.Background(), "valid-span")
 	defer span.End()
 	// Verify span is embedded in the returned context.
 	spanFromCtx := trace.SpanFromContext(ctx)
 	assert.Equal(t, span, spanFromCtx)
+
+	span.End()
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "valid-span", spans[0].Name())
 }

--- a/services/operational-gateway/observability/tracing_test.go
+++ b/services/operational-gateway/observability/tracing_test.go
@@ -1,0 +1,103 @@
+package observability
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+func TestTracer_ReturnsNonNil(t *testing.T) {
+	tr := Tracer()
+	assert.NotNil(t, tr)
+}
+
+func TestStartSpan_CreatesSpan(t *testing.T) {
+	ctx, span := StartSpan(context.Background(), "test-span",
+		AttrTenantID.String("tenant-1"),
+		AttrInstructionID.String("inst-1"),
+	)
+	require.NotNil(t, span)
+	require.NotNil(t, ctx)
+	span.End()
+}
+
+func TestStartSpan_WithMultipleAttributes(t *testing.T) {
+	attrs := []attribute.KeyValue{
+		AttrInstructionType.String("kyc.verify"),
+		AttrProviderName.String("Onfido"),
+		AttrAttemptCount.Int(1),
+		AttrMaxAttempts.Int(3),
+		AttrBatchSize.Int(10),
+	}
+	ctx, span := StartSpan(context.Background(), "multi-attr-span", attrs...)
+	require.NotNil(t, span)
+	require.NotNil(t, ctx)
+	span.End()
+}
+
+func TestRecordError_NilError(t *testing.T) {
+	_, span := StartSpan(context.Background(), "test")
+	defer span.End()
+	// Should not panic.
+	RecordError(span, nil)
+}
+
+func TestRecordError_NilSpan(t *testing.T) {
+	// Should not panic.
+	RecordError(nil, errors.New("test error"))
+}
+
+func TestRecordError_WithError(t *testing.T) {
+	// Use a recording span to verify error is recorded.
+	_, span := StartSpan(context.Background(), "error-span")
+	defer span.End()
+	RecordError(span, errors.New("test error"))
+	// Verify span is still valid (no panic).
+}
+
+func TestRecordError_SetsErrorStatus(t *testing.T) {
+	// Use noop tracer to verify no panic; status is set internally.
+	tracer := noop.NewTracerProvider().Tracer("test")
+	ctx, span := tracer.Start(context.Background(), "test-op")
+	_ = ctx
+	RecordError(span, errors.New("something went wrong"))
+	span.End()
+}
+
+func TestAttributeKeys_AreDistinct(t *testing.T) {
+	keys := []attribute.Key{
+		AttrTenantID,
+		AttrInstructionID,
+		AttrInstructionType,
+		AttrInstructionStatus,
+		AttrProviderConnectionID,
+		AttrProviderName,
+		AttrAttemptCount,
+		AttrMaxAttempts,
+		AttrErrorCode,
+		AttrBatchSize,
+	}
+	seen := make(map[attribute.Key]bool)
+	for _, k := range keys {
+		assert.False(t, seen[k], "duplicate attribute key: %s", k)
+		seen[k] = true
+	}
+}
+
+// Verify the trace package codes constant is accessible.
+func TestCodes_ErrorConstant(t *testing.T) {
+	assert.Equal(t, codes.Error, codes.Error)
+}
+
+// Verify SpanKindInternal is used.
+func TestStartSpan_UsesInternalKind(t *testing.T) {
+	// StartSpan uses trace.SpanKindInternal; verify it compiles.
+	_ = trace.SpanKindInternal
+}

--- a/services/operational-gateway/observability/tracing_test.go
+++ b/services/operational-gateway/observability/tracing_test.go
@@ -66,11 +66,12 @@ func TestRecordError_WithError(t *testing.T) {
 
 func TestRecordError_SetsErrorStatus(t *testing.T) {
 	// Use noop tracer to verify no panic; status is set internally.
-	tracer := noop.NewTracerProvider().Tracer("test")
-	ctx, span := tracer.Start(context.Background(), "test-op")
-	_ = ctx
-	RecordError(span, errors.New("something went wrong"))
-	span.End()
+	assert.NotPanics(t, func() {
+		tracer := noop.NewTracerProvider().Tracer("test")
+		_, span := tracer.Start(context.Background(), "test-op")
+		RecordError(span, errors.New("something went wrong"))
+		span.End()
+	})
 }
 
 func TestAttributeKeys_AreDistinct(t *testing.T) {
@@ -100,6 +101,7 @@ func TestCodes_ErrorConstant(t *testing.T) {
 
 // Verify SpanKindInternal is used.
 func TestStartSpan_UsesInternalKind(t *testing.T) {
+	t.Helper()
 	// StartSpan uses trace.SpanKindInternal; verify it compiles.
-	_ = trace.SpanKindInternal
+	assert.NotNil(t, trace.SpanKindInternal)
 }

--- a/services/operational-gateway/service/grpc_mappers_test.go
+++ b/services/operational-gateway/service/grpc_mappers_test.go
@@ -334,7 +334,8 @@ func TestAnyToProtoValue_AllTypes(t *testing.T) {
 	t.Run("Nil", func(t *testing.T) {
 		v := anyToProtoValue(nil)
 		assert.NotNil(t, v)
-		assert.NotNil(t, v.GetNullValue())
+		_, ok := v.GetKind().(*structpb.Value_NullValue)
+		assert.True(t, ok)
 	})
 
 	t.Run("Bool", func(t *testing.T) {
@@ -402,7 +403,8 @@ func TestAnyToProtoValue_AllTypes(t *testing.T) {
 
 	t.Run("UnsupportedType_ReturnsNull", func(t *testing.T) {
 		v := anyToProtoValue(struct{}{})
-		assert.NotNil(t, v.GetNullValue())
+		_, ok := v.GetKind().(*structpb.Value_NullValue)
+		assert.True(t, ok)
 	})
 }
 

--- a/services/operational-gateway/service/grpc_mappers_test.go
+++ b/services/operational-gateway/service/grpc_mappers_test.go
@@ -1,0 +1,590 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// ========== domainToProtoStatus ==========
+
+func TestDomainToProtoStatus_AllStatuses(t *testing.T) {
+	tests := []struct {
+		domain domain.InstructionStatus
+		proto  opgatewayv1.InstructionStatus
+	}{
+		{domain.InstructionStatusPending, opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_PENDING},
+		{domain.InstructionStatusDispatching, opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_DISPATCHING},
+		{domain.InstructionStatusDelivered, opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_DELIVERED},
+		{domain.InstructionStatusAcknowledged, opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_ACKNOWLEDGED},
+		{domain.InstructionStatusRetrying, opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_RETRYING},
+		{domain.InstructionStatusFailed, opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_FAILED},
+		{domain.InstructionStatusExpired, opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_EXPIRED},
+		{domain.InstructionStatusCancelled, opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_CANCELLED},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.domain), func(t *testing.T) {
+			assert.Equal(t, tt.proto, domainToProtoStatus(tt.domain))
+		})
+	}
+}
+
+func TestDomainToProtoStatus_Unknown(t *testing.T) {
+	assert.Equal(t, opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_UNSPECIFIED, domainToProtoStatus("BOGUS"))
+}
+
+// ========== protoToDomainStatus ==========
+
+func TestProtoToDomainStatus_AllStatuses(t *testing.T) {
+	tests := []struct {
+		proto  opgatewayv1.InstructionStatus
+		domain domain.InstructionStatus
+	}{
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_UNSPECIFIED, ""},
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_PENDING, domain.InstructionStatusPending},
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_DISPATCHING, domain.InstructionStatusDispatching},
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_DELIVERED, domain.InstructionStatusDelivered},
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_ACKNOWLEDGED, domain.InstructionStatusAcknowledged},
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_RETRYING, domain.InstructionStatusRetrying},
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_FAILED, domain.InstructionStatusFailed},
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_EXPIRED, domain.InstructionStatusExpired},
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_CANCELLED, domain.InstructionStatusCancelled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.proto.String(), func(t *testing.T) {
+			assert.Equal(t, tt.domain, protoToDomainStatus(tt.proto))
+		})
+	}
+}
+
+func TestProtoToDomainStatus_Unrecognized(t *testing.T) {
+	assert.Equal(t, domain.InstructionStatus(""), protoToDomainStatus(opgatewayv1.InstructionStatus(999)))
+}
+
+// ========== domainToProtoPriority ==========
+
+func TestDomainToProtoPriority_AllPriorities(t *testing.T) {
+	tests := []struct {
+		domain domain.Priority
+		proto  opgatewayv1.Priority
+	}{
+		{domain.PriorityLow, opgatewayv1.Priority_PRIORITY_LOW},
+		{domain.PriorityNormal, opgatewayv1.Priority_PRIORITY_NORMAL},
+		{domain.PriorityHigh, opgatewayv1.Priority_PRIORITY_HIGH},
+		{domain.PriorityCritical, opgatewayv1.Priority_PRIORITY_CRITICAL},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.domain), func(t *testing.T) {
+			assert.Equal(t, tt.proto, domainToProtoPriority(tt.domain))
+		})
+	}
+}
+
+func TestDomainToProtoPriority_Unknown(t *testing.T) {
+	assert.Equal(t, opgatewayv1.Priority_PRIORITY_NORMAL, domainToProtoPriority("BOGUS"))
+}
+
+// ========== protoToDomainPriority ==========
+
+func TestProtoToDomainPriority_AllPriorities(t *testing.T) {
+	tests := []struct {
+		proto    opgatewayv1.Priority
+		expected domain.Priority
+	}{
+		{opgatewayv1.Priority_PRIORITY_UNSPECIFIED, domain.PriorityNormal},
+		{opgatewayv1.Priority_PRIORITY_LOW, domain.PriorityLow},
+		{opgatewayv1.Priority_PRIORITY_NORMAL, domain.PriorityNormal},
+		{opgatewayv1.Priority_PRIORITY_HIGH, domain.PriorityHigh},
+		{opgatewayv1.Priority_PRIORITY_CRITICAL, domain.PriorityCritical},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.proto.String(), func(t *testing.T) {
+			assert.Equal(t, tt.expected, protoToDomainPriority(tt.proto))
+		})
+	}
+}
+
+func TestProtoToDomainPriority_Unrecognized(t *testing.T) {
+	assert.Equal(t, domain.PriorityNormal, protoToDomainPriority(opgatewayv1.Priority(999)))
+}
+
+// ========== domainToProtoProtocol ==========
+
+func TestDomainToProtoProtocol_AllProtocols(t *testing.T) {
+	tests := []struct {
+		domain domain.Protocol
+		proto  opgatewayv1.Protocol
+	}{
+		{domain.ProtocolHTTPS, opgatewayv1.Protocol_PROTOCOL_HTTPS},
+		{domain.ProtocolGRPC, opgatewayv1.Protocol_PROTOCOL_GRPC},
+		{domain.ProtocolWebhook, opgatewayv1.Protocol_PROTOCOL_WEBHOOK},
+		{domain.ProtocolMQTT, opgatewayv1.Protocol_PROTOCOL_MQTT},
+		{domain.ProtocolAMQP, opgatewayv1.Protocol_PROTOCOL_AMQP},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.domain), func(t *testing.T) {
+			assert.Equal(t, tt.proto, domainToProtoProtocol(tt.domain))
+		})
+	}
+}
+
+func TestDomainToProtoProtocol_Unknown(t *testing.T) {
+	assert.Equal(t, opgatewayv1.Protocol_PROTOCOL_UNSPECIFIED, domainToProtoProtocol("BOGUS"))
+}
+
+// ========== protoToDomainProtocol ==========
+
+func TestProtoToDomainProtocol_AllProtocols(t *testing.T) {
+	tests := []struct {
+		proto  opgatewayv1.Protocol
+		domain domain.Protocol
+	}{
+		{opgatewayv1.Protocol_PROTOCOL_UNSPECIFIED, ""},
+		{opgatewayv1.Protocol_PROTOCOL_HTTPS, domain.ProtocolHTTPS},
+		{opgatewayv1.Protocol_PROTOCOL_GRPC, domain.ProtocolGRPC},
+		{opgatewayv1.Protocol_PROTOCOL_WEBHOOK, domain.ProtocolWebhook},
+		{opgatewayv1.Protocol_PROTOCOL_MQTT, domain.ProtocolMQTT},
+		{opgatewayv1.Protocol_PROTOCOL_AMQP, domain.ProtocolAMQP},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.proto.String(), func(t *testing.T) {
+			assert.Equal(t, tt.domain, protoToDomainProtocol(tt.proto))
+		})
+	}
+}
+
+func TestProtoToDomainProtocol_Unrecognized(t *testing.T) {
+	assert.Equal(t, domain.Protocol(""), protoToDomainProtocol(opgatewayv1.Protocol(999)))
+}
+
+// ========== domainToProtoHealthStatus ==========
+
+func TestDomainToProtoHealthStatus_AllStatuses(t *testing.T) {
+	tests := []struct {
+		domain domain.HealthStatus
+		proto  opgatewayv1.HealthStatus
+	}{
+		{domain.HealthStatusUnknown, opgatewayv1.HealthStatus_HEALTH_STATUS_UNSPECIFIED},
+		{domain.HealthStatusHealthy, opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY},
+		{domain.HealthStatusDegraded, opgatewayv1.HealthStatus_HEALTH_STATUS_DEGRADED},
+		{domain.HealthStatusUnhealthy, opgatewayv1.HealthStatus_HEALTH_STATUS_UNHEALTHY},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.domain), func(t *testing.T) {
+			assert.Equal(t, tt.proto, domainToProtoHealthStatus(tt.domain))
+		})
+	}
+}
+
+func TestDomainToProtoHealthStatus_Unknown(t *testing.T) {
+	assert.Equal(t, opgatewayv1.HealthStatus_HEALTH_STATUS_UNSPECIFIED, domainToProtoHealthStatus("BOGUS"))
+}
+
+// ========== protoToDomainAuthConfig ==========
+
+func TestProtoToDomainAuthConfig_AllTypes(t *testing.T) {
+	t.Run("ApiKey", func(t *testing.T) {
+		req := &opgatewayv1.UpsertConnectionRequest{
+			AuthConfig: &opgatewayv1.UpsertConnectionRequest_ApiKey{
+				ApiKey: &opgatewayv1.ApiKeyAuth{HeaderName: "X-Key", SecretRef: "ref"},
+			},
+		}
+		auth := protoToDomainAuthConfig(req)
+		apiKey, ok := auth.(*domain.APIKeyAuth)
+		assert.True(t, ok)
+		assert.Equal(t, "X-Key", apiKey.HeaderName)
+		assert.Equal(t, "ref", apiKey.SecretRef)
+	})
+
+	t.Run("Basic", func(t *testing.T) {
+		req := &opgatewayv1.UpsertConnectionRequest{
+			AuthConfig: &opgatewayv1.UpsertConnectionRequest_Basic{
+				Basic: &opgatewayv1.BasicAuth{Username: "user", PasswordSecretRef: "pass-ref"},
+			},
+		}
+		auth := protoToDomainAuthConfig(req)
+		basic, ok := auth.(*domain.BasicAuth)
+		assert.True(t, ok)
+		assert.Equal(t, "user", basic.Username)
+		assert.Equal(t, "pass-ref", basic.PasswordRef)
+	})
+
+	t.Run("OAuth2", func(t *testing.T) {
+		req := &opgatewayv1.UpsertConnectionRequest{
+			AuthConfig: &opgatewayv1.UpsertConnectionRequest_Oauth2{
+				Oauth2: &opgatewayv1.OAuth2Auth{
+					TokenUrl:        "https://auth.example.com/token",
+					ClientId:        "client-1",
+					ClientSecretRef: "secret-ref",
+					Scopes:          []string{"read", "write"},
+				},
+			},
+		}
+		auth := protoToDomainAuthConfig(req)
+		oauth, ok := auth.(*domain.OAuth2Auth)
+		assert.True(t, ok)
+		assert.Equal(t, "https://auth.example.com/token", oauth.TokenURL)
+		assert.Equal(t, "client-1", oauth.ClientID)
+		assert.Equal(t, "secret-ref", oauth.ClientSecretRef)
+		assert.Equal(t, []string{"read", "write"}, oauth.Scopes)
+	})
+
+	t.Run("HMAC", func(t *testing.T) {
+		req := &opgatewayv1.UpsertConnectionRequest{
+			AuthConfig: &opgatewayv1.UpsertConnectionRequest_Hmac{
+				Hmac: &opgatewayv1.HMACAuth{
+					Algorithm:       "SHA256",
+					SecretRef:       "hmac-ref",
+					SignatureHeader: "X-Signature",
+				},
+			},
+		}
+		auth := protoToDomainAuthConfig(req)
+		hmac, ok := auth.(*domain.HMACAuth)
+		assert.True(t, ok)
+		assert.Equal(t, "SHA256", hmac.Algorithm)
+		assert.Equal(t, "hmac-ref", hmac.SecretRef)
+		assert.Equal(t, "X-Signature", hmac.SignatureHeader)
+	})
+
+	t.Run("MTLS", func(t *testing.T) {
+		req := &opgatewayv1.UpsertConnectionRequest{
+			AuthConfig: &opgatewayv1.UpsertConnectionRequest_Mtls{
+				Mtls: &opgatewayv1.MTLSAuth{
+					ClientCertSecretRef: "cert-ref",
+					ClientKeySecretRef:  "key-ref",
+					CaCertSecretRef:     "ca-ref",
+				},
+			},
+		}
+		auth := protoToDomainAuthConfig(req)
+		mtls, ok := auth.(*domain.MTLSAuth)
+		assert.True(t, ok)
+		assert.Equal(t, "cert-ref", mtls.ClientCertRef)
+		assert.Equal(t, "key-ref", mtls.ClientKeyRef)
+		assert.Equal(t, "ca-ref", mtls.CACertRef)
+	})
+
+	t.Run("NilAuthConfig", func(t *testing.T) {
+		req := &opgatewayv1.UpsertConnectionRequest{}
+		auth := protoToDomainAuthConfig(req)
+		assert.Nil(t, auth)
+	})
+}
+
+// ========== protoToDomainRetryPolicy ==========
+
+func TestProtoToDomainRetryPolicy(t *testing.T) {
+	t.Run("NilProto_ReturnsDefaults", func(t *testing.T) {
+		p := protoToDomainRetryPolicy(nil)
+		assert.Equal(t, 3, p.MaxAttempts)
+		assert.Equal(t, 2.0, p.BackoffMultiplier)
+	})
+
+	t.Run("CustomValues", func(t *testing.T) {
+		p := protoToDomainRetryPolicy(&opgatewayv1.RetryPolicy{
+			MaxAttempts:           5,
+			InitialBackoffSeconds: 2,
+			MaxBackoffSeconds:     120,
+			BackoffMultiplier:     3.0,
+		})
+		assert.Equal(t, 5, p.MaxAttempts)
+		assert.Equal(t, 3.0, p.BackoffMultiplier)
+	})
+
+	t.Run("ZeroFields_KeepDefaults", func(t *testing.T) {
+		p := protoToDomainRetryPolicy(&opgatewayv1.RetryPolicy{})
+		assert.Equal(t, 3, p.MaxAttempts)
+	})
+}
+
+// ========== protoToDomainRateLimit ==========
+
+func TestProtoToDomainRateLimit(t *testing.T) {
+	t.Run("NilProto_ReturnsEmpty", func(t *testing.T) {
+		r := protoToDomainRateLimit(nil)
+		assert.Equal(t, float64(0), r.RequestsPerSecond)
+		assert.Equal(t, 0, r.BurstSize)
+	})
+
+	t.Run("ValidValues", func(t *testing.T) {
+		r := protoToDomainRateLimit(&opgatewayv1.RateLimit{
+			RequestsPerSecond: 100.0,
+			BurstSize:         50,
+		})
+		assert.Equal(t, 100.0, r.RequestsPerSecond)
+		assert.Equal(t, 50, r.BurstSize)
+	})
+}
+
+// ========== anyToProtoValue ==========
+
+func TestAnyToProtoValue_AllTypes(t *testing.T) {
+	t.Run("Nil", func(t *testing.T) {
+		v := anyToProtoValue(nil)
+		assert.NotNil(t, v)
+		assert.NotNil(t, v.GetNullValue())
+	})
+
+	t.Run("Bool", func(t *testing.T) {
+		v := anyToProtoValue(true)
+		assert.True(t, v.GetBoolValue())
+	})
+
+	t.Run("Float64", func(t *testing.T) {
+		v := anyToProtoValue(float64(3.14))
+		assert.InDelta(t, 3.14, v.GetNumberValue(), 0.001)
+	})
+
+	t.Run("Float32", func(t *testing.T) {
+		v := anyToProtoValue(float32(2.5))
+		assert.InDelta(t, 2.5, v.GetNumberValue(), 0.01)
+	})
+
+	t.Run("Int", func(t *testing.T) {
+		v := anyToProtoValue(42)
+		assert.Equal(t, float64(42), v.GetNumberValue())
+	})
+
+	t.Run("Int32", func(t *testing.T) {
+		v := anyToProtoValue(int32(42))
+		assert.Equal(t, float64(42), v.GetNumberValue())
+	})
+
+	t.Run("Int64", func(t *testing.T) {
+		v := anyToProtoValue(int64(42))
+		assert.Equal(t, float64(42), v.GetNumberValue())
+	})
+
+	t.Run("Uint", func(t *testing.T) {
+		v := anyToProtoValue(uint(42))
+		assert.Equal(t, float64(42), v.GetNumberValue())
+	})
+
+	t.Run("Uint32", func(t *testing.T) {
+		v := anyToProtoValue(uint32(42))
+		assert.Equal(t, float64(42), v.GetNumberValue())
+	})
+
+	t.Run("Uint64", func(t *testing.T) {
+		v := anyToProtoValue(uint64(42))
+		assert.Equal(t, float64(42), v.GetNumberValue())
+	})
+
+	t.Run("String", func(t *testing.T) {
+		v := anyToProtoValue("hello")
+		assert.Equal(t, "hello", v.GetStringValue())
+	})
+
+	t.Run("SliceAny", func(t *testing.T) {
+		v := anyToProtoValue([]any{"a", float64(1)})
+		list := v.GetListValue()
+		assert.Len(t, list.GetValues(), 2)
+		assert.Equal(t, "a", list.GetValues()[0].GetStringValue())
+	})
+
+	t.Run("NestedMap", func(t *testing.T) {
+		v := anyToProtoValue(map[string]any{"key": "value"})
+		s := v.GetStructValue()
+		assert.Equal(t, "value", s.Fields["key"].GetStringValue())
+	})
+
+	t.Run("UnsupportedType_ReturnsNull", func(t *testing.T) {
+		v := anyToProtoValue(struct{}{})
+		assert.NotNil(t, v.GetNullValue())
+	})
+}
+
+// ========== protoValueToAny ==========
+
+func TestProtoValueToAny_AllTypes(t *testing.T) {
+	t.Run("Nil", func(t *testing.T) {
+		assert.Nil(t, protoValueToAny(nil))
+	})
+
+	t.Run("NullValue", func(t *testing.T) {
+		assert.Nil(t, protoValueToAny(structpb.NewNullValue()))
+	})
+
+	t.Run("Bool", func(t *testing.T) {
+		assert.Equal(t, true, protoValueToAny(structpb.NewBoolValue(true)))
+	})
+
+	t.Run("Number", func(t *testing.T) {
+		assert.Equal(t, float64(42), protoValueToAny(structpb.NewNumberValue(42)))
+	})
+
+	t.Run("String", func(t *testing.T) {
+		assert.Equal(t, "hello", protoValueToAny(structpb.NewStringValue("hello")))
+	})
+
+	t.Run("List", func(t *testing.T) {
+		list := structpb.NewListValue(&structpb.ListValue{
+			Values: []*structpb.Value{structpb.NewStringValue("a"), structpb.NewNumberValue(1)},
+		})
+		result := protoValueToAny(list)
+		items, ok := result.([]any)
+		assert.True(t, ok)
+		assert.Len(t, items, 2)
+	})
+
+	t.Run("NilList", func(t *testing.T) {
+		v := &structpb.Value{Kind: &structpb.Value_ListValue{ListValue: nil}}
+		result := protoValueToAny(v)
+		items, ok := result.([]any)
+		assert.True(t, ok)
+		assert.Empty(t, items)
+	})
+
+	t.Run("Struct", func(t *testing.T) {
+		s, _ := structpb.NewStruct(map[string]any{"k": "v"})
+		v := structpb.NewStructValue(s)
+		result := protoValueToAny(v)
+		m, ok := result.(map[string]any)
+		assert.True(t, ok)
+		assert.Equal(t, "v", m["k"])
+	})
+}
+
+// ========== mapToStruct / structToMap roundtrip ==========
+
+func TestMapToStruct_NilMap(t *testing.T) {
+	assert.Nil(t, mapToStruct(nil))
+}
+
+func TestStructToMap_NilStruct(t *testing.T) {
+	m := structToMap(nil)
+	assert.NotNil(t, m)
+	assert.Empty(t, m)
+}
+
+func TestStructToMapRoundtrip(t *testing.T) {
+	original := map[string]any{
+		"str":  "hello",
+		"num":  float64(42),
+		"bool": true,
+	}
+	s := mapToStruct(original)
+	result := structToMap(s)
+	assert.Equal(t, "hello", result["str"])
+	assert.Equal(t, float64(42), result["num"])
+	assert.Equal(t, true, result["bool"])
+}
+
+// ========== connectionToProto ==========
+
+func TestConnectionToProto_AllAuthTypes(t *testing.T) {
+	base := func(auth domain.AuthConfig) *domain.ProviderConnection {
+		conn, _ := domain.NewProviderConnection(
+			testTenantID(), "Provider", "type", domain.ProtocolHTTPS,
+			"https://api.example.com", auth,
+			domain.RetryPolicy{MaxAttempts: 3}, domain.RateLimitConfig{},
+		)
+		return conn
+	}
+
+	t.Run("OAuth2", func(t *testing.T) {
+		conn := base(&domain.OAuth2Auth{
+			TokenURL:        "https://auth.example.com/token",
+			ClientID:        "c1",
+			ClientSecretRef: "cs",
+			Scopes:          []string{"read"},
+		})
+		p := connectionToProto(conn)
+		oauth := p.GetOauth2()
+		assert.NotNil(t, oauth)
+		assert.Equal(t, "https://auth.example.com/token", oauth.TokenUrl)
+	})
+
+	t.Run("HMAC", func(t *testing.T) {
+		conn := base(&domain.HMACAuth{
+			Algorithm:       "SHA256",
+			SecretRef:       "ref",
+			SignatureHeader: "X-Sig",
+		})
+		p := connectionToProto(conn)
+		hmac := p.GetHmac()
+		assert.NotNil(t, hmac)
+		assert.Equal(t, "SHA256", hmac.Algorithm)
+	})
+
+	t.Run("MTLS", func(t *testing.T) {
+		conn := base(&domain.MTLSAuth{
+			ClientCertRef: "cert",
+			ClientKeyRef:  "key",
+			CACertRef:     "ca",
+		})
+		p := connectionToProto(conn)
+		mtls := p.GetMtls()
+		assert.NotNil(t, mtls)
+		assert.Equal(t, "cert", mtls.ClientCertSecretRef)
+	})
+
+	t.Run("BasicAuth", func(t *testing.T) {
+		conn := base(&domain.BasicAuth{
+			Username:    "user",
+			PasswordRef: "pass",
+		})
+		p := connectionToProto(conn)
+		basic := p.GetBasic()
+		assert.NotNil(t, basic)
+		assert.Equal(t, "user", basic.Username)
+	})
+
+	t.Run("WithRateLimit", func(t *testing.T) {
+		conn, _ := domain.NewProviderConnection(
+			testTenantID(), "Provider", "type", domain.ProtocolHTTPS,
+			"https://api.example.com",
+			&domain.APIKeyAuth{HeaderName: "X-Key", SecretRef: "ref"},
+			domain.RetryPolicy{MaxAttempts: 3},
+			domain.RateLimitConfig{RequestsPerSecond: 100, BurstSize: 50},
+		)
+		p := connectionToProto(conn)
+		assert.NotNil(t, p.RateLimit)
+		assert.Equal(t, float64(100), p.RateLimit.RequestsPerSecond)
+	})
+}
+
+// ========== instructionToProto ==========
+
+func TestInstructionToProto_WithAttempts(t *testing.T) {
+	inst, err := domain.NewInstruction(
+		uuid.MustParse(testTenantID()), "test.cmd", "conn-1",
+		map[string]any{"key": "val"},
+	)
+	assert.NoError(t, err)
+
+	// Add an attempt.
+	inst.Attempts = append(inst.Attempts, domain.InstructionAttempt{
+		AttemptNumber: 1,
+		FailureReason: "timeout",
+	})
+
+	p := instructionToProto(inst)
+	assert.Len(t, p.Attempts, 1)
+	assert.Equal(t, int32(1), p.Attempts[0].AttemptNumber)
+	assert.Equal(t, "timeout", p.Attempts[0].ErrorMessage)
+}
+
+// ========== attemptToProto ==========
+
+func TestAttemptToProto(t *testing.T) {
+	a := domain.InstructionAttempt{
+		AttemptNumber: 3,
+		FailureReason: "connection refused",
+	}
+	p := attemptToProto(a)
+	assert.Equal(t, int32(3), p.AttemptNumber)
+	assert.Equal(t, "connection refused", p.ErrorMessage)
+}

--- a/services/operational-gateway/service/grpc_query_test.go
+++ b/services/operational-gateway/service/grpc_query_test.go
@@ -494,6 +494,7 @@ func TestDispatchInstruction_WithOptionalFields(t *testing.T) {
 	assert.Equal(t, opgatewayv1.Priority_PRIORITY_HIGH, resp.Instruction.Priority)
 	assert.Equal(t, "corr-123", resp.Instruction.CorrelationId)
 	assert.Equal(t, "cause-456", resp.Instruction.CausationId)
+	assert.Equal(t, "test", resp.Instruction.Metadata["env"])
 }
 
 // ========== CancelInstruction additional unhappy paths ==========

--- a/services/operational-gateway/service/grpc_query_test.go
+++ b/services/operational-gateway/service/grpc_query_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
@@ -94,8 +95,29 @@ func TestListInstructions_StatusFilter(t *testing.T) {
 }
 
 func TestListInstructions_DateRange(t *testing.T) {
-	svc, _, _ := newTestOGService(t)
+	svc, instRepo, _ := newTestOGService(t)
 	ctx := tenantContext("test-tenant")
+	tid := testTenantID()
+	tidUUID := tenantIDToUUID(tenant.TenantID(tid))
+
+	// Seed instructions at different dates.
+	before, _ := domain.NewInstruction(uuid.MustParse(tidUUID), "cmd.before", uuid.New().String(), map[string]any{"k": "v"})
+	before.ID = uuid.New()
+	before.CreatedAt = time.Date(2024, 12, 15, 0, 0, 0, 0, time.UTC)
+
+	inside, _ := domain.NewInstruction(uuid.MustParse(tidUUID), "cmd.inside", uuid.New().String(), map[string]any{"k": "v"})
+	inside.ID = uuid.New()
+	inside.CreatedAt = time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC)
+
+	after, _ := domain.NewInstruction(uuid.MustParse(tidUUID), "cmd.after", uuid.New().String(), map[string]any{"k": "v"})
+	after.ID = uuid.New()
+	after.CreatedAt = time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	instRepo.mu.Lock()
+	instRepo.instructions[before.ID] = before
+	instRepo.instructions[inside.ID] = inside
+	instRepo.instructions[after.ID] = after
+	instRepo.mu.Unlock()
 
 	resp, err := svc.ListInstructions(ctx, &opgatewayv1.ListInstructionsRequest{
 		DateRange: &commonpb.DateRange{
@@ -104,7 +126,8 @@ func TestListInstructions_DateRange(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.NotNil(t, resp)
+	assert.Len(t, resp.Instructions, 1)
+	assert.Equal(t, "cmd.inside", resp.Instructions[0].InstructionType)
 }
 
 func TestListInstructions_InvalidStartDate(t *testing.T) {

--- a/services/operational-gateway/service/grpc_query_test.go
+++ b/services/operational-gateway/service/grpc_query_test.go
@@ -1,0 +1,772 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+	"github.com/meridianhub/meridian/services/operational-gateway/ports"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+	"gorm.io/gorm"
+)
+
+// ========== encodeOffsetToken / decodeOffsetToken ==========
+
+func TestEncodeDecodeOffsetToken_Roundtrip(t *testing.T) {
+	for _, offset := range []int{0, 1, 50, 1000} {
+		token := encodeOffsetToken(offset)
+		decoded, err := decodeOffsetToken(token)
+		require.NoError(t, err)
+		assert.Equal(t, offset, decoded)
+	}
+}
+
+func TestDecodeOffsetToken_InvalidFormat(t *testing.T) {
+	_, err := decodeOffsetToken("garbage")
+	assert.ErrorIs(t, err, errInvalidPageTokenFormat)
+}
+
+func TestDecodeOffsetToken_InvalidNumber(t *testing.T) {
+	_, err := decodeOffsetToken("offset:abc")
+	assert.Error(t, err)
+}
+
+func TestDecodeOffsetToken_NegativeOffset(t *testing.T) {
+	_, err := decodeOffsetToken("offset:-1")
+	assert.ErrorIs(t, err, errNegativePageOffset)
+}
+
+// ========== parseDate ==========
+
+func TestParseDate_Valid(t *testing.T) {
+	d, err := parseDate("2025-03-15")
+	require.NoError(t, err)
+	assert.Equal(t, 2025, d.Year())
+	assert.Equal(t, 3, int(d.Month()))
+	assert.Equal(t, 15, d.Day())
+}
+
+func TestParseDate_Invalid(t *testing.T) {
+	_, err := parseDate("not-a-date")
+	assert.Error(t, err)
+}
+
+func TestParseDate_WrongFormat(t *testing.T) {
+	_, err := parseDate("03/15/2025")
+	assert.Error(t, err)
+}
+
+// ========== ListInstructions filter tests ==========
+
+func TestListInstructions_StatusFilter(t *testing.T) {
+	svc, instRepo, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+	tid := uuid.MustParse(testTenantID())
+
+	// Create instructions in different statuses.
+	pending, err := domain.NewInstruction(tid, "device.command", "conn", map[string]any{"i": float64(1)})
+	require.NoError(t, err)
+	pending.ID = uuid.New()
+	instRepo.instructions[pending.ID] = pending
+
+	dispatching, err := domain.NewInstruction(tid, "device.command", "conn", map[string]any{"i": float64(2)})
+	require.NoError(t, err)
+	dispatching.ID = uuid.New()
+	require.NoError(t, dispatching.MarkDispatching())
+	instRepo.instructions[dispatching.ID] = dispatching
+
+	resp, err := svc.ListInstructions(ctx, &opgatewayv1.ListInstructionsRequest{
+		Status: []opgatewayv1.InstructionStatus{
+			opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_PENDING,
+		},
+	})
+	require.NoError(t, err)
+	assert.Len(t, resp.Instructions, 1)
+	assert.Equal(t, opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_PENDING, resp.Instructions[0].Status)
+}
+
+func TestListInstructions_DateRange(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	resp, err := svc.ListInstructions(ctx, &opgatewayv1.ListInstructionsRequest{
+		DateRange: &commonpb.DateRange{
+			StartDate: "2025-01-01",
+			EndDate:   "2025-12-31",
+		},
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+}
+
+func TestListInstructions_InvalidStartDate(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.ListInstructions(ctx, &opgatewayv1.ListInstructionsRequest{
+		DateRange: &commonpb.DateRange{
+			StartDate: "not-a-date",
+		},
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestListInstructions_InvalidEndDate(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.ListInstructions(ctx, &opgatewayv1.ListInstructionsRequest{
+		DateRange: &commonpb.DateRange{
+			EndDate: "bad-date",
+		},
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestListInstructions_InvertedDateRange(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.ListInstructions(ctx, &opgatewayv1.ListInstructionsRequest{
+		DateRange: &commonpb.DateRange{
+			StartDate: "2025-12-31",
+			EndDate:   "2025-01-01",
+		},
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "start_date")
+}
+
+func TestListInstructions_InstructionTypeFilter(t *testing.T) {
+	svc, instRepo, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+	tid := uuid.MustParse(testTenantID())
+
+	inst1, _ := domain.NewInstruction(tid, "device.command", "conn", map[string]any{"i": float64(1)})
+	inst1.ID = uuid.New()
+	instRepo.instructions[inst1.ID] = inst1
+
+	inst2, _ := domain.NewInstruction(tid, "kyc.verify", "conn", map[string]any{"i": float64(2)})
+	inst2.ID = uuid.New()
+	instRepo.instructions[inst2.ID] = inst2
+
+	resp, err := svc.ListInstructions(ctx, &opgatewayv1.ListInstructionsRequest{
+		InstructionType: "device.command",
+	})
+	require.NoError(t, err)
+	assert.Len(t, resp.Instructions, 1)
+}
+
+// ========== GetInstruction - repo internal error ==========
+
+func TestGetInstruction_RepoInternalError(t *testing.T) {
+	svc, instRepo, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+	instRepo.findErr = assert.AnError
+
+	_, err := svc.GetInstruction(ctx, &opgatewayv1.GetInstructionRequest{
+		InstructionId: uuid.New().String(),
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
+// ========== ProcessCallback additional unhappy paths ==========
+
+func TestProcessCallback_MissingTenant(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+
+	_, err := svc.ProcessCallback(context.Background(), &opgatewayv1.ProcessCallbackRequest{
+		InstructionId:  uuid.New().String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "k"},
+		Callback:       &opgatewayv1.CallbackPayload{},
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestProcessCallback_MissingIdempotencyKey(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.ProcessCallback(ctx, &opgatewayv1.ProcessCallbackRequest{
+		InstructionId: uuid.New().String(),
+		Callback:      &opgatewayv1.CallbackPayload{},
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestProcessCallback_MissingCallback(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.ProcessCallback(ctx, &opgatewayv1.ProcessCallbackRequest{
+		InstructionId:  uuid.New().String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "k"},
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestProcessCallback_InvalidUUID(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.ProcessCallback(ctx, &opgatewayv1.ProcessCallbackRequest{
+		InstructionId:  "not-a-uuid",
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "k"},
+		Callback:       &opgatewayv1.CallbackPayload{},
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestProcessCallback_NoIdentifier(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.ProcessCallback(ctx, &opgatewayv1.ProcessCallbackRequest{
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "k"},
+		Callback:       &opgatewayv1.CallbackPayload{},
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestProcessCallback_NotFound(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.ProcessCallback(ctx, &opgatewayv1.ProcessCallbackRequest{
+		InstructionId:  uuid.New().String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "k"},
+		Callback:       &opgatewayv1.CallbackPayload{},
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestProcessCallback_WrongTenant(t *testing.T) {
+	svc, instRepo, _ := newTestOGService(t)
+
+	otherTenantID := uuid.New()
+	inst, err := domain.NewInstruction(otherTenantID, "device.command", "conn", map[string]any{"x": float64(1)})
+	require.NoError(t, err)
+	inst.ID = uuid.New()
+	require.NoError(t, inst.MarkDispatching())
+	require.NoError(t, inst.MarkDelivered())
+	instRepo.instructions[inst.ID] = inst
+
+	ctx := tenantContext("test-tenant")
+	_, err = svc.ProcessCallback(ctx, &opgatewayv1.ProcessCallbackRequest{
+		InstructionId:  inst.ID.String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "k"},
+		Callback:       &opgatewayv1.CallbackPayload{},
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestProcessCallback_NotDelivered(t *testing.T) {
+	svc, instRepo, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	tid := uuid.MustParse(testTenantID())
+	inst, err := domain.NewInstruction(tid, "device.command", "conn", map[string]any{"x": float64(1)})
+	require.NoError(t, err)
+	inst.ID = uuid.New()
+	// Leave in PENDING — cannot be acknowledged.
+	instRepo.instructions[inst.ID] = inst
+
+	_, err = svc.ProcessCallback(ctx, &opgatewayv1.ProcessCallbackRequest{
+		InstructionId:  inst.ID.String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "k"},
+		Callback:       &opgatewayv1.CallbackPayload{},
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestProcessCallback_RepoInternalError(t *testing.T) {
+	svc, instRepo, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+	instRepo.findErr = assert.AnError
+
+	_, err := svc.ProcessCallback(ctx, &opgatewayv1.ProcessCallbackRequest{
+		InstructionId:  uuid.New().String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "k"},
+		Callback:       &opgatewayv1.CallbackPayload{},
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
+func TestProcessCallback_SaveConflict(t *testing.T) {
+	svc, instRepo, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	inst := makeDeliveredInstruction(t, instRepo)
+	instRepo.saveErr = ports.ErrInstructionConflict
+
+	_, err := svc.ProcessCallback(ctx, &opgatewayv1.ProcessCallbackRequest{
+		InstructionId:  inst.ID.String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "k"},
+		Callback:       &opgatewayv1.CallbackPayload{},
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Aborted, st.Code())
+}
+
+func TestProcessCallback_SaveInternalError(t *testing.T) {
+	svc, instRepo, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	inst := makeDeliveredInstruction(t, instRepo)
+	instRepo.saveErr = assert.AnError
+
+	_, err := svc.ProcessCallback(ctx, &opgatewayv1.ProcessCallbackRequest{
+		InstructionId:  inst.ID.String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "k"},
+		Callback:       &opgatewayv1.CallbackPayload{},
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
+// ========== TestConnection tests ==========
+
+func TestTestConnection_Success(t *testing.T) {
+	svc, connRepo := newTestConnService(t)
+	ctx := tenantContext("test-tenant")
+	tid := tenantIDToUUID("test-tenant")
+	connID := uuid.New().String()
+
+	conn, err := domain.NewProviderConnection(tid, "Provider", "type", domain.ProtocolHTTPS,
+		"https://api.example.com", &domain.APIKeyAuth{HeaderName: "X-Key", SecretRef: "ref"},
+		domain.RetryPolicy{MaxAttempts: 3}, domain.RateLimitConfig{})
+	require.NoError(t, err)
+	conn.ConnectionID = connID
+	connRepo.connections[tid+":"+connID] = conn
+
+	_, err = svc.TestConnection(ctx, &opgatewayv1.TestConnectionRequest{
+		ConnectionId: connID,
+	})
+
+	// Should return Unimplemented (Phase 2 placeholder).
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unimplemented, st.Code())
+}
+
+func TestTestConnection_MissingTenant(t *testing.T) {
+	svc, _ := newTestConnService(t)
+
+	_, err := svc.TestConnection(context.Background(), &opgatewayv1.TestConnectionRequest{
+		ConnectionId: uuid.New().String(),
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestTestConnection_NotFound(t *testing.T) {
+	svc, _ := newTestConnService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.TestConnection(ctx, &opgatewayv1.TestConnectionRequest{
+		ConnectionId: uuid.New().String(),
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestTestConnection_RepoError(t *testing.T) {
+	svc, connRepo := newTestConnService(t)
+	ctx := tenantContext("test-tenant")
+	connRepo.findErr = assert.AnError
+
+	_, err := svc.TestConnection(ctx, &opgatewayv1.TestConnectionRequest{
+		ConnectionId: uuid.New().String(),
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
+// ========== DispatchInstruction additional unhappy paths ==========
+
+func TestDispatchInstruction_DuplicateIdempotencyKey(t *testing.T) {
+	svc, instRepo, _ := newTestOGService(t)
+	instRepo.saveErr = ports.ErrDuplicateIdempotency
+	ctx := tenantContext("test-tenant")
+
+	payload, _ := structpb.NewStruct(map[string]any{"x": float64(1)})
+	_, err := svc.DispatchInstruction(ctx, &opgatewayv1.DispatchInstructionRequest{
+		InstructionType: "device.command",
+		Payload:         payload,
+		IdempotencyKey:  &commonpb.IdempotencyKey{Key: "dup"},
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.AlreadyExists, st.Code())
+}
+
+func TestDispatchInstruction_WithOptionalFields(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	payload, _ := structpb.NewStruct(map[string]any{"x": float64(1)})
+	resp, err := svc.DispatchInstruction(ctx, &opgatewayv1.DispatchInstructionRequest{
+		InstructionType: "device.command",
+		Payload:         payload,
+		IdempotencyKey:  &commonpb.IdempotencyKey{Key: "idem-opts"},
+		Priority:        opgatewayv1.Priority_PRIORITY_HIGH,
+		CorrelationId:   "corr-123",
+		CausationId:     "cause-456",
+		Metadata:        map[string]string{"env": "test"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, opgatewayv1.Priority_PRIORITY_HIGH, resp.Instruction.Priority)
+	assert.Equal(t, "corr-123", resp.Instruction.CorrelationId)
+	assert.Equal(t, "cause-456", resp.Instruction.CausationId)
+}
+
+// ========== CancelInstruction additional unhappy paths ==========
+
+func TestCancelInstruction_MissingTenant(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+
+	_, err := svc.CancelInstruction(context.Background(), &opgatewayv1.CancelInstructionRequest{
+		InstructionId: uuid.New().String(),
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestCancelInstruction_InvalidUUID(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.CancelInstruction(ctx, &opgatewayv1.CancelInstructionRequest{
+		InstructionId: "not-a-uuid",
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestCancelInstruction_RepoInternalError(t *testing.T) {
+	svc, instRepo, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+	instRepo.findErr = assert.AnError
+
+	_, err := svc.CancelInstruction(ctx, &opgatewayv1.CancelInstructionRequest{
+		InstructionId: uuid.New().String(),
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
+func TestCancelInstruction_SaveConflict(t *testing.T) {
+	svc, instRepo, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	tid := uuid.MustParse(testTenantID())
+	inst, err := domain.NewInstruction(tid, "device.command", "conn", map[string]any{"x": float64(1)})
+	require.NoError(t, err)
+	inst.ID = uuid.New()
+	instRepo.instructions[inst.ID] = inst
+	instRepo.saveErr = ports.ErrInstructionConflict
+
+	_, err = svc.CancelInstruction(ctx, &opgatewayv1.CancelInstructionRequest{
+		InstructionId: inst.ID.String(),
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Aborted, st.Code())
+}
+
+// ========== UpsertConnection additional unhappy paths ==========
+
+func TestUpsertConnection_MissingAuthConfig(t *testing.T) {
+	svc, _ := newTestConnService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.UpsertConnection(ctx, &opgatewayv1.UpsertConnectionRequest{
+		ProviderName: "Provider",
+		ProviderType: "type",
+		Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
+		BaseUrl:      "https://api.example.com",
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestUpsertConnection_InvalidConnectionID(t *testing.T) {
+	svc, _ := newTestConnService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.UpsertConnection(ctx, &opgatewayv1.UpsertConnectionRequest{
+		ProviderName: "Provider",
+		ProviderType: "type",
+		Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
+		BaseUrl:      "https://api.example.com",
+		ConnectionId: "not-a-uuid",
+		AuthConfig: &opgatewayv1.UpsertConnectionRequest_ApiKey{
+			ApiKey: &opgatewayv1.ApiKeyAuth{HeaderName: "X-Key", SecretRef: "ref"},
+		},
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestUpsertConnection_RepoError(t *testing.T) {
+	svc, connRepo := newTestConnService(t)
+	ctx := tenantContext("test-tenant")
+	connRepo.upsertErr = assert.AnError
+
+	_, err := svc.UpsertConnection(ctx, &opgatewayv1.UpsertConnectionRequest{
+		ProviderName: "Provider",
+		ProviderType: "type",
+		Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
+		BaseUrl:      "https://api.example.com",
+		AuthConfig: &opgatewayv1.UpsertConnectionRequest_ApiKey{
+			ApiKey: &opgatewayv1.ApiKeyAuth{HeaderName: "X-Key", SecretRef: "ref"},
+		},
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
+// ========== GetConnection - repo internal error ==========
+
+func TestGetConnection_RepoError(t *testing.T) {
+	svc, connRepo := newTestConnService(t)
+	ctx := tenantContext("test-tenant")
+	connRepo.findErr = assert.AnError
+
+	_, err := svc.GetConnection(ctx, &opgatewayv1.GetConnectionRequest{
+		ConnectionId: uuid.New().String(),
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
+func TestGetConnection_MissingTenant(t *testing.T) {
+	svc, _ := newTestConnService(t)
+
+	_, err := svc.GetConnection(context.Background(), &opgatewayv1.GetConnectionRequest{
+		ConnectionId: uuid.New().String(),
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+// ========== ListConnections additional tests ==========
+
+func TestListConnections_Pagination(t *testing.T) {
+	svc, connRepo := newTestConnService(t)
+	ctx := tenantContext("test-tenant")
+	tid := tenantIDToUUID("test-tenant")
+
+	for i := 0; i < 5; i++ {
+		conn, err := domain.NewProviderConnection(tid, "Provider", "type", domain.ProtocolHTTPS,
+			"https://api.example.com", &domain.APIKeyAuth{HeaderName: "X-Key", SecretRef: "ref"},
+			domain.RetryPolicy{MaxAttempts: 3}, domain.RateLimitConfig{})
+		require.NoError(t, err)
+		connRepo.connections[tid+":"+conn.ConnectionID] = conn
+	}
+
+	resp, err := svc.ListConnections(ctx, &opgatewayv1.ListConnectionsRequest{
+		Pagination: &commonpb.Pagination{PageSize: 2},
+	})
+	require.NoError(t, err)
+	assert.Len(t, resp.Connections, 2)
+	assert.NotEmpty(t, resp.Pagination.NextPageToken)
+}
+
+func TestListConnections_ProtocolFilter(t *testing.T) {
+	svc, connRepo := newTestConnService(t)
+	ctx := tenantContext("test-tenant")
+	tid := tenantIDToUUID("test-tenant")
+
+	httpsConn, _ := domain.NewProviderConnection(tid, "HTTPS-Provider", "type", domain.ProtocolHTTPS,
+		"https://api.example.com", &domain.APIKeyAuth{HeaderName: "X-Key", SecretRef: "ref"},
+		domain.RetryPolicy{MaxAttempts: 3}, domain.RateLimitConfig{})
+	connRepo.connections[tid+":"+httpsConn.ConnectionID] = httpsConn
+
+	grpcConn, _ := domain.NewProviderConnection(tid, "GRPC-Provider", "type", domain.ProtocolGRPC,
+		"grpc://api.example.com", &domain.APIKeyAuth{HeaderName: "X-Key", SecretRef: "ref"},
+		domain.RetryPolicy{MaxAttempts: 3}, domain.RateLimitConfig{})
+	connRepo.connections[tid+":"+grpcConn.ConnectionID] = grpcConn
+
+	resp, err := svc.ListConnections(ctx, &opgatewayv1.ListConnectionsRequest{
+		Protocol: opgatewayv1.Protocol_PROTOCOL_HTTPS,
+	})
+	require.NoError(t, err)
+	assert.Len(t, resp.Connections, 1)
+	assert.Equal(t, "HTTPS-Provider", resp.Connections[0].ProviderName)
+}
+
+func TestListConnections_InvalidPageToken(t *testing.T) {
+	svc, _ := newTestConnService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.ListConnections(ctx, &opgatewayv1.ListConnectionsRequest{
+		Pagination: &commonpb.Pagination{PageToken: "garbage"},
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+// ========== saveInstructionWithEvent ==========
+
+func TestSaveInstructionWithEvent_PartialConfig(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	// Set only db but not others — partial configuration.
+	svc.db = &gorm.DB{}
+
+	tid := uuid.MustParse(testTenantID())
+	inst, err := domain.NewInstruction(tid, "device.command", "conn", map[string]any{"x": float64(1)})
+	require.NoError(t, err)
+
+	err = svc.saveInstructionWithEvent(context.Background(), inst, "key", nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEventPublishingPartialConfig)
+}
+
+func TestSaveInstructionWithEvent_NoPublishing(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+
+	tid := uuid.MustParse(testTenantID())
+	inst, err := domain.NewInstruction(tid, "device.command", "conn", map[string]any{"x": float64(1)})
+	require.NoError(t, err)
+
+	// No event publishing configured — should fall back to plain save.
+	err = svc.saveInstructionWithEvent(context.Background(), inst, "key", nil)
+	require.NoError(t, err)
+}
+
+func TestSaveInstructionWithEvent_NilPublishFunc(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+
+	tid := uuid.MustParse(testTenantID())
+	inst, err := domain.NewInstruction(tid, "device.command", "conn", map[string]any{"x": float64(1)})
+	require.NoError(t, err)
+
+	// No event publishing configured, publishEvent is nil.
+	err = svc.saveInstructionWithEvent(context.Background(), inst, "idem-key", nil)
+	require.NoError(t, err)
+}
+
+// ========== tenantIDToUUID ==========
+
+func TestTenantIDToUUID_ValidUUID(t *testing.T) {
+	id := uuid.New().String()
+	// Pass a real UUID through — should come back unchanged.
+	assert.Equal(t, id, tenantIDToUUID(tenant.TenantID(id)))
+}
+
+func TestTenantIDToUUID_AlphanumericSlug(t *testing.T) {
+	result := tenantIDToUUID("my-org")
+	_, err := uuid.Parse(result)
+	assert.NoError(t, err, "should produce a valid UUID from a slug")
+}
+
+func TestTenantIDToUUID_Deterministic(t *testing.T) {
+	a := tenantIDToUUID("same-slug")
+	b := tenantIDToUUID("same-slug")
+	assert.Equal(t, a, b)
+}

--- a/services/operational-gateway/service/grpc_route_service_test.go
+++ b/services/operational-gateway/service/grpc_route_service_test.go
@@ -1,0 +1,420 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+	"github.com/meridianhub/meridian/services/operational-gateway/ports"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ========== Mock route repository ==========
+
+type mockRouteRepo struct {
+	mu        sync.RWMutex
+	routes    map[string]*domain.Route // key: tenantID:instructionType
+	upsertErr error
+	findErr   error
+	listErr   error
+}
+
+func newMockRouteRepo() *mockRouteRepo {
+	return &mockRouteRepo{
+		routes: make(map[string]*domain.Route),
+	}
+}
+
+func (m *mockRouteRepo) Upsert(_ context.Context, route *domain.Route) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.upsertErr != nil {
+		return m.upsertErr
+	}
+	stored := *route
+	m.routes[route.TenantID+":"+route.InstructionType] = &stored
+	return nil
+}
+
+func (m *mockRouteRepo) FindByInstructionType(_ context.Context, tenantID string, instructionType string) (*domain.Route, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.findErr != nil {
+		return nil, m.findErr
+	}
+	route, ok := m.routes[tenantID+":"+instructionType]
+	if !ok {
+		return nil, ports.ErrRouteNotFound
+	}
+	stored := *route
+	return &stored, nil
+}
+
+func (m *mockRouteRepo) ListByTenant(_ context.Context, tenantID string) ([]*domain.Route, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	var result []*domain.Route
+	for _, r := range m.routes {
+		if r.TenantID == tenantID {
+			stored := *r
+			result = append(result, &stored)
+		}
+	}
+	return result, nil
+}
+
+// ========== Test helpers ==========
+
+func newTestRouteService(t *testing.T) (*InstructionRouteService, *mockRouteRepo, *mockConnectionRepo) {
+	t.Helper()
+	routeRepo := newMockRouteRepo()
+	connRepo := newMockConnectionRepo()
+	svc, err := NewInstructionRouteService(routeRepo, connRepo, nil)
+	require.NoError(t, err)
+	return svc, routeRepo, connRepo
+}
+
+func seedConnection(connRepo *mockConnectionRepo, tenantID, connectionID string) {
+	conn := &domain.ProviderConnection{
+		TenantID:     tenantID,
+		ConnectionID: connectionID,
+		ProviderName: "TestProvider",
+		Protocol:     domain.ProtocolHTTPS,
+		BaseURL:      "https://api.example.com",
+	}
+	connRepo.mu.Lock()
+	connRepo.connections[tenantID+":"+connectionID] = conn
+	connRepo.mu.Unlock()
+}
+
+// ========== Constructor tests ==========
+
+func TestNewInstructionRouteService_NilRouteRepo(t *testing.T) {
+	_, err := NewInstructionRouteService(nil, newMockConnectionRepo(), nil)
+	assert.ErrorIs(t, err, ErrRouteRepoNil)
+}
+
+func TestNewInstructionRouteService_NilConnRepo(t *testing.T) {
+	_, err := NewInstructionRouteService(newMockRouteRepo(), nil, nil)
+	assert.ErrorIs(t, err, ErrConnectionRepoNil)
+}
+
+func TestNewInstructionRouteService_Success(t *testing.T) {
+	svc, err := NewInstructionRouteService(newMockRouteRepo(), newMockConnectionRepo(), nil)
+	require.NoError(t, err)
+	assert.NotNil(t, svc)
+}
+
+// ========== UpsertRoute tests ==========
+
+func TestUpsertRoute_Success(t *testing.T) {
+	svc, _, connRepo := newTestRouteService(t)
+	ctx := tenantContext("test-tenant")
+	tid := testTenantID()
+	connID := uuid.New().String()
+	seedConnection(connRepo, tid, connID)
+
+	resp, err := svc.UpsertRoute(ctx, &opgatewayv1.UpsertRouteRequest{
+		InstructionType:    "kyc.verify",
+		ConnectionId:       connID,
+		OutboundMapping:    "kyc-outbound",
+		InboundMapping:     "kyc-inbound",
+		HttpMethod:         "POST",
+		PathTemplate:       "/v1/checks",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp.Route)
+	assert.Equal(t, "kyc.verify", resp.Route.InstructionType)
+	assert.Equal(t, connID, resp.Route.ConnectionId)
+	assert.Equal(t, "kyc-outbound", resp.Route.OutboundMapping)
+	assert.Equal(t, "kyc-inbound", resp.Route.InboundMapping)
+	assert.Equal(t, "POST", resp.Route.HttpMethod)
+	assert.Equal(t, "/v1/checks", resp.Route.PathTemplate)
+}
+
+func TestUpsertRoute_MissingTenant(t *testing.T) {
+	svc, _, _ := newTestRouteService(t)
+
+	_, err := svc.UpsertRoute(context.Background(), &opgatewayv1.UpsertRouteRequest{
+		InstructionType: "kyc.verify",
+		ConnectionId:    uuid.New().String(),
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestUpsertRoute_MissingInstructionType(t *testing.T) {
+	svc, _, _ := newTestRouteService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.UpsertRoute(ctx, &opgatewayv1.UpsertRouteRequest{
+		ConnectionId: uuid.New().String(),
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestUpsertRoute_MissingConnectionID(t *testing.T) {
+	svc, _, _ := newTestRouteService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.UpsertRoute(ctx, &opgatewayv1.UpsertRouteRequest{
+		InstructionType: "kyc.verify",
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestUpsertRoute_ConnectionNotFound(t *testing.T) {
+	svc, _, _ := newTestRouteService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.UpsertRoute(ctx, &opgatewayv1.UpsertRouteRequest{
+		InstructionType: "kyc.verify",
+		ConnectionId:    uuid.New().String(),
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestUpsertRoute_ConnectionRepoError(t *testing.T) {
+	svc, _, connRepo := newTestRouteService(t)
+	ctx := tenantContext("test-tenant")
+	connRepo.findErr = assert.AnError
+
+	_, err := svc.UpsertRoute(ctx, &opgatewayv1.UpsertRouteRequest{
+		InstructionType: "kyc.verify",
+		ConnectionId:    uuid.New().String(),
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
+func TestUpsertRoute_FallbackConnectionNotFound(t *testing.T) {
+	svc, _, connRepo := newTestRouteService(t)
+	ctx := tenantContext("test-tenant")
+	tid := testTenantID()
+	connID := uuid.New().String()
+	seedConnection(connRepo, tid, connID)
+
+	_, err := svc.UpsertRoute(ctx, &opgatewayv1.UpsertRouteRequest{
+		InstructionType:      "kyc.verify",
+		ConnectionId:         connID,
+		FallbackConnectionId: uuid.New().String(), // does not exist
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+	assert.Contains(t, st.Message(), "fallback")
+}
+
+func TestUpsertRoute_RouteRepoError(t *testing.T) {
+	svc, routeRepo, connRepo := newTestRouteService(t)
+	ctx := tenantContext("test-tenant")
+	tid := testTenantID()
+	connID := uuid.New().String()
+	seedConnection(connRepo, tid, connID)
+	routeRepo.upsertErr = assert.AnError
+
+	_, err := svc.UpsertRoute(ctx, &opgatewayv1.UpsertRouteRequest{
+		InstructionType: "kyc.verify",
+		ConnectionId:    connID,
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
+func TestUpsertRoute_WithFallback(t *testing.T) {
+	svc, _, connRepo := newTestRouteService(t)
+	ctx := tenantContext("test-tenant")
+	tid := testTenantID()
+	connID := uuid.New().String()
+	fallbackID := uuid.New().String()
+	seedConnection(connRepo, tid, connID)
+	seedConnection(connRepo, tid, fallbackID)
+
+	resp, err := svc.UpsertRoute(ctx, &opgatewayv1.UpsertRouteRequest{
+		InstructionType:      "kyc.verify",
+		ConnectionId:         connID,
+		FallbackConnectionId: fallbackID,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, fallbackID, resp.Route.FallbackConnectionId)
+}
+
+// ========== GetRoute tests ==========
+
+func TestGetRoute_Success(t *testing.T) {
+	svc, routeRepo, _ := newTestRouteService(t)
+	ctx := tenantContext("test-tenant")
+	tid := testTenantID()
+
+	route, err := domain.NewRoute(tid, "kyc.verify", uuid.New().String())
+	require.NoError(t, err)
+	routeRepo.routes[tid+":kyc.verify"] = route
+
+	resp, err := svc.GetRoute(ctx, &opgatewayv1.GetRouteRequest{
+		InstructionType: "kyc.verify",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "kyc.verify", resp.Route.InstructionType)
+}
+
+func TestGetRoute_MissingInstructionType(t *testing.T) {
+	svc, _, _ := newTestRouteService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.GetRoute(ctx, &opgatewayv1.GetRouteRequest{})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestGetRoute_MissingTenant(t *testing.T) {
+	svc, _, _ := newTestRouteService(t)
+
+	_, err := svc.GetRoute(context.Background(), &opgatewayv1.GetRouteRequest{
+		InstructionType: "kyc.verify",
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestGetRoute_NotFound(t *testing.T) {
+	svc, _, _ := newTestRouteService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.GetRoute(ctx, &opgatewayv1.GetRouteRequest{
+		InstructionType: "nonexistent.type",
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestGetRoute_RepoError(t *testing.T) {
+	svc, routeRepo, _ := newTestRouteService(t)
+	ctx := tenantContext("test-tenant")
+	routeRepo.findErr = assert.AnError
+
+	_, err := svc.GetRoute(ctx, &opgatewayv1.GetRouteRequest{
+		InstructionType: "kyc.verify",
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
+// ========== ListRoutes tests ==========
+
+func TestListRoutes_Success(t *testing.T) {
+	svc, routeRepo, _ := newTestRouteService(t)
+	ctx := tenantContext("test-tenant")
+	tid := testTenantID()
+
+	for _, itype := range []string{"kyc.verify", "device.command", "notification.send"} {
+		route, err := domain.NewRoute(tid, itype, uuid.New().String())
+		require.NoError(t, err)
+		routeRepo.routes[tid+":"+itype] = route
+	}
+
+	resp, err := svc.ListRoutes(ctx, &opgatewayv1.ListRoutesRequest{})
+	require.NoError(t, err)
+	assert.Len(t, resp.Routes, 3)
+}
+
+func TestListRoutes_MissingTenant(t *testing.T) {
+	svc, _, _ := newTestRouteService(t)
+
+	_, err := svc.ListRoutes(context.Background(), &opgatewayv1.ListRoutesRequest{})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestListRoutes_Empty(t *testing.T) {
+	svc, _, _ := newTestRouteService(t)
+	ctx := tenantContext("test-tenant")
+
+	resp, err := svc.ListRoutes(ctx, &opgatewayv1.ListRoutesRequest{})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Routes)
+}
+
+func TestListRoutes_RepoError(t *testing.T) {
+	svc, routeRepo, _ := newTestRouteService(t)
+	ctx := tenantContext("test-tenant")
+	routeRepo.listErr = assert.AnError
+
+	_, err := svc.ListRoutes(ctx, &opgatewayv1.ListRoutesRequest{})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
+// ========== routeToProto ==========
+
+func TestRouteToProto(t *testing.T) {
+	route := &domain.Route{
+		TenantID:             testTenantID(),
+		InstructionType:      "kyc.verify",
+		ConnectionID:         "conn-1",
+		FallbackConnectionID: "conn-2",
+		OutboundMapping:      "outbound",
+		InboundMapping:       "inbound",
+		HTTPMethod:           "POST",
+		PathTemplate:         "/v1/checks",
+	}
+
+	p := routeToProto(route)
+	assert.Equal(t, "kyc.verify", p.InstructionType)
+	assert.Equal(t, "conn-1", p.ConnectionId)
+	assert.Equal(t, "conn-2", p.FallbackConnectionId)
+	assert.Equal(t, "outbound", p.OutboundMapping)
+	assert.Equal(t, "inbound", p.InboundMapping)
+	assert.Equal(t, "POST", p.HttpMethod)
+	assert.Equal(t, "/v1/checks", p.PathTemplate)
+}

--- a/services/operational-gateway/service/grpc_route_service_test.go
+++ b/services/operational-gateway/service/grpc_route_service_test.go
@@ -124,12 +124,12 @@ func TestUpsertRoute_Success(t *testing.T) {
 	seedConnection(connRepo, tid, connID)
 
 	resp, err := svc.UpsertRoute(ctx, &opgatewayv1.UpsertRouteRequest{
-		InstructionType:    "kyc.verify",
-		ConnectionId:       connID,
-		OutboundMapping:    "kyc-outbound",
-		InboundMapping:     "kyc-inbound",
-		HttpMethod:         "POST",
-		PathTemplate:       "/v1/checks",
+		InstructionType: "kyc.verify",
+		ConnectionId:    connID,
+		OutboundMapping: "kyc-outbound",
+		InboundMapping:  "kyc-inbound",
+		HttpMethod:      "POST",
+		PathTemplate:    "/v1/checks",
 	})
 
 	require.NoError(t, err)

--- a/services/operational-gateway/service/grpc_service_test.go
+++ b/services/operational-gateway/service/grpc_service_test.go
@@ -88,6 +88,12 @@ func (m *mockInstructionRepo) ListByTenant(_ context.Context, params ports.ListI
 				continue
 			}
 		}
+		if !params.CreatedAfter.IsZero() && inst.CreatedAt.Before(params.CreatedAfter) {
+			continue
+		}
+		if !params.CreatedBefore.IsZero() && inst.CreatedAt.After(params.CreatedBefore) {
+			continue
+		}
 		stored := *inst
 		result = append(result, &stored)
 	}


### PR DESCRIPTION
## Summary

- Increase operational-gateway test coverage from 63.3% to 80.8%
- Add targeted unhappy path and edge case tests across service, client, persistence, and observability layers
- Task Master: test-coverage-80 task 14

## Changes Made

**Service layer** (46.9% → 91.5%):
- Proto enum mapper tests for all status, priority, protocol, and health mappings
- Complete InstructionRouteService test suite (UpsertRoute, GetRoute, ListRoutes) — was 0% coverage
- ProcessCallback unhappy paths (missing tenant, invalid UUID, wrong tenant, not-delivered state, save conflict)
- CancelInstruction / DispatchInstruction / UpsertConnection additional error paths
- ListInstructions filter tests (status, date range, instruction type)
- saveInstructionWithEvent partial configuration detection
- TestConnection placeholder verification

**Client layer** (58.9% → 82.2%):
- `client.New()` with Target, custom dial options, resilience config, and default verification
- `client.Close()` and `Conn()` accessor
- `stringToPriority` and `instructionStatusToString` exhaustive mapping tests
- `optionalStringParam` edge cases

**Persistence layer** (62.0% → 71.2%):
- JSONB/JSONBString/AuthConfigJSON/RetryPolicyJSON/RateLimitJSON Value/Scan unit tests
- Auth config JSON roundtrip for all 5 auth types (api_key, basic, oauth2, hmac, mtls)
- Instruction and Connection entity↔domain mapper roundtrip
- Priority int↔string and health status mapping

**Observability** (68.4% → 100%):
- Tracer, StartSpan, RecordError with nil/error edge cases
- Attribute key distinctness verification

## Test plan

- [x] All new tests pass locally: `go test ./services/operational-gateway/...`
- [x] Coverage verified above 80% target: 80.8%
- [ ] CI passes