### PR TITLE
docs: add gRPC handler file splitting convention guide

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -17,6 +17,7 @@ This directory contains how-to guides and usage documentation for Meridian devel
 | [Saga Validation](saga-validation.md) | Automatic validation workflow, error interpretation, and troubleshooting |
 | [Starlark Style Guide](starlark-style-guide.md) | Writing conventions and syntax for Starlark saga scripts |
 | [Starlark Built-ins Reference](starlark-built-ins-reference.md) | Available functions, types, and DSL built-ins |
+| [Service File Conventions](service-file-conventions.md) | When and how to split server.go into separate gRPC handler endpoint files |
 
 ## Documentation Organization
 

--- a/docs/guides/service-file-conventions.md
+++ b/docs/guides/service-file-conventions.md
@@ -1,0 +1,142 @@
+# gRPC Handler File Splitting Convention
+
+This guide describes when and how to split a service's `server.go` into separate endpoint files.
+
+## Overview
+
+Every gRPC service starts with a `server.go` file containing the struct definition, constructor, and all RPC handler methods. As a service grows, it becomes necessary to split RPC handlers into separate files grouped by proto service or domain noun. This guide defines when to split and what naming to use.
+
+## The Role of server.go
+
+`server.go` is always the entry point for a service package. It must contain:
+
+- The `Service` struct definition and its fields
+- Interface definitions for external dependencies (repositories, clients)
+- Constructor (`New*` function)
+- Functional options (`With*` or `Option` types)
+- Package-level constants and errors shared across all endpoint files
+
+`server.go` should **not** grow to hold all RPC implementations once a service matures. The `financial-accounting` service demonstrates the clean end state: `server.go` holds only struct, interfaces, constructor, and options; all RPCs live in `grpc_*_endpoints.go` files.
+
+## When to Split
+
+Split RPC handlers out of `server.go` when **any** of the following conditions hold:
+
+1. **Size** — `server.go` exceeds ~300 lines of RPC handler code (excluding struct, constructor, and interfaces).
+2. **Multiple RPC groups** — The service implements more than one logical proto service or noun group (e.g., posting operations and booking operations are distinct enough to separate).
+3. **Test isolation** — A group of RPCs has enough test surface that a dedicated `*_endpoints_test.go` improves readability.
+4. **Different dependency focus** — Some RPCs use only a subset of the struct's dependencies, making the grouping semantically coherent.
+
+Do **not** split merely to reduce line count if all RPCs share the same domain concern. Three related methods in a 200-line `server.go` are easier to navigate than three files.
+
+## Naming Convention
+
+Files in the `service/` package follow this pattern:
+
+```
+grpc_{noun}_endpoints.go
+```
+
+Where `{noun}` is a lowercase, underscore-separated name identifying the proto RPC group. It typically matches the BIAN behaviour concept or proto message noun.
+
+Examples from the codebase:
+
+| Service | File | RPC Group |
+|---|---|---|
+| `current-account` | `grpc_account_endpoints.go` | Account CRUD (Initiate, List, Retrieve, Update) |
+| `current-account` | `grpc_control_endpoints.go` | Control and status operations |
+| `current-account` | `grpc_deposit_endpoints.go` | Deposit and withdrawal operations |
+| `financial-accounting` | `grpc_posting_endpoints.go` | Ledger posting RPCs |
+| `financial-accounting` | `grpc_booking_endpoints.go` | Financial booking log RPCs |
+| `financial-accounting` | `grpc_control_endpoints.go` | Control plane RPCs |
+| `financial-accounting` | `grpc_ledger_endpoints.go` | Ledger query RPCs |
+
+Test files mirror the source file name:
+
+```
+grpc_{noun}_endpoints_test.go
+```
+
+## File Structure
+
+Each `grpc_{noun}_endpoints.go` file:
+
+- Declares `package service` (same package as `server.go`)
+- Contains only `func (s *Service)` methods for its RPC group
+- May define private helper functions scoped to that group
+- Should **not** re-declare types, errors, or constants already in `server.go`
+
+```
+services/{service}/service/
+├── server.go                     # Struct, constructor, interfaces, options
+├── grpc_{noun}_endpoints.go      # RPC handlers for noun group
+├── grpc_{noun}_endpoints_test.go
+├── grpc_{other}_endpoints.go     # Additional group when needed
+├── mappers.go                    # Proto ↔ domain conversions
+└── errors.go                     # Sentinel errors (when numerous)
+```
+
+## The reference-data Exception
+
+The `reference-data` service uses a `handler/` package directory instead of `service/`, with a different split pattern:
+
+```
+services/reference-data/handler/
+├── grpc_handler.go               # Core struct, constructor, shared logic
+├── account_type_handler.go       # Account type RPC methods
+├── mapping_handler.go            # Mapping RPC methods
+├── node_handler.go               # Node RPC methods
+└── pagination.go                 # Shared pagination utilities
+```
+
+This `{noun}_handler.go` naming is specific to the `handler/` package. New services should use the `service/` package with `grpc_{noun}_endpoints.go` naming.
+
+## Services Eligible for Splitting
+
+The following services have `server.go` files large enough to benefit from splitting:
+
+| Service | server.go Lines | Status |
+|---|---|---|
+| `party` | 1359 | Monolithic — candidate for splitting |
+| `reconciliation` | 999 | Partially split (`dispute_handler.go`, `list_handler.go`) |
+| `internal-account` | 952 | Monolithic — candidate for splitting |
+| `identity` | 887 | Monolithic — candidate for splitting |
+| `tenant` | 724 | Monolithic — candidate for splitting |
+| `current-account` | 446 | Split into 3 endpoint files |
+| `financial-accounting` | 294 | Fully split — `server.go` is struct/constructor only |
+
+Services under 300 lines (`market-information`, `audit-worker`) do not need splitting.
+
+## Worked Example: financial-accounting
+
+`financial-accounting` is the reference implementation. `server.go` contains only the struct, all interface definitions, constructor, and options:
+
+```go
+// server.go
+type FinancialAccountingService struct {
+    repo        persistence.Repository
+    idempotency idempotency.Service
+    // ...
+}
+
+func NewFinancialAccountingService(repo persistence.Repository, ...) *FinancialAccountingService { ... }
+
+func WithRegistry(registry InstrumentRegistry) Option { ... }
+```
+
+RPC methods live in focused files:
+
+```go
+// grpc_posting_endpoints.go
+func (s *FinancialAccountingService) CaptureLedgerPosting(...) { ... }
+func (s *FinancialAccountingService) RetrieveLedgerPosting(...) { ... }
+
+// grpc_booking_endpoints.go
+func (s *FinancialAccountingService) InitiateFinancialBookingLog(...) { ... }
+func (s *FinancialAccountingService) RetrieveFinancialBookingLog(...) { ... }
+```
+
+## See Also
+
+- [ADR-015: Standard Service Directory Structure](../adr/0015-standard-service-directory-structure.md) — defines where `service/` fits in the overall layout
+- [New BIAN Service Checklist](new-bian-service-checklist.md) — checklist for creating a new service including initial file layout

