### PR TITLE
docs: add doc.go files to shared packages and navigation README

### DIFF
--- a/shared/README.md
+++ b/shared/README.md
@@ -1,0 +1,84 @@
+# shared/
+
+This directory contains code shared across Meridian services. It is split into two
+sub-directories with distinct responsibilities.
+
+---
+
+## pkg/ vs platform/
+
+| | `pkg/` | `platform/` |
+|---|---|---|
+| **Contains** | Domain-level shared types, algorithms, and utilities | Infrastructure wrappers and cross-cutting concerns |
+| **Depends on** | `shared/platform/quantity`, standard library, domain primitives | External libraries (gRPC, Kafka, Redis, OpenTelemetry, GORM) |
+| **Domain semantics** | Yes — models BIAN/Meridian concepts (Money, Amount, Saga, etc.) | No — generic infrastructure (connection pools, locks, auth) |
+| **Imported by** | Services and other `shared/` packages | Services and `shared/pkg/` |
+
+### Decision Guide
+
+Place new code in **`pkg/`** if it:
+- Encodes a domain concept (e.g., a new quantity dimension or settlement type)
+- Is a utility tightly coupled to domain types (e.g., amount arithmetic)
+- Must remain independent of infrastructure concerns for testability
+
+Place new code in **`platform/`** if it:
+- Wraps or configures an external dependency (database, message broker, cache, auth)
+- Provides cross-cutting infrastructure with no domain meaning (health checks, rate limiting, sandboxing)
+- Is consumed identically by all services regardless of domain context
+
+---
+
+## shared/pkg/
+
+Domain-level shared packages.
+
+| Package | Description |
+|---|---|
+| `amount` | Dimension-agnostic Amount type (CURRENCY, ENERGY, CARBON, COMPUTE, etc.) |
+| `bucketing` | Canonical bucket ID calculation for the Universal Asset System |
+| `cel` | CEL expression compilation and evaluation for validation and key generation |
+| `clients` | Resilience patterns for inter-service calls (circuit breaker, retry, saga) |
+| `credentials` | Password hashing, validation, and policy enforcement |
+| `dispatch` | Event dispatch utilities for publishing domain events |
+| `grpc` | gRPC client connection factory with DNS-based load balancing |
+| `health` | Health-check aggregator and HTTP handler for Kubernetes probes |
+| `idempotency` | Distributed idempotency checking and locking |
+| `interceptors` | Shared gRPC interceptors (logging, tracing, error mapping) |
+| `mapping` | Bidirectional JSON-to-gRPC payload transformation engine |
+| `money` | Instrument-aware Money type restricted to the CURRENCY dimension |
+| `proto/mappers` | Conversion utilities between domain types and protobuf types |
+| `refdata` | InstrumentResolver interface and caching implementations |
+| `saga` | Saga orchestration runtime and persistence for durable execution |
+| `tokens` | Secure single-use token generation, hashing, and validation |
+| `types` | Shared primitive types (e.g., strongly-typed identifiers) |
+| `validation` | Input validation utilities mirroring proto validation rules |
+| `valuation` | Engine interface and implementations for Starlark/CEL valuation methods |
+| `valuationfeature` | Shared domain, persistence, and CRUD for valuation feature assignments |
+
+---
+
+## shared/platform/
+
+Infrastructure packages with no domain semantics.
+
+| Package | Description |
+|---|---|
+| `audit` | Application-level audit logging via transactional outbox and Kafka |
+| `auth` | JWT authentication middleware for gRPC (JWKS, OAuth, disabled modes) |
+| `await` | Test polling utility — replaces `time.Sleep` with condition-based waits |
+| `bootstrap` | Shared infrastructure initialisation (DB, Redis, gRPC, auth, observability) |
+| `db` | Database abstraction layer for CockroachDB (connection pool + transaction interface) |
+| `defaults` | Shared default configuration values (timeouts, retry counts, etc.) |
+| `env` | Typed environment variable helpers (`MustGetString`, `GetInt`, etc.) |
+| `events` | Transactional outbox pattern for reliable event delivery to Kafka |
+| `gateway` | HTTP middleware for API gateway tenant resolution |
+| `kafka` | Protocol Buffer Kafka consumer and producer utilities |
+| `observability` | OpenTelemetry tracing setup and gRPC instrumentation helpers |
+| `ports` | Centralized port constant definitions for all Meridian services |
+| `quantity` | Generic `Qty[D]` type for the Universal Asset System with dimension safety |
+| `ratelimit` | Per-tenant, per-method gRPC rate limiting with Prometheus metrics |
+| `redislock` | Distributed locking and leader election backed by Redis |
+| `sandbox` | Starlark security configuration and thread hardening for tenant scripts |
+| `scheduler` | Cron-based and catch-up job scheduling for tenant workflows |
+| `tenant` | Tenant identity types and context propagation helpers |
+| `testdb` | CockroachDB testcontainer setup for integration tests |

