### PR TITLE
docs: add error, repository, and value type convention guides

### DIFF
--- a/docs/guides/error-conventions.md
+++ b/docs/guides/error-conventions.md
@@ -124,8 +124,8 @@ The service layer translates domain and persistence errors into gRPC status code
 | Error | gRPC Code | HTTP Equivalent | Notes |
 |-------|-----------|-----------------|-------|
 | `domain.ErrNotFound` | `codes.NotFound` | 404 | Entity doesn't exist |
-| `persistence.ErrNotFound` | `codes.NotFound` | 404 | Row missing in DB |
-| `domain.ErrConflict` / `persistence.ErrAlreadyExists` | `codes.AlreadyExists` | 409 | Duplicate unique key |
+| `persistence.Err{Entity}NotFound` | `codes.NotFound` | 404 | Row missing in DB |
+| `domain.ErrConflict` / `persistence.Err{Entity}Exists` | `codes.AlreadyExists` | 409 | Duplicate unique key |
 | `persistence.ErrVersionConflict` | `codes.Aborted` | 409 | Concurrent modification—retry |
 | `domain.ErrInvalidStatusTransition` | `codes.FailedPrecondition` | 422 | State machine violation |
 | `domain.ErrUnauthorized` | `codes.PermissionDenied` | 403 | Authorization failed |

