### PR TITLE
test: increase market-information service coverage to 80%+

### DIFF
--- a/services/market-information/adapters/persistence/source_repository_unhappy_test.go
+++ b/services/market-information/adapters/persistence/source_repository_unhappy_test.go
@@ -1,0 +1,156 @@
+package persistence_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/market-information/adapters/persistence"
+	"github.com/meridianhub/meridian/services/market-information/adapters/persistence/testhelpers"
+	"github.com/meridianhub/meridian/services/market-information/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSourceRepository_Delete(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	t.Run("soft-deletes existing source", func(t *testing.T) {
+		source, err := domain.NewDataSource("DELETE_ME", "Delete Me", "To be deleted", domain.SourceTypeAPI, 50)
+		require.NoError(t, err)
+		err = tc.Repos.Source.Save(ctx, source)
+		require.NoError(t, err)
+
+		// Delete
+		err = tc.Repos.Source.Delete(ctx, "DELETE_ME")
+		require.NoError(t, err)
+
+		// Should not be findable
+		_, err = tc.Repos.Source.FindByCode(ctx, "DELETE_ME")
+		assert.ErrorIs(t, err, domain.ErrDataSourceNotFound)
+	})
+
+	t.Run("returns not found for non-existent source", func(t *testing.T) {
+		err := tc.Repos.Source.Delete(ctx, "NONEXISTENT_CODE")
+		assert.ErrorIs(t, err, domain.ErrDataSourceNotFound)
+	})
+
+	t.Run("returns not found for already deleted source", func(t *testing.T) {
+		source, err := domain.NewDataSource("DELETE_TWICE", "Delete Twice", "", domain.SourceTypeAPI, 50)
+		require.NoError(t, err)
+		err = tc.Repos.Source.Save(ctx, source)
+		require.NoError(t, err)
+
+		err = tc.Repos.Source.Delete(ctx, "DELETE_TWICE")
+		require.NoError(t, err)
+
+		err = tc.Repos.Source.Delete(ctx, "DELETE_TWICE")
+		assert.ErrorIs(t, err, domain.ErrDataSourceNotFound)
+	})
+
+	t.Run("deleted source excluded from list", func(t *testing.T) {
+		source, err := domain.NewDataSource("DELETE_LIST_TEST", "Delete List", "", domain.SourceTypeAPI, 50)
+		require.NoError(t, err)
+		err = tc.Repos.Source.Save(ctx, source)
+		require.NoError(t, err)
+
+		err = tc.Repos.Source.Delete(ctx, "DELETE_LIST_TEST")
+		require.NoError(t, err)
+
+		sources, _, err := tc.Repos.Source.List(ctx, false, 100, "")
+		require.NoError(t, err)
+		for _, s := range sources {
+			assert.NotEqual(t, "DELETE_LIST_TEST", s.Code())
+		}
+	})
+}
+
+func TestSourceRepository_GetTrustLevel(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	// Cast to concrete type to access GetTrustLevel (not on domain interface)
+	sourceRepo := tc.Repos.Source.(*persistence.SourceRepository)
+
+	ctx := context.Background()
+
+	t.Run("returns trust level for existing source", func(t *testing.T) {
+		source, err := domain.NewDataSource("TRUST_LEVEL_TEST", "Trust Level Test", "", domain.SourceTypeAPI, 85)
+		require.NoError(t, err)
+		err = tc.Repos.Source.Save(ctx, source)
+		require.NoError(t, err)
+
+		// Get the source ID
+		found, err := tc.Repos.Source.FindByCode(ctx, "TRUST_LEVEL_TEST")
+		require.NoError(t, err)
+
+		trustLevel, err := sourceRepo.GetTrustLevel(ctx, found.ID())
+		require.NoError(t, err)
+		assert.Equal(t, 85, trustLevel)
+	})
+
+	t.Run("returns not found for non-existent source", func(t *testing.T) {
+		_, err := sourceRepo.GetTrustLevel(ctx, uuid.New())
+		assert.ErrorIs(t, err, domain.ErrDataSourceNotFound)
+	})
+
+	t.Run("returns not found for deleted source", func(t *testing.T) {
+		source, err := domain.NewDataSource("TRUST_DELETED", "Trust Deleted", "", domain.SourceTypeAPI, 50)
+		require.NoError(t, err)
+		err = tc.Repos.Source.Save(ctx, source)
+		require.NoError(t, err)
+
+		found, err := tc.Repos.Source.FindByCode(ctx, "TRUST_DELETED")
+		require.NoError(t, err)
+
+		err = tc.Repos.Source.Delete(ctx, "TRUST_DELETED")
+		require.NoError(t, err)
+
+		_, err = sourceRepo.GetTrustLevel(ctx, found.ID())
+		assert.ErrorIs(t, err, domain.ErrDataSourceNotFound)
+	})
+}
+
+func TestSourceRepository_List_Pagination(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Create enough sources for pagination testing
+	for i := 0; i < 5; i++ {
+		code := "PAGE_SRC_" + string(rune('A'+i))
+		source, err := domain.NewDataSource(code, "Source "+code, "", domain.SourceTypeAPI, 50+i)
+		require.NoError(t, err)
+		err = tc.Repos.Source.Save(ctx, source)
+		require.NoError(t, err)
+	}
+
+	t.Run("paginates with small page size", func(t *testing.T) {
+		// First page
+		page1, token1, err := tc.Repos.Source.List(ctx, false, 2, "")
+		require.NoError(t, err)
+		assert.Len(t, page1, 2)
+		assert.NotEmpty(t, token1)
+
+		// Second page
+		page2, token2, err := tc.Repos.Source.List(ctx, false, 2, token1)
+		require.NoError(t, err)
+		assert.Len(t, page2, 2)
+		assert.NotEmpty(t, token2)
+
+		// Third page
+		page3, token3, err := tc.Repos.Source.List(ctx, false, 2, token2)
+		require.NoError(t, err)
+		assert.Len(t, page3, 1)
+		assert.Empty(t, token3) // No more pages
+	})
+
+	t.Run("rejects invalid page token", func(t *testing.T) {
+		_, _, err := tc.Repos.Source.List(ctx, false, 10, "invalid-token!!!")
+		assert.ErrorIs(t, err, domain.ErrInvalidPageToken)
+	})
+}