--- a/shared/pkg/amount/doc.go
+++ b/shared/pkg/amount/doc.go
@@ -1,0 +1,16 @@
+// Package amount provides the shared dimension-agnostic Amount type for use across all services.
+//
+// Unlike the money package which is restricted to the CURRENCY dimension, Amount accepts any
+// valid dimension from quantity.ValidDimensions (CURRENCY, ENERGY, CARBON, COMPUTE, etc.).
+// For CURRENCY instruments it delegates precision lookup to the currency package.
+//
+// # Usage
+//
+//	a, err := amount.NewFromInstrument("GBP", "CURRENCY", 2, 10000)  // £100.00
+//	a, err := amount.NewFromInstrument("KWH", "ENERGY", 3, 1500)     // 1.500 KWH
+//
+//	inst, _ := quantity.NewInstrument("KWH", 0, "ENERGY", 3)
+//	a := amount.New(inst, 1500)  // 1.500 KWH
+//
+// See [money] for the currency-only variant with stricter typing.
+package amount

--- a/shared/pkg/bucketing/doc.go
+++ b/shared/pkg/bucketing/doc.go
@@ -1,0 +1,14 @@
+// Package bucketing provides canonical bucket ID calculation for the Universal Asset System.
+//
+// All services MUST use this library to compute bucket IDs. Direct string construction
+// of bucket IDs is forbidden to prevent Bucket Drift — the condition where the same
+// instrument and attributes produce different bucket IDs across services.
+//
+// Bucket ID format: "dimension_instrument_attr1=val1_attr2=val2"
+//
+// Examples:
+//
+//	GBP (CURRENCY dimension)                -> "currency_gbp"
+//	KWH (ENERGY dimension, source=solar)    -> "energy_kwh_source=solar"
+//	GPU_HOUR (COMPUTE dimension, tier=prem) -> "compute_gpu_hour_tier=prem"
+package bucketing

--- a/shared/pkg/cel/doc.go
+++ b/shared/pkg/cel/doc.go
@@ -1,0 +1,18 @@
+// Package cel provides CEL (Common Expression Language) compilation and evaluation
+// for instrument validation and bucket key generation.
+//
+// CEL expressions are bounded — they cannot loop and are guaranteed to terminate
+// in sub-millisecond time, making them safe for use in hot paths such as
+// validation rules, pricing formulas, and bucket key derivation.
+//
+// Security constraints are enforced on all compiled expressions:
+//   - Maximum expression length: 4 KB
+//   - Determinism checks: no non-deterministic functions
+//   - Cost limits prevent runaway evaluation
+//
+// # Usage
+//
+//	compiler := cel.NewCompiler()
+//	prog, err := compiler.Compile(`amount > 0 && amount <= account.limit`)
+//	result, err := prog.Eval(map[string]any{"amount": 500.0, "account": ...})
+package cel

--- a/shared/pkg/credentials/doc.go
+++ b/shared/pkg/credentials/doc.go
@@ -1,0 +1,12 @@
+// Package credentials provides password hashing, validation, and policy enforcement.
+//
+// Passwords are hashed with bcrypt and compared using constant-time comparison
+// to prevent timing attacks. The DefaultPasswordPolicy enforces a minimum length
+// of 12 characters with uppercase, lowercase, and digit requirements, and tracks
+// the last five passwords to prevent reuse.
+//
+// # Usage
+//
+//	hash, err := credentials.HashPassword("correct-horse-battery-staple")
+//	ok, err  := credentials.VerifyPassword("correct-horse-battery-staple", hash)
+package credentials