--- a/docs/guides/error-conventions.md
+++ b/docs/guides/error-conventions.md
@@ -1,0 +1,244 @@
+---
+name: error-conventions
+description: Naming patterns for domain errors and gRPC status code mapping in Meridian services
+triggers:
+  - Adding errors to a domain package
+  - Mapping domain errors to gRPC status codes
+  - Implementing error handling in a service layer
+  - Reviewing error types across services
+---
+
+# Error Conventions
+
+This guide documents the error naming patterns used across Meridian services and explains
+how domain errors map to gRPC status codes.
+
+## Error Layers
+
+Meridian services follow hexagonal architecture, and errors exist at two distinct layers:
+
+| Layer | Package | Naming | Purpose |
+|-------|---------|--------|---------|
+| Domain | `services/{service}/domain/` | Semantic, entity-neutral | Express business rule violations |
+| Persistence | `services/{service}/adapters/persistence/` | Entity-prefixed | Express storage-level failures |
+
+Services should check domain errors in the service layer and translate them to gRPC codes.
+Persistence errors leak through when the domain layer doesn't define an equivalent sentinel.
+
+## Domain Layer Errors
+
+Domain errors live in `domain/errors.go` or alongside the repository interface in
+`domain/repository.go`. They express business rule violations in terms that the domain
+understands, without leaking persistence details.
+
+### Standard Sentinel Errors
+
+Every service that reads or writes persistent state should define these sentinels:
+
+```go
+// domain/repository.go or domain/errors.go
+var (
+    // ErrNotFound is returned when a domain entity is not found.
+    ErrNotFound = errors.New("entity not found")
+
+    // ErrConflict is returned when an entity with the same unique key already exists.
+    ErrConflict = errors.New("entity conflict")
+
+    // ErrOptimisticLock is returned when a concurrent write is detected (version mismatch).
+    ErrOptimisticLock = errors.New("optimistic lock failure: resource was modified")
+
+    // ErrInvalidStatusTransition is returned when a state machine transition is invalid.
+    ErrInvalidStatusTransition = errors.New("invalid status transition")
+)
+```
+
+**Real examples from the codebase:**
+
+```go
+// services/reconciliation/domain/errors.go
+var (
+    ErrNotFound              = errors.New("entity not found")
+    ErrConflict              = errors.New("entity conflict")
+    ErrOptimisticLock        = errors.New("optimistic lock failure: resource was modified")
+    ErrInvalidStatusTransition = errors.New("invalid status transition")
+    ErrEmptyAccountID        = errors.New("account ID cannot be empty")
+    ErrInvalidPeriod         = errors.New("period start must be before period end")
+    ErrRunNotRunning         = errors.New("settlement run is not in running state")
+)
+
+// services/position-keeping/domain/repository.go
+var (
+    ErrNotFound       = errors.New("financial position log not found")
+    ErrConflict       = errors.New("financial position log conflict")
+    ErrOptimisticLock = errors.New("optimistic lock failure: resource was modified")
+)
+```
+
+### Domain-Specific Validation Errors
+
+For validation errors beyond the standard sentinels, use descriptive `Err` prefixed names
+that are self-documenting without needing to check the entity type:
+
+```go
+var (
+    ErrEmptyAccountID        = errors.New("account ID cannot be empty")
+    ErrEmptyInstrumentCode   = errors.New("instrument code cannot be empty")
+    ErrInvalidPeriod         = errors.New("period start must be before period end")
+    ErrNegativeAmount        = errors.New("amount cannot be negative")
+    ErrUnauthorized          = errors.New("unauthorized: insufficient permissions")
+)
+```
+
+These errors are defined in the domain package and used in entity constructors and
+mutation methods—not in the service or persistence layers.
+
+## Persistence Layer Errors
+
+Persistence errors live in `adapters/persistence/` and are **entity-prefixed** to avoid
+ambiguity when multiple entity types share a repository file.
+
+```go
+// services/party/adapters/persistence/repository.go
+var (
+    ErrPartyNotFound     = errors.New("party not found")
+    ErrPartyExists       = errors.New("party already exists")
+    ErrVersionConflict   = errors.New("version conflict: party was modified by another transaction")
+    ErrAssociationExists = errors.New("association already exists between parties")
+    ErrInvalidCursor     = errors.New("invalid pagination cursor")
+)
+```
+
+**Why entity-prefixed in persistence but not domain?**
+
+- Domain errors represent business concepts (one error per concept, regardless of entity)
+- Persistence files may contain multiple entity repositories—prefixing prevents shadowing
+- Service code checks `persistence.ErrVersionConflict` specifically, not domain-level equivalents
+
+## gRPC Status Code Mapping
+
+The service layer translates domain and persistence errors into gRPC status codes. Use
+`errors.Is` (not string comparison) to match sentinel errors.
+
+### Standard Mapping Table
+
+| Error | gRPC Code | HTTP Equivalent | Notes |
+|-------|-----------|-----------------|-------|
+| `domain.ErrNotFound` | `codes.NotFound` | 404 | Entity doesn't exist |
+| `persistence.ErrNotFound` | `codes.NotFound` | 404 | Row missing in DB |
+| `domain.ErrConflict` / `persistence.ErrAlreadyExists` | `codes.AlreadyExists` | 409 | Duplicate unique key |
+| `persistence.ErrVersionConflict` | `codes.Aborted` | 409 | Concurrent modification—retry |
+| `domain.ErrInvalidStatusTransition` | `codes.FailedPrecondition` | 422 | State machine violation |
+| `domain.ErrUnauthorized` | `codes.PermissionDenied` | 403 | Authorization failed |
+| Validation failures (input) | `codes.InvalidArgument` | 400 | Caller error, don't retry |
+| All other errors | `codes.Internal` | 500 | Log and don't leak details |
+
+### Implementation Pattern
+
+```go
+func (s *Service) ExecuteOperation(
+    ctx context.Context,
+    req *pb.OperationRequest,
+) (*pb.OperationResponse, error) {
+    entity, err := s.repo.FindByID(ctx, id)
+    if err != nil {
+        switch {
+        case errors.Is(err, domain.ErrNotFound):
+            return nil, status.Errorf(codes.NotFound, "entity %s not found", id)
+        default:
+            s.logger.Error("failed to find entity", "error", err, "id", id)
+            return nil, status.Error(codes.Internal, "internal error")
+        }
+    }
+
+    if err := entity.Transition(newState); err != nil {
+        switch {
+        case errors.Is(err, domain.ErrInvalidStatusTransition):
+            return nil, status.Errorf(codes.FailedPrecondition, "invalid transition: %v", err)
+        default:
+            return nil, status.Error(codes.Internal, "internal error")
+        }
+    }
+
+    if err := s.repo.Update(ctx, entity); err != nil {
+        switch {
+        case errors.Is(err, persistence.ErrVersionConflict):
+            return nil, status.Error(codes.Aborted, "concurrent modification detected, please retry")
+        default:
+            s.logger.Error("failed to update entity", "error", err)
+            return nil, status.Error(codes.Internal, "internal error")
+        }
+    }
+
+    return &pb.OperationResponse{...}, nil
+}
+```
+
+**Real example from `services/tenant/service/grpc_service.go`:**
+
+```go
+// errors.Is chain for update operation
+if errors.Is(err, persistence.ErrVersionConflict) {
+    return nil, status.Errorf(codes.Aborted, "concurrent modification detected, please retry")
+}
+if errors.Is(err, domain.ErrNotFound) {
+    return nil, status.Errorf(codes.NotFound, "tenant %s not found", req.TenantId)
+}
+return nil, status.Errorf(codes.Internal, "failed to update tenant status")
+```
+
+### Error Message Guidelines
+
+- **`codes.NotFound`**: Include the entity type and identifier: `"tenant %s not found"`
+- **`codes.InvalidArgument`**: Include what was invalid and why: `"invalid tenant ID: %v"`
+- **`codes.AlreadyExists`**: Include the conflicting value: `"slug %s is already taken"`
+- **`codes.Aborted`**: Use a consistent message callers can check: `"concurrent modification detected, please retry"`
+- **`codes.Internal`**: Never leak internal details—log the actual error, return a generic message
+
+### What NOT to Do
+
+```go
+// DON'T: Compare error strings
+if err.Error() == "entity not found" { ... }
+
+// DON'T: Use codes.Unknown for known conditions
+return nil, status.Error(codes.Unknown, err.Error())
+
+// DON'T: Leak internal error details to callers
+return nil, status.Errorf(codes.Internal, "SQL error: %v", err)
+
+// DON'T: Use codes.Internal for caller errors (validation failures)
+return nil, status.Error(codes.Internal, "amount is required")
+// Should be codes.InvalidArgument
+```
+
+## Shared Package Errors
+
+Packages in `shared/` define their own sentinels. Service code typically wraps or re-exports
+these as needed:
+
+```go
+// shared/platform/quantity
+var ErrInstrumentMismatch = errors.New("instrument mismatch: ...")
+var ErrDivisionByZero     = errors.New("division by zero")
+
+// shared/pkg/money
+var ErrInvalidCurrency  = errors.New("invalid currency")
+var ErrCurrencyMismatch = quantity.ErrInstrumentMismatch  // aliased
+var ErrAmountOverflow   = errors.New("amount overflow")
+
+// shared/pkg/amount
+var ErrInvalidDimension = errors.New("invalid dimension")
+```
+
+When quantity/money/amount errors bubble up through a service, map them to
+`codes.InvalidArgument` if they result from bad input, or `codes.Internal` if they
+indicate a programming error.
+
+## Organizing Error Files
+
+| Scenario | File | Pattern |
+|----------|------|---------|
+| Few errors, simple service | `domain/repository.go` | Group with the interface they apply to |
+| Many errors, complex service | `domain/errors.go` | Dedicated file, grouped by category |
+| Persistence-level errors | `adapters/persistence/repository.go` | Top of file, entity-prefixed |
+| Service-level construction errors | `service/grpc_service.go` | Inline `var` block, self-descriptive |

--- a/docs/guides/error-conventions.md
+++ b/docs/guides/error-conventions.md
@@ -126,7 +126,7 @@ The service layer translates domain and persistence errors into gRPC status code
 | `domain.ErrNotFound` | `codes.NotFound` | 404 | Entity doesn't exist |
 | `persistence.Err{Entity}NotFound` | `codes.NotFound` | 404 | Row missing in DB |
 | `domain.ErrConflict` / `persistence.Err{Entity}Exists` | `codes.AlreadyExists` | 409 | Duplicate unique key |
-| `persistence.ErrVersionConflict` | `codes.Aborted` | 409 | Concurrent modification—retry |
+| `domain.ErrOptimisticLock` / `persistence.ErrVersionConflict` | `codes.Aborted` | 409 | Concurrent modification—retry |
 | `domain.ErrInvalidStatusTransition` | `codes.FailedPrecondition` | 422 | State machine violation |
 | `domain.ErrUnauthorized` | `codes.PermissionDenied` | 403 | Authorization failed |
 | Validation failures (input) | `codes.InvalidArgument` | 400 | Caller error, don't retry |

