### PR TITLE
test: add unhappy path tests for control-plane service

### DIFF
--- a/services/control-plane/internal/admin/balance_sheet_handler_test.go
+++ b/services/control-plane/internal/admin/balance_sheet_handler_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -217,6 +218,62 @@ func TestClassificationToProto(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestBalanceSheetHandler_GetBalanceSheet_ServiceError(t *testing.T) {
+	client := &mockPKClient{err: fmt.Errorf("database unavailable")}
+	svc := NewBalanceSheetService(client, nil)
+	handler := NewBalanceSheetHandler(svc, nil)
+
+	req := &controlplanev1.GetBalanceSheetRequest{
+		TenantId: "acme",
+	}
+
+	_, err := handler.GetBalanceSheet(context.Background(), req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+	assert.Contains(t, st.Message(), "failed to generate balance sheet")
+}
+
+func TestBalanceSheetHandler_GetPositionDetails_ServiceError(t *testing.T) {
+	client := &mockPKClient{err: fmt.Errorf("connection refused")}
+	svc := NewBalanceSheetService(client, nil)
+	handler := NewBalanceSheetHandler(svc, nil)
+
+	req := &controlplanev1.GetPositionDetailsRequest{
+		TenantId:    "acme",
+		AccountType: "CASH",
+		Instrument:  "GBP",
+	}
+
+	_, err := handler.GetPositionDetails(context.Background(), req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+	assert.Contains(t, st.Message(), "failed to get position details")
+}
+
+func TestBalanceSheetHandler_ExportBalanceSheetCSV_ServiceError(t *testing.T) {
+	client := &mockPKClient{err: fmt.Errorf("timeout")}
+	svc := NewBalanceSheetService(client, nil)
+	handler := NewBalanceSheetHandler(svc, nil)
+
+	req := &controlplanev1.ExportBalanceSheetCSVRequest{
+		TenantId: "acme",
+	}
+
+	_, err := handler.ExportBalanceSheetCSV(context.Background(), req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+	assert.Contains(t, st.Message(), "failed to export balance sheet CSV")
 }
 
 func TestNormalBalanceToProto(t *testing.T) {

--- a/services/control-plane/internal/admin/balance_sheet_test.go
+++ b/services/control-plane/internal/admin/balance_sheet_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -426,6 +427,204 @@ func (m *paginatedMockPKClient) ListFinancialPositionLogs(_ context.Context, req
 
 func (m *paginatedMockPKClient) GetAccountBalance(_ context.Context, _ *positionkeepingv1.GetAccountBalanceRequest) (*positionkeepingv1.GetAccountBalanceResponse, error) {
 	return nil, nil
+}
+
+func TestGetBalanceSheet_ServiceError(t *testing.T) {
+	client := &mockPKClient{err: fmt.Errorf("rpc error: unavailable")}
+	svc := NewBalanceSheetService(client, nil)
+
+	_, err := svc.GetBalanceSheet(context.Background(), "acme", time.Now().UTC())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fetch position logs")
+}
+
+func TestGetPositionDetails_ServiceError(t *testing.T) {
+	client := &mockPKClient{err: fmt.Errorf("rpc error: unavailable")}
+	svc := NewBalanceSheetService(client, nil)
+
+	_, err := svc.GetPositionDetails(context.Background(), "acme", "CASH", "GBP", time.Now().UTC())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fetch position logs")
+}
+
+func TestExportBalanceSheetCSV_ServiceError(t *testing.T) {
+	client := &mockPKClient{err: fmt.Errorf("rpc error: unavailable")}
+	svc := NewBalanceSheetService(client, nil)
+
+	_, err := svc.ExportBalanceSheetCSV(context.Background(), "acme", time.Now().UTC())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fetch position logs")
+}
+
+func TestSanitizeCSVCell(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"empty string", "", ""},
+		{"normal text", "CASH", "CASH"},
+		{"equals formula", "=SUM(A1:A10)", "'=SUM(A1:A10)"},
+		{"plus formula", "+1+2", "'+1+2"},
+		{"minus formula", "-1-2", "'-1-2"},
+		{"at formula", "@SUM(A1)", "'@SUM(A1)"},
+		{"normal number", "5000", "5000"},
+		{"normal with spaces", "ACCOUNTS PAYABLE", "ACCOUNTS PAYABLE"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeCSVCell(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetBalanceSheet_ZeroAsOf(t *testing.T) {
+	// When asOf is zero, the service should default to now (not error)
+	client := &mockPKClient{logs: nil}
+	svc := NewBalanceSheetService(client, nil)
+
+	bs, err := svc.GetBalanceSheet(context.Background(), "acme", time.Time{})
+	require.NoError(t, err)
+	require.NotNil(t, bs)
+	// asOf should have been set to approximately now
+	assert.False(t, bs.AsOf.IsZero())
+}
+
+func TestGetBalanceSheet_UnixEpochAsOf(t *testing.T) {
+	// A nil proto Timestamp converts to Unix epoch — should be treated as "now"
+	client := &mockPKClient{logs: nil}
+	svc := NewBalanceSheetService(client, nil)
+
+	epoch := time.Unix(0, 0)
+	bs, err := svc.GetBalanceSheet(context.Background(), "acme", epoch)
+	require.NoError(t, err)
+	require.NotNil(t, bs)
+	assert.NotEqual(t, int64(0), bs.AsOf.Unix())
+}
+
+func TestExtractInstrument_NilAmount(t *testing.T) {
+	// Log with an entry whose Amount is nil
+	log := &positionkeepingv1.FinancialPositionLog{
+		LogId:     "log-nil-amount",
+		AccountId: "test_CASH_001",
+		TransactionLogEntries: []*positionkeepingv1.TransactionLogEntry{
+			{
+				EntryId:   "entry-1",
+				Amount:    nil,
+				Direction: commonv1.PostingDirection_POSTING_DIRECTION_DEBIT,
+			},
+		},
+		CreatedAt: timestamppb.Now(),
+		UpdatedAt: timestamppb.Now(),
+	}
+	assert.Equal(t, instrumentUnknown, extractInstrument(log))
+}
+
+func TestExtractInstrument_EmptyCurrencyCode(t *testing.T) {
+	log := makeLog("test_CASH_001", "log-1", "",
+		txnEntry{units: 100, nanos: 0, direction: "DEBIT"},
+	)
+	// makeLog uses "" as the currency code, extractInstrument should return UNKNOWN
+	assert.Equal(t, instrumentUnknown, extractInstrument(log))
+}
+
+func TestEntryAmount_NilEntry(t *testing.T) {
+	// Entry with nil Amount
+	entry := &positionkeepingv1.TransactionLogEntry{
+		Amount: nil,
+	}
+	result := entryAmount(entry)
+	assert.True(t, result.IsZero())
+}
+
+func TestEntryAmount_NilMoney(t *testing.T) {
+	// Entry with MoneyAmount but nil inner Amount
+	entry := &positionkeepingv1.TransactionLogEntry{
+		Amount: &commonv1.MoneyAmount{
+			Amount: nil,
+		},
+	}
+	result := entryAmount(entry)
+	assert.True(t, result.IsZero())
+}
+
+func TestComputeLogBalance_UnspecifiedDirection(t *testing.T) {
+	// Entries with UNSPECIFIED direction should be ignored
+	log := &positionkeepingv1.FinancialPositionLog{
+		LogId:     "log-unspecified",
+		AccountId: "test_CASH_001",
+		TransactionLogEntries: []*positionkeepingv1.TransactionLogEntry{
+			{
+				EntryId: "entry-1",
+				Amount: &commonv1.MoneyAmount{
+					Amount: &money.Money{
+						CurrencyCode: "GBP",
+						Units:        100,
+						Nanos:        0,
+					},
+				},
+				Direction: commonv1.PostingDirection_POSTING_DIRECTION_UNSPECIFIED,
+			},
+			{
+				EntryId: "entry-2",
+				Amount: &commonv1.MoneyAmount{
+					Amount: &money.Money{
+						CurrencyCode: "GBP",
+						Units:        200,
+						Nanos:        0,
+					},
+				},
+				Direction: commonv1.PostingDirection_POSTING_DIRECTION_DEBIT,
+			},
+		},
+		CreatedAt: timestamppb.Now(),
+		UpdatedAt: timestamppb.Now(),
+	}
+	result := computeLogBalance(log)
+	// Only the DEBIT entry should count
+	assert.True(t, result.Equal(decimal.NewFromInt(200)))
+}
+
+func TestExtractAccountType_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name      string
+		accountID string
+		expected  string
+	}{
+		{"single segment no underscore", "simple", "simple"},
+		{"tenant with trailing numeric only", "acme_001", "001"},
+		{"empty segments", "acme__CASH__001", "CASH"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractAccountType(tt.accountID)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsUpperAlpha(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"CASH", true},
+		{"Cash", false},
+		{"cash", false},
+		{"123", false},
+		{"CASH1", false},
+		{"", false},
+		{"A", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isUpperAlpha(tt.input))
+		})
+	}
 }
 
 func TestGetBalanceSheet_Pagination(t *testing.T) {

--- a/services/control-plane/internal/admin/export_test.go
+++ b/services/control-plane/internal/admin/export_test.go
@@ -228,9 +228,9 @@ func TestExportCSV_DeepNesting(t *testing.T) {
 	assert.Equal(t, "2", records[3][0]) // grandchild
 
 	// Verify parent saga chain
-	assert.Equal(t, "", records[1][11])                                          // root has no parent
-	assert.Equal(t, "11111111-1111-1111-1111-111111111111", records[2][11])      // child's parent is root
-	assert.Equal(t, "22222222-2222-2222-2222-222222222222", records[3][11])      // grandchild's parent is child
+	assert.Equal(t, "", records[1][11])                                     // root has no parent
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", records[2][11]) // child's parent is root
+	assert.Equal(t, "22222222-2222-2222-2222-222222222222", records[3][11]) // grandchild's parent is child
 }
 
 func TestFlattenTree_NilKnowledgeAt(t *testing.T) {

--- a/services/control-plane/internal/admin/export_test.go
+++ b/services/control-plane/internal/admin/export_test.go
@@ -151,6 +151,166 @@ func TestExportUnsupportedFormat(t *testing.T) {
 	assert.Contains(t, err.Error(), "xml")
 }
 
+func TestExportCSV_NilTree(t *testing.T) {
+	var buf bytes.Buffer
+	err := ExportCausationTree(&buf, nil, 0, ExportFormatCSV)
+	require.NoError(t, err)
+
+	reader := csv.NewReader(strings.NewReader(buf.String()))
+	records, err := reader.ReadAll()
+	require.NoError(t, err)
+
+	// Should only contain the header row (flattenTree returns nil for nil node)
+	require.Len(t, records, 1)
+	assert.Equal(t, "depth", records[0][0])
+}
+
+func TestExportCSV_DeepNesting(t *testing.T) {
+	now := time.Now()
+	grandchild := &saga.CausationTreeNode{
+		SagaID:   uuid.MustParse("33333333-3333-3333-3333-333333333333"),
+		SagaName: "grandchild_saga",
+		Status:   "COMPLETED",
+		Steps: []saga.StepNode{
+			{
+				Index:      0,
+				Name:       "gc_step",
+				Status:     "COMPLETED",
+				ExecutedAt: &now,
+			},
+		},
+	}
+
+	child := &saga.CausationTreeNode{
+		SagaID:   uuid.MustParse("22222222-2222-2222-2222-222222222222"),
+		SagaName: "child_saga",
+		Status:   "COMPLETED",
+		Steps: []saga.StepNode{
+			{
+				Index:      0,
+				Name:       "child_step",
+				Status:     "COMPLETED",
+				ExecutedAt: &now,
+				ChildSagas: []*saga.CausationTreeNode{grandchild},
+			},
+		},
+	}
+
+	root := &saga.CausationTreeNode{
+		SagaID:   uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+		SagaName: "root_saga",
+		Status:   "COMPLETED",
+		Steps: []saga.StepNode{
+			{
+				Index:      0,
+				Name:       "root_step",
+				Status:     "COMPLETED",
+				ExecutedAt: &now,
+				ChildSagas: []*saga.CausationTreeNode{child},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := ExportCausationTree(&buf, root, 3, ExportFormatCSV)
+	require.NoError(t, err)
+
+	reader := csv.NewReader(strings.NewReader(buf.String()))
+	records, err := reader.ReadAll()
+	require.NoError(t, err)
+
+	// Header + root_step(depth 0) + child_step(depth 1) + gc_step(depth 2) = 4 rows
+	require.Len(t, records, 4)
+
+	// Verify depths
+	assert.Equal(t, "0", records[1][0]) // root
+	assert.Equal(t, "1", records[2][0]) // child
+	assert.Equal(t, "2", records[3][0]) // grandchild
+
+	// Verify parent saga chain
+	assert.Equal(t, "", records[1][11])                                          // root has no parent
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", records[2][11])      // child's parent is root
+	assert.Equal(t, "22222222-2222-2222-2222-222222222222", records[3][11])      // grandchild's parent is child
+}
+
+func TestFlattenTree_NilKnowledgeAt(t *testing.T) {
+	// Node with nil KnowledgeAt and nil FailedStep
+	tree := &saga.CausationTreeNode{
+		SagaID:      uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+		SagaName:    "test_saga",
+		Status:      "PENDING",
+		KnowledgeAt: nil,
+		FailedStep:  nil,
+		Steps:       []saga.StepNode{},
+	}
+
+	var buf bytes.Buffer
+	err := ExportCausationTree(&buf, tree, 1, ExportFormatCSV)
+	require.NoError(t, err)
+
+	reader := csv.NewReader(strings.NewReader(buf.String()))
+	records, err := reader.ReadAll()
+	require.NoError(t, err)
+
+	require.Len(t, records, 2)
+	// knowledgeAt column should be empty
+	assert.Equal(t, "", records[1][10])
+	// failedStep column should be empty
+	assert.Equal(t, "", records[1][9])
+}
+
+func TestFlattenTree_StepWithNilExecutedAtAndError(t *testing.T) {
+	tree := &saga.CausationTreeNode{
+		SagaID:   uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+		SagaName: "test_saga",
+		Status:   "PENDING",
+		Steps: []saga.StepNode{
+			{
+				Index:      0,
+				Name:       "pending_step",
+				Status:     "PENDING",
+				ExecutedAt: nil,
+				Error:      nil,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := ExportCausationTree(&buf, tree, 1, ExportFormatCSV)
+	require.NoError(t, err)
+
+	reader := csv.NewReader(strings.NewReader(buf.String()))
+	records, err := reader.ReadAll()
+	require.NoError(t, err)
+
+	require.Len(t, records, 2)
+	// executedAt column should be empty
+	assert.Equal(t, "", records[1][7])
+	// stepError column should be empty
+	assert.Equal(t, "", records[1][8])
+}
+
+type errorWriter struct {
+	failAfter int
+	written   int
+}
+
+func (e *errorWriter) Write(p []byte) (n int, err error) {
+	e.written++
+	if e.written > e.failAfter {
+		return 0, errors.New("write error")
+	}
+	return len(p), nil
+}
+
+func TestExportJSON_WriteError(t *testing.T) {
+	tree := buildTestTree()
+	w := &errorWriter{failAfter: 0}
+
+	err := ExportCausationTree(w, tree, 2, ExportFormatJSON)
+	require.Error(t, err)
+}
+
 func TestExportJSON_NilTree(t *testing.T) {
 	var buf bytes.Buffer
 	err := ExportCausationTree(&buf, nil, 0, ExportFormatJSON)

--- a/services/control-plane/internal/applier/apply_job_integration_test.go
+++ b/services/control-plane/internal/applier/apply_job_integration_test.go
@@ -1,0 +1,217 @@
+package applier
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyJobRepository_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool := testdb.NewTestPool(t, testdb.WithMigrations("control-plane"))
+	repo := NewApplyJobRepository(pool)
+	ctx := context.Background()
+
+	t.Run("Create", func(t *testing.T) {
+		job, err := repo.Create(ctx, 1)
+		require.NoError(t, err)
+		require.NotNil(t, job)
+
+		assert.NotEqual(t, uuid.Nil, job.ID)
+		assert.Equal(t, 1, job.ManifestVersion)
+		assert.Equal(t, ApplyJobStatusPending, job.Status)
+		assert.Empty(t, job.Error)
+		assert.Nil(t, job.SagaExecutionID)
+		assert.Nil(t, job.CompletedAt)
+		assert.False(t, job.CreatedAt.IsZero())
+	})
+
+	t.Run("GetByID", func(t *testing.T) {
+		created, err := repo.Create(ctx, 5)
+		require.NoError(t, err)
+
+		found, err := repo.GetByID(ctx, created.ID)
+		require.NoError(t, err)
+		require.NotNil(t, found)
+
+		assert.Equal(t, created.ID, found.ID)
+		assert.Equal(t, 5, found.ManifestVersion)
+		assert.Equal(t, ApplyJobStatusPending, found.Status)
+		assert.Nil(t, found.SagaExecutionID)
+		assert.Empty(t, found.Error)
+	})
+
+	t.Run("GetByID_NotFound", func(t *testing.T) {
+		_, err := repo.GetByID(ctx, uuid.New())
+		require.ErrorIs(t, err, ErrJobNotFound)
+	})
+
+	t.Run("GetByManifestVersion", func(t *testing.T) {
+		_, err := repo.Create(ctx, 100)
+		require.NoError(t, err)
+
+		second, err := repo.Create(ctx, 100)
+		require.NoError(t, err)
+
+		found, err := repo.GetByManifestVersion(ctx, 100)
+		require.NoError(t, err)
+		require.NotNil(t, found)
+		assert.Equal(t, second.ID, found.ID)
+	})
+
+	t.Run("GetByManifestVersion_NotFound", func(t *testing.T) {
+		_, err := repo.GetByManifestVersion(ctx, 9999)
+		require.ErrorIs(t, err, ErrJobNotFound)
+	})
+
+	t.Run("MarkApplying", func(t *testing.T) {
+		job, err := repo.Create(ctx, 200)
+		require.NoError(t, err)
+
+		sagaID := uuid.New()
+		err = repo.MarkApplying(ctx, job.ID, sagaID)
+		require.NoError(t, err)
+
+		found, err := repo.GetByID(ctx, job.ID)
+		require.NoError(t, err)
+		assert.Equal(t, ApplyJobStatusApplying, found.Status)
+		require.NotNil(t, found.SagaExecutionID)
+		assert.Equal(t, sagaID, *found.SagaExecutionID)
+	})
+
+	t.Run("MarkApplying_NotFound", func(t *testing.T) {
+		err := repo.MarkApplying(ctx, uuid.New(), uuid.New())
+		require.ErrorIs(t, err, ErrJobNotFound)
+	})
+
+	t.Run("MarkApplying_WrongStatus", func(t *testing.T) {
+		job, err := repo.Create(ctx, 201)
+		require.NoError(t, err)
+
+		err = repo.MarkApplying(ctx, job.ID, uuid.New())
+		require.NoError(t, err)
+
+		// Already APPLYING, cannot mark APPLYING again
+		err = repo.MarkApplying(ctx, job.ID, uuid.New())
+		require.ErrorIs(t, err, ErrJobNotFound)
+	})
+
+	t.Run("MarkApplied", func(t *testing.T) {
+		job, err := repo.Create(ctx, 300)
+		require.NoError(t, err)
+
+		err = repo.MarkApplying(ctx, job.ID, uuid.New())
+		require.NoError(t, err)
+
+		err = repo.MarkApplied(ctx, job.ID)
+		require.NoError(t, err)
+
+		found, err := repo.GetByID(ctx, job.ID)
+		require.NoError(t, err)
+		assert.Equal(t, ApplyJobStatusApplied, found.Status)
+		assert.NotNil(t, found.CompletedAt)
+	})
+
+	t.Run("MarkApplied_NotFound", func(t *testing.T) {
+		err := repo.MarkApplied(ctx, uuid.New())
+		require.ErrorIs(t, err, ErrJobNotFound)
+	})
+
+	t.Run("MarkApplied_WrongStatus", func(t *testing.T) {
+		job, err := repo.Create(ctx, 301)
+		require.NoError(t, err)
+
+		// PENDING -> cannot MarkApplied (needs APPLYING)
+		err = repo.MarkApplied(ctx, job.ID)
+		require.ErrorIs(t, err, ErrJobNotFound)
+	})
+
+	t.Run("MarkFailed_FromPending", func(t *testing.T) {
+		job, err := repo.Create(ctx, 400)
+		require.NoError(t, err)
+
+		err = repo.MarkFailed(ctx, job.ID, "something went wrong")
+		require.NoError(t, err)
+
+		found, err := repo.GetByID(ctx, job.ID)
+		require.NoError(t, err)
+		assert.Equal(t, ApplyJobStatusFailed, found.Status)
+		assert.Equal(t, "something went wrong", found.Error)
+		assert.NotNil(t, found.CompletedAt)
+	})
+
+	t.Run("MarkFailed_FromApplying", func(t *testing.T) {
+		job, err := repo.Create(ctx, 401)
+		require.NoError(t, err)
+
+		err = repo.MarkApplying(ctx, job.ID, uuid.New())
+		require.NoError(t, err)
+
+		err = repo.MarkFailed(ctx, job.ID, "saga execution error")
+		require.NoError(t, err)
+
+		found, err := repo.GetByID(ctx, job.ID)
+		require.NoError(t, err)
+		assert.Equal(t, ApplyJobStatusFailed, found.Status)
+		assert.Equal(t, "saga execution error", found.Error)
+	})
+
+	t.Run("MarkFailed_NotFound", func(t *testing.T) {
+		err := repo.MarkFailed(ctx, uuid.New(), "error")
+		require.ErrorIs(t, err, ErrJobNotFound)
+	})
+
+	t.Run("MarkFailed_WrongStatus_Applied", func(t *testing.T) {
+		job, err := repo.Create(ctx, 402)
+		require.NoError(t, err)
+
+		err = repo.MarkApplying(ctx, job.ID, uuid.New())
+		require.NoError(t, err)
+		err = repo.MarkApplied(ctx, job.ID)
+		require.NoError(t, err)
+
+		// Cannot fail an APPLIED job
+		err = repo.MarkFailed(ctx, job.ID, "too late")
+		require.ErrorIs(t, err, ErrJobNotFound)
+	})
+
+	t.Run("FullLifecycle", func(t *testing.T) {
+		// Create
+		job, err := repo.Create(ctx, 500)
+		require.NoError(t, err)
+		assert.Equal(t, ApplyJobStatusPending, job.Status)
+
+		// Mark applying
+		sagaID := uuid.New()
+		err = repo.MarkApplying(ctx, job.ID, sagaID)
+		require.NoError(t, err)
+
+		found, err := repo.GetByID(ctx, job.ID)
+		require.NoError(t, err)
+		assert.Equal(t, ApplyJobStatusApplying, found.Status)
+		require.NotNil(t, found.SagaExecutionID)
+		assert.Equal(t, sagaID, *found.SagaExecutionID)
+
+		// Mark applied
+		err = repo.MarkApplied(ctx, job.ID)
+		require.NoError(t, err)
+
+		found, err = repo.GetByID(ctx, job.ID)
+		require.NoError(t, err)
+		assert.Equal(t, ApplyJobStatusApplied, found.Status)
+		assert.NotNil(t, found.CompletedAt)
+
+		// Retrievable by manifest version
+		byVersion, err := repo.GetByManifestVersion(ctx, 500)
+		require.NoError(t, err)
+		assert.Equal(t, job.ID, byVersion.ID)
+		assert.Equal(t, ApplyJobStatusApplied, byVersion.Status)
+	})
+}

--- a/services/control-plane/internal/applier/bootstrap_test.go
+++ b/services/control-plane/internal/applier/bootstrap_test.go
@@ -68,7 +68,7 @@ func TestParseInt(t *testing.T) {
 		{"100", 100},
 		{"", 0},
 		{"abc", 0},
-		{"1a2b3", 123},
+		{"1a2b3", 123}, // parseInt extracts all digits; versions are pre-split by "."
 		{"v2", 2},
 	}
 
@@ -128,8 +128,7 @@ func TestLoadEmbeddedApplyManifest_ReturnsLatestVersion(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "1.3.0", version)
 	assert.NotEmpty(t, script)
-	// Script should not have leading/trailing whitespace (TrimSpace applied)
-	assert.Equal(t, script, script) // sanity check it's not empty
+	// Verify TrimSpace was applied: no leading whitespace
 	assert.NotEqual(t, ' ', rune(script[0]))
 }
 

--- a/services/control-plane/internal/applier/bootstrap_test.go
+++ b/services/control-plane/internal/applier/bootstrap_test.go
@@ -66,6 +66,10 @@ func TestParseInt(t *testing.T) {
 		{"1", 1},
 		{"42", 42},
 		{"100", 100},
+		{"", 0},
+		{"abc", 0},
+		{"1a2b3", 123},
+		{"v2", 2},
 	}
 
 	for _, tt := range tests {
@@ -73,4 +77,62 @@ func TestParseInt(t *testing.T) {
 			assert.Equal(t, tt.expected, parseInt(tt.input))
 		})
 	}
+}
+
+func TestVersionFilenamePattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		matches bool
+		version string
+	}{
+		{"valid version", "v1.0.0.star", true, "1.0.0"},
+		{"valid higher version", "v2.10.3.star", true, "2.10.3"},
+		{"no v prefix", "1.0.0.star", false, ""},
+		{"wrong extension", "v1.0.0.txt", false, ""},
+		{"directory name", "v1.0.0", false, ""},
+		{"non-numeric", "vx.y.z.star", false, ""},
+		{"partial version", "v1.0.star", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := versionFilenamePattern.FindStringSubmatch(tt.input)
+			if tt.matches {
+				require.NotNil(t, matches)
+				assert.Equal(t, tt.version, matches[1])
+			} else {
+				assert.Nil(t, matches)
+			}
+		})
+	}
+}
+
+func TestIsSemverGreater_EqualVersions(t *testing.T) {
+	// Equal versions should return false
+	assert.False(t, isSemverGreater("1.0.0", "1.0.0"))
+	assert.False(t, isSemverGreater("0.0.0", "0.0.0"))
+	assert.False(t, isSemverGreater("99.99.99", "99.99.99"))
+}
+
+func TestIsSemverGreater_EmptyB(t *testing.T) {
+	// When b is empty, always returns true (any version is greater than nothing)
+	assert.True(t, isSemverGreater("", ""))
+	assert.True(t, isSemverGreater("0.0.0", ""))
+}
+
+func TestLoadEmbeddedApplyManifest_ReturnsLatestVersion(t *testing.T) {
+	// The embedded defaults contain v1.0.0, v1.1.0, v1.2.0, v1.3.0
+	// loadEmbeddedApplyManifest should return v1.3.0 as the latest
+	script, version, err := loadEmbeddedApplyManifest()
+	require.NoError(t, err)
+	assert.Equal(t, "1.3.0", version)
+	assert.NotEmpty(t, script)
+	// Script should not have leading/trailing whitespace (TrimSpace applied)
+	assert.Equal(t, script, script) // sanity check it's not empty
+	assert.NotEqual(t, ' ', rune(script[0]))
+}
+
+func TestErrNoEmbeddedScript(t *testing.T) {
+	assert.EqualError(t, ErrNoEmbeddedScript, "embedded apply_manifest saga script not found")
 }

--- a/services/control-plane/internal/applier/resource_patcher_test.go
+++ b/services/control-plane/internal/applier/resource_patcher_test.go
@@ -1,0 +1,747 @@
+package applier
+
+import (
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Helper key functions ---
+
+func TestValRuleKey(t *testing.T) {
+	assert.Equal(t, "GBP->KWH", valRuleKey("gbp", "kwh"))
+	assert.Equal(t, "USD->EUR", valRuleKey("USD", "EUR"))
+	assert.Equal(t, "->", valRuleKey("", ""))
+}
+
+func TestPartyTypeKey(t *testing.T) {
+	assert.Equal(t, "tenant-1:INDIVIDUAL", partyTypeKey("tenant-1", "INDIVIDUAL"))
+	assert.Equal(t, ":", partyTypeKey("", ""))
+}
+
+func TestMappingKey(t *testing.T) {
+	assert.Equal(t, "my-mapping:1", mappingKey("my-mapping", 1))
+	assert.Equal(t, "transform:5", mappingKey("transform", 5))
+}
+
+// --- patchResource error paths ---
+
+func TestPatchResource_UnsupportedResourceType(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_UNSPECIFIED,
+	}
+
+	_, err := patchResource(base, req)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedResourceType)
+}
+
+func TestPatchResource_InstrumentTypeMismatch(t *testing.T) {
+	base := newTestManifest()
+	// Declare resource type as instrument but provide an account type payload
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INSTRUMENT,
+		Resource: &controlplanev1.ApplyResourceRequest_AccountType{
+			AccountType: &controlplanev1.AccountTypeDefinition{Code: "CURRENT"},
+		},
+	}
+
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_AccountTypeTypeMismatch(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_ACCOUNT_TYPE,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: &controlplanev1.InstrumentDefinition{Code: "GBP"},
+		},
+	}
+
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_ValuationRuleTypeMismatch(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_VALUATION_RULE,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: &controlplanev1.InstrumentDefinition{Code: "GBP"},
+		},
+	}
+
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_SagaTypeMismatch(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_SAGA,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: &controlplanev1.InstrumentDefinition{Code: "GBP"},
+		},
+	}
+
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_ProviderConnectionTypeMismatch(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_PROVIDER_CONNECTION,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: &controlplanev1.InstrumentDefinition{Code: "GBP"},
+		},
+	}
+
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_InstructionRouteTypeMismatch(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INSTRUCTION_ROUTE,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: &controlplanev1.InstrumentDefinition{Code: "GBP"},
+		},
+	}
+
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_MarketDataSourceTypeMismatch(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_MARKET_DATA_SOURCE,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: &controlplanev1.InstrumentDefinition{Code: "GBP"},
+		},
+	}
+
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_MarketDataSetTypeMismatch(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_MARKET_DATA_SET,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: &controlplanev1.InstrumentDefinition{Code: "GBP"},
+		},
+	}
+
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_OrganizationTypeMismatch(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_ORGANIZATION,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: &controlplanev1.InstrumentDefinition{Code: "GBP"},
+		},
+	}
+
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_InternalAccountTypeMismatch(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INTERNAL_ACCOUNT,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: &controlplanev1.InstrumentDefinition{Code: "GBP"},
+		},
+	}
+
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+// --- Patch resource types not yet covered ---
+
+func TestPatchResource_AddPartyType(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_PARTY_TYPE,
+		Resource: &controlplanev1.ApplyResourceRequest_PartyType{
+			PartyType: &partyv1.PartyTypeDefinition{
+				TenantId:  "tenant-1",
+				PartyType: "INDIVIDUAL",
+			},
+		},
+	}
+
+	patched, err := patchResource(base, req)
+	require.NoError(t, err)
+	require.Len(t, patched.PartyTypes, 1)
+	assert.Equal(t, "INDIVIDUAL", patched.PartyTypes[0].GetPartyType())
+	assert.Equal(t, "tenant-1", patched.PartyTypes[0].GetTenantId())
+}
+
+func TestPatchResource_UpdatePartyType(t *testing.T) {
+	base := newTestManifest()
+	base.PartyTypes = []*partyv1.PartyTypeDefinition{
+		{TenantId: "tenant-1", PartyType: "INDIVIDUAL"},
+	}
+
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_PARTY_TYPE,
+		Resource: &controlplanev1.ApplyResourceRequest_PartyType{
+			PartyType: &partyv1.PartyTypeDefinition{
+				TenantId:  "tenant-1",
+				PartyType: "INDIVIDUAL",
+			},
+		},
+	}
+
+	patched, err := patchResource(base, req)
+	require.NoError(t, err)
+	require.Len(t, patched.PartyTypes, 1)
+}
+
+func TestPatchResource_PartyTypeTypeMismatch(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_PARTY_TYPE,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: &controlplanev1.InstrumentDefinition{Code: "GBP"},
+		},
+	}
+
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_AddMapping(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_MAPPING,
+		Resource: &controlplanev1.ApplyResourceRequest_Mapping{
+			Mapping: &mappingv1.MappingDefinition{
+				Name:    "transform-payments",
+				Version: 1,
+			},
+		},
+	}
+
+	patched, err := patchResource(base, req)
+	require.NoError(t, err)
+	require.Len(t, patched.Mappings, 1)
+	assert.Equal(t, "transform-payments", patched.Mappings[0].GetName())
+	assert.Equal(t, int32(1), patched.Mappings[0].GetVersion())
+}
+
+func TestPatchResource_UpdateMapping(t *testing.T) {
+	base := newTestManifest()
+	base.Mappings = []*mappingv1.MappingDefinition{
+		{Name: "transform-payments", Version: 1},
+	}
+
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_MAPPING,
+		Resource: &controlplanev1.ApplyResourceRequest_Mapping{
+			Mapping: &mappingv1.MappingDefinition{
+				Name:    "transform-payments",
+				Version: 1,
+			},
+		},
+	}
+
+	patched, err := patchResource(base, req)
+	require.NoError(t, err)
+	require.Len(t, patched.Mappings, 1)
+}
+
+func TestPatchResource_MappingTypeMismatch(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_MAPPING,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: &controlplanev1.InstrumentDefinition{Code: "GBP"},
+		},
+	}
+
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_AddInstructionRoute(t *testing.T) {
+	base := newTestManifest()
+	require.Nil(t, base.OperationalGateway)
+
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INSTRUCTION_ROUTE,
+		Resource: &controlplanev1.ApplyResourceRequest_InstructionRoute{
+			InstructionRoute: &controlplanev1.InstructionRouteConfig{
+				InstructionType: "payment.initiate",
+				ConnectionId:    "stripe-payments",
+			},
+		},
+	}
+
+	patched, err := patchResource(base, req)
+	require.NoError(t, err)
+	require.NotNil(t, patched.OperationalGateway)
+	require.Len(t, patched.OperationalGateway.InstructionRoutes, 1)
+	assert.Equal(t, "payment.initiate", patched.OperationalGateway.InstructionRoutes[0].GetInstructionType())
+}
+
+func TestPatchResource_AddMarketDataSet(t *testing.T) {
+	base := newTestManifest()
+	require.Nil(t, base.MarketData)
+
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_MARKET_DATA_SET,
+		Resource: &controlplanev1.ApplyResourceRequest_MarketDataSet{
+			MarketDataSet: &controlplanev1.MarketDataSetDefinition{
+				Code:       "USD_EUR_FX",
+				Unit:       "USD/EUR",
+				SourceCode: "BLOOMBERG",
+			},
+		},
+	}
+
+	patched, err := patchResource(base, req)
+	require.NoError(t, err)
+	require.NotNil(t, patched.MarketData)
+	require.Len(t, patched.MarketData.Datasets, 1)
+	assert.Equal(t, "USD_EUR_FX", patched.MarketData.Datasets[0].GetCode())
+}
+
+func TestPatchResource_AddValuationRule(t *testing.T) {
+	base := newTestManifest()
+
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_VALUATION_RULE,
+		Resource: &controlplanev1.ApplyResourceRequest_ValuationRule{
+			ValuationRule: &controlplanev1.ValuationRule{
+				FromInstrument: "GBP",
+				ToInstrument:   "KWH",
+				Method:         controlplanev1.ValuationMethod_VALUATION_METHOD_FIXED,
+			},
+		},
+	}
+
+	patched, err := patchResource(base, req)
+	require.NoError(t, err)
+	require.Len(t, patched.ValuationRules, 1)
+	assert.Equal(t, "GBP", patched.ValuationRules[0].GetFromInstrument())
+	assert.Equal(t, "KWH", patched.ValuationRules[0].GetToInstrument())
+}
+
+func TestPatchResource_UpdateValuationRule(t *testing.T) {
+	base := newTestManifest()
+	base.ValuationRules = []*controlplanev1.ValuationRule{
+		{FromInstrument: "GBP", ToInstrument: "KWH", Method: controlplanev1.ValuationMethod_VALUATION_METHOD_FIXED},
+	}
+
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_VALUATION_RULE,
+		Resource: &controlplanev1.ApplyResourceRequest_ValuationRule{
+			ValuationRule: &controlplanev1.ValuationRule{
+				FromInstrument: "GBP",
+				ToInstrument:   "KWH",
+				Method:         controlplanev1.ValuationMethod_VALUATION_METHOD_SPOT_RATE,
+			},
+		},
+	}
+
+	patched, err := patchResource(base, req)
+	require.NoError(t, err)
+	require.Len(t, patched.ValuationRules, 1)
+	assert.Equal(t, controlplanev1.ValuationMethod_VALUATION_METHOD_SPOT_RATE, patched.ValuationRules[0].GetMethod())
+}
+
+// --- resourceID additional coverage ---
+
+func TestResourceID_PartyType(t *testing.T) {
+	req := &controlplanev1.ApplyResourceRequest{
+		Resource: &controlplanev1.ApplyResourceRequest_PartyType{
+			PartyType: &partyv1.PartyTypeDefinition{
+				TenantId:  "tenant-1",
+				PartyType: "INDIVIDUAL",
+			},
+		},
+	}
+	assert.Equal(t, "tenant-1:INDIVIDUAL", resourceID(req))
+}
+
+func TestResourceID_Mapping(t *testing.T) {
+	req := &controlplanev1.ApplyResourceRequest{
+		Resource: &controlplanev1.ApplyResourceRequest_Mapping{
+			Mapping: &mappingv1.MappingDefinition{
+				Name:    "transform",
+				Version: 3,
+			},
+		},
+	}
+	assert.Equal(t, "transform:3", resourceID(req))
+}
+
+func TestResourceID_ProviderConnection(t *testing.T) {
+	req := &controlplanev1.ApplyResourceRequest{
+		Resource: &controlplanev1.ApplyResourceRequest_ProviderConnection{
+			ProviderConnection: &controlplanev1.ProviderConnectionConfig{
+				ConnectionId: "stripe-payments",
+			},
+		},
+	}
+	assert.Equal(t, "stripe-payments", resourceID(req))
+}
+
+func TestResourceID_InstructionRoute(t *testing.T) {
+	req := &controlplanev1.ApplyResourceRequest{
+		Resource: &controlplanev1.ApplyResourceRequest_InstructionRoute{
+			InstructionRoute: &controlplanev1.InstructionRouteConfig{
+				InstructionType: "payment.initiate",
+			},
+		},
+	}
+	assert.Equal(t, "payment.initiate", resourceID(req))
+}
+
+func TestResourceID_MarketDataSource(t *testing.T) {
+	req := &controlplanev1.ApplyResourceRequest{
+		Resource: &controlplanev1.ApplyResourceRequest_MarketDataSource{
+			MarketDataSource: &controlplanev1.MarketDataSourceDefinition{
+				Code: "BLOOMBERG",
+			},
+		},
+	}
+	assert.Equal(t, "BLOOMBERG", resourceID(req))
+}
+
+func TestResourceID_MarketDataSet(t *testing.T) {
+	req := &controlplanev1.ApplyResourceRequest{
+		Resource: &controlplanev1.ApplyResourceRequest_MarketDataSet{
+			MarketDataSet: &controlplanev1.MarketDataSetDefinition{
+				Code: "USD_EUR_FX",
+			},
+		},
+	}
+	assert.Equal(t, "USD_EUR_FX", resourceID(req))
+}
+
+func TestResourceID_InternalAccount(t *testing.T) {
+	req := &controlplanev1.ApplyResourceRequest{
+		Resource: &controlplanev1.ApplyResourceRequest_InternalAccount{
+			InternalAccount: &controlplanev1.InternalAccountDefinition{
+				Code: "REVENUE_GBP",
+			},
+		},
+	}
+	assert.Equal(t, "REVENUE_GBP", resourceID(req))
+}
+
+func TestResourceID_NilResource(t *testing.T) {
+	req := &controlplanev1.ApplyResourceRequest{}
+	assert.Equal(t, "", resourceID(req))
+}
+
+// --- upsertInSlice ---
+
+func TestUpsertInSlice_AppendNew(t *testing.T) {
+	type item struct{ Code string }
+	slice := []item{{Code: "A"}, {Code: "B"}}
+	result := upsertInSlice(slice, item{Code: "C"}, func(i item) string { return i.Code }, "C")
+	require.Len(t, result, 3)
+	assert.Equal(t, "C", result[2].Code)
+}
+
+func TestUpsertInSlice_ReplaceExisting(t *testing.T) {
+	type item struct {
+		Code string
+		Name string
+	}
+	slice := []item{{Code: "A", Name: "Alpha"}, {Code: "B", Name: "Beta"}}
+	result := upsertInSlice(slice, item{Code: "A", Name: "Updated"}, func(i item) string { return i.Code }, "A")
+	require.Len(t, result, 2)
+	assert.Equal(t, "Updated", result[0].Name)
+}
+
+func TestUpsertInSlice_EmptySlice(t *testing.T) {
+	type item struct{ Code string }
+	var slice []item
+	result := upsertInSlice(slice, item{Code: "A"}, func(i item) string { return i.Code }, "A")
+	require.Len(t, result, 1)
+}
+
+// --- Nil payload variants for patcher functions ---
+
+func TestPatchResource_InstrumentNilPayload(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INSTRUMENT,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: nil,
+		},
+	}
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_AccountTypeNilPayload(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_ACCOUNT_TYPE,
+		Resource: &controlplanev1.ApplyResourceRequest_AccountType{
+			AccountType: nil,
+		},
+	}
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_SagaNilPayload(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_SAGA,
+		Resource: &controlplanev1.ApplyResourceRequest_Saga{
+			Saga: nil,
+		},
+	}
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_ValuationRuleNilPayload(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_VALUATION_RULE,
+		Resource: &controlplanev1.ApplyResourceRequest_ValuationRule{
+			ValuationRule: nil,
+		},
+	}
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_PartyTypeNilPayload(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_PARTY_TYPE,
+		Resource: &controlplanev1.ApplyResourceRequest_PartyType{
+			PartyType: nil,
+		},
+	}
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_MappingNilPayload(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_MAPPING,
+		Resource: &controlplanev1.ApplyResourceRequest_Mapping{
+			Mapping: nil,
+		},
+	}
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_ProviderConnectionNilPayload(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_PROVIDER_CONNECTION,
+		Resource: &controlplanev1.ApplyResourceRequest_ProviderConnection{
+			ProviderConnection: nil,
+		},
+	}
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_InstructionRouteNilPayload(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INSTRUCTION_ROUTE,
+		Resource: &controlplanev1.ApplyResourceRequest_InstructionRoute{
+			InstructionRoute: nil,
+		},
+	}
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_MarketDataSourceNilPayload(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_MARKET_DATA_SOURCE,
+		Resource: &controlplanev1.ApplyResourceRequest_MarketDataSource{
+			MarketDataSource: nil,
+		},
+	}
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_MarketDataSetNilPayload(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_MARKET_DATA_SET,
+		Resource: &controlplanev1.ApplyResourceRequest_MarketDataSet{
+			MarketDataSet: nil,
+		},
+	}
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_OrganizationNilPayload(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_ORGANIZATION,
+		Resource: &controlplanev1.ApplyResourceRequest_Organization{
+			Organization: nil,
+		},
+	}
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+func TestPatchResource_InternalAccountNilPayload(t *testing.T) {
+	base := newTestManifest()
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INTERNAL_ACCOUNT,
+		Resource: &controlplanev1.ApplyResourceRequest_InternalAccount{
+			InternalAccount: nil,
+		},
+	}
+	_, err := patchResource(base, req)
+	require.ErrorIs(t, err, ErrResourceTypeMismatch)
+}
+
+// --- Existing OperationalGateway / MarketData upsert (not nil init) ---
+
+func TestPatchResource_ProviderConnection_ExistingGateway(t *testing.T) {
+	base := newTestManifest()
+	base.OperationalGateway = &controlplanev1.OperationalGatewayConfig{
+		ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+			{ConnectionId: "existing-conn", ProviderName: "OldProvider"},
+		},
+	}
+
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_PROVIDER_CONNECTION,
+		Resource: &controlplanev1.ApplyResourceRequest_ProviderConnection{
+			ProviderConnection: &controlplanev1.ProviderConnectionConfig{
+				ConnectionId: "new-conn",
+				ProviderName: "NewProvider",
+			},
+		},
+	}
+
+	patched, err := patchResource(base, req)
+	require.NoError(t, err)
+	require.Len(t, patched.OperationalGateway.ProviderConnections, 2)
+}
+
+func TestPatchResource_InstructionRoute_ExistingGateway(t *testing.T) {
+	base := newTestManifest()
+	base.OperationalGateway = &controlplanev1.OperationalGatewayConfig{
+		InstructionRoutes: []*controlplanev1.InstructionRouteConfig{
+			{InstructionType: "existing.route"},
+		},
+	}
+
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INSTRUCTION_ROUTE,
+		Resource: &controlplanev1.ApplyResourceRequest_InstructionRoute{
+			InstructionRoute: &controlplanev1.InstructionRouteConfig{
+				InstructionType: "new.route",
+			},
+		},
+	}
+
+	patched, err := patchResource(base, req)
+	require.NoError(t, err)
+	require.Len(t, patched.OperationalGateway.InstructionRoutes, 2)
+}
+
+func TestPatchResource_MarketDataSource_ExistingMarketData(t *testing.T) {
+	base := newTestManifest()
+	base.MarketData = &controlplanev1.MarketDataConfig{
+		Sources: []*controlplanev1.MarketDataSourceDefinition{
+			{Code: "EXISTING_SOURCE"},
+		},
+	}
+
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_MARKET_DATA_SOURCE,
+		Resource: &controlplanev1.ApplyResourceRequest_MarketDataSource{
+			MarketDataSource: &controlplanev1.MarketDataSourceDefinition{
+				Code: "NEW_SOURCE",
+			},
+		},
+	}
+
+	patched, err := patchResource(base, req)
+	require.NoError(t, err)
+	require.Len(t, patched.MarketData.Sources, 2)
+}
+
+func TestPatchResource_MarketDataSet_ExistingMarketData(t *testing.T) {
+	base := newTestManifest()
+	base.MarketData = &controlplanev1.MarketDataConfig{
+		Datasets: []*controlplanev1.MarketDataSetDefinition{
+			{Code: "EXISTING_DATASET"},
+		},
+	}
+
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_MARKET_DATA_SET,
+		Resource: &controlplanev1.ApplyResourceRequest_MarketDataSet{
+			MarketDataSet: &controlplanev1.MarketDataSetDefinition{
+				Code: "NEW_DATASET",
+			},
+		},
+	}
+
+	patched, err := patchResource(base, req)
+	require.NoError(t, err)
+	require.Len(t, patched.MarketData.Datasets, 2)
+}
+
+// --- patchResource does not mutate base ---
+
+func TestPatchResource_DoesNotMutateBase(t *testing.T) {
+	base := newTestManifest()
+	originalLen := len(base.Instruments)
+
+	req := &controlplanev1.ApplyResourceRequest{
+		ResourceType: controlplanev1.ManifestResourceType_MANIFEST_RESOURCE_TYPE_INSTRUMENT,
+		Resource: &controlplanev1.ApplyResourceRequest_Instrument{
+			Instrument: &controlplanev1.InstrumentDefinition{
+				Code: "USD",
+				Name: "US Dollar",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "USD",
+					Precision: 2,
+				},
+			},
+		},
+	}
+
+	patched, err := patchResource(base, req)
+	require.NoError(t, err)
+
+	assert.Len(t, base.Instruments, originalLen, "base should not be mutated")
+	assert.Len(t, patched.Instruments, originalLen+1, "patched should have one more instrument")
+}