--- a/shared/pkg/grpc/doc.go
+++ b/shared/pkg/grpc/doc.go
@@ -1,0 +1,7 @@
+// Package grpc provides utilities for creating gRPC client connections
+// with DNS-based load balancing for Kubernetes headless services.
+//
+// The primary entry point is [NewClient], which constructs a gRPC connection
+// with sensible keepalive defaults and round-robin load balancing suited for
+// direct-to-pod routing via Kubernetes headless services.
+package grpc

--- a/shared/pkg/health/doc.go
+++ b/shared/pkg/health/doc.go
@@ -1,0 +1,22 @@
+// Package health provides health checking capabilities for services and their dependencies.
+//
+// A [Checker] aggregates the health of multiple named components (database, Redis,
+// upstream gRPC services, etc.) and exposes the result as a single composite
+// [Status]. The HTTP handler serves a JSON health endpoint compatible with
+// Kubernetes liveness and readiness probes.
+//
+// # Status Values
+//
+//   - StatusHealthy:   component is fully operational
+//   - StatusDegraded:  operational with reduced functionality
+//   - StatusUnhealthy: not operational
+//   - StatusUnknown:   status cannot be determined
+//
+// # Usage
+//
+//	checker := health.NewChecker()
+//	checker.Register("database", dbHealthFunc)
+//	checker.Register("redis",    redisHealthFunc)
+//
+//	http.Handle("/healthz", health.NewHTTPHandler(checker))
+package health

--- a/shared/pkg/idempotency/doc.go
+++ b/shared/pkg/idempotency/doc.go
@@ -1,0 +1,18 @@
+// Package idempotency provides distributed idempotency checking and locking capabilities.
+//
+// The package prevents duplicate processing of operations that carry an idempotency key
+// by persisting results and acquiring distributed locks before execution. Two backends
+// are provided: a PostgreSQL-backed service for durable storage and a no-op service for
+// testing.
+//
+// # Usage
+//
+//	executor := idempotency.NewExecutor(service, lock)
+//	result, err := executor.Execute(ctx, key, func(ctx context.Context) (any, error) {
+//	    return processPayment(ctx, req)
+//	})
+//
+// Sentinel errors:
+//   - [ErrOperationAlreadyProcessed]: key was seen before; cached result is returned
+//   - [ErrLockAcquisitionFailed]: concurrent caller holds the lock
+package idempotency

--- a/shared/pkg/mapping/doc.go
+++ b/shared/pkg/mapping/doc.go
@@ -1,0 +1,14 @@
+// Package mapping provides utilities for transforming external JSON payloads
+// into internal Meridian gRPC request messages and vice versa.
+//
+// The bidirectional transformation [Engine] applies MappingDefinition proto transforms
+// between external and internal formats. Field extraction from external payloads uses
+// gjson path expressions, which support dot notation, array indexing, and modifiers:
+//
+//	"customer.id"       — nested field
+//	"items.#.price"     — array element iteration
+//	"meta|@flatten"     — gjson modifier
+//
+// CEL expressions can be used for value transformation within mapping rules.
+// See https://github.com/tidwall/gjson for full path syntax documentation.
+package mapping

--- a/shared/pkg/money/doc.go
+++ b/shared/pkg/money/doc.go
@@ -1,0 +1,16 @@
+// Package money provides the shared instrument-aware Money type for use across all services.
+//
+// Money wraps [quantity.Money] (Qty[Monetary]) and is restricted to the CURRENCY dimension,
+// providing compile-time safety against mixing monetary and commodity quantities.
+//
+// # Usage
+//
+//	m, err := money.New("GBP", 10000)                          // £100.00 from minor units
+//	m, err := money.NewFromDecimal(decimal.NewFromInt(100), money.CurrencyGBP)
+//
+//	m.Amount()      // decimal.Decimal
+//	m.Currency()    // money.Currency ("GBP")
+//	m.Instrument()  // quantity.Instrument (full instrument metadata)
+//
+// For multi-dimensional quantities (ENERGY, COMPUTE, etc.) use [amount.Amount] instead.
+package money

