### PR TITLE
fix: Set VITE_BASE_DOMAIN in demo CI for tenant subdomain resolution

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -131,7 +131,6 @@ jobs:
         env:
           VITE_API_BASE_URL: https://demo.meridianhub.cloud
           VITE_BASE_DOMAIN: demo.meridianhub.cloud
-          VITE_DEMO_MODE: "true"
           VITE_BUILD_VERSION: ${{ github.ref_name }}
           VITE_BUILD_COMMIT: ${{ github.sha }}
         run: npx vite build

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -130,6 +130,7 @@ jobs:
         working-directory: frontend
         env:
           VITE_API_BASE_URL: https://demo.meridianhub.cloud
+          VITE_BASE_DOMAIN: demo.meridianhub.cloud
           VITE_DEMO_MODE: "true"
           VITE_BUILD_VERSION: ${{ github.ref_name }}
           VITE_BUILD_COMMIT: ${{ github.sha }}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -503,7 +503,7 @@ function ApiClientBridge({ children }: { children: ReactNode }) {
 }
 
 /**
- * In dev/demo mode, auto-select the first real tenant for platform admins
+ * In DEV and E2E mode, auto-select the first real tenant for platform admins
  * so pages show data immediately after login.
  */
 function DevTenantAutoSelector() {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -254,7 +254,7 @@ function LoginPage() {
           <p className="mt-2 text-muted-foreground">Please sign in to continue.</p>
         </div>
 
-        {/* Dex login form - shown in demo mode and production */}
+        {/* Password login form - shown in production builds only */}
         {!import.meta.env.DEV && (
           <form onSubmit={(e) => void handleLogin(e)} className="space-y-4">
             <div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -255,7 +255,7 @@ function LoginPage() {
         </div>
 
         {/* Dex login form - shown in demo mode and production */}
-        {(import.meta.env.VITE_DEMO_MODE === 'true' || !import.meta.env.DEV) && (
+        {!import.meta.env.DEV && (
           <form onSubmit={(e) => void handleLogin(e)} className="space-y-4">
             <div>
               <label htmlFor="email" className="block text-sm font-medium mb-1">
@@ -300,7 +300,7 @@ function LoginPage() {
         {/* External auth provider buttons */}
         {externalProviders.length > 0 && (
           <>
-            {(import.meta.env.VITE_DEMO_MODE === 'true' || !import.meta.env.DEV) && <AuthDivider />}
+            {!import.meta.env.DEV && <AuthDivider />}
             <div className="space-y-2">
               {externalProviders.map((provider: AuthProviderType) => (
                 <ProviderButton
@@ -530,7 +530,7 @@ function AuthenticatedApp() {
   return (
     <TenantProvider>
       <ApiClientBridge>
-        {(import.meta.env.DEV || import.meta.env.VITE_E2E_MODE === 'true' || import.meta.env.VITE_DEMO_MODE === 'true') && <DevTenantAutoSelector />}
+        {(import.meta.env.DEV || import.meta.env.VITE_E2E_MODE === 'true') && <DevTenantAutoSelector />}
         <TooltipProvider>
           <Toaster position="top-right" richColors closeButton />
           <BrowserRouter>

--- a/frontend/src/api/transport.ts
+++ b/frontend/src/api/transport.ts
@@ -14,12 +14,10 @@ export function createTenantTransport(
   onUnauthenticated?: () => void,
 ): Transport {
   // If the browser is already on a tenant subdomain, API calls go to the same
-  // origin (subdomain routing). Otherwise in dev/demo mode, route via
-  // X-Tenant-Slug header (the gateway's LOCAL_DEV_MODE resolves from the header).
+  // origin (subdomain routing). Otherwise in dev mode, route via X-Tenant-Slug
+  // header (the gateway's LOCAL_DEV_MODE resolves from the header).
   const onSubdomain = isOnTenantSubdomain()
-  const useHeaderRouting =
-    !onSubdomain &&
-    (import.meta.env.DEV || import.meta.env.VITE_DEMO_MODE === 'true')
+  const useHeaderRouting = !onSubdomain && import.meta.env.DEV
   const configuredPath = new URL(apiConfig.baseUrl).pathname.replace(/\/$/, '')
   const baseUrl = onSubdomain
     ? `${window.location.origin}${configuredPath}`

--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -83,7 +83,15 @@ export function parseJWT(token: unknown): JWTClaims | null {
 
     return {
       userId,
-      tenantId: typeof decoded.tenantId === 'string' ? decoded.tenantId : undefined,
+      // Prefer x-tenant-slug (the URL-safe subdomain slug), fall back to tenantId
+      // for dev tokens. The backend also sends x-tenant-id (the internal tenant ID)
+      // but that uses underscores and cannot be used for subdomain routing.
+      tenantId:
+        typeof decoded['x-tenant-slug'] === 'string'
+          ? decoded['x-tenant-slug']
+          : typeof decoded.tenantId === 'string'
+            ? decoded.tenantId
+            : undefined,
       roles: effectiveRoles,
       scopes,
       exp: decoded.exp,
@@ -179,11 +187,9 @@ export function AuthProvider({ children, initialToken }: AuthProviderProps) {
       sessionStorage.removeItem(SESSION_STORAGE_KEY)
       return false
     }
-    // Validate that the token's tenantId matches the current subdomain tenant.
+    // Validate that the token's tenant slug matches the current subdomain.
     // This prevents session bleeding across subdomains for all token paths
     // (restore, login, refresh).
-    // Invariant: JWT tenantId holds the tenant slug (same value used in subdomains).
-    // See tenant-context.tsx where claims.tenantId is used directly as tenantSlug.
     const currentSlug = getTenantSlugFromSubdomain(window.location.hostname)
     if (currentSlug && parsed.tenantId && parsed.tenantId !== currentSlug) {
       authGenerationRef.current += 1

--- a/frontend/src/contexts/tenant-context.tsx
+++ b/frontend/src/contexts/tenant-context.tsx
@@ -75,7 +75,11 @@ export function TenantProvider({ children }: { children: ReactNode }) {
   }, [])
 
   // For tenant users, slug comes from JWT claims or falls back to the current
-  // subdomain (needed in demo mode where OIDC tokens lack tenantId).
+  // subdomain. The fallback is the primary path: the backend JWT uses the
+  // "x-tenant-id" claim key (tenant ID, e.g. "volterra_energy") which doesn't
+  // match the frontend's "tenantId" field, so subdomain parsing provides the
+  // slug (e.g. "volterra-energy"). VITE_BASE_DOMAIN must match the deployment
+  // domain for subdomain extraction to work correctly.
   const tenantSlug = isPlatformAdmin
     ? selectedTenant?.slug ?? null
     : claims?.tenantId ?? getTenantSlugFromSubdomain(window.location.hostname)

--- a/frontend/src/contexts/tenant-context.tsx
+++ b/frontend/src/contexts/tenant-context.tsx
@@ -74,12 +74,9 @@ export function TenantProvider({ children }: { children: ReactNode }) {
     setTenantTheme(theme)
   }, [])
 
-  // For tenant users, slug comes from JWT claims or falls back to the current
-  // subdomain. The fallback is the primary path: the backend JWT uses the
-  // "x-tenant-id" claim key (tenant ID, e.g. "volterra_energy") which doesn't
-  // match the frontend's "tenantId" field, so subdomain parsing provides the
-  // slug (e.g. "volterra-energy"). VITE_BASE_DOMAIN must match the deployment
-  // domain for subdomain extraction to work correctly.
+  // For tenant users, slug comes from JWT claims (x-tenant-slug) or falls back
+  // to subdomain parsing. VITE_BASE_DOMAIN must match the deployment domain
+  // for the subdomain fallback to work correctly.
   const tenantSlug = isPlatformAdmin
     ? selectedTenant?.slug ?? null
     : claims?.tenantId ?? getTenantSlugFromSubdomain(window.location.hostname)

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -11,8 +11,8 @@ interface ImportMetaEnv {
   readonly VITE_AUTH_AUDIENCE: string
   readonly VITE_AUTH_CLIENT_ID: string
   readonly VITE_AUTH_DOMAIN: string
-  readonly VITE_DEMO_MODE: string
   readonly VITE_E2E_MODE?: string
+  readonly VITE_BASE_DOMAIN?: string
   readonly VITE_MCP_SERVER_URL?: string
 }
 

--- a/services/api-gateway/auth_flows_test.go
+++ b/services/api-gateway/auth_flows_test.go
@@ -293,7 +293,7 @@ func TestAuthFlow_BFFSSOInitiate_RedirectsToTenantScopedDex(t *testing.T) {
 	u, err := url.Parse(location)
 	require.NoError(t, err)
 
-	assert.Equal(t, "acme_corp."+authFlowBaseDomain, u.Host,
+	assert.Equal(t, "acme."+authFlowBaseDomain, u.Host,
 		"redirect must include tenant subdomain in Dex URL")
 	assert.Equal(t, "/dex/auth/meridian", u.Path)
 	assert.Equal(t, "https", u.Scheme)
@@ -462,7 +462,7 @@ func TestAuthFlow_BFFSSOInitiate_DifferentConnectors(t *testing.T) {
 
 			assert.Equal(t, "/dex/auth/"+connID, u.Path,
 				"redirect path should contain connector ID")
-			assert.Equal(t, "acme_corp."+authFlowBaseDomain, u.Host,
+			assert.Equal(t, "acme."+authFlowBaseDomain, u.Host,
 				"redirect host should include tenant subdomain")
 		})
 	}

--- a/services/api-gateway/auth_handler.go
+++ b/services/api-gateway/auth_handler.go
@@ -136,6 +136,11 @@ func (h *AuthHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 
 	// Build claims and sign JWT.
 	claims := connector.BuildClaims(identity, tenantID)
+	// Include the tenant slug for frontend subdomain routing. The slug differs
+	// from the tenant ID (e.g. slug "volterra-energy" vs ID "volterra_energy").
+	if slug, ok := tenant.SlugFromContext(ctx); ok {
+		claims[tenant.TenantSlugKey] = slug
+	}
 	tokenStr, err := h.signer.SignClaims(claims, h.tokenTTL)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "auth: failed to sign token",

--- a/services/api-gateway/auth_handler.go
+++ b/services/api-gateway/auth_handler.go
@@ -138,7 +138,7 @@ func (h *AuthHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	claims := connector.BuildClaims(identity, tenantID)
 	// Include the tenant slug for frontend subdomain routing. The slug differs
 	// from the tenant ID (e.g. slug "volterra-energy" vs ID "volterra_energy").
-	if slug, ok := tenant.SlugFromContext(ctx); ok {
+	if slug, ok := tenant.SlugFromContext(ctx); ok && slug != "" {
 		claims[tenant.TenantSlugKey] = slug
 	}
 	tokenStr, err := h.signer.SignClaims(claims, h.tokenTTL)

--- a/services/api-gateway/auth_handler_test.go
+++ b/services/api-gateway/auth_handler_test.go
@@ -3,10 +3,12 @@ package gateway_test
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	gateway "github.com/meridianhub/meridian/services/api-gateway"
@@ -16,6 +18,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// decodeJWTPayload extracts the raw claims map from a JWT token string.
+func decodeJWTPayload(t *testing.T, token string) map[string]interface{} {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3, "JWT must have 3 parts")
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+	var claims map[string]interface{}
+	require.NoError(t, json.Unmarshal(payload, &claims))
+	return claims
+}
 
 // stubConnector is a test implementation of connector.PasswordConnector.
 type stubConnector struct {
@@ -68,10 +82,11 @@ func TestAuthHandler_LoginSuccess(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
-	// Inject tenant context (normally done by tenant resolver middleware)
-	tid, _ := tenant.NewTenantID("volterra")
+	// Inject tenant context (normally done by tenant resolver middleware).
+	// Use distinct ID and slug to verify the JWT carries both correctly.
+	tid, _ := tenant.NewTenantID("volterra_energy")
 	ctx := tenant.WithTenant(req.Context(), tid)
-	ctx = tenant.WithSlug(ctx, "volterra")
+	ctx = tenant.WithSlug(ctx, "volterra-energy")
 	req = req.WithContext(ctx)
 
 	rec := httptest.NewRecorder()
@@ -93,8 +108,15 @@ func TestAuthHandler_LoginSuccess(t *testing.T) {
 	claims, err := validator.ValidateToken(resp["access_token"].(string))
 	require.NoError(t, err)
 	assert.Equal(t, "user@example.com", claims.Email)
-	assert.Equal(t, "volterra", claims.TenantID)
+	assert.Equal(t, "volterra_energy", claims.TenantID)
 	assert.Equal(t, []string{"operator"}, claims.Roles)
+
+	// Verify x-tenant-slug is included with the slug value (not the tenant ID).
+	rawClaims := decodeJWTPayload(t, resp["access_token"].(string))
+	assert.Equal(t, "volterra-energy", rawClaims["x-tenant-slug"],
+		"JWT should carry x-tenant-slug with the URL-safe slug, not the tenant ID")
+	assert.Equal(t, "volterra_energy", rawClaims["x-tenant-id"],
+		"JWT should carry x-tenant-id with the internal tenant ID")
 }
 
 func TestAuthHandler_InvalidCredentials(t *testing.T) {

--- a/services/api-gateway/auth_handler_test.go
+++ b/services/api-gateway/auth_handler_test.go
@@ -70,7 +70,9 @@ func TestAuthHandler_LoginSuccess(t *testing.T) {
 
 	// Inject tenant context (normally done by tenant resolver middleware)
 	tid, _ := tenant.NewTenantID("volterra")
-	req = req.WithContext(tenant.WithTenant(req.Context(), tid))
+	ctx := tenant.WithTenant(req.Context(), tid)
+	ctx = tenant.WithSlug(ctx, "volterra")
+	req = req.WithContext(ctx)
 
 	rec := httptest.NewRecorder()
 	handler.HandleLogin(rec, req)

--- a/services/api-gateway/auth_sso_handler.go
+++ b/services/api-gateway/auth_sso_handler.go
@@ -233,7 +233,7 @@ func (h *SSOHandler) HandleInitiate(w http.ResponseWriter, r *http.Request) {
 	// uses a tenant-scoped URL so that the Dex MeridianConnector receives tenant
 	// context via the subdomain. Path-escape the connector ID to prevent
 	// path traversal (e.g., "../../admin" → "%2E%2E%2Fadmin").
-	authURL := h.buildDexAuthURL(tenantID, connectorID)
+	authURL := h.buildDexAuthURL(tenantSlug, connectorID)
 	params := url.Values{
 		"client_id":             {h.clientID},
 		"redirect_uri":          {h.callbackURL},
@@ -383,13 +383,13 @@ func (h *SSOHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 }
 
 // buildDexAuthURL constructs the Dex authorization URL. When baseDomain is
-// configured, the URL includes the tenant slug as a subdomain prefix so that
-// the MeridianConnector can resolve tenant context from the request host.
-// Falls back to the bare dexIssuerURL when baseDomain is not set.
-func (h *SSOHandler) buildDexAuthURL(tenantID tenant.TenantID, connectorID string) string {
+// configured and a slug is provided, the URL includes the tenant slug as a
+// subdomain prefix so that the MeridianConnector can resolve tenant context
+// from the request host. Falls back to the bare dexIssuerURL otherwise.
+func (h *SSOHandler) buildDexAuthURL(slug string, connectorID string) string {
 	escapedConnector := url.PathEscape(connectorID)
 
-	if h.baseDomain == "" {
+	if h.baseDomain == "" || slug == "" {
 		return h.dexIssuerURL + "/auth/" + escapedConnector
 	}
 
@@ -400,7 +400,7 @@ func (h *SSOHandler) buildDexAuthURL(tenantID tenant.TenantID, connectorID strin
 		return h.dexIssuerURL + "/auth/" + escapedConnector
 	}
 
-	tenantSlug := strings.ToLower(tenantID.String())
+	tenantSlug := strings.ToLower(slug)
 	baseDomain := strings.TrimSuffix(strings.TrimSpace(h.baseDomain), ".")
 	tenantHost := tenantSlug + "." + baseDomain
 	// Preserve any explicit port from the Dex issuer URL (e.g., :5556 in dev),

--- a/services/api-gateway/auth_sso_handler.go
+++ b/services/api-gateway/auth_sso_handler.go
@@ -214,9 +214,11 @@ func (h *SSOHandler) HandleInitiate(w http.ResponseWriter, r *http.Request) {
 
 	returnURL := sanitizeReturnURL(r.URL.Query().Get("return_url"))
 
+	tenantSlug, _ := tenant.SlugFromContext(ctx)
 	stateKey, err := h.stateStore.Set(StateData{
 		CodeVerifier: codeVerifier,
 		TenantID:     tenantID,
+		TenantSlug:   tenantSlug,
 		ReturnURL:    returnURL,
 	})
 	if err != nil {
@@ -342,6 +344,9 @@ func (h *SSOHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 
 	// Sign Meridian JWT.
 	claims := connector.BuildClaims(identity, stateData.TenantID)
+	if stateData.TenantSlug != "" {
+		claims[tenant.TenantSlugKey] = stateData.TenantSlug
+	}
 	tokenStr, err := h.signer.SignClaims(claims, h.tokenTTL)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "sso: failed to sign token",

--- a/services/api-gateway/auth_sso_handler_test.go
+++ b/services/api-gateway/auth_sso_handler_test.go
@@ -607,7 +607,9 @@ func TestHandleInitiate_RedirectsTenantScopedDexURL(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/sso/google", nil)
 	tid, _ := tenant.NewTenantID("acme")
-	req = req.WithContext(tenant.WithTenant(req.Context(), tid))
+	ctx := tenant.WithTenant(req.Context(), tid)
+	ctx = tenant.WithSlug(ctx, "acme")
+	req = req.WithContext(ctx)
 	req.SetPathValue("connector_id", "google")
 
 	rec := httptest.NewRecorder()

--- a/services/api-gateway/auth_sso_handler_test.go
+++ b/services/api-gateway/auth_sso_handler_test.go
@@ -642,7 +642,9 @@ func TestHandleInitiate_MeridianConnector_HasTenantInRedirect(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/sso/meridian", nil)
 	tid, _ := tenant.NewTenantID("volterra")
-	req = req.WithContext(tenant.WithTenant(req.Context(), tid))
+	ctx := tenant.WithTenant(req.Context(), tid)
+	ctx = tenant.WithSlug(ctx, "volterra")
+	req = req.WithContext(ctx)
 	req.SetPathValue("connector_id", "meridian")
 
 	rec := httptest.NewRecorder()
@@ -707,7 +709,9 @@ func TestHandleInitiate_PreservesPortInTenantScopedURL(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/sso/meridian", nil)
 	tid, _ := tenant.NewTenantID("acme")
-	req = req.WithContext(tenant.WithTenant(req.Context(), tid))
+	ctx := tenant.WithTenant(req.Context(), tid)
+	ctx = tenant.WithSlug(ctx, "acme")
+	req = req.WithContext(ctx)
 	req.SetPathValue("connector_id", "meridian")
 
 	rec := httptest.NewRecorder()

--- a/services/api-gateway/auth_sso_state.go
+++ b/services/api-gateway/auth_sso_state.go
@@ -19,6 +19,7 @@ var ErrStateStoreFull = errors.New("state store: capacity limit reached")
 type StateData struct {
 	CodeVerifier string
 	TenantID     tenant.TenantID
+	TenantSlug   string // subdomain slug for JWT claims (may differ from TenantID)
 	ReturnURL    string
 }
 

--- a/shared/platform/gateway/tenant_resolver.go
+++ b/shared/platform/gateway/tenant_resolver.go
@@ -238,6 +238,7 @@ func (m *TenantResolverMiddleware) HandlerOptionalTenant(next http.Handler) http
 
 		r.Header.Set(tenant.TenantIDKey, string(tenantID))
 		ctx = tenant.WithTenant(ctx, tenantID)
+		ctx = tenant.WithSlug(ctx, slug)
 		r = r.WithContext(ctx)
 
 		next.ServeHTTP(w, r)
@@ -284,8 +285,9 @@ func (m *TenantResolverMiddleware) Handler(next http.Handler) http.Handler {
 		// Step 5: Inject tenant ID into request header
 		r.Header.Set(tenant.TenantIDKey, string(tenantID))
 
-		// Step 6: Add tenant to context
+		// Step 6: Add tenant ID and slug to context
 		ctx = tenant.WithTenant(ctx, tenantID)
+		ctx = tenant.WithSlug(ctx, slug)
 
 		// Step 7: Update request with new context
 		r = r.WithContext(ctx)

--- a/shared/platform/tenant/context.go
+++ b/shared/platform/tenant/context.go
@@ -8,9 +8,27 @@ type contextKey string
 // tenantContextKey is the context key for tenant ID.
 const tenantContextKey contextKey = TenantIDKey
 
+// slugContextKey is the context key for the tenant slug.
+const slugContextKey contextKey = TenantSlugKey
+
 // WithTenant returns a new context with the tenant ID attached.
 func WithTenant(ctx context.Context, tenantID TenantID) context.Context {
 	return context.WithValue(ctx, tenantContextKey, tenantID)
+}
+
+// WithSlug returns a new context with the tenant slug attached.
+func WithSlug(ctx context.Context, slug string) context.Context {
+	return context.WithValue(ctx, slugContextKey, slug)
+}
+
+// SlugFromContext extracts the tenant slug from the context.
+// Returns the slug and true if present, or empty string and false if not.
+func SlugFromContext(ctx context.Context) (string, bool) {
+	if ctx == nil {
+		return "", false
+	}
+	s, ok := ctx.Value(slugContextKey).(string)
+	return s, ok
 }
 
 // FromContext extracts the tenant ID from the context.

--- a/shared/platform/tenant/keys.go
+++ b/shared/platform/tenant/keys.go
@@ -6,3 +6,8 @@ package tenant
 // BREAKING CHANGE: Renamed from "x-org-id" to "x-tenant-id" to disambiguate
 // from BIAN Party.Organization domain concept.
 const TenantIDKey = "x-tenant-id"
+
+// TenantSlugKey is the key for the tenant slug (URL-safe subdomain identifier).
+// The slug differs from the tenant ID: slug uses hyphens (e.g. "volterra-energy")
+// while the ID uses underscores (e.g. "volterra_energy").
+const TenantSlugKey = "x-tenant-slug"

--- a/shared/platform/tenant/tenant_test.go
+++ b/shared/platform/tenant/tenant_test.go
@@ -304,3 +304,52 @@ func TestPropagateToBackground_NilContext(t *testing.T) {
 		t.Error("PropagateToBackground(nil) should not have tenant")
 	}
 }
+
+func TestSlugContextRoundTrip(t *testing.T) {
+	ctx := tenant.WithSlug(context.Background(), "volterra-energy")
+
+	slug, ok := tenant.SlugFromContext(ctx)
+	if !ok {
+		t.Error("SlugFromContext returned ok=false for context with slug")
+	}
+	if slug != "volterra-energy" {
+		t.Errorf("SlugFromContext returned %q, want %q", slug, "volterra-energy")
+	}
+}
+
+func TestSlugFromContext_Missing(t *testing.T) {
+	slug, ok := tenant.SlugFromContext(context.Background())
+	if ok {
+		t.Error("SlugFromContext returned ok=true for context without slug")
+	}
+	if slug != "" {
+		t.Errorf("SlugFromContext returned %q, want empty string", slug)
+	}
+}
+
+func TestSlugFromContext_NilContext(t *testing.T) {
+	//nolint:staticcheck // SA1012: intentionally testing nil context handling
+	slug, ok := tenant.SlugFromContext(nil)
+	if ok {
+		t.Error("SlugFromContext returned ok=true for nil context")
+	}
+	if slug != "" {
+		t.Errorf("SlugFromContext returned %q for nil context, want empty string", slug)
+	}
+}
+
+func TestSlugAndTenantIDIndependent(t *testing.T) {
+	tid := tenant.MustNewTenantID("volterra_energy")
+	ctx := tenant.WithTenant(context.Background(), tid)
+	ctx = tenant.WithSlug(ctx, "volterra-energy")
+
+	gotID, ok := tenant.FromContext(ctx)
+	if !ok || gotID != tid {
+		t.Errorf("FromContext returned (%q, %v), want (%q, true)", gotID, ok, tid)
+	}
+
+	gotSlug, ok := tenant.SlugFromContext(ctx)
+	if !ok || gotSlug != "volterra-energy" {
+		t.Errorf("SlugFromContext returned (%q, %v), want (%q, true)", gotSlug, ok, "volterra-energy")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `VITE_BASE_DOMAIN=demo.meridianhub.cloud` to the demo deploy CI frontend build
- Include `x-tenant-slug` claim in JWT so the frontend can identify the tenant without relying on subdomain parsing
- Store tenant slug in request context alongside tenant ID in the gateway resolver

## Root Cause

Two compounding issues prevented tenant-scoped pages from loading:

**1. Missing VITE_BASE_DOMAIN in CI build**

The frontend's `getTenantSlugFromSubdomain()` defaults `VITE_BASE_DOMAIN` to `meridianhub.cloud`. On `volterra-energy.demo.meridianhub.cloud`, this extracted `volterra-energy.demo` (multi-segment, rejected) instead of `volterra-energy`.

**2. JWT claim name mismatch (ID vs slug)**

The backend JWT contained `x-tenant-id: "volterra_energy"` (the internal tenant ID with underscores) but the frontend parsed `tenantId` (camelCase). Since neither claim existed in the expected format, `claims.tenantId` was always `undefined`, making subdomain parsing the only path — which was broken by issue #1.

**Fix**: Both issues are now resolved:
- CI sets `VITE_BASE_DOMAIN` correctly for subdomain fallback
- Backend includes `x-tenant-slug` in JWT with the URL-safe slug value
- Frontend reads `x-tenant-slug` first, falls back to `tenantId` for dev tokens

## Changes

| File | Change |
|------|--------|
| `.github/workflows/deploy-demo.yml` | Add `VITE_BASE_DOMAIN` env var to frontend build |
| `shared/platform/tenant/keys.go` | Add `TenantSlugKey` constant |
| `shared/platform/tenant/context.go` | Add `WithSlug`/`SlugFromContext` for slug context storage |
| `shared/platform/gateway/tenant_resolver.go` | Store slug in context alongside tenant ID |
| `services/api-gateway/auth_handler.go` | Include `x-tenant-slug` in password login JWT |
| `services/api-gateway/auth_sso_handler.go` | Include `x-tenant-slug` in SSO callback JWT |
| `services/api-gateway/auth_sso_state.go` | Add `TenantSlug` to SSO state data |
| `frontend/src/contexts/auth-context.tsx` | Read `x-tenant-slug` from JWT claims |
| `frontend/src/contexts/tenant-context.tsx` | Update comment documenting resolution flow |

## Test plan

- [ ] Merge and deploy to demo (`git push origin develop:demo`)
- [ ] Login as `operator@volterra.energy` at `volterra-energy.demo.meridianhub.cloud`
- [ ] Verify accounts, transactions, parties pages show data
- [ ] Verify MCP config page shows `volterra-energy.demo.meridianhub.cloud/mcp`
- [ ] Verify platform admin login at `demo.meridianhub.cloud` still works