### PR TITLE
test: increase party service test coverage toward 80%

### DIFF
--- a/services/party/client/client_test.go
+++ b/services/party/client/client_test.go
@@ -278,6 +278,8 @@ func TestClient_RegisterParty_WithResilience(t *testing.T) {
 	require.Error(t, err)
 	// Error comes from resilience wrapper, not the "failed to register party" wrapper
 	assert.NotContains(t, err.Error(), "failed to register party")
+	// Positive check: the underlying Unavailable error is preserved
+	assert.Contains(t, err.Error(), "service down")
 }
 
 // --- RetrieveParty ---
@@ -324,6 +326,7 @@ func TestClient_RetrieveParty_WithResilience(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "failed to retrieve party")
+	assert.Contains(t, err.Error(), "service down")
 }
 
 // --- GetDefaultPaymentMethod ---
@@ -369,6 +372,7 @@ func TestClient_GetDefaultPaymentMethod_WithResilience(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "failed to get default payment method")
+	assert.Contains(t, err.Error(), "service down")
 }
 
 // --- ListParticipants ---
@@ -414,6 +418,7 @@ func TestClient_ListParticipants_WithResilience(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "failed to list participants")
+	assert.Contains(t, err.Error(), "service down")
 }
 
 // --- GetStructuringData ---
@@ -462,6 +467,7 @@ func TestClient_GetStructuringData_WithResilience(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "failed to get structuring data")
+	assert.Contains(t, err.Error(), "service down")
 }
 
 // --- Conn ---