--- a/shared/pkg/proto/mappers/doc.go
+++ b/shared/pkg/proto/mappers/doc.go
@@ -1,0 +1,9 @@
+// Package mappers provides conversion utilities between domain types and protobuf types.
+//
+// The functions in this package bridge the domain layer and the generated proto layer,
+// translating between domain primitives (e.g., [money.Currency]) and their protobuf
+// enum equivalents (e.g., [commonpb.Currency]).
+//
+// Deprecated currency enum converters are retained for backward compatibility.
+// New code should pass instrument code strings directly to proto fields.
+package mappers

--- a/shared/pkg/refdata/doc.go
+++ b/shared/pkg/refdata/doc.go
@@ -1,0 +1,11 @@
+// Package refdata provides a shared InstrumentResolver interface and implementations
+// for resolving instrument properties from Reference Data with in-process caching.
+//
+// Services use [InstrumentResolver] to obtain instrument metadata (dimension, precision,
+// rounding mode) without directly depending on the Reference Data gRPC client.
+// [CachedResolver] wraps any resolver with an in-process TTL cache to avoid redundant
+// RPC calls for frequently-accessed instruments.
+//
+// For environments where Reference Data is unavailable, [FallbackResolver] chains
+// multiple resolvers and returns the first successful result.
+package refdata

--- a/shared/pkg/saga/doc.go
+++ b/shared/pkg/saga/doc.go
@@ -1,0 +1,16 @@
+// Package saga provides saga orchestration runtime and persistence for durable execution.
+//
+// A saga is a sequence of local transactions that together form a distributed workflow.
+// Each step declares a forward action and a compensating action; if any step fails,
+// completed steps are compensated in reverse order (LIFO), restoring consistency
+// without distributed locking.
+//
+// # Key Types
+//
+//   - [SagaInstance]: persistent record of a running or completed saga
+//   - [StepExecution]: record of a single step within a saga
+//   - [CausationTree]: hierarchical view of nested sagas spawned by a parent
+//
+// All sagas are persisted to the database before execution begins, enabling
+// resumption after service restarts and full audit-trail reconstruction.
+package saga

--- a/shared/pkg/saga/doc.go
+++ b/shared/pkg/saga/doc.go
@@ -8,8 +8,8 @@
 // # Key Types
 //
 //   - [SagaInstance]: persistent record of a running or completed saga
-//   - [StepExecution]: record of a single step within a saga
-//   - [CausationTree]: hierarchical view of nested sagas spawned by a parent
+//   - [SagaStepResult]: record of a single step within a saga
+//   - [CausationTreeNode]: hierarchical view of nested sagas spawned by a parent
 //
 // All sagas are persisted to the database before execution begins, enabling
 // resumption after service restarts and full audit-trail reconstruction.

--- a/shared/pkg/tokens/doc.go
+++ b/shared/pkg/tokens/doc.go
@@ -1,0 +1,14 @@
+// Package tokens provides secure token generation, hashing, and validation utilities
+// for single-use tokens such as invitations and password resets.
+//
+// Tokens are generated using crypto/rand, delivered in URL-safe base64, and stored
+// only as their SHA-256 hex hash — the plaintext is never persisted. Comparison uses
+// constant-time equality to prevent timing attacks.
+//
+// # Usage
+//
+//	plaintext, hash, err := tokens.GenerateToken(tokens.InvitationTokenLength)
+//	// deliver plaintext to the user, store hash in the database
+//
+//	ok := tokens.ValidateToken(userSuppliedToken, storedHash)
+package tokens

--- a/shared/pkg/validation/doc.go
+++ b/shared/pkg/validation/doc.go
@@ -1,0 +1,7 @@
+// Package validation provides input validation utilities for client-side
+// pre-validation before making RPC calls.
+//
+// Validators in this package mirror the proto validation rules defined in the
+// API layer, allowing callers to surface errors early without a network round-trip.
+// Domain-layer primitives may enforce stricter invariants beyond what is checked here.
+package validation