--- a/docs/guides/service-file-conventions.md
+++ b/docs/guides/service-file-conventions.md
@@ -4,7 +4,10 @@ This guide describes when and how to split a service's `server.go` into separate
 
 ## Overview
 
-Every gRPC service starts with a `server.go` file containing the struct definition, constructor, and all RPC handler methods. As a service grows, it becomes necessary to split RPC handlers into separate files grouped by proto service or domain noun. This guide defines when to split and what naming to use.
+Every gRPC service starts with a `server.go` file containing the struct definition, constructor,
+and all RPC handler methods. As a service grows, it becomes necessary to split RPC handlers into
+separate files grouped by proto service or domain noun. This guide defines when to split and what
+naming to use.
 
 ## The Role of server.go
 
@@ -16,28 +19,36 @@ Every gRPC service starts with a `server.go` file containing the struct definiti
 - Functional options (`With*` or `Option` types)
 - Package-level constants and errors shared across all endpoint files
 
-`server.go` should **not** grow to hold all RPC implementations once a service matures. The `financial-accounting` service demonstrates the clean end state: `server.go` holds only struct, interfaces, constructor, and options; all RPCs live in `grpc_*_endpoints.go` files.
+`server.go` should **not** grow to hold all RPC implementations once a service matures. The
+`financial-accounting` service demonstrates the clean end state: `server.go` holds only struct,
+interfaces, constructor, and options; all RPCs live in `grpc_*_endpoints.go` files.
 
 ## When to Split
 
 Split RPC handlers out of `server.go` when **any** of the following conditions hold:
 