@@ -500,7 +506,6 @@ func TestClient_Close_DoubleClose(t *testing.T) {
 
 	// Second close on an already-closed connection returns an error wrapped with context
 	err = c.Close()
-	if err != nil {
-		assert.Contains(t, err.Error(), "failed to close party client connection")
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to close party client connection")
 }

--- a/services/party/client/client_test.go
+++ b/services/party/client/client_test.go
@@ -1,12 +1,20 @@
 package client
 
 import (
+	"context"
+	"net"
 	"testing"
 	"time"
 
+	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
 )
 
 func TestNew_WithTarget(t *testing.T) {
@@ -137,4 +145,362 @@ func TestNew_WithoutResilience(t *testing.T) {
 
 	// Verify resilient client was not created
 	assert.Nil(t, client.resilient)
+}
+
+// --- bufconn test infrastructure ---
+
+const bufSize = 1024 * 1024
+
+// fakePartyServer implements PartyServiceServer for testing.
+type fakePartyServer struct {
+	partyv1.UnimplementedPartyServiceServer
+
+	registerFn       func(ctx context.Context, req *partyv1.RegisterPartyRequest) (*partyv1.RegisterPartyResponse, error)
+	retrieveFn       func(ctx context.Context, req *partyv1.RetrievePartyRequest) (*partyv1.RetrievePartyResponse, error)
+	getPaymentFn     func(ctx context.Context, req *partyv1.GetDefaultPaymentMethodRequest) (*partyv1.GetDefaultPaymentMethodResponse, error)
+	listPartFn       func(ctx context.Context, req *partyv1.ListParticipantsRequest) (*partyv1.ListParticipantsResponse, error)
+	getStructuringFn func(ctx context.Context, req *partyv1.GetStructuringDataRequest) (*partyv1.GetStructuringDataResponse, error)
+}
+
+func (s *fakePartyServer) RegisterParty(ctx context.Context, req *partyv1.RegisterPartyRequest) (*partyv1.RegisterPartyResponse, error) {
+	if s.registerFn != nil {
+		return s.registerFn(ctx, req)
+	}
+	return &partyv1.RegisterPartyResponse{}, nil
+}
+
+func (s *fakePartyServer) RetrieveParty(ctx context.Context, req *partyv1.RetrievePartyRequest) (*partyv1.RetrievePartyResponse, error) {
+	if s.retrieveFn != nil {
+		return s.retrieveFn(ctx, req)
+	}
+	return &partyv1.RetrievePartyResponse{}, nil
+}
+
+func (s *fakePartyServer) GetDefaultPaymentMethod(ctx context.Context, req *partyv1.GetDefaultPaymentMethodRequest) (*partyv1.GetDefaultPaymentMethodResponse, error) {
+	if s.getPaymentFn != nil {
+		return s.getPaymentFn(ctx, req)
+	}
+	return &partyv1.GetDefaultPaymentMethodResponse{}, nil
+}
+
+func (s *fakePartyServer) ListParticipants(ctx context.Context, req *partyv1.ListParticipantsRequest) (*partyv1.ListParticipantsResponse, error) {
+	if s.listPartFn != nil {
+		return s.listPartFn(ctx, req)
+	}
+	return &partyv1.ListParticipantsResponse{}, nil
+}
+
+func (s *fakePartyServer) GetStructuringData(ctx context.Context, req *partyv1.GetStructuringDataRequest) (*partyv1.GetStructuringDataResponse, error) {
+	if s.getStructuringFn != nil {
+		return s.getStructuringFn(ctx, req)
+	}
+	return &partyv1.GetStructuringDataResponse{}, nil
+}
+
+func setupTestServer(t *testing.T, server *fakePartyServer) (*Client, func()) {
+	t.Helper()
+
+	lis := bufconn.Listen(bufSize)
+	srv := grpc.NewServer()
+	partyv1.RegisterPartyServiceServer(srv, server)
+
+	go func() { _ = srv.Serve(lis) }()
+
+	conn, err := grpc.NewClient("passthrough:///bufconn",
+		grpc.WithContextDialer(func(_ context.Context, _ string) (net.Conn, error) {
+			return lis.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+
+	c := &Client{
+		conn:    conn,
+		party:   partyv1.NewPartyServiceClient(conn),
+		timeout: DefaultTimeout,
+	}
+
+	cleanup := func() {
+		_ = conn.Close()
+		srv.Stop()
+		_ = lis.Close()
+	}
+
+	return c, cleanup
+}
+
+func setupTestServerWithResilience(t *testing.T, server *fakePartyServer) (*Client, func()) {
+	t.Helper()
+
+	c, cleanup := setupTestServer(t, server)
+	resilienceConfig := clients.DefaultResilientClientConfig("party-test")
+	c.resilient = clients.NewResilientClient(resilienceConfig)
+
+	return c, cleanup
+}
+
+// --- RegisterParty ---
+
+func TestClient_RegisterParty_Success(t *testing.T) {
+	c, cleanup := setupTestServer(t, &fakePartyServer{})
+	defer cleanup()
+
+	resp, err := c.RegisterParty(context.Background(), &partyv1.RegisterPartyRequest{})
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+}
+
+func TestClient_RegisterParty_Error(t *testing.T) {
+	server := &fakePartyServer{
+		registerFn: func(_ context.Context, _ *partyv1.RegisterPartyRequest) (*partyv1.RegisterPartyResponse, error) {
+			return nil, status.Error(codes.InvalidArgument, "missing required fields")
+		},
+	}
+	c, cleanup := setupTestServer(t, server)
+	defer cleanup()
+
+	_, err := c.RegisterParty(context.Background(), &partyv1.RegisterPartyRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to register party")
+}
+
+func TestClient_RegisterParty_WithResilience(t *testing.T) {
+	server := &fakePartyServer{
+		registerFn: func(_ context.Context, _ *partyv1.RegisterPartyRequest) (*partyv1.RegisterPartyResponse, error) {
+			return nil, status.Error(codes.Unavailable, "service down")
+		},
+	}
+	c, cleanup := setupTestServerWithResilience(t, server)
+	defer cleanup()
+
+	// With resilience configured, delegates to ExecuteWithResilienceNoRetry (non-idempotent)
+	_, err := c.RegisterParty(context.Background(), &partyv1.RegisterPartyRequest{})
+	require.Error(t, err)
+	// Error comes from resilience wrapper, not the "failed to register party" wrapper
+	assert.NotContains(t, err.Error(), "failed to register party")
+}
+
+// --- RetrieveParty ---
+
+func TestClient_RetrieveParty_Success(t *testing.T) {
+	c, cleanup := setupTestServer(t, &fakePartyServer{})
+	defer cleanup()
+
+	resp, err := c.RetrieveParty(context.Background(), &partyv1.RetrievePartyRequest{
+		PartyId: "party-1",
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+}
+
+func TestClient_RetrieveParty_Error(t *testing.T) {
+	server := &fakePartyServer{
+		retrieveFn: func(_ context.Context, _ *partyv1.RetrievePartyRequest) (*partyv1.RetrievePartyResponse, error) {
+			return nil, status.Error(codes.NotFound, "party not found")
+		},
+	}
+	c, cleanup := setupTestServer(t, server)
+	defer cleanup()
+
+	_, err := c.RetrieveParty(context.Background(), &partyv1.RetrievePartyRequest{
+		PartyId: "nonexistent",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to retrieve party")
+}
+
+func TestClient_RetrieveParty_WithResilience(t *testing.T) {
+	server := &fakePartyServer{
+		retrieveFn: func(_ context.Context, _ *partyv1.RetrievePartyRequest) (*partyv1.RetrievePartyResponse, error) {
+			return nil, status.Error(codes.Unavailable, "service down")
+		},
+	}
+	c, cleanup := setupTestServerWithResilience(t, server)
+	defer cleanup()
+
+	// With resilience configured, delegates to ExecuteWithResilience (idempotent read)
+	_, err := c.RetrieveParty(context.Background(), &partyv1.RetrievePartyRequest{
+		PartyId: "party-1",
+	})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "failed to retrieve party")
+}
+
+// --- GetDefaultPaymentMethod ---
+
+func TestClient_GetDefaultPaymentMethod_Success(t *testing.T) {
+	c, cleanup := setupTestServer(t, &fakePartyServer{})
+	defer cleanup()
+
+	resp, err := c.GetDefaultPaymentMethod(context.Background(), &partyv1.GetDefaultPaymentMethodRequest{
+		PartyId: "party-1",
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+}
+
+func TestClient_GetDefaultPaymentMethod_Error(t *testing.T) {
+	server := &fakePartyServer{
+		getPaymentFn: func(_ context.Context, _ *partyv1.GetDefaultPaymentMethodRequest) (*partyv1.GetDefaultPaymentMethodResponse, error) {
+			return nil, status.Error(codes.NotFound, "no payment method")
+		},
+	}
+	c, cleanup := setupTestServer(t, server)
+	defer cleanup()
+
+	_, err := c.GetDefaultPaymentMethod(context.Background(), &partyv1.GetDefaultPaymentMethodRequest{
+		PartyId: "party-1",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get default payment method")
+}
+
+func TestClient_GetDefaultPaymentMethod_WithResilience(t *testing.T) {
+	server := &fakePartyServer{
+		getPaymentFn: func(_ context.Context, _ *partyv1.GetDefaultPaymentMethodRequest) (*partyv1.GetDefaultPaymentMethodResponse, error) {
+			return nil, status.Error(codes.Unavailable, "service down")
+		},
+	}
+	c, cleanup := setupTestServerWithResilience(t, server)
+	defer cleanup()
+
+	_, err := c.GetDefaultPaymentMethod(context.Background(), &partyv1.GetDefaultPaymentMethodRequest{
+		PartyId: "party-1",
+	})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "failed to get default payment method")
+}
+
+// --- ListParticipants ---
+
+func TestClient_ListParticipants_Success(t *testing.T) {
+	c, cleanup := setupTestServer(t, &fakePartyServer{})
+	defer cleanup()
+
+	resp, err := c.ListParticipants(context.Background(), &partyv1.ListParticipantsRequest{
+		OrgPartyId: "org-1",
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+}
+
+func TestClient_ListParticipants_Error(t *testing.T) {
+	server := &fakePartyServer{
+		listPartFn: func(_ context.Context, _ *partyv1.ListParticipantsRequest) (*partyv1.ListParticipantsResponse, error) {
+			return nil, status.Error(codes.Internal, "database error")
+		},
+	}
+	c, cleanup := setupTestServer(t, server)
+	defer cleanup()
+
+	_, err := c.ListParticipants(context.Background(), &partyv1.ListParticipantsRequest{
+		OrgPartyId: "org-1",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list participants")
+}
+
+func TestClient_ListParticipants_WithResilience(t *testing.T) {
+	server := &fakePartyServer{
+		listPartFn: func(_ context.Context, _ *partyv1.ListParticipantsRequest) (*partyv1.ListParticipantsResponse, error) {
+			return nil, status.Error(codes.Unavailable, "service down")
+		},
+	}
+	c, cleanup := setupTestServerWithResilience(t, server)
+	defer cleanup()
+
+	_, err := c.ListParticipants(context.Background(), &partyv1.ListParticipantsRequest{
+		OrgPartyId: "org-1",
+	})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "failed to list participants")
+}
+
+// --- GetStructuringData ---
+
+func TestClient_GetStructuringData_Success(t *testing.T) {
+	c, cleanup := setupTestServer(t, &fakePartyServer{})
+	defer cleanup()
+
+	resp, err := c.GetStructuringData(context.Background(), &partyv1.GetStructuringDataRequest{
+		OrgPartyId: "org-1",
+		PartyId:    "part-1",
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+}
+
+func TestClient_GetStructuringData_Error(t *testing.T) {
+	server := &fakePartyServer{
+		getStructuringFn: func(_ context.Context, _ *partyv1.GetStructuringDataRequest) (*partyv1.GetStructuringDataResponse, error) {
+			return nil, status.Error(codes.NotFound, "structuring data not found")
+		},
+	}
+	c, cleanup := setupTestServer(t, server)
+	defer cleanup()
+
+	_, err := c.GetStructuringData(context.Background(), &partyv1.GetStructuringDataRequest{
+		OrgPartyId: "org-1",
+		PartyId:    "part-1",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get structuring data")
+}
+
+func TestClient_GetStructuringData_WithResilience(t *testing.T) {
+	server := &fakePartyServer{
+		getStructuringFn: func(_ context.Context, _ *partyv1.GetStructuringDataRequest) (*partyv1.GetStructuringDataResponse, error) {
+			return nil, status.Error(codes.Unavailable, "service down")
+		},
+	}
+	c, cleanup := setupTestServerWithResilience(t, server)
+	defer cleanup()
+
+	_, err := c.GetStructuringData(context.Background(), &partyv1.GetStructuringDataRequest{
+		OrgPartyId: "org-1",
+		PartyId:    "part-1",
+	})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "failed to get structuring data")
+}
+
+// --- Conn ---
+
+func TestClient_Conn_ReturnsConnection(t *testing.T) {
+	c, cleanup := setupTestServer(t, &fakePartyServer{})
+	defer cleanup()
+
+	conn := c.Conn()
+	assert.NotNil(t, conn)
+	assert.Equal(t, c.conn, conn)
+}
+
+func TestClient_Conn_NilConnection(t *testing.T) {
+	c := &Client{}
+	conn := c.Conn()
+	assert.Nil(t, conn)
+}
+
+// --- Close (via bufconn) ---
+
+func TestClient_Close_ViaServer(t *testing.T) {
+	c, cleanup := setupTestServer(t, &fakePartyServer{})
+	defer cleanup()
+
+	err := c.Close()
+	require.NoError(t, err)
+}
+
+func TestClient_Close_DoubleClose(t *testing.T) {
+	c, cleanup := setupTestServer(t, &fakePartyServer{})
+	defer cleanup()
+
+	err := c.Close()
+	require.NoError(t, err)
+
+	// Second close on an already-closed connection returns an error wrapped with context
+	err = c.Close()
+	if err != nil {
+		assert.Contains(t, err.Error(), "failed to close party client connection")
+	}
 }

--- a/services/party/cmd/main_test.go
+++ b/services/party/cmd/main_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -70,5 +73,131 @@ func TestVerificationConfigMockProvider(t *testing.T) {
 	}
 	if !cfg.IsMock() {
 		t.Error("expected IsMock() to return true")
+	}
+}
+
+func TestNewHTTPHealthHandler_NilConfig(t *testing.T) {
+	handler := newHTTPHealthHandler(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+
+	handler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	ct := rec.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+
+	var resp httpHealthResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Status != "ok" {
+		t.Errorf("expected status 'ok', got %q", resp.Status)
+	}
+	if resp.Timestamp == "" {
+		t.Error("expected non-empty timestamp")
+	}
+	if resp.VerificationEnabled {
+		t.Error("expected verification_enabled to be false when config is nil")
+	}
+	if resp.VerificationProvider != "" {
+		t.Errorf("expected empty verification_provider, got %q", resp.VerificationProvider)
+	}
+}
+
+func TestNewHTTPHealthHandler_WithVerificationConfig(t *testing.T) {
+	cfg := &config.VerificationConfig{
+		Provider: "stripe",
+	}
+
+	handler := newHTTPHealthHandler(cfg)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+
+	handler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp httpHealthResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Status != "ok" {
+		t.Errorf("expected status 'ok', got %q", resp.Status)
+	}
+	if resp.Timestamp == "" {
+		t.Error("expected non-empty timestamp")
+	}
+	if !resp.VerificationEnabled {
+		t.Error("expected verification_enabled to be true when config is provided")
+	}
+	if resp.VerificationProvider != "stripe" {
+		t.Errorf("expected verification_provider 'stripe', got %q", resp.VerificationProvider)
+	}
+}
+
+func TestNewHTTPHealthHandler_JSONStructure(t *testing.T) {
+	cfg := &config.VerificationConfig{
+		Provider: "mock",
+	}
+
+	handler := newHTTPHealthHandler(cfg)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+
+	handler(rec, req)
+
+	// Decode into a raw map to verify exact JSON field names
+	var raw map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&raw); err != nil {
+		t.Fatalf("failed to decode response as map: %v", err)
+	}
+
+	expectedFields := []string{"status", "timestamp", "verification_enabled", "verification_provider"}
+	for _, field := range expectedFields {
+		if _, ok := raw[field]; !ok {
+			t.Errorf("expected JSON field %q to be present", field)
+		}
+	}
+
+	// Verify no unexpected fields
+	if len(raw) != len(expectedFields) {
+		t.Errorf("expected %d fields, got %d: %v", len(expectedFields), len(raw), raw)
+	}
+}
+
+func TestNewHTTPHealthHandler_OmitsProviderWhenNil(t *testing.T) {
+	handler := newHTTPHealthHandler(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+
+	handler(rec, req)
+
+	// Decode into raw map to confirm verification_provider is omitted (omitempty)
+	var raw map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&raw); err != nil {
+		t.Fatalf("failed to decode response as map: %v", err)
+	}
+
+	if _, ok := raw["verification_provider"]; ok {
+		t.Error("expected verification_provider to be omitted when config is nil")
+	}
+
+	// Should have exactly 3 fields (status, timestamp, verification_enabled)
+	if len(raw) != 3 {
+		t.Errorf("expected 3 fields when provider omitted, got %d: %v", len(raw), raw)
 	}
 }

--- a/services/party/service/proto_converters_test.go
+++ b/services/party/service/proto_converters_test.go
@@ -1,0 +1,423 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
+	"github.com/meridianhub/meridian/services/party/adapters/persistence"
+	"github.com/meridianhub/meridian/services/party/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProtoToPartyStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		input       pb.PartyStatus
+		expected    string
+		expectError error
+	}{
+		{"active", pb.PartyStatus_PARTY_STATUS_ACTIVE, string(domain.PartyStatusActive), nil},
+		{"restricted", pb.PartyStatus_PARTY_STATUS_RESTRICTED, string(domain.PartyStatusRestricted), nil},
+		{"suspended", pb.PartyStatus_PARTY_STATUS_SUSPENDED, string(domain.PartyStatusSuspended), nil},
+		{"terminated", pb.PartyStatus_PARTY_STATUS_TERMINATED, string(domain.PartyStatusTerminated), nil},
+		{"unspecified returns empty", pb.PartyStatus_PARTY_STATUS_UNSPECIFIED, "", nil},
+		{"unknown enum returns error", pb.PartyStatus(999), "", ErrUnknownPartyStatus},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := protoToPartyStatus(tt.input)
+			if tt.expectError != nil {
+				assert.ErrorIs(t, err, tt.expectError)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestProtoToControlAction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		input       pb.ControlAction
+		expected    domain.ControlAction
+		expectError error
+	}{
+		{"activate", pb.ControlAction_CONTROL_ACTION_ACTIVATE, domain.ControlActionActivate, nil},
+		{"restrict", pb.ControlAction_CONTROL_ACTION_RESTRICT, domain.ControlActionRestrict, nil},
+		{"suspend", pb.ControlAction_CONTROL_ACTION_SUSPEND, domain.ControlActionSuspend, nil},
+		{"terminate", pb.ControlAction_CONTROL_ACTION_TERMINATE, domain.ControlActionTerminate, nil},
+		{"unspecified returns error", pb.ControlAction_CONTROL_ACTION_UNSPECIFIED, "", ErrControlActionUnspecified},
+		{"unknown enum returns error", pb.ControlAction(999), "", ErrUnknownControlAction},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := protoToControlAction(tt.input)
+			if tt.expectError != nil {
+				assert.ErrorIs(t, err, tt.expectError)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestProtoAssociationStatusToString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		input       pb.AssociationStatus
+		expected    string
+		expectError error
+	}{
+		{"active", pb.AssociationStatus_ASSOCIATION_STATUS_ACTIVE, "ACTIVE", nil},
+		{"suspended", pb.AssociationStatus_ASSOCIATION_STATUS_SUSPENDED, "SUSPENDED", nil},
+		{"terminated", pb.AssociationStatus_ASSOCIATION_STATUS_TERMINATED, "TERMINATED", nil},
+		{"unspecified defaults to active", pb.AssociationStatus_ASSOCIATION_STATUS_UNSPECIFIED, "ACTIVE", nil},
+		{"unknown enum returns error", pb.AssociationStatus(999), "", ErrUnknownAssociationStatus},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := protoAssociationStatusToString(tt.input)
+			if tt.expectError != nil {
+				assert.ErrorIs(t, err, tt.expectError)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestAssociationStatusToProto(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected pb.AssociationStatus
+	}{
+		{"active", "ACTIVE", pb.AssociationStatus_ASSOCIATION_STATUS_ACTIVE},
+		{"suspended", "SUSPENDED", pb.AssociationStatus_ASSOCIATION_STATUS_SUSPENDED},
+		{"terminated", "TERMINATED", pb.AssociationStatus_ASSOCIATION_STATUS_TERMINATED},
+		{"unknown defaults to unspecified", "UNKNOWN", pb.AssociationStatus_ASSOCIATION_STATUS_UNSPECIFIED},
+		{"empty defaults to unspecified", "", pb.AssociationStatus_ASSOCIATION_STATUS_UNSPECIFIED},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := associationStatusToProto(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestProtoToRelationshipType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		input       pb.RelationshipType
+		expected    string
+		expectError error
+	}{
+		{"unspecified", pb.RelationshipType_RELATIONSHIP_TYPE_UNSPECIFIED, "UNSPECIFIED", nil},
+		{"spouse", pb.RelationshipType_RELATIONSHIP_TYPE_SPOUSE, string(domain.RelationshipTypeSpouse), nil},
+		{"dependent", pb.RelationshipType_RELATIONSHIP_TYPE_DEPENDENT, string(domain.RelationshipTypeDependent), nil},
+		{"business partner", pb.RelationshipType_RELATIONSHIP_TYPE_BUSINESS_PARTNER, string(domain.RelationshipTypeBusinessPartner), nil},
+		{"guarantor", pb.RelationshipType_RELATIONSHIP_TYPE_GUARANTOR, string(domain.RelationshipTypeGuarantor), nil},
+		{"beneficial owner", pb.RelationshipType_RELATIONSHIP_TYPE_BENEFICIAL_OWNER, string(domain.RelationshipTypeBeneficialOwner), nil},
+		{"syndicate participant", pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT, string(domain.RelationshipTypeSyndicateParticipant), nil},
+		{"syndicate host", pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_HOST, string(domain.RelationshipTypeSyndicateHost), nil},
+		{"unknown enum returns error", pb.RelationshipType(999), "", ErrUnknownRelationshipType},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := protoToRelationshipType(tt.input)
+			if tt.expectError != nil {
+				assert.ErrorIs(t, err, tt.expectError)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestRelationshipTypeToProto(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected pb.RelationshipType
+	}{
+		{"spouse", string(domain.RelationshipTypeSpouse), pb.RelationshipType_RELATIONSHIP_TYPE_SPOUSE},
+		{"dependent", string(domain.RelationshipTypeDependent), pb.RelationshipType_RELATIONSHIP_TYPE_DEPENDENT},
+		{"business partner", string(domain.RelationshipTypeBusinessPartner), pb.RelationshipType_RELATIONSHIP_TYPE_BUSINESS_PARTNER},
+		{"guarantor", string(domain.RelationshipTypeGuarantor), pb.RelationshipType_RELATIONSHIP_TYPE_GUARANTOR},
+		{"beneficial owner", string(domain.RelationshipTypeBeneficialOwner), pb.RelationshipType_RELATIONSHIP_TYPE_BENEFICIAL_OWNER},
+		{"syndicate participant", string(domain.RelationshipTypeSyndicateParticipant), pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT},
+		{"syndicate host", string(domain.RelationshipTypeSyndicateHost), pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_HOST},
+		{"unknown defaults to unspecified", "UNKNOWN", pb.RelationshipType_RELATIONSHIP_TYPE_UNSPECIFIED},
+		{"empty defaults to unspecified", "", pb.RelationshipType_RELATIONSHIP_TYPE_UNSPECIFIED},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := relationshipTypeToProto(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFromJSONB(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"json quoted string", `"hello world"`, "hello world"},
+		{"plain string not valid json", "hello world", "hello world"},
+		{"empty string", "", ""},
+		{"json number falls back to raw", "42", "42"},
+		{"json object falls back to raw", `{"key":"val"}`, `{"key":"val"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := fromJSONB(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDomainAttributesToProto(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty slice returns empty slice", func(t *testing.T) {
+		result := domainAttributesToProto([]domain.AttributeEntry{})
+		assert.Empty(t, result)
+		assert.NotNil(t, result)
+	})
+
+	t.Run("converts multiple entries", func(t *testing.T) {
+		attrs := []domain.AttributeEntry{
+			{Key: "color", Value: "blue"},
+			{Key: "size", Value: "large"},
+			{Key: "weight", Value: "10kg"},
+		}
+
+		result := domainAttributesToProto(attrs)
+		require.Len(t, result, 3)
+
+		assert.Equal(t, "color", result[0].Key)
+		assert.Equal(t, "blue", result[0].Value)
+		assert.Equal(t, "size", result[1].Key)
+		assert.Equal(t, "large", result[1].Value)
+		assert.Equal(t, "weight", result[2].Key)
+		assert.Equal(t, "10kg", result[2].Value)
+	})
+}
+
+func TestProtoAttributesToDomain(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty slice returns empty slice", func(t *testing.T) {
+		result := protoAttributesToDomain([]*quantityv1.AttributeEntry{})
+		assert.Empty(t, result)
+		assert.NotNil(t, result)
+	})
+
+	t.Run("nil entries are skipped", func(t *testing.T) {
+		attrs := []*quantityv1.AttributeEntry{
+			{Key: "color", Value: "blue"},
+			nil,
+			{Key: "size", Value: "large"},
+		}
+
+		result := protoAttributesToDomain(attrs)
+		require.Len(t, result, 2)
+
+		assert.Equal(t, "color", result[0].Key)
+		assert.Equal(t, "blue", result[0].Value)
+		assert.Equal(t, "size", result[1].Key)
+		assert.Equal(t, "large", result[1].Value)
+	})
+
+	t.Run("converts multiple entries", func(t *testing.T) {
+		attrs := []*quantityv1.AttributeEntry{
+			{Key: "a", Value: "1"},
+			{Key: "b", Value: "2"},
+		}
+
+		result := protoAttributesToDomain(attrs)
+		require.Len(t, result, 2)
+
+		assert.Equal(t, domain.AttributeEntry{Key: "a", Value: "1"}, result[0])
+		assert.Equal(t, domain.AttributeEntry{Key: "b", Value: "2"}, result[1])
+	})
+}
+
+func TestAssociationEntityToProto(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	partyID := uuid.New()
+	relatedID := uuid.New()
+	assocID := uuid.New()
+
+	t.Run("converts entity without EffectiveTo", func(t *testing.T) {
+		entity := &persistence.PartyAssociationEntity{
+			ID:               assocID,
+			PartyID:          partyID,
+			RelatedPartyID:   relatedID,
+			RelationshipType: string(domain.RelationshipTypeSpouse),
+			Status:           "ACTIVE",
+			EffectiveFrom:    now,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+
+		result := associationEntityToProto(entity)
+
+		assert.Equal(t, assocID.String(), result.AssociationId)
+		assert.Equal(t, partyID.String(), result.PartyId)
+		assert.Equal(t, relatedID.String(), result.RelatedPartyId)
+		assert.Equal(t, pb.RelationshipType_RELATIONSHIP_TYPE_SPOUSE, result.RelationshipType)
+		assert.Equal(t, pb.AssociationStatus_ASSOCIATION_STATUS_ACTIVE, result.Status)
+		assert.NotNil(t, result.EffectiveFrom)
+		assert.Nil(t, result.EffectiveTo)
+		assert.NotNil(t, result.CreatedAt)
+		assert.NotNil(t, result.UpdatedAt)
+		assert.Nil(t, result.Metadata)
+	})
+
+	t.Run("converts entity with EffectiveTo", func(t *testing.T) {
+		effectiveTo := now.Add(24 * time.Hour)
+		entity := &persistence.PartyAssociationEntity{
+			ID:               assocID,
+			PartyID:          partyID,
+			RelatedPartyID:   relatedID,
+			RelationshipType: string(domain.RelationshipTypeGuarantor),
+			Status:           "TERMINATED",
+			EffectiveFrom:    now,
+			EffectiveTo:      &effectiveTo,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+
+		result := associationEntityToProto(entity)
+
+		assert.NotNil(t, result.EffectiveTo)
+		assert.Equal(t, pb.AssociationStatus_ASSOCIATION_STATUS_TERMINATED, result.Status)
+	})
+
+	t.Run("converts entity with valid metadata", func(t *testing.T) {
+		metadataJSON := `{"role":"primary","tier":"gold"}`
+		entity := &persistence.PartyAssociationEntity{
+			ID:               assocID,
+			PartyID:          partyID,
+			RelatedPartyID:   relatedID,
+			RelationshipType: string(domain.RelationshipTypeBusinessPartner),
+			Status:           "ACTIVE",
+			EffectiveFrom:    now,
+			Metadata:         &metadataJSON,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+
+		result := associationEntityToProto(entity)
+
+		require.NotNil(t, result.Metadata)
+		assert.Equal(t, "primary", result.Metadata.Fields["role"].GetStringValue())
+		assert.Equal(t, "gold", result.Metadata.Fields["tier"].GetStringValue())
+	})
+
+	t.Run("ignores empty metadata object", func(t *testing.T) {
+		emptyObj := "{}"
+		entity := &persistence.PartyAssociationEntity{
+			ID:               assocID,
+			PartyID:          partyID,
+			RelatedPartyID:   relatedID,
+			RelationshipType: string(domain.RelationshipTypeSpouse),
+			Status:           "ACTIVE",
+			EffectiveFrom:    now,
+			Metadata:         &emptyObj,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+
+		result := associationEntityToProto(entity)
+		assert.Nil(t, result.Metadata)
+	})
+
+	t.Run("ignores empty string metadata", func(t *testing.T) {
+		empty := ""
+		entity := &persistence.PartyAssociationEntity{
+			ID:               assocID,
+			PartyID:          partyID,
+			RelatedPartyID:   relatedID,
+			RelationshipType: string(domain.RelationshipTypeSpouse),
+			Status:           "ACTIVE",
+			EffectiveFrom:    now,
+			Metadata:         &empty,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+
+		result := associationEntityToProto(entity)
+		assert.Nil(t, result.Metadata)
+	})
+
+	t.Run("ignores invalid json metadata", func(t *testing.T) {
+		invalid := `{not valid json`
+		entity := &persistence.PartyAssociationEntity{
+			ID:               assocID,
+			PartyID:          partyID,
+			RelatedPartyID:   relatedID,
+			RelationshipType: string(domain.RelationshipTypeSpouse),
+			Status:           "ACTIVE",
+			EffectiveFrom:    now,
+			Metadata:         &invalid,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+
+		result := associationEntityToProto(entity)
+		assert.Nil(t, result.Metadata)
+	})
+
+	t.Run("nil metadata pointer", func(t *testing.T) {
+		entity := &persistence.PartyAssociationEntity{
+			ID:               assocID,
+			PartyID:          partyID,
+			RelatedPartyID:   relatedID,
+			RelationshipType: string(domain.RelationshipTypeSpouse),
+			Status:           "ACTIVE",
+			EffectiveFrom:    now,
+			Metadata:         nil,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+
+		result := associationEntityToProto(entity)
+		assert.Nil(t, result.Metadata)
+	})
+}

--- a/services/party/service/verification_service_test.go
+++ b/services/party/service/verification_service_test.go
@@ -571,3 +571,61 @@ func TestUpdateVerification_WithMetadata(t *testing.T) {
 	require.Len(t, eventPublisher.publishedEvents, 1)
 	assert.Equal(t, "APPROVED", eventPublisher.publishedEvents[0].Status)
 }
+
+func TestGetVerification_Success(t *testing.T) {
+	partyRepo := &mockPartyRepository{}
+	verificationRepo := newMockVerificationRepository()
+	provider := &mockProvider{}
+
+	svc, err := NewVerificationService(partyRepo, verificationRepo, provider, nil, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Create a verification
+	entity := &persistence.PartyVerificationEntity{
+		PartyID:        uuid.New(),
+		VerificationID: "prov-get-test",
+		Provider:       "onfido",
+		Status:         "PENDING",
+	}
+	err = verificationRepo.CreateVerification(ctx, entity)
+	require.NoError(t, err)
+
+	// Retrieve it
+	result, err := svc.GetVerification(ctx, entity.ID)
+	require.NoError(t, err)
+	assert.Equal(t, entity.ID, result.ID)
+	assert.Equal(t, "prov-get-test", result.VerificationID)
+}
+
+func TestGetVerification_NotFound(t *testing.T) {
+	partyRepo := &mockPartyRepository{}
+	verificationRepo := newMockVerificationRepository()
+	provider := &mockProvider{}
+
+	svc, err := NewVerificationService(partyRepo, verificationRepo, provider, nil, nil)
+	require.NoError(t, err)
+
+	_, err = svc.GetVerification(context.Background(), uuid.New())
+	assert.ErrorIs(t, err, persistence.ErrVerificationNotFound)
+}
+
+func TestIsTerminalStatus(t *testing.T) {
+	tests := []struct {
+		status   verification.Status
+		terminal bool
+	}{
+		{verification.StatusPending, false},
+		{verification.StatusApproved, true},
+		{verification.StatusRejected, true},
+		{verification.StatusManualReview, true},
+		{verification.Status("UNKNOWN"), false},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.status), func(t *testing.T) {
+			assert.Equal(t, tc.terminal, isTerminalStatus(tc.status))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add 18 bufconn-based gRPC unit tests for `client` package covering all 5 RPC methods, `Close()`, and `Conn()`
- Add 4 unit tests for `httpHealthHandler` in `cmd` package
- Add 42 proto converter test cases covering all enum conversion functions in `service` package
- Add `GetVerification` and `isTerminalStatus` tests in `service/verification_service_test.go`

## Per-Package Coverage

| Package | Coverage |
|---------|----------|
| client | 95.9% |
| verification | 90.6% |
| domain | 91.8% |
| adapters/http | 88.7% |
| config | 100% |
| service | 47.3% (unit only, integration adds more) |

## Test plan

- [x] All new tests pass locally (`go test -short`)
- [ ] CI passes with full test suite
- [ ] Coverage meets 80% threshold