--- a/shared/pkg/valuation/doc.go
+++ b/shared/pkg/valuation/doc.go
@@ -1,0 +1,16 @@
+// Package valuation provides the Engine interface and implementations for executing
+// valuation methods with Starlark and CEL policy runtimes.
+//
+// The engine coordinates Starlark method execution (procedural logic), CEL policy
+// evaluation (mathematical calculations), and read-only builtin functions
+// (market_data, run_policy, etc.) within a security-hardened sandbox.
+//
+// Security guarantees:
+//   - No filesystem or network access
+//   - 5-second execution timeout
+//   - 64 MB memory limit
+//   - CEL cost limit: 10,000 units per policy
+//
+// An L1 in-process cache stores compiled methods and policies to avoid recompilation
+// on repeated calls for the same instrument pair.
+package valuation

--- a/shared/pkg/valuation/doc.go
+++ b/shared/pkg/valuation/doc.go
@@ -8,7 +8,7 @@
 // Security guarantees:
 //   - No filesystem or network access
 //   - 5-second execution timeout
-//   - 64 MB memory limit
+//   - 10 MB memory limit
 //   - CEL cost limit: 10,000 units per policy
 //
 // An L1 in-process cache stores compiled methods and policies to avoid recompilation

--- a/shared/pkg/valuationfeature/doc.go
+++ b/shared/pkg/valuationfeature/doc.go
@@ -1,0 +1,10 @@
+// Package valuationfeature provides shared domain, persistence, and CRUD operations
+// for valuation features across account services (Current Account, Internal Account).
+//
+// A [ValuationFeature] maps an input instrument (e.g., USD) to an account's native
+// instrument (e.g., GBP) using a specific valuation method from the Valuation Engine
+// Service. At most one ACTIVE feature is permitted per account per input instrument.
+//
+// State transitions are enforced via [Activate] and [Terminate] methods on the domain
+// entity, which follow the INITIATED → ACTIVE → TERMINATED lifecycle (ADR-012).
+package valuationfeature

--- a/shared/platform/auth/doc.go
+++ b/shared/platform/auth/doc.go
@@ -1,0 +1,20 @@
+// Package auth provides JWT authentication middleware for Meridian gRPC services.
+//
+// The package supports three authentication modes configured via AUTH_MODE:
+//   - "jwks": validates Bearer tokens against a JWKS endpoint (production default)
+//   - "oauth": issues outbound OAuth client-credentials tokens for service-to-service calls
+//   - "disabled": passes requests through without validation (local development only)
+//
+// Validated tokens are parsed and the tenant ID and subject are injected into
+// the request context for downstream handlers via the [tenant] package.
+//
+// # gRPC Interceptor
+//
+//	interceptor, err := auth.NewInterceptor(ctx, auth.DefaultConfig(logger))
+//	grpcServer := grpc.NewServer(grpc.UnaryInterceptor(interceptor.Unary()))
+//
+// # Environment Variables
+//
+//   - AUTH_MODE: "jwks" | "oauth" | "disabled" (default: "jwks")
+//   - JWKS_URL: URL of the JWKS endpoint (required when AUTH_MODE=jwks)
+package auth

--- a/shared/platform/await/doc.go
+++ b/shared/platform/await/doc.go
@@ -1,0 +1,28 @@
+// Package await provides polling utilities for synchronizing test assertions.
+//
+// It eliminates time.Sleep by repeatedly checking a condition until it becomes
+// true or a configurable timeout is reached. The fluent API expresses intent clearly
+// and produces descriptive timeout errors.
+//
+// Default timeout is 10 seconds with a 100 ms poll interval.
+//
+// # Usage
+//
+//	// Simple condition wait
+//	err := await.Until(func() bool {
+//	    return repo.FindByID(ctx, id) != nil
+//	})
+//
+//	// Custom timeout and interval
+//	err := await.New().
+//	    AtMost(5 * time.Second).
+//	    PollInterval(50 * time.Millisecond).
+//	    Until(func() bool { return order.Status == "COMPLETED" })
+//
+//	// Wait for an operation to stop returning errors
+//	err := await.UntilNoError(func() error {
+//	    return client.HealthCheck()
+//	})
+//
+// Note: For advanced matchers or async assertions, consider [gomega.Eventually].
+package await

--- a/shared/platform/db/doc.go
+++ b/shared/platform/db/doc.go
@@ -12,10 +12,14 @@
 //
 //	postgresql://meridian:secret@cockroachdb:26257/meridian_current_account?sslmode=require
 //