--- a/services/control-plane/internal/generator/export_test.go
+++ b/services/control-plane/internal/generator/export_test.go
@@ -65,3 +65,18 @@ func (c *ClaudeLLMClient) Model() string {
 
 // YAMLToProtoManifest is the exported test hook for yamlToProtoManifest.
 var YAMLToProtoManifest = yamlToProtoManifest
+
+// ExtractManifestMetadata is the exported test hook for extractManifestMetadata.
+var ExtractManifestMetadata = extractManifestMetadata
+
+// PatternNames is the exported test hook for patternNames.
+var PatternNames = patternNames
+
+// ToProtoValidationErrors is the exported test hook for toProtoValidationErrors.
+var ToProtoValidationErrors = toProtoValidationErrors
+
+// ConvertYAMLToJSONCompatible is the exported test hook for convertYAMLToJSONCompatible.
+var ConvertYAMLToJSONCompatible = convertYAMLToJSONCompatible
+
+// ApplyAmendImpact is the exported test hook for applyAmendImpact.
+var ApplyAmendImpactFn = applyAmendImpact

--- a/services/control-plane/internal/generator/service_test.go
+++ b/services/control-plane/internal/generator/service_test.go
@@ -822,6 +822,300 @@ func TestGenerateManifest_PatternNamesPopulated(t *testing.T) {
 	assert.True(t, resp.Valid)
 }
 
+// --- extractManifestMetadata tests (via export_test.go) ---
+
+func TestExtractManifestMetadata_ValidYAML(t *testing.T) {
+	yamlStr := `
+instruments:
+  - code: GBP
+    name: British Pound
+  - code: EUR
+    name: Euro
+account_types:
+  - code: CURRENT
+    name: Current Account
+  - code: SAVINGS
+    name: Savings Account
+sagas:
+  - name: transfer_funds
+  - name: settle_trade
+`
+	meta, err := generator.ExtractManifestMetadata(yamlStr)
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+	assert.Equal(t, []string{"GBP", "EUR"}, meta.InstrumentsCreated)
+	assert.Equal(t, []string{"CURRENT", "SAVINGS"}, meta.AccountTypesCreated)
+	assert.Equal(t, []string{"transfer_funds", "settle_trade"}, meta.SagasCreated)
+}
+
+func TestExtractManifestMetadata_EmptyYAML(t *testing.T) {
+	yamlStr := `
+instruments: []
+account_types: []
+sagas: []
+`
+	meta, err := generator.ExtractManifestMetadata(yamlStr)
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+	assert.Empty(t, meta.InstrumentsCreated)
+	assert.Empty(t, meta.AccountTypesCreated)
+	assert.Empty(t, meta.SagasCreated)
+}
+
+func TestExtractManifestMetadata_InvalidYAML(t *testing.T) {
+	_, err := generator.ExtractManifestMetadata("{{{{not valid yaml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse manifest YAML")
+}
+
+// --- patternNames tests ---
+
+func TestPatternNames_Empty(t *testing.T) {
+	result := generator.PatternNames(nil)
+	assert.Nil(t, result)
+
+	result = generator.PatternNames([]generator.PatternMatch{})
+	assert.Nil(t, result)
+}
+
+func TestPatternNames_WithItems(t *testing.T) {
+	patterns := []generator.PatternMatch{
+		{Name: "energy-settlement"},
+		{Name: "carbon-offset"},
+		{Name: "neobank-payments"},
+	}
+	result := generator.PatternNames(patterns)
+	assert.Equal(t, []string{"energy-settlement", "carbon-offset", "neobank-payments"}, result)
+}
+
+// --- toProtoValidationErrors tests ---
+
+func TestToProtoValidationErrors_Empty(t *testing.T) {
+	result := generator.ToProtoValidationErrors(nil)
+	assert.Nil(t, result)
+
+	result = generator.ToProtoValidationErrors([]generator.ValidationError{})
+	assert.Nil(t, result)
+}
+
+func TestToProtoValidationErrors_WithItems(t *testing.T) {
+	errs := []generator.ValidationError{
+		{
+			Code:         "ERR_001",
+			Path:         "instruments[0].code",
+			Message:      "invalid code",
+			Suggestion:   "use uppercase",
+			ResourceType: "instrument",
+			ResourceID:   "gbp",
+		},
+		{
+			Code:    "ERR_002",
+			Path:    "sagas[0]",
+			Message: "unknown handler",
+		},
+	}
+	result := generator.ToProtoValidationErrors(errs)
+	require.Len(t, result, 2)
+	assert.Equal(t, "ERR_001", result[0].Code)
+	assert.Equal(t, "instruments[0].code", result[0].Path)
+	assert.Equal(t, "invalid code", result[0].Message)
+	assert.Equal(t, "use uppercase", result[0].Suggestion)
+	assert.Equal(t, "instrument", result[0].ResourceType)
+	assert.Equal(t, "gbp", result[0].ResourceId)
+
+	assert.Equal(t, "ERR_002", result[1].Code)
+	assert.Equal(t, "sagas[0]", result[1].Path)
+	assert.Equal(t, "unknown handler", result[1].Message)
+}
+
+// --- convertYAMLToJSONCompatible tests ---
+
+func TestConvertYAMLToJSONCompatible(t *testing.T) {
+	t.Run("map[string]interface{}", func(t *testing.T) {
+		input := map[string]interface{}{
+			"key": "value",
+			"nested": map[string]interface{}{
+				"inner": "data",
+			},
+		}
+		result := generator.ConvertYAMLToJSONCompatible(input)
+		m, ok := result.(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "value", m["key"])
+		nested, ok := m["nested"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "data", nested["inner"])
+	})
+
+	t.Run("map[interface{}]interface{}", func(t *testing.T) {
+		input := map[interface{}]interface{}{
+			"key":   "value",
+			42:      "numeric-key",
+			"nested": map[interface{}]interface{}{
+				"inner": "data",
+			},
+		}
+		result := generator.ConvertYAMLToJSONCompatible(input)
+		m, ok := result.(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "value", m["key"])
+		assert.Equal(t, "numeric-key", m["42"])
+		nested, ok := m["nested"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "data", nested["inner"])
+	})
+
+	t.Run("[]interface{}", func(t *testing.T) {
+		input := []interface{}{
+			"a",
+			map[string]interface{}{"b": "c"},
+			42,
+		}
+		result := generator.ConvertYAMLToJSONCompatible(input)
+		arr, ok := result.([]interface{})
+		require.True(t, ok)
+		require.Len(t, arr, 3)
+		assert.Equal(t, "a", arr[0])
+		m, ok := arr[1].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "c", m["b"])
+		assert.Equal(t, 42, arr[2])
+	})
+
+	t.Run("scalar values pass through", func(t *testing.T) {
+		assert.Equal(t, "hello", generator.ConvertYAMLToJSONCompatible("hello"))
+		assert.Equal(t, 42, generator.ConvertYAMLToJSONCompatible(42))
+		assert.Equal(t, true, generator.ConvertYAMLToJSONCompatible(true))
+		assert.Nil(t, generator.ConvertYAMLToJSONCompatible(nil))
+	})
+}
+
+// --- yamlToProtoManifest tests ---
+
+func TestYamlToProtoManifest_Valid(t *testing.T) {
+	yamlStr := `
+version: "1.0"
+metadata:
+  name: test-economy
+instruments:
+  - code: GBP
+    name: British Pound
+`
+	m, err := generator.YAMLToProtoManifest(yamlStr)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Equal(t, "1.0", m.Version)
+	assert.Equal(t, "test-economy", m.Metadata.GetName())
+	require.Len(t, m.Instruments, 1)
+	assert.Equal(t, "GBP", m.Instruments[0].Code)
+}
+
+func TestYamlToProtoManifest_InvalidYAML(t *testing.T) {
+	_, err := generator.YAMLToProtoManifest("{{{{not valid yaml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse manifest YAML")
+}
+
+// --- applyAmendImpact tests ---
+
+func TestApplyAmendImpact_AdditionsAndRemovals(t *testing.T) {
+	originalYAML := `
+instruments:
+  - code: GBP
+  - code: USD
+account_types:
+  - code: CURRENT
+sagas:
+  - name: transfer
+`
+	amendedYAML := `
+instruments:
+  - code: GBP
+  - code: EUR
+account_types:
+  - code: CURRENT
+  - code: SAVINGS
+sagas:
+  - name: transfer
+`
+	meta := &controlplanev1.GenerationMetadata{}
+	warnings := generator.ApplyAmendImpactFn(originalYAML, amendedYAML, meta)
+
+	// USD was removed, so we expect a removal warning.
+	var removedPaths []string
+	for _, w := range warnings {
+		if w.Code == "AMEND_RESOURCE_REMOVED" {
+			removedPaths = append(removedPaths, w.Path)
+		}
+	}
+	assert.Contains(t, removedPaths, "instrument:USD")
+
+	// Decisions should be populated.
+	assert.NotEmpty(t, meta.Decisions)
+}
+
+func TestApplyAmendImpact_NoRemovals(t *testing.T) {
+	originalYAML := `
+instruments:
+  - code: GBP
+`
+	amendedYAML := `
+instruments:
+  - code: GBP
+  - code: EUR
+`
+	meta := &controlplanev1.GenerationMetadata{}
+	warnings := generator.ApplyAmendImpactFn(originalYAML, amendedYAML, meta)
+
+	// No removals, so no AMEND_RESOURCE_REMOVED warnings.
+	for _, w := range warnings {
+		assert.NotEqual(t, "AMEND_RESOURCE_REMOVED", w.Code)
+	}
+	assert.NotEmpty(t, meta.Decisions)
+}
+
+// --- GenerateManifest error path: LLM fix error ---
+
+func TestGenerateManifest_CreateMode_LLMFixError(t *testing.T) {
+	val := &mockValidatorSequence{
+		responses: []*generator.ValidationResult{
+			{
+				Valid: false,
+				Errors: []generator.ValidationError{
+					{Code: "ERR", Path: "x", Message: "bad"},
+				},
+			},
+		},
+	}
+	llm := &mockGenerateLLMClient{
+		generateResponse: minimalValidYAML,
+		fixErr:           errors.New("fix API down"),
+	}
+	svc := buildService(t, llm, val)
+
+	_, err := svc.GenerateManifest(context.Background(), &controlplanev1.GenerateManifestRequest{
+		Description:      "A bank",
+		MaxFixIterations: 1,
+	})
+	// The validate-fix loop should propagate the fix error.
+	require.Error(t, err)
+}
+
+// --- GenerateManifest: validator error on initial pass ---
+
+func TestGenerateManifest_CreateMode_ValidatorError(t *testing.T) {
+	val := &mockValidatorSequence{
+		errs: []error{errors.New("validator backend down")},
+	}
+	llm := &mockGenerateLLMClient{generateResponse: minimalValidYAML}
+	svc := buildService(t, llm, val)
+
+	_, err := svc.GenerateManifest(context.Background(), &controlplanev1.GenerateManifestRequest{
+		Description: "A bank",
+	})
+	require.Error(t, err)
+}
+
 // cookbookWithOnePattern returns a minimal cookbook FS with one energy-related pattern.
 func cookbookWithOnePattern() fstest.MapFS {
 	return fstest.MapFS{

--- a/services/control-plane/internal/generator/service_test.go
+++ b/services/control-plane/internal/generator/service_test.go
@@ -949,8 +949,8 @@ func TestConvertYAMLToJSONCompatible(t *testing.T) {
 
 	t.Run("map[interface{}]interface{}", func(t *testing.T) {
 		input := map[interface{}]interface{}{
-			"key":   "value",
-			42:      "numeric-key",
+			"key": "value",
+			42:    "numeric-key",
 			"nested": map[interface{}]interface{}{
 				"inner": "data",
 			},

--- a/services/control-plane/internal/staff/service_test.go
+++ b/services/control-plane/internal/staff/service_test.go
@@ -296,6 +296,69 @@ func TestStaffService(t *testing.T) {
 		})
 	})
 
+	t.Run("ValidateAPIKeyFull", func(t *testing.T) {
+		// Create an active user for full validation tests
+		fullUser, err := svc.InviteStaff(ctx, "full-validate@example.com", "Full User", "admin")
+		require.NoError(t, err)
+		err = svc.ActivateStaff(ctx, fullUser.ID, "auth0|fullvalidate")
+		require.NoError(t, err)
+
+		t.Run("validate_full_success", func(t *testing.T) {
+			result, err := svc.CreateAPIKey(ctx, fullUser.ID, "acme", "full-key", []string{"read", "write"}, 0)
+			require.NoError(t, err)
+
+			validated, err := svc.ValidateAPIKeyFull(ctx, result.KeyPrefix, result.PlaintextKey)
+			require.NoError(t, err)
+			require.NotNil(t, validated)
+
+			assert.Equal(t, fullUser.ID, validated.User.ID)
+			assert.Equal(t, "full-validate@example.com", validated.User.Email)
+			assert.Equal(t, "admin", validated.User.Role)
+			assert.Equal(t, "active", validated.User.Status)
+			assert.Equal(t, []string{"read", "write"}, validated.Scopes)
+			assert.Equal(t, 100, validated.RateLimitRPS)
+		})
+
+		t.Run("validate_full_wrong_key", func(t *testing.T) {
+			result, err := svc.CreateAPIKey(ctx, fullUser.ID, "acme", "full-wrong", nil, 0)
+			require.NoError(t, err)
+
+			_, err = svc.ValidateAPIKeyFull(ctx, result.KeyPrefix, "pk_acme_completely_wrong")
+			require.ErrorIs(t, err, staff.ErrInvalidAPIKey)
+		})
+
+		t.Run("validate_full_expired", func(t *testing.T) {
+			result, err := svc.CreateAPIKey(ctx, fullUser.ID, "acme", "full-expired", nil, 1*time.Millisecond)
+			require.NoError(t, err)
+
+			time.Sleep(10 * time.Millisecond) //nolint:forbidigo // triggers API key expiry (1ms TTL)
+
+			_, err = svc.ValidateAPIKeyFull(ctx, result.KeyPrefix, result.PlaintextKey)
+			require.ErrorIs(t, err, staff.ErrAPIKeyExpired)
+		})
+
+		t.Run("validate_full_suspended_staff", func(t *testing.T) {
+			suspUser, err := svc.InviteStaff(ctx, "full-susp@example.com", "FullSusp", "operator")
+			require.NoError(t, err)
+			err = svc.ActivateStaff(ctx, suspUser.ID, "auth0|fullsusp")
+			require.NoError(t, err)
+
+			result, err := svc.CreateAPIKey(ctx, suspUser.ID, "acme", "full-susp-key", nil, 0)
+			require.NoError(t, err)
+
+			err = svc.SuspendStaff(ctx, suspUser.ID)
+			require.NoError(t, err)
+
+			_, err = svc.ValidateAPIKeyFull(ctx, result.KeyPrefix, result.PlaintextKey)
+			require.ErrorIs(t, err, staff.ErrStaffSuspended)
+		})
+
+		t.Run("validate_full_not_found", func(t *testing.T) {
+			_, err := svc.ValidateAPIKeyFull(ctx, "pk_nonexistent_12345678", "pk_nonexistent_12345678abcdef")
+			require.ErrorIs(t, err, staff.ErrAPIKeyNotFound)
+		})
+	})
+
 	t.Run("MapRoleToAuth", func(t *testing.T) {
 		tests := []struct {
 			staffRole string
@@ -364,4 +427,13 @@ func TestStaffIsolation_DifferentTenants(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, usersB, 1)
 	assert.Equal(t, "Alice B", usersB[0].Name)
+}
+
+func TestNewService_NilLogger(t *testing.T) {
+	gormDB, cleanup := testdb.SetupCockroachDB(t, nil)
+	defer cleanup()
+
+	// Should not panic when logger is nil; falls back to slog.Default()
+	svc := staff.NewService(gormDB, nil)
+	require.NotNil(t, svc)
 }

--- a/services/control-plane/service/bootstrap_test.go
+++ b/services/control-plane/service/bootstrap_test.go
@@ -209,7 +209,7 @@ func TestRegisterEconomyGeneratorService_WithOptions(t *testing.T) {
 	err := RegisterEconomyGeneratorService(server, EconomyGeneratorConfig{
 		SchemaRegistry: schema.NewRegistry(),
 		LLMClient:      &fakeLLMClient{},
-		Validator:       &fakeManifestValidator{},
+		Validator:      &fakeManifestValidator{},
 	})
 	require.NoError(t, err)
 }

--- a/services/control-plane/service/bootstrap_test.go
+++ b/services/control-plane/service/bootstrap_test.go
@@ -1,13 +1,23 @@
 package service
 
 import (
+	"context"
 	"testing"
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/services/control-plane/internal/generator"
+	"github.com/meridianhub/meridian/services/control-plane/internal/manifest"
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
 )
+
+// ---------------------------------------------------------------------------
+// ValidateManifest tests
+// ---------------------------------------------------------------------------
 
 func TestValidateManifest_Valid(t *testing.T) {
 	mf := &controlplanev1.Manifest{}
@@ -43,4 +53,189 @@ func TestValidateManifest_Invalid(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, result.Valid)
 	assert.NotEmpty(t, result.Errors)
+}
+
+func TestValidateManifest_WithWarnings(t *testing.T) {
+	// A manifest with an event-triggered saga but no filter should produce
+	// a MISSING_EVENT_FILTER warning while remaining valid.
+	mf := &controlplanev1.Manifest{}
+	err := protojson.Unmarshal([]byte(`{
+		"version": "1.0",
+		"metadata": {"name": "test-warnings", "industry": "platform"},
+		"instruments": [{
+			"code": "GBP",
+			"name": "British Pound",
+			"type": "INSTRUMENT_TYPE_FIAT",
+			"dimensions": {"unit": "GBP", "precision": 2}
+		}],
+		"accountTypes": [{
+			"code": "CLEARING",
+			"name": "Clearing",
+			"normalBalance": "NORMAL_BALANCE_DEBIT",
+			"allowedInstruments": ["GBP"]
+		}],
+		"sagas": [{
+			"name": "on_transaction_captured",
+			"trigger": "event:position-keeping.transaction-captured.v1",
+			"script": "def execute(ctx):\n    return {}\n"
+		}]
+	}`), mf)
+	require.NoError(t, err)
+
+	result, err := ValidateManifest(mf, nil)
+	require.NoError(t, err)
+	assert.True(t, result.Valid, "manifest with warnings should still be valid; errors: %v", result.Errors)
+	assert.NotEmpty(t, result.Warnings, "expected at least one warning")
+
+	found := false
+	for _, w := range result.Warnings {
+		if w.Code == "MISSING_EVENT_FILTER" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected MISSING_EVENT_FILTER warning, got: %v", result.Warnings)
+}
+
+// ---------------------------------------------------------------------------
+// RegisterApplyManifestService tests
+// ---------------------------------------------------------------------------
+
+func TestRegisterApplyManifestService_NilPool(t *testing.T) {
+	server := grpc.NewServer()
+	defer server.Stop()
+
+	err := RegisterApplyManifestService(server, ApplyManifestServiceConfig{
+		Pool: nil,
+	})
+	require.ErrorIs(t, err, ErrPoolRequired)
+}
+
+func TestRegisterApplyManifestService_Success(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires testcontainer")
+	}
+
+	// Start a CockroachDB container and obtain a pgxpool.Pool via testdb.NewTestPool.
+	pool := testdb.NewTestPool(t)
+
+	server := grpc.NewServer()
+	defer server.Stop()
+
+	err := RegisterApplyManifestService(server, ApplyManifestServiceConfig{
+		Pool: pool,
+	})
+	require.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// RegisterManifestHistoryService tests
+// ---------------------------------------------------------------------------
+
+func TestRegisterManifestHistoryService_NilDB(t *testing.T) {
+	server := grpc.NewServer()
+	defer server.Stop()
+
+	err := RegisterManifestHistoryService(server, ManifestHistoryServiceConfig{
+		DB: nil,
+	})
+	require.ErrorIs(t, err, ErrDBRequired)
+}
+
+func TestRegisterManifestHistoryService_Success(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires testcontainer")
+	}
+
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+	defer cleanup()
+
+	server := grpc.NewServer()
+	defer server.Stop()
+
+	err := RegisterManifestHistoryService(server, ManifestHistoryServiceConfig{
+		DB: db,
+	})
+	require.NoError(t, err)
+}
+
+func TestRegisterManifestHistoryService_WithExportCollectors(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires testcontainer")
+	}
+
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+	defer cleanup()
+
+	server := grpc.NewServer()
+	defer server.Stop()
+
+	err := RegisterManifestHistoryService(server, ManifestHistoryServiceConfig{
+		DB:               db,
+		ExportCollectors: &manifest.ExportCollectors{},
+	})
+	require.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// RegisterEconomyGeneratorService tests
+// ---------------------------------------------------------------------------
+
+func TestRegisterEconomyGeneratorService_NilRegistry(t *testing.T) {
+	server := grpc.NewServer()
+	defer server.Stop()
+
+	err := RegisterEconomyGeneratorService(server, EconomyGeneratorConfig{
+		SchemaRegistry: nil,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "schema registry is required")
+}
+
+func TestRegisterEconomyGeneratorService_Success(t *testing.T) {
+	server := grpc.NewServer()
+	defer server.Stop()
+
+	err := RegisterEconomyGeneratorService(server, EconomyGeneratorConfig{
+		SchemaRegistry: schema.NewRegistry(),
+	})
+	require.NoError(t, err)
+}
+
+func TestRegisterEconomyGeneratorService_WithOptions(t *testing.T) {
+	server := grpc.NewServer()
+	defer server.Stop()
+
+	err := RegisterEconomyGeneratorService(server, EconomyGeneratorConfig{
+		SchemaRegistry: schema.NewRegistry(),
+		LLMClient:      &fakeLLMClient{},
+		Validator:       &fakeManifestValidator{},
+	})
+	require.NoError(t, err)
+}
+
+// fakeLLMClient satisfies generator.LLMClient for testing.
+type fakeLLMClient struct{}
+
+func (f *fakeLLMClient) Generate(_ context.Context, _ string) (string, error) { return "", nil }
+func (f *fakeLLMClient) Fix(_ context.Context, _ string, _ []generator.ValidationError) (string, error) {
+	return "", nil
+}
+
+// fakeManifestValidator satisfies generator.ManifestValidator for testing.
+type fakeManifestValidator struct{}
+
+func (f *fakeManifestValidator) ValidateDryRun(_ context.Context, _ string) (*generator.ValidationResult, error) {
+	return &generator.ValidationResult{Valid: true}, nil
+}
+
+// ---------------------------------------------------------------------------
+// NewHandlerDeps test
+// ---------------------------------------------------------------------------
+
+func TestNewHandlerDeps_ReturnsNonNil(t *testing.T) {
+	// NewHandlerDeps wraps gRPC client constructors. Passing a nil conn is
+	// safe because the clients are lazy (they only dial on RPC calls).
+	deps := NewHandlerDeps(nil)
+	require.NotNil(t, deps)
 }


### PR DESCRIPTION
## Summary

- Add unhappy path and edge case tests across control-plane service packages
- Target: increase overall control-plane test coverage from 72.4% toward 80%

## Coverage Improvements

| Package | Before | After |
|---------|--------|-------|
| staff | 74.4% | 87.5% |
| service | 12.9% | 80.6% |
| generator | 77.7% | 80.4% |
| admin | 65.6% | 82.1% |
| applier | 57.5% | 66.4% |

## Changes Made

- **staff**: `ValidateAPIKeyFull` tests (success, wrong key, expired, suspended, not found), nil logger branch
- **service**: Registration error paths (nil pool, nil DB, nil registry), `ExportCollectors` branch, `NewHandlerDeps`, economy generator with LLM/validator options
- **generator**: `extractManifestMetadata`, `convertYAMLToJSONCompatible`, `patternNames`, `toProtoValidationErrors`, `applyAmendImpact`, `yamlToProtoManifest`, `NewManifestValidatorAdapter`
- **admin**: Balance sheet handler/service error propagation, `sanitizeCSVCell` formula injection prevention, CSV export edge cases, deep tree nesting, nil field handling
- **applier**: `ApplyJobRepository` integration tests (Create, MarkApplying, MarkApplied, MarkFailed, GetByID, GetByManifestVersion), resource patcher type mismatch/nil payload/helper tests, bootstrap edge cases

## Test plan

- [x] All new tests pass locally
- [ ] CI passes