### PR TITLE
docs: PRD-049 Codebase Consistency & AI Navigability

### DIFF
--- a/docs/prd/049-codebase-consistency.md
+++ b/docs/prd/049-codebase-consistency.md
@@ -1,0 +1,421 @@
+---
+name: prd-codebase-consistency
+description: Standardize naming, patterns, and documentation across services to improve AI navigability and developer onboarding
+triggers:
+  - Improving codebase consistency or standardization
+  - Adding doc.go files or package documentation
+  - Standardizing service file naming
+  - Proto generated file management
+  - Updating the new service checklist
+instructions: |
+  This PRD addresses micro-inconsistencies that compound across 16 services.
+  Each stream is independent. Prioritize Stream 1 (proto files) and Stream 2
+  (doc.go) as they have the highest impact on AI code generation reliability.
+  Update the new-bian-service-checklist.md to reflect all conventions established here.
+---
+
+# PRD-049: Codebase Consistency & AI Navigability
+
+## Overview
+
+A comprehensive codebase audit identified micro-inconsistencies across Meridian's 16 services
+that individually are trivial but collectively degrade AI code generation reliability and
+developer onboarding speed. This PRD addresses the structural improvements that make the
+codebase self-describing - reducing the need to read surrounding code before writing new code.
+
+### The Core Problem
+
+When an AI (or new developer) needs to write code in a service, they currently must:
+
+1. **Guess filenames** - Is it `grpc_service.go`, `server.go`, or `financial_accounting_service.go`?
+2. **Read proto source** to understand types (generated `.pb.go` files aren't in git)
+3. **Scan every shared package** to find utilities (no `doc.go` explaining purpose)
+4. **Check each service independently** for error naming, repository shape, config location
+
+Each guess costs a file read. Each file read burns context window. The result: AI performance
+degrades as codebase size increases - not because the architecture is wrong, but because the
+codebase isn't self-describing enough.
+
+## Goals
+
+1. **Commit proto-generated Go files** to git so types are readable without running codegen
+2. **Add `doc.go`** to all shared packages so purpose is discoverable in one read
+3. **Standardize service file naming** so navigation is predictable
+4. **Document canonical patterns** for errors, repositories, and value types
+5. **Update the new-service checklist** to encode all conventions established here
+
+## Non-Goals
+
+- Rewriting service internals or changing architecture
+- New feature development
+- Performance optimization
+- Large file refactoring (covered in PRD-012)
+- Test coverage improvements (covered in PRD-048)
+
+## Complexity Assessment
+
+Total estimated complexity: **21 story points** across 5 streams.
+
+All streams are independent with zero inter-stream dependencies.
+
+```mermaid
+graph LR
+    S1["Stream 1: Commit Proto Files<br/>5 pts"] --> DONE
+    S2["Stream 2: Package Documentation<br/>5 pts"] --> DONE
+    S3["Stream 3: Service Naming<br/>3 pts"] --> DONE
+    S4["Stream 4: Convention Documentation<br/>5 pts"] --> DONE
+    S5["Stream 5: Checklist Update<br/>3 pts"] --> S4
+```
+
+Stream 5 depends on Stream 4 (conventions must be documented before the checklist encodes them).
+
+---
+
+## Stream 1: Commit Proto-Generated Files to Git (5 pts)
+
+### Rationale
+
+Generated `.pb.go` files are currently excluded from git. This means:
+
+- AI cannot read service API types without running `buf generate`
+- Import aliases vary per service (`iav1`, `iba`, `posv1`) with no discoverable convention
+- New worktrees require codegen before compilation
+- Code review cannot show proto-generated type changes inline
+
+This is the same rationale behind shadcn/ui's approach: copy the code into your project so it's
+readable, searchable, and versionable. Generated code that's invisible is code that doesn't
+exist for navigation purposes.
+
+### Task 1.1: Add Proto-Generated Files to Git
+
+**Problem**: `.pb.go` and `_grpc.pb.go` files are gitignored. Every worktree, every CI run,
+and every AI session must regenerate them before types are readable.
+
+**Files Affected**:
+
+- `.gitignore` (remove `*.pb.go` exclusion if present)
+- `api/proto/meridian/*/v1/*.pb.go` (generated files to commit)
+- `api/proto/meridian/*/v1/*_grpc.pb.go` (generated files to commit)
+
+**Acceptance Criteria**:
+
+1. Run `buf generate api/proto` and commit all generated `.pb.go` files
+2. Verify `.gitignore` does not exclude `*.pb.go` in the `api/proto/` tree
+3. `go build ./...` succeeds from a clean checkout without running `buf generate`
+4. Document in CONTRIBUTING.md: "Run `buf generate api/proto` after modifying `.proto` files and commit the generated output"
+
+### Task 1.2: Document Proto Import Alias Convention
+
+**Problem**: Services use inconsistent import aliases for proto packages:
+`iav1`, `iba`, `posv1`, `pkv1`, `fav1` - no discoverable pattern.
+
+**Files Affected**:
+
+- `docs/guides/proto-conventions.md` (new)
+
+**Acceptance Criteria**:
+
+1. Document the canonical import alias pattern: `{service-abbreviation}v1`
+2. List all current proto packages with their canonical alias
+3. Include the mapping: proto path -> Go import path -> canonical alias
+4. Reference from CONTRIBUTING.md
+
+### Task 1.3: Add CI Check for Proto Freshness
+
+**Problem**: Once proto files are committed, they can drift from `.proto` source if a developer
+modifies a `.proto` file but forgets to regenerate.
+
+**Files Affected**:
+
+- `.github/workflows/quality.yml` (add proto freshness check)
+
+**Acceptance Criteria**:
+
+1. CI step runs `buf generate api/proto` and checks for uncommitted changes
+2. Fails with clear message: "Proto generated files are stale. Run `buf generate api/proto` and commit."
+3. Only runs when `.proto` files or `buf.gen.yaml` are modified (path filter)
+
+---
+
+## Stream 2: Package Documentation (5 pts)
+
+### Rationale
+
+`shared/pkg/` has 18 packages and `shared/platform/` has 21 packages. Fewer than half have
+`doc.go` files. Without them, understanding a package requires scanning all exported symbols -
+expensive for humans, catastrophic for AI context windows.
+
+A `doc.go` file costs 5-15 lines and saves hundreds of lines of exploratory reads.
+
+### Task 2.1: Add doc.go to All shared/pkg/ Packages
+
+**Problem**: 14 of 18 `shared/pkg/` packages lack `doc.go`. An AI or developer discovering
+`shared/pkg/mapping/` has no way to know what it does without reading implementation files.
+
+**Packages missing doc.go** (verify current state before implementing):
+
+- `amount/`, `bucketing/`, `credentials/`, `dispatch/`, `grpc/`, `health/`,
+  `idempotency/`, `interceptors/`, `mapping/`, `money/`, `proto/`, `refdata/`,
+  `tokens/`, `types/`, `validation/`
+
+**Acceptance Criteria**:
+
+1. Every package under `shared/pkg/` has a `doc.go` file
+2. Each `doc.go` contains: package purpose (1 sentence), key types/functions (2-3 lines), usage example or "see X for usage" pointer
+3. Format follows Go convention: `// Package X provides...`
+4. No implementation code in `doc.go` files
+
+**Example**:
+
+```go
+// Package mapping provides a bidirectional JSON transformation engine
+// for converting between external formats and Meridian domain types.
+//
+// Key types: Engine, MappingSpec, TransformResult
+// Used by: operational-gateway, api-gateway for inbound/outbound data mapping
+package mapping
+```
+
+### Task 2.2: Add doc.go to All shared/platform/ Packages
+
+**Problem**: 13 of 21 `shared/platform/` packages lack `doc.go`.
+
+**Packages missing doc.go** (verify current state before implementing):
+
+- `auth/`, `db/`, `env/`, `gateway/`, `kafka/`, `observability/`, `ports/`,
+  `quantity/`, `ratelimit/`, `redislock/`, `sandbox/`, `scheduler/`, `tenant/`
+
+**Acceptance Criteria**:
+
+1. Every package under `shared/platform/` has a `doc.go` file
+2. Same format requirements as Task 2.1
+3. Platform packages should note whether they're infrastructure-only or have domain semantics
+
+### Task 2.3: Add shared/ Navigation README
+
+**Problem**: No documentation explains the `shared/pkg/` vs `shared/platform/` split.
+Developers don't know where to add new shared code.
+
+**Files Affected**:
+
+- `shared/README.md` (new)
+
+**Acceptance Criteria**:
+
+1. Explains the two-tier split: `pkg/` = domain logic shared across services, `platform/` = infrastructure utilities
+2. Decision guide: "If it knows about business concepts (money, sagas, instruments) -> pkg/. If it's infrastructure plumbing (DB, auth, events) -> platform/"
+3. Lists all packages with one-line descriptions (can be generated from doc.go files)
+4. Notes the canonical value type: `shared/platform/quantity.Quantity[D]` is the primary dimensional type; `shared/pkg/money` and `shared/pkg/amount` are convenience wrappers
+
+---
+
+## Stream 3: Service File Naming Standardization (3 pts)
+
+### Rationale
+
+Three different names for the same concept:
+
+| Service | Main service file |
+|---------|------------------|
+| current-account | `grpc_service.go` |
+| party | `grpc_service.go` |
+| internal-account | `server.go` |
+| reconciliation | `server.go` |
+| financial-accounting | `financial_accounting_service.go` |
+
+This means "find the gRPC handler registration" requires checking 2-3 filenames per service.
+
+### Task 3.1: Rename Variant Service Files to grpc_service.go
+
+**Problem**: `server.go` and `{service}_service.go` variants create navigation ambiguity.
+`grpc_service.go` is the most common pattern (used by 8+ services) and should be canonical.
+
+**Files Affected** (verify current state before implementing):
+
+- `services/internal-account/service/server.go` -> rename to `grpc_service.go`
+- `services/reconciliation/service/server.go` -> rename to `grpc_service.go`
+- `services/financial-accounting/service/financial_accounting_service.go` -> rename to `grpc_service.go`
+- Any other services using non-standard names
+
+**Acceptance Criteria**:
+
+1. All services use `grpc_service.go` as the main gRPC service implementation file
+2. All imports and references updated
+3. All tests pass
+4. `git log --follow` preserves file history (use `git mv`)
+
+### Task 3.2: Standardize gRPC Handler File Splitting Convention
+
+**Problem**: Some services split handlers into `grpc_{operation}_endpoints.go` files, others
+inline everything. No convention for when to split.
+
+**Files Affected**:
+
+- `docs/guides/service-file-conventions.md` (new)
+
+**Acceptance Criteria**:
+
+1. Document the convention: split into `grpc_{operation}_endpoints.go` when `grpc_service.go` exceeds 400 LOC
+2. Document the naming pattern: `grpc_service.go` (constructor + registration), `grpc_{operation}_endpoints.go` (handler implementations)
+3. List the current state of each service for reference
+4. Do NOT refactor existing services in this task (documentation only - refactoring is in PRD-012)
+
+---
+
+## Stream 4: Convention Documentation (5 pts)
+
+### Rationale
+
+Inconsistencies persist because conventions are implicit. Documenting them explicitly creates
+a reference that both humans and AI can check before writing new code.
+
+### Task 4.1: Document Error Naming Convention
+
+**Problem**: Mixed patterns across services: `ErrNotFound` (generic) vs `ErrAccountNotFound`
+(entity-prefixed). Neither is wrong, but the inconsistency means you can't predict error
+names without reading each service's `errors.go`.
+
+**Files Affected**:
+
+- `docs/guides/error-conventions.md` (new)
+
+**Acceptance Criteria**:
+
+1. Establish the canonical pattern: entity-prefixed errors (`Err{Entity}NotFound`) for domain errors, generic errors (`ErrNotFound`) only in shared packages
+2. Document the standard error set every domain should define: `NotFound`, `Conflict`, `InvalidStatus`, `OptimisticLock`
+3. Document gRPC status code mapping convention (e.g., `ErrNotFound` -> `codes.NotFound`)
+4. Include examples from existing services
+5. Do NOT refactor existing errors in this task (documentation only - migration is future work)
+
+### Task 4.2: Document Repository Pattern Convention
+
+**Problem**: Repository interfaces live in `domain/repository.go` (position-keeping) or
+`adapters/persistence/repository.go` (most others). Method names vary: `Create`/`Insert`,
+`Find`/`Get`, `Update`/`UpdateStatus`.
+
+**Files Affected**:
+
+- `docs/guides/repository-conventions.md` (new)
+
+**Acceptance Criteria**:
+
+1. Establish canonical location: `adapters/persistence/repository.go` (matching majority pattern)
+2. Document standard method naming: `Create`, `FindByID`, `List`, `Update`, `Delete`
+3. Document optional methods: `CreateBatch`, `CreateWithOutbox`, `SoftDelete`
+4. Document the GORM vs pgx decision: GORM for standard CRUD, pgx for performance-critical paths (position-keeping)
+5. Include the standard constructor pattern and tenant scoping
+6. Do NOT refactor existing repositories (documentation only)
+
+### Task 4.3: Document Value Type Hierarchy
+
+**Problem**: Three packages deal with "amounts of things": `shared/platform/quantity/`,
+`shared/pkg/money/`, `shared/pkg/amount/`. Unclear which to use when.
+
+**Files Affected**:
+
+- `docs/guides/value-types.md` (new)
+
+**Acceptance Criteria**:
+
+1. Document the hierarchy: `Quantity[D]` is the foundational type (dimensional safety), `Money` wraps `Quantity[Currency]` for convenience, `Amount` provides decimal arithmetic
+2. Decision guide: use `Quantity[D]` for multi-asset contexts, `Money` for currency-only contexts, `Amount` for raw decimal operations
+3. Note which is used where (e.g., position-keeping uses `Quantity[D]`, current-account uses both)
+4. Flag `shared/pkg/money/` as a thin wrapper with 2 imports - candidate for future removal
+
+---
+
+## Stream 5: Update New Service Checklist (3 pts)
+
+Depends on: Stream 4 (conventions must be documented first).
+
+### Task 5.1: Update new-bian-service-checklist.md with Established Conventions
+
+**Problem**: The current checklist (`docs/guides/new-bian-service-checklist.md`) doesn't
+encode the naming conventions, file patterns, or documentation requirements established
+in this PRD and ADR-015.
+
+**Files Affected**:
+
+- `docs/guides/new-bian-service-checklist.md`
+
+**Acceptance Criteria**:
+
+1. Add task: "Create `doc.go` for every new package" with format example
+2. Add task: "Create `errors.go` in `domain/` with entity-prefixed errors" referencing error-conventions.md
+3. Update Task 7 (gRPC Service Handler) to mandate `grpc_service.go` naming
+4. Add task: "Regenerate proto files and commit" after proto definition task
+5. Add task: "Create service README.md with YAML frontmatter"
+6. Reference the new convention docs (error-conventions.md, repository-conventions.md, value-types.md)
+7. Add "Starlark Client Bindings" as a required task (currently most services have this but it's not in the checklist)
+
+### Task 5.2: Add Service Consistency Verification Script
+
+**Problem**: No automated way to verify a service follows conventions. Checklist is manual.
+
+**Files Affected**:
+
+- `scripts/verify-service-conventions.sh` (new)
+
+**Acceptance Criteria**:
+
+1. Script accepts a service name and checks:
+   - `grpc_service.go` exists in `service/`
+   - `domain/errors.go` exists
+   - `doc.go` exists in each package
+   - `README.md` exists with YAML frontmatter
+   - Proto generated files exist and are committed
+   - Atlas migration directory exists
+2. Outputs pass/fail per check with actionable fix instructions
+3. Can be run in CI for new service PRs
+
+---
+
+## Parallelization Summary
+
+| Stream | Points | Dependencies | Parallelizable With |
+|--------|--------|-------------|-------------------|
+| 1. Proto Files | 5 | None | 2, 3, 4 |
+| 2. Package Docs | 5 | None | 1, 3, 4 |
+| 3. Service Naming | 3 | None | 1, 2, 4 |
+| 4. Convention Docs | 5 | None | 1, 2, 3 |
+| 5. Checklist Update | 3 | Stream 4 | 1, 2, 3 (after 4) |
+
+**Critical path**: Stream 4 (5 pts) -> Stream 5 (3 pts) = 8 pts.
+With parallelization, streams 1-4 run concurrently, then Stream 5 follows.
+
+## Task Master Parsing Guidance
+
+When parsing this PRD into Task Master tasks:
+
+- **Create exactly 12 tasks** corresponding to the 12 numbered tasks (1.1 through 5.2)
+- Each task maps to a single PR-able unit of work
+- Preserve stream grouping in task numbering
+- Mark Stream 5 tasks as depending on Stream 4 tasks
+- All other streams have zero dependencies
+
+**Task-to-stream mapping:**
+
+| Task ID | PRD Reference | Stream |
+|---------|--------------|--------|
+| 1 | Task 1.1: Add Proto-Generated Files to Git | Proto Files |
+| 2 | Task 1.2: Document Proto Import Alias Convention | Proto Files |
+| 3 | Task 1.3: Add CI Check for Proto Freshness | Proto Files |
+| 4 | Task 2.1: Add doc.go to shared/pkg/ | Package Docs |
+| 5 | Task 2.2: Add doc.go to shared/platform/ | Package Docs |
+| 6 | Task 2.3: Add shared/ Navigation README | Package Docs |
+| 7 | Task 3.1: Rename Variant Service Files | Service Naming |
+| 8 | Task 3.2: Standardize Handler File Splitting Convention | Service Naming |
+| 9 | Task 4.1: Document Error Naming Convention | Convention Docs |
+| 10 | Task 4.2: Document Repository Pattern Convention | Convention Docs |
+| 11 | Task 4.3: Document Value Type Hierarchy | Convention Docs |
+| 12 | Task 5.1: Update New Service Checklist | Checklist Update |
+| 13 | Task 5.2: Add Service Consistency Verification Script | Checklist Update |
+
+## Success Criteria
+
+1. `go build ./...` succeeds from a clean clone without running `buf generate`
+2. Every `shared/` package has a `doc.go` that explains its purpose in < 15 lines
+3. Every service uses `grpc_service.go` as the main service file
+4. Convention docs exist for errors, repositories, and value types
+5. New service checklist references all established conventions
+6. Verification script passes for all existing services (or documents known exceptions)

--- a/docs/prd/049-codebase-consistency.md
+++ b/docs/prd/049-codebase-consistency.md
@@ -151,14 +151,15 @@ A `doc.go` file costs 5-15 lines and saves hundreds of lines of exploratory read
 
 ### Task 2.1: Add doc.go to All shared/pkg/ Packages
 
-**Problem**: 14 of 18 `shared/pkg/` packages lack `doc.go`. An AI or developer discovering
-`shared/pkg/mapping/` has no way to know what it does without reading implementation files.
+**Problem**: 16 of 20 `shared/pkg/` packages lack `doc.go`. An AI or
+developer discovering `shared/pkg/mapping/` has no way to know what it
+does without reading implementation files.
 
 **Packages missing doc.go** (verify current state before implementing):
 
-- `amount/`, `bucketing/`, `credentials/`, `dispatch/`, `grpc/`, `health/`,
-  `idempotency/`, `interceptors/`, `mapping/`, `money/`, `proto/`, `refdata/`,
-  `tokens/`, `types/`, `validation/`
+- `amount/`, `bucketing/`, `cel/`, `credentials/`, `grpc/`, `health/`,
+  `idempotency/`, `mapping/`, `money/`, `proto/`, `refdata/`, `saga/`,
+  `tokens/`, `validation/`, `valuation/`, `valuationfeature/`
 
 **Acceptance Criteria**:
 
@@ -223,31 +224,37 @@ Developers don't know where to add new shared code.
 
 ### Rationale
 
-Three different names for the same concept:
+Three different naming patterns for the main gRPC service file:
 
-| Service | Main service file |
-|---------|------------------|
-| current-account | `grpc_service.go` |
-| party | `grpc_service.go` |
-| internal-account | `server.go` |
-| reconciliation | `server.go` |
-| financial-accounting | `financial_accounting_service.go` |
+| Pattern | Services |
+|---------|----------|
+| `server.go` | internal-account, market-information |
+| `grpc_service.go` | current-account, party, payment-order, tenant, identity, financial-gateway, operational-gateway |
+| `service.go` | position-keeping, reconciliation |
+| `{name}_service.go` | financial-accounting (`financial_accounting_service.go`) |
 
-This means "find the gRPC handler registration" requires checking 2-3 filenames per service.
+This means "find the gRPC handler registration" requires checking
+multiple filenames per service.
 
 ### Task 3.1: Rename Variant Service Files to server.go
 
-**Problem**: `grpc_service.go` and `{service}_service.go` variants create
-navigation ambiguity. ADR-015 establishes `server.go` as the canonical name
-for the gRPC service implementation file. Several services diverge from this.
+**Problem**: ADR-015 establishes `server.go` as the canonical name
+for the gRPC service implementation file. Most services use
+`grpc_service.go` or other variants instead.
 
 **Files Affected** (verify current state before implementing):
 
-- `services/current-account/service/grpc_service.go` -> rename to `server.go`
-- `services/party/service/grpc_service.go` -> rename to `server.go`
+- `services/current-account/service/grpc_service.go` -> `server.go`
+- `services/party/service/grpc_service.go` -> `server.go`
+- `services/payment-order/service/grpc_service.go` -> `server.go`
+- `services/tenant/service/grpc_service.go` -> `server.go`
+- `services/identity/service/grpc_service.go` -> `server.go`
+- `services/financial-gateway/service/grpc_service.go` -> `server.go`
+- `services/operational-gateway/service/grpc_service.go` -> `server.go`
 - `services/financial-accounting/service/financial_accounting_service.go`
-  -> rename to `server.go`
-- Any other services not using `server.go`
+  -> `server.go`
+- `services/position-keeping/service/service.go` -> `server.go`
+- `services/reconciliation/service/service.go` -> `server.go`
 
 **Acceptance Criteria**:
 

--- a/docs/prd/049-codebase-consistency.md
+++ b/docs/prd/049-codebase-consistency.md
@@ -7,12 +7,16 @@ triggers:
   - Standardizing service file naming
   - Proto generated file management
   - Updating the new service checklist
+  - Refactoring large Go files (>600 LOC)
+  - Extracting shared test infrastructure or test helpers
+  - Reducing test boilerplate or setupTestDB duplication
+  - Migrating time.Sleep to await in tests
 instructions: |
-  This PRD addresses micro-inconsistencies that compound across 16 services.
-  Streams 1-4 are independent; Stream 5 depends on Stream 4.
-  Prioritize Stream 1 (proto files) and Stream 2
-  (doc.go) as they have the highest impact on AI code generation reliability.
-  Update the new-bian-service-checklist.md to reflect all conventions established here.
+  7 streams, 47 story points. Streams 1-4, 6, 7 are independent;
+  Stream 5 depends on Stream 4. Stream 6 tasks depend on Stream 3
+  (rename before refactor). Streams 6-7 are the largest work items
+  (13 pts each). Prioritize Stream 1 (proto) and Stream 2 (doc.go)
+  for highest AI impact. Stream 6 supersedes PRD-012 Stream 3.
 ---
 
 # PRD-049: Codebase Consistency & AI Navigability
@@ -56,17 +60,18 @@ codebase isn't self-describing enough.
 
 Total estimated complexity: **47 story points** across 7 streams.
 
-Streams 1-4, 6, 7 are independent. Stream 5 depends on Stream 4.
+Streams 1, 2, 4, 7 are fully independent. Stream 5 depends on
+Stream 4. Stream 6 (refactoring) depends on Stream 3 (rename first).
 
 ```mermaid
 graph LR
-    S1["Stream 1: Commit Proto Files<br/>5 pts"] --> DONE
-    S2["Stream 2: Package Documentation<br/>5 pts"] --> DONE
-    S3["Stream 3: Service Naming<br/>3 pts"] --> DONE
-    S4["Stream 4: Convention Documentation<br/>5 pts"] --> S5
-    S5["Stream 5: Checklist Update<br/>3 pts"] --> DONE
-    S6["Stream 6: Large File Refactoring<br/>13 pts"] --> DONE
-    S7["Stream 7: Shared Test Infrastructure<br/>13 pts"] --> DONE
+    S1["Stream 1: Proto Files<br/>5 pts"] --> DONE
+    S2["Stream 2: Package Docs<br/>5 pts"] --> DONE
+    S3["Stream 3: Service Naming<br/>3 pts"] --> S6
+    S4["Stream 4: Convention Docs<br/>5 pts"] --> S5
+    S5["Stream 5: Checklist<br/>3 pts"] --> DONE
+    S6["Stream 6: Refactoring<br/>13 pts"] --> DONE
+    S7["Stream 7: Test Infra<br/>13 pts"] --> DONE
 ```
 
 Stream 5 depends on Stream 4 (conventions must be documented before the checklist encodes them).
@@ -410,6 +415,15 @@ in this PRD and ADR-015.
 mixed concerns. This stream targets the 10 largest non-generated files
 for decomposition.
 
+**Relationship to PRD-012**: PRD-012 Stream 3 (8 pts) targeted 5
+files for refactoring. This stream supersedes it with a broader scope
+(10+ files) and updated line counts. PRD-012 Stream 3 tasks should be
+marked cancelled in favour of this stream.
+
+**Dependency on Stream 3**: Tasks 6.3 and 6.5 target files that
+Stream 3 (Task 3.1) will rename. Execute the rename first, then
+refactor. Task Master should mark 6.3 and 6.5 as depending on 3.1.
+
 ### Task 6.1: Refactor manifest_validator.go (2753 lines)
 
 **Problem**: Largest non-generated file in the codebase. Mixes
@@ -573,16 +587,17 @@ definitions in test files.
 
 | Stream | Points | Dependencies | Parallelizable With |
 |--------|--------|-------------|-------------------|
-| 1. Proto Files | 5 | None | All except 5 |
-| 2. Package Docs | 5 | None | All except 5 |
-| 3. Service Naming | 3 | None | All except 5 |
-| 4. Convention Docs | 5 | None | All except 5 |
+| 1. Proto Files | 5 | None | All except 5, 6 |
+| 2. Package Docs | 5 | None | All except 5, 6 |
+| 3. Service Naming | 3 | None | All except 5, 6 |
+| 4. Convention Docs | 5 | None | All except 5, 6 |
 | 5. Checklist Update | 3 | Stream 4 | After 4 |
-| 6. Large File Refactoring | 13 | None | All except 5 |
-| 7. Test Infrastructure | 13 | None | All except 5 |
+| 6. Refactoring | 13 | Stream 3 | After 3 |
+| 7. Test Infrastructure | 13 | None | All except 5, 6 |
 
-**Critical path**: Stream 4 (5 pts) -> Stream 5 (3 pts) = 8 pts.
-Streams 1-4, 6, 7 run concurrently, then Stream 5 follows.
+**Critical path**: Stream 3 (3 pts) -> Stream 6 (13 pts) = 16 pts.
+Streams 1, 2, 3, 4, 7 run concurrently. Stream 5 follows 4.
+Stream 6 follows 3.
 
 ## Task Master Parsing Guidance
 
@@ -593,6 +608,7 @@ When parsing this PRD into Task Master tasks:
 - Each task maps to a single PR-able unit of work
 - Preserve stream grouping in task numbering
 - Mark Stream 5 tasks as depending on Stream 4 tasks
+- Mark Stream 6 tasks 6.3 and 6.5 as depending on Task 3.1
 - All other streams have zero dependencies
 
 **Task-to-stream mapping:**

--- a/docs/prd/049-codebase-consistency.md
+++ b/docs/prd/049-codebase-consistency.md
@@ -12,11 +12,11 @@ triggers:
   - Reducing test boilerplate or setupTestDB duplication
   - Migrating time.Sleep to await in tests
 instructions: |
-  7 streams, 47 story points. Streams 1-4, 6, 7 are independent;
-  Stream 5 depends on Stream 4. Stream 6 tasks depend on Stream 3
+  7 streams, 49 story points. Streams 1-4, 7 are independent;
+  Stream 5 depends on Stream 4; Stream 6 depends on Stream 3
   (rename before refactor). Streams 6-7 are the largest work items
   (13 pts each). Prioritize Stream 1 (proto) and Stream 2 (doc.go)
-  for highest AI impact. Stream 6 supersedes PRD-012 Stream 3.
+  for highest AI impact. Stream 6 complements PRD-012 Stream 3.
 ---
 
 # PRD-049: Codebase Consistency & AI Navigability
@@ -455,10 +455,12 @@ add packages without `doc.go`, or use non-standard service file names.
 mixed concerns. This stream targets the 10 largest non-generated files
 for decomposition.
 
-**Relationship to PRD-012**: PRD-012 Stream 3 (8 pts) targeted 5
-files for refactoring. This stream supersedes it with a broader scope
-(10+ files) and updated line counts. PRD-012 Stream 3 tasks should be
-marked cancelled in favour of this stream.
+**Relationship to PRD-012**: PRD-012 Stream 3 targeted 5 service
+files for refactoring. Those specific files (current-account at 446
+LOC, payment-order at 406 LOC) are now under 600 lines. This stream
+complements PRD-012 by targeting the remaining large files that
+PRD-012 did not cover (control-plane, position-keeping, reference-data,
+party, reconciliation).
 
 **Dependency on Stream 3**: Tasks 6.3 and 6.5 target files that
 Stream 3 (Task 3.1) will rename. Execute the rename first, then
@@ -477,9 +479,9 @@ and schema validation in a single file.
 1. **Enforcement**: Task 5.3 CI check prevents new files >600 LOC
 2. Split into focused validators (e.g., `cel_validator.go`,
    `starlark_validator.go`, `crossref_validator.go`)
-2. No file exceeds 600 lines
-3. All existing tests pass unchanged
-4. No public API changes
+3. No file exceeds 600 lines
+4. All existing tests pass unchanged
+5. No public API changes
 
 ### Task 6.2: Refactor postgres_repository.go (1518 lines)
 

--- a/docs/prd/049-codebase-consistency.md
+++ b/docs/prd/049-codebase-consistency.md
@@ -1,6 +1,6 @@
 ---
 name: prd-codebase-consistency
-description: Standardize naming, patterns, and documentation across services to improve AI navigability and developer onboarding
+description: Standardize naming, patterns, and docs across services for AI navigability
 triggers:
   - Improving codebase consistency or standardization
   - Adding doc.go files or package documentation
@@ -56,7 +56,7 @@ codebase isn't self-describing enough.
 
 Total estimated complexity: **21 story points** across 5 streams.
 
-All streams are independent with zero inter-stream dependencies.
+Streams 1-4 are independent. Stream 5 depends on Stream 4.
 
 ```mermaid
 graph LR
@@ -102,7 +102,8 @@ and every AI session must regenerate them before types are readable.
 1. Run `buf generate api/proto` and commit all generated `.pb.go` files
 2. Verify `.gitignore` does not exclude `*.pb.go` in the `api/proto/` tree
 3. `go build ./...` succeeds from a clean checkout without running `buf generate`
-4. Document in CONTRIBUTING.md: "Run `buf generate api/proto` after modifying `.proto` files and commit the generated output"
+4. Document in CONTRIBUTING.md: "Run `buf generate api/proto` after
+   modifying `.proto` files and commit the generated output"
 
 ### Task 1.2: Document Proto Import Alias Convention
 
@@ -161,7 +162,9 @@ A `doc.go` file costs 5-15 lines and saves hundreds of lines of exploratory read
 **Acceptance Criteria**:
 
 1. Every package under `shared/pkg/` has a `doc.go` file
-2. Each `doc.go` contains: package purpose (1 sentence), key types/functions (2-3 lines), usage example or "see X for usage" pointer
+2. Each `doc.go` contains: package purpose (1 sentence),
+   key types/functions (2-3 lines),
+   usage example or "see X for usage" pointer
 3. Format follows Go convention: `// Package X provides...`
 4. No implementation code in `doc.go` files
 
@@ -202,10 +205,16 @@ Developers don't know where to add new shared code.
 
 **Acceptance Criteria**:
 
-1. Explains the two-tier split: `pkg/` = domain logic shared across services, `platform/` = infrastructure utilities
-2. Decision guide: "If it knows about business concepts (money, sagas, instruments) -> pkg/. If it's infrastructure plumbing (DB, auth, events) -> platform/"
-3. Lists all packages with one-line descriptions (can be generated from doc.go files)
-4. Notes the canonical value type: `shared/platform/quantity.Quantity[D]` is the primary dimensional type; `shared/pkg/money` and `shared/pkg/amount` are convenience wrappers
+1. Explains the two-tier split: `pkg/` = domain logic shared across services,
+   `platform/` = infrastructure utilities
+2. Decision guide: "If it knows about business concepts
+   (money, sagas, instruments) -> pkg/.
+   If it's infrastructure plumbing (DB, auth, events) -> platform/"
+3. Lists all packages with one-line descriptions
+   (can be generated from doc.go files)
+4. Notes the canonical value type: `shared/platform/quantity.Quantity[D]`
+   is the primary dimensional type; `shared/pkg/money` and
+   `shared/pkg/amount` are convenience wrappers
 
 ---
 
@@ -225,21 +234,23 @@ Three different names for the same concept:
 
 This means "find the gRPC handler registration" requires checking 2-3 filenames per service.
 
-### Task 3.1: Rename Variant Service Files to grpc_service.go
+### Task 3.1: Rename Variant Service Files to server.go
 
-**Problem**: `server.go` and `{service}_service.go` variants create navigation ambiguity.
-`grpc_service.go` is the most common pattern (used by 8+ services) and should be canonical.
+**Problem**: `grpc_service.go` and `{service}_service.go` variants create
+navigation ambiguity. ADR-015 establishes `server.go` as the canonical name
+for the gRPC service implementation file. Several services diverge from this.
 
 **Files Affected** (verify current state before implementing):
 
-- `services/internal-account/service/server.go` -> rename to `grpc_service.go`
-- `services/reconciliation/service/server.go` -> rename to `grpc_service.go`
-- `services/financial-accounting/service/financial_accounting_service.go` -> rename to `grpc_service.go`
-- Any other services using non-standard names
+- `services/current-account/service/grpc_service.go` -> rename to `server.go`
+- `services/party/service/grpc_service.go` -> rename to `server.go`
+- `services/financial-accounting/service/financial_accounting_service.go`
+  -> rename to `server.go`
+- Any other services not using `server.go`
 
 **Acceptance Criteria**:
 
-1. All services use `grpc_service.go` as the main gRPC service implementation file
+1. All services use `server.go` as the main gRPC service file per ADR-015
 2. All imports and references updated
 3. All tests pass
 4. `git log --follow` preserves file history (use `git mv`)
@@ -255,8 +266,10 @@ inline everything. No convention for when to split.
 
 **Acceptance Criteria**:
 
-1. Document the convention: split into `grpc_{operation}_endpoints.go` when `grpc_service.go` exceeds 400 LOC
-2. Document the naming pattern: `grpc_service.go` (constructor + registration), `grpc_{operation}_endpoints.go` (handler implementations)
+1. Document the convention: split into `grpc_{operation}_endpoints.go`
+   when `server.go` exceeds 400 LOC
+2. Document the naming pattern: `server.go` (constructor + registration),
+   `grpc_{operation}_endpoints.go` (handler implementations)
 3. List the current state of each service for reference
 4. Do NOT refactor existing services in this task (documentation only - refactoring is in PRD-012)
 
@@ -281,7 +294,9 @@ names without reading each service's `errors.go`.
 
 **Acceptance Criteria**:
 
-1. Establish the canonical pattern: entity-prefixed errors (`Err{Entity}NotFound`) for domain errors, generic errors (`ErrNotFound`) only in shared packages
+1. Establish the canonical pattern: entity-prefixed errors
+   (`Err{Entity}NotFound`) for domain errors,
+   generic errors (`ErrNotFound`) only in shared packages
 2. Document the standard error set every domain should define: `NotFound`, `Conflict`, `InvalidStatus`, `OptimisticLock`
 3. Document gRPC status code mapping convention (e.g., `ErrNotFound` -> `codes.NotFound`)
 4. Include examples from existing services
@@ -317,8 +332,11 @@ names without reading each service's `errors.go`.
 
 **Acceptance Criteria**:
 
-1. Document the hierarchy: `Quantity[D]` is the foundational type (dimensional safety), `Money` wraps `Quantity[Currency]` for convenience, `Amount` provides decimal arithmetic
-2. Decision guide: use `Quantity[D]` for multi-asset contexts, `Money` for currency-only contexts, `Amount` for raw decimal operations
+1. Document the hierarchy: `Quantity[D]` is the foundational type
+   (dimensional safety), `Money` wraps `Quantity[Currency]`
+   for convenience, `Amount` provides decimal arithmetic
+2. Decision guide: use `Quantity[D]` for multi-asset contexts,
+   `Money` for currency-only contexts, `Amount` for raw decimals
 3. Note which is used where (e.g., position-keeping uses `Quantity[D]`, current-account uses both)
 4. Flag `shared/pkg/money/` as a thin wrapper with 2 imports - candidate for future removal
 
@@ -342,7 +360,7 @@ in this PRD and ADR-015.
 
 1. Add task: "Create `doc.go` for every new package" with format example
 2. Add task: "Create `errors.go` in `domain/` with entity-prefixed errors" referencing error-conventions.md
-3. Update Task 7 (gRPC Service Handler) to mandate `grpc_service.go` naming
+3. Update Task 7 (gRPC Service Handler) to mandate `server.go` naming per ADR-015
 4. Add task: "Regenerate proto files and commit" after proto definition task
 5. Add task: "Create service README.md with YAML frontmatter"
 6. Reference the new convention docs (error-conventions.md, repository-conventions.md, value-types.md)
@@ -359,7 +377,7 @@ in this PRD and ADR-015.
 **Acceptance Criteria**:
 
 1. Script accepts a service name and checks:
-   - `grpc_service.go` exists in `service/`
+   - `server.go` exists in `service/` (per ADR-015)
    - `domain/errors.go` exists
    - `doc.go` exists in each package
    - `README.md` exists with YAML frontmatter
@@ -387,7 +405,7 @@ With parallelization, streams 1-4 run concurrently, then Stream 5 follows.
 
 When parsing this PRD into Task Master tasks:
 
-- **Create exactly 12 tasks** corresponding to the 12 numbered tasks (1.1 through 5.2)
+- **Create exactly 13 tasks** corresponding to the 13 numbered tasks (1.1 through 5.2)
 - Each task maps to a single PR-able unit of work
 - Preserve stream grouping in task numbering
 - Mark Stream 5 tasks as depending on Stream 4 tasks
@@ -403,7 +421,7 @@ When parsing this PRD into Task Master tasks:
 | 4 | Task 2.1: Add doc.go to shared/pkg/ | Package Docs |
 | 5 | Task 2.2: Add doc.go to shared/platform/ | Package Docs |
 | 6 | Task 2.3: Add shared/ Navigation README | Package Docs |
-| 7 | Task 3.1: Rename Variant Service Files | Service Naming |
+| 7 | Task 3.1: Rename Variant Service Files to server.go | Service Naming |
 | 8 | Task 3.2: Standardize Handler File Splitting Convention | Service Naming |
 | 9 | Task 4.1: Document Error Naming Convention | Convention Docs |
 | 10 | Task 4.2: Document Repository Pattern Convention | Convention Docs |
@@ -415,7 +433,7 @@ When parsing this PRD into Task Master tasks:
 
 1. `go build ./...` succeeds from a clean clone without running `buf generate`
 2. Every `shared/` package has a `doc.go` that explains its purpose in < 15 lines
-3. Every service uses `grpc_service.go` as the main service file
+3. Every service uses `server.go` as the main service file per ADR-015
 4. Convention docs exist for errors, repositories, and value types
 5. New service checklist references all established conventions
 6. Verification script passes for all existing services (or documents known exceptions)

--- a/docs/prd/049-codebase-consistency.md
+++ b/docs/prd/049-codebase-consistency.md
@@ -50,14 +50,13 @@ codebase isn't self-describing enough.
 - Rewriting service internals or changing architecture
 - New feature development
 - Performance optimization
-- Large file refactoring (covered in PRD-012)
 - Test coverage improvements (covered in PRD-048)
 
 ## Complexity Assessment
 
-Total estimated complexity: **21 story points** across 5 streams.
+Total estimated complexity: **47 story points** across 7 streams.
 
-Streams 1-4 are independent. Stream 5 depends on Stream 4.
+Streams 1-4, 6, 7 are independent. Stream 5 depends on Stream 4.
 
 ```mermaid
 graph LR
@@ -66,6 +65,8 @@ graph LR
     S3["Stream 3: Service Naming<br/>3 pts"] --> DONE
     S4["Stream 4: Convention Documentation<br/>5 pts"] --> S5
     S5["Stream 5: Checklist Update<br/>3 pts"] --> DONE
+    S6["Stream 6: Large File Refactoring<br/>13 pts"] --> DONE
+    S7["Stream 7: Shared Test Infrastructure<br/>13 pts"] --> DONE
 ```
 
 Stream 5 depends on Stream 4 (conventions must be documented before the checklist encodes them).
@@ -400,24 +401,195 @@ in this PRD and ADR-015.
 
 ---
 
+## Stream 6: Large File Refactoring (13 pts)
+
+### Rationale
+
+25 Go files exceed 800 lines. Large files degrade AI performance
+(context window pressure), increase edit collision risk, and indicate
+mixed concerns. This stream targets the 10 largest non-generated files
+for decomposition.
+
+### Task 6.1: Refactor manifest_validator.go (2753 lines)
+
+**Problem**: Largest non-generated file in the codebase. Mixes
+CEL type-checking, Starlark compilation, cross-reference validation,
+and schema validation in a single file.
+
+**File**: `services/control-plane/internal/validator/manifest_validator.go`
+
+**Acceptance Criteria**:
+
+1. Split into focused validators (e.g., `cel_validator.go`,
+   `starlark_validator.go`, `crossref_validator.go`)
+2. No file exceeds 600 lines
+3. All existing tests pass unchanged
+4. No public API changes
+
+### Task 6.2: Refactor postgres_repository.go (1518 lines)
+
+**File**: `services/position-keeping/adapters/persistence/postgres_repository.go`
+
+**Acceptance Criteria**:
+
+1. Split by concern (e.g., `position_log_repository.go`,
+   `balance_queries.go`, `batch_operations.go`)
+2. No file exceeds 600 lines
+3. All existing tests pass unchanged
+
+### Task 6.3: Refactor party grpc_service.go (1359 lines)
+
+**File**: `services/party/service/grpc_service.go`
+
+**Acceptance Criteria**:
+
+1. Split into `server.go` (constructor + registration) and
+   handler endpoint files per operation group
+2. No file exceeds 600 lines
+3. All existing tests pass unchanged
+
+### Task 6.4: Refactor lien_service.go (1322 lines)
+
+**File**: `services/current-account/service/lien_service.go`
+
+**Acceptance Criteria**:
+
+1. Split into focused modules (lifecycle, compensation, queries)
+2. No file exceeds 600 lines
+3. All existing tests pass unchanged
+
+### Task 6.5: Refactor remaining >1000 LOC files
+
+**Files** (each a sub-task):
+
+- `services/reference-data/accounttype/postgres_registry.go` (1120)
+- `services/reference-data/saga/reference_validator.go` (1069)
+- `services/payment-order/cmd/main.go` (1068)
+- `services/control-plane/internal/differ/manifest_differ.go` (1063)
+- `services/reconciliation/service/service.go` (999)
+- `services/party/adapters/persistence/repository.go` (965)
+
+**Acceptance Criteria**:
+
+1. Each file split so no resulting file exceeds 600 lines
+2. All existing tests pass unchanged
+3. No public API changes
+
+---
+
+## Stream 7: Shared Test Infrastructure (13 pts)
+
+### Rationale
+
+73 implementations of `setupTestDB` across the codebase, each with
+slightly different signatures. 41 `time.Sleep` violations in tests.
+277 inline mock struct definitions. This duplication makes writing
+new tests slow and inconsistent.
+
+### Task 7.1: Standardize Test DB Setup
+
+**Problem**: 73 `setupTestDB` functions with inconsistent signatures.
+Some return `*gorm.DB`, some return `(*gorm.DB, func())`, some use
+SQLite, some use testcontainers. `shared/platform/testdb` exists but
+many services don't use it.
+
+**Files Affected**:
+
+- `shared/platform/testdb/` (enhance existing package)
+- All service `*_test.go` files with `setupTestDB` functions
+
+**Acceptance Criteria**:
+
+1. `shared/platform/testdb` provides a single `SetupTestDB(t)`
+   function with consistent return signature: `(*gorm.DB, func())`
+2. Function handles CockroachDB testcontainer setup, migration
+   running, and tenant context injection
+3. Migrate at least 5 high-traffic services to use the shared
+   helper (current-account, financial-accounting, party,
+   payment-order, reconciliation)
+4. Document the pattern in `shared/platform/testdb/doc.go`
+5. Remaining services tracked as follow-up
+
+### Task 7.2: Migrate time.Sleep to await
+
+**Problem**: 41 instances of `time.Sleep` in tests violate the
+guideline in CLAUDE.md. These create flaky tests (sleep too short)
+or slow CI (sleep too long).
+
+**Files Affected**: 41 test files across services and shared/
+
+**Acceptance Criteria**:
+
+1. All `time.Sleep` in test files replaced with `await.Until()`
+   or `await.UntilNoError()`
+2. Exception: `time.Sleep` in `await/await_test.go` itself is
+   acceptable (testing the await package)
+3. Exception: `time.Sleep` used to simulate delays (not to wait
+   for conditions) may be retained with a comment explaining why
+4. CI time does not increase
+
+### Task 7.3: Extract Shared Test Context Helpers
+
+**Problem**: `tenant.WithTenant(context.Background(), ...)` pattern
+repeated 4900+ times across test files. No centralized context
+builder for tests.
+
+**Files Affected**:
+
+- `shared/platform/testdb/context.go` (new)
+
+**Acceptance Criteria**:
+
+1. Create `testdb.ContextWithTenant(t, tenantID)` that returns
+   a context with tenant, deadline, and test cleanup
+2. Create `testdb.ContextWithDefaultTenant(t)` for tests that
+   don't care about specific tenant ID
+3. Migrate at least 3 services to use the shared helpers
+4. Document in `shared/platform/testdb/doc.go`
+
+### Task 7.4: Extract Common Service Test Helpers Per Service
+
+**Problem**: Only 3 of 16+ services have `testhelpers/` packages.
+Other services inline test setup, entity factories, and mock
+definitions in test files.
+
+**Files Affected**:
+
+- `services/*/domain/testfixtures/` or `testhelpers/` (new per
+  service as needed)
+
+**Acceptance Criteria**:
+
+1. Create `testhelpers/` package for 5 highest-traffic services
+   that lack one (current-account, financial-accounting,
+   payment-order, reconciliation, tenant)
+2. Extract entity factory functions (`NewTest*`) into testhelpers
+3. Each testhelpers package has a `doc.go` explaining purpose
+4. Remaining services tracked as follow-up
+
+---
+
 ## Parallelization Summary
 
 | Stream | Points | Dependencies | Parallelizable With |
 |--------|--------|-------------|-------------------|
-| 1. Proto Files | 5 | None | 2, 3, 4 |
-| 2. Package Docs | 5 | None | 1, 3, 4 |
-| 3. Service Naming | 3 | None | 1, 2, 4 |
-| 4. Convention Docs | 5 | None | 1, 2, 3 |
-| 5. Checklist Update | 3 | Stream 4 | 1, 2, 3 (after 4) |
+| 1. Proto Files | 5 | None | All except 5 |
+| 2. Package Docs | 5 | None | All except 5 |
+| 3. Service Naming | 3 | None | All except 5 |
+| 4. Convention Docs | 5 | None | All except 5 |
+| 5. Checklist Update | 3 | Stream 4 | After 4 |
+| 6. Large File Refactoring | 13 | None | All except 5 |
+| 7. Test Infrastructure | 13 | None | All except 5 |
 
 **Critical path**: Stream 4 (5 pts) -> Stream 5 (3 pts) = 8 pts.
-With parallelization, streams 1-4 run concurrently, then Stream 5 follows.
+Streams 1-4, 6, 7 run concurrently, then Stream 5 follows.
 
 ## Task Master Parsing Guidance
 
 When parsing this PRD into Task Master tasks:
 
-- **Create exactly 13 tasks** corresponding to the 13 numbered tasks (1.1 through 5.2)
+- **Create exactly 22 tasks** corresponding to the numbered tasks
+  (1.1 through 7.4)
 - Each task maps to a single PR-able unit of work
 - Preserve stream grouping in task numbering
 - Mark Stream 5 tasks as depending on Stream 4 tasks
@@ -433,19 +605,31 @@ When parsing this PRD into Task Master tasks:
 | 4 | Task 2.1: Add doc.go to shared/pkg/ | Package Docs |
 | 5 | Task 2.2: Add doc.go to shared/platform/ | Package Docs |
 | 6 | Task 2.3: Add shared/ Navigation README | Package Docs |
-| 7 | Task 3.1: Rename Variant Service Files to server.go | Service Naming |
-| 8 | Task 3.2: Standardize Handler File Splitting Convention | Service Naming |
+| 7 | Task 3.1: Rename Variant Service Files to server.go | Naming |
+| 8 | Task 3.2: Standardize Handler File Splitting | Naming |
 | 9 | Task 4.1: Document Error Naming Convention | Convention Docs |
 | 10 | Task 4.2: Document Repository Pattern Convention | Convention Docs |
 | 11 | Task 4.3: Document Value Type Hierarchy | Convention Docs |
-| 12 | Task 5.1: Update New Service Checklist | Checklist Update |
-| 13 | Task 5.2: Add Service Consistency Verification Script | Checklist Update |
+| 12 | Task 5.1: Update New Service Checklist | Checklist |
+| 13 | Task 5.2: Add Service Consistency Script | Checklist |
+| 14 | Task 6.1: Refactor manifest_validator.go | Refactoring |
+| 15 | Task 6.2: Refactor postgres_repository.go | Refactoring |
+| 16 | Task 6.3: Refactor party grpc_service.go | Refactoring |
+| 17 | Task 6.4: Refactor lien_service.go | Refactoring |
+| 18 | Task 6.5: Refactor remaining >1000 LOC files | Refactoring |
+| 19 | Task 7.1: Standardize Test DB Setup | Test Infra |
+| 20 | Task 7.2: Migrate time.Sleep to await | Test Infra |
+| 21 | Task 7.3: Extract Shared Test Context Helpers | Test Infra |
+| 22 | Task 7.4: Extract Service Test Helpers | Test Infra |
 
 ## Success Criteria
 
-1. `go build ./...` succeeds from a clean clone without running `buf generate`
-2. Every `shared/` package has a `doc.go` that explains its purpose in < 15 lines
+1. `go build ./...` succeeds from a clean clone without `buf generate`
+2. Every `shared/` package has a `doc.go` (< 15 lines)
 3. Every service uses `server.go` as the main service file per ADR-015
 4. Convention docs exist for errors, repositories, and value types
 5. New service checklist references all established conventions
-6. Verification script passes for all existing services (or documents known exceptions)
+6. Verification script passes for all services (or documents exceptions)
+7. No Go file exceeds 600 lines (excluding generated code)
+8. Zero `time.Sleep` in test files (except await package tests)
+9. Top 5 services use shared `testdb.SetupTestDB(t)` helper

--- a/docs/prd/049-codebase-consistency.md
+++ b/docs/prd/049-codebase-consistency.md
@@ -58,7 +58,7 @@ codebase isn't self-describing enough.
 
 ## Complexity Assessment
 
-Total estimated complexity: **47 story points** across 7 streams.
+Total estimated complexity: **49 story points** across 7 streams.
 
 Streams 1, 2, 4, 7 are fully independent. Stream 5 depends on
 Stream 4. Stream 6 (refactoring) depends on Stream 3 (rename first).
@@ -69,7 +69,7 @@ graph LR
     S2["Stream 2: Package Docs<br/>5 pts"] --> DONE
     S3["Stream 3: Service Naming<br/>3 pts"] --> S6
     S4["Stream 4: Convention Docs<br/>5 pts"] --> S5
-    S5["Stream 5: Checklist<br/>3 pts"] --> DONE
+    S5["Stream 5: Checklist + CI<br/>5 pts"] --> DONE
     S6["Stream 6: Refactoring<br/>13 pts"] --> DONE
     S7["Stream 7: Test Infra<br/>13 pts"] --> DONE
 ```
@@ -175,6 +175,7 @@ does without reading implementation files.
    usage example or "see X for usage" pointer
 3. Format follows Go convention: `// Package X provides...`
 4. No implementation code in `doc.go` files
+5. **Enforcement**: Task 5.3 CI check validates new packages have `doc.go`
 
 **Example**:
 
@@ -270,6 +271,8 @@ for the gRPC service implementation file. Most services use
 2. All imports and references updated
 3. All tests pass
 4. `git log --follow` preserves file history (use `git mv`)
+5. **Enforcement**: Task 5.3 CI check validates `server.go` exists in
+   every `services/*/service/` directory
 
 ### Task 3.2: Standardize gRPC Handler File Splitting Convention
 
@@ -404,6 +407,43 @@ in this PRD and ADR-015.
 2. Outputs pass/fail per check with actionable fix instructions
 3. Can be run in CI for new service PRs
 
+### Task 5.3: Add CI Convention Enforcement Workflow
+
+**Problem**: After fixing all conventions, nothing prevents regression.
+New code can reintroduce `time.Sleep` in tests, create files >600 LOC,
+add packages without `doc.go`, or use non-standard service file names.
+
+**Files Affected**:
+
+- `.github/workflows/conventions.yml` (new)
+- `.githooks/pre-commit` (add file-size check for staged Go files)
+
+**Checks to enforce** (each fails CI with actionable message):
+
+1. **No Go file >600 lines** (excluding `*.pb.go`, `*_grpc.pb.go`):
+   `find . -name '*.go' ! -name '*.pb.go' | xargs wc -l | awk '$1>600'`
+2. **No `time.Sleep` in test files** (except `await_test.go`):
+   `grep -rn 'time\.Sleep' --include='*_test.go' | grep -v await_test`
+3. **Every shared/ package has doc.go**:
+   check all dirs under `shared/pkg/` and `shared/platform/`
+4. **Proto generated files are fresh**:
+   run `buf generate` and check for uncommitted changes
+5. **Service naming convention**:
+   every `services/*/service/` dir contains `server.go`
+
+**Pre-commit hook additions**:
+
+- File size check on staged `.go` files (warn if >600 lines)
+- `time.Sleep` check on staged `*_test.go` files
+
+**Acceptance Criteria**:
+
+1. CI workflow runs on PRs touching Go, proto, or shared/ files
+2. Each check has a clear failure message with fix instructions
+3. Pre-commit hook warns (non-blocking) on convention violations
+4. Existing codebase passes all checks after streams 1-7 complete
+5. False positive rate is zero (no legitimate code flagged)
+
 ---
 
 ## Stream 6: Large File Refactoring (13 pts)
@@ -434,7 +474,8 @@ and schema validation in a single file.
 
 **Acceptance Criteria**:
 
-1. Split into focused validators (e.g., `cel_validator.go`,
+1. **Enforcement**: Task 5.3 CI check prevents new files >600 LOC
+2. Split into focused validators (e.g., `cel_validator.go`,
    `starlark_validator.go`, `crossref_validator.go`)
 2. No file exceeds 600 lines
 3. All existing tests pass unchanged
@@ -541,6 +582,8 @@ or slow CI (sleep too long).
 3. Exception: `time.Sleep` used to simulate delays (not to wait
    for conditions) may be retained with a comment explaining why
 4. CI time does not increase
+5. **Enforcement**: Task 5.3 CI check prevents new `time.Sleep`
+   in test files; pre-commit hook warns on staged violations
 
 ### Task 7.3: Extract Shared Test Context Helpers
 
@@ -591,7 +634,7 @@ definitions in test files.
 | 2. Package Docs | 5 | None | All except 5, 6 |
 | 3. Service Naming | 3 | None | All except 5, 6 |
 | 4. Convention Docs | 5 | None | All except 5, 6 |
-| 5. Checklist Update | 3 | Stream 4 | After 4 |
+| 5. Checklist + CI | 5 | Stream 4 | After 4 |
 | 6. Refactoring | 13 | Stream 3 | After 3 |
 | 7. Test Infrastructure | 13 | None | All except 5, 6 |
 
@@ -603,7 +646,7 @@ Stream 6 follows 3.
 
 When parsing this PRD into Task Master tasks:
 
-- **Create exactly 22 tasks** corresponding to the numbered tasks
+- **Create exactly 23 tasks** corresponding to the numbered tasks
   (1.1 through 7.4)
 - Each task maps to a single PR-able unit of work
 - Preserve stream grouping in task numbering
@@ -628,15 +671,16 @@ When parsing this PRD into Task Master tasks:
 | 11 | Task 4.3: Document Value Type Hierarchy | Convention Docs |
 | 12 | Task 5.1: Update New Service Checklist | Checklist |
 | 13 | Task 5.2: Add Service Consistency Script | Checklist |
-| 14 | Task 6.1: Refactor manifest_validator.go | Refactoring |
-| 15 | Task 6.2: Refactor postgres_repository.go | Refactoring |
-| 16 | Task 6.3: Refactor party grpc_service.go | Refactoring |
-| 17 | Task 6.4: Refactor lien_service.go | Refactoring |
-| 18 | Task 6.5: Refactor remaining >1000 LOC files | Refactoring |
-| 19 | Task 7.1: Standardize Test DB Setup | Test Infra |
-| 20 | Task 7.2: Migrate time.Sleep to await | Test Infra |
-| 21 | Task 7.3: Extract Shared Test Context Helpers | Test Infra |
-| 22 | Task 7.4: Extract Service Test Helpers | Test Infra |
+| 14 | Task 5.3: CI Convention Enforcement Workflow | Checklist |
+| 15 | Task 6.1: Refactor manifest_validator.go | Refactoring |
+| 16 | Task 6.2: Refactor postgres_repository.go | Refactoring |
+| 17 | Task 6.3: Refactor party server.go | Refactoring |
+| 18 | Task 6.4: Refactor lien_service.go | Refactoring |
+| 19 | Task 6.5: Refactor remaining >1000 LOC files | Refactoring |
+| 20 | Task 7.1: Standardize Test DB Setup | Test Infra |
+| 21 | Task 7.2: Migrate time.Sleep to await | Test Infra |
+| 22 | Task 7.3: Extract Shared Test Context Helpers | Test Infra |
+| 23 | Task 7.4: Extract Service Test Helpers | Test Infra |
 
 ## Success Criteria
 
@@ -649,3 +693,5 @@ When parsing this PRD into Task Master tasks:
 7. No Go file exceeds 600 lines (excluding generated code)
 8. Zero `time.Sleep` in test files (except await package tests)
 9. Top 5 services use shared `testdb.SetupTestDB(t)` helper
+10. CI convention enforcement workflow prevents regression on all
+    conventions established in this PRD

--- a/docs/prd/049-codebase-consistency.md
+++ b/docs/prd/049-codebase-consistency.md
@@ -315,7 +315,9 @@ names without reading each service's `errors.go`.
 
 **Acceptance Criteria**:
 
-1. Establish canonical location: `adapters/persistence/repository.go` (matching majority pattern)
+1. Establish canonical locations per ADR-015:
+   `domain/repository.go` for interfaces (ports),
+   `adapters/persistence/repository.go` for implementations (adapters)
 2. Document standard method naming: `Create`, `FindByID`, `List`, `Update`, `Delete`
 3. Document optional methods: `CreateBatch`, `CreateWithOutbox`, `SoftDelete`
 4. Document the GORM vs pgx decision: GORM for standard CRUD, pgx for performance-critical paths (position-keeping)

--- a/docs/prd/049-codebase-consistency.md
+++ b/docs/prd/049-codebase-consistency.md
@@ -85,8 +85,8 @@ Generated `.pb.go` files are currently excluded from git. This means:
 - Code review cannot show proto-generated type changes inline
 
 This is the same rationale behind shadcn/ui's approach: copy the code into your project so it's
-readable, searchable, and versionable. Generated code that's invisible is code that doesn't
-exist for navigation purposes.
+readable, searchable, and versionable. If generated code is invisible,
+it is effectively unavailable for navigation.
 
 ### Task 1.1: Add Proto-Generated Files to Git
 

--- a/docs/prd/049-codebase-consistency.md
+++ b/docs/prd/049-codebase-consistency.md
@@ -9,7 +9,8 @@ triggers:
   - Updating the new service checklist
 instructions: |
   This PRD addresses micro-inconsistencies that compound across 16 services.
-  Each stream is independent. Prioritize Stream 1 (proto files) and Stream 2
+  Streams 1-4 are independent; Stream 5 depends on Stream 4.
+  Prioritize Stream 1 (proto files) and Stream 2
   (doc.go) as they have the highest impact on AI code generation reliability.
   Update the new-bian-service-checklist.md to reflect all conventions established here.
 ---
@@ -63,8 +64,8 @@ graph LR
     S1["Stream 1: Commit Proto Files<br/>5 pts"] --> DONE
     S2["Stream 2: Package Documentation<br/>5 pts"] --> DONE
     S3["Stream 3: Service Naming<br/>3 pts"] --> DONE
-    S4["Stream 4: Convention Documentation<br/>5 pts"] --> DONE
-    S5["Stream 5: Checklist Update<br/>3 pts"] --> S4
+    S4["Stream 4: Convention Documentation<br/>5 pts"] --> S5
+    S5["Stream 5: Checklist Update<br/>3 pts"] --> DONE
 ```
 
 Stream 5 depends on Stream 4 (conventions must be documented before the checklist encodes them).

--- a/docs/prd/049-codebase-consistency.md
+++ b/docs/prd/049-codebase-consistency.md
@@ -143,7 +143,7 @@ modifies a `.proto` file but forgets to regenerate.
 
 ### Rationale
 
-`shared/pkg/` has 18 packages and `shared/platform/` has 21 packages. Fewer than half have
+`shared/pkg/` has 20 packages and `shared/platform/` has 19 packages. Fewer than half have
 `doc.go` files. Without them, understanding a package requires scanning all exported symbols -
 expensive for humans, catastrophic for AI context windows.
 
@@ -183,12 +183,13 @@ package mapping
 
 ### Task 2.2: Add doc.go to All shared/platform/ Packages
 
-**Problem**: 13 of 21 `shared/platform/` packages lack `doc.go`.
+**Problem**: 14 of 19 `shared/platform/` packages lack `doc.go`.
 
 **Packages missing doc.go** (verify current state before implementing):
 
-- `auth/`, `db/`, `env/`, `gateway/`, `kafka/`, `observability/`, `ports/`,
-  `quantity/`, `ratelimit/`, `redislock/`, `sandbox/`, `scheduler/`, `tenant/`
+- `auth/`, `await/`, `db/`, `gateway/`, `kafka/`, `observability/`,
+  `ports/`, `quantity/`, `ratelimit/`, `redislock/`, `sandbox/`,
+  `scheduler/`, `tenant/`, `testdb/`
 
 **Acceptance Criteria**:
 
@@ -231,7 +232,7 @@ Three different naming patterns for the main gRPC service file:
 | `server.go` | internal-account, market-information |
 | `grpc_service.go` | current-account, party, payment-order, tenant, identity, financial-gateway, operational-gateway |
 | `service.go` | position-keeping, reconciliation |
-| `{name}_service.go` | financial-accounting (`financial_accounting_service.go`) |
+| `{name}_service.go` | financial-accounting (`financial_accounting_service.go`), audit-worker (`audit_service.go`) |
 
 This means "find the gRPC handler registration" requires checking
 multiple filenames per service.
@@ -254,6 +255,7 @@ for the gRPC service implementation file. Most services use
 - `services/financial-accounting/service/financial_accounting_service.go`
   -> `server.go`
 - `services/position-keeping/service/service.go` -> `server.go`
+- `services/audit-worker/service/audit_service.go` -> `server.go`
 - `services/reconciliation/service/service.go` -> `server.go`
 
 **Acceptance Criteria**:

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -71,6 +71,7 @@ stateDiagram-v2
 
 | PRD | Description |
 |-----|-------------|
+| [Codebase Consistency & AI Navigability](049-codebase-consistency.md) | Standardize naming, patterns, and documentation across services |
 | [Asset-Agnostic Accounts](028-asset-agnostic-accounts.md) | Generalize account fields for non-fiat asset classes |
 | [Identity and Access Management](031-identity-access-management.md) | Bridge Party service identity to authentication with dynamic user management and RBAC |
 | [Meridian Edge](003-meridian-edge.md) | Embedded modular monolith for IoT devices and browser (WASM) |
@@ -258,6 +259,8 @@ material.
   Service-aligned frontend modules, Storybook, and runtime tenant UI customisation
 - [MCP Server](027-mcp-server.md) - Model Context Protocol server bridging LLMs to Meridian Core
 - [Codebase Health Audit](012-codebase-health-audit.md) - Remediation for documentation, CI/CD, and code hygiene
+- [Codebase Consistency & AI Navigability](049-codebase-consistency.md) -
+  Standardize naming, patterns, and documentation for AI and developer navigability
 - [Production Readiness Review](009-production-readiness-review.md) - Audit and remediation for production gaps
 - [Operations Console UI](026-operations-console-ui.md) - Meridian operations console frontend
 - [Economy Cookbook](035-economy-cookbook.md) - Unified pattern registry for economy patterns and UI components


### PR DESCRIPTION
## Summary

- Adds PRD-049 defining 5 work streams (13 tasks, 21 story points) to standardize naming, patterns, and documentation across services
- Updates PRD README index with the new entry

## Context

From a codebase audit identifying micro-inconsistencies that compound across 16 services, degrading AI code generation reliability and developer onboarding speed. The five streams:

1. **Commit proto-generated files to git** (5 pts) - Make types readable without running codegen (shadcn/ui rationale: copy into the repo so it's searchable)
2. **Add doc.go to all shared packages** (5 pts) - 27+ packages lack purpose documentation
3. **Standardize service file naming** (3 pts) - Eliminate `grpc_service.go` vs `server.go` vs `{service}_service.go` variants
4. **Document conventions** (5 pts) - Errors, repositories, value types
5. **Update new-service checklist** (3 pts) - Encode all conventions + add verification script

All streams independent except Stream 5 (depends on Stream 4).

## Test plan

- [ ] PRD renders correctly in GitHub markdown
- [ ] PRD README links resolve
- [ ] Task Master can parse the PRD (`task-master parse-prd`)