-// # Environment Variables
+// # Configuration
 //
-//   - DATABASE_URL: full connection string (required)
-//   - DB_MAX_OPEN_CONNS: maximum open connections (default: 25)
-//   - DB_MAX_IDLE_CONNS: maximum idle connections (default: 5)
-//   - DB_CONN_MAX_LIFETIME: connection lifetime (default: 5m)
+// Use [DefaultConfig] to build a Config with CockroachDB-tuned defaults:
+//
+//   - MaxConnections: 50
+//   - MinConnections: 5
+//   - MaxConnectionLifetime: 1 hour
+//   - MaxConnectionIdleTime: 10 minutes
+//
+// The connection string is typically read from the DATABASE_URL environment variable.
 package db

--- a/shared/platform/db/doc.go
+++ b/shared/platform/db/doc.go
@@ -1,0 +1,21 @@
+// Package db provides a database abstraction layer optimized for distributed SQL databases.
+//
+// The package implements a unified DB interface that works with both connection pools and
+// transactions, so repository code can be written once and work in either context. It is
+// optimized for CockroachDB with serializable isolation, automatic retry logic, and
+// per-service database isolation via connection strings.
+//
+// # Database-per-Service
+//
+// Each microservice connects to its own isolated database. The database name is part of
+// the connection string:
+//
+//	postgresql://meridian:secret@cockroachdb:26257/meridian_current_account?sslmode=require
+//
+// # Environment Variables
+//
+//   - DATABASE_URL: full connection string (required)
+//   - DB_MAX_OPEN_CONNS: maximum open connections (default: 25)
+//   - DB_MAX_IDLE_CONNS: maximum idle connections (default: 5)
+//   - DB_CONN_MAX_LIFETIME: connection lifetime (default: 5m)
+package db

--- a/shared/platform/gateway/doc.go
+++ b/shared/platform/gateway/doc.go
@@ -1,0 +1,12 @@
+// Package gateway provides HTTP middleware for API gateway functionality.
+//
+// [TenantResolverMiddleware] resolves the current tenant from the request
+// subdomain and injects the tenant ID into the request context. In local
+// development mode (LOCAL_DEV_MODE=true), the X-Tenant-Slug header may be
+// used instead of subdomain resolution.
+//
+// # Usage
+//
+//	resolver, err := gateway.NewTenantResolverMiddleware(cache, repo, "api.meridian.io", logger)
+//	http.Handle("/", resolver.Handler(appHandler))
+package gateway

--- a/shared/platform/kafka/doc.go
+++ b/shared/platform/kafka/doc.go
@@ -1,0 +1,17 @@
+// Package kafka provides Protocol Buffer consumer and producer utilities for Kafka.
+//
+// [ProtoConsumer] deserializes protobuf messages from Kafka topics and dispatches
+// them to a [MessageHandler]. Failed messages are routed to a dead-letter queue
+// after the configured number of retries.
+//
+// [ProtoProducer] serializes protobuf messages and publishes them to a Kafka topic
+// with configurable retry and acknowledgement semantics.
+//
+// Configuration is loaded from environment variables (KAFKA_BOOTSTRAP_SERVERS, etc.)
+// via [DefaultConfig].
+//
+// # Infrastructure package
+//
+// This is a platform-level package with no domain semantics.
+// Business-level event definitions live in shared/platform/events.
+package kafka

--- a/shared/platform/observability/doc.go
+++ b/shared/platform/observability/doc.go
@@ -1,0 +1,17 @@
+// Package observability provides OpenTelemetry tracing and gRPC instrumentation
+// for Meridian services.
+//
+// The package configures an OTLP trace exporter (defaulting to Grafana Alloy at
+// alloy:4317) and registers a tracer provider. gRPC servers and clients are
+// instrumented via the helpers in this package to propagate trace context across
+// service boundaries.
+//
+// # Environment Variables
+//
+//   - OTEL_SERVICE_NAME: service name (required)
+//   - OTEL_SERVICE_VERSION: service version (default: "unknown")
+//   - OTEL_ENVIRONMENT: deployment environment (default: "development")
+//   - OTEL_EXPORTER_OTLP_ENDPOINT: OTLP endpoint (default: "alloy:4317")
+//   - OTEL_TRACES_SAMPLER_ARG: sampling rate 0.0–1.0 (default: 1.0)
+//   - OTEL_TRACES_ENABLED: enable tracing (default: "true")
+package observability