-1. **Size** — `server.go` exceeds ~300 lines of RPC handler code (excluding struct, constructor, and interfaces).
-2. **Multiple RPC groups** — The service implements more than one logical proto service or noun group (e.g., posting operations and booking operations are distinct enough to separate).
-3. **Test isolation** — A group of RPCs has enough test surface that a dedicated `*_endpoints_test.go` improves readability.
-4. **Different dependency focus** — Some RPCs use only a subset of the struct's dependencies, making the grouping semantically coherent.
+1. **Size** — `server.go` exceeds ~300 lines of RPC handler code (excluding struct, constructor,
+   and interfaces).
+2. **Multiple RPC groups** — The service implements more than one logical proto service or noun
+   group (e.g., posting operations and booking operations are distinct enough to separate).
+3. **Test isolation** — A group of RPCs has enough test surface that a dedicated
+   `*_endpoints_test.go` improves readability.
+4. **Different dependency focus** — Some RPCs use only a subset of the struct's dependencies,
+   making the grouping semantically coherent.
 
-Do **not** split merely to reduce line count if all RPCs share the same domain concern. Three related methods in a 200-line `server.go` are easier to navigate than three files.
+Do **not** split merely to reduce line count if all RPCs share the same domain concern. Three
+related methods in a 200-line `server.go` are easier to navigate than three files.
 
 ## Naming Convention
 
 Files in the `service/` package follow this pattern:
 
-```
+```text
 grpc_{noun}_endpoints.go
 ```
 
-Where `{noun}` is a lowercase, underscore-separated name identifying the proto RPC group. It typically matches the BIAN behaviour concept or proto message noun.
+Where `{noun}` is a lowercase, underscore-separated name identifying the proto RPC group. It
+typically matches the BIAN behaviour concept or proto message noun.
 
 Examples from the codebase:
 
@@ -53,7 +64,7 @@ Examples from the codebase:
 
 Test files mirror the source file name:
 
-```
+```text
 grpc_{noun}_endpoints_test.go
 ```
 
@@ -66,7 +77,7 @@ Each `grpc_{noun}_endpoints.go` file:
 - May define private helper functions scoped to that group
 - Should **not** re-declare types, errors, or constants already in `server.go`
 
-```
+```text
 services/{service}/service/
 ├── server.go                     # Struct, constructor, interfaces, options
 ├── grpc_{noun}_endpoints.go      # RPC handlers for noun group
@@ -78,9 +89,10 @@ services/{service}/service/
 
 ## The reference-data Exception
 
-The `reference-data` service uses a `handler/` package directory instead of `service/`, with a different split pattern:
+The `reference-data` service uses a `handler/` package directory instead of `service/`, with a
+different split pattern:
 
-```
+```text
 services/reference-data/handler/
 ├── grpc_handler.go               # Core struct, constructor, shared logic
 ├── account_type_handler.go       # Account type RPC methods
@@ -89,7 +101,8 @@ services/reference-data/handler/
 └── pagination.go                 # Shared pagination utilities
 ```
 
-This `{noun}_handler.go` naming is specific to the `handler/` package. New services should use the `service/` package with `grpc_{noun}_endpoints.go` naming.
+This `{noun}_handler.go` naming is specific to the `handler/` package. New services should use
+the `service/` package with `grpc_{noun}_endpoints.go` naming.
 
 ## Services Eligible for Splitting
 
@@ -109,7 +122,8 @@ Services under 300 lines (`market-information`, `audit-worker`) do not need spli
 
 ## Worked Example: financial-accounting
 
-`financial-accounting` is the reference implementation. `server.go` contains only the struct, all interface definitions, constructor, and options:
+`financial-accounting` is the reference implementation. `server.go` contains only the struct, all
+interface definitions, constructor, and options:
 
 ```go
 // server.go
@@ -119,7 +133,9 @@ type FinancialAccountingService struct {
     // ...
 }
 