--- a/docs/guides/new-bian-service-checklist.md
+++ b/docs/guides/new-bian-service-checklist.md
@@ -42,6 +42,17 @@ Before starting, ensure you have:
 | `services/current-account/` | Inter-service clients, complex domain logic |
 | `services/financial-accounting/` | Kafka messaging, complex observability |
 
+## Convention Guides
+
+These guides document patterns you will apply throughout service creation. Read them before
+starting, and reference them when working on the relevant tasks.
+
+| Guide | Apply When |
+|-------|------------|
+| [Error Conventions](error-conventions.md) | Task 2 (domain errors), Task 7 (gRPC error mapping) |
+| [Repository Conventions](repository-conventions.md) | Task 2 (repository interface), Task 3 (GORM implementation) |
+| [Value Types](value-types.md) | Task 2 (domain model fields), Task 3 (persistence mapping) |
+
 ---
 
 ## Service Creation Tasks
@@ -105,6 +116,11 @@ go build ./...                # Verify generated code compiles
 
 Create the domain model with business rules and validation.
 
+**Convention references**:
+- [Error Conventions](error-conventions.md) — sentinel error naming and where to define them
+- [Repository Conventions](repository-conventions.md) — interface location, method naming, error documentation
+- [Value Types](value-types.md) — choosing between Money, Asset, and Amount for domain fields
+
 **Files to create:**
 
 - `{entity}.go` - Domain entity with:
@@ -112,6 +128,8 @@ Create the domain model with business rules and validation.
   - Constructor (`New{Entity}`) enforcing invariants
   - Mutation methods that validate state transitions
   - Value objects (enums, status types)
+- `errors.go` or `repository.go` - Sentinel errors (see [Error Conventions](error-conventions.md))
+- `repository.go` - Repository interface (port) with documented error contracts
 - `{entity}_test.go` - Unit tests for domain logic
 
 **Reference**: `services/party/domain/party.go`
@@ -167,13 +185,19 @@ go test ./services/{service}/domain/... -v
 
 Implement the repository using GORM.
 
+**Convention references**:
+- [Repository Conventions](repository-conventions.md) — entity-prefixed errors, TableName, optimistic locking, tenant scoping
+- [Value Types](value-types.md) — mapping Qty/Money/Amount to/from persistence columns
+
 **Files to create:**
 
 - `{entity}_entity.go` - Database entity with GORM tags
 - `repository.go` - Repository implementation with:
+  - Compile-time interface assertion (`var _ domain.{Entity}Repository = (*{Entity}Repository)(nil)`)
+  - Entity-prefixed sentinel errors (see [Error Conventions](error-conventions.md))
   - Optimistic locking via version field
-  - Soft delete support
-  - Context-based audit fields
+  - Tenant scoping via `db.WithGormTenantScope`
+  - Soft delete support (where applicable)
 - `repository_test.go` - Integration tests with Testcontainers
 
 **Reference**: `services/party/adapters/persistence/`
@@ -382,6 +406,8 @@ psql -h localhost -p 26257 -U {service}_svc -d meridian_{service} -c "\dt"
 ### Task 7: gRPC Service Handler
 
 **Location**: `services/{service}/service/`
+
+**Convention reference**: [Error Conventions](error-conventions.md) — gRPC status code mapping table and error message guidelines.
 
 Implement the gRPC service.
 

--- a/docs/guides/repository-conventions.md
+++ b/docs/guides/repository-conventions.md
@@ -17,7 +17,7 @@ implementations across Meridian services. It follows the directory structure def
 
 ## Directory Layout
 
-```
+```text
 services/{service}/
 ├── domain/
 │   └── repository.go       # Interface (port) + sentinel errors