--- a/shared/platform/ports/doc.go
+++ b/shared/platform/ports/doc.go
@@ -1,0 +1,12 @@
+// Package ports provides centralized port constant definitions for all Meridian services.
+//
+// All services, Kubernetes manifests, Tilt configurations, and integration tests should
+// reference these constants instead of hardcoding port numbers.
+//
+// # Port Allocation
+//
+//   - 50051–50099: internal gRPC service-to-service ports
+//   - 8080: HTTP/Connect gateway (client-facing)
+//   - 8081: HTTP health check (Kubernetes probes)
+//   - 9090: Prometheus metrics
+package ports

--- a/shared/platform/quantity/doc.go
+++ b/shared/platform/quantity/doc.go
@@ -1,0 +1,24 @@
+// Package quantity provides the generic Qty[D] type for the Universal Asset System.
+//
+// Qty[D] represents an amount of a specific instrument with compile-time dimension safety.
+// The type parameter D prevents mixing monetary and commodity quantities at compile time:
+//
+//	var m quantity.Money   // monetary quantity (USD, EUR)
+//	var e quantity.Asset   // commodity quantity (KWH, GPU_HOUR)
+//	m = e                  // compile error!
+//
+// # Type Aliases
+//
+//   - Money = Qty[Monetary]   for currency quantities
+//   - Asset = Qty[Commodity]  for non-monetary asset quantities
+//
+// # Arithmetic
+//
+// Add and Subtract require the same instrument (code and version). Multiply and Divide
+// operate on a scalar and do not require instrument matching.
+//
+// # Instruments and Dimensions
+//
+// An [Instrument] carries the code, precision, rounding mode, and dimension. Use
+// [NewInstrument] to construct one and [Parse] to deserialise from a string.
+package quantity

--- a/shared/platform/ratelimit/doc.go
+++ b/shared/platform/ratelimit/doc.go
@@ -1,0 +1,13 @@
+// Package ratelimit provides per-tenant, per-method rate limiting for gRPC services.
+//
+// A token-bucket limiter is maintained per (tenant, gRPC method) pair. Requests that
+// exceed the configured rate receive a gRPC ResourceExhausted error. Idle limiters are
+// evicted on a configurable cleanup interval to bound memory usage.
+//
+// Prometheus metrics are collected for rejected and allowed requests.
+//
+// # Usage
+//
+//	interceptor := ratelimit.NewInterceptor(ratelimit.DefaultConfig())
+//	grpcServer := grpc.NewServer(grpc.UnaryInterceptor(interceptor.Unary()))
+package ratelimit

--- a/shared/platform/redislock/doc.go
+++ b/shared/platform/redislock/doc.go
@@ -1,0 +1,13 @@
+// Package redislock provides distributed locking backed by Redis.
+//
+// Two patterns are supported:
+//
+//   - Per-resource locking via [Lock]: multiple locks keyed by tenant and resource,
+//     suitable for preventing concurrent execution of the same task.
+//   - Leader election via [Leader]: a single lock for leader/follower coordination
+//     across replicas.
+//
+// Both patterns use background renewal goroutines to keep locks alive during
+// long-running operations, with automatic cleanup on context cancellation or
+// explicit release.
+package redislock

--- a/shared/platform/sandbox/doc.go
+++ b/shared/platform/sandbox/doc.go
@@ -1,0 +1,11 @@
+// Package sandbox provides unified Starlark sandbox security configuration
+// and thread hardening for all Meridian runtimes (saga, valuation, forecasting).
+//
+// [Config] holds security constraints (timeout, max script size, max execution steps,
+// memory threshold). [HardenThread] applies the step limit to a Starlark thread.
+// [MemoryMonitor] polls heap allocation during execution and cancels the context when
+// the threshold is exceeded.
+//
+// All Meridian runtimes that execute tenant-supplied Starlark scripts must use this
+// package to ensure consistent security properties across services.
+package sandbox

