### PR TITLE
refactor: replace time.Sleep with await in test files

### DIFF
--- a/cmd/meridian/gateway_test.go
+++ b/cmd/meridian/gateway_test.go
@@ -57,7 +57,7 @@ func TestWireGateway_Config(t *testing.T) {
 			conn.Close()
 			break
 		}
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond) //nolint:forbidigo // poll interval waiting for server bind
 	}
 	require.NoError(t, dialErr, "gateway server did not start")
 

--- a/services/api-gateway/auth/jwt_middleware_test.go
+++ b/services/api-gateway/auth/jwt_middleware_test.go
@@ -1057,7 +1057,7 @@ func TestJWTMiddleware_IntegrationWithRealToken_ExpirationBoundary(t *testing.T)
 	// This is testing real-time token expiration, not waiting for async operations.
 	waitTime := time.Until(expiresAt) + 100*time.Millisecond
 	if waitTime > 0 {
-		time.Sleep(waitTime)
+		time.Sleep(waitTime) //nolint:forbidigo // waits for real JWT token expiration
 	}
 
 	// Token should be rejected after expiration

--- a/services/api-gateway/auth_sso_state_test.go
+++ b/services/api-gateway/auth_sso_state_test.go
@@ -67,7 +67,7 @@ func TestStateStore_ExpiredEntry(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	time.Sleep(5 * time.Millisecond)
+	time.Sleep(5 * time.Millisecond) //nolint:forbidigo // triggers TTL expiry to test expiration behavior
 
 	_, ok := store.Get(key)
 	assert.False(t, ok, "expired entry should not be returned")

--- a/services/api-gateway/cache/forward_curve_cache_test.go
+++ b/services/api-gateway/cache/forward_curve_cache_test.go
@@ -126,12 +126,13 @@ func TestForwardCurveCache_L2Hit(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "45.5", obs.Value.String())
 
-	// Wait for L1 to expire
-	time.Sleep(60 * time.Millisecond)
-
-	// Second call: L2 hit (L1 expired)
-	obs2, err := cache1.Get(ctx, "ELEC_PEAK", ts)
-	require.NoError(t, err)
+	// Poll until L1 expires and the next Get registers an L2 hit
+	var obs2 *Observation
+	require.NoError(t, await.New().AtMost(500*time.Millisecond).PollInterval(10*time.Millisecond).Until(func() bool {
+		obs2, _ = cache1.Get(ctx, "ELEC_PEAK", ts)
+		return cache1.Stats().L2Hits >= 1
+	}))
+	require.NotNil(t, obs2)
 	assert.Equal(t, "45.5", obs2.Value.String())
 
 	// Source should only be called once
@@ -181,12 +182,11 @@ func TestForwardCurveCache_L1TTLExpiry(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), atomic.LoadInt64(&source.calls))
 
-	// Wait for TTL expiry
-	time.Sleep(60 * time.Millisecond)
-
-	// Should re-query source after TTL expiry
-	_, err = cache.Get(ctx, "ELEC_PEAK", ts)
-	require.NoError(t, err)
+	// Poll until TTL expires and source is re-queried
+	require.NoError(t, await.New().AtMost(500*time.Millisecond).PollInterval(10*time.Millisecond).Until(func() bool {
+		_, _ = cache.Get(ctx, "ELEC_PEAK", ts)
+		return atomic.LoadInt64(&source.calls) >= 2
+	}))
 	assert.Equal(t, int64(2), atomic.LoadInt64(&source.calls))
 }
 
@@ -212,12 +212,13 @@ func TestForwardCurveCache_RedisFailureGraceful(t *testing.T) {
 	// Shut down Redis
 	mr.Close()
 
-	// Wait for L1 to expire
-	time.Sleep(60 * time.Millisecond)
-
-	// Should degrade gracefully: L2 fails -> L3
-	obs2, err := cache.Get(ctx, "ELEC_PEAK", ts)
-	require.NoError(t, err)
+	// Poll until L1 expires; source is called again as L2 (Redis) is down
+	var obs2 *Observation
+	require.NoError(t, await.New().AtMost(500*time.Millisecond).PollInterval(10*time.Millisecond).Until(func() bool {
+		obs2, _ = cache.Get(ctx, "ELEC_PEAK", ts)
+		return atomic.LoadInt64(&source.calls) >= 2
+	}))
+	require.NotNil(t, obs2)
 	assert.Equal(t, "45.5", obs2.Value.String())
 
 	// Source called twice (initial + after Redis failure)

--- a/services/api-gateway/eventstream/adapters/local_fanout_test.go
+++ b/services/api-gateway/eventstream/adapters/local_fanout_test.go
@@ -396,13 +396,13 @@ func TestLocalFanOut_ConcurrentSubscribeUnsubscribePublish(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			time.Sleep(20 * time.Millisecond)
+			time.Sleep(20 * time.Millisecond) //nolint:forbidigo // staggers unsubscribe relative to concurrent publish goroutines
 			_ = fo.Unsubscribe(context.Background(), tenant)
 		}()
 	}
 
 	// Let everything run, then cancel to unblock remaining subscribers.
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond) //nolint:forbidigo // allows concurrent goroutines to run before cancellation
 	cancel()
 	wg.Wait()
 }

--- a/services/api-gateway/eventstream/integration_test.go
+++ b/services/api-gateway/eventstream/integration_test.go
@@ -1008,7 +1008,7 @@ func TestLoad_ConcurrentConnections_Throughput(t *testing.T) {
 		elapsed := time.Since(emitStart)
 		expected := time.Duration(i+1) * emitInterval
 		if expected > elapsed {
-			time.Sleep(expected - elapsed)
+			time.Sleep(expected - elapsed) //nolint:forbidigo // paces event emission to simulate real-time throughput
 		}
 	}
 	emitDuration := time.Since(emitStart)
@@ -1196,7 +1196,7 @@ func TestLoad_HighThroughput_EventsPerSecond(t *testing.T) {
 		elapsed := time.Since(emitStart)
 		expected := time.Duration(i+1) * interval
 		if expected > elapsed {
-			time.Sleep(expected - elapsed)
+			time.Sleep(expected - elapsed) //nolint:forbidigo // paces event emission to simulate real-time throughput
 		}
 	}
 

--- a/services/api-gateway/eventstream/router_test.go
+++ b/services/api-gateway/eventstream/router_test.go
@@ -186,7 +186,7 @@ func TestRouter_HandleEvent_TenantIsolation(t *testing.T) {
 	require.NoError(t, err, "tenant-A connection should have received event")
 
 	// Give some time to ensure tenant-B doesn't receive anything
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond) //nolint:forbidigo // no observable condition; confirms absence of delivery
 	assert.Equal(t, 0, connB.ReceivedCount(), "tenant-B connection must not receive tenant-A's event")
 }
 
@@ -223,7 +223,7 @@ func TestRouter_HandleEvent_SubscriptionFilterMatch(t *testing.T) {
 	require.NoError(t, err)
 
 	// Give time to confirm no delivery
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond) //nolint:forbidigo // no observable condition; confirms absence of delivery
 	assert.Equal(t, 0, conn.ReceivedCount(), "connection should not receive non-matching channel event")
 }
 
@@ -272,7 +272,7 @@ func TestRouter_UnregisterConnection_StopsDelivery(t *testing.T) {
 	err := fanOut.Publish(context.Background(), event)
 	require.NoError(t, err)
 
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond) //nolint:forbidigo // no observable condition; confirms absence of delivery
 	assert.Equal(t, 0, conn.ReceivedCount(), "unregistered connection should not receive events")
 }
 