--- a/docs/guides/repository-conventions.md
+++ b/docs/guides/repository-conventions.md
@@ -112,7 +112,13 @@ type TenantRepository interface {
     GetBySlug(ctx context.Context, slug string) (*Tenant, error)
     IsSlugAvailable(ctx context.Context, slug string) (bool, error)
     UpdateStatus(ctx context.Context, id tenant.TenantID, status Status, currentVersion int) (*Tenant, error)
-    UpdateStatusWithError(ctx context.Context, id tenant.TenantID, status Status, errorMsg string, currentVersion int) (*Tenant, error)
+    UpdateStatusWithError(
+        ctx context.Context,
+        id tenant.TenantID,
+        status Status,
+        errorMsg string,
+        currentVersion int,
+    ) (*Tenant, error)
     List(ctx context.Context, statusFilter *Status, pageSize int, pageToken string) ([]*Tenant, string, error)
 }
 ```

--- a/docs/guides/repository-conventions.md
+++ b/docs/guides/repository-conventions.md
@@ -149,13 +149,18 @@ Every entity that is an aggregate root includes:
 ```go
 type SettlementRunEntity struct {
     ID        uuid.UUID      `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+    RunID     uuid.UUID      `gorm:"column:run_id;uniqueIndex;type:uuid;not null"` // business key
     CreatedAt time.Time      `gorm:"not null;default:now()"`
     UpdatedAt time.Time      `gorm:"not null;default:now()"`
-    DeletedAt gorm.DeletedAt `gorm:"index"`           // soft delete (optional)
+    DeletedAt gorm.DeletedAt `gorm:"index"`              // soft delete (optional)
     Version   int64          `gorm:"not null;default:1"` // optimistic locking
     // ... domain fields
 }
 ```
+
+> **DB PK vs business key**: `ID` is the CockroachDB-managed row primary key
+> (`gen_random_uuid()`). `RunID` is the domain-visible identifier, uniquely indexed and
+> used in all WHERE clauses. The domain layer never exposes `ID` directly.
 
 ### TableName
 

--- a/docs/guides/repository-conventions.md
+++ b/docs/guides/repository-conventions.md
@@ -103,13 +103,17 @@ type FinancialPositionLogRepository interface {
 }
 
 // services/tenant/domain/repository.go
+// Note: tenant uses UpdateStatus (targeted) rather than a full Update method.
+// Domain entities with multiple write paths may use targeted update methods
+// rather than a single generic Update.
 type TenantRepository interface {
     Create(ctx context.Context, tenant *Tenant) error
     GetByID(ctx context.Context, id tenant.TenantID) (*Tenant, error)
     GetBySlug(ctx context.Context, slug string) (*Tenant, error)
     IsSlugAvailable(ctx context.Context, slug string) (bool, error)
-    Update(ctx context.Context, tenant *Tenant) error
-    List(ctx context.Context, filter TenantFilter) ([]*Tenant, int64, error)
+    UpdateStatus(ctx context.Context, id tenant.TenantID, status Status, currentVersion int) (*Tenant, error)
+    UpdateStatusWithError(ctx context.Context, id tenant.TenantID, status Status, errorMsg string, currentVersion int) (*Tenant, error)
+    List(ctx context.Context, statusFilter *Status, pageSize int, pageToken string) ([]*Tenant, string, error)
 }
 ```
 
@@ -136,6 +140,14 @@ FindByID(ctx context.Context, runID uuid.UUID) (*SettlementRun, error)
 // Returns ErrOptimisticLock if the version doesn't match.
 Update(ctx context.Context, run *SettlementRun) error
 ```
+
+> **ErrOptimisticLock vs ErrVersionConflict**: The domain layer defines `ErrOptimisticLock`
+> as the semantic error for concurrent modification. The persistence layer defines
+> `ErrVersionConflict` (entity-prefixed in practice, e.g., no prefix needed when there is
+> only one entity type per repo file). Both name the same condition at different layers.
+> Service code checks `persistence.ErrVersionConflict`; domain interface comments reference
+> `ErrOptimisticLock`. This is intentional layering—domain errors describe business
+> semantics, persistence errors describe storage outcomes.
 
 ## GORM Entity Structure
 

--- a/docs/guides/repository-conventions.md
+++ b/docs/guides/repository-conventions.md
@@ -178,7 +178,8 @@ type SettlementRunEntity struct {
 
 > **DB PK vs business key**: `ID` is the CockroachDB-managed row primary key
 > (`gen_random_uuid()`). `RunID` is the domain-visible identifier, uniquely indexed and
-> used in all WHERE clauses. The domain layer never exposes `ID` directly.
+> used in business-key lookups (`WHERE run_id = ?`). Internal FK relationships may still
+> use `ID`. The domain layer never exposes `ID` directly.
 
 ### TableName
 

--- a/docs/guides/repository-conventions.md
+++ b/docs/guides/repository-conventions.md
@@ -1,0 +1,340 @@
+---
+name: repository-conventions
+description: Canonical repository locations, interface naming, method naming, and implementation patterns per ADR-015
+triggers:
+  - Adding a repository to a service
+  - Naming repository methods
+  - Implementing GORM persistence
+  - Adding optimistic locking to an entity
+  - Where do repository interfaces go?
+---
+
+# Repository Conventions
+
+This guide establishes canonical patterns for repository interfaces and their GORM
+implementations across Meridian services. It follows the directory structure defined in
+[ADR-015](../adr/0015-standard-service-directory-structure.md).
+
+## Directory Layout
+
+```
+services/{service}/
+├── domain/
+│   └── repository.go       # Interface (port) + sentinel errors
+└── adapters/
+    └── persistence/
+        ├── {entity}.go      # GORM entity struct
+        └── repository.go    # GORM implementation (adapter)
+```
+
+The domain package defines the **interface** (what the repository can do). The persistence
+package provides the **implementation** (how it does it with GORM and CockroachDB).
+
+**Why this separation?** The service layer depends only on the domain interface. Tests can
+substitute a fake repository without touching GORM. New adapters (Redis, in-memory) can be
+added without changing the domain.
+
+## Interface Location and Naming
+
+Repository interfaces always live in `domain/repository.go` alongside the sentinel errors
+they document.
+
+**Interface naming**: `{Entity}Repository` for single-entity repos. When a service manages
+multiple entity types, define one interface per aggregate root:
+
+```go
+// domain/repository.go
+package domain
+
+// SettlementRunRepository defines the contract for persisting and retrieving settlement runs.
+type SettlementRunRepository interface {
+    // ...
+}
+
+// VarianceRepository defines the contract for persisting variances.
+type VarianceRepository interface {
+    // ...
+}
+```
+
+The compile-time interface check lives in the implementation file:
+
+```go
+// adapters/persistence/repository.go
+var _ domain.SettlementRunRepository = (*SettlementRunRepository)(nil)
+```
+
+## Method Naming
+
+Meridian uses a consistent verb vocabulary. Choose the right verb based on semantics:
+
+| Operation | Verb | When to use |
+|-----------|------|-------------|
+| Insert new entity | `Create` | Creating any new aggregate root |
+| Insert multiple atomically | `CreateBatch` | Bulk inserts within one transaction |
+| Fetch by primary key | `FindByID` | Single entity by UUID/ID |
+| Fetch by foreign key | `FindBy{Field}` | One-to-many lookups |
+| Fetch multiple | `List` | Paginated/filtered queries |
+| Update existing | `Update` | Full aggregate update (uses optimistic locking) |
+| Partial field update | `UpdateStatus`, `UpdateFields` | Targeted SQL UPDATE, no version check needed |
+| Remove row | `Delete` | Hard delete (rare—prefer status transitions) |
+| Soft delete | `Archive` or status transition | Prefer over Delete |
+| Upsert | `Upsert` | Only where idempotency requires it |
+| Existence check | `Exists` or `IsAvailable` | Boolean queries without loading the entity |
+
+**Real examples from the codebase:**
+
+```go
+// services/reconciliation/domain/repository.go
+type SettlementRunRepository interface {
+    Create(ctx context.Context, run *SettlementRun) error
+    FindByID(ctx context.Context, runID uuid.UUID) (*SettlementRun, error)
+    Update(ctx context.Context, run *SettlementRun) error
+    List(ctx context.Context, filter RunFilter) ([]*SettlementRun, error)
+}
+
+// services/position-keeping/domain/repository.go
+type FinancialPositionLogRepository interface {
+    Create(ctx context.Context, log *FinancialPositionLog) error
+    CreateBatch(ctx context.Context, logs []*FinancialPositionLog) error
+    FindByID(ctx context.Context, logID uuid.UUID) (*FinancialPositionLog, error)
+    FindByAccountID(ctx context.Context, accountID string, filter LogFilter) ([]*FinancialPositionLog, error)
+    Update(ctx context.Context, log *FinancialPositionLog) error
+}
+
+// services/tenant/domain/repository.go
+type TenantRepository interface {
+    Create(ctx context.Context, tenant *Tenant) error
+    GetByID(ctx context.Context, id tenant.TenantID) (*Tenant, error)
+    GetBySlug(ctx context.Context, slug string) (*Tenant, error)
+    IsSlugAvailable(ctx context.Context, slug string) (bool, error)
+    Update(ctx context.Context, tenant *Tenant) error
+    List(ctx context.Context, filter TenantFilter) ([]*Tenant, int64, error)
+}
+```
+
+> Note: `GetByID` vs `FindByID` — both exist in the codebase. Prefer `FindByID` for new
+> services (consistent with the majority pattern in domain repositories). `GetByID` is
+> acceptable but avoid mixing both in the same interface.
+
+## Error Documentation Convention
+
+Document each method's error contract in the interface comment. This makes callers aware
+of sentinel errors without reading the implementation:
+
+```go
+// Create persists a new SettlementRun.
+// Returns ErrConflict if a run with the same RunID already exists.
+Create(ctx context.Context, run *SettlementRun) error
+
+// FindByID retrieves a SettlementRun by its RunID.
+// Returns ErrNotFound if the run doesn't exist.
+FindByID(ctx context.Context, runID uuid.UUID) (*SettlementRun, error)
+
+// Update updates an existing SettlementRun using optimistic locking.
+// Returns ErrNotFound if the run doesn't exist.
+// Returns ErrOptimisticLock if the version doesn't match.
+Update(ctx context.Context, run *SettlementRun) error
+```
+
+## GORM Entity Structure
+
+GORM entities live in `adapters/persistence/` alongside the repository. Use flat structs
+(no nesting) and explicit GORM tags.
+
+### Standard Fields
+
+Every entity that is an aggregate root includes:
+
+```go
+type SettlementRunEntity struct {
+    ID        uuid.UUID      `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+    CreatedAt time.Time      `gorm:"not null;default:now()"`
+    UpdatedAt time.Time      `gorm:"not null;default:now()"`
+    DeletedAt gorm.DeletedAt `gorm:"index"`           // soft delete (optional)
+    Version   int64          `gorm:"not null;default:1"` // optimistic locking
+    // ... domain fields
+}
+```
+
+### TableName
+
+Every entity **must** implement `TableName()` returning a singular, unqualified name:
+
+```go
+// TableName returns the singular, unqualified table name.
+// Unqualified (no schema prefix) allows search_path routing for tenant isolation.
+func (SettlementRunEntity) TableName() string {
+    return "settlement_run"  // singular, no schema prefix
+}
+```
+
+**Why singular?** Natural SQL syntax: `FROM settlement_run WHERE ...`
+
+**Why unqualified?** CockroachDB's `search_path` routes queries to the correct tenant
+schema. Adding a schema prefix bypasses this routing.
+
+## Optimistic Locking Pattern
+
+All mutable aggregate roots use optimistic locking. The domain entity carries a `Version`
+field, incremented on every write. The repository checks that the DB version matches before
+updating:
+
+```go
+// In the domain entity:
+type SettlementRun struct {
+    id      uuid.UUID
+    version int64
+    // ...
+}
+
+func (r *SettlementRun) Version() int64 { return r.version }
+
+// In the GORM repository Update method:
+func (r *SettlementRunRepository) Update(ctx context.Context, run *domain.SettlementRun) error {
+    // The entity's Version was already incremented by the domain before calling Update.
+    // Check that the DB still has the *previous* version.
+    expectedDBVersion := run.Version() - 1
+
+    result := tx.Model(&SettlementRunEntity{}).
+        Where("run_id = ? AND version = ?", run.ID(), expectedDBVersion).
+        Updates(map[string]interface{}{
+            "status":     string(run.Status()),
+            "version":    run.Version(),
+            "updated_at": time.Now(),
+        })
+
+    if result.Error != nil {
+        return result.Error
+    }
+    if result.RowsAffected == 0 {
+        // Either the entity was deleted (ErrNotFound) or concurrently modified (ErrVersionConflict).
+        // Distinguish by doing a follow-up existence check, or return ErrVersionConflict by default.
+        return ErrVersionConflict
+    }
+    return nil
+}
+```
+
+The service layer maps `persistence.ErrVersionConflict` to `codes.Aborted`, signaling
+the caller to reload and retry.
+
+## Tenant Scoping
+
+All queries must run within a tenant-scoped transaction. Use `db.WithGormTenantScope`:
+
+```go
+func (r *VarianceRepository) withTenantTransaction(
+    ctx context.Context,
+    fn func(tx *gorm.DB) error,
+) error {
+    tx, err := db.WithGormTenantScope(ctx, r.db.WithContext(ctx))
+    if err != nil {
+        return err
+    }
+    return tx.Transaction(fn)
+}
+```
+
+Never use `r.db` directly for tenant-scoped data. Always pass `ctx` through so the
+tenant interceptor can set `search_path` on the connection.
+
+## Pagination
+
+Use `Limit` + `Offset` for simple pagination, or cursor-based pagination when the result
+set is large or ordering by created_at is needed.
+
+### Offset Pagination
+
+```go
+type Filter struct {
+    Status *RunStatus
+    Limit  int
+    Offset int
+}
+
+// In the query:
+query = query.Limit(filter.Limit).Offset(filter.Offset)
+```
+
+### Cursor Pagination
+
+Used in `services/party` for large party lists. The cursor encodes `created_at + id` to
+handle ties:
+
+```go
+type PartyCursor struct {
+    CreatedAt time.Time
+    ID        uuid.UUID
+}
+
+// Encode cursor to opaque page token
+func EncodePartyCursor(c PartyCursor) string {
+    data := c.CreatedAt.Format(time.RFC3339Nano) + "|" + c.ID.String()
+    return base64.URLEncoding.EncodeToString([]byte(data))
+}
+```
+
+Use cursor pagination when:
+- The dataset is large (thousands of rows)
+- Stable ordering is required under concurrent inserts
+- The caller needs to resume from a previous position
+
+## Constructor and Compile-Time Check
+
+Always add the compile-time interface assertion in the implementation file:
+
+```go
+package persistence
+
+// Compile-time check that VarianceRepository implements domain.VarianceRepository.
+var _ domain.VarianceRepository = (*VarianceRepository)(nil)
+
+type VarianceRepository struct {
+    db *gorm.DB
+}
+
+func NewVarianceRepository(db *gorm.DB) *VarianceRepository {
+    return &VarianceRepository{db: db}
+}
+```
+
+This catches interface drift at compile time rather than at runtime.
+
+## Integration Tests
+
+Every repository implementation requires integration tests using CockroachDB Testcontainers:
+
+```go
+func TestVarianceRepository(t *testing.T) {
+    db, cleanup := testdb.SetupCockroachDB(t, []interface{}{&VarianceEntity{}})
+    defer cleanup()
+
+    repo := NewVarianceRepository(db)
+
+    t.Run("Create and FindByID", func(t *testing.T) {
+        // happy path
+    })
+
+    t.Run("FindByID returns ErrNotFound for missing entity", func(t *testing.T) {
+        _, err := repo.FindByID(ctx, uuid.New())
+        assert.ErrorIs(t, err, domain.ErrNotFound)
+    })
+
+    t.Run("Update returns ErrVersionConflict on concurrent modification", func(t *testing.T) {
+        // create entity, simulate concurrent write, verify conflict
+        assert.ErrorIs(t, err, ErrVersionConflict)
+    })
+}
+```
+
+See [testcontainers-usage.md](testcontainers-usage.md) for full setup details.
+
+## Reference Implementations
+
+| Service | Best Reference For |
+|---------|--------------------|
+| `services/party/adapters/persistence/` | Cursor pagination, multiple entity types |
+| `services/reconciliation/adapters/persistence/` | Multiple repositories in one service |
+| `services/position-keeping/adapters/persistence/` | Batch inserts, complex queries |
+| `services/tenant/adapters/persistence/` | Soft delete, slug indexing |

--- a/docs/guides/repository-conventions.md
+++ b/docs/guides/repository-conventions.md
@@ -143,17 +143,9 @@ FindByID(ctx context.Context, runID uuid.UUID) (*SettlementRun, error)
 
 // Update updates an existing SettlementRun using optimistic locking.
 // Returns ErrNotFound if the run doesn't exist.
-// Returns ErrOptimisticLock if the version doesn't match.
+// Returns ErrVersionConflict if the version doesn't match.
 Update(ctx context.Context, run *SettlementRun) error
 ```
-
-> **ErrOptimisticLock vs ErrVersionConflict**: The domain layer defines `ErrOptimisticLock`
-> as the semantic error for concurrent modification. The persistence layer defines
-> `ErrVersionConflict` (entity-prefixed in practice, e.g., no prefix needed when there is
-> only one entity type per repo file). Both name the same condition at different layers.
-> Service code checks `persistence.ErrVersionConflict`; domain interface comments reference
-> `ErrOptimisticLock`. This is intentional layering—domain errors describe business
-> semantics, persistence errors describe storage outcomes.
 
 ## GORM Entity Structure
 

--- a/docs/guides/repository-conventions.md
+++ b/docs/guides/repository-conventions.md
@@ -143,7 +143,8 @@ FindByID(ctx context.Context, runID uuid.UUID) (*SettlementRun, error)
 
 // Update updates an existing SettlementRun using optimistic locking.
 // Returns ErrNotFound if the run doesn't exist.
-// Returns ErrVersionConflict if the version doesn't match.
+// Returns ErrOptimisticLock if the version doesn't match (domain sentinel).
+// The persistence implementation surfaces this as ErrVersionConflict.
 Update(ctx context.Context, run *SettlementRun) error
 ```
 

--- a/docs/guides/value-types.md
+++ b/docs/guides/value-types.md
@@ -17,7 +17,7 @@ relate, and when to use each.
 
 ## Type Hierarchy
 
-```
+```text
 shared/platform/quantity/
 └── Qty[D Dimension]          ← generic base type (phantom-typed)
     ├── type Money = Qty[Monetary]    ← currency quantities (GBP, USD, EUR)
@@ -54,7 +54,7 @@ or `decimal.Decimal` fields cannot prevent.
 
 ## Quick Decision Guide
 
-```
+```text
 Is the value always a fiat currency (USD, GBP, EUR...)?
 ├── Yes → Does this code interact with legacy APIs or cross-service protos?
 │         ├── Yes → shared/pkg/money.Money

--- a/docs/guides/value-types.md
+++ b/docs/guides/value-types.md
@@ -1,0 +1,320 @@
+---
+name: value-types
+description: Relationship between Qty[D], Money, Asset, Amount, and shared/pkg/money types, with a decision guide
+triggers:
+  - Representing a monetary amount in Go
+  - Representing energy, carbon, or compute quantities
+  - Choosing between Money and Amount types
+  - Cross-service communication with non-currency instruments
+  - What type should I use for a financial field?
+---
+
+# Value Types: Qty, Money, Asset, and Amount
+
+Meridian uses a layered type system for representing quantities of any asset class—currency,
+energy, carbon credits, compute hours, and more. This guide explains each type, how they
+relate, and when to use each.
+
+## Type Hierarchy
+
+```
+shared/platform/quantity/
+└── Qty[D Dimension]          ← generic base type (phantom-typed)
+    ├── type Money = Qty[Monetary]    ← currency quantities (GBP, USD, EUR)
+    └── type Asset = Qty[Commodity]   ← non-currency assets (KWH, GPU_HOUR, TONNE_CO2E)
+
+shared/pkg/money/
+└── Money                     ← thin wrapper around quantity.Money
+                                 adds minor-unit constructors and Currency type
+                                 (preferred for legacy/inter-service money operations)
+
+shared/pkg/amount/
+└── Amount                    ← dimension-agnostic value type
+                                 accepts any valid dimension at runtime
+                                 used for cross-service communication and persistence
+```
+
+See [ADR-013](../adr/0013-generic-asset-quantity-types.md) for the architectural rationale.
+
+## The Phantom Type Pattern
+
+`Qty[D]` uses Go generics with phantom types to enforce dimension safety at compile time.
+`Monetary` and `Commodity` are empty structs—they carry zero runtime overhead but prevent
+accidental mixing in the type system:
+
+```go
+var money quantity.Money   // Qty[Monetary]
+var energy quantity.Asset  // Qty[Commodity]
+
+money = energy  // compile error: cannot use Qty[Commodity] as Qty[Monetary]
+```
+
+This eliminates a category of bugs (mixing kilowatt-hours with British pounds) that JSON
+or `decimal.Decimal` fields cannot prevent.
+
+## Quick Decision Guide
+
+```
+Is the value always a fiat currency (USD, GBP, EUR...)?
+├── Yes → Does this code interact with legacy APIs or cross-service protos?
+│         ├── Yes → shared/pkg/money.Money
+│         └── No  → quantity.Money (Qty[Monetary])
+└── No  → Is the dimension known at compile time?
+           ├── Yes, commodity (KWH, GPU_HOUR, TONNE_CO2E) → quantity.Asset (Qty[Commodity])
+           └── No (any dimension, runtime) → shared/pkg/amount.Amount
+```
+
+## Type Reference
+
+### `quantity.Qty[D]` — Generic Base Type
+
+**Package**: `shared/platform/quantity`
+
+The foundational type. All quantity arithmetic in Meridian ultimately operates on `Qty[D]`.
+It holds a `decimal.Decimal` amount and an `Instrument` (code, version, precision, dimension).
+
+```go
+import "github.com/meridianhub/meridian/shared/platform/quantity"
+
+// Direct use (uncommon—prefer the named aliases)
+qty := quantity.New[quantity.Monetary](decimal.NewFromInt(100), instrument)
+```
+
+Use `Qty[D]` directly when writing generic functions that must work across dimensions:
+
+```go
+func Sum[D quantity.Dimension](items []quantity.Qty[D]) (quantity.Qty[D], error) {
+    // ...
+}
+```
+
+### `quantity.Money` — Currency Quantities
+
+**Type alias**: `type Money = Qty[Monetary]`
+
+**Package**: `shared/platform/quantity`
+
+Use `quantity.Money` for currency values inside domain packages that already import
+`shared/platform/quantity`. Most services re-export this as a local type alias:
+
+```go
+// services/financial-accounting/domain/quantity.go
+type Money = quantity.Money  // re-exported for use within this service's domain
+```
+
+**Factory functions** (from `shared/platform/quantity`):
+
+```go
+m := quantity.NewMoney(decimal.NewFromInt(100), instrument)  // from decimal
+m := quantity.NewMoneyFromInt(10000, instrument)             // from minor units
+m := quantity.ZeroMoney(instrument)                          // zero value
+```
+
+### `quantity.Asset` — Commodity Quantities
+
+**Type alias**: `type Asset = Qty[Commodity]`
+
+**Package**: `shared/platform/quantity`
+
+Use `quantity.Asset` for non-monetary instruments: energy (KWH), compute (GPU_HOUR),
+carbon credits (TONNE_CO2E), and other physical or digital commodities.
+
+```go
+// services/position-keeping/domain/quantity.go re-exports this as:
+type Asset = quantity.Asset
+
+// Usage in domain code:
+assetQty := quantity.NewAsset(decimal.NewFromFloat(1.5), kwhInstrument)
+```
+
+Compile-time safety prevents mixing `Asset` with `Money`:
+
+```go
+var energy quantity.Asset
+var funds  quantity.Money
+total := energy.Add(funds)  // compile error
+```
+
+### `shared/pkg/money.Money` — Cross-Service Currency Type
+
+**Package**: `shared/pkg/money`
+
+A thin wrapper around `quantity.Money` that adds:
+
+- Named `Currency` type (`money.CurrencyGBP`, `money.CurrencyUSD`, ...)
+- Minor-unit constructors (`money.New("GBP", 10000)` → £100.00)
+- Overflow-safe `ToMinorUnits()` with explicit error
+- `AmountCents()` for backward compatibility (deprecated, use `ToMinorUnits()`)
+
+```go
+import "github.com/meridianhub/meridian/shared/pkg/money"
+
+// From minor units (cents, pence)
+m, err := money.New("GBP", 10000)    // £100.00
+
+// From decimal major units
+m, err := money.NewFromDecimal(decimal.NewFromInt(100), money.CurrencyGBP)
+
+// Arithmetic
+sum, err := m1.Add(m2)          // returns ErrCurrencyMismatch if currencies differ
+diff, err := m1.Subtract(m2)
+product := m.Multiply(factor)
+
+// Conversion
+cents, err := m.ToMinorUnits()  // returns ErrAmountOverflow if out of int64 range
+```
+
+**When to use `shared/pkg/money.Money` over `quantity.Money`:**
+
+- Payment gateways and external APIs that speak in minor units (Stripe, Adyen)
+- Services that predate the `quantity` package and use the minor-unit API
+- Any code that needs the named `Currency` type with `IsValid()`, `ParseCurrency()`, etc.
+
+### `shared/pkg/amount.Amount` — Dimension-Agnostic Type
+
+**Package**: `shared/pkg/amount`
+
+`Amount` is the bridge type for contexts where the instrument dimension is not known at
+compile time—typically persistence and cross-service communication.
+
+Unlike `Money` (currency-only) and `Asset` (commodity-only), `Amount` accepts any
+dimension in `quantity.ValidDimensions`: `CURRENCY`, `ENERGY`, `CARBON`, `COMPUTE`, etc.
+
+```go
+import "github.com/meridianhub/meridian/shared/pkg/amount"
+
+// From persisted columns (code, dimension, precision, minor units)
+a, err := amount.NewFromInstrument("GBP",  "CURRENCY", 2, 10000)  // £100.00
+a, err := amount.NewFromInstrument("KWH",  "ENERGY",   3, 1500)   // 1.500 KWH
+a, err := amount.NewFromInstrument("GPU_HOUR", "COMPUTE", 4, 5000) // 0.5000 GPU_HOUR
+
+// From a resolved instrument
+a := amount.New(instrument, minorUnits)
+a := amount.NewFromDecimal(instrument, majorUnits)
+
+// Arithmetic
+sum, err := a1.Add(a2)          // ErrInstrumentMismatch if instruments differ
+diff, err := a1.Subtract(a2)
+product := a.Multiply(factor)
+
+// Accessors
+a.InstrumentCode() // "KWH"
+a.Dimension()      // "ENERGY"
+a.Precision()      // 3
+a.Amount()         // decimal.Decimal
+```
+
+**Use `Amount` when:**
+
+- Reading from or writing to a database table that stores generic instrument quantities
+- Building gRPC proto messages that must represent any asset class
+- A function receives quantities from reference data without compile-time dimension knowledge
+- Implementing position-keeping logic that handles both currency and commodity positions
+
+## Persistence Mapping
+
+### Storing Quantity Values
+
+Both `Money` and `Asset` must be decomposed for storage. Store three columns:
+
+| Column | Type | Example |
+|--------|------|---------|
+| `instrument_code` | `VARCHAR(20)` | `"GBP"`, `"KWH"` |
+| `dimension` | `VARCHAR(20)` | `"CURRENCY"`, `"ENERGY"` |
+| `amount` | `DECIMAL(38,18)` | `100.000000000000000000` |
+
+Or store minor units as `BIGINT` for currencies (more compact, avoids floating-point):
+
+| Column | Type | Example |
+|--------|------|---------|
+| `instrument_code` | `VARCHAR(20)` | `"GBP"` |
+| `amount_minor` | `BIGINT` | `10000` (= £100.00) |
+
+### Loading from Persistence
+
+Use `amount.NewFromInstrument` to reconstruct from persisted columns:
+
+```go
+// From GORM entity
+func toDomain(e *PositionEntity) (*domain.Position, error) {
+    qty, err := amount.NewFromInstrument(
+        e.InstrumentCode,
+        e.Dimension,
+        e.Precision,
+        e.AmountMinor,
+    )
+    if err != nil {
+        return nil, fmt.Errorf("reconstruct position amount: %w", err)
+    }
+    // ...
+}
+```
+
+For currency-only services using minor-unit storage:
+
+```go
+m, err := money.New(e.CurrencyCode, e.AmountMinor)
+```
+
+## Proto Representation
+
+In protobuf messages, represent quantities as structured fields (not raw `double`):
+
+```protobuf
+message Quantity {
+  string instrument_code = 1;  // "GBP", "KWH"
+  string dimension       = 2;  // "CURRENCY", "ENERGY"
+  int64  amount_minor    = 3;  // in smallest unit (pence, watt-hours)
+  int32  precision       = 4;  // decimal places (2 for GBP, 3 for KWH)
+}
+```
+
+In the service layer, map proto quantities to `Amount`:
+
+```go
+func protoToAmount(q *pb.Quantity) (sharedamount.Amount, error) {
+    return sharedamount.NewFromInstrument(
+        q.InstrumentCode,
+        q.Dimension,
+        int(q.Precision),
+        q.AmountMinor,
+    )
+}
+```
+
+## Service Domain Re-exports
+
+Each service's `domain/quantity.go` re-exports the types it needs, providing a stable
+local name that doesn't require services to import `shared/platform/quantity` directly:
+
+```go
+// services/position-keeping/domain/quantity.go
+package domain
+
+import (
+    sharedamount "github.com/meridianhub/meridian/shared/pkg/amount"
+    "github.com/meridianhub/meridian/shared/platform/quantity"
+)
+
+type (
+    Qty[D quantity.Dimension] = quantity.Qty[D]
+    Money                     = quantity.Money
+    Asset                     = quantity.Asset
+    Amount                    = sharedamount.Amount
+    Monetary                  = quantity.Monetary
+    Commodity                 = quantity.Commodity
+    Instrument                = quantity.Instrument
+)
+```
+
+This pattern lets domain code write `Money` rather than `quantity.Money`, and avoids
+leaking the shared package path into every domain file.
+
+## Summary Table
+
+| Type | Package | Dimension | Use For |
+|------|---------|-----------|---------|
+| `Qty[Monetary]` / `Money` | `shared/platform/quantity` | Currency only | Domain arithmetic with currencies |
+| `Qty[Commodity]` / `Asset` | `shared/platform/quantity` | Commodity only | Domain arithmetic with non-currency assets |
+| `money.Money` | `shared/pkg/money` | Currency only | Minor-unit APIs, payment gateways, legacy code |
+| `amount.Amount` | `shared/pkg/amount` | Any dimension | Persistence, protos, dimension-agnostic functions |


### PR DESCRIPTION
## Summary

- **error-conventions.md** (Task 9): documents entity-prefixed error naming pattern for domain and persistence layers, sentinel error vocabulary, and the canonical gRPC status code mapping table with real code examples
- **repository-conventions.md** (Task 10): establishes canonical repository locations per ADR-015, method naming vocabulary (Create/FindByID/Update/List), optimistic locking pattern, tenant scoping requirements, and GORM entity structure
- **value-types.md** (Task 11): explains the `Qty[D]`/`Money`/`Asset`/`Amount` type hierarchy with a decision guide and persistence/proto mapping examples
- **new-bian-service-checklist.md** (Task 12): adds a Convention Guides reference table and inline references in Tasks 2, 3, and 7

All examples are drawn directly from the codebase (reconciliation, party, position-keeping, tenant services). No idealized patterns.

## Test plan

- [ ] Verify new guide files render correctly in GitHub
- [ ] Verify checklist cross-references resolve to correct anchors
- [ ] Confirm no existing checklist content was altered (only additions)