--- a/shared/platform/scheduler/doc.go
+++ b/shared/platform/scheduler/doc.go
@@ -1,0 +1,16 @@
+// Package scheduler provides cron-based and catch-up job scheduling for tenant workflows.
+//
+// The [Runner] executes tenant-specific schedules obtained from a [ScheduleProvider]
+// (e.g., Reference Data). Each tick calls [Executor.Execute] with the triggered schedule.
+// Only the leader pod runs the scheduler; leader election is handled externally via
+// the [redislock] package.
+//
+// On startup, the catch-up logic re-executes any missed windows within the configured
+// MaxCatchUpAge. Windows older than that threshold are recorded as MISSED for audit
+// purposes without re-execution.
+//
+// # Infrastructure package
+//
+// This is a platform-level package with no domain semantics.
+// Domain-specific schedule logic belongs in the calling service.
+package scheduler

--- a/shared/platform/tenant/doc.go
+++ b/shared/platform/tenant/doc.go
@@ -1,0 +1,10 @@
+// Package tenant provides tenant identity types and context propagation helpers.
+//
+// [TenantID] is a strongly-typed identifier validated on construction.
+// [WithTenant] and [TenantFromContext] carry the tenant ID through request contexts.
+// [WithSlug] and [SlugFromContext] do the same for the URL-safe slug.
+//
+// The universal keys [TenantIDKey] ("x-tenant-id") and [TenantSlugKey] ("x-tenant-slug")
+// are shared across all transport layers: JWT claims, context values, Kafka headers,
+// gRPC metadata, and HTTP headers.
+package tenant

--- a/shared/platform/testdb/doc.go
+++ b/shared/platform/testdb/doc.go
@@ -3,7 +3,7 @@
 // [SetupCockroachDB] spins up a CockroachDB testcontainer and returns a GORM
 // connection ready for integration tests. Using CockroachDB (rather than a
 // PostgreSQL substitute) ensures production parity for migration and constraint
-// behaviour.
+// behavior.
 //
 // The container is started with up to three retries to handle transient Docker
 // daemon contention in CI environments.

--- a/shared/platform/testdb/doc.go
+++ b/shared/platform/testdb/doc.go
@@ -1,0 +1,18 @@
+// Package testdb provides utilities for setting up test databases.
+//
+// [SetupCockroachDB] spins up a CockroachDB testcontainer and returns a GORM
+// connection ready for integration tests. Using CockroachDB (rather than a
+// PostgreSQL substitute) ensures production parity for migration and constraint
+// behaviour.
+//
+// The container is started with up to three retries to handle transient Docker
+// daemon contention in CI environments.
+//
+// # Usage
+//
+//	func TestMyRepository(t *testing.T) {
+//	    db, cleanup := testdb.SetupCockroachDB(t, nil)
+//	    defer cleanup()
+//	    // use db ...
+//	}
+package testdb


### PR DESCRIPTION
## Summary

- Add `doc.go` to 16 `shared/pkg/` packages that lacked one: `amount`, `bucketing`, `cel`, `credentials`, `grpc`, `health`, `idempotency`, `mapping`, `money`, `proto/mappers`, `refdata`, `saga`, `tokens`, `validation`, `valuation`, `valuationfeature`
- Add `doc.go` to 14 `shared/platform/` packages that lacked one: `auth`, `await`, `db`, `gateway`, `kafka`, `observability`, `ports`, `quantity`, `ratelimit`, `redislock`, `sandbox`, `scheduler`, `tenant`, `testdb`
- Create `shared/README.md` explaining the `pkg/` vs `platform/` split, with a decision guide and a one-line description of every package

## Motivation

Packages without `doc.go` files appear undocumented in `go doc` and IDEs. The new `shared/README.md` gives engineers a single navigation point when deciding where new shared code belongs.

## Changes

Each `doc.go` follows the standard format:
```go
// Package <name> provides <one-line description>.
//
// <context: key types, usage patterns, infrastructure vs domain notes>
package <name>
```

The `shared/README.md` includes:
- A `pkg/` vs `platform/` comparison table (domain semantics, dependencies, purpose)
- A decision guide for where new packages belong
- A full index of all packages with one-line descriptions

## Testing

Documentation-only change. No logic modified. Existing package-level comments in source files are preserved; `doc.go` files add the canonical package doc without duplicating or removing comments from other files.