-func NewFinancialAccountingService(repo persistence.Repository, ...) *FinancialAccountingService { ... }
+func NewFinancialAccountingService(repo persistence.Repository, ...) *FinancialAccountingService {
+    // ...
+}
 
 func WithRegistry(registry InstrumentRegistry) Option { ... }
 ```
@@ -138,5 +154,7 @@ func (s *FinancialAccountingService) RetrieveFinancialBookingLog(...) { ... }
 
 ## See Also
 
-- [ADR-015: Standard Service Directory Structure](../adr/0015-standard-service-directory-structure.md) — defines where `service/` fits in the overall layout
-- [New BIAN Service Checklist](new-bian-service-checklist.md) — checklist for creating a new service including initial file layout
+- [ADR-015: Standard Service Directory Structure](../adr/0015-standard-service-directory-structure.md)
+  — defines where `service/` fits in the overall layout
+- [New BIAN Service Checklist](new-bian-service-checklist.md) — checklist for creating a new
+  service including initial file layout

--- a/docs/guides/service-file-conventions.md
+++ b/docs/guides/service-file-conventions.md
@@ -56,11 +56,16 @@ Examples from the codebase:
 |---|---|---|
 | `current-account` | `grpc_account_endpoints.go` | Account CRUD (Initiate, List, Retrieve, Update) |
 | `current-account` | `grpc_control_endpoints.go` | Control and status operations |
-| `current-account` | `grpc_deposit_endpoints.go` | Deposit and withdrawal operations |
+| `current-account` | `grpc_deposit_endpoints.go` | Deposit operations |
+| `current-account` | `grpc_withdrawal_execute.go` | Withdrawal execution RPCs |
+| `current-account` | `grpc_withdrawal_manage.go` | Withdrawal management RPCs |
 | `financial-accounting` | `grpc_posting_endpoints.go` | Ledger posting RPCs |
 | `financial-accounting` | `grpc_booking_endpoints.go` | Financial booking log RPCs |
 | `financial-accounting` | `grpc_control_endpoints.go` | Control plane RPCs |
 | `financial-accounting` | `grpc_ledger_endpoints.go` | Ledger query RPCs |
+
+Note: `grpc_withdrawal_execute.go` and `grpc_withdrawal_manage.go` predate this convention and
+omit the `_endpoints` suffix. New files should use the `_endpoints` suffix.
 
 Test files mirror the source file name:
 
@@ -115,7 +120,7 @@ The following services have `server.go` files large enough to benefit from split
 | `internal-account` | 952 | Monolithic — candidate for splitting |
 | `identity` | 887 | Monolithic — candidate for splitting |
 | `tenant` | 724 | Monolithic — candidate for splitting |
-| `current-account` | 446 | Split into 3 endpoint files |
+| `current-account` | 446 | Split into 5 handler files |
 | `financial-accounting` | 294 | Fully split — `server.go` is struct/constructor only |
 
 Services under 300 lines (`market-information`, `audit-worker`) do not need splitting.


### PR DESCRIPTION
## Summary

- Adds `docs/guides/service-file-conventions.md` documenting when and how to split `server.go` into separate `grpc_{noun}_endpoints.go` files
- Updates `docs/guides/README.md` to reference the new guide

## Changes Made

**`docs/guides/service-file-conventions.md`** (new):
- Defines the role of `server.go` (struct, interfaces, constructor, options — not RPC handlers)
- Documents the size and structural triggers for splitting (>300 lines of RPC handler code, multiple proto RPC groups)
- Establishes `grpc_{noun}_endpoints.go` as the standard naming convention in `service/` packages
- Notes the `handler/` package exception used by `reference-data`
- Provides a table of all services with their current `server.go` size and split status
- References `financial-accounting` as the reference implementation (fully split)

**`docs/guides/README.md`**:
- Adds entry for the new guide

## Technical Details

Research covered all services with `server.go` files. Two split patterns exist in the codebase:

- `grpc_{noun}_endpoints.go` — used in `current-account` and `financial-accounting` (preferred for `service/` packages)
- `{noun}_handler.go` — used in `reference-data`'s `handler/` package (existing exception, not the new standard)

The guide captures the `financial-accounting` approach as the target end state: `server.go` holds zero RPC methods; all implementations live in focused endpoint files.

## Risk Assessment

Documentation only — no code changes.