--- a/services/market-information/service/dataset_service_unhappy_test.go
+++ b/services/market-information/service/dataset_service_unhappy_test.go
@@ -1,0 +1,380 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	"github.com/meridianhub/meridian/services/market-information/adapters/persistence/testhelpers"
+	"github.com/meridianhub/meridian/services/market-information/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func setupTestServerWithCelValidator(t *testing.T) (*Server, *testhelpers.TestContainer, func()) {
+	t.Helper()
+
+	tc := testhelpers.SetupTestContainer(t)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	validator, err := NewCelValidator()
+	require.NoError(t, err)
+
+	server, err := NewServer(
+		tc.Repos.DataSet,
+		tc.Repos.Observation,
+		tc.Repos.Source,
+		WithLogger(logger),
+		WithCelValidator(validator),
+	)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		tc.Cleanup(t)
+	}
+
+	return server, tc, cleanup
+}
+
+func TestValidateCelExpressions(t *testing.T) {
+	server, _, cleanup := setupTestServerWithCelValidator(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	t.Run("rejects invalid validation expression on register", func(t *testing.T) {
+		req := &pb.RegisterDataSetRequest{
+			Code:                    "INVALID_CEL_VALIDATION",
+			DisplayName:             "Invalid CEL Test",
+			Category:                pb.DataCategory_DATA_CATEGORY_FX_RATE,
+			ValidationExpression:    "invalid_func(x, y, z)",
+			ResolutionKeyExpression: "has(observation_context.pair) ? observation_context.pair : 'default'",
+		}
+
+		_, err := server.RegisterDataSet(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "validation_expression")
+	})
+
+	t.Run("rejects invalid resolution key expression on register", func(t *testing.T) {
+		req := &pb.RegisterDataSetRequest{
+			Code:                    "INVALID_CEL_RESOLUTION",
+			DisplayName:             "Invalid CEL Resolution",
+			Category:                pb.DataCategory_DATA_CATEGORY_FX_RATE,
+			ValidationExpression:    "true",
+			ResolutionKeyExpression: "nonexistent_var + broken",
+		}
+
+		_, err := server.RegisterDataSet(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "resolution_key_expression")
+	})
+
+	t.Run("rejects invalid error message expression on register", func(t *testing.T) {
+		req := &pb.RegisterDataSetRequest{
+			Code:                    "INVALID_CEL_ERROR_MSG",
+			DisplayName:             "Invalid CEL Error Msg",
+			Category:                pb.DataCategory_DATA_CATEGORY_FX_RATE,
+			ValidationExpression:    "true",
+			ResolutionKeyExpression: "has(observation_context.pair) ? observation_context.pair : 'default'",
+			ErrorMessageExpression:  "broken_func(nonexistent_var)",
+		}
+
+		_, err := server.RegisterDataSet(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "error_message_expression")
+	})
+}
+
+func TestUpdateDataSet_CelValidation(t *testing.T) {
+	server, _, cleanup := setupTestServerWithCelValidator(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	t.Run("rejects invalid CEL expression on update", func(t *testing.T) {
+		// Register a valid dataset first
+		registerReq := &pb.RegisterDataSetRequest{
+			Code:                    "UPDATE_CEL_TEST",
+			DisplayName:             "Update CEL Test",
+			Category:                pb.DataCategory_DATA_CATEGORY_FX_RATE,
+			ValidationExpression:    "decimal(value) > decimal('0')",
+			ResolutionKeyExpression: "has(observation_context.pair) ? observation_context.pair : 'default'",
+		}
+
+		registerResp, err := server.RegisterDataSet(ctx, registerReq)
+		require.NoError(t, err)
+
+		// Update with invalid expression
+		updateReq := &pb.UpdateDataSetRequest{
+			Code:                 "UPDATE_CEL_TEST",
+			Version:              registerResp.Dataset.Version,
+			ValidationExpression: "broken_syntax >>>",
+		}
+
+		_, err = server.UpdateDataSet(ctx, updateReq)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("validates CEL expressions on activation", func(t *testing.T) {
+		registerReq := &pb.RegisterDataSetRequest{
+			Code:                    "ACTIVATE_CEL_TEST",
+			DisplayName:             "Activate CEL Test",
+			Category:                pb.DataCategory_DATA_CATEGORY_FX_RATE,
+			ValidationExpression:    "decimal(value) > decimal('0')",
+			ResolutionKeyExpression: "has(observation_context.pair) ? observation_context.pair : 'default'",
+		}
+
+		registerResp, err := server.RegisterDataSet(ctx, registerReq)
+		require.NoError(t, err)
+
+		activateResp, err := server.ActivateDataSet(ctx, &pb.ActivateDataSetRequest{
+			Code:    "ACTIVATE_CEL_TEST",
+			Version: registerResp.Dataset.Version,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, pb.DataSetStatus_DATA_SET_STATUS_ACTIVE, activateResp.Dataset.Status)
+	})
+}
+
+func TestDeprecateDataSet_FromDraft(t *testing.T) {
+	server, _, cleanup := setupTestServerForDataSet(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	t.Run("deprecates draft dataset", func(t *testing.T) {
+		registerReq := &pb.RegisterDataSetRequest{
+			Code:                    "DEPRECATE_DRAFT_TEST",
+			DisplayName:             "Deprecate Draft Test",
+			Category:                pb.DataCategory_DATA_CATEGORY_FX_RATE,
+			ValidationExpression:    "true",
+			ResolutionKeyExpression: "key",
+		}
+
+		registerResp, err := server.RegisterDataSet(ctx, registerReq)
+		require.NoError(t, err)
+
+		deprecateResp, err := server.DeprecateDataSet(ctx, &pb.DeprecateDataSetRequest{
+			Code:    "DEPRECATE_DRAFT_TEST",
+			Version: registerResp.Dataset.Version,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, pb.DataSetStatus_DATA_SET_STATUS_DEPRECATED, deprecateResp.Dataset.Status)
+	})
+}
+
+func TestProtoStatusToDomain(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       pb.DataSetStatus
+		expected    domain.DataSetStatus
+		expectError bool
+	}{
+		{"unspecified returns error", pb.DataSetStatus_DATA_SET_STATUS_UNSPECIFIED, "", true},
+		{"draft", pb.DataSetStatus_DATA_SET_STATUS_DRAFT, domain.DataSetStatusDraft, false},
+		{"active", pb.DataSetStatus_DATA_SET_STATUS_ACTIVE, domain.DataSetStatusActive, false},
+		{"deprecated", pb.DataSetStatus_DATA_SET_STATUS_DEPRECATED, domain.DataSetStatusDeprecated, false},
+		{"unknown value returns error", pb.DataSetStatus(999), "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := protoStatusToDomain(tt.input)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestDomainStatusToProto(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    domain.DataSetStatus
+		expected pb.DataSetStatus
+	}{
+		{"draft", domain.DataSetStatusDraft, pb.DataSetStatus_DATA_SET_STATUS_DRAFT},
+		{"active", domain.DataSetStatusActive, pb.DataSetStatus_DATA_SET_STATUS_ACTIVE},
+		{"deprecated", domain.DataSetStatusDeprecated, pb.DataSetStatus_DATA_SET_STATUS_DEPRECATED},
+		{"unknown returns unspecified", domain.DataSetStatus("UNKNOWN"), pb.DataSetStatus_DATA_SET_STATUS_UNSPECIFIED},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := domainStatusToProto(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDomainCategoryToProto(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    domain.DataCategory
+		expected pb.DataCategory
+	}{
+		{"pricing maps to fx rate", domain.DataCategoryPricing, pb.DataCategory_DATA_CATEGORY_FX_RATE},
+		{"contextual maps to index value", domain.DataCategoryContextual, pb.DataCategory_DATA_CATEGORY_INDEX_VALUE},
+		{"utilization maps to index value", domain.DataCategoryUtilization, pb.DataCategory_DATA_CATEGORY_INDEX_VALUE},
+		{"unknown maps to unspecified", domain.DataCategory("UNKNOWN"), pb.DataCategory_DATA_CATEGORY_UNSPECIFIED},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := domainCategoryToProto(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestProtoCategoryToDomain(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       pb.DataCategory
+		expected    domain.DataCategory
+		expectError bool
+	}{
+		{"unspecified returns error", pb.DataCategory_DATA_CATEGORY_UNSPECIFIED, "", true},
+		{"fx rate maps to pricing", pb.DataCategory_DATA_CATEGORY_FX_RATE, domain.DataCategoryPricing, false},
+		{"interest rate maps to pricing", pb.DataCategory_DATA_CATEGORY_INTEREST_RATE, domain.DataCategoryPricing, false},
+		{"commodity price maps to pricing", pb.DataCategory_DATA_CATEGORY_COMMODITY_PRICE, domain.DataCategoryPricing, false},
+		{"equity price maps to pricing", pb.DataCategory_DATA_CATEGORY_EQUITY_PRICE, domain.DataCategoryPricing, false},
+		{"energy price maps to pricing", pb.DataCategory_DATA_CATEGORY_ENERGY_PRICE, domain.DataCategoryPricing, false},
+		{"carbon price maps to pricing", pb.DataCategory_DATA_CATEGORY_CARBON_PRICE, domain.DataCategoryPricing, false},
+		{"benchmark rate maps to pricing", pb.DataCategory_DATA_CATEGORY_BENCHMARK_RATE, domain.DataCategoryPricing, false},
+		{"credit spread maps to pricing", pb.DataCategory_DATA_CATEGORY_CREDIT_SPREAD, domain.DataCategoryPricing, false},
+		{"index value maps to contextual", pb.DataCategory_DATA_CATEGORY_INDEX_VALUE, domain.DataCategoryContextual, false},
+		{"volatility maps to contextual", pb.DataCategory_DATA_CATEGORY_VOLATILITY, domain.DataCategoryContextual, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := protoCategoryToDomain(tt.input)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestListDataSets_InvalidStatusFilter(t *testing.T) {
+	server, _, cleanup := setupTestServerForDataSet(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	t.Run("rejects invalid status filter", func(t *testing.T) {
+		listReq := &pb.ListDataSetsRequest{
+			StatusFilter: pb.DataSetStatus(999),
+			PageSize:     10,
+		}
+
+		_, err := server.ListDataSets(ctx, listReq)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+}
+
+func TestListDataSets_Pagination(t *testing.T) {
+	server, _, cleanup := setupTestServerForDataSet(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	t.Run("caps page size at maximum", func(t *testing.T) {
+		listReq := &pb.ListDataSetsRequest{
+			PageSize: 500, // Exceeds max of 100
+		}
+
+		resp, err := server.ListDataSets(ctx, listReq)
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+	})
+
+	t.Run("applies default page size", func(t *testing.T) {
+		listReq := &pb.ListDataSetsRequest{
+			PageSize: 0,
+		}
+
+		resp, err := server.ListDataSets(ctx, listReq)
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+	})
+
+	t.Run("rejects invalid page token", func(t *testing.T) {
+		listReq := &pb.ListDataSetsRequest{
+			PageSize:  10,
+			PageToken: "invalid-token-!!!",
+		}
+
+		_, err := server.ListDataSets(ctx, listReq)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "page_token")
+	})
+}
+
+func TestMapDataSetDomainError(t *testing.T) {
+	server, _, cleanup := setupTestServerForDataSet(t)
+	defer cleanup()
+
+	tests := []struct {
+		name         string
+		err          error
+		expectedCode codes.Code
+	}{
+		{"not found", domain.ErrDataSetNotFound, codes.NotFound},
+		{"duplicate code", domain.ErrDuplicateDataSetCode, codes.AlreadyExists},
+		{"invalid transition", domain.ErrInvalidStatusTransition, codes.FailedPrecondition},
+		{"deprecated", domain.ErrDataSetDeprecated, codes.FailedPrecondition},
+		{"version mismatch", domain.ErrVersionMismatch, codes.Aborted},
+		{"code required", domain.ErrCodeRequired, codes.InvalidArgument},
+		{"name required", domain.ErrNameRequired, codes.InvalidArgument},
+		{"validation expr required", domain.ErrValidationExpressionRequired, codes.InvalidArgument},
+		{"resolution key expr required", domain.ErrResolutionKeyExpressionRequired, codes.InvalidArgument},
+		{"invalid category", domain.ErrInvalidDataCategory, codes.InvalidArgument},
+		{"unknown error", errors.New("some unknown error"), codes.Internal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := server.mapDataSetDomainError(tt.err, "TestOp", "TEST_CODE")
+			st, ok := status.FromError(result)
+			require.True(t, ok)
+			assert.Equal(t, tt.expectedCode, st.Code())
+		})
+	}
+}

--- a/services/market-information/service/event_publisher_test.go
+++ b/services/market-information/service/event_publisher_test.go
@@ -1,0 +1,225 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	"github.com/meridianhub/meridian/services/market-information/domain"
+)
+
+// mockProtoPublisher implements protoPublisher for testing.
+type mockProtoPublisher struct {
+	publishedMessages []publishedMessage
+	publishErr        error
+	flushReturn       int
+	closed            bool
+}
+
+type publishedMessage struct {
+	topic string
+	key   string
+	msg   proto.Message
+}
+
+func (m *mockProtoPublisher) PublishWithTenant(_ context.Context, topic, key string, msg proto.Message) error {
+	if m.publishErr != nil {
+		return m.publishErr
+	}
+	m.publishedMessages = append(m.publishedMessages, publishedMessage{topic: topic, key: key, msg: msg})
+	return nil
+}
+
+func (m *mockProtoPublisher) FlushWithTimeout(_ int) int {
+	return m.flushReturn
+}
+
+func (m *mockProtoPublisher) Close() {
+	m.closed = true
+}
+
+func TestNewKafkaObservationPublisher(t *testing.T) {
+	t.Run("returns error for nil producer", func(t *testing.T) {
+		_, err := NewKafkaObservationPublisher(nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrNilProducer)
+	})
+
+	t.Run("creates publisher with valid producer", func(t *testing.T) {
+		pub, err := NewKafkaObservationPublisher(&mockProtoPublisher{})
+		require.NoError(t, err)
+		assert.NotNil(t, pub)
+		assert.Equal(t, ObservationRecordedTopic, pub.topic)
+		assert.Equal(t, DeprecatedObservationRecordedTopic, pub.deprecatedTopic)
+	})
+}
+
+func createTestObservation(t *testing.T) domain.MarketPriceObservation {
+	t.Helper()
+	now := time.Now()
+	obs, err := domain.NewMarketPriceObservation(
+		"TEST_DATASET",
+		uuid.New(),
+		"EUR/USD",
+		decimal.NewFromFloat(1.1234),
+		"Test Unit",
+		now,
+		now,
+		now.Add(24*time.Hour),
+		uuid.New(),
+		domain.QualityLevelActual,
+		80,
+		domain.NewObservationContext(map[string]string{"currency_pair": "EUR/USD"}),
+	)
+	require.NoError(t, err)
+	return obs
+}
+
+func TestKafkaObservationPublisher_PublishObservationRecorded(t *testing.T) {
+	t.Run("publishes to both topics", func(t *testing.T) {
+		mock := &mockProtoPublisher{}
+		pub, err := NewKafkaObservationPublisher(mock)
+		require.NoError(t, err)
+
+		obs := createTestObservation(t)
+		err = pub.PublishObservationRecorded(context.Background(), obs)
+		require.NoError(t, err)
+
+		assert.Len(t, mock.publishedMessages, 2)
+		assert.Equal(t, ObservationRecordedTopic, mock.publishedMessages[0].topic)
+		assert.Equal(t, "TEST_DATASET", mock.publishedMessages[0].key)
+		assert.Equal(t, DeprecatedObservationRecordedTopic, mock.publishedMessages[1].topic)
+	})
+
+	t.Run("returns error when primary publish fails", func(t *testing.T) {
+		mock := &mockProtoPublisher{publishErr: errors.New("kafka down")}
+		pub, err := NewKafkaObservationPublisher(mock)
+		require.NoError(t, err)
+
+		obs := createTestObservation(t)
+		err = pub.PublishObservationRecorded(context.Background(), obs)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to publish ObservationRecorded event")
+	})
+}
+
+func TestKafkaObservationPublisher_Close(t *testing.T) {
+	mock := &mockProtoPublisher{}
+	pub, err := NewKafkaObservationPublisher(mock)
+	require.NoError(t, err)
+
+	pub.Close()
+	assert.True(t, mock.closed)
+}
+
+func TestKafkaObservationPublisher_FlushWithTimeout(t *testing.T) {
+	mock := &mockProtoPublisher{flushReturn: 3}
+	pub, err := NewKafkaObservationPublisher(mock)
+	require.NoError(t, err)
+
+	result := pub.FlushWithTimeout(5000)
+	assert.Equal(t, 3, result)
+}
+
+func TestKafkaObservationPublisher_Publish(t *testing.T) {
+	t.Run("publishes ObservationRecorded event", func(t *testing.T) {
+		mock := &mockProtoPublisher{}
+		pub, err := NewKafkaObservationPublisher(mock)
+		require.NoError(t, err)
+
+		event := &marketinformationv1.ObservationRecorded{
+			ObservationId: uuid.New().String(),
+			DatasetCode:   "TEST_DS",
+			Value:         "1.23",
+			RecordedAt:    timestamppb.Now(),
+		}
+
+		err = pub.Publish(context.Background(), event)
+		require.NoError(t, err)
+		assert.Len(t, mock.publishedMessages, 2)
+		assert.Equal(t, "TEST_DS", mock.publishedMessages[0].key)
+	})
+
+	t.Run("returns error for unsupported event type", func(t *testing.T) {
+		mock := &mockProtoPublisher{}
+		pub, err := NewKafkaObservationPublisher(mock)
+		require.NoError(t, err)
+
+		err = pub.Publish(context.Background(), "unsupported")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrUnsupportedEventType)
+	})
+
+	t.Run("returns error when primary publish fails", func(t *testing.T) {
+		mock := &mockProtoPublisher{publishErr: errors.New("kafka down")}
+		pub, err := NewKafkaObservationPublisher(mock)
+		require.NoError(t, err)
+
+		event := &marketinformationv1.ObservationRecorded{
+			DatasetCode: "TEST",
+		}
+		err = pub.Publish(context.Background(), event)
+		require.Error(t, err)
+	})
+}
+
+func TestMapObservationToProtoEvent(t *testing.T) {
+	obs := createTestObservation(t)
+	event := mapObservationToProtoEvent(obs)
+
+	assert.Equal(t, obs.ID().String(), event.ObservationId)
+	assert.Equal(t, obs.DataSetCode(), event.DatasetCode)
+	assert.Equal(t, obs.ResolutionKey(), event.ResolutionKeyValue)
+	assert.Equal(t, obs.Value().String(), event.Value)
+	assert.Equal(t, obs.SourceID().String(), event.SourceId)
+	assert.NotNil(t, event.ObservedAt)
+	assert.NotNil(t, event.RecordedAt)
+}
+
+func TestMapQualityLevelToProto(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    domain.QualityLevel
+		expected marketinformationv1.QualityLevel
+	}{
+		{"estimate", domain.QualityLevelEstimate, marketinformationv1.QualityLevel_QUALITY_LEVEL_ESTIMATE},
+		{"actual", domain.QualityLevelActual, marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL},
+		{"verified maps to actual", domain.QualityLevelVerified, marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL},
+		{"unknown maps to unspecified", domain.QualityLevel(99), marketinformationv1.QualityLevel_QUALITY_LEVEL_UNSPECIFIED},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mapQualityLevelToProto(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestShouldPublishObservationEvent(t *testing.T) {
+	tests := []struct {
+		name     string
+		quality  domain.QualityLevel
+		expected bool
+	}{
+		{"actual publishes", domain.QualityLevelActual, true},
+		{"verified publishes", domain.QualityLevelVerified, true},
+		{"estimate does not publish", domain.QualityLevelEstimate, false},
+		{"unknown does not publish", domain.QualityLevel(99), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, shouldPublishObservationEvent(tt.quality))
+		})
+	}
+}

--- a/services/market-information/service/observation_service_unhappy_test.go
+++ b/services/market-information/service/observation_service_unhappy_test.go
@@ -1,0 +1,700 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
+	"github.com/meridianhub/meridian/services/market-information/adapters/persistence/testhelpers"
+	"github.com/meridianhub/meridian/services/market-information/domain"
+)
+
+func setupTestServerWithCel(t *testing.T) (*Server, *testhelpers.TestContainer, func()) {
+	t.Helper()
+
+	tc := testhelpers.SetupTestContainer(t)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	validator, err := NewCelValidator()
+	require.NoError(t, err)
+
+	server, err := NewServer(
+		tc.Repos.DataSet,
+		tc.Repos.Observation,
+		tc.Repos.Source,
+		WithLogger(logger),
+		WithCelValidator(validator),
+	)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		tc.Cleanup(t)
+	}
+
+	return server, tc, cleanup
+}
+
+func setupActiveDatasetAndSource(t *testing.T, server *Server, ctx context.Context, dsCode, srcCode string) {
+	t.Helper()
+
+	// Register and activate dataset
+	registerResp, err := server.RegisterDataSet(ctx, &pb.RegisterDataSetRequest{
+		Code:                    dsCode,
+		DisplayName:             "Test Dataset " + dsCode,
+		Category:                pb.DataCategory_DATA_CATEGORY_FX_RATE,
+		ValidationExpression:    "decimal(value) > decimal('0')",
+		ResolutionKeyExpression: "has(observation_context.currency_pair) ? observation_context.currency_pair : 'default'",
+		ErrorMessageExpression:  "'Value ' + value + ' failed validation for dataset ' + dataset_code",
+	})
+	require.NoError(t, err)
+
+	_, err = server.ActivateDataSet(ctx, &pb.ActivateDataSetRequest{
+		Code:    dsCode,
+		Version: registerResp.Dataset.Version,
+	})
+	require.NoError(t, err)
+
+	// Register source
+	_, err = server.RegisterDataSource(ctx, &pb.RegisterDataSourceRequest{
+		Code:       srcCode,
+		Name:       "Test Source " + srcCode,
+		TrustLevel: 80,
+	})
+	require.NoError(t, err)
+}
+
+func TestRecordObservation_CELValidation(t *testing.T) {
+	server, _, cleanup := setupTestServerWithCel(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	dsCode := "CEL_VALIDATION_DS"
+	srcCode := "CEL_VALIDATION_SRC"
+	setupActiveDatasetAndSource(t, server, ctx, dsCode, srcCode)
+
+	t.Run("rejects observation failing CEL validation", func(t *testing.T) {
+		now := timestamppb.Now()
+		req := &pb.RecordObservationRequest{
+			DatasetCode: dsCode,
+			SourceCode:  srcCode,
+			Value:       "-1.0",
+			ObservedAt:  now,
+			ValidFrom:   now,
+			Quality:     pb.QualityLevel_QUALITY_LEVEL_ACTUAL,
+			Attributes: []*quantityv1.AttributeEntry{
+				{Key: "currency_pair", Value: "EUR/USD"},
+			},
+		}
+
+		_, err := server.RecordObservation(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("computes resolution key from CEL expression", func(t *testing.T) {
+		now := timestamppb.Now()
+		req := &pb.RecordObservationRequest{
+			DatasetCode: dsCode,
+			SourceCode:  srcCode,
+			Value:       "1.1234",
+			ObservedAt:  now,
+			ValidFrom:   now,
+			Quality:     pb.QualityLevel_QUALITY_LEVEL_ACTUAL,
+			Attributes: []*quantityv1.AttributeEntry{
+				{Key: "currency_pair", Value: "EUR/USD"},
+			},
+		}
+
+		resp, err := server.RecordObservation(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, "EUR/USD", resp.Observation.ResolutionKeyValue)
+	})
+
+	t.Run("uses default resolution key when no context provided", func(t *testing.T) {
+		now := timestamppb.Now()
+		req := &pb.RecordObservationRequest{
+			DatasetCode: dsCode,
+			SourceCode:  srcCode,
+			Value:       "1.0",
+			ObservedAt:  now,
+			ValidFrom:   now,
+			Quality:     pb.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+		}
+
+		resp, err := server.RecordObservation(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, "default", resp.Observation.ResolutionKeyValue)
+	})
+}
+
+func TestRecordObservation_NilObservedAt(t *testing.T) {
+	server, _, cleanup := setupTestServerWithCel(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	dsCode := "NIL_TS_DS"
+	srcCode := "NIL_TS_SRC"
+	setupActiveDatasetAndSource(t, server, ctx, dsCode, srcCode)
+
+	t.Run("rejects nil observed_at", func(t *testing.T) {
+		req := &pb.RecordObservationRequest{
+			DatasetCode: dsCode,
+			SourceCode:  srcCode,
+			Value:       "1.0",
+			ObservedAt:  nil,
+			ValidFrom:   timestamppb.Now(),
+			Quality:     pb.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+		}
+
+		_, err := server.RecordObservation(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "observed_at")
+	})
+}
+
+func TestRecordObservation_WithExplicitValidTo(t *testing.T) {
+	server, _, cleanup := setupTestServerWithCel(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	dsCode := "VALID_TO_DS"
+	srcCode := "VALID_TO_SRC"
+	setupActiveDatasetAndSource(t, server, ctx, dsCode, srcCode)
+
+	t.Run("records observation with explicit valid_to", func(t *testing.T) {
+		now := time.Now()
+		req := &pb.RecordObservationRequest{
+			DatasetCode: dsCode,
+			SourceCode:  srcCode,
+			Value:       "1.5",
+			ObservedAt:  timestamppb.New(now),
+			ValidFrom:   timestamppb.New(now),
+			ValidTo:     timestamppb.New(now.Add(48 * time.Hour)),
+			Quality:     pb.QualityLevel_QUALITY_LEVEL_ACTUAL,
+			Attributes: []*quantityv1.AttributeEntry{
+				{Key: "currency_pair", Value: "GBP/USD"},
+			},
+		}
+
+		resp, err := server.RecordObservation(ctx, req)
+		require.NoError(t, err)
+		assert.NotNil(t, resp.Observation)
+	})
+}
+
+func TestComputeResolutionKey_WithoutValidator(t *testing.T) {
+	// Create server without CEL validator
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	server, err := NewServer(
+		tc.Repos.DataSet,
+		tc.Repos.Observation,
+		tc.Repos.Source,
+		WithLogger(logger),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Register and activate dataset (no CEL validation since no validator)
+	registerResp, err := server.RegisterDataSet(ctx, &pb.RegisterDataSetRequest{
+		Code:                    "NO_CEL_DS",
+		DisplayName:             "No CEL Dataset",
+		Category:                pb.DataCategory_DATA_CATEGORY_FX_RATE,
+		ValidationExpression:    "true",
+		ResolutionKeyExpression: "key",
+	})
+	require.NoError(t, err)
+
+	_, err = server.ActivateDataSet(ctx, &pb.ActivateDataSetRequest{
+		Code:    "NO_CEL_DS",
+		Version: registerResp.Dataset.Version,
+	})
+	require.NoError(t, err)
+
+	_, err = server.RegisterDataSource(ctx, &pb.RegisterDataSourceRequest{
+		Code:       "NO_CEL_SRC",
+		Name:       "No CEL Source",
+		TrustLevel: 50,
+	})
+	require.NoError(t, err)
+
+	t.Run("uses context value as resolution key without validator", func(t *testing.T) {
+		now := timestamppb.Now()
+		resp, err := server.RecordObservation(ctx, &pb.RecordObservationRequest{
+			DatasetCode: "NO_CEL_DS",
+			SourceCode:  "NO_CEL_SRC",
+			Value:       "1.0",
+			ObservedAt:  now,
+			ValidFrom:   now,
+			Quality:     pb.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+			Attributes: []*quantityv1.AttributeEntry{
+				{Key: "currency_pair", Value: "EUR/USD"},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "EUR/USD", resp.Observation.ResolutionKeyValue)
+	})
+
+	t.Run("uses default resolution key without context", func(t *testing.T) {
+		now := timestamppb.Now()
+		resp, err := server.RecordObservation(ctx, &pb.RecordObservationRequest{
+			DatasetCode: "NO_CEL_DS",
+			SourceCode:  "NO_CEL_SRC",
+			Value:       "2.0",
+			ObservedAt:  now,
+			ValidFrom:   now,
+			Quality:     pb.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "default", resp.Observation.ResolutionKeyValue)
+	})
+}
+
+func TestProtoQualityLevelToDomain(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    pb.QualityLevel
+		expected domain.QualityLevel
+	}{
+		{"unspecified defaults to estimate", pb.QualityLevel_QUALITY_LEVEL_UNSPECIFIED, domain.QualityLevelEstimate},
+		{"estimate", pb.QualityLevel_QUALITY_LEVEL_ESTIMATE, domain.QualityLevelEstimate},
+		{"provisional maps to estimate", pb.QualityLevel_QUALITY_LEVEL_PROVISIONAL, domain.QualityLevelEstimate},
+		{"actual", pb.QualityLevel_QUALITY_LEVEL_ACTUAL, domain.QualityLevelActual},
+		{"revised maps to verified", pb.QualityLevel_QUALITY_LEVEL_REVISED, domain.QualityLevelVerified},
+		{"unknown defaults to estimate", pb.QualityLevel(999), domain.QualityLevelEstimate},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := protoQualityLevelToDomain(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDomainQualityLevelToProto(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    domain.QualityLevel
+		expected pb.QualityLevel
+	}{
+		{"estimate", domain.QualityLevelEstimate, pb.QualityLevel_QUALITY_LEVEL_ESTIMATE},
+		{"actual", domain.QualityLevelActual, pb.QualityLevel_QUALITY_LEVEL_ACTUAL},
+		{"verified maps to actual", domain.QualityLevelVerified, pb.QualityLevel_QUALITY_LEVEL_ACTUAL},
+		{"unknown maps to unspecified", domain.QualityLevel(99), pb.QualityLevel_QUALITY_LEVEL_UNSPECIFIED},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := domainQualityLevelToProto(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMapObservationDomainError(t *testing.T) {
+	server, _, cleanup := setupTestServerForObservation(t)
+	defer cleanup()
+
+	tests := []struct {
+		name         string
+		err          error
+		expectedCode codes.Code
+	}{
+		{"observation not found", domain.ErrObservationNotFound, codes.NotFound},
+		{"dataset not found", domain.ErrDataSetNotFound, codes.NotFound},
+		{"source not found", domain.ErrDataSourceNotFound, codes.NotFound},
+		{"dataset deprecated", domain.ErrDataSetDeprecated, codes.FailedPrecondition},
+		{"invalid temporal bounds", domain.ErrInvalidTemporalBounds, codes.InvalidArgument},
+		{"invalid quality level", domain.ErrInvalidQualityLevel, codes.InvalidArgument},
+		{"dataset code required", domain.ErrDataSetCodeRequired, codes.InvalidArgument},
+		{"source ID required", domain.ErrSourceIDRequired, codes.InvalidArgument},
+		{"resolution key required", domain.ErrResolutionKeyRequired, codes.InvalidArgument},
+		{"unit required", domain.ErrUnitRequired, codes.InvalidArgument},
+		{"causation ID required", domain.ErrCausationIDRequired, codes.InvalidArgument},
+		{"invalid trust level", domain.ErrInvalidTrustLevel, codes.InvalidArgument},
+		{"unknown error", errors.New("unknown error"), codes.Internal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := server.mapObservationDomainError(tt.err, "TestOp", "test-id")
+			st, ok := status.FromError(result)
+			require.True(t, ok)
+			assert.Equal(t, tt.expectedCode, st.Code())
+		})
+	}
+}
+
+func TestMapSourceDomainError(t *testing.T) {
+	server, _, cleanup := setupTestServerForSource(t)
+	defer cleanup()
+
+	tests := []struct {
+		name         string
+		err          error
+		expectedCode codes.Code
+	}{
+		{"source not found", domain.ErrDataSourceNotFound, codes.NotFound},
+		{"duplicate code", domain.ErrDuplicateDataSourceCode, codes.AlreadyExists},
+		{"code required", domain.ErrDataSourceCodeRequired, codes.InvalidArgument},
+		{"name required", domain.ErrDataSourceNameRequired, codes.InvalidArgument},
+		{"invalid source type", domain.ErrInvalidSourceType, codes.InvalidArgument},
+		{"invalid trust level", domain.ErrInvalidTrustLevel, codes.InvalidArgument},
+		{"unknown error", errors.New("unknown error"), codes.Internal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := server.mapSourceDomainError(tt.err, "TestOp", "test-code")
+			st, ok := status.FromError(result)
+			require.True(t, ok)
+			assert.Equal(t, tt.expectedCode, st.Code())
+		})
+	}
+}
+
+func TestListObservations_Pagination(t *testing.T) {
+	server, _, cleanup := setupTestServerForObservation(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	t.Run("caps page size at maximum", func(t *testing.T) {
+		// Need a real dataset for the query to work
+		registerResp, err := server.RegisterDataSet(ctx, &pb.RegisterDataSetRequest{
+			Code:                    "PAGE_CAP_DS",
+			DisplayName:             "Page Cap Test",
+			Category:                pb.DataCategory_DATA_CATEGORY_FX_RATE,
+			ValidationExpression:    "true",
+			ResolutionKeyExpression: "key",
+		})
+		require.NoError(t, err)
+
+		_, err = server.ActivateDataSet(ctx, &pb.ActivateDataSetRequest{
+			Code:    "PAGE_CAP_DS",
+			Version: registerResp.Dataset.Version,
+		})
+		require.NoError(t, err)
+
+		resp, err := server.ListObservations(ctx, &pb.ListObservationsRequest{
+			DatasetCode: "PAGE_CAP_DS",
+			PageSize:    5000, // Exceeds max of 1000
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, int32(0), resp.TotalCount)
+	})
+
+	t.Run("rejects invalid page token", func(t *testing.T) {
+		_, err := server.ListObservations(ctx, &pb.ListObservationsRequest{
+			DatasetCode: "PAGE_CAP_DS",
+			PageSize:    10,
+			PageToken:   "bad-token!!!",
+		})
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+}
+
+func TestRecordObservationBatch_WithCelValidation(t *testing.T) {
+	server, _, cleanup := setupTestServerWithCel(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	dsCode := "BATCH_CEL_DS"
+	srcCode := "BATCH_CEL_SRC"
+	setupActiveDatasetAndSource(t, server, ctx, dsCode, srcCode)
+
+	t.Run("batch with mixed valid and invalid values", func(t *testing.T) {
+		now := timestamppb.Now()
+		resp, err := server.RecordObservationBatch(ctx, &pb.RecordObservationBatchRequest{
+			Observations: []*pb.BatchObservationEntry{
+				{
+					DatasetCode: dsCode,
+					SourceCode:  srcCode,
+					Value:       "1.5",
+					ObservedAt:  now,
+					ValidFrom:   now,
+					Quality:     pb.QualityLevel_QUALITY_LEVEL_ACTUAL,
+					Attributes: []*quantityv1.AttributeEntry{
+						{Key: "currency_pair", Value: "EUR/USD"},
+					},
+					ClientReference: "good-1",
+				},
+				{
+					DatasetCode: dsCode,
+					SourceCode:  srcCode,
+					Value:       "-1.0",
+					ObservedAt:  now,
+					ValidFrom:   now,
+					Quality:     pb.QualityLevel_QUALITY_LEVEL_ACTUAL,
+					Attributes: []*quantityv1.AttributeEntry{
+						{Key: "currency_pair", Value: "GBP/USD"},
+					},
+					ClientReference: "bad-1",
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), resp.TotalCount)
+		assert.Equal(t, int32(1), resp.SuccessCount)
+		assert.Equal(t, int32(1), resp.FailureCount)
+
+		// Check individual results
+		assert.True(t, resp.Results[0].Success)
+		assert.Equal(t, "good-1", resp.Results[0].ClientReference)
+		assert.False(t, resp.Results[1].Success)
+		assert.Equal(t, "bad-1", resp.Results[1].ClientReference)
+	})
+
+	t.Run("batch with missing timestamps", func(t *testing.T) {
+		resp, err := server.RecordObservationBatch(ctx, &pb.RecordObservationBatchRequest{
+			Observations: []*pb.BatchObservationEntry{
+				{
+					DatasetCode: dsCode,
+					SourceCode:  srcCode,
+					Value:       "1.0",
+					ObservedAt:  nil, // missing
+					ValidFrom:   timestamppb.Now(),
+					Quality:     pb.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+				},
+				{
+					DatasetCode: dsCode,
+					SourceCode:  srcCode,
+					Value:       "2.0",
+					ObservedAt:  timestamppb.Now(),
+					ValidFrom:   nil, // missing
+					Quality:     pb.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(0), resp.SuccessCount)
+		assert.Equal(t, int32(2), resp.FailureCount)
+		assert.Contains(t, resp.Results[0].ErrorMessage, "observed_at")
+		assert.Contains(t, resp.Results[1].ErrorMessage, "valid_from")
+	})
+
+	t.Run("batch with non-existent source", func(t *testing.T) {
+		now := timestamppb.Now()
+		resp, err := server.RecordObservationBatch(ctx, &pb.RecordObservationBatchRequest{
+			Observations: []*pb.BatchObservationEntry{
+				{
+					DatasetCode: dsCode,
+					SourceCode:  "NONEXISTENT_SRC",
+					Value:       "1.0",
+					ObservedAt:  now,
+					ValidFrom:   now,
+					Quality:     pb.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), resp.FailureCount)
+		assert.Contains(t, resp.Results[0].ErrorMessage, "source not found")
+	})
+
+	t.Run("batch with inactive dataset", func(t *testing.T) {
+		// Register but don't activate
+		_, err := server.RegisterDataSet(ctx, &pb.RegisterDataSetRequest{
+			Code:                    "BATCH_DRAFT_DS",
+			DisplayName:             "Batch Draft Dataset",
+			Category:                pb.DataCategory_DATA_CATEGORY_FX_RATE,
+			ValidationExpression:    "true",
+			ResolutionKeyExpression: "'default'",
+		})
+		require.NoError(t, err)
+
+		now := timestamppb.Now()
+		resp, err := server.RecordObservationBatch(ctx, &pb.RecordObservationBatchRequest{
+			Observations: []*pb.BatchObservationEntry{
+				{
+					DatasetCode: "BATCH_DRAFT_DS",
+					SourceCode:  srcCode,
+					Value:       "1.0",
+					ObservedAt:  now,
+					ValidFrom:   now,
+					Quality:     pb.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), resp.FailureCount)
+		assert.Contains(t, resp.Results[0].ErrorMessage, "not active")
+	})
+
+	t.Run("batch with invalid decimal value", func(t *testing.T) {
+		now := timestamppb.Now()
+		resp, err := server.RecordObservationBatch(ctx, &pb.RecordObservationBatchRequest{
+			Observations: []*pb.BatchObservationEntry{
+				{
+					DatasetCode: dsCode,
+					SourceCode:  srcCode,
+					Value:       "not-a-number",
+					ObservedAt:  now,
+					ValidFrom:   now,
+					Quality:     pb.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), resp.FailureCount)
+		assert.Contains(t, resp.Results[0].ErrorMessage, "invalid decimal value")
+	})
+}
+
+func TestRecordObservation_WithEventPublisher(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	validator, err := NewCelValidator()
+	require.NoError(t, err)
+
+	mock := &mockPublisher{}
+	server, err := NewServer(
+		tc.Repos.DataSet,
+		tc.Repos.Observation,
+		tc.Repos.Source,
+		WithLogger(logger),
+		WithCelValidator(validator),
+		WithEventPublisher(mock),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	dsCode := "EVENT_PUB_DS"
+	srcCode := "EVENT_PUB_SRC"
+	setupActiveDatasetAndSource(t, server, ctx, dsCode, srcCode)
+
+	t.Run("publishes event for ACTUAL quality", func(t *testing.T) {
+		now := timestamppb.Now()
+		_, err := server.RecordObservation(ctx, &pb.RecordObservationRequest{
+			DatasetCode: dsCode,
+			SourceCode:  srcCode,
+			Value:       "1.5",
+			ObservedAt:  now,
+			ValidFrom:   now,
+			Quality:     pb.QualityLevel_QUALITY_LEVEL_ACTUAL,
+			Attributes: []*quantityv1.AttributeEntry{
+				{Key: "currency_pair", Value: "EUR/USD"},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, mock.publishCount)
+	})
+
+	t.Run("does not publish event for ESTIMATE quality", func(t *testing.T) {
+		mock.publishCount = 0 // reset
+		now := timestamppb.Now()
+		_, err := server.RecordObservation(ctx, &pb.RecordObservationRequest{
+			DatasetCode: dsCode,
+			SourceCode:  srcCode,
+			Value:       "2.5",
+			ObservedAt:  now,
+			ValidFrom:   now,
+			Quality:     pb.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+			Attributes: []*quantityv1.AttributeEntry{
+				{Key: "currency_pair", Value: "USD/JPY"},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 0, mock.publishCount)
+	})
+}
+
+// mockPublisher implements EventPublisher for testing event publishing.
+type mockPublisher struct {
+	publishCount int
+	publishErr   error
+}
+
+func (m *mockPublisher) Publish(_ context.Context, _ any) error {
+	if m.publishErr != nil {
+		return m.publishErr
+	}
+	m.publishCount++
+	return nil
+}
+
+func TestListObservations_WithFilters(t *testing.T) {
+	server, _, cleanup := setupTestServerWithCel(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	dsCode := "FILTER_OBS_DS"
+	srcCode := "FILTER_OBS_SRC"
+	setupActiveDatasetAndSource(t, server, ctx, dsCode, srcCode)
+
+	// Record some observations
+	now := time.Now()
+	for i := 0; i < 3; i++ {
+		_, err := server.RecordObservation(ctx, &pb.RecordObservationRequest{
+			DatasetCode: dsCode,
+			SourceCode:  srcCode,
+			Value:       "1.0",
+			ObservedAt:  timestamppb.New(now.Add(time.Duration(i) * time.Hour)),
+			ValidFrom:   timestamppb.New(now),
+			Quality:     pb.QualityLevel_QUALITY_LEVEL_ACTUAL,
+			Attributes: []*quantityv1.AttributeEntry{
+				{Key: "currency_pair", Value: "EUR/USD"},
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	t.Run("filters by quality level", func(t *testing.T) {
+		resp, err := server.ListObservations(ctx, &pb.ListObservationsRequest{
+			DatasetCode:   dsCode,
+			QualityFilter: pb.QualityLevel_QUALITY_LEVEL_ACTUAL,
+			PageSize:      100,
+		})
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(resp.Observations), 3)
+	})
+
+	t.Run("filters by time range", func(t *testing.T) {
+		resp, err := server.ListObservations(ctx, &pb.ListObservationsRequest{
+			DatasetCode:  dsCode,
+			ObservedFrom: timestamppb.New(now.Add(-1 * time.Hour)),
+			ObservedTo:   timestamppb.New(now.Add(30 * time.Minute)),
+			PageSize:     100,
+		})
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(resp.Observations), 1)
+	})
+
+	t.Run("filters by resolution key", func(t *testing.T) {
+		resp, err := server.ListObservations(ctx, &pb.ListObservationsRequest{
+			DatasetCode:        dsCode,
+			ResolutionKeyValue: "EUR/USD",
+			PageSize:           100,
+		})
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(resp.Observations), 3)
+	})
+}

--- a/services/market-information/service/server_test.go
+++ b/services/market-information/service/server_test.go
@@ -1,0 +1,100 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/market-information/adapters/persistence/testhelpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewServer_NilDependencies(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	t.Run("returns error for nil dataset repository", func(t *testing.T) {
+		_, err := NewServer(nil, tc.Repos.Observation, tc.Repos.Source)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrDataSetRepositoryNil)
+	})
+
+	t.Run("returns error for nil observation repository", func(t *testing.T) {
+		_, err := NewServer(tc.Repos.DataSet, nil, tc.Repos.Source)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrObservationRepositoryNil)
+	})
+
+	t.Run("returns error for nil source repository", func(t *testing.T) {
+		_, err := NewServer(tc.Repos.DataSet, tc.Repos.Observation, nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrSourceRepositoryNil)
+	})
+}
+
+func TestNewServer_WithOptions(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	t.Run("applies WithCelValidator option", func(t *testing.T) {
+		validator, err := NewCelValidator()
+		require.NoError(t, err)
+
+		server, err := NewServer(
+			tc.Repos.DataSet,
+			tc.Repos.Observation,
+			tc.Repos.Source,
+			WithCelValidator(validator),
+		)
+		require.NoError(t, err)
+		assert.NotNil(t, server.celValidator)
+	})
+
+	t.Run("applies WithEventPublisher option", func(t *testing.T) {
+		pub := &mockEventPublisher{}
+
+		server, err := NewServer(
+			tc.Repos.DataSet,
+			tc.Repos.Observation,
+			tc.Repos.Source,
+			WithEventPublisher(pub),
+		)
+		require.NoError(t, err)
+		assert.NotNil(t, server.eventPublisher)
+	})
+
+	t.Run("applies WithLogger option", func(t *testing.T) {
+		logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+		server, err := NewServer(
+			tc.Repos.DataSet,
+			tc.Repos.Observation,
+			tc.Repos.Source,
+			WithLogger(logger),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, logger, server.logger)
+	})
+
+	t.Run("defaults logger when not provided", func(t *testing.T) {
+		server, err := NewServer(
+			tc.Repos.DataSet,
+			tc.Repos.Observation,
+			tc.Repos.Source,
+		)
+		require.NoError(t, err)
+		assert.NotNil(t, server.logger)
+	})
+}
+
+// mockEventPublisher implements EventPublisher for testing.
+type mockEventPublisher struct {
+	publishedEvents []any
+}
+
+func (m *mockEventPublisher) Publish(_ context.Context, event any) error {
+	m.publishedEvents = append(m.publishedEvents, event)
+	return nil
+}


### PR DESCRIPTION
## Summary

- Add unhappy path and edge case tests to bring market-information service coverage above 80%
- Service layer: 62.6% → 83.1%, persistence: 81.8%, domain: 96.2%
- 5 new test files covering server initialization, CEL validation, dataset/observation/source error paths, event publishing, proto mapping, and pagination

## Test plan

- [x] All service layer tests pass (`go test ./services/market-information/service/...`)
- [x] All persistence layer tests pass (`go test ./services/market-information/adapters/persistence/...`)
- [x] Coverage exceeds 80% threshold for all packages
- [ ] CI passes