--- a/services/api-gateway/internal/middleware/mapping_middleware_test.go
+++ b/services/api-gateway/internal/middleware/mapping_middleware_test.go
@@ -364,7 +364,7 @@ func TestCachedMappingResolver_ExpiredEntry(t *testing.T) {
 	assert.Equal(t, 1, delegate.calls)
 
 	// Wait for expiry
-	time.Sleep(5 * time.Millisecond)
+	time.Sleep(5 * time.Millisecond) //nolint:forbidigo // triggers cache TTL expiry to test re-resolution
 
 	// Second call should re-resolve
 	_, err = cached.Resolve(context.Background(), "tenant-1", "stripe-webhook")

--- a/services/api-gateway/server_test.go
+++ b/services/api-gateway/server_test.go
@@ -405,7 +405,7 @@ func TestServer_StartAndShutdown(t *testing.T) {
 	// Intentional sleep: Give server time to start and bind the port.
 	// The server doesn't expose a "started" state we can poll. This is a unit test
 	// verifying lifecycle; the mutex in Server ensures thread-safety regardless of timing.
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond) //nolint:forbidigo // no observable started state to poll
 
 	select {
 	case err := <-serverErr:

--- a/services/control-plane/internal/staff/service_test.go
+++ b/services/control-plane/internal/staff/service_test.go
@@ -257,7 +257,7 @@ func TestStaffService(t *testing.T) {
 			result, err := svc.CreateAPIKey(ctx, apiUser.ID, "acme", "expired-test", nil, 1*time.Millisecond)
 			require.NoError(t, err)
 
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond) //nolint:forbidigo // triggers API key expiry (1ms TTL)
 
 			_, err = svc.ValidateAPIKey(ctx, result.KeyPrefix, result.PlaintextKey)
 			require.ErrorIs(t, err, staff.ErrAPIKeyExpired)

--- a/services/control-plane/internal/stripe/idempotency_test.go
+++ b/services/control-plane/internal/stripe/idempotency_test.go
@@ -110,7 +110,7 @@ func TestIdempotencyKeyStability(t *testing.T) {
 	key1 := generateIdempotencyKey(eventID, eventType)
 
 	// Simulate passage of time
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond) //nolint:forbidigo // ensures distinct timestamps to test key stability
 
 	key2 := generateIdempotencyKey(eventID, eventType)
 

--- a/services/current-account/service/account_resolver_test.go
+++ b/services/current-account/service/account_resolver_test.go
@@ -12,6 +12,8 @@ import (
 	internalaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_account/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/shared/platform/await"
 )
 
 // mockInternalAccountClient is a mock implementation for testing.
@@ -172,13 +174,15 @@ func TestAccountResolver_GetDepositClearingAccount_CacheExpiry(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, mockClient.getCallCount())
 
-	// Wait for cache to expire
-	time.Sleep(20 * time.Millisecond)
+	// Wait for cache to expire, then verify the next call reaches the client
+	var secondErr error
+	require.NoError(t, await.New().AtMost(500*time.Millisecond).PollInterval(5*time.Millisecond).Until(func() bool {
+		_, secondErr = resolver.GetDepositClearingAccount(context.Background(), "GBP")
+		return mockClient.getCallCount() >= 2
+	}), "cache should have expired and triggered a new client call")
 
-	// Second call - cache expired, should call client again
-	_, err = resolver.GetDepositClearingAccount(context.Background(), "GBP")
-	require.NoError(t, err)
-	assert.Equal(t, 2, mockClient.getCallCount())
+	require.NoError(t, secondErr)
+	assert.GreaterOrEqual(t, mockClient.getCallCount(), 2)
 }
 
 func TestAccountResolver_GetDepositClearingAccount_NoClearingAccountFound(t *testing.T) {

--- a/services/current-account/service/grpc_service_test.go
+++ b/services/current-account/service/grpc_service_test.go
@@ -1271,7 +1271,7 @@ func TestListCurrentAccounts(t *testing.T) {
 			acc, err := domain.NewCurrentAccount(fmt.Sprintf("ACC-%03d", i), iban, uuid.New().String(), "GBP")
 			require.NoError(t, err)
 			require.NoError(t, repo.Save(ctx, acc))
-			time.Sleep(2 * time.Millisecond) // ensure distinct created_at for cursor ordering
+			time.Sleep(2 * time.Millisecond) //nolint:forbidigo // ensures distinct created_at for cursor ordering
 		}
 
 		// First page: page_size=2

--- a/services/current-account/webhook/notifier_test.go
+++ b/services/current-account/webhook/notifier_test.go
@@ -246,7 +246,7 @@ func TestHTTPNotifier_ContextCancellation(t *testing.T) {
 	// Server that waits longer than the context timeout
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// Intentional sleep: Simulate slow server to test context timeout handling
-		time.Sleep(1 * time.Second)
+		time.Sleep(1 * time.Second) //nolint:forbidigo // simulates slow server response to trigger context timeout
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()

--- a/services/event-router/adapters/mds/market_data_publisher_test.go
+++ b/services/event-router/adapters/mds/market_data_publisher_test.go
@@ -466,7 +466,7 @@ func TestMarketDataPublisher_CircuitBreaker(t *testing.T) {
 			default:
 				pub.Publish(testMeasurement("tenant-1", "current-account", "Op", 1, ts.Add(time.Duration(i)*time.Millisecond)))
 				i++
-				time.Sleep(10 * time.Millisecond)
+				time.Sleep(10 * time.Millisecond) //nolint:forbidigo // simulates publish rate in circuit breaker test
 			}
 		}
 	}()

--- a/services/financial-accounting/adapters/persistence/repository_test.go
+++ b/services/financial-accounting/adapters/persistence/repository_test.go
@@ -351,7 +351,7 @@ func TestGetPostingsByBookingLogID_OrderedByCreatedAt(t *testing.T) {
 	require.NoError(t, repo.SavePosting(ctx, posting1))
 	// Intentional sleep: DB auto-populates CreatedAt on insert; sleep ensures
 	// distinct timestamps for ordering verification (domain CreatedAt is not persisted)
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond) //nolint:forbidigo // ensures distinct DB-generated timestamps for ordering verification
 	require.NoError(t, repo.SavePosting(ctx, posting2))
 
 	// Retrieve postings - should be ordered by created_at

--- a/services/financial-accounting/domain/financial_booking_log_test.go
+++ b/services/financial-accounting/domain/financial_booking_log_test.go
@@ -141,7 +141,7 @@ func TestFinancialBookingLog_WithStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Intentional sleep: Ensure time has advanced for distinct UpdatedAt timestamps
-			time.Sleep(time.Millisecond)
+			time.Sleep(time.Millisecond) //nolint:forbidigo // ensures distinct timestamps
 			beforeUpdate := time.Now().UTC()
 
 			updated := original.WithStatus(tt.newStatus)
@@ -227,7 +227,7 @@ func TestFinancialBookingLog_WithChartOfAccountsRules(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Intentional sleep: Ensure time has advanced for distinct UpdatedAt timestamps
-			time.Sleep(time.Millisecond)
+			time.Sleep(time.Millisecond) //nolint:forbidigo // ensures distinct timestamps
 			beforeUpdate := time.Now().UTC()
 
 			updated := original.WithChartOfAccountsRules(tt.newRules)

--- a/services/financial-accounting/observability/metrics_test.go
+++ b/services/financial-accounting/observability/metrics_test.go
@@ -176,7 +176,7 @@ func TestOperationTimer(t *testing.T) {
 		assert.Equal(t, initialInFlight+1, testutil.ToFloat64(operationsInFlight.WithLabelValues(OperationRetrieveLedgerPosting)))
 
 		// Intentional sleep: Simulate work to measure elapsed time in metrics
-		time.Sleep(5 * time.Millisecond)
+		time.Sleep(5 * time.Millisecond) //nolint:forbidigo // simulates operation latency for metrics measurement
 
 		// Record success
 		timer.ObserveSuccess()

--- a/services/financial-accounting/service/account_resolver_test.go
+++ b/services/financial-accounting/service/account_resolver_test.go
@@ -13,6 +13,8 @@ import (
 	internalaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_account/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/shared/platform/await"
 )
 
 // mockInternalAccountClient is a mock implementation for testing.
@@ -31,7 +33,7 @@ type mockInternalAccountClient struct {
 
 func (m *mockInternalAccountClient) ListInternalAccounts(_ context.Context, req *internalaccountv1.ListInternalAccountsRequest) (*internalaccountv1.ListInternalAccountsResponse, error) {
 	if m.latency > 0 {
-		time.Sleep(m.latency)
+		time.Sleep(m.latency) //nolint:forbidigo // mock: simulates configurable backend latency for singleflight coalescing tests
 	}
 	m.callCount.Add(1)
 	m.mu.Lock()
@@ -236,13 +238,15 @@ func TestCacheTTL_Expiration(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, mockClient.getCallCount(), "Should still be cached")
 
-	// Wait for cache to expire
-	time.Sleep(shortTTL + 10*time.Millisecond)
+	// Wait for cache to expire, then verify the next call reaches the backend
+	var thirdErr error
+	require.NoError(t, await.New().AtMost(500*time.Millisecond).PollInterval(5*time.Millisecond).Until(func() bool {
+		_, thirdErr = resolver.GetDepositClearingAccount(context.Background(), "GBP")
+		return mockClient.getCallCount() >= 2
+	}), "Expired cache should trigger new backend call")
 
-	// Third call - cache expired, should call backend again
-	_, err = resolver.GetDepositClearingAccount(context.Background(), "GBP")
-	require.NoError(t, err)
-	assert.Equal(t, 2, mockClient.getCallCount(), "Expired cache should trigger new backend call")
+	require.NoError(t, thirdErr)
+	assert.GreaterOrEqual(t, mockClient.getCallCount(), 2)
 }
 
 func TestCacheStampede_SingleflightCoalescing(t *testing.T) {

--- a/services/financial-accounting/service/grpc_integration_test.go
+++ b/services/financial-accounting/service/grpc_integration_test.go
@@ -877,7 +877,7 @@ func TestListLedgerPostings_Integration_Success(t *testing.T) {
 		}
 		require.NoError(t, ts.repo.SavePosting(ctx, posting))
 		// Intentional sleep: Ensure different timestamps for ordering tests
-		time.Sleep(time.Millisecond)
+		time.Sleep(time.Millisecond) //nolint:forbidigo // ensures distinct timestamps
 	}
 
 	// List all postings
@@ -1036,7 +1036,7 @@ func TestListLedgerPostings_Integration_Pagination(t *testing.T) {
 		}
 		require.NoError(t, ts.repo.SavePosting(ctx, posting))
 		// Intentional sleep: Ensure different timestamps for pagination ordering
-		time.Sleep(time.Millisecond)
+		time.Sleep(time.Millisecond) //nolint:forbidigo // ensures distinct timestamps
 	}
 
 	// Get first page

--- a/services/financial-accounting/service/idempotency_chaos_test.go
+++ b/services/financial-accounting/service/idempotency_chaos_test.go
@@ -98,7 +98,7 @@ func TestChaos_CrashAfterMarkPending_CleanupWorkerMarksAsFailed(t *testing.T) {
 
 	// Intentional sleep: Wait for the key to become stale (short threshold for testing).
 	// This is testing time-based staleness detection.
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond) //nolint:forbidigo // triggers staleness timeout for cleanup worker test
 
 	// Configure cleanup worker with short threshold
 	cfg := config.IdempotencyCleanupConfig{
@@ -446,7 +446,7 @@ func TestConcurrency_RaceBetweenCleanupAndStoreResult(t *testing.T) {
 		require.NoError(t, err)
 
 		// Intentional sleep: Wait just long enough for the key to potentially become stale
-		time.Sleep(15 * time.Millisecond)
+		time.Sleep(15 * time.Millisecond) //nolint:forbidigo // chaos: simulates random concurrent delay
 
 		// Now try to store result (racing with cleanup worker)
 		completedResult := idempotency.Result{
@@ -460,7 +460,7 @@ func TestConcurrency_RaceBetweenCleanupAndStoreResult(t *testing.T) {
 		_ = redisSvc.StoreResult(ctx, completedResult) // Ignore error - we're testing the race
 
 		// Intentional sleep: Wait a bit and check final state after race condition
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond) //nolint:forbidigo // chaos: simulates random concurrent delay
 
 		result, err := redisSvc.Check(ctx, raceKey)
 		if err != nil {
@@ -554,7 +554,7 @@ func TestLoad_SustainedTraffic_AllOperationsComplete(t *testing.T) {
 
 			_, err := executor.Execute(ctx, key, time.Hour, func(_ context.Context) ([]byte, error) {
 				// Intentional sleep: Simulate variable processing time for load testing
-				time.Sleep(time.Duration(rand.Intn(30)) * time.Millisecond)
+				time.Sleep(time.Duration(rand.Intn(30)) * time.Millisecond) //nolint:forbidigo // simulates variable processing latency for load testing
 				return []byte(`{"success":true}`), nil
 			})
 
@@ -632,7 +632,7 @@ func TestLoad_PendingDuration_P99Under1Second(t *testing.T) {
 			start := time.Now()
 			_, err := executor.Execute(ctx, key, time.Hour, func(_ context.Context) ([]byte, error) {
 				// Intentional sleep: Variable processing time (10-100ms) for p99 latency testing
-				time.Sleep(time.Duration(10+rand.Intn(90)) * time.Millisecond)
+				time.Sleep(time.Duration(10+rand.Intn(90)) * time.Millisecond) //nolint:forbidigo // simulates variable processing latency for p99 measurement
 				return []byte(`{"success":true}`), nil
 			})
 
@@ -721,7 +721,7 @@ func TestMeta_VerifyConcurrencyTestDetectsRaces(t *testing.T) {
 			_, _ = executor.Execute(context.Background(), key, time.Hour, func(_ context.Context) ([]byte, error) {
 				atomic.AddInt32(&executionCount, 1)
 				// Intentional sleep: Simulate work to test concurrency behavior
-				time.Sleep(10 * time.Millisecond)
+				time.Sleep(10 * time.Millisecond) //nolint:forbidigo // simulates work duration to expose concurrent execution window
 				return nil, nil
 			})
 		}()
@@ -773,7 +773,7 @@ func (b *brokenConcurrencyChecker) MarkPending(_ context.Context, key idempotenc
 
 	// Intentional sleep: Add delay BEFORE locking to create race window where multiple
 	// goroutines can all pass Check() before any of them complete MarkPending()
-	time.Sleep(5 * time.Millisecond)
+	time.Sleep(5 * time.Millisecond) //nolint:forbidigo // simulates latency in broken mock to expose race window
 
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -855,7 +855,7 @@ func TestMeta_VerifyMetricsConsistency(t *testing.T) {
 	wg.Wait()
 
 	// Intentional sleep: Give metrics a moment to settle after concurrent operations
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond) //nolint:forbidigo // simulates settling time after concurrent goroutines complete
 
 	// Get metrics
 	pendingSuccess := testutil.ToFloat64(

--- a/services/financial-accounting/worker/idempotency_cleanup_worker_test.go
+++ b/services/financial-accounting/worker/idempotency_cleanup_worker_test.go
@@ -81,8 +81,7 @@ func TestCleanupWorker_StaleKeyMarkedAsFailed(t *testing.T) {
 	err = redisSvc.MarkPending(ctx, staleKey, time.Hour)
 	require.NoError(t, err)
 
-	// Intentional sleep: Wait for the key to become stale (older than threshold).
-	// This is testing time-based staleness detection, not async operations.
+	//nolint:forbidigo // Intentional: tests time-based staleness detection; key must age before cleanup runs
 	time.Sleep(50 * time.Millisecond)
 
 	// Configure worker with very short threshold
@@ -169,9 +168,7 @@ func TestCleanupWorker_FreshKeyNotMarked(t *testing.T) {
 		_ = w.Start(workerCtx)
 	}()
 
-	// Intentional sleep: Wait for a few cleanup iterations to pass.
-	// We're testing that fresh keys are NOT modified, so we must allow time for the
-	// worker to run multiple cycles without touching them.
+	//nolint:forbidigo // Intentional: verifying fresh keys are not modified (negative assertion) requires waiting for cycles
 	time.Sleep(300 * time.Millisecond)
 
 	// Verify the key is still PENDING
@@ -206,7 +203,7 @@ func TestCleanupWorker_BatchProcessing(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Intentional sleep: Wait for keys to become stale (older than threshold)
+	//nolint:forbidigo // Intentional: keys must age past the staleness threshold before cleanup can detect them
 	time.Sleep(50 * time.Millisecond)
 
 	// Configure worker with batch size of 100 (so we need 2 batches)
@@ -272,7 +269,7 @@ func TestCleanupWorker_GracefulShutdown(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Intentional sleep: Wait for keys to become stale (older than threshold)
+	//nolint:forbidigo // Intentional: keys must age past the staleness threshold before cleanup can detect them
 	time.Sleep(50 * time.Millisecond)
 
 	// Configure worker with short intervals
@@ -299,7 +296,7 @@ func TestCleanupWorker_GracefulShutdown(t *testing.T) {
 	// Wait for worker to start
 	<-startedChan
 
-	// Intentional sleep: Let worker run for a few cycles before shutting down
+	//nolint:forbidigo // Intentional: allows worker to run a few cycles before testing graceful shutdown
 	time.Sleep(100 * time.Millisecond)
 
 	// Stop the worker gracefully via context cancellation
@@ -428,7 +425,7 @@ func TestCleanupWorker_MetricsRecorded(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Intentional sleep: Wait for keys to become stale (older than threshold)
+	//nolint:forbidigo // Intentional: keys must age past the staleness threshold before cleanup can detect them
 	time.Sleep(50 * time.Millisecond)
 
 	// Configure worker with short threshold

--- a/services/internal-account/adapters/persistence/repository_integration_test.go
+++ b/services/internal-account/adapters/persistence/repository_integration_test.go
@@ -415,7 +415,7 @@ func TestIntegration_OptimisticLocking_Concurrent(t *testing.T) {
 			}
 
 			// Small delay to increase contention
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond) //nolint:forbidigo // simulates latency to increase concurrent contention
 
 			// Try to update
 			renamed, err := acc.Rename(fmt.Sprintf("Updated by goroutine %d", idx))
@@ -716,7 +716,7 @@ func TestIntegration_AwaitPattern(t *testing.T) {
 
 	// Save account in goroutine with small delay
 	go func() {
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond) //nolint:forbidigo // simulates async save delay
 		_ = tc.repo.Save(ctx, account)
 	}()
 

--- a/services/internal-account/domain/internal_account_test.go
+++ b/services/internal-account/domain/internal_account_test.go
@@ -306,7 +306,7 @@ func TestImmutability(t *testing.T) {
 	originalUpdatedAt := original.UpdatedAt()
 
 	// Give some time for timestamp difference
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(1 * time.Millisecond) //nolint:forbidigo // ensures distinct timestamps
 
 	// Perform a status change
 	suspended, err := original.Suspend("Testing immutability")
@@ -982,7 +982,7 @@ func TestTimestamps_UpdatedAtChangesOnModification(t *testing.T) {
 	originalUpdatedAt := account.UpdatedAt()
 
 	// Wait a tiny bit to ensure timestamp difference
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(1 * time.Millisecond) //nolint:forbidigo // ensures distinct timestamps
 
 	// Suspend should update the timestamp
 	suspended, err := account.Suspend("Test")

--- a/services/internal-account/e2e/e2e_test.go
+++ b/services/internal-account/e2e/e2e_test.go
@@ -1286,7 +1286,7 @@ func TestE2E_AsyncOperationsWithAwait(t *testing.T) {
 
 		// Create account in goroutine with delay
 		go func() {
-			time.Sleep(100 * time.Millisecond) // Simulate async processing delay
+			time.Sleep(100 * time.Millisecond) //nolint:forbidigo // simulates async processing delay
 			_, _ = tc.svc.InitiateInternalAccount(ctx, &pb.InitiateInternalAccountRequest{
 				AccountCode:     accountCode,
 				Name:            "Async Created Account",
@@ -1333,7 +1333,7 @@ func TestE2E_AsyncOperationsWithAwait(t *testing.T) {
 
 		// Suspend in goroutine
 		go func() {
-			time.Sleep(150 * time.Millisecond)
+			time.Sleep(150 * time.Millisecond) //nolint:forbidigo // simulates async processing delay
 			_, _ = tc.svc.ControlInternalAccount(ctx, &pb.ControlInternalAccountRequest{
 				AccountId:     accountCode,
 				ControlAction: pb.ControlAction_CONTROL_ACTION_SUSPEND,
@@ -1364,7 +1364,7 @@ func TestE2E_AsyncOperationsWithAwait(t *testing.T) {
 
 		// Create account with delay
 		go func() {
-			time.Sleep(200 * time.Millisecond)
+			time.Sleep(200 * time.Millisecond) //nolint:forbidigo // simulates async processing delay
 			_, _ = tc.svc.InitiateInternalAccount(ctx, &pb.InitiateInternalAccountRequest{
 				AccountCode:     uniqueCode,
 				Name:            "Retry Test Account",

--- a/services/internal-account/observability/metrics_test.go
+++ b/services/internal-account/observability/metrics_test.go
@@ -123,7 +123,7 @@ func TestOperationTimer(t *testing.T) {
 		assert.Equal(t, initialInFlight+1, testutil.ToFloat64(operationsInFlight.WithLabelValues(OperationRetrieve)))
 
 		// Intentional sleep: Simulate work to measure elapsed time in metrics
-		time.Sleep(5 * time.Millisecond)
+		time.Sleep(5 * time.Millisecond) //nolint:forbidigo // simulates operation latency for metrics measurement
 
 		// Record success
 		timer.ObserveSuccess()

--- a/services/internal-account/service/health_coverage_test.go
+++ b/services/internal-account/service/health_coverage_test.go
@@ -197,14 +197,14 @@ func TestWatch_TickerFires(t *testing.T) {
 	}()
 
 	// Wait until at least 2 responses have been sent (initial + at least one ticker response)
-	_ = await.New().
-		AtMost(2 * time.Second).
+	require.NoError(t, await.New().
+		AtMost(2*time.Second).
 		PollInterval(time.Millisecond).
 		Until(func() bool {
 			stream.mu.Lock()
 			defer stream.mu.Unlock()
 			return len(stream.responses) >= 2
-		})
+		}), "should receive at least 2 health watch responses")
 
 	cancel() // cancel context to terminate Watch
 

--- a/services/internal-account/service/health_coverage_test.go
+++ b/services/internal-account/service/health_coverage_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/meridianhub/meridian/services/internal-account/adapters/persistence"
 	"github.com/meridianhub/meridian/shared/pkg/health"
+	"github.com/meridianhub/meridian/shared/platform/await"
 	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -196,16 +197,14 @@ func TestWatch_TickerFires(t *testing.T) {
 	}()
 
 	// Wait until at least 2 responses have been sent (initial + at least one ticker response)
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		stream.mu.Lock()
-		n := len(stream.responses)
-		stream.mu.Unlock()
-		if n >= 2 {
-			break
-		}
-		time.Sleep(time.Millisecond)
-	}
+	_ = await.New().
+		AtMost(2 * time.Second).
+		PollInterval(time.Millisecond).
+		Until(func() bool {
+			stream.mu.Lock()
+			defer stream.mu.Unlock()
+			return len(stream.responses) >= 2
+		})
 
 	cancel() // cancel context to terminate Watch
 

--- a/services/market-information/adapters/external/ecb/ecb_client_test.go
+++ b/services/market-information/adapters/external/ecb/ecb_client_test.go
@@ -40,7 +40,7 @@ EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2024-01-15,1.0876`
 func TestClient_FetchDailyRates_Timeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// Intentional sleep: Delay response to test timeout handling
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond) //nolint:forbidigo // simulates slow HTTP server to trigger client timeout
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -86,7 +86,7 @@ func TestClient_FetchDailyRates_Non200Status(t *testing.T) {
 func TestClient_FetchDailyRates_ContextCancellation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// Intentional sleep: Delay response to test context cancellation handling
-		time.Sleep(1 * time.Second)
+		time.Sleep(1 * time.Second) //nolint:forbidigo // simulates slow HTTP server to ensure client context cancellation is tested
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -188,7 +188,7 @@ func TestClient_OptionEndpointOverridesConfig(t *testing.T) {
 func TestClient_ConfigTimeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// Intentional sleep: Delay response to test timeout configuration
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond) //nolint:forbidigo // simulates slow HTTP server to trigger configured client timeout
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()

--- a/services/market-information/adapters/external/ecb/ecb_worker_test.go
+++ b/services/market-information/adapters/external/ecb/ecb_worker_test.go
@@ -243,8 +243,7 @@ func TestWorker_FetchError(t *testing.T) {
 	ctx := context.Background()
 	worker.Start(ctx)
 
-	// Wait briefly to allow the initial fetch to fail
-	// Since fetch fails, no observations should be recorded
+	//nolint:forbidigo // Intentional: verifying no observations recorded on fetch error (negative assertion) requires waiting
 	time.Sleep(200 * time.Millisecond)
 
 	worker.Stop()
@@ -272,7 +271,7 @@ func TestWorker_ParseError(t *testing.T) {
 	ctx := context.Background()
 	worker.Start(ctx)
 
-	// Wait briefly for initial fetch
+	//nolint:forbidigo // Intentional: verifying no observations recorded on parse error (negative assertion) requires waiting
 	time.Sleep(200 * time.Millisecond)
 
 	worker.Stop()
@@ -495,7 +494,7 @@ func TestWorker_RateLimited(t *testing.T) {
 	ctx := context.Background()
 	worker.Start(ctx)
 
-	// Wait briefly for fetch attempt
+	//nolint:forbidigo // Intentional: verifying no observations recorded on rate limiting (negative assertion) requires waiting
 	time.Sleep(200 * time.Millisecond)
 
 	worker.Stop()
@@ -642,7 +641,7 @@ func TestWorker_ImmediateFailureOnPermanentError(t *testing.T) {
 		})
 	require.NoError(t, err)
 
-	// Wait a bit more to ensure no retries happen
+	//nolint:forbidigo // Intentional: verifying no retries for permanent error (negative assertion) requires waiting
 	time.Sleep(500 * time.Millisecond)
 
 	worker.Stop()
@@ -687,7 +686,8 @@ func TestWorker_ContextCancellationDuringBackoff(t *testing.T) {
 
 	// Cancel context during backoff wait (before second attempt)
 	// First backoff is 1s, so cancel immediately after first failure
-	time.Sleep(100 * time.Millisecond) // Small delay to ensure we're in backoff
+	//nolint:forbidigo // Intentional: timed delay to ensure cancellation lands during backoff window, not before first attempt
+	time.Sleep(100 * time.Millisecond)
 	cancel()
 
 	// Worker should stop gracefully

--- a/services/market-information/adapters/external/ecb/ecb_worker_test.go
+++ b/services/market-information/adapters/external/ecb/ecb_worker_test.go
@@ -227,7 +227,9 @@ func TestWorker_ContextCancellation(t *testing.T) {
 
 func TestWorker_FetchError(t *testing.T) {
 	// Server returns error
+	var fetchCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fetchCount.Add(1)
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte("internal error"))
 	}))
@@ -243,8 +245,11 @@ func TestWorker_FetchError(t *testing.T) {
 	ctx := context.Background()
 	worker.Start(ctx)
 
-	//nolint:forbidigo // Intentional: verifying no observations recorded on fetch error (negative assertion) requires waiting
-	time.Sleep(200 * time.Millisecond)
+	// Wait until the worker has made at least one fetch attempt before asserting
+	err := await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		return fetchCount.Load() >= 1
+	})
+	require.NoError(t, err, "worker should make at least one fetch attempt")
 
 	worker.Stop()
 
@@ -255,7 +260,9 @@ func TestWorker_FetchError(t *testing.T) {
 
 func TestWorker_ParseError(t *testing.T) {
 	// Server returns invalid CSV
+	var fetchCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fetchCount.Add(1)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("invalid,csv,format"))
 	}))
@@ -271,8 +278,11 @@ func TestWorker_ParseError(t *testing.T) {
 	ctx := context.Background()
 	worker.Start(ctx)
 
-	//nolint:forbidigo // Intentional: verifying no observations recorded on parse error (negative assertion) requires waiting
-	time.Sleep(200 * time.Millisecond)
+	// Wait until the worker has made at least one fetch attempt before asserting
+	err := await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		return fetchCount.Load() >= 1
+	})
+	require.NoError(t, err, "worker should make at least one fetch attempt")
 
 	worker.Stop()
 
@@ -478,7 +488,9 @@ func TestWorker_ObservationAttributes(t *testing.T) {
 }
 
 func TestWorker_RateLimited(t *testing.T) {
+	var fetchCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fetchCount.Add(1)
 		w.WriteHeader(http.StatusTooManyRequests)
 		_, _ = w.Write([]byte("rate limited"))
 	}))
@@ -494,8 +506,11 @@ func TestWorker_RateLimited(t *testing.T) {
 	ctx := context.Background()
 	worker.Start(ctx)
 
-	//nolint:forbidigo // Intentional: verifying no observations recorded on rate limiting (negative assertion) requires waiting
-	time.Sleep(200 * time.Millisecond)
+	// Wait until the worker has made at least one fetch attempt before asserting
+	err := await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		return fetchCount.Load() >= 1
+	})
+	require.NoError(t, err, "worker should make at least one fetch attempt")
 
 	worker.Stop()
 
@@ -641,8 +656,8 @@ func TestWorker_ImmediateFailureOnPermanentError(t *testing.T) {
 		})
 	require.NoError(t, err)
 
-	//nolint:forbidigo // Intentional: verifying no retries for permanent error (negative assertion) requires waiting
-	time.Sleep(500 * time.Millisecond)
+	//nolint:forbidigo // Intentional: wait past first retry backoff (~1s) to verify no retry occurs for permanent error
+	time.Sleep(1500 * time.Millisecond)
 
 	worker.Stop()
 

--- a/services/market-information/e2e/e2e_test.go
+++ b/services/market-information/e2e/e2e_test.go
@@ -1053,7 +1053,7 @@ func TestE2E_AsyncOperationsWithAwait(t *testing.T) {
 
 		// Create observation in goroutine with delay
 		go func() {
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(100 * time.Millisecond) //nolint:forbidigo // simulates async processing delay
 			now := time.Now().UTC()
 			obs, _ := domain.NewMarketPriceObservation(
 				"ASYNC_TEST",

--- a/services/market-information/observability/metrics_test.go
+++ b/services/market-information/observability/metrics_test.go
@@ -12,7 +12,7 @@ func TestOperationTimer_ObserveSuccess(t *testing.T) {
 		timer := NewOperationTimer(OperationDefineDataset)
 
 		// Simulate some work
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond) //nolint:forbidigo // simulates operation latency for metrics measurement
 
 		timer.ObserveSuccess()
 

--- a/services/operational-gateway/adapters/httpadapter/http_dispatcher_test.go
+++ b/services/operational-gateway/adapters/httpadapter/http_dispatcher_test.go
@@ -799,7 +799,7 @@ func TestDispatch_LargeResponseBody_TruncatesAt1MiB(t *testing.T) {
 func TestDispatch_ContextDeadlineExceeded_ReturnsError(t *testing.T) {
 	// Server delays response beyond the context deadline.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(500 * time.Millisecond) //nolint:forbidigo // simulates slow HTTP server to trigger context deadline exceeded
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()

--- a/services/party/adapters/persistence/verification_repository_test.go
+++ b/services/party/adapters/persistence/verification_repository_test.go
@@ -302,8 +302,7 @@ func TestListVerificationsByParty(t *testing.T) {
 		}
 		err := repo.CreateVerification(ctx, verification)
 		require.NoError(t, err)
-		// Intentional sleep: Ensure different timestamps for ordering tests
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond) //nolint:forbidigo // ensures distinct timestamps for DB ordering test
 	}
 
 	// List verifications

--- a/services/party/verification/provider_test.go
+++ b/services/party/verification/provider_test.go
@@ -121,8 +121,7 @@ func TestMockProvider_SimulatedDelay_RespectsContextCancellation(t *testing.T) {
 
 	// Cancel context after a short time
 	go func() {
-		// Intentional sleep: Delay before cancelling to test cancellation handling
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond) //nolint:forbidigo // triggers context cancellation mid-verification
 		cancel()
 	}()
 

--- a/services/party/verification/timeout_handler_test.go
+++ b/services/party/verification/timeout_handler_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/services/party/adapters/persistence"
+	"github.com/meridianhub/meridian/shared/platform/await"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -166,8 +167,10 @@ func TestTimeoutHandler_DetectsTimedOutVerifications(t *testing.T) {
 		close(done)
 	}()
 
-	// Wait for at least one poll cycle
-	time.Sleep(200 * time.Millisecond)
+	// Wait for the handler to process the timed-out verification
+	require.NoError(t, await.New().AtMost(5*time.Second).PollInterval(10*time.Millisecond).Until(func() bool {
+		return len(repo.getUpdatedCalls()) >= 1
+	}), "handler did not process timed-out verification within timeout")
 	cancel()
 	<-done
 
@@ -231,7 +234,9 @@ func TestTimeoutHandler_ProviderReturnsApproved(t *testing.T) {
 		close(done)
 	}()
 
-	time.Sleep(200 * time.Millisecond)
+	require.NoError(t, await.New().AtMost(5*time.Second).PollInterval(10*time.Millisecond).Until(func() bool {
+		return len(repo.getUpdatedCalls()) >= 1
+	}), "handler did not process verification within timeout")
 	cancel()
 	<-done
 
@@ -290,7 +295,9 @@ func TestTimeoutHandler_ProviderReturnsRejected(t *testing.T) {
 		close(done)
 	}()
 
-	time.Sleep(200 * time.Millisecond)
+	require.NoError(t, await.New().AtMost(5*time.Second).PollInterval(10*time.Millisecond).Until(func() bool {
+		return len(repo.getUpdatedCalls()) >= 1
+	}), "handler did not process verification within timeout")
 	cancel()
 	<-done
 
@@ -338,7 +345,7 @@ func TestTimeoutHandler_IgnoresCompletedVerifications(t *testing.T) {
 		close(done)
 	}()
 
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond) //nolint:forbidigo // gives handler time to run at least one poll cycle (asserting absence of processing)
 	cancel()
 	<-done
 
@@ -445,7 +452,14 @@ func TestTimeoutHandler_HandlesProviderErrorsGracefully(t *testing.T) {
 		close(done)
 	}()
 
-	time.Sleep(200 * time.Millisecond)
+	require.NoError(t, await.New().AtMost(5*time.Second).PollInterval(10*time.Millisecond).Until(func() bool {
+		for _, u := range repo.getUpdatedCalls() {
+			if u.VerificationID == v2 {
+				return true
+			}
+		}
+		return false
+	}), "handler did not process provider-ok verification within timeout")
 	cancel()
 	<-done
 
@@ -524,7 +538,9 @@ func TestTimeoutHandler_ProviderReturnsManualReview(t *testing.T) {
 		close(done)
 	}()
 
-	time.Sleep(200 * time.Millisecond)
+	require.NoError(t, await.New().AtMost(5*time.Second).PollInterval(10*time.Millisecond).Until(func() bool {
+		return len(repo.getUpdatedCalls()) >= 1
+	}), "handler did not process verification within timeout")
 	cancel()
 	<-done
 

--- a/services/payment-order/adapters/gateway/stripe/client_test.go
+++ b/services/payment-order/adapters/gateway/stripe/client_test.go
@@ -168,7 +168,7 @@ func TestClientFactory_NewClient_CacheExpires(t *testing.T) {
 	assert.Equal(t, int64(1), provider.callCount.Load())
 
 	// Wait for cache to expire
-	time.Sleep(60 * time.Millisecond)
+	time.Sleep(60 * time.Millisecond) //nolint:forbidigo // triggers cache TTL expiry
 
 	// Second call should fetch again
 	_, err = factory.NewClient(ctx)

--- a/services/payment-order/adapters/gateway/stripe/manifest_tenant_config_test.go
+++ b/services/payment-order/adapters/gateway/stripe/manifest_tenant_config_test.go
@@ -159,7 +159,7 @@ func TestManifestTenantConfigProvider_CacheExpiry(t *testing.T) {
 	assert.Equal(t, int32(1), mock.callCount.Load())
 
 	// Wait for cache to expire
-	time.Sleep(5 * time.Millisecond)
+	time.Sleep(5 * time.Millisecond) //nolint:forbidigo // triggers cache TTL expiry
 
 	// Second call - cache expired
 	_, err = provider.GetTenantConfig("tenant_abc")

--- a/services/payment-order/e2e/e2e_test.go
+++ b/services/payment-order/e2e/e2e_test.go
@@ -1117,7 +1117,7 @@ func TestPaymentSaga_E2E_Idempotency(t *testing.T) {
 
 	// InitiateLien should only be called once (not for the duplicate)
 	// Give some time for potential extra calls
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond) //nolint:forbidigo // gives time for potential duplicate calls to materialize
 	assert.LessOrEqual(t, atomic.LoadInt32(&env.CurrentAccountClient.initiateLienCalls), int32(1),
 		"InitiateLien should be called at most once for idempotent requests")
 }

--- a/services/payment-order/service/account_resolver_test.go
+++ b/services/payment-order/service/account_resolver_test.go
@@ -12,6 +12,8 @@ import (
 	internalaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_account/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/shared/platform/await"
 )
 
 // mockInternalAccountClient is a mock implementation of InternalAccountClient for testing.
@@ -220,13 +222,15 @@ func TestAccountResolver_GetSettlementClearingAccount_CacheExpiry(t *testing.T) 
 	require.NoError(t, err)
 	assert.Equal(t, 1, mockClient.getCallCount())
 
-	// Wait for cache to expire (3x safety margin for CI scheduling variance)
-	time.Sleep(3 * cacheTTL)
+	// Wait for cache to expire, then verify the next call reaches the client
+	var secondErr error
+	require.NoError(t, await.New().AtMost(500*time.Millisecond).PollInterval(5*time.Millisecond).Until(func() bool {
+		_, secondErr = resolver.GetSettlementClearingAccount(context.Background(), "GBP")
+		return mockClient.getCallCount() >= 2
+	}), "cache should have expired and triggered a new client call")
 
-	// Second call - cache expired, should call client again
-	_, err = resolver.GetSettlementClearingAccount(context.Background(), "GBP")
-	require.NoError(t, err)
-	assert.Equal(t, 2, mockClient.getCallCount())
+	require.NoError(t, secondErr)
+	assert.GreaterOrEqual(t, mockClient.getCallCount(), 2)
 }
 
 // =============================================================================

--- a/services/payment-order/worker/dunning_worker_test.go
+++ b/services/payment-order/worker/dunning_worker_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"github.com/meridianhub/meridian/shared/platform/await"
 	"github.com/meridianhub/meridian/shared/platform/scheduler"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/redis/go-redis/v9"
@@ -126,7 +127,7 @@ func TestDunningWorker_StartStop(t *testing.T) {
 		<-started
 
 		// Give the poll loop time to run at least once
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond) //nolint:forbidigo // gives poll loop time to run at least once
 
 		w.Stop()
 
@@ -153,7 +154,7 @@ func TestDunningWorker_StartStop(t *testing.T) {
 		<-started
 
 		// Give Start time to acquire running state
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond) //nolint:forbidigo // gives worker time to enter running state
 
 		err = w.Start(context.Background())
 		assert.ErrorIs(t, err, scheduler.ErrAlreadyRunning)
@@ -174,7 +175,7 @@ func TestDunningWorker_StartStop(t *testing.T) {
 			errCh <- w.Start(ctx)
 		}()
 
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond) //nolint:forbidigo // gives worker time to start before cancellation
 		cancel()
 
 		select {
@@ -238,20 +239,13 @@ func TestDunningWorker_ScheduleAndProcess(t *testing.T) {
 		}()
 
 		// Wait for the callback to fire
-		deadline := time.After(5 * time.Second)
-		for !callbackCalled.Load() {
-			select {
-			case <-deadline:
-				t.Fatal("callback was not called within timeout")
-			default:
-				time.Sleep(10 * time.Millisecond)
-			}
-		}
+		require.NoError(t, await.New().AtMost(5*time.Second).PollInterval(10*time.Millisecond).Until(func() bool {
+			return callbackCalled.Load()
+		}), "callback was not called within timeout")
 
 		// Wait for the ZREM to complete (happens after callback in the same poll cycle).
 		// Poll before calling Stop() to avoid context cancellation racing with ZREM.
-		zsetDeadline := time.After(5 * time.Second)
-		for {
+		require.NoError(t, await.New().AtMost(5*time.Second).PollInterval(10*time.Millisecond).Until(func() bool {
 			members, zErr := client.ZRangeArgs(context.Background(), redis.ZRangeArgs{
 				Key:     zsetKey,
 				Start:   "-inf",
@@ -259,16 +253,8 @@ func TestDunningWorker_ScheduleAndProcess(t *testing.T) {
 				ByScore: true,
 			}).Result()
 			require.NoError(t, zErr)
-			if len(members) == 0 {
-				break
-			}
-			select {
-			case <-zsetDeadline:
-				t.Fatalf("ZSET not drained within timeout, remaining: %v", members)
-			default:
-				time.Sleep(10 * time.Millisecond)
-			}
-		}
+			return len(members) == 0
+		}), "ZSET not drained within timeout")
 
 		w.Stop()
 	})
@@ -312,7 +298,7 @@ func TestDunningWorker_ScheduleAndProcess(t *testing.T) {
 		}()
 
 		// Wait for a poll cycle
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond) //nolint:forbidigo // gives worker time to run at least one poll cycle
 		w.Stop()
 
 		assert.False(t, callbackCalled.Load(), "callback should not be called for non-failed billing run")
@@ -339,7 +325,7 @@ func TestDunningWorker_ScheduleAndProcess(t *testing.T) {
 			_ = w.Start(context.Background())
 		}()
 
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond) //nolint:forbidigo // gives worker time to run at least one poll cycle
 		w.Stop()
 
 		// Verify the retry was removed from the ZSET (dropped)
@@ -389,7 +375,7 @@ func TestDunningWorker_ScheduleAndProcess(t *testing.T) {
 			_ = w.Start(context.Background())
 		}()
 
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond) //nolint:forbidigo // gives worker time to run at least one poll cycle
 		w.Stop()
 
 		// Verify the retry is still in the ZSET
@@ -538,7 +524,7 @@ func TestDunningWorker_GracefulShutdownWaitsForInFlight(t *testing.T) {
 
 	var callbackCompleted atomic.Bool
 	slowCallback := func(_ context.Context, _ *domain.BillingRun) error {
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond) //nolint:forbidigo // simulates slow callback latency
 		callbackCompleted.Store(true)
 		return nil
 	}
@@ -558,7 +544,7 @@ func TestDunningWorker_GracefulShutdownWaitsForInFlight(t *testing.T) {
 	}()
 
 	// Wait for the callback to start
-	time.Sleep(150 * time.Millisecond)
+	time.Sleep(150 * time.Millisecond) //nolint:forbidigo // gives worker time to start processing callback
 
 	// Stop should wait for the slow callback to complete
 	w.Stop()
@@ -593,7 +579,7 @@ func TestDunningWorker_InvalidMemberInZSET(t *testing.T) {
 		_ = w.Start(ctx)
 	}()
 
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond) //nolint:forbidigo // gives worker time to run at least one poll cycle
 	w.Stop()
 
 	// Invalid member should be removed
@@ -636,7 +622,7 @@ func TestDunningWorker_RepoErrorRetainsRetry(t *testing.T) {
 		_ = w.Start(ctx)
 	}()
 
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond) //nolint:forbidigo // gives worker time to run at least one poll cycle
 	w.Stop()
 
 	// Retry should still be in the ZSET
@@ -798,15 +784,9 @@ func TestDunningWorker_TenantIsolation_Processing(t *testing.T) {
 	}()
 
 	// Wait for both to be processed
-	deadline := time.After(5 * time.Second)
-	for !processedA.Load() || !processedB.Load() {
-		select {
-		case <-deadline:
-			t.Fatalf("expected both tenants processed, got A=%v B=%v", processedA.Load(), processedB.Load())
-		default:
-			time.Sleep(10 * time.Millisecond)
-		}
-	}
+	require.NoError(t, await.New().AtMost(5*time.Second).PollInterval(10*time.Millisecond).Until(func() bool {
+		return processedA.Load() && processedB.Load()
+	}), "expected both tenants to be processed within timeout")
 
 	// Both billing runs should have been processed
 	assert.True(t, processedA.Load(), "tenant A's billing run should have been processed")
@@ -815,20 +795,11 @@ func TestDunningWorker_TenantIsolation_Processing(t *testing.T) {
 	// Wait for ZSET cleanup to complete (ZRem happens after the callback)
 	keyA := dunningRetryZSetPrefix + tenantA
 	keyB := dunningRetryZSetPrefix + tenantB
-	cleanupDeadline := time.After(5 * time.Second)
-	for {
+	require.NoError(t, await.New().AtMost(5*time.Second).PollInterval(10*time.Millisecond).Until(func() bool {
 		countA, _ := client.ZCard(ctx, keyA).Result()
 		countB, _ := client.ZCard(ctx, keyB).Result()
-		if countA == 0 && countB == 0 {
-			break
-		}
-		select {
-		case <-cleanupDeadline:
-			t.Fatalf("ZSET cleanup timeout: A=%d B=%d", countA, countB)
-		default:
-			time.Sleep(10 * time.Millisecond)
-		}
-	}
+		return countA == 0 && countB == 0
+	}), "ZSET cleanup timeout")
 
 	w.Stop()
 

--- a/services/position-keeping/cmd/main_test.go
+++ b/services/position-keeping/cmd/main_test.go
@@ -287,7 +287,7 @@ func TestHealthServer_Watch_RespectsContext(t *testing.T) {
 	}()
 
 	// Intentional sleep: Give grpc health watch time to send initial status
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond) //nolint:forbidigo // gives gRPC health Watch time to send initial status
 
 	// Cancel the context
 	streamCancel()

--- a/services/position-keeping/cmd/main_test.go
+++ b/services/position-keeping/cmd/main_test.go
@@ -5,12 +5,15 @@ import (
 	"errors"
 	"log/slog"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/meridianhub/meridian/services/position-keeping/app"
 	"github.com/meridianhub/meridian/services/position-keeping/observability"
 	"github.com/meridianhub/meridian/shared/pkg/health"
+	"github.com/meridianhub/meridian/shared/platform/await"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
@@ -18,6 +21,7 @@ import (
 type mockHealthWatchServer struct {
 	grpc_health_v1.Health_WatchServer
 	ctx       context.Context
+	mu        sync.Mutex
 	responses []*grpc_health_v1.HealthCheckResponse
 	sendErr   error
 }
@@ -30,8 +34,25 @@ func (m *mockHealthWatchServer) Send(resp *grpc_health_v1.HealthCheckResponse) e
 	if m.sendErr != nil {
 		return m.sendErr
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.responses = append(m.responses, resp)
 	return nil
+}
+
+func (m *mockHealthWatchServer) responseCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.responses)
+}
+
+func (m *mockHealthWatchServer) firstResponse() *grpc_health_v1.HealthCheckResponse {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.responses) == 0 {
+		return nil
+	}
+	return m.responses[0]
 }
 
 func TestHealthServer_Check_WithHealthyDatabase(t *testing.T) {
@@ -222,12 +243,11 @@ func TestHealthServer_Watch_SendsInitialStatus(t *testing.T) {
 	}
 
 	// Verify at least initial status was sent
-	if len(mockStream.responses) < 1 {
-		t.Errorf("Watch() sent %d responses, want at least 1", len(mockStream.responses))
+	if mockStream.responseCount() < 1 {
+		t.Errorf("Watch() sent %d responses, want at least 1", mockStream.responseCount())
 	}
 
-	if len(mockStream.responses) > 0 {
-		firstResp := mockStream.responses[0]
+	if firstResp := mockStream.firstResponse(); firstResp != nil {
 		if firstResp.Status != grpc_health_v1.HealthCheckResponse_SERVING &&
 			firstResp.Status != grpc_health_v1.HealthCheckResponse_NOT_SERVING {
 			t.Errorf("Watch() initial status = %v, want SERVING or NOT_SERVING", firstResp.Status)
@@ -286,8 +306,10 @@ func TestHealthServer_Watch_RespectsContext(t *testing.T) {
 		done <- healthSrv.Watch(&grpc_health_v1.HealthCheckRequest{}, mockStream)
 	}()
 
-	// Intentional sleep: Give grpc health watch time to send initial status
-	time.Sleep(50 * time.Millisecond) //nolint:forbidigo // gives gRPC health Watch time to send initial status
+	// Wait for Watch to send initial status before cancelling
+	require.NoError(t, await.New().AtMost(500*time.Millisecond).PollInterval(5*time.Millisecond).Until(func() bool {
+		return mockStream.responseCount() >= 1
+	}), "Watch should send at least one response before cancellation")
 
 	// Cancel the context
 	streamCancel()

--- a/services/position-keeping/service/account_validator_test.go
+++ b/services/position-keeping/service/account_validator_test.go
@@ -220,12 +220,11 @@ func TestValidateExists_CacheMiss(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, client.GetCallCount())
 
-	// Wait for cache to expire
-	time.Sleep(5 * time.Millisecond) //nolint:forbidigo // triggers cache TTL expiry
-
-	// Second call - cache should have expired
-	err = validator.ValidateExists(context.Background(), "cache-miss-account")
-	require.NoError(t, err)
+	// Poll until cache expires and the next call increments the backend call count
+	require.NoError(t, await.New().AtMost(500*time.Millisecond).PollInterval(5*time.Millisecond).Until(func() bool {
+		_ = validator.ValidateExists(context.Background(), "cache-miss-account")
+		return client.GetCallCount() >= 2
+	}), "cache should expire and trigger a new backend call")
 	assert.Equal(t, 2, client.GetCallCount()) // Count should increase
 }
 

--- a/services/position-keeping/service/account_validator_test.go
+++ b/services/position-keeping/service/account_validator_test.go
@@ -221,7 +221,7 @@ func TestValidateExists_CacheMiss(t *testing.T) {
 	assert.Equal(t, 1, client.GetCallCount())
 
 	// Wait for cache to expire
-	time.Sleep(5 * time.Millisecond)
+	time.Sleep(5 * time.Millisecond) //nolint:forbidigo // triggers cache TTL expiry
 
 	// Second call - cache should have expired
 	err = validator.ValidateExists(context.Background(), "cache-miss-account")
@@ -303,7 +303,7 @@ func TestValidateExists_ConcurrentRequests_NoStampede(t *testing.T) {
 		retrieveFunc: func(_ context.Context, req *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
 			callCount.Add(1)
 			// Simulate slow service response
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(50 * time.Millisecond) //nolint:forbidigo // simulates slow service response latency
 			return &currentaccountv1.RetrieveCurrentAccountResponse{
 				Facility: &currentaccountv1.CurrentAccountFacility{
 					AccountId: req.GetAccountId(),

--- a/services/position-keeping/worker/compaction_worker_test.go
+++ b/services/position-keeping/worker/compaction_worker_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/meridianhub/meridian/shared/platform/await"
+	"github.com/stretchr/testify/require"
 )
 
 // mockPool creates a minimal pool configuration for testing

--- a/services/position-keeping/worker/compaction_worker_test.go
+++ b/services/position-keeping/worker/compaction_worker_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/shared/platform/await"
 )
 
 // mockPool creates a minimal pool configuration for testing
@@ -284,8 +285,12 @@ func TestCompactionWorker_ContextCancellation(t *testing.T) {
 		startErr <- worker.Start(ctx)
 	}()
 
-	// Give worker time to start
-	time.Sleep(50 * time.Millisecond)
+	// Wait for worker to enter running state
+	_ = await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		worker.mu.Lock()
+		defer worker.mu.Unlock()
+		return worker.running
+	})
 
 	// Cancel context
 	cancel()
@@ -322,8 +327,12 @@ func TestCompactionWorker_StopSignal(t *testing.T) {
 		startErr <- worker.Start(ctx)
 	}()
 
-	// Give worker time to start
-	time.Sleep(50 * time.Millisecond)
+	// Wait for worker to enter running state
+	_ = await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		worker.mu.Lock()
+		defer worker.mu.Unlock()
+		return worker.running
+	})
 
 	// Call Stop
 	var wg sync.WaitGroup

--- a/services/position-keeping/worker/compaction_worker_test.go
+++ b/services/position-keeping/worker/compaction_worker_test.go
@@ -286,11 +286,11 @@ func TestCompactionWorker_ContextCancellation(t *testing.T) {
 	}()
 
 	// Wait for worker to enter running state
-	_ = await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+	require.NoError(t, await.New().AtMost(2*time.Second).PollInterval(10*time.Millisecond).Until(func() bool {
 		worker.mu.Lock()
 		defer worker.mu.Unlock()
 		return worker.running
-	})
+	}), "worker should reach running state")
 
 	// Cancel context
 	cancel()
@@ -328,11 +328,11 @@ func TestCompactionWorker_StopSignal(t *testing.T) {
 	}()
 
 	// Wait for worker to enter running state
-	_ = await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+	require.NoError(t, await.New().AtMost(2*time.Second).PollInterval(10*time.Millisecond).Until(func() bool {
 		worker.mu.Lock()
 		defer worker.mu.Unlock()
 		return worker.running
-	})
+	}), "worker should reach running state")
 
 	// Call Stop
 	var wg sync.WaitGroup

--- a/services/reconciliation/adapters/persistence/balance_assertion_repository_test.go
+++ b/services/reconciliation/adapters/persistence/balance_assertion_repository_test.go
@@ -331,7 +331,7 @@ func TestBalanceAssertionRepository_ListPagination(t *testing.T) {
 		a := newTestBalanceAssertion(t)
 		require.NoError(t, repo.Create(ctx, a))
 		// Small delay to ensure distinct created_at for ordering
-		time.Sleep(time.Millisecond)
+		time.Sleep(time.Millisecond) //nolint:forbidigo // ensures distinct timestamps for DB ordering test
 	}
 
 	t.Run("limit", func(t *testing.T) {

--- a/services/reconciliation/service/finalizer_test.go
+++ b/services/reconciliation/service/finalizer_test.go
@@ -366,7 +366,7 @@ func TestFinalizeSettlement_LockExhaustedRetries(t *testing.T) {
 
 	// Cancel context after first attempt to speed up test
 	go func() {
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond) //nolint:forbidigo // triggers lock retry cancellation after first attempt
 		cancel()
 	}()
 

--- a/services/reference-data/accounttype/postgres_registry_test.go
+++ b/services/reference-data/accounttype/postgres_registry_test.go
@@ -595,7 +595,7 @@ func TestPostgresAccountTypeRegistry_LifecycleTimestamps(t *testing.T) {
 		original, err := reg.GetDefinition(ctx, "TIMESTAMPS_AT", 1)
 		require.NoError(t, err)
 
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond) //nolint:forbidigo // ensures distinct timestamps between read and update
 
 		updates := &accounttype.Definition{DisplayName: "Updated Name"}
 		require.NoError(t, reg.UpdateDefinition(ctx, "TIMESTAMPS_AT", 1, updates))

--- a/services/reference-data/cache/account_type_cache_test.go
+++ b/services/reference-data/cache/account_type_cache_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/meridianhub/meridian/services/reference-data/accounttype"
+	"github.com/meridianhub/meridian/shared/platform/await"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
 
@@ -260,7 +261,7 @@ func TestLocalAccountTypeCache_TTLExpiry_RegularDefinition(t *testing.T) {
 	require.NotNil(t, cached)
 
 	// Wait for TTL expiry
-	time.Sleep(60 * time.Millisecond)
+	time.Sleep(60 * time.Millisecond) //nolint:forbidigo // triggers TTL expiry to test cache expiration
 
 	// Should be expired
 	expired := cache.Get(ctx, def.Code, def.Version)
@@ -396,7 +397,7 @@ func TestLocalAccountTypeCache_ExpiredSystemBlueprintTriggersBackgroundRefresh(t
 	lruCache.Add(AccountTypeKey{Code: "SYSTEM_NOSTRO", Version: 1}, entry)
 
 	// Wait for expiry
-	time.Sleep(60 * time.Millisecond)
+	time.Sleep(60 * time.Millisecond) //nolint:forbidigo // triggers TTL expiry to test stale-while-revalidate behavior
 
 	// Get should return stale entry (not nil) and trigger background refresh
 	result := cache.Get(ctx, "SYSTEM_NOSTRO", 1)
@@ -404,7 +405,14 @@ func TestLocalAccountTypeCache_ExpiredSystemBlueprintTriggersBackgroundRefresh(t
 	assert.Equal(t, "SYSTEM_NOSTRO", result.Definition.Code)
 
 	// Wait for background refresh to complete
-	time.Sleep(100 * time.Millisecond)
+	err := await.New().
+		AtMost(2 * time.Second).
+		PollInterval(20 * time.Millisecond).
+		Until(func() bool {
+			refreshed := cache.Get(ctx, "SYSTEM_NOSTRO", 1)
+			return refreshed != nil && refreshed.ExpiresAt().After(time.Now())
+		})
+	require.NoError(t, err, "background refresh should complete with fresh TTL")
 
 	// After refresh, entry should have a fresh TTL
 	refreshed := cache.Get(ctx, "SYSTEM_NOSTRO", 1)

--- a/services/reference-data/cache/account_type_cache_test.go
+++ b/services/reference-data/cache/account_type_cache_test.go
@@ -405,7 +405,7 @@ func TestLocalAccountTypeCache_ExpiredSystemBlueprintTriggersBackgroundRefresh(t
 	assert.Equal(t, "SYSTEM_NOSTRO", result.Definition.Code)
 
 	// Wait for background refresh to complete
-	err := await.New().
+	err = await.New().
 		AtMost(2 * time.Second).
 		PollInterval(20 * time.Millisecond).
 		Until(func() bool {

--- a/services/reference-data/cache/instrument_cache_test.go
+++ b/services/reference-data/cache/instrument_cache_test.go
@@ -131,7 +131,7 @@ func TestInstrumentCache_TTLExpiration(t *testing.T) {
 	require.NotNil(t, result)
 
 	// Wait for expiration
-	time.Sleep(60 * time.Millisecond)
+	time.Sleep(60 * time.Millisecond) //nolint:forbidigo // triggers TTL expiry to test cache expiration
 
 	// Should be expired now
 	result = cache.Get(ctx, "USD", 1)
@@ -576,7 +576,7 @@ func TestInstrumentCache_GetOrLoad_SingleflightDeduplication(t *testing.T) {
 			results[idx], errs[idx] = cache.GetOrLoad(ctx, "USD", 1, func() (*CachedInstrument, error) {
 				atomic.AddInt32(&loadCalled, 1)
 				// Simulate some load time to increase overlap window
-				time.Sleep(10 * time.Millisecond)
+				time.Sleep(10 * time.Millisecond) //nolint:forbidigo // simulates loader latency to create singleflight overlap
 				return newTestInstrument("USD", 1), nil
 			})
 		}(i)
@@ -613,7 +613,7 @@ func TestInstrumentCache_GetOrLoad_SingleflightTenantIsolation(t *testing.T) {
 		defer wg.Done()
 		_, _ = cache.GetOrLoad(ctx1, "USD", 1, func() (*CachedInstrument, error) {
 			atomic.AddInt32(&loadCalled1, 1)
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond) //nolint:forbidigo // simulates loader latency to test tenant isolation
 			return newTestInstrument("USD", 1), nil
 		})
 	}()
@@ -622,7 +622,7 @@ func TestInstrumentCache_GetOrLoad_SingleflightTenantIsolation(t *testing.T) {
 		defer wg.Done()
 		_, _ = cache.GetOrLoad(ctx2, "USD", 1, func() (*CachedInstrument, error) {
 			atomic.AddInt32(&loadCalled2, 1)
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond) //nolint:forbidigo // simulates loader latency to test tenant isolation
 			return newTestInstrument("USD", 1), nil
 		})
 	}()

--- a/services/reference-data/cache/tiered_cache_test.go
+++ b/services/reference-data/cache/tiered_cache_test.go
@@ -38,7 +38,7 @@ func (m *mockSource) GetDefinition(ctx context.Context, code string, version int
 	atomic.AddInt32(&m.loadCount, 1)
 
 	if m.loadDelay > 0 {
-		time.Sleep(m.loadDelay)
+		time.Sleep(m.loadDelay) //nolint:forbidigo // simulates source latency in mock
 	}
 
 	if m.loadErr != nil {

--- a/services/reference-data/e2e/e2e_test.go
+++ b/services/reference-data/e2e/e2e_test.go
@@ -342,35 +342,45 @@ func seedSystemInstrument(t *testing.T, pool *pgxpool.Pool, ctx context.Context,
 	require.NoError(t, tx.Commit(ctx))
 }
 
-// insertPosition inserts a position record directly via SQL.
-func insertPosition(t *testing.T, pool *pgxpool.Pool, ctx context.Context, accountID, instrumentCode, bucketKey string, amount decimal.Decimal, dimension string, attributes map[string]string) uuid.UUID {
-	t.Helper()
-
+// insertPositionErr inserts a position record directly via SQL, returning any error.
+// Use this variant when calling from goroutines (to avoid t.Fatal from a non-test goroutine).
+func insertPositionErr(pool *pgxpool.Pool, ctx context.Context, accountID, instrumentCode, bucketKey string, amount decimal.Decimal, dimension string, attributes map[string]string) (uuid.UUID, error) {
 	tenantID, _ := tenant.FromContext(ctx)
 	schemaName := tenantID.SchemaName()
 
 	id := uuid.New()
 
 	tx, err := pool.Begin(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		return uuid.Nil, err
+	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
-	require.NoError(t, err)
+	if _, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName))); err != nil {
+		return uuid.Nil, err
+	}
 
 	var attrsJSON interface{}
 	if attributes != nil {
 		attrsJSON = attributes
 	}
 
-	_, err = tx.Exec(ctx, `
+	if _, err = tx.Exec(ctx, `
 		INSERT INTO position (id, created_at, created_by, account_id, instrument_code, bucket_key, amount, dimension, attributes)
 		VALUES ($1, NOW(), 'test-system', $2, $3, $4, $5, $6, $7)`,
 		id, accountID, instrumentCode, bucketKey, amount, dimension, attrsJSON,
-	)
-	require.NoError(t, err)
+	); err != nil {
+		return uuid.Nil, err
+	}
 
-	require.NoError(t, tx.Commit(ctx))
+	return id, tx.Commit(ctx)
+}
+
+// insertPosition inserts a position record directly via SQL.
+func insertPosition(t *testing.T, pool *pgxpool.Pool, ctx context.Context, accountID, instrumentCode, bucketKey string, amount decimal.Decimal, dimension string, attributes map[string]string) uuid.UUID {
+	t.Helper()
+	id, err := insertPositionErr(pool, ctx, accountID, instrumentCode, bucketKey, amount, dimension, attributes)
+	require.NoError(t, err)
 	return id
 }
 
@@ -1079,11 +1089,14 @@ func TestE2E_AsyncOperationsWithAwait(t *testing.T) {
 	})
 
 	t.Run("Wait for position to appear", func(t *testing.T) {
-		// Simulate async position creation
+		// Simulate async position creation; use a channel to propagate errors
+		// back to the main goroutine (avoid t.Fatal from non-test goroutines).
+		insertErrCh := make(chan error, 1)
 		go func() {
 			time.Sleep(150 * time.Millisecond) //nolint:forbidigo // simulates async position creation delay
-			insertPosition(t, pool, ctx, "ASYNC-ACC", "ASYNC_TEST", "bucket",
+			_, err := insertPositionErr(pool, ctx, "ASYNC-ACC", "ASYNC_TEST", "bucket",
 				decimal.NewFromFloat(123.45), "Custom", nil)
+			insertErrCh <- err
 		}()
 
 		// Use await to poll for position
@@ -1104,6 +1117,7 @@ func TestE2E_AsyncOperationsWithAwait(t *testing.T) {
 			})
 
 		require.NoError(t, err, "position should be created")
+		require.NoError(t, <-insertErrCh, "async insertPosition should succeed")
 		assert.True(t, decimal.NewFromFloat(123.45).Equal(finalTotal))
 		assert.Equal(t, int64(1), finalCount)
 	})

--- a/services/reference-data/e2e/e2e_test.go
+++ b/services/reference-data/e2e/e2e_test.go
@@ -1059,7 +1059,7 @@ func TestE2E_AsyncOperationsWithAwait(t *testing.T) {
 
 		// Simulate async activation (in real scenario, this might be an event handler)
 		go func() {
-			time.Sleep(100 * time.Millisecond) // Simulate delay
+			time.Sleep(100 * time.Millisecond) //nolint:forbidigo // simulates async event handler delay
 			_ = reg.ActivateInstrument(ctx, "ASYNC_TEST", 1)
 		}()
 
@@ -1081,7 +1081,7 @@ func TestE2E_AsyncOperationsWithAwait(t *testing.T) {
 	t.Run("Wait for position to appear", func(t *testing.T) {
 		// Simulate async position creation
 		go func() {
-			time.Sleep(150 * time.Millisecond)
+			time.Sleep(150 * time.Millisecond) //nolint:forbidigo // simulates async position creation delay
 			insertPosition(t, pool, ctx, "ASYNC-ACC", "ASYNC_TEST", "bucket",
 				decimal.NewFromFloat(123.45), "Custom", nil)
 		}()

--- a/services/reference-data/middleware/rate_limit_interceptor_test.go
+++ b/services/reference-data/middleware/rate_limit_interceptor_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/meridianhub/meridian/shared/platform/await"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -206,7 +207,7 @@ func TestRateLimitInterceptor_TokenReplenishment(t *testing.T) {
 	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
 
 	// Wait for token to replenish
-	time.Sleep(60 * time.Millisecond)
+	time.Sleep(60 * time.Millisecond) //nolint:forbidigo // triggers rate limit token replenishment
 
 	// Should succeed again
 	_, err = handler(ctx, nil, info, testHandler)
@@ -276,7 +277,13 @@ func TestRateLimitInterceptor_CleanupIdleLimiters(t *testing.T) {
 	assert.Equal(t, 1, interceptor.ActiveLimiters())
 
 	// Wait for cleanup to evict it
-	time.Sleep(200 * time.Millisecond)
+	err = await.New().
+		AtMost(2 * time.Second).
+		PollInterval(20 * time.Millisecond).
+		Until(func() bool {
+			return interceptor.ActiveLimiters() == 0
+		})
+	require.NoError(t, err, "idle limiter should be evicted by cleanup")
 
 	assert.Equal(t, 0, interceptor.ActiveLimiters())
 }
@@ -343,7 +350,15 @@ func TestRateLimitMetrics_ActiveLimitersGauge(t *testing.T) {
 	assert.Equal(t, float64(3), gaugeMetric.Gauge.GetValue())
 
 	// Wait for cleanup
-	time.Sleep(200 * time.Millisecond)
+	err = await.New().
+		AtMost(2 * time.Second).
+		PollInterval(20 * time.Millisecond).
+		Until(func() bool {
+			m := &dto.Metric{}
+			_ = metrics.active.Write(m)
+			return m.Gauge.GetValue() == 0
+		})
+	require.NoError(t, err, "active limiters gauge should reach 0 after cleanup")
 
 	err = metrics.active.Write(gaugeMetric)
 	require.NoError(t, err)

--- a/services/reference-data/registry/postgres_registry_test.go
+++ b/services/reference-data/registry/postgres_registry_test.go
@@ -999,7 +999,7 @@ func TestPostgresRegistry_UpdatedAtManagement(t *testing.T) {
 		original, err := reg.GetDefinition(ctx, "TIMESTAMP1", 1)
 		require.NoError(t, err)
 
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond) //nolint:forbidigo // ensures distinct timestamps between read and update
 
 		updates := &registry.InstrumentDefinition{
 			DisplayName: "Updated Name",
@@ -1015,7 +1015,7 @@ func TestPostgresRegistry_UpdatedAtManagement(t *testing.T) {
 		before, err := reg.GetDefinition(ctx, "TIMESTAMP1", 1)
 		require.NoError(t, err)
 
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond) //nolint:forbidigo // ensures distinct timestamps between read and activation
 
 		require.NoError(t, reg.ActivateInstrument(ctx, "TIMESTAMP1", 1))
 
@@ -1029,7 +1029,7 @@ func TestPostgresRegistry_UpdatedAtManagement(t *testing.T) {
 		before, err := reg.GetDefinition(ctx, "TIMESTAMP1", 1)
 		require.NoError(t, err)
 
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond) //nolint:forbidigo // ensures distinct timestamps between read and deprecation
 
 		require.NoError(t, reg.DeprecateInstrument(ctx, "TIMESTAMP1", 1, nil))
 

--- a/services/tenant/adapters/persistence/repository_test.go
+++ b/services/tenant/adapters/persistence/repository_test.go
@@ -385,9 +385,7 @@ func TestRepository_List(t *testing.T) {
 		tenant := newTestTenant(string(rune('a'+i)) + "_tenant")
 		err := repo.Create(ctx, tenant)
 		require.NoError(t, err)
-		// Intentional sleep: Ensure distinct created_at timestamps for ordering tests.
-		// Database timestamp precision requires actual time to pass.
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond) //nolint:forbidigo // ensures distinct timestamps for DB ordering test
 	}
 
 	// List all tenants
@@ -441,8 +439,7 @@ func TestRepository_List_Pagination(t *testing.T) {
 		tenant := newTestTenant("page_tenant_" + string(rune('a'+i)))
 		err := repo.Create(ctx, tenant)
 		require.NoError(t, err)
-		// Intentional sleep: Ensure distinct timestamps for pagination ordering
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond) //nolint:forbidigo // ensures distinct timestamps for DB ordering test
 	}
 
 	// Get first page of 3

--- a/services/tenant/notifier/slack_test.go
+++ b/services/tenant/notifier/slack_test.go
@@ -328,8 +328,7 @@ func TestSendAlert_ConnectionError(t *testing.T) {
 
 func TestSendAlert_ContextCancellation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		// Intentional sleep: Simulate slow server to test context cancellation behavior
-		time.Sleep(5 * time.Second)
+		time.Sleep(5 * time.Second) //nolint:forbidigo // simulates slow server response to test context cancellation
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()

--- a/services/tenant/pagerduty/client_test.go
+++ b/services/tenant/pagerduty/client_test.go
@@ -327,8 +327,7 @@ func TestClient_TriggerAlert_NetworkError(t *testing.T) {
 
 func TestClient_TriggerAlert_ContextCancellation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		// Intentional sleep: Delay response to test context cancellation handling
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond) //nolint:forbidigo // simulates slow server response to test context cancellation
 		w.WriteHeader(http.StatusAccepted)
 	}))
 	defer server.Close()

--- a/services/tenant/provisioner/circuit_breaker_test.go
+++ b/services/tenant/provisioner/circuit_breaker_test.go
@@ -528,8 +528,7 @@ func TestBreakerBehavior_HalfOpenMaxRequests(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			_, execErr := breaker.Execute(func() (any, error) {
-				// Intentional sleep: Hold the slot to test MaxRequests limiting
-				time.Sleep(50 * time.Millisecond)
+				time.Sleep(50 * time.Millisecond) //nolint:forbidigo // holds slot to test MaxRequests limiting in half-open state
 				return "success", nil
 			})
 			results <- execErr

--- a/services/tenant/worker/provisioning_worker_test.go
+++ b/services/tenant/worker/provisioning_worker_test.go
@@ -271,7 +271,7 @@ func TestProvisioningWorker_Start_ContextCancellation(t *testing.T) {
 	}()
 
 	// Intentional sleep: Let it run through at least one poll interval before stopping
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond) //nolint:forbidigo // gives worker time to run at least one poll cycle
 
 	// Cancel context
 	cancel()
@@ -308,7 +308,7 @@ func TestProvisioningWorker_Start_ExplicitStop(t *testing.T) {
 	}()
 
 	// Intentional sleep: Let it run through at least one poll interval before stopping
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond) //nolint:forbidigo // gives worker time to run at least one poll cycle
 
 	// Call Stop()
 	worker.Stop()
@@ -1534,8 +1534,7 @@ func TestProcessPendingTenants_ConcurrentClaimSkipped(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
-		// Intentional sleep: Small delay to create race condition for concurrent claim testing
-		time.Sleep(1 * time.Millisecond)
+		time.Sleep(1 * time.Millisecond) //nolint:forbidigo // simulates concurrent work delay for race condition testing
 		worker.processPendingTenants(ctx)
 	}()
 

--- a/services/tenant/worker/rate_limiter_test.go
+++ b/services/tenant/worker/rate_limiter_test.go
@@ -73,9 +73,7 @@ func TestAlertRateLimiter_Allow_TokenRefill(t *testing.T) {
 	assert.True(t, limiter.Allow(alertType))
 	assert.False(t, limiter.Allow(alertType))
 
-	// Intentional sleep: Wait for real time to pass so rate limiter can refill.
-	// Rate limiting is fundamentally time-based; we need to wait for token refill.
-	time.Sleep(1100 * time.Millisecond)
+	time.Sleep(1100 * time.Millisecond) //nolint:forbidigo // triggers rate limiter token refill (rate limiting is time-based)
 
 	// Should have 1 token refilled
 	assert.True(t, limiter.Allow(alertType))

--- a/shared/pkg/cel/determinism_test.go
+++ b/shared/pkg/cel/determinism_test.go
@@ -293,6 +293,7 @@ func TestBucketKeyDeterminismTimeSensitivity(t *testing.T) {
 	}
 
 	for _, interval := range intervals {
+		//nolint:forbidigo // advances time between evaluations to verify CEL determinism across temporal gaps
 		time.Sleep(interval)
 		result, _, err := prg.Eval(input)
 		require.NoError(t, err)

--- a/shared/pkg/cel/security_test.go
+++ b/shared/pkg/cel/security_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/meridianhub/meridian/shared/platform/await"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -114,10 +115,12 @@ func TestPoisonPillNoGoroutineLeaks(t *testing.T) {
 		t.Logf("Attempted expression %d (blocked as expected)", i)
 	}
 
-	// Allow any cleanup
+	// Allow any cleanup - wait for goroutines to settle within acceptable threshold
 	runtime.GC()
-	time.Sleep(100 * time.Millisecond)
-	runtime.GC()
+	_ = await.AtMost(500 * time.Millisecond).PollInterval(10 * time.Millisecond).Until(func() bool {
+		runtime.GC()
+		return runtime.NumGoroutine() <= initialGoroutines+2
+	})
 
 	finalGoroutines := runtime.NumGoroutine()
 	t.Logf("Final goroutines: %d", finalGoroutines)

--- a/shared/pkg/clients/circuitbreaker_test.go
+++ b/shared/pkg/clients/circuitbreaker_test.go
@@ -352,7 +352,7 @@ func TestCircuitBreaker_ContextTimeout(t *testing.T) {
 	defer cancel()
 
 	_, err := cb.Execute(ctx, func() (any, error) {
-		// Intentional sleep: Simulates slow operation to trigger context deadline exceeded
+		//nolint:forbidigo // simulates slow operation latency to trigger context deadline exceeded
 		time.Sleep(100 * time.Millisecond)
 		return "should timeout", nil
 	})
@@ -395,7 +395,7 @@ func TestCircuitBreaker_ConcurrentExecution(t *testing.T) {
 	for i := 0; i < numGoroutines; i++ {
 		go func() {
 			_, err := cb.Execute(ctx, func() (any, error) {
-				// Intentional sleep: Simulates concurrent work to test thread-safety
+				//nolint:forbidigo // simulates concurrent work latency to test thread-safety
 				time.Sleep(10 * time.Millisecond)
 				return successString, nil
 			})
@@ -444,8 +444,7 @@ func TestCircuitBreaker_ResetAfterInterval(t *testing.T) {
 	assert.Equal(t, gobreaker.StateClosed, cb.State(), "should remain closed below threshold")
 
 	// Wait for interval to reset counts.
-	// Intentional sleep: We need time to actually pass for the circuit breaker's internal
-	// interval timer to reset. There's no observable state change we can poll for.
+	//nolint:forbidigo // triggers circuit breaker interval timer reset; no observable state change to poll
 	time.Sleep(250 * time.Millisecond)
 
 	// Execute 3 more failures (should not trip because counts were reset)
@@ -552,7 +551,7 @@ func TestCircuitBreaker_MaxRequestsInHalfOpen(t *testing.T) {
 			defer wg.Done()
 			_, err := cb.Execute(ctx, func() (any, error) {
 				executedCount.Add(1)
-				// Intentional sleep: Hold the slot to test MaxRequests limiting
+				//nolint:forbidigo // holds the slot to test MaxRequests limiting in half-open state
 				time.Sleep(50 * time.Millisecond)
 				return successString, nil
 			})
@@ -666,13 +665,13 @@ func TestCircuitBreaker_ContextCancellationInHalfOpen(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		_, execErr = cb.Execute(ctx, func() (any, error) {
-			// Intentional sleep: Simulate a slow operation to test context cancellation
+			//nolint:forbidigo // simulates slow operation latency to test context cancellation in half-open state
 			time.Sleep(200 * time.Millisecond)
 			return successString, nil
 		})
 	}()
 
-	// Intentional sleep: Cancel the context while the request is in-flight
+	//nolint:forbidigo // ensures context is cancelled while the slow operation is still in-flight
 	time.Sleep(50 * time.Millisecond)
 	cancel()
 

--- a/shared/pkg/clients/retry_test.go
+++ b/shared/pkg/clients/retry_test.go
@@ -322,7 +322,7 @@ func TestRetryContextDeadlineExceeded(t *testing.T) {
 	attempts := 0
 	fn := func() error {
 		attempts++
-		// Intentional sleep: Simulate slow operation to trigger context deadline
+		//nolint:forbidigo // simulates slow operation latency to trigger context deadline
 		time.Sleep(30 * time.Millisecond)
 		return status.Error(codes.Unavailable, "service unavailable")
 	}

--- a/shared/pkg/health/checkers_test.go
+++ b/shared/pkg/health/checkers_test.go
@@ -410,6 +410,7 @@ func TestHTTPChecker_Check_UnhealthyStatusCode(t *testing.T) {
 // TestHTTPChecker_Check_Timeout tests timeout behavior
 func TestHTTPChecker_Check_Timeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		//nolint:forbidigo // simulates slow HTTP handler to trigger client timeout
 		time.Sleep(200 * time.Millisecond)
 		w.WriteHeader(http.StatusOK)
 	}))

--- a/shared/pkg/idempotency/executor_test.go
+++ b/shared/pkg/idempotency/executor_test.go
@@ -301,7 +301,7 @@ func TestExecutor_Execute_ConcurrentRequests(t *testing.T) {
 			defer wg.Done()
 			_, err := executor.Execute(context.Background(), key, time.Hour, func(_ context.Context) ([]byte, error) {
 				atomic.AddInt32(&executionCount, 1)
-				// Intentional sleep: Simulate work to test concurrent idempotency enforcement
+				//nolint:forbidigo // simulates work latency to test concurrent idempotency enforcement
 				time.Sleep(10 * time.Millisecond)
 				return []byte("result"), nil
 			})

--- a/shared/pkg/idempotency/metrics_test.go
+++ b/shared/pkg/idempotency/metrics_test.go
@@ -173,7 +173,7 @@ func TestMetricsCollector_FullWorkflow(t *testing.T) {
 	start := time.Now()
 	collector.RecordPending("payment")
 
-	// Intentional sleep: Simulate work to ensure non-zero duration is recorded in metrics
+	//nolint:forbidigo // ensures non-zero duration is recorded in metrics histogram
 	time.Sleep(10 * time.Millisecond)
 
 	// Record completion
@@ -197,7 +197,7 @@ func TestMetricsCollector_FailureWorkflow(t *testing.T) {
 	start := time.Now()
 	collector.RecordPending("refund")
 
-	// Intentional sleep: Simulate work before failure to ensure non-zero duration
+	//nolint:forbidigo // ensures non-zero duration is recorded in metrics histogram before failure
 	time.Sleep(5 * time.Millisecond)
 
 	// Record failure

--- a/shared/pkg/idempotency/postgres_service_test.go
+++ b/shared/pkg/idempotency/postgres_service_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/shared/platform/await"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/cockroachdb"
 )
@@ -464,18 +465,20 @@ func TestPostgresService_StartCleanup(t *testing.T) {
 	cleanupSvc.StartCleanup(ctx)
 
 	// Wait for cleanup to run
-	time.Sleep(500 * time.Millisecond)
-
-	// Row should be cleaned up
-	var count int
-	err = svc.pool.QueryRow(ctx,
-		`SELECT COUNT(*) FROM _idempotency_keys WHERE key = $1`, key.String(),
-	).Scan(&count)
-	if err != nil {
-		t.Fatalf("Count query failed: %v", err)
-	}
-	if count != 0 {
-		t.Errorf("Expected 0 rows after cleanup, got %d", count)
+	awaitCleanupErr := await.New().
+		AtMost(5 * time.Second).
+		PollInterval(100 * time.Millisecond).
+		Until(func() bool {
+			var count int
+			if err := svc.pool.QueryRow(ctx,
+				`SELECT COUNT(*) FROM _idempotency_keys WHERE key = $1`, key.String(),
+			).Scan(&count); err != nil {
+				return false
+			}
+			return count == 0
+		})
+	if awaitCleanupErr != nil {
+		t.Errorf("Expected 0 rows after cleanup, but row was not cleaned up within timeout")
 	}
 }
 

--- a/shared/pkg/saga/lease_renewer_test.go
+++ b/shared/pkg/saga/lease_renewer_test.go
@@ -93,8 +93,15 @@ func TestLeaseRenewer_RenewsLeaseAtInterval(t *testing.T) {
 
 	// Verify multiple renewals occurred by waiting and checking again
 	firstExpiry := getLeaseExpiresAtForTest(t, db, sagaID)
-	time.Sleep(200 * time.Millisecond)
-	secondExpiry := getLeaseExpiresAtForTest(t, db, sagaID)
+	var secondExpiry time.Time
+	awaitErr2 := await.New().
+		AtMost(2 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			secondExpiry = getLeaseExpiresAtForTest(t, db, sagaID)
+			return secondExpiry.After(firstExpiry) || secondExpiry.Equal(firstExpiry)
+		})
+	require.NoError(t, awaitErr2, "Lease should continue to be renewed")
 
 	// The claimed_at should have been updated
 	assert.True(t, secondExpiry.After(firstExpiry) || secondExpiry.Equal(firstExpiry),
@@ -176,8 +183,15 @@ func TestLeaseRenewer_StopsOnStopCall(t *testing.T) {
 	ctx := context.Background()
 	renewer.Start(ctx)
 
-	// Verify renewer is running
-	time.Sleep(100 * time.Millisecond)
+	// Verify renewer is running by waiting for at least one renewal
+	initialGoroutinesStop := runtime.NumGoroutine()
+	awaitStopErr := await.New().
+		AtMost(1 * time.Second).
+		PollInterval(10 * time.Millisecond).
+		Until(func() bool {
+			return runtime.NumGoroutine() > initialGoroutinesStop
+		})
+	require.NoError(t, awaitStopErr, "Renewer goroutine should be running before Stop")
 
 	// Call Stop and verify it completes within reasonable time
 	stopped := make(chan struct{})
@@ -219,7 +233,14 @@ func TestLeaseRenewer_StopIsIdempotent(t *testing.T) {
 	ctx := context.Background()
 	renewer.Start(ctx)
 
-	time.Sleep(100 * time.Millisecond)
+	initialGoroutinesIdempotent := runtime.NumGoroutine()
+	awaitIdempotentErr := await.New().
+		AtMost(1 * time.Second).
+		PollInterval(10 * time.Millisecond).
+		Until(func() bool {
+			return runtime.NumGoroutine() > initialGoroutinesIdempotent
+		})
+	require.NoError(t, awaitIdempotentErr, "Renewer goroutine should be running before Stop")
 
 	// Call Stop() multiple times - should not panic
 	renewer.Stop()
@@ -278,11 +299,16 @@ func TestLeaseRenewer_ContinuesOnRenewalFailure(t *testing.T) {
 
 	// Renewer should continue running (not crash) even with failures
 	beforeCount := renewalCount.Load()
-	time.Sleep(200 * time.Millisecond)
-	afterCount := renewalCount.Load()
+	awaitContinueErr := await.New().
+		AtMost(2 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return renewalCount.Load() > beforeCount
+		})
+	require.NoError(t, awaitContinueErr, "Renewer should continue attempting renewals despite failures")
 
 	// The callback should still be called even though the DB operation fails
-	assert.Greater(t, afterCount, beforeCount, "Renewer should continue attempting renewals despite failures")
+	assert.Greater(t, renewalCount.Load(), beforeCount, "Renewer should continue attempting renewals despite failures")
 }
 
 func TestLeaseRenewer_ConfigurationFromEnvironment(t *testing.T) {
@@ -327,8 +353,15 @@ func TestLeaseRenewer_NoGoroutineLeak(t *testing.T) {
 		renewer := NewLeaseRenewer(sagaID, claimService, logger, WithRenewalInterval(50*time.Millisecond))
 
 		ctx, cancel := context.WithCancel(context.Background())
+		preLeak := runtime.NumGoroutine()
 		renewer.Start(ctx)
-		time.Sleep(100 * time.Millisecond)
+		awaitLeakErr := await.New().
+			AtMost(1 * time.Second).
+			PollInterval(10 * time.Millisecond).
+			Until(func() bool {
+				return runtime.NumGoroutine() > preLeak
+			})
+		require.NoError(t, awaitLeakErr, "Renewer goroutine should start")
 		cancel()
 		renewer.Stop()
 	}

--- a/shared/pkg/saga/lease_renewer_test.go
+++ b/shared/pkg/saga/lease_renewer_test.go
@@ -91,7 +91,7 @@ func TestLeaseRenewer_RenewsLeaseAtInterval(t *testing.T) {
 		})
 	require.NoError(t, err, "Lease should be renewed")
 
-	// Verify multiple renewals occurred by waiting and checking again
+	// Verify multiple renewals occurred by waiting for a strictly later expiry
 	firstExpiry := getLeaseExpiresAtForTest(t, db, sagaID)
 	var secondExpiry time.Time
 	awaitErr2 := await.New().
@@ -99,12 +99,12 @@ func TestLeaseRenewer_RenewsLeaseAtInterval(t *testing.T) {
 		PollInterval(50 * time.Millisecond).
 		Until(func() bool {
 			secondExpiry = getLeaseExpiresAtForTest(t, db, sagaID)
-			return secondExpiry.After(firstExpiry) || secondExpiry.Equal(firstExpiry)
+			return secondExpiry.After(firstExpiry)
 		})
 	require.NoError(t, awaitErr2, "Lease should continue to be renewed")
 
 	// The claimed_at should have been updated
-	assert.True(t, secondExpiry.After(firstExpiry) || secondExpiry.Equal(firstExpiry),
+	assert.True(t, secondExpiry.After(firstExpiry),
 		"Lease should continue to be renewed")
 }
 
@@ -181,10 +181,11 @@ func TestLeaseRenewer_StopsOnStopCall(t *testing.T) {
 	renewer := NewLeaseRenewer(sagaID, claimService, logger, WithRenewalInterval(50*time.Millisecond))
 
 	ctx := context.Background()
+	// Capture baseline before Start so the goroutine is not yet counted
+	initialGoroutinesStop := runtime.NumGoroutine()
 	renewer.Start(ctx)
 
-	// Verify renewer is running by waiting for at least one renewal
-	initialGoroutinesStop := runtime.NumGoroutine()
+	// Verify renewer is running by waiting for the background goroutine to appear
 	awaitStopErr := await.New().
 		AtMost(1 * time.Second).
 		PollInterval(10 * time.Millisecond).

--- a/shared/pkg/saga/runtime_security_test.go
+++ b/shared/pkg/saga/runtime_security_test.go
@@ -84,6 +84,7 @@ result = long_running()
 
 	// Cancel after a short delay
 	go func() {
+		//nolint:forbidigo // triggers context cancellation while long-running saga security test executes
 		time.Sleep(50 * time.Millisecond)
 		cancel()
 	}()

--- a/shared/pkg/saga/runtime_test.go
+++ b/shared/pkg/saga/runtime_test.go
@@ -73,6 +73,7 @@ for i in range(10000000):
 
 	// Cancel after a short delay
 	go func() {
+		//nolint:forbidigo // triggers context cancellation while long-running saga script executes
 		time.Sleep(50 * time.Millisecond)
 		cancel()
 	}()

--- a/shared/pkg/saga/step_execution_integration_test.go
+++ b/shared/pkg/saga/step_execution_integration_test.go
@@ -379,7 +379,7 @@ func TestIntegration_ConcurrentReplay(t *testing.T) {
 	executionCount := int32(0)
 	handler := func(_ context.Context, _ map[string]interface{}) (interface{}, error) {
 		atomic.AddInt32(&executionCount, 1)
-		// Simulate work
+		//nolint:forbidigo // simulates step handler work latency to test concurrent idempotency enforcement
 		time.Sleep(10 * time.Millisecond)
 		return map[string]interface{}{"result": "done"}, nil
 	}

--- a/shared/pkg/saga/suspend_test.go
+++ b/shared/pkg/saga/suspend_test.go
@@ -648,6 +648,7 @@ func TestIntegration_TimeoutWorker_GracefulShutdown(t *testing.T) {
 	}()
 
 	// Let it run for a bit
+	//nolint:forbidigo // allows worker to complete multiple poll cycles before testing graceful shutdown
 	time.Sleep(250 * time.Millisecond)
 
 	// Cancel context to stop worker

--- a/shared/pkg/saga/validation/cache_test.go
+++ b/shared/pkg/saga/validation/cache_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/shared/platform/await"
 )
 
 func TestValidationCache_GetMiss(t *testing.T) {
@@ -73,12 +75,11 @@ func TestValidationCache_TTLExpiration(t *testing.T) {
 	assert.True(t, ok, "expected cache hit before TTL")
 	require.NotNil(t, result)
 
-	// Wait for TTL to expire
-	time.Sleep(60 * time.Millisecond)
-
-	// Should miss after TTL
-	result, ok = cache.Get("expiring script")
-	assert.False(t, ok, "expected cache miss after TTL expiration")
+	// Wait for TTL to expire, polling until cache misses
+	require.NoError(t, await.New().AtMost(500*time.Millisecond).PollInterval(10*time.Millisecond).Until(func() bool {
+		result, ok = cache.Get("expiring script")
+		return !ok
+	}), "expected cache miss after TTL expiration")
 	assert.Nil(t, result)
 }
 
@@ -121,8 +122,11 @@ func TestValidationCache_EvictExpired(t *testing.T) {
 	cache.Set("script1", &ValidationResult{Success: true})
 	cache.Set("script2", &ValidationResult{Success: true})
 
-	// Wait for TTL to expire
-	time.Sleep(60 * time.Millisecond)
+	// Wait for TTL to expire, polling until script1 is gone
+	require.NoError(t, await.New().AtMost(500*time.Millisecond).PollInterval(10*time.Millisecond).Until(func() bool {
+		_, expired := cache.Get("script1")
+		return !expired
+	}))
 
 	// Add a new entry that won't be expired
 	cache.Set("script3", &ValidationResult{Success: true})
@@ -184,7 +188,7 @@ func TestValidationCache_ConcurrentMixedOperations(_ *testing.T) {
 				script := "mixed script " + string(rune('A'+(id+j)%26))
 				cache.Set(script, &ValidationResult{Success: true})
 				cache.Get(script)
-				time.Sleep(5 * time.Millisecond)
+				time.Sleep(5 * time.Millisecond) //nolint:forbidigo // simulates realistic concurrent access timing between operations
 			}
 		}(i)
 	}
@@ -203,14 +207,17 @@ func TestValidationCache_StartStop(t *testing.T) {
 	// Start background eviction
 	cache.Start(ctx)
 
-	// Let some eviction cycles run
-	time.Sleep(200 * time.Millisecond)
+	// Wait for background eviction to remove the expired entry
+	require.NoError(t, await.New().AtMost(1*time.Second).PollInterval(20*time.Millisecond).Until(func() bool {
+		_, ok := cache.Get("script1")
+		return !ok
+	}))
 
 	// Cancel context to stop background eviction
 	cancel()
 
 	// Give goroutine time to stop
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond) //nolint:forbidigo // goroutine lifecycle: brief wait for background goroutine to observe context cancellation
 
 	// Cache should still work after stop
 	cache.Set("script2", &ValidationResult{Success: true})
@@ -254,7 +261,7 @@ func TestValidationCache_ZeroTTL(t *testing.T) {
 
 	cache.Set("script", &ValidationResult{Success: true})
 
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond) //nolint:forbidigo // intentional: verifies zero-TTL entries do NOT expire (no condition to poll against)
 
 	result, ok := cache.Get("script")
 	assert.True(t, ok, "entry should not expire with zero TTL")

--- a/shared/pkg/valuation/cache_test.go
+++ b/shared/pkg/valuation/cache_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/meridianhub/meridian/shared/pkg/valuation"
+	"github.com/meridianhub/meridian/shared/platform/await"
 )
 
 func TestInMemoryCache_MethodCaching(t *testing.T) {
@@ -83,12 +84,11 @@ func TestInMemoryCache_MethodTTL(t *testing.T) {
 	cached, _ := cache.GetMethod("method-1", intPtr(1))
 	assert.NotNil(t, cached)
 
-	// Wait for TTL to expire
-	time.Sleep(100 * time.Millisecond)
-
-	// Lookup after TTL returns nil (expired)
-	cached, _ = cache.GetMethod("method-1", intPtr(1))
-	assert.Nil(t, cached, "entry should be expired")
+	// Wait for TTL to expire, polling until GetMethod returns nil (expired)
+	require.NoError(t, await.New().AtMost(500*time.Millisecond).PollInterval(10*time.Millisecond).Until(func() bool {
+		cached, _ = cache.GetMethod("method-1", intPtr(1))
+		return cached == nil
+	}), "entry should be expired")
 }
 
 func TestInMemoryCache_PolicyCaching(t *testing.T) {

--- a/shared/platform/audit/worker_test.go
+++ b/shared/platform/audit/worker_test.go
@@ -393,8 +393,7 @@ func TestAuditWorker_GracefulShutdown(t *testing.T) {
 
 	worker.Start(ctx)
 
-	// Intentional sleep: Give worker time to start and enter its run loop.
-	// There's no observable state we can poll for to detect "worker is running".
+	//nolint:forbidigo // Intentional: worker has no observable "started" state to poll
 	time.Sleep(100 * time.Millisecond)
 
 	// Call Stop() and measure time
@@ -589,7 +588,7 @@ func TestAuditWorker_MultipleStartStop(t *testing.T) {
 	// Start and stop
 	ctx, cancel := context.WithCancel(context.Background())
 	worker.Start(ctx)
-	// Intentional sleep: Give worker time to start its run loop
+	//nolint:forbidigo // Intentional: worker has no observable "started" state to poll
 	time.Sleep(100 * time.Millisecond)
 	worker.Stop()
 	cancel()
@@ -604,7 +603,7 @@ func TestAuditWorker_MultipleStartStop(t *testing.T) {
 	ctx2, cancel2 := context.WithCancel(context.Background())
 	defer cancel2()
 	worker2.Start(ctx2)
-	// Intentional sleep: Give worker time to start its run loop
+	//nolint:forbidigo // Intentional: worker has no observable "started" state to poll
 	time.Sleep(100 * time.Millisecond)
 	worker2.Stop()
 
@@ -756,7 +755,7 @@ func TestAuditWorker_Stop_MultipleCallsSafe(t *testing.T) {
 
 	worker.Start(ctx)
 
-	// Intentional sleep: Give worker time to start its run loop
+	//nolint:forbidigo // Intentional: worker has no observable "started" state to poll
 	time.Sleep(100 * time.Millisecond)
 
 	// Call Stop() multiple times concurrently - should not panic
@@ -773,7 +772,7 @@ func TestAuditWorker_Stop_MultipleCallsSafe(t *testing.T) {
 
 	// Verify worker actually stopped by checking it doesn't process new entries
 	createTestEntries(t, db, 5)
-	// Intentional sleep: Wait to verify worker does NOT process new entries after stop
+	//nolint:forbidigo // Intentional: verifying worker does not process entries after stop (negative assertion) requires waiting
 	time.Sleep(200 * time.Millisecond)
 
 	var processed int64

--- a/shared/platform/auth/jwks_test.go
+++ b/shared/platform/auth/jwks_test.go
@@ -229,7 +229,7 @@ func TestJWKSProvider_GetKey(t *testing.T) {
 		provider, err := NewJWKSProvider(ctx, cfg)
 		require.NoError(t, err)
 
-		// Intentional sleep: Wait for cache TTL to expire to test cache refresh behavior
+		//nolint:forbidigo // triggers cache TTL expiration to test cache refresh behavior
 		time.Sleep(10 * time.Millisecond)
 
 		key, err := provider.GetKey(ctx, "test-key-1")
@@ -264,7 +264,7 @@ func TestJWKSProvider_GetKey(t *testing.T) {
 		provider, err := NewJWKSProvider(ctx, cfg)
 		require.NoError(t, err)
 
-		// Intentional sleep: Wait for cache TTL to expire to test stale cache behavior
+		//nolint:forbidigo // triggers cache TTL expiration to test stale cache behavior with refresh failure
 		time.Sleep(10 * time.Millisecond)
 
 		// Should still return cached key even though refresh fails
@@ -490,7 +490,7 @@ func TestJWKSProvider_Close(t *testing.T) {
 		err = provider.Close()
 		assert.NoError(t, err)
 
-		// Intentional sleep: Give time for goroutine to exit after close
+		//nolint:forbidigo // gives auto-refresh goroutine time to exit after provider.Close()
 		time.Sleep(200 * time.Millisecond)
 	})
 

--- a/shared/platform/auth/oauth_test.go
+++ b/shared/platform/auth/oauth_test.go
@@ -197,8 +197,7 @@ func TestOAuth2Client_GetToken(t *testing.T) {
 		assert.Equal(t, "refreshed-token", token1)
 		assert.Equal(t, 1, requestCount)
 
-		// Intentional sleep: Wait for token to expire to test token refresh behavior.
-		// OAuth token expiration is time-based by design.
+		//nolint:forbidigo // triggers OAuth token expiration; token TTL is time-based with no observable state change
 		time.Sleep(2 * time.Second)
 
 		// Second call should refresh token

--- a/shared/platform/bootstrap/lazy_test.go
+++ b/shared/platform/bootstrap/lazy_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/meridianhub/meridian/shared/platform/await"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -130,11 +131,11 @@ func TestLazyClient_ContextCancellation_StopsBackground(t *testing.T) {
 	// Cancel context to stop background goroutine
 	cancel()
 
-	// Give goroutine time to observe cancellation
+	//nolint:forbidigo // gives goroutine time to observe context cancellation before sampling attempt count
 	time.Sleep(50 * time.Millisecond)
 
 	countAfterCancel := attempts.Load()
-	// Wait a bit more to ensure no new attempts happen
+	//nolint:forbidigo // ensures no new attempts are made after context cancellation (absence of activity)
 	time.Sleep(50 * time.Millisecond)
 
 	if got := attempts.Load(); got != countAfterCancel {
@@ -232,12 +233,7 @@ func TestLazyClient_ConcurrentGet_NoRace(t *testing.T) {
 // waitForReady polls IsReady() until true or timeout.
 func waitForReady[T any](t *testing.T, lc *LazyClient[T], timeout time.Duration) {
 	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if lc.IsReady() {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
+	if err := await.AtMost(timeout).PollInterval(5 * time.Millisecond).Until(lc.IsReady); err != nil {
+		t.Fatal("LazyClient did not become ready within timeout")
 	}
-	t.Fatal("LazyClient did not become ready within timeout")
 }

--- a/shared/platform/db/integration_test.go
+++ b/shared/platform/db/integration_test.go
@@ -59,7 +59,7 @@ func setupPostgresContainer(ctx context.Context, t *testing.T) (*PostgresPool, f
 			break
 		}
 		t.Logf("Ping attempt %d failed: %v, retrying...", attempt, pingErr)
-		// Intentional sleep: Exponential backoff for database connection retry
+		//nolint:forbidigo // exponential backoff between database connection retry attempts
 		time.Sleep(time.Duration(attempt) * 500 * time.Millisecond)
 	}
 	require.NoError(t, pingErr, "failed to ping postgres after retries")
@@ -493,7 +493,7 @@ func TestPostgresPool_Integration_ContextCancellation(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Millisecond)
 		defer cancel()
 
-		// Intentional sleep: Wait for context timeout to trigger before executing query
+		//nolint:forbidigo // ensures nanosecond-TTL context has expired before executing query
 		time.Sleep(10 * time.Millisecond)
 
 		// Query should fail due to timeout
@@ -516,7 +516,7 @@ func TestPostgresPool_Integration_ContextCancellation(t *testing.T) {
 		defer cancel()
 
 		err := WithTransaction(timeoutCtx, pool, func(_ DB) error {
-			// Intentional sleep: Simulate slow operation to trigger context timeout
+			//nolint:forbidigo // simulates slow transaction to trigger context timeout
 			time.Sleep(200 * time.Millisecond)
 			return nil
 		})

--- a/shared/platform/db/pool_coverage_test.go
+++ b/shared/platform/db/pool_coverage_test.go
@@ -56,7 +56,7 @@ func TestPostgresPool_Integration_CloseWithContext(t *testing.T) {
 		closeCtx, cancel := context.WithTimeout(ctx, 1*time.Nanosecond)
 		defer cancel()
 
-		// Intentional sleep: Allow context to definitely expire before testing close behavior
+		//nolint:forbidigo // ensures nanosecond-TTL context has expired before calling CloseWithContext
 		time.Sleep(10 * time.Millisecond)
 
 		err := tempPool.CloseWithContext(closeCtx)
@@ -485,8 +485,7 @@ func TestHealthChecker_Integration(t *testing.T) {
 		require.NoError(t, err, "checker should become healthy after first check")
 		checker.Stop()
 
-		// Intentional sleep: Wait for checks to become stale (2x interval).
-		// We need actual time to pass for staleness detection to trigger.
+		//nolint:forbidigo // triggers health check staleness detection; requires actual time to pass beyond 2x interval
 		time.Sleep(30 * time.Millisecond)
 
 		// Should now be unhealthy due to staleness

--- a/shared/platform/db/pool_leak_test.go
+++ b/shared/platform/db/pool_leak_test.go
@@ -150,7 +150,7 @@ func TestPoolCloseWithContext_TimeoutDuringClose(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
 	defer cancel()
 
-	// Intentional sleep: Ensure context expires before/during Close to test race handling
+	//nolint:forbidigo // ensures nanosecond-TTL context has expired before calling Close to test race handling
 	time.Sleep(1 * time.Millisecond)
 
 	// CloseWithContext may succeed or fail depending on timing

--- a/shared/platform/events/outbox_test.go
+++ b/shared/platform/events/outbox_test.go
@@ -155,7 +155,7 @@ func TestPostgresOutboxRepository_FetchUnprocessed(t *testing.T) {
 	for i := range entries {
 		err := db.Create(&entries[i]).Error
 		require.NoError(t, err)
-		// Intentional sleep: Ensure different created_at timestamps for ordering tests
+		//nolint:forbidigo // Intentional: ensures distinct created_at timestamps for ordering tests
 		time.Sleep(10 * time.Millisecond)
 	}
 

--- a/shared/platform/events/worker_test.go
+++ b/shared/platform/events/worker_test.go
@@ -389,8 +389,7 @@ func TestWorker_GracefulShutdown(t *testing.T) {
 	ctx := context.Background()
 	worker.Start(ctx)
 
-	// Intentional sleep: Give worker time to start its run loop.
-	// The worker doesn't expose a "started" state we can poll.
+	//nolint:forbidigo // Intentional: worker has no observable "started" state to poll
 	time.Sleep(50 * time.Millisecond)
 
 	// Stop should complete without hanging
@@ -420,8 +419,7 @@ func TestWorker_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	worker.Start(ctx)
 
-	// Intentional sleep: Give worker time to start its run loop.
-	// The worker doesn't expose a "started" state we can poll.
+	//nolint:forbidigo // Intentional: worker has no observable "started" state to poll
 	time.Sleep(50 * time.Millisecond)
 
 	// Cancel context

--- a/shared/platform/gateway/inmemory_cache_test.go
+++ b/shared/platform/gateway/inmemory_cache_test.go
@@ -249,7 +249,7 @@ func TestInMemorySlugCache_BackgroundCleanup(t *testing.T) {
 
 		// Intentional sleep: Wait for multiple cleanup cycles to run (50ms interval x 3 = 150ms)
 		// to verify they don't remove entries that haven't expired (1 hour TTL).
-		time.Sleep(150 * time.Millisecond)
+		time.Sleep(150 * time.Millisecond) //nolint:forbidigo // verifies non-expired entries are NOT removed — no condition to poll against
 
 		// Entry should still exist
 		assert.Equal(t, 1, cache.Size())

--- a/shared/platform/observability/metrics_test.go
+++ b/shared/platform/observability/metrics_test.go
@@ -310,14 +310,13 @@ func TestStartMetricsServer(t *testing.T) {
 		}
 	}()
 
-	// Intentional sleep: Give metrics server time to start.
-	// The server doesn't expose a "started" state we can poll.
+	//nolint:forbidigo // metrics server does not expose a ready state; time-based startup wait required
 	time.Sleep(100 * time.Millisecond)
 
 	// Cancel context to shutdown server
 	cancel()
 
-	// Intentional sleep: Allow time for graceful shutdown to complete.
+	//nolint:forbidigo // allows graceful HTTP server shutdown to complete before checking for errors
 	time.Sleep(100 * time.Millisecond)
 
 	// Check if there were any errors

--- a/shared/platform/redislock/lock_test.go
+++ b/shared/platform/redislock/lock_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/meridianhub/meridian/shared/platform/await"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -188,6 +190,7 @@ func TestLock_ContextCancellation(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
+	initialGoroutines := runtime.NumGoroutine()
 	acquired, _, err := l.Acquire(ctx, "tenant-1", "resource-a")
 	require.NoError(t, err)
 	assert.True(t, acquired)
@@ -196,7 +199,9 @@ func TestLock_ContextCancellation(t *testing.T) {
 	cancel()
 
 	// Give goroutine time to exit
-	time.Sleep(100 * time.Millisecond)
+	_ = await.AtMost(1 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		return runtime.NumGoroutine() <= initialGoroutines
+	})
 
 	// Lock map entry may still exist but renewal has stopped
 	// This tests that cancellation doesn't panic

--- a/shared/platform/scheduler/catchup_test.go
+++ b/shared/platform/scheduler/catchup_test.go
@@ -157,7 +157,7 @@ func TestCatchUp_RecentExecution_NoCatchUpNeeded(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Give a moment for any catch-up to complete.
+	//nolint:forbidigo // Intentional: verifying no catch-up occurs (negative assertion) requires waiting
 	time.Sleep(200 * time.Millisecond)
 
 	// Executor should not have been called by catch-up.
@@ -324,6 +324,7 @@ func TestCatchUp_NoExecutionStore_IsNoOp(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	//nolint:forbidigo // Intentional: verifying no catch-up occurs without a store (negative assertion) requires waiting
 	time.Sleep(200 * time.Millisecond)
 
 	// Executor should not have been called by catch-up (no store = no catch-up).
@@ -437,8 +438,7 @@ func TestCatchUp_LockNotAcquired_SkipsCatchUp(t *testing.T) {
 		_ = s.Start(ctx)
 	}()
 
-	// Wait for scheduler to start (schedule won't register since lock fails for cron too).
-	// Instead, wait a moment for the start sequence to complete.
+	//nolint:forbidigo // Intentional: lock failure prevents observable state; waiting to confirm no catch-up occurs
 	time.Sleep(500 * time.Millisecond)
 
 	// No catch-up records should exist.

--- a/shared/platform/scheduler/cron_test.go
+++ b/shared/platform/scheduler/cron_test.go
@@ -596,7 +596,7 @@ func TestCronScheduler_ProviderError_ContinuesRunning(t *testing.T) {
 		errCh <- s.Start(ctx)
 	}()
 
-	// Let a few refresh cycles run with error
+	//nolint:forbidigo // Intentional: verifying negative condition (scheduler still running) requires waiting
 	time.Sleep(500 * time.Millisecond)
 
 	// Scheduler should still be running despite provider errors
@@ -645,7 +645,7 @@ func TestCronScheduler_LockError_SkipsExecution(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Give time for cron to fire (seconds-level, fast)
+	//nolint:forbidigo // Intentional: verifying cron fires but executor is skipped (negative assertion) requires waiting
 	time.Sleep(2 * time.Second)
 
 	// Executor should not have been called (lock error prevents execution)

--- a/shared/platform/scheduler/lifecycle_test.go
+++ b/shared/platform/scheduler/lifecycle_test.go
@@ -125,11 +125,12 @@ func TestWorkerLifecycle_Stop_WaitsForInFlightWork(t *testing.T) {
 
 	// Start guarded work that takes time
 	go lc.ExecuteGuarded(func() {
+		//nolint:forbidigo // Intentional: simulates in-flight work duration for shutdown test
 		time.Sleep(200 * time.Millisecond)
 		close(workDone)
 	})
 
-	// Give time for ExecuteGuarded to register
+	//nolint:forbidigo // Intentional: lifecycle has no observable state to poll for "guard registered"
 	time.Sleep(50 * time.Millisecond)
 
 	// Stop should wait for guarded work to finish
@@ -160,10 +161,11 @@ func TestWorkerLifecycle_Stop_TimesOut(t *testing.T) {
 
 	// Start guarded work that takes longer than timeout
 	go lc.ExecuteGuarded(func() {
+		//nolint:forbidigo // Intentional: simulates work that outlasts the shutdown timeout
 		time.Sleep(5 * time.Second)
 	})
 
-	// Give time for ExecuteGuarded to register
+	//nolint:forbidigo // Intentional: lifecycle has no observable state to poll for "guard registered"
 	time.Sleep(50 * time.Millisecond)
 
 	start := time.Now()
@@ -220,6 +222,7 @@ func TestWorkerLifecycle_ExecuteGuarded_TracksWaitGroup(t *testing.T) {
 			defer wg.Done()
 			lc.ExecuteGuarded(func() {
 				counter.Add(1)
+				//nolint:forbidigo // Intentional: simulates concurrent work duration for WaitGroup tracking test
 				time.Sleep(50 * time.Millisecond)
 			})
 		}()

--- a/tests/clearinge2e/error_handling_test.go
+++ b/tests/clearinge2e/error_handling_test.go
@@ -172,7 +172,7 @@ func TestClearingErrorHandling(t *testing.T) {
 		shortCtx, cancel := context.WithTimeout(ctx, 1*time.Nanosecond)
 		defer cancel()
 
-		time.Sleep(10 * time.Millisecond) // Ensure context has expired
+		time.Sleep(10 * time.Millisecond) //nolint:forbidigo // triggers context expiry (context has 1ns timeout)
 
 		// Verify context is done
 		assert.Error(t, shortCtx.Err(), "context should be cancelled")
@@ -398,7 +398,7 @@ func TestServiceRecoveryScenarios(t *testing.T) {
 		// In pgxpool, connections are managed and reconnected as needed
 		// Here we just verify continued operation after a pause
 
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond) //nolint:forbidigo // simulates brief connection pause in reconnect resilience test
 
 		// Operations should still work
 		resolvedID, _, found2 := getClearingAccountByPurpose(t, ctx,

--- a/tests/clearinge2e/payment_settlement_test.go
+++ b/tests/clearinge2e/payment_settlement_test.go
@@ -305,7 +305,7 @@ func TestPaymentSettlementFlow(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			time.Sleep(50 * time.Millisecond) // Simulate processing delay
+			time.Sleep(50 * time.Millisecond) //nolint:forbidigo // simulates async settlement processing delay
 
 			// Debit customer, credit clearing
 			legRef := paymentRef + "-SETTLE"

--- a/tests/integration/error_handling_test.go
+++ b/tests/integration/error_handling_test.go
@@ -577,7 +577,7 @@ func TestDatabase_ConnectionFailure_ContextTimeout(t *testing.T) {
 
 	dbOperation := func() error {
 		attemptCount++
-		time.Sleep(100 * time.Millisecond) // Simulate slow operation
+		time.Sleep(100 * time.Millisecond) //nolint:forbidigo // triggers context timeout by simulating slow operation
 		return errDatabaseUnavailable
 	}
 


### PR DESCRIPTION
## Summary

Migrates `time.Sleep` usage in test files to the `shared/platform/await` package, as required by the project testing guidelines.

- Replaces sleeps that wait for observable async conditions with `await.Until()` polling
- Annotates retained sleeps with `//nolint:forbidigo` and a reason explaining why they must stay

## Changes Made

**91 test files modified** across services, shared packages, and integration tests.

**Replaced with `await.Until`** (observable conditions can be polled):
- Cache TTL expiry: polls cache returning nil or source call count incrementing
- Lease renewer: polls renewal count and goroutine state
- Worker startup: polls ready conditions
- Rate limiter cleanup: polls active limiter count returning zero
- Account resolver TTL: polls backend call count

**Annotated with `//nolint:forbidigo`** (sleep is the test stimulus):
- HTTP handler bodies simulating server latency for timeout tests
- Chaos tests with random concurrent delays
- Timestamp separation (1ms) for deterministic DB ordering
- Circuit breaker interval timer resets
- Negative assertions requiring elapsed time (no observable condition to poll)
- Mock implementations simulating configurable latency

## Technical Details

The `await` package (`shared/platform/await`) provides:
- 10s default timeout, 100ms default poll interval
- `await.Until(func() bool)` for condition polling
- `await.New().AtMost(X).PollInterval(Y).Until(...)` for custom timeouts
- `await.UntilNoError(func() error)` for operation polling

## Testing

- Packages with no proto dependencies tested locally and pass
- All syntax verified via `gofmt -e`
- CI will validate the full build

## Task Reference

049-codebase-consistency.21