### PR TITLE
test: increase reconciliation service coverage to 80.2%

### DIFF
--- a/services/reconciliation/adapters/messaging/kafka_publisher_test.go
+++ b/services/reconciliation/adapters/messaging/kafka_publisher_test.go
@@ -55,6 +55,13 @@ func TestDeprecatedTopicFor(t *testing.T) {
 	assert.Empty(t, deprecatedTopicFor("unknown.topic"))
 }
 
+// accountIDEvent implements the hasAccountID interface used by extractPartitionKey.
+type accountIDEvent struct {
+	accountID string
+}
+
+func (e accountIDEvent) GetAccountID() string { return e.accountID }
+
 func TestExtractPartitionKey(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -62,7 +69,12 @@ func TestExtractPartitionKey(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "event with account_id",
+			name:     "event implementing hasAccountID interface",
+			event:    accountIDEvent{accountID: "acct-direct"},
+			expected: "acct-direct",
+		},
+		{
+			name:     "event with account_id in JSON map",
 			event:    map[string]string{"account_id": "acct-123", "run_id": "run-456"},
 			expected: "acct-123",
 		},
@@ -79,6 +91,11 @@ func TestExtractPartitionKey(t *testing.T) {
 		{
 			name:     "nil event",
 			event:    nil,
+			expected: "",
+		},
+		{
+			name:     "unmarshalable event",
+			event:    make(chan int),
 			expected: "",
 		},
 	}

--- a/services/reconciliation/adapters/messaging/outbox_event_publisher_test.go
+++ b/services/reconciliation/adapters/messaging/outbox_event_publisher_test.go
@@ -1,0 +1,154 @@
+package messaging
+
+import (
+	"context"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	// Create outbox table for the publisher
+	err = db.Exec(`CREATE TABLE IF NOT EXISTS outbox_events (
+		id TEXT PRIMARY KEY,
+		event_type TEXT NOT NULL,
+		topic TEXT NOT NULL,
+		payload BLOB NOT NULL,
+		aggregate_type TEXT NOT NULL,
+		aggregate_id TEXT NOT NULL,
+		partition_key TEXT NOT NULL,
+		service_name TEXT NOT NULL,
+		correlation_id TEXT,
+		status TEXT NOT NULL DEFAULT 'PENDING',
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	)`).Error
+	require.NoError(t, err)
+
+	return db
+}
+
+func TestNewOutboxEventPublisher(t *testing.T) {
+	db := setupTestDB(t)
+	publisher := events.NewOutboxPublisher("reconciliation")
+
+	p := NewOutboxEventPublisher(db, publisher)
+	assert.NotNil(t, p)
+}
+
+func TestOutboxEventPublisher_Close(t *testing.T) {
+	db := setupTestDB(t)
+	publisher := events.NewOutboxPublisher("reconciliation")
+
+	p := NewOutboxEventPublisher(db, publisher)
+	// Close should not panic
+	p.Close()
+}
+
+func TestOutboxEventPublisher_UnsupportedTopic(t *testing.T) {
+	db := setupTestDB(t)
+	publisher := events.NewOutboxPublisher("reconciliation")
+
+	p := NewOutboxEventPublisher(db, publisher)
+	err := p.Publish(context.Background(), "unknown.topic", map[string]string{"key": "value"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errUnsupportedTopic)
+}
+
+func TestOutboxEventPublisher_DisputeCreated_WrongType(t *testing.T) {
+	db := setupTestDB(t)
+	publisher := events.NewOutboxPublisher("reconciliation")
+
+	p := NewOutboxEventPublisher(db, publisher)
+	err := p.Publish(context.Background(), TopicDisputeCreated, "not-an-event")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errUnexpectedType)
+}
+
+func TestOutboxEventPublisher_DisputeResolved_WrongType(t *testing.T) {
+	db := setupTestDB(t)
+	publisher := events.NewOutboxPublisher("reconciliation")
+
+	p := NewOutboxEventPublisher(db, publisher)
+	err := p.Publish(context.Background(), TopicDisputeResolved, "not-an-event")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errUnexpectedType)
+}
+
+func TestOutboxEventPublisher_PositionLockRequested_WrongType(t *testing.T) {
+	db := setupTestDB(t)
+	publisher := events.NewOutboxPublisher("reconciliation")
+
+	p := NewOutboxEventPublisher(db, publisher)
+	err := p.Publish(context.Background(), TopicPositionLockRequested, "not-an-event")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errUnexpectedType)
+}
+
+// mockDisputeCreatedEvent implements the disputeCreatedEvent interface for testing.
+type mockDisputeCreatedEvent struct{}
+
+func (m mockDisputeCreatedEvent) GetDisputeID() string  { return "disp-001" }
+func (m mockDisputeCreatedEvent) GetVarianceID() string  { return "var-001" }
+func (m mockDisputeCreatedEvent) GetRunID() string       { return "run-001" }
+func (m mockDisputeCreatedEvent) GetAccountID() string   { return "ACC-001" }
+func (m mockDisputeCreatedEvent) GetReason() string      { return "test reason" }
+func (m mockDisputeCreatedEvent) GetRaisedBy() string    { return "user-001" }
+
+// mockDisputeResolvedEvent implements the disputeResolvedEvent interface.
+type mockDisputeResolvedEvent struct{}
+
+func (m mockDisputeResolvedEvent) GetDisputeID() string  { return "disp-001" }
+func (m mockDisputeResolvedEvent) GetVarianceID() string { return "var-001" }
+func (m mockDisputeResolvedEvent) GetRunID() string      { return "run-001" }
+func (m mockDisputeResolvedEvent) GetAccountID() string  { return "ACC-001" }
+func (m mockDisputeResolvedEvent) GetAction() string     { return "RESOLVED" }
+func (m mockDisputeResolvedEvent) GetResolution() string { return "accepted variance" }
+func (m mockDisputeResolvedEvent) GetResolvedBy() string { return "user-002" }
+
+// mockPositionLockEvent implements the positionLockRequestedEvent interface.
+type mockPositionLockEvent struct{}
+
+func (m mockPositionLockEvent) GetRunID() string       { return "run-001" }
+func (m mockPositionLockEvent) GetAccountID() string   { return "ACC-001" }
+func (m mockPositionLockEvent) GetScope() string       { return "ACCOUNT" }
+func (m mockPositionLockEvent) GetPeriodStart() string { return "2026-01-01T00:00:00Z" }
+func (m mockPositionLockEvent) GetPeriodEnd() string   { return "2026-01-02T00:00:00Z" }
+func (m mockPositionLockEvent) GetStatus() string      { return "RUNNING" }
+
+func TestOutboxEventPublisher_DisputeCreated_ValidEvent(t *testing.T) {
+	db := setupTestDB(t)
+	publisher := events.NewOutboxPublisher("reconciliation")
+
+	p := NewOutboxEventPublisher(db, publisher)
+	// This will fail on the outbox Publish call because the outbox table schema
+	// doesn't match exactly, but it exercises the proto creation path
+	err := p.Publish(context.Background(), TopicDisputeCreated, mockDisputeCreatedEvent{})
+	// The error may be from outbox table mismatch, but proto creation path is covered
+	_ = err
+}
+
+func TestOutboxEventPublisher_DisputeResolved_ValidEvent(t *testing.T) {
+	db := setupTestDB(t)
+	publisher := events.NewOutboxPublisher("reconciliation")
+
+	p := NewOutboxEventPublisher(db, publisher)
+	err := p.Publish(context.Background(), TopicDisputeResolved, mockDisputeResolvedEvent{})
+	_ = err
+}
+
+func TestOutboxEventPublisher_PositionLockRequested_ValidEvent(t *testing.T) {
+	db := setupTestDB(t)
+	publisher := events.NewOutboxPublisher("reconciliation")
+
+	p := NewOutboxEventPublisher(db, publisher)
+	err := p.Publish(context.Background(), TopicPositionLockRequested, mockPositionLockEvent{})
+	_ = err
+}

--- a/services/reconciliation/adapters/messaging/outbox_event_publisher_test.go
+++ b/services/reconciliation/adapters/messaging/outbox_event_publisher_test.go
@@ -96,11 +96,11 @@ func TestOutboxEventPublisher_PositionLockRequested_WrongType(t *testing.T) {
 type mockDisputeCreatedEvent struct{}
 
 func (m mockDisputeCreatedEvent) GetDisputeID() string  { return "disp-001" }
-func (m mockDisputeCreatedEvent) GetVarianceID() string  { return "var-001" }
-func (m mockDisputeCreatedEvent) GetRunID() string       { return "run-001" }
-func (m mockDisputeCreatedEvent) GetAccountID() string   { return "ACC-001" }
-func (m mockDisputeCreatedEvent) GetReason() string      { return "test reason" }
-func (m mockDisputeCreatedEvent) GetRaisedBy() string    { return "user-001" }
+func (m mockDisputeCreatedEvent) GetVarianceID() string { return "var-001" }
+func (m mockDisputeCreatedEvent) GetRunID() string      { return "run-001" }
+func (m mockDisputeCreatedEvent) GetAccountID() string  { return "ACC-001" }
+func (m mockDisputeCreatedEvent) GetReason() string     { return "test reason" }
+func (m mockDisputeCreatedEvent) GetRaisedBy() string   { return "user-001" }
 
 // mockDisputeResolvedEvent implements the disputeResolvedEvent interface.
 type mockDisputeResolvedEvent struct{}
@@ -128,11 +128,10 @@ func TestOutboxEventPublisher_DisputeCreated_ValidEvent(t *testing.T) {
 	publisher := events.NewOutboxPublisher("reconciliation")
 
 	p := NewOutboxEventPublisher(db, publisher)
-	// This will fail on the outbox Publish call because the outbox table schema
-	// doesn't match exactly, but it exercises the proto creation path
+	// May error on outbox table schema mismatch, but proves the type assertion
+	// passed and the proto was built (not errUnexpectedType).
 	err := p.Publish(context.Background(), TopicDisputeCreated, mockDisputeCreatedEvent{})
-	// The error may be from outbox table mismatch, but proto creation path is covered
-	_ = err
+	assert.NotErrorIs(t, err, errUnexpectedType)
 }
 
 func TestOutboxEventPublisher_DisputeResolved_ValidEvent(t *testing.T) {
@@ -141,7 +140,7 @@ func TestOutboxEventPublisher_DisputeResolved_ValidEvent(t *testing.T) {
 
 	p := NewOutboxEventPublisher(db, publisher)
 	err := p.Publish(context.Background(), TopicDisputeResolved, mockDisputeResolvedEvent{})
-	_ = err
+	assert.NotErrorIs(t, err, errUnexpectedType)
 }
 
 func TestOutboxEventPublisher_PositionLockRequested_ValidEvent(t *testing.T) {
@@ -150,5 +149,5 @@ func TestOutboxEventPublisher_PositionLockRequested_ValidEvent(t *testing.T) {
 
 	p := NewOutboxEventPublisher(db, publisher)
 	err := p.Publish(context.Background(), TopicPositionLockRequested, mockPositionLockEvent{})
-	_ = err
+	assert.NotErrorIs(t, err, errUnexpectedType)
 }

--- a/services/reconciliation/client/client_test.go
+++ b/services/reconciliation/client/client_test.go
@@ -25,8 +25,29 @@ type mockReconciliationServer struct {
 	initiateResp *reconciliationv1.InitiateAccountReconciliationResponse
 	initiateErr  error
 
+	executeResp *reconciliationv1.ExecuteAccountReconciliationResponse
+	executeErr  error
+
 	retrieveResp *reconciliationv1.RetrieveAccountReconciliationResponse
 	retrieveErr  error
+
+	controlResp *reconciliationv1.ControlAccountReconciliationResponse
+	controlErr  error
+
+	listResultsResp *reconciliationv1.ListReconciliationResultsResponse
+	listResultsErr  error
+
+	assertBalanceResp *reconciliationv1.AssertBalanceResponse
+	assertBalanceErr  error
+
+	initiateDisputeResp *reconciliationv1.InitiateDisputeResponse
+	initiateDisputeErr  error
+
+	controlDisputeResp *reconciliationv1.ControlDisputeResponse
+	controlDisputeErr  error
+
+	retrieveDisputeResp *reconciliationv1.RetrieveDisputeResponse
+	retrieveDisputeErr  error
 }
 
 func (m *mockReconciliationServer) InitiateAccountReconciliation(
@@ -39,6 +60,16 @@ func (m *mockReconciliationServer) InitiateAccountReconciliation(
 	return m.initiateResp, nil
 }
 
+func (m *mockReconciliationServer) ExecuteAccountReconciliation(
+	_ context.Context,
+	_ *reconciliationv1.ExecuteAccountReconciliationRequest,
+) (*reconciliationv1.ExecuteAccountReconciliationResponse, error) {
+	if m.executeErr != nil {
+		return nil, m.executeErr
+	}
+	return m.executeResp, nil
+}
+
 func (m *mockReconciliationServer) RetrieveAccountReconciliation(
 	_ context.Context,
 	_ *reconciliationv1.RetrieveAccountReconciliationRequest,
@@ -47,6 +78,66 @@ func (m *mockReconciliationServer) RetrieveAccountReconciliation(
 		return nil, m.retrieveErr
 	}
 	return m.retrieveResp, nil
+}
+
+func (m *mockReconciliationServer) ControlAccountReconciliation(
+	_ context.Context,
+	_ *reconciliationv1.ControlAccountReconciliationRequest,
+) (*reconciliationv1.ControlAccountReconciliationResponse, error) {
+	if m.controlErr != nil {
+		return nil, m.controlErr
+	}
+	return m.controlResp, nil
+}
+
+func (m *mockReconciliationServer) ListReconciliationResults(
+	_ context.Context,
+	_ *reconciliationv1.ListReconciliationResultsRequest,
+) (*reconciliationv1.ListReconciliationResultsResponse, error) {
+	if m.listResultsErr != nil {
+		return nil, m.listResultsErr
+	}
+	return m.listResultsResp, nil
+}
+
+func (m *mockReconciliationServer) AssertBalance(
+	_ context.Context,
+	_ *reconciliationv1.AssertBalanceRequest,
+) (*reconciliationv1.AssertBalanceResponse, error) {
+	if m.assertBalanceErr != nil {
+		return nil, m.assertBalanceErr
+	}
+	return m.assertBalanceResp, nil
+}
+
+func (m *mockReconciliationServer) InitiateDispute(
+	_ context.Context,
+	_ *reconciliationv1.InitiateDisputeRequest,
+) (*reconciliationv1.InitiateDisputeResponse, error) {
+	if m.initiateDisputeErr != nil {
+		return nil, m.initiateDisputeErr
+	}
+	return m.initiateDisputeResp, nil
+}
+
+func (m *mockReconciliationServer) ControlDispute(
+	_ context.Context,
+	_ *reconciliationv1.ControlDisputeRequest,
+) (*reconciliationv1.ControlDisputeResponse, error) {
+	if m.controlDisputeErr != nil {
+		return nil, m.controlDisputeErr
+	}
+	return m.controlDisputeResp, nil
+}
+
+func (m *mockReconciliationServer) RetrieveDispute(
+	_ context.Context,
+	_ *reconciliationv1.RetrieveDisputeRequest,
+) (*reconciliationv1.RetrieveDisputeResponse, error) {
+	if m.retrieveDisputeErr != nil {
+		return nil, m.retrieveDisputeErr
+	}
+	return m.retrieveDisputeResp, nil
 }
 
 func setupTestServer(t *testing.T, mock *mockReconciliationServer) (client.Config, func()) {
@@ -95,6 +186,34 @@ func TestNew_DirectConnection(t *testing.T) {
 	require.NotNil(t, c)
 }
 
+func TestNew_DefaultsApplied(t *testing.T) {
+	mock := &mockReconciliationServer{}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	// Clear timeout to test default
+	cfg.Timeout = 0
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+	require.NotNil(t, c)
+}
+
+func TestNew_ServiceNameConnection(t *testing.T) {
+	// ServiceName path uses platformgrpc.NewClient which may fail without real DNS,
+	// but we can test that it doesn't panic and returns an error or success.
+	_, _, err := client.New(client.Config{
+		ServiceName: "reconciliation",
+		Namespace:   "test-ns",
+		Port:        50058,
+	})
+	// This may succeed (creating a lazy connection) or fail depending on resolver
+	// The key is it doesn't panic and handles the path
+	if err != nil {
+		assert.Contains(t, err.Error(), "reconciliation")
+	}
+}
+
 func TestInitiateAccountReconciliation_Unimplemented(t *testing.T) {
 	mock := &mockReconciliationServer{
 		initiateErr: status.Error(codes.Unimplemented, "not implemented"),
@@ -111,6 +230,72 @@ func TestInitiateAccountReconciliation_Unimplemented(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, resp)
 	assert.Contains(t, err.Error(), "failed to initiate account reconciliation")
+}
+
+func TestInitiateAccountReconciliation_Success(t *testing.T) {
+	mock := &mockReconciliationServer{
+		initiateResp: &reconciliationv1.InitiateAccountReconciliationResponse{
+			Run: &reconciliationv1.SettlementRunSummary{
+				RunId: "run-001",
+			},
+		},
+	}
+
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	resp, err := c.InitiateAccountReconciliation(context.Background(), &reconciliationv1.InitiateAccountReconciliationRequest{
+		AccountId: "ACC-001",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "run-001", resp.GetRun().GetRunId())
+}
+
+func TestExecuteAccountReconciliation_Error(t *testing.T) {
+	mock := &mockReconciliationServer{
+		executeErr: status.Error(codes.NotFound, "run not found"),
+	}
+
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	resp, err := c.ExecuteAccountReconciliation(context.Background(), &reconciliationv1.ExecuteAccountReconciliationRequest{
+		RunId: "run-001",
+	})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "failed to execute account reconciliation")
+}
+
+func TestExecuteAccountReconciliation_Success(t *testing.T) {
+	mock := &mockReconciliationServer{
+		executeResp: &reconciliationv1.ExecuteAccountReconciliationResponse{
+			Run: &reconciliationv1.SettlementRunSummary{
+				RunId: "run-001",
+			},
+		},
+	}
+
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	resp, err := c.ExecuteAccountReconciliation(context.Background(), &reconciliationv1.ExecuteAccountReconciliationRequest{
+		RunId: "run-001",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "run-001", resp.GetRun().GetRunId())
 }
 
 func TestRetrieveAccountReconciliation_NotFound(t *testing.T) {
@@ -133,6 +318,305 @@ func TestRetrieveAccountReconciliation_NotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to retrieve account reconciliation")
 }
 
+func TestRetrieveAccountReconciliation_Success(t *testing.T) {
+	mock := &mockReconciliationServer{
+		retrieveResp: &reconciliationv1.RetrieveAccountReconciliationResponse{
+			Run: &reconciliationv1.SettlementRunSummary{
+				RunId:  "run-001",
+				Status: reconciliationv1.RunStatus_RUN_STATUS_COMPLETED,
+			},
+		},
+	}
+
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	resp, err := c.RetrieveAccountReconciliation(context.Background(), &reconciliationv1.RetrieveAccountReconciliationRequest{
+		RunId: "run-001",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "run-001", resp.GetRun().GetRunId())
+}
+
+func TestControlAccountReconciliation_Error(t *testing.T) {
+	mock := &mockReconciliationServer{
+		controlErr: status.Error(codes.FailedPrecondition, "cannot cancel completed run"),
+	}
+
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	resp, err := c.ControlAccountReconciliation(context.Background(), &reconciliationv1.ControlAccountReconciliationRequest{
+		RunId:  "run-001",
+		Action: reconciliationv1.ControlAction_CONTROL_ACTION_CANCEL,
+	})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "failed to control account reconciliation")
+}
+
+func TestControlAccountReconciliation_Success(t *testing.T) {
+	mock := &mockReconciliationServer{
+		controlResp: &reconciliationv1.ControlAccountReconciliationResponse{
+			Run: &reconciliationv1.SettlementRunSummary{
+				RunId: "run-001",
+			},
+		},
+	}
+
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	resp, err := c.ControlAccountReconciliation(context.Background(), &reconciliationv1.ControlAccountReconciliationRequest{
+		RunId:  "run-001",
+		Action: reconciliationv1.ControlAction_CONTROL_ACTION_CANCEL,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "run-001", resp.GetRun().GetRunId())
+}
+
+func TestListReconciliationResults_Error(t *testing.T) {
+	mock := &mockReconciliationServer{
+		listResultsErr: status.Error(codes.NotFound, "run not found"),
+	}
+
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	resp, err := c.ListReconciliationResults(context.Background(), &reconciliationv1.ListReconciliationResultsRequest{
+		RunId: "run-001",
+	})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "failed to list reconciliation results")
+}
+
+func TestListReconciliationResults_Success(t *testing.T) {
+	mock := &mockReconciliationServer{
+		listResultsResp: &reconciliationv1.ListReconciliationResultsResponse{
+			Variances: []*reconciliationv1.VarianceDetail{
+				{VarianceId: "var-001"},
+			},
+		},
+	}
+
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	resp, err := c.ListReconciliationResults(context.Background(), &reconciliationv1.ListReconciliationResultsRequest{
+		RunId: "run-001",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.GetVariances(), 1)
+	assert.Equal(t, "var-001", resp.GetVariances()[0].GetVarianceId())
+}
+
+func TestAssertBalance_Error(t *testing.T) {
+	mock := &mockReconciliationServer{
+		assertBalanceErr: status.Error(codes.InvalidArgument, "invalid expression"),
+	}
+
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	resp, err := c.AssertBalance(context.Background(), &reconciliationv1.AssertBalanceRequest{
+		AccountId:       "ACC-001",
+		InstrumentCode:  "GBP",
+		Expression:      "INVALID",
+		ExpectedBalance: "100.00",
+	})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "failed to assert balance")
+}
+
+func TestAssertBalance_Success(t *testing.T) {
+	mock := &mockReconciliationServer{
+		assertBalanceResp: &reconciliationv1.AssertBalanceResponse{
+			Assertion: &reconciliationv1.BalanceAssertionDetail{
+				AssertionId: "assert-001",
+			},
+		},
+	}
+
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	resp, err := c.AssertBalance(context.Background(), &reconciliationv1.AssertBalanceRequest{
+		AccountId:       "ACC-001",
+		InstrumentCode:  "GBP",
+		Expression:      "DEBIT == CREDIT",
+		ExpectedBalance: "100.00",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "assert-001", resp.GetAssertion().GetAssertionId())
+}
+
+func TestInitiateDispute_Error(t *testing.T) {
+	mock := &mockReconciliationServer{
+		initiateDisputeErr: status.Error(codes.NotFound, "variance not found"),
+	}
+
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	resp, err := c.InitiateDispute(context.Background(), &reconciliationv1.InitiateDisputeRequest{
+		VarianceId: "var-001",
+		RunId:      "run-001",
+		AccountId:  "ACC-001",
+		Reason:     "incorrect amount",
+		RaisedBy:   "user-001",
+	})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "failed to initiate dispute")
+}
+
+func TestInitiateDispute_Success(t *testing.T) {
+	mock := &mockReconciliationServer{
+		initiateDisputeResp: &reconciliationv1.InitiateDisputeResponse{
+			Dispute: &reconciliationv1.DisputeDetail{
+				DisputeId: "disp-001",
+			},
+		},
+	}
+
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	resp, err := c.InitiateDispute(context.Background(), &reconciliationv1.InitiateDisputeRequest{
+		VarianceId: "var-001",
+		RunId:      "run-001",
+		AccountId:  "ACC-001",
+		Reason:     "incorrect amount",
+		RaisedBy:   "user-001",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "disp-001", resp.GetDispute().GetDisputeId())
+}
+
+func TestControlDispute_Error(t *testing.T) {
+	mock := &mockReconciliationServer{
+		controlDisputeErr: status.Error(codes.FailedPrecondition, "dispute already resolved"),
+	}
+
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	resp, err := c.ControlDispute(context.Background(), &reconciliationv1.ControlDisputeRequest{
+		DisputeId: "disp-001",
+	})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "failed to control dispute")
+}
+
+func TestControlDispute_Success(t *testing.T) {
+	mock := &mockReconciliationServer{
+		controlDisputeResp: &reconciliationv1.ControlDisputeResponse{
+			Dispute: &reconciliationv1.DisputeDetail{
+				DisputeId: "disp-001",
+			},
+		},
+	}
+
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	resp, err := c.ControlDispute(context.Background(), &reconciliationv1.ControlDisputeRequest{
+		DisputeId: "disp-001",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "disp-001", resp.GetDispute().GetDisputeId())
+}
+
+func TestRetrieveDispute_Error(t *testing.T) {
+	mock := &mockReconciliationServer{
+		retrieveDisputeErr: status.Error(codes.NotFound, "dispute not found"),
+	}
+
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	resp, err := c.RetrieveDispute(context.Background(), &reconciliationv1.RetrieveDisputeRequest{
+		DisputeId: "disp-001",
+	})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "failed to retrieve dispute")
+}
+
+func TestRetrieveDispute_Success(t *testing.T) {
+	mock := &mockReconciliationServer{
+		retrieveDisputeResp: &reconciliationv1.RetrieveDisputeResponse{
+			Dispute: &reconciliationv1.DisputeDetail{
+				DisputeId: "disp-001",
+			},
+		},
+	}
+
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	resp, err := c.RetrieveDispute(context.Background(), &reconciliationv1.RetrieveDisputeRequest{
+		DisputeId: "disp-001",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "disp-001", resp.GetDispute().GetDisputeId())
+}
+
 func TestClose(t *testing.T) {
 	mock := &mockReconciliationServer{}
 	cfg, cleanup := setupTestServer(t, mock)
@@ -143,4 +627,17 @@ func TestClose(t *testing.T) {
 
 	err = c.Close()
 	assert.NoError(t, err)
+}
+
+func TestConn(t *testing.T) {
+	mock := &mockReconciliationServer{}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	conn := c.Conn()
+	assert.NotNil(t, conn)
 }

--- a/services/reconciliation/client/starlark_test.go
+++ b/services/reconciliation/client/starlark_test.go
@@ -1,0 +1,744 @@
+package client_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"github.com/meridianhub/meridian/services/reconciliation/client"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+)
+
+func newTestStarlarkContext() *saga.StarlarkContext {
+	return &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		CorrelationID:   uuid.New(),
+		KnowledgeAt:     time.Now(),
+		IdempotencyKey:  "saga_test_step_1",
+	}
+}
+
+func TestRegisterStarlarkHandlers(t *testing.T) {
+	mock := &mockReconciliationServer{}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	registry := saga.NewHandlerRegistry()
+	err = client.RegisterStarlarkHandlers(registry, c)
+	require.NoError(t, err)
+
+	// Verify all expected handlers are registered
+	expectedHandlers := []string{
+		"reconciliation.initiate_run",
+		"reconciliation.execute_run",
+		"reconciliation.retrieve_run",
+		"reconciliation.cancel_run",
+		"reconciliation.assert_balance",
+		"reconciliation.initiate_dispute",
+	}
+	for _, name := range expectedHandlers {
+		handler, err := registry.Get(name)
+		assert.NoError(t, err, "handler %s should be registered", name)
+		assert.NotNil(t, handler, "handler %s should not be nil", name)
+	}
+}
+
+func TestInitiateRunHandler_Success(t *testing.T) {
+	mock := &mockReconciliationServer{
+		initiateResp: &reconciliationv1.InitiateAccountReconciliationResponse{
+			Run: &reconciliationv1.SettlementRunSummary{
+				RunId: "run-001",
+			},
+		},
+	}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("reconciliation.initiate_run")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	result, err := handler(ctx, map[string]any{
+		"account_id":      "ACC-001",
+		"initiated_by":    "test-user",
+		"scope":           "ACCOUNT",
+		"settlement_type": "DAILY",
+	})
+	require.NoError(t, err)
+
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "run-001", resultMap["run_id"])
+	assert.Equal(t, "PENDING", resultMap["status"])
+}
+
+func TestInitiateRunHandler_MissingAccountID(t *testing.T) {
+	mock := &mockReconciliationServer{}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("reconciliation.initiate_run")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{
+		"initiated_by": "test-user",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "account_id")
+}
+
+func TestInitiateRunHandler_MissingInitiatedBy(t *testing.T) {
+	mock := &mockReconciliationServer{}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("reconciliation.initiate_run")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{
+		"account_id": "ACC-001",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "initiated_by")
+}
+
+func TestInitiateRunHandler_GRPCError(t *testing.T) {
+	mock := &mockReconciliationServer{
+		initiateErr: status.Error(codes.Internal, "server error"),
+	}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("reconciliation.initiate_run")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{
+		"account_id":   "ACC-001",
+		"initiated_by": "test-user",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reconciliation.initiate_run")
+}
+
+func TestInitiateRunHandler_ScopeVariants(t *testing.T) {
+	scopes := []string{"ACCOUNT", "INSTRUMENT", "PORTFOLIO", "FULL", "UNKNOWN"}
+	for _, scope := range scopes {
+		t.Run(scope, func(t *testing.T) {
+			mock := &mockReconciliationServer{
+				initiateResp: &reconciliationv1.InitiateAccountReconciliationResponse{
+					Run: &reconciliationv1.SettlementRunSummary{RunId: "run-001"},
+				},
+			}
+			cfg, cleanup := setupTestServer(t, mock)
+			defer cleanup()
+
+			c, clientCleanup, err := client.New(cfg)
+			require.NoError(t, err)
+			defer clientCleanup()
+
+			registry := saga.NewHandlerRegistry()
+			require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+			handler, err := registry.Get("reconciliation.initiate_run")
+			require.NoError(t, err)
+
+			ctx := newTestStarlarkContext()
+			result, err := handler(ctx, map[string]any{
+				"account_id":   "ACC-001",
+				"initiated_by": "test-user",
+				"scope":        scope,
+			})
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+		})
+	}
+}
+
+func TestInitiateRunHandler_SettlementTypeVariants(t *testing.T) {
+	types := []string{"DAILY", "WEEKLY", "MONTHLY", "ON_DEMAND", "END_OF_DAY", "REAL_TIME", "UNKNOWN", ""}
+	for _, st := range types {
+		t.Run(st, func(t *testing.T) {
+			mock := &mockReconciliationServer{
+				initiateResp: &reconciliationv1.InitiateAccountReconciliationResponse{
+					Run: &reconciliationv1.SettlementRunSummary{RunId: "run-001"},
+				},
+			}
+			cfg, cleanup := setupTestServer(t, mock)
+			defer cleanup()
+
+			c, clientCleanup, err := client.New(cfg)
+			require.NoError(t, err)
+			defer clientCleanup()
+
+			registry := saga.NewHandlerRegistry()
+			require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+			handler, err := registry.Get("reconciliation.initiate_run")
+			require.NoError(t, err)
+
+			ctx := newTestStarlarkContext()
+			params := map[string]any{
+				"account_id":   "ACC-001",
+				"initiated_by": "test-user",
+			}
+			if st != "" {
+				params["settlement_type"] = st
+			}
+			result, err := handler(ctx, params)
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+		})
+	}
+}
+
+func TestExecuteRunHandler_Success(t *testing.T) {
+	mock := &mockReconciliationServer{
+		executeResp: &reconciliationv1.ExecuteAccountReconciliationResponse{
+			Run: &reconciliationv1.SettlementRunSummary{RunId: "run-001"},
+		},
+	}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("reconciliation.execute_run")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	result, err := handler(ctx, map[string]any{"run_id": "run-001"})
+	require.NoError(t, err)
+
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "run-001", resultMap["run_id"])
+	assert.Equal(t, "RUNNING", resultMap["status"])
+}
+
+func TestExecuteRunHandler_MissingRunID(t *testing.T) {
+	mock := &mockReconciliationServer{}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("reconciliation.execute_run")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "run_id")
+}
+
+func TestExecuteRunHandler_GRPCError(t *testing.T) {
+	mock := &mockReconciliationServer{
+		executeErr: status.Error(codes.Internal, "execution failed"),
+	}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("reconciliation.execute_run")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{"run_id": "run-001"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reconciliation.execute_run")
+}
+
+func TestRetrieveRunHandler_Success(t *testing.T) {
+	mock := &mockReconciliationServer{
+		retrieveResp: &reconciliationv1.RetrieveAccountReconciliationResponse{
+			Run: &reconciliationv1.SettlementRunSummary{
+				RunId:         "run-001",
+				Status:        reconciliationv1.RunStatus_RUN_STATUS_COMPLETED,
+				VarianceCount: 3,
+			},
+		},
+	}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("reconciliation.retrieve_run")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	result, err := handler(ctx, map[string]any{"run_id": "run-001"})
+	require.NoError(t, err)
+
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "run-001", resultMap["run_id"])
+	assert.Equal(t, int64(3), resultMap["variance_count"])
+}
+
+func TestRetrieveRunHandler_MissingRunID(t *testing.T) {
+	mock := &mockReconciliationServer{}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("reconciliation.retrieve_run")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{})
+	require.Error(t, err)
+}
+
+func TestRetrieveRunHandler_GRPCError(t *testing.T) {
+	mock := &mockReconciliationServer{
+		retrieveErr: status.Error(codes.Internal, "server error"),
+	}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("reconciliation.retrieve_run")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{"run_id": "run-001"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reconciliation.retrieve_run")
+}
+
+func TestCancelRunHandler_Success(t *testing.T) {
+	mock := &mockReconciliationServer{
+		controlResp: &reconciliationv1.ControlAccountReconciliationResponse{
+			Run: &reconciliationv1.SettlementRunSummary{RunId: "run-001"},
+		},
+	}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("reconciliation.cancel_run")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	result, err := handler(ctx, map[string]any{
+		"run_id": "run-001",
+		"reason": "compensation rollback",
+	})
+	require.NoError(t, err)
+
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "run-001", resultMap["run_id"])
+	assert.Equal(t, "CANCELLED", resultMap["status"])
+}
+
+func TestCancelRunHandler_MissingRunID(t *testing.T) {
+	mock := &mockReconciliationServer{}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("reconciliation.cancel_run")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{})
+	require.Error(t, err)
+}
+
+func TestCancelRunHandler_GRPCError(t *testing.T) {
+	mock := &mockReconciliationServer{
+		controlErr: status.Error(codes.Internal, "cancel failed"),
+	}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("reconciliation.cancel_run")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{"run_id": "run-001"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reconciliation.cancel_run")
+}
+
+func TestAssertBalanceHandler_Success(t *testing.T) {
+	mock := &mockReconciliationServer{
+		assertBalanceResp: &reconciliationv1.AssertBalanceResponse{
+			Assertion: &reconciliationv1.BalanceAssertionDetail{
+				AssertionId: "assert-001",
+				Status:      reconciliationv1.AssertionStatus_ASSERTION_STATUS_PASSED,
+			},
+		},
+	}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("reconciliation.assert_balance")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	result, err := handler(ctx, map[string]any{
+		"account_id":       "ACC-001",
+		"instrument_code":  "GBP",
+		"expression":       "DEBIT == CREDIT",
+		"expected_balance": "100.00",
+	})
+	require.NoError(t, err)
+
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "assert-001", resultMap["assertion_id"])
+}
+
+func TestAssertBalanceHandler_MissingParams(t *testing.T) {
+	mock := &mockReconciliationServer{}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("reconciliation.assert_balance")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+
+	// Missing account_id
+	_, err = handler(ctx, map[string]any{
+		"instrument_code":  "GBP",
+		"expression":       "DEBIT == CREDIT",
+		"expected_balance": "100.00",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "account_id")
+
+	// Missing instrument_code
+	_, err = handler(ctx, map[string]any{
+		"account_id":       "ACC-001",
+		"expression":       "DEBIT == CREDIT",
+		"expected_balance": "100.00",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "instrument_code")
+
+	// Missing expression
+	_, err = handler(ctx, map[string]any{
+		"account_id":       "ACC-001",
+		"instrument_code":  "GBP",
+		"expected_balance": "100.00",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expression")
+
+	// Missing expected_balance
+	_, err = handler(ctx, map[string]any{
+		"account_id":      "ACC-001",
+		"instrument_code": "GBP",
+		"expression":      "DEBIT == CREDIT",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected_balance")
+}
+
+func TestAssertBalanceHandler_GRPCError(t *testing.T) {
+	mock := &mockReconciliationServer{
+		assertBalanceErr: status.Error(codes.Internal, "assertion failed"),
+	}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("reconciliation.assert_balance")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{
+		"account_id":       "ACC-001",
+		"instrument_code":  "GBP",
+		"expression":       "DEBIT == CREDIT",
+		"expected_balance": "100.00",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reconciliation.assert_balance")
+}
+
+func TestInitiateDisputeHandler_Success(t *testing.T) {
+	mock := &mockReconciliationServer{
+		initiateDisputeResp: &reconciliationv1.InitiateDisputeResponse{
+			Dispute: &reconciliationv1.DisputeDetail{
+				DisputeId: "disp-001",
+			},
+		},
+	}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("reconciliation.initiate_dispute")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	result, err := handler(ctx, map[string]any{
+		"variance_id": "var-001",
+		"run_id":      "run-001",
+		"account_id":  "ACC-001",
+		"reason":      "incorrect amount",
+		"raised_by":   "user-001",
+	})
+	require.NoError(t, err)
+
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "disp-001", resultMap["dispute_id"])
+	assert.Equal(t, "OPEN", resultMap["status"])
+}
+
+func TestInitiateDisputeHandler_MissingParams(t *testing.T) {
+	mock := &mockReconciliationServer{}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("reconciliation.initiate_dispute")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+
+	// Missing variance_id
+	_, err = handler(ctx, map[string]any{
+		"run_id":     "run-001",
+		"account_id": "ACC-001",
+		"reason":     "incorrect",
+		"raised_by":  "user-001",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "variance_id")
+
+	// Missing run_id
+	_, err = handler(ctx, map[string]any{
+		"variance_id": "var-001",
+		"account_id":  "ACC-001",
+		"reason":      "incorrect",
+		"raised_by":   "user-001",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "run_id")
+
+	// Missing account_id
+	_, err = handler(ctx, map[string]any{
+		"variance_id": "var-001",
+		"run_id":      "run-001",
+		"reason":      "incorrect",
+		"raised_by":   "user-001",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "account_id")
+
+	// Missing reason
+	_, err = handler(ctx, map[string]any{
+		"variance_id": "var-001",
+		"run_id":      "run-001",
+		"account_id":  "ACC-001",
+		"raised_by":   "user-001",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reason")
+
+	// Missing raised_by
+	_, err = handler(ctx, map[string]any{
+		"variance_id": "var-001",
+		"run_id":      "run-001",
+		"account_id":  "ACC-001",
+		"reason":      "incorrect",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "raised_by")
+}
+
+func TestInitiateDisputeHandler_GRPCError(t *testing.T) {
+	mock := &mockReconciliationServer{
+		initiateDisputeErr: status.Error(codes.Internal, "dispute creation failed"),
+	}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("reconciliation.initiate_dispute")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{
+		"variance_id": "var-001",
+		"run_id":      "run-001",
+		"account_id":  "ACC-001",
+		"reason":      "incorrect",
+		"raised_by":   "user-001",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reconciliation.initiate_dispute")
+}
+
+func TestOptionalString_NonStringType(t *testing.T) {
+	// Test the optionalString path where value is not a string
+	// This is exercised indirectly via scope/settlement_type with non-string values
+	mock := &mockReconciliationServer{
+		initiateResp: &reconciliationv1.InitiateAccountReconciliationResponse{
+			Run: &reconciliationv1.SettlementRunSummary{RunId: "run-001"},
+		},
+	}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, client.RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("reconciliation.initiate_run")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	// Pass non-string values for optional params to exercise optionalString fallback
+	result, err := handler(ctx, map[string]any{
+		"account_id":      "ACC-001",
+		"initiated_by":    "test-user",
+		"scope":           42,    // not a string
+		"settlement_type": false, // not a string
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}

--- a/services/reconciliation/cmd/main_test.go
+++ b/services/reconciliation/cmd/main_test.go
@@ -630,6 +630,37 @@ func TestMainWiring_HealthCheckWithRedis(t *testing.T) {
 	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
 }
 
+func TestBuildValuationComponents_NoRefDataURL(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	cfg := &config.Config{
+		Services: config.ServiceURLsConfig{
+			ReferenceDataURL: "",
+		},
+	}
+
+	engine, provider, conn := buildValuationComponents(cfg, logger)
+	assert.NotNil(t, engine, "valuation engine should always be created")
+	assert.NotNil(t, provider, "reference data provider should always be created")
+	assert.Nil(t, conn, "connection should be nil when no URL configured")
+}
+
+func TestBuildValuationComponents_WithRefDataURL(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	cfg := &config.Config{
+		Services: config.ServiceURLsConfig{
+			ReferenceDataURL: "localhost:50099",
+		},
+	}
+
+	engine, provider, conn := buildValuationComponents(cfg, logger)
+	assert.NotNil(t, engine, "valuation engine should always be created")
+	assert.NotNil(t, provider, "reference data provider should always be created")
+	assert.NotNil(t, conn, "connection should be created when URL is configured")
+	if conn != nil {
+		_ = conn.Close()
+	}
+}
+
 func TestMainWiring_HealthCheckWithRedisDown(t *testing.T) {
 	db, cleanup := setupIntegrationDB(t)
 	defer cleanup()

--- a/services/reconciliation/domain/domain_coverage_test.go
+++ b/services/reconciliation/domain/domain_coverage_test.go
@@ -1,0 +1,218 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// String() method tests for types that didn't have them
+
+func TestAssertionStatus_String(t *testing.T) {
+	assert.Equal(t, "PASSED", AssertionStatusPassed.String())
+	assert.Equal(t, "FAILED", AssertionStatusFailed.String())
+	assert.Equal(t, "PENDING", AssertionStatusPending.String())
+	assert.Equal(t, "OVERRIDE", AssertionStatusOverride.String())
+}
+
+func TestDisputeStatus_String(t *testing.T) {
+	assert.Equal(t, "OPEN", DisputeStatusOpen.String())
+	assert.Equal(t, "UNDER_REVIEW", DisputeStatusUnderReview.String())
+	assert.Equal(t, "ESCALATED", DisputeStatusEscalated.String())
+	assert.Equal(t, "RESOLVED", DisputeStatusResolved.String())
+	assert.Equal(t, "REJECTED", DisputeStatusRejected.String())
+}
+
+func TestReconciliationScope_String(t *testing.T) {
+	assert.Equal(t, "ACCOUNT", ReconciliationScopeAccount.String())
+	assert.Equal(t, "INSTRUMENT", ReconciliationScopeInstrument.String())
+	assert.Equal(t, "PORTFOLIO", ReconciliationScopePortfolio.String())
+	assert.Equal(t, "FULL", ReconciliationScopeFull.String())
+}
+
+func TestSettlementType_String(t *testing.T) {
+	assert.Equal(t, "DAILY", SettlementTypeDaily.String())
+	assert.Equal(t, "WEEKLY", SettlementTypeWeekly.String())
+	assert.Equal(t, "MONTHLY", SettlementTypeMonthly.String())
+	assert.Equal(t, "ON_DEMAND", SettlementTypeOnDemand.String())
+	assert.Equal(t, "END_OF_DAY", SettlementTypeEndOfDay.String())
+	assert.Equal(t, "REAL_TIME", SettlementTypeRealTime.String())
+	assert.Equal(t, "FINAL", SettlementTypeFinal.String())
+}
+
+func TestVarianceReason_String(t *testing.T) {
+	assert.Equal(t, "AMOUNT_MISMATCH", VarianceReasonAmountMismatch.String())
+	assert.Equal(t, "MISSING_ENTRY", VarianceReasonMissingEntry.String())
+	assert.Equal(t, "OTHER", VarianceReasonOther.String())
+}
+
+func TestVarianceStatus_String(t *testing.T) {
+	assert.Equal(t, "DETECTED", VarianceStatusDetected.String())
+	assert.Equal(t, "VALUED", VarianceStatusValued.String())
+	assert.Equal(t, "OPEN", VarianceStatusOpen.String())
+	assert.Equal(t, "RESOLVED", VarianceStatusResolved.String())
+}
+
+// Settlement run lifecycle tests
+
+func TestSettlementRun_SetVarianceCount(t *testing.T) {
+	run := &SettlementRun{
+		RunID:   uuid.New(),
+		Status:  RunStatusRunning,
+		Version: 1,
+	}
+	run.SetVarianceCount(5)
+	assert.Equal(t, 5, run.VarianceCount)
+	assert.Equal(t, int64(2), run.Version)
+}
+
+func TestSettlementRun_Finalize(t *testing.T) {
+	now := time.Now().UTC()
+	run := &SettlementRun{
+		RunID:       uuid.New(),
+		Status:      RunStatusCompleted,
+		CompletedAt: &now,
+		Version:     1,
+	}
+	err := run.Finalize()
+	require.NoError(t, err)
+	assert.Equal(t, RunStatusFinalized, run.Status)
+	assert.NotNil(t, run.CompletedAt)
+}
+
+func TestSettlementRun_Finalize_InvalidStatus(t *testing.T) {
+	run := &SettlementRun{
+		RunID:  uuid.New(),
+		Status: RunStatusPending,
+	}
+	err := run.Finalize()
+	assert.ErrorIs(t, err, ErrInvalidStatusTransition)
+}
+
+func TestSettlementRun_Finalize_NilCompletedAt(t *testing.T) {
+	run := &SettlementRun{
+		RunID:   uuid.New(),
+		Status:  RunStatusCompleted,
+		Version: 1,
+	}
+	err := run.Finalize()
+	require.NoError(t, err)
+	assert.NotNil(t, run.CompletedAt)
+}
+
+func TestSettlementRun_IsFinalSettlement(t *testing.T) {
+	run := &SettlementRun{SettlementType: SettlementTypeFinal}
+	assert.True(t, run.IsFinalSettlement())
+
+	run2 := &SettlementRun{SettlementType: SettlementTypeDaily}
+	assert.False(t, run2.IsFinalSettlement())
+}
+
+// Variance Value transition
+
+func TestVariance_Value(t *testing.T) {
+	v := &Variance{
+		VarianceID: uuid.New(),
+		Status:     VarianceStatusDetected,
+	}
+	err := v.Value(decimal.NewFromFloat(50.25), "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, VarianceStatusValued, v.Status)
+	assert.Equal(t, "GBP", v.Currency)
+	assert.True(t, decimal.NewFromFloat(50.25).Equal(v.ValueDelta))
+}
+
+func TestVariance_Value_InvalidStatus(t *testing.T) {
+	v := &Variance{
+		VarianceID: uuid.New(),
+		Status:     VarianceStatusResolved,
+	}
+	err := v.Value(decimal.NewFromFloat(50.25), "GBP")
+	assert.ErrorIs(t, err, ErrInvalidStatusTransition)
+}
+
+// ImbalanceTrend tests
+
+func TestImbalanceTrend_IsPersistent(t *testing.T) {
+	trend := &ImbalanceTrend{ConsecutiveDays: 2}
+	assert.False(t, trend.IsPersistent())
+
+	trend.ConsecutiveDays = 3
+	assert.True(t, trend.IsPersistent())
+
+	trend.ConsecutiveDays = 5
+	assert.True(t, trend.IsPersistent())
+}
+
+func TestImbalanceTrend_RecordImbalance(t *testing.T) {
+	trend := &ImbalanceTrend{
+		TrendID:        uuid.New(),
+		InstrumentCode: "GBP",
+	}
+
+	assertionID := uuid.New()
+	amount := decimal.NewFromFloat(100.50)
+
+	trend.RecordImbalance(amount, assertionID)
+	assert.Equal(t, 1, trend.ConsecutiveDays)
+	assert.True(t, amount.Equal(trend.LastImbalanceAmount))
+	assert.Equal(t, assertionID, trend.LastAssertionID)
+	assert.Nil(t, trend.ResolvedAt)
+
+	// Recording again on the same day should not increment
+	trend.RecordImbalance(amount, assertionID)
+	assert.Equal(t, 1, trend.ConsecutiveDays)
+}
+
+func TestImbalanceTrend_RecordImbalance_DifferentDay(t *testing.T) {
+	trend := &ImbalanceTrend{
+		TrendID:        uuid.New(),
+		InstrumentCode: "GBP",
+		// Set last detected to yesterday
+		LastDetectedAt: time.Now().UTC().Add(-25 * time.Hour),
+	}
+
+	assertionID := uuid.New()
+	amount := decimal.NewFromFloat(100.50)
+
+	trend.RecordImbalance(amount, assertionID)
+	assert.Equal(t, 1, trend.ConsecutiveDays)
+}
+
+func TestImbalanceTrend_Resolve(t *testing.T) {
+	trend := &ImbalanceTrend{
+		TrendID:         uuid.New(),
+		ConsecutiveDays: 5,
+	}
+
+	trend.Resolve()
+	assert.Equal(t, 0, trend.ConsecutiveDays)
+	assert.NotNil(t, trend.ResolvedAt)
+}
+
+// Balance imbalance event
+
+func TestNewBalanceImbalanceDetectedEvent(t *testing.T) {
+	assertionID := uuid.New()
+	totalDebits := decimal.NewFromFloat(1000.00)
+	totalCredits := decimal.NewFromFloat(900.00)
+	imbalance := decimal.NewFromFloat(100.00)
+
+	event := NewBalanceImbalanceDetectedEvent(
+		assertionID, "GBP",
+		totalDebits, totalCredits, imbalance,
+		AssertionScopePositionLedger,
+		true, 5,
+	)
+	assert.NotNil(t, event)
+	assert.Equal(t, assertionID, event.AssertionID)
+	assert.Equal(t, "GBP", event.InstrumentCode)
+	assert.Equal(t, 5, event.ConsecutiveDays)
+	assert.True(t, event.IsPersistent)
+	assert.Equal(t, "P1_CRITICAL", event.Severity)
+	assert.NotEqual(t, uuid.Nil, event.EventID)
+}

--- a/services/reconciliation/observability/health_test.go
+++ b/services/reconciliation/observability/health_test.go
@@ -1,0 +1,54 @@
+package observability
+
+import (
+	"context"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/pkg/health"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestNewDatabaseChecker_NilPanics(t *testing.T) {
+	require.Panics(t, func() {
+		NewDatabaseChecker(nil)
+	})
+}
+
+func TestDatabaseChecker_Name(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	checker := NewDatabaseChecker(db)
+	assert.Equal(t, "database", checker.Name())
+}
+
+func TestDatabaseChecker_Healthy(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	checker := NewDatabaseChecker(db)
+	result := checker.Check(context.Background())
+	assert.Equal(t, health.StatusHealthy, result.Status)
+	assert.Contains(t, result.Message, "successful")
+	assert.NoError(t, result.Error)
+	assert.Equal(t, "database", result.Name)
+}
+
+func TestDatabaseChecker_Unhealthy(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	// Close the underlying connection to simulate failure
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	checker := NewDatabaseChecker(db)
+	result := checker.Check(context.Background())
+	assert.Equal(t, health.StatusUnhealthy, result.Status)
+	assert.Contains(t, result.Message, "ping failed")
+	assert.Error(t, result.Error)
+}

--- a/services/reconciliation/observability/tracing_test.go
+++ b/services/reconciliation/observability/tracing_test.go
@@ -1,0 +1,50 @@
+package observability
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestTracer(t *testing.T) {
+	tracer := Tracer()
+	assert.NotNil(t, tracer)
+}
+
+func TestStartSpan(t *testing.T) {
+	ctx := context.Background()
+	spanCtx, span := StartSpan(ctx, "test-operation",
+		AttrRunID.String("run-001"),
+		AttrAccountID.String("ACC-001"),
+	)
+	defer span.End()
+
+	assert.NotNil(t, spanCtx)
+	assert.NotNil(t, span)
+}
+
+func TestStartSpan_NoAttributes(t *testing.T) {
+	ctx := context.Background()
+	spanCtx, span := StartSpan(ctx, "test-operation")
+	defer span.End()
+
+	assert.NotNil(t, spanCtx)
+	assert.NotNil(t, span)
+}
+
+func TestAttributeKeys(t *testing.T) {
+	// Verify attribute keys are usable
+	attrs := []attribute.KeyValue{
+		AttrRunID.String("run-001"),
+		AttrAccountID.String("ACC-001"),
+		AttrInstrumentCode.String("GBP"),
+		AttrRunType.String("manual"),
+		AttrVarianceCount.Int(5),
+		AttrSnapshotCount.Int(10),
+		AttrDisputeID.String("disp-001"),
+		AttrVarianceID.String("var-001"),
+	}
+	assert.Len(t, attrs, 8)
+}

--- a/services/reconciliation/service/event_types_test.go
+++ b/services/reconciliation/service/event_types_test.go
@@ -1,0 +1,63 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDisputeCreatedEvent_Getters(t *testing.T) {
+	e := DisputeCreatedEvent{
+		DisputeID:  "disp-001",
+		VarianceID: "var-001",
+		RunID:      "run-001",
+		AccountID:  "ACC-001",
+		Reason:     "incorrect amount",
+		RaisedBy:   "user-001",
+	}
+
+	assert.Equal(t, "disp-001", e.GetDisputeID())
+	assert.Equal(t, "var-001", e.GetVarianceID())
+	assert.Equal(t, "run-001", e.GetRunID())
+	assert.Equal(t, "ACC-001", e.GetAccountID())
+	assert.Equal(t, "incorrect amount", e.GetReason())
+	assert.Equal(t, "user-001", e.GetRaisedBy())
+}
+
+func TestDisputeResolvedEvent_Getters(t *testing.T) {
+	e := DisputeResolvedEvent{
+		DisputeID:  "disp-001",
+		VarianceID: "var-001",
+		RunID:      "run-001",
+		AccountID:  "ACC-001",
+		Action:     "RESOLVED",
+		Resolution: "accepted variance",
+		ResolvedBy: "user-002",
+	}
+
+	assert.Equal(t, "disp-001", e.GetDisputeID())
+	assert.Equal(t, "var-001", e.GetVarianceID())
+	assert.Equal(t, "run-001", e.GetRunID())
+	assert.Equal(t, "ACC-001", e.GetAccountID())
+	assert.Equal(t, "RESOLVED", e.GetAction())
+	assert.Equal(t, "accepted variance", e.GetResolution())
+	assert.Equal(t, "user-002", e.GetResolvedBy())
+}
+
+func TestPositionLockRequestedEvent_Getters(t *testing.T) {
+	e := PositionLockRequestedEvent{
+		RunID:       "run-001",
+		AccountID:   "ACC-001",
+		Scope:       "ACCOUNT",
+		PeriodStart: "2026-01-01T00:00:00Z",
+		PeriodEnd:   "2026-01-02T00:00:00Z",
+		Status:      "RUNNING",
+	}
+
+	assert.Equal(t, "run-001", e.GetRunID())
+	assert.Equal(t, "ACC-001", e.GetAccountID())
+	assert.Equal(t, "ACCOUNT", e.GetScope())
+	assert.Equal(t, "2026-01-01T00:00:00Z", e.GetPeriodStart())
+	assert.Equal(t, "2026-01-02T00:00:00Z", e.GetPeriodEnd())
+	assert.Equal(t, "RUNNING", e.GetStatus())
+}

--- a/services/reconciliation/service/mapping_test.go
+++ b/services/reconciliation/service/mapping_test.go
@@ -691,3 +691,57 @@ func TestDecodeCursorNegativeOffset(t *testing.T) {
 	_, err := decodeCursor(encoded)
 	assert.Error(t, err)
 }
+
+func TestToDomainRunStatus(t *testing.T) {
+	tests := []struct {
+		name  string
+		proto reconciliationv1.RunStatus
+		want  domain.RunStatus
+	}{
+		{"unspecified defaults to pending", reconciliationv1.RunStatus_RUN_STATUS_UNSPECIFIED, domain.RunStatusPending},
+		{"pending", reconciliationv1.RunStatus_RUN_STATUS_PENDING, domain.RunStatusPending},
+		{"running", reconciliationv1.RunStatus_RUN_STATUS_RUNNING, domain.RunStatusRunning},
+		{"completed", reconciliationv1.RunStatus_RUN_STATUS_COMPLETED, domain.RunStatusCompleted},
+		{"failed", reconciliationv1.RunStatus_RUN_STATUS_FAILED, domain.RunStatusFailed},
+		{"cancelled", reconciliationv1.RunStatus_RUN_STATUS_CANCELLED, domain.RunStatusCancelled},
+		{"paused", reconciliationv1.RunStatus_RUN_STATUS_PAUSED, domain.RunStatusPaused},
+		{"unknown defaults to pending", reconciliationv1.RunStatus(999), domain.RunStatusPending},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toDomainRunStatus(tt.proto)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestToDomainDisputeStatusFilter(t *testing.T) {
+	tests := []struct {
+		name  string
+		proto reconciliationv1.DisputeStatus
+		want  *domain.DisputeStatus
+	}{
+		{"open", reconciliationv1.DisputeStatus_DISPUTE_STATUS_OPEN, ptrD(domain.DisputeStatusOpen)},
+		{"under review", reconciliationv1.DisputeStatus_DISPUTE_STATUS_UNDER_REVIEW, ptrD(domain.DisputeStatusUnderReview)},
+		{"escalated", reconciliationv1.DisputeStatus_DISPUTE_STATUS_ESCALATED, ptrD(domain.DisputeStatusEscalated)},
+		{"resolved", reconciliationv1.DisputeStatus_DISPUTE_STATUS_RESOLVED, ptrD(domain.DisputeStatusResolved)},
+		{"rejected", reconciliationv1.DisputeStatus_DISPUTE_STATUS_REJECTED, ptrD(domain.DisputeStatusRejected)},
+		{"unspecified returns nil", reconciliationv1.DisputeStatus_DISPUTE_STATUS_UNSPECIFIED, nil},
+		{"unknown returns nil", reconciliationv1.DisputeStatus(999), nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toDomainDisputeStatusFilter(tt.proto)
+			if tt.want == nil {
+				assert.Nil(t, got)
+			} else {
+				require.NotNil(t, got)
+				assert.Equal(t, *tt.want, *got)
+			}
+		})
+	}
+}
+
+func ptrD(s domain.DisputeStatus) *domain.DisputeStatus { return &s }

--- a/services/reconciliation/service/pk_position_provider_test.go
+++ b/services/reconciliation/service/pk_position_provider_test.go
@@ -155,7 +155,7 @@ func TestMoneyToDecimal(t *testing.T) {
 		{"units only", &money.Money{Units: 100, Nanos: 0}, "100", nil},
 		{"units and nanos", &money.Money{Units: 42, Nanos: 750000000}, "42.75", nil},
 		{"zero", &money.Money{Units: 0, Nanos: 0}, "0", nil},
-		{"negative", &money.Money{Units: -10, Nanos: 500000000}, "-9.5", nil},
+		{"negative", &money.Money{Units: -10, Nanos: -500000000}, "-10.5", nil},
 		{"nil returns error", nil, "0", ErrNilMoneyValue},
 	}
 

--- a/services/reconciliation/service/pk_position_provider_test.go
+++ b/services/reconciliation/service/pk_position_provider_test.go
@@ -1,0 +1,173 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/type/money"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// stubPKClient implements positionkeepingv1.PositionKeepingServiceClient for testing.
+type stubPKClient struct {
+	positionkeepingv1.PositionKeepingServiceClient
+	resp *positionkeepingv1.ListFinancialPositionLogsResponse
+	err  error
+}
+
+func (s *stubPKClient) ListFinancialPositionLogs(_ context.Context, _ *positionkeepingv1.ListFinancialPositionLogsRequest, _ ...grpc.CallOption) (*positionkeepingv1.ListFinancialPositionLogsResponse, error) {
+	return s.resp, s.err
+}
+
+func TestNewPKPositionProvider(t *testing.T) {
+	client := &stubPKClient{}
+	provider := NewPKPositionProvider(client)
+	assert.NotNil(t, provider)
+}
+
+func TestFetchPositions_Success(t *testing.T) {
+	client := &stubPKClient{
+		resp: &positionkeepingv1.ListFinancialPositionLogsResponse{
+			Logs: []*positionkeepingv1.FinancialPositionLog{
+				{
+					LogId:     "log-1",
+					AccountId: "acc-001",
+					TransactionLogEntries: []*positionkeepingv1.TransactionLogEntry{
+						{
+							Amount:    &commonv1.MoneyAmount{Amount: &money.Money{CurrencyCode: "GBP", Units: 100, Nanos: 500000000}},
+							Direction: commonv1.PostingDirection_POSTING_DIRECTION_CREDIT,
+						},
+						{
+							Amount:    &commonv1.MoneyAmount{Amount: &money.Money{CurrencyCode: "GBP", Units: 30, Nanos: 0}},
+							Direction: commonv1.PostingDirection_POSTING_DIRECTION_DEBIT,
+						},
+					},
+				},
+			},
+			Pagination: &commonv1.PaginationResponse{NextPageToken: "next-page"},
+		},
+	}
+
+	provider := NewPKPositionProvider(client)
+	page, err := provider.FetchPositions(context.Background(), "acc-001", 10, "")
+	require.NoError(t, err)
+	require.Len(t, page.Records, 1)
+
+	rec := page.Records[0]
+	assert.Equal(t, "acc-001", rec.AccountID)
+	assert.Equal(t, "GBP", rec.InstrumentCode)
+	// 100.5 credit - 30 debit = 70.5
+	assert.True(t, decimal.NewFromFloat(70.5).Equal(rec.Balance))
+	assert.Equal(t, "position-keeping", rec.SourceSystem)
+	assert.Equal(t, "log-1", rec.Attributes["log_id"])
+	assert.Equal(t, "next-page", page.NextPageToken)
+}
+
+func TestFetchPositions_GRPCError(t *testing.T) {
+	client := &stubPKClient{err: status.Error(codes.Unavailable, "service down")}
+
+	provider := NewPKPositionProvider(client)
+	_, err := provider.FetchPositions(context.Background(), "acc-001", 10, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list financial position logs from PK")
+}
+
+func TestFetchPositions_EmptyLogs(t *testing.T) {
+	client := &stubPKClient{
+		resp: &positionkeepingv1.ListFinancialPositionLogsResponse{
+			Logs: nil,
+		},
+	}
+
+	provider := NewPKPositionProvider(client)
+	page, err := provider.FetchPositions(context.Background(), "acc-001", 10, "")
+	require.NoError(t, err)
+	assert.Empty(t, page.Records)
+	assert.Empty(t, page.NextPageToken)
+}
+
+func TestFetchPositions_UnspecifiedDirection(t *testing.T) {
+	client := &stubPKClient{
+		resp: &positionkeepingv1.ListFinancialPositionLogsResponse{
+			Logs: []*positionkeepingv1.FinancialPositionLog{
+				{
+					LogId:     "log-1",
+					AccountId: "acc-001",
+					TransactionLogEntries: []*positionkeepingv1.TransactionLogEntry{
+						{
+							Amount:    &commonv1.MoneyAmount{Amount: &money.Money{CurrencyCode: "GBP", Units: 50, Nanos: 0}},
+							Direction: commonv1.PostingDirection_POSTING_DIRECTION_UNSPECIFIED,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	provider := NewPKPositionProvider(client)
+	page, err := provider.FetchPositions(context.Background(), "acc-001", 10, "")
+	require.NoError(t, err)
+	require.Len(t, page.Records, 1)
+	assert.True(t, decimal.Zero.Equal(page.Records[0].Balance))
+	assert.Equal(t, "GBP", page.Records[0].InstrumentCode)
+}
+
+func TestFetchPositions_NilAmount(t *testing.T) {
+	client := &stubPKClient{
+		resp: &positionkeepingv1.ListFinancialPositionLogsResponse{
+			Logs: []*positionkeepingv1.FinancialPositionLog{
+				{
+					LogId:     "log-1",
+					AccountId: "acc-001",
+					TransactionLogEntries: []*positionkeepingv1.TransactionLogEntry{
+						{
+							Amount:    &commonv1.MoneyAmount{Amount: nil},
+							Direction: commonv1.PostingDirection_POSTING_DIRECTION_CREDIT,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	provider := NewPKPositionProvider(client)
+	page, err := provider.FetchPositions(context.Background(), "acc-001", 10, "")
+	require.NoError(t, err)
+	require.Len(t, page.Records, 1)
+	assert.True(t, decimal.Zero.Equal(page.Records[0].Balance))
+	assert.Equal(t, "UNKNOWN", page.Records[0].InstrumentCode)
+}
+
+func TestMoneyToDecimal(t *testing.T) {
+	tests := []struct {
+		name    string
+		money   *money.Money
+		want    string
+		wantErr error
+	}{
+		{"units only", &money.Money{Units: 100, Nanos: 0}, "100", nil},
+		{"units and nanos", &money.Money{Units: 42, Nanos: 750000000}, "42.75", nil},
+		{"zero", &money.Money{Units: 0, Nanos: 0}, "0", nil},
+		{"negative", &money.Money{Units: -10, Nanos: 500000000}, "-9.5", nil},
+		{"nil returns error", nil, "0", ErrNilMoneyValue},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := moneyToDecimal(tt.money)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got.String())
+			}
+		})
+	}
+}

--- a/services/reconciliation/service/server_options_test.go
+++ b/services/reconciliation/service/server_options_test.go
@@ -1,0 +1,125 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/stretchr/testify/assert"
+)
+
+// Minimal stubs for option tests.
+
+type stubDisputeRepo struct{ domain.DisputeRepository }
+type stubRunRepo struct{ domain.SettlementRunRepository }
+type stubVarianceFinder struct{}
+
+func (stubVarianceFinder) FindByID(_ context.Context, _ uuid.UUID) (*domain.Variance, error) {
+	return nil, nil
+}
+
+func (stubVarianceFinder) UpdateStatus(_ context.Context, _ uuid.UUID, _ domain.VarianceStatus) error {
+	return nil
+}
+
+type stubVarianceLister struct{}
+
+func (stubVarianceLister) List(_ context.Context, _ domain.VarianceFilter) ([]*domain.Variance, error) {
+	return nil, nil
+}
+
+type stubSagaRuntime struct{}
+
+func (stubSagaRuntime) InvokeSaga(_ context.Context, _ string, _ map[string]interface{}) error {
+	return nil
+}
+
+type stubEventPublisher struct{}
+
+func (stubEventPublisher) Publish(_ context.Context, _ string, _ interface{}) error { return nil }
+
+func TestWithDisputeRepository(t *testing.T) {
+	repo := stubDisputeRepo{}
+	svc := NewAccountReconciliationService(WithDisputeRepository(repo))
+	assert.Equal(t, repo, svc.disputeRepo)
+}
+
+func TestWithSettlementRunRepository(t *testing.T) {
+	repo := stubRunRepo{}
+	svc := NewAccountReconciliationService(WithSettlementRunRepository(repo))
+	assert.Equal(t, repo, svc.runRepo)
+}
+
+func TestWithVarianceRepository(t *testing.T) {
+	repo := stubVarianceFinder{}
+	svc := NewAccountReconciliationService(WithVarianceRepository(repo))
+	assert.Equal(t, repo, svc.varianceRepo)
+}
+
+func TestWithVarianceListRepository(t *testing.T) {
+	repo := stubVarianceLister{}
+	svc := NewAccountReconciliationService(WithVarianceListRepository(repo))
+	assert.Equal(t, repo, svc.varianceListRepo)
+}
+
+func TestWithSagaRuntime(t *testing.T) {
+	rt := stubSagaRuntime{}
+	svc := NewAccountReconciliationService(WithSagaRuntime(rt))
+	assert.Equal(t, rt, svc.sagaRuntime)
+}
+
+func TestWithEventPublisher(t *testing.T) {
+	pub := stubEventPublisher{}
+	svc := NewAccountReconciliationService(WithEventPublisher(pub))
+	assert.Equal(t, pub, svc.eventPublisher)
+}
+
+func TestWithBalanceAssertor(t *testing.T) {
+	a := &BalanceAssertor{}
+	svc := NewAccountReconciliationService(WithBalanceAssertor(a))
+	assert.Equal(t, a, svc.assertor)
+}
+
+func TestWithLogger(t *testing.T) {
+	l := slog.Default()
+	svc := NewAccountReconciliationService(WithLogger(l))
+	assert.Equal(t, l, svc.logger)
+}
+
+func TestWithSnapshotCapturer(t *testing.T) {
+	fn := func(_ context.Context, _ uuid.UUID) error { return nil }
+	svc := NewAccountReconciliationService(WithSnapshotCapturer(fn))
+	assert.NotNil(t, svc.snapshotCapturer)
+}
+
+func TestWithVarianceDetector(t *testing.T) {
+	fn := func(_ context.Context, _ uuid.UUID) ([]*domain.Variance, error) { return nil, nil }
+	svc := NewAccountReconciliationService(WithVarianceDetector(fn))
+	assert.NotNil(t, svc.varianceDetector)
+}
+
+func TestWithVarianceValuator(t *testing.T) {
+	fn := func(_ context.Context, _ uuid.UUID) error { return nil }
+	svc := NewAccountReconciliationService(WithVarianceValuator(fn))
+	assert.NotNil(t, svc.varianceValuator)
+}
+
+func TestNewAccountReconciliationService_MultipleOptions(t *testing.T) {
+	l := slog.Default()
+	pub := stubEventPublisher{}
+	svc := NewAccountReconciliationService(
+		WithLogger(l),
+		WithEventPublisher(pub),
+	)
+	assert.Equal(t, l, svc.logger)
+	assert.Equal(t, pub, svc.eventPublisher)
+	assert.NotNil(t, svc.pauseSignals)
+}
+
+func TestNewAccountReconciliationService_NoOptions(t *testing.T) {
+	svc := NewAccountReconciliationService()
+	assert.NotNil(t, svc)
+	assert.NotNil(t, svc.pauseSignals)
+}

--- a/services/reconciliation/service/server_options_test.go
+++ b/services/reconciliation/service/server_options_test.go
@@ -13,7 +13,9 @@ import (
 // Minimal stubs for option tests.
 
 type stubDisputeRepo struct{ domain.DisputeRepository }
+
 type stubRunRepo struct{ domain.SettlementRunRepository }
+
 type stubVarianceFinder struct{}
 
 func (stubVarianceFinder) FindByID(_ context.Context, _ uuid.UUID) (*domain.Variance, error) {

--- a/services/reconciliation/worker/metrics_test.go
+++ b/services/reconciliation/worker/metrics_test.go
@@ -1,0 +1,40 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSchedulerMetricsWithRegistry(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewSchedulerMetricsWithRegistry(reg)
+	assert.NotNil(t, m)
+}
+
+func TestSchedulerMetrics_RecordRunTriggered(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewSchedulerMetricsWithRegistry(reg)
+	// Should not panic
+	m.RecordRunTriggered("GBP")
+	m.RecordRunTriggered("kWh")
+}
+
+func TestSchedulerMetrics_RecordError(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewSchedulerMetricsWithRegistry(reg)
+	m.RecordError("connection_failed")
+}
+
+func TestSchedulerMetrics_ObserveRefreshDuration(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewSchedulerMetricsWithRegistry(reg)
+	m.ObserveRefreshDuration(0.5)
+}
+
+func TestSchedulerMetrics_RecordCatchUp(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewSchedulerMetricsWithRegistry(reg)
+	m.RecordCatchUp(3)
+}

--- a/services/reconciliation/worker/metrics_test.go
+++ b/services/reconciliation/worker/metrics_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewSchedulerMetricsWithRegistry(t *testing.T) {
@@ -16,21 +17,32 @@ func TestNewSchedulerMetricsWithRegistry(t *testing.T) {
 func TestSchedulerMetrics_RecordRunTriggered(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	m := NewSchedulerMetricsWithRegistry(reg)
-	// Should not panic
 	m.RecordRunTriggered("GBP")
 	m.RecordRunTriggered("kWh")
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	assert.NotEmpty(t, families)
 }
 
 func TestSchedulerMetrics_RecordError(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	m := NewSchedulerMetricsWithRegistry(reg)
 	m.RecordError("connection_failed")
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	assert.NotEmpty(t, families)
 }
 
 func TestSchedulerMetrics_ObserveRefreshDuration(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	m := NewSchedulerMetricsWithRegistry(reg)
 	m.ObserveRefreshDuration(0.5)
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	assert.NotEmpty(t, families)
 }
 
 func TestSchedulerMetrics_RecordCatchUp(t *testing.T) {

--- a/services/reconciliation/worker/metrics_test.go
+++ b/services/reconciliation/worker/metrics_test.go
@@ -49,4 +49,8 @@ func TestSchedulerMetrics_RecordCatchUp(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	m := NewSchedulerMetricsWithRegistry(reg)
 	m.RecordCatchUp(3)
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	assert.NotEmpty(t, families)
 }


### PR DESCRIPTION
## Summary

- Increases reconciliation service test coverage from **68.6% → 80.2%**, exceeding the 80% target
- Adds and expands unit tests across 7 packages with no production code changes

## Coverage by Package

| Package | Before | After | Delta |
|---------|--------|-------|-------|
| client | 12.0% | 89.9% | +77.9% |
| observability | 61.6% | 98.1% | +36.5% |
| domain | 85.3% | 97.9% | +12.6% |
| service | 80.2% | 85.0% | +4.8% |
| worker | 93.4% | 96.1% | +2.7% |
| messaging | 31.3% | 61.4% | +30.1% |
| cmd | 11.1% | 16.6% | +5.5% |

## What's Tested

- **client**: All 10 gRPC methods (success + error paths), Starlark handler registration and invocation
- **observability**: Database health checker, tracing with span attributes
- **domain**: All status/type String() methods, settlement run lifecycle (Finalize, SetVarianceCount), variance transitions, imbalance trends, balance imbalance events
- **service**: Proto↔domain mapping conversions (toDomainRunStatus, toDomainDisputeStatusFilter), all 14 WithXxx option setters, PKPositionProvider with mock gRPC client, moneyToDecimal, event type getters
- **worker**: Scheduler metrics with isolated Prometheus registries
- **messaging**: Outbox event publisher (topic routing, type validation, mock events), partition key extraction edge cases

## Test plan

- [x] All tests pass locally (`go test ./services/reconciliation/... -count=1`)
- [x] Coverage verified at 80.2% via `go tool cover -func`
- [ ] CI passes