### PR TITLE
test: Add unhappy path tests for shared/platform packages

### DIFF
--- a/shared/platform/audit/consumer_test.go
+++ b/shared/platform/audit/consumer_test.go
@@ -1,0 +1,118 @@
+package audit
+
+import (
+	"testing"
+
+	auditv1 "github.com/meridianhub/meridian/api/proto/meridian/audit/v1"
+)
+
+func TestIsValidSchemaName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"valid simple", "acme_bank", true},
+		{"valid with numbers", "tenant_123", true},
+		{"valid underscore prefix", "_private", true},
+		{"valid uppercase", "Public", true},
+		{"empty string", "", false},
+		{"starts with number", "123tenant", false},
+		{"contains hyphen", "acme-bank", false},
+		{"contains space", "acme bank", false},
+		{"contains dot", "acme.bank", false},
+		{"contains semicolon", "acme;drop", false},
+		{"SQL injection attempt", "acme'; DROP TABLE--", false},
+		{"too long", string(make([]byte, 64)), false},
+		{"max length", "a" + string(make([]byte, 62)), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Fill the byte slices with valid chars for the length tests
+			if tt.name == "too long" {
+				input := make([]byte, 64)
+				for i := range input {
+					input[i] = 'a'
+				}
+				tt.input = string(input)
+			}
+			if tt.name == "max length" {
+				input := make([]byte, 63)
+				for i := range input {
+					input[i] = 'a'
+				}
+				tt.input = string(input)
+			}
+
+			got := isValidSchemaName(tt.input)
+			if got != tt.expected {
+				t.Errorf("isValidSchemaName(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestQuoteIdentifier(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"simple name", "acme_bank", `"acme_bank"`},
+		{"with double quote", `acme"bank`, `"acme""bank"`},
+		{"empty string", "", `""`},
+		{"already quoted", `"test"`, `"""test"""`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := quoteIdentifier(tt.input)
+			if got != tt.expected {
+				t.Errorf("quoteIdentifier(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestProtoToOperation(t *testing.T) {
+	tests := []struct {
+		name     string
+		op       auditv1.AuditOperation
+		expected string
+	}{
+		{"insert", auditv1.AuditOperation_AUDIT_OPERATION_INSERT, "INSERT"},
+		{"update", auditv1.AuditOperation_AUDIT_OPERATION_UPDATE, "UPDATE"},
+		{"delete", auditv1.AuditOperation_AUDIT_OPERATION_DELETE, "DELETE"},
+		{"initial import", auditv1.AuditOperation_AUDIT_OPERATION_INITIAL_IMPORT, "INITIAL_IMPORT"},
+		{"unspecified", auditv1.AuditOperation_AUDIT_OPERATION_UNSPECIFIED, ""},
+		{"unknown value", auditv1.AuditOperation(999), ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := protoToOperation(tt.op)
+			if got != tt.expected {
+				t.Errorf("protoToOperation(%v) = %q, want %q", tt.op, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewConsumer_Validation(t *testing.T) {
+	t.Run("empty bootstrap servers", func(t *testing.T) {
+		_, err := NewConsumer(ConsumerConfig{})
+		if err != ErrEmptyBootstrapServers {
+			t.Errorf("expected ErrEmptyBootstrapServers, got %v", err)
+		}
+	})
+
+	t.Run("nil database", func(t *testing.T) {
+		_, err := NewConsumer(ConsumerConfig{
+			BootstrapServers: "localhost:9092",
+		})
+		if err != ErrNilDatabase {
+			t.Errorf("expected ErrNilDatabase, got %v", err)
+		}
+	})
+}

--- a/shared/platform/audit/consumer_test.go
+++ b/shared/platform/audit/consumer_test.go
@@ -1,6 +1,7 @@
 package audit
 
 import (
+	"errors"
 	"testing"
 
 	auditv1 "github.com/meridianhub/meridian/api/proto/meridian/audit/v1"
@@ -102,7 +103,7 @@ func TestProtoToOperation(t *testing.T) {
 func TestNewConsumer_Validation(t *testing.T) {
 	t.Run("empty bootstrap servers", func(t *testing.T) {
 		_, err := NewConsumer(ConsumerConfig{})
-		if err != ErrEmptyBootstrapServers {
+		if !errors.Is(err, ErrEmptyBootstrapServers) {
 			t.Errorf("expected ErrEmptyBootstrapServers, got %v", err)
 		}
 	})
@@ -111,7 +112,7 @@ func TestNewConsumer_Validation(t *testing.T) {
 		_, err := NewConsumer(ConsumerConfig{
 			BootstrapServers: "localhost:9092",
 		})
-		if err != ErrNilDatabase {
+		if !errors.Is(err, ErrNilDatabase) {
 			t.Errorf("expected ErrNilDatabase, got %v", err)
 		}
 	})

--- a/shared/platform/audit/metrics_test.go
+++ b/shared/platform/audit/metrics_test.go
@@ -7,16 +7,16 @@ import (
 func TestRecordKafkaMetrics(t *testing.T) {
 	// These are simple counter/gauge/histogram wrappers.
 	// Test that they don't panic when called with valid arguments.
-	t.Run("RecordPollInterval", func(t *testing.T) {
+	t.Run("RecordPollInterval", func(_ *testing.T) {
 		RecordPollInterval("test_schema", 5.0)
 	})
 
-	t.Run("RecordKafkaPublished", func(t *testing.T) {
+	t.Run("RecordKafkaPublished", func(_ *testing.T) {
 		RecordKafkaPublished("test_schema", "INSERT", "success")
 		RecordKafkaPublished("test_schema", "UPDATE", "failure")
 	})
 
-	t.Run("RecordKafkaConsumed", func(t *testing.T) {
+	t.Run("RecordKafkaConsumed", func(_ *testing.T) {
 		RecordKafkaConsumed("test_schema", "INSERT", "success")
 		RecordKafkaConsumed("test_schema", "DELETE", "failure")
 	})

--- a/shared/platform/audit/metrics_test.go
+++ b/shared/platform/audit/metrics_test.go
@@ -21,19 +21,19 @@ func TestRecordKafkaMetrics(t *testing.T) {
 		RecordKafkaConsumed("test_schema", "DELETE", "failure")
 	})
 
-	t.Run("RecordKafkaPublishDuration", func(t *testing.T) {
+	t.Run("RecordKafkaPublishDuration", func(_ *testing.T) {
 		RecordKafkaPublishDuration(0.123)
 	})
 
-	t.Run("RecordKafkaConsumeDuration", func(t *testing.T) {
+	t.Run("RecordKafkaConsumeDuration", func(_ *testing.T) {
 		RecordKafkaConsumeDuration(0.456)
 	})
 
-	t.Run("RecordKafkaConsumerLag", func(t *testing.T) {
+	t.Run("RecordKafkaConsumerLag", func(_ *testing.T) {
 		RecordKafkaConsumerLag(42.0)
 	})
 
-	t.Run("RecordKafkaDLQ", func(t *testing.T) {
+	t.Run("RecordKafkaDLQ", func(_ *testing.T) {
 		RecordKafkaDLQ("test_schema", "max_retries_exceeded")
 	})
 }

--- a/shared/platform/audit/metrics_test.go
+++ b/shared/platform/audit/metrics_test.go
@@ -1,0 +1,39 @@
+package audit
+
+import (
+	"testing"
+)
+
+func TestRecordKafkaMetrics(t *testing.T) {
+	// These are simple counter/gauge/histogram wrappers.
+	// Test that they don't panic when called with valid arguments.
+	t.Run("RecordPollInterval", func(t *testing.T) {
+		RecordPollInterval("test_schema", 5.0)
+	})
+
+	t.Run("RecordKafkaPublished", func(t *testing.T) {
+		RecordKafkaPublished("test_schema", "INSERT", "success")
+		RecordKafkaPublished("test_schema", "UPDATE", "failure")
+	})
+
+	t.Run("RecordKafkaConsumed", func(t *testing.T) {
+		RecordKafkaConsumed("test_schema", "INSERT", "success")
+		RecordKafkaConsumed("test_schema", "DELETE", "failure")
+	})
+
+	t.Run("RecordKafkaPublishDuration", func(t *testing.T) {
+		RecordKafkaPublishDuration(0.123)
+	})
+
+	t.Run("RecordKafkaConsumeDuration", func(t *testing.T) {
+		RecordKafkaConsumeDuration(0.456)
+	})
+
+	t.Run("RecordKafkaConsumerLag", func(t *testing.T) {
+		RecordKafkaConsumerLag(42.0)
+	})
+
+	t.Run("RecordKafkaDLQ", func(t *testing.T) {
+		RecordKafkaDLQ("test_schema", "max_retries_exceeded")
+	})
+}

--- a/shared/platform/audit/publisher_unit_test.go
+++ b/shared/platform/audit/publisher_unit_test.go
@@ -1,0 +1,89 @@
+package audit
+
+import (
+	"context"
+	"testing"
+
+	auditv1 "github.com/meridianhub/meridian/api/proto/meridian/audit/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPublisher_Publish_EmptyRecordID(t *testing.T) {
+	p := &Publisher{enabled: true}
+
+	event := &auditv1.AuditEvent{
+		RecordId: "",
+	}
+
+	err := p.Publish(context.Background(), event)
+	assert.ErrorIs(t, err, ErrEmptyRecordID)
+}
+
+func TestPublisher_Close_NilProducer(t *testing.T) {
+	p := &Publisher{
+		producer: nil,
+	}
+
+	err := p.Close()
+	assert.NoError(t, err)
+}
+
+func TestPublishToKafkaWithFallback_DisabledPublisher(t *testing.T) {
+	original := GetGlobalPublisher()
+	defer SetGlobalPublisher(original)
+
+	// Set a disabled publisher
+	p := &Publisher{enabled: false}
+	SetGlobalPublisher(p)
+
+	// Call publishToKafkaWithFallback - should take the "disabled" fallback path
+	// We can't test the full path without a DB, but we verify the metric path is hit
+	// by checking it doesn't panic. The actual DB write will fail, which is expected.
+	db := setupHooksTestDB(t)
+
+	err := publishToKafkaWithFallback(
+		db,
+		"test_table",
+		"INSERT",
+		"record-1",
+		"",
+		`{"key":"value"}`,
+		"test-user",
+		"test_schema",
+	)
+
+	// Should succeed - writes to outbox via fallback
+	assert.NoError(t, err)
+
+	// Verify outbox was written
+	var count int64
+	db.Model(&testAuditOutbox{}).Count(&count)
+	assert.Equal(t, int64(1), count)
+}
+
+func TestPublishToKafkaWithFallback_NilPublisher(t *testing.T) {
+	original := GetGlobalPublisher()
+	defer SetGlobalPublisher(original)
+
+	SetGlobalPublisher(nil)
+
+	db := setupHooksTestDB(t)
+
+	err := publishToKafkaWithFallback(
+		db,
+		"test_table",
+		"UPDATE",
+		"record-2",
+		`{"old":"data"}`,
+		`{"new":"data"}`,
+		"",
+		"test_schema",
+	)
+
+	assert.NoError(t, err)
+
+	// Verify outbox entry created with nil ChangedBy
+	var count int64
+	db.Model(&testAuditOutbox{}).Count(&count)
+	assert.Equal(t, int64(1), count)
+}

--- a/shared/platform/events/metrics_test.go
+++ b/shared/platform/events/metrics_test.go
@@ -1,0 +1,38 @@
+package events
+
+import (
+	"testing"
+)
+
+func TestRecordStuckEntriesReset(t *testing.T) {
+	// Verify it doesn't panic with valid arguments.
+	RecordStuckEntriesReset("test-service", 5)
+	RecordStuckEntriesReset("test-service", 0)
+}
+
+func TestRecordOutboxDepth(t *testing.T) {
+	RecordOutboxDepth("test-service", 10)
+	RecordOutboxDepth("test-service", 0)
+}
+
+func TestRecordPublished(t *testing.T) {
+	RecordPublished("test-service", "event.type", "success")
+	RecordPublished("test-service", "event.type", "failure")
+	RecordPublished("test-service", "event.type", "timeout")
+}
+
+func TestRecordDLQEntry(t *testing.T) {
+	RecordDLQEntry("test-service", "event.type")
+}
+
+func TestRecordProcessingDuration(t *testing.T) {
+	RecordProcessingDuration("test-service", 1.234)
+}
+
+func TestRecordEntryAge(t *testing.T) {
+	RecordEntryAge("test-service", 0.5)
+}
+
+func TestRecordRetry(t *testing.T) {
+	RecordRetry("test-service", "event.type")
+}

--- a/shared/platform/events/metrics_test.go
+++ b/shared/platform/events/metrics_test.go
@@ -4,35 +4,35 @@ import (
 	"testing"
 )
 
-func TestRecordStuckEntriesReset(t *testing.T) {
+func TestRecordStuckEntriesReset(_ *testing.T) {
 	// Verify it doesn't panic with valid arguments.
 	RecordStuckEntriesReset("test-service", 5)
 	RecordStuckEntriesReset("test-service", 0)
 }
 
-func TestRecordOutboxDepth(t *testing.T) {
+func TestRecordOutboxDepth(_ *testing.T) {
 	RecordOutboxDepth("test-service", 10)
 	RecordOutboxDepth("test-service", 0)
 }
 
-func TestRecordPublished(t *testing.T) {
+func TestRecordPublished(_ *testing.T) {
 	RecordPublished("test-service", "event.type", "success")
 	RecordPublished("test-service", "event.type", "failure")
 	RecordPublished("test-service", "event.type", "timeout")
 }
 
-func TestRecordDLQEntry(t *testing.T) {
+func TestRecordDLQEntry(_ *testing.T) {
 	RecordDLQEntry("test-service", "event.type")
 }
 
-func TestRecordProcessingDuration(t *testing.T) {
+func TestRecordProcessingDuration(_ *testing.T) {
 	RecordProcessingDuration("test-service", 1.234)
 }
 
-func TestRecordEntryAge(t *testing.T) {
+func TestRecordEntryAge(_ *testing.T) {
 	RecordEntryAge("test-service", 0.5)
 }
 
-func TestRecordRetry(t *testing.T) {
+func TestRecordRetry(_ *testing.T) {
 	RecordRetry("test-service", "event.type")
 }

--- a/shared/platform/events/outbox_pgx_integration_test.go
+++ b/shared/platform/events/outbox_pgx_integration_test.go
@@ -1,0 +1,576 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+)
+
+// setupPgxOutboxRepo creates a pgxpool.Pool with the event_outbox table for testing.
+func setupPgxOutboxRepo(t *testing.T) (*PgxOutboxRepository, func()) {
+	t.Helper()
+
+	pool := testdb.NewTestPool(t)
+
+	// Create the event_outbox table manually.
+	ctx := context.Background()
+	_, err := pool.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS event_outbox (
+			id UUID PRIMARY KEY,
+			event_type VARCHAR(200) NOT NULL,
+			aggregate_id VARCHAR(100) NOT NULL,
+			aggregate_type VARCHAR(100) NOT NULL,
+			event_payload BYTEA NOT NULL,
+			correlation_id VARCHAR(100),
+			causation_id VARCHAR(100),
+			status VARCHAR(20) NOT NULL,
+			topic VARCHAR(200) NOT NULL,
+			partition_key VARCHAR(200),
+			created_at TIMESTAMPTZ NOT NULL,
+			processed_at TIMESTAMPTZ,
+			retry_count INT NOT NULL DEFAULT 0,
+			last_error TEXT,
+			service_name VARCHAR(100) NOT NULL,
+			tenant_id VARCHAR(100) NOT NULL DEFAULT ''
+		)
+	`)
+	require.NoError(t, err)
+
+	repo := NewPgxOutboxRepository(pool)
+	cleanup := func() {
+		pool.Close()
+	}
+
+	return repo, cleanup
+}
+
+func TestPgxOutboxRepository_InsertWithPgxTx(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testdb.NewTestPool(t)
+	ctx := context.Background()
+
+	_, err := pool.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS event_outbox (
+			id UUID PRIMARY KEY,
+			event_type VARCHAR(200) NOT NULL,
+			aggregate_id VARCHAR(100) NOT NULL,
+			aggregate_type VARCHAR(100) NOT NULL,
+			event_payload BYTEA NOT NULL,
+			correlation_id VARCHAR(100),
+			causation_id VARCHAR(100),
+			status VARCHAR(20) NOT NULL,
+			topic VARCHAR(200) NOT NULL,
+			partition_key VARCHAR(200),
+			created_at TIMESTAMPTZ NOT NULL,
+			processed_at TIMESTAMPTZ,
+			retry_count INT NOT NULL DEFAULT 0,
+			last_error TEXT,
+			service_name VARCHAR(100) NOT NULL,
+			tenant_id VARCHAR(100) NOT NULL DEFAULT ''
+		)
+	`)
+	require.NoError(t, err)
+
+	repo := NewPgxOutboxRepository(pool)
+
+	t.Run("successful insert", func(t *testing.T) {
+		tx, err := pool.Begin(ctx)
+		require.NoError(t, err)
+
+		entry := NewEventOutbox("event.type", "agg-1", "Type", []byte(`{"test":1}`), "topic", "service", "corr-1", "tenant-1")
+		err = repo.InsertWithPgxTx(ctx, tx, entry)
+		require.NoError(t, err)
+
+		err = tx.Commit(ctx)
+		require.NoError(t, err)
+
+		// Verify persisted
+		var count int
+		err = pool.QueryRow(ctx, "SELECT COUNT(*) FROM event_outbox WHERE id = $1", entry.ID).Scan(&count)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+	})
+
+	t.Run("nil transaction returns error", func(t *testing.T) {
+		entry := NewEventOutbox("event.type", "agg-2", "Type", []byte(`{}`), "topic", "service", "", "")
+		err := repo.InsertWithPgxTx(ctx, nil, entry)
+		assert.ErrorIs(t, err, ErrNilTransaction)
+	})
+
+	t.Run("generates UUID if nil", func(t *testing.T) {
+		tx, err := pool.Begin(ctx)
+		require.NoError(t, err)
+
+		entry := &EventOutbox{
+			EventType:     "event.type",
+			AggregateID:   "agg-3",
+			AggregateType: "Type",
+			EventPayload:  []byte(`{}`),
+			Topic:         "topic",
+			ServiceName:   "service",
+		}
+		err = repo.InsertWithPgxTx(ctx, tx, entry)
+		require.NoError(t, err)
+		assert.NotEqual(t, uuid.Nil, entry.ID)
+		assert.Equal(t, StatusPending, entry.Status)
+		assert.False(t, entry.CreatedAt.IsZero())
+
+		err = tx.Commit(ctx)
+		require.NoError(t, err)
+	})
+}
+
+func TestPgxOutboxRepository_FetchUnprocessed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	repo, cleanup := setupPgxOutboxRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Insert test entries directly.
+	for i := 0; i < 5; i++ {
+		entry := NewEventOutbox("event.type", "agg", "Type", []byte(`{}`), "topic", "pgx-svc", "", "")
+		_, err := repo.pool.Exec(ctx,
+			`INSERT INTO event_outbox (id, event_type, aggregate_id, aggregate_type, event_payload, status, topic, created_at, retry_count, service_name, tenant_id)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+			entry.ID, entry.EventType, entry.AggregateID, entry.AggregateType, entry.EventPayload,
+			StatusPending, entry.Topic, entry.CreatedAt, 0, entry.ServiceName, "",
+		)
+		require.NoError(t, err)
+	}
+
+	t.Run("fetches pending entries", func(t *testing.T) {
+		entries, err := repo.FetchUnprocessed(ctx, "pgx-svc", 10)
+		require.NoError(t, err)
+		assert.Len(t, entries, 5)
+	})
+
+	t.Run("respects limit", func(t *testing.T) {
+		entries, err := repo.FetchUnprocessed(ctx, "pgx-svc", 3)
+		require.NoError(t, err)
+		assert.Len(t, entries, 3)
+	})
+
+	t.Run("filters by service name", func(t *testing.T) {
+		entries, err := repo.FetchUnprocessed(ctx, "other-svc", 10)
+		require.NoError(t, err)
+		assert.Empty(t, entries)
+	})
+}
+
+func TestPgxOutboxRepository_FetchAndLockForProcessing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	repo, cleanup := setupPgxOutboxRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Insert entries.
+	var ids []uuid.UUID
+	for i := 0; i < 3; i++ {
+		entry := NewEventOutbox("event.type", "agg", "Type", []byte(`{}`), "topic", "lock-svc", "", "")
+		_, err := repo.pool.Exec(ctx,
+			`INSERT INTO event_outbox (id, event_type, aggregate_id, aggregate_type, event_payload, status, topic, created_at, retry_count, service_name, tenant_id)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+			entry.ID, entry.EventType, entry.AggregateID, entry.AggregateType, entry.EventPayload,
+			StatusPending, entry.Topic, entry.CreatedAt, 0, entry.ServiceName, "",
+		)
+		require.NoError(t, err)
+		ids = append(ids, entry.ID)
+	}
+
+	t.Run("fetches and marks as processing", func(t *testing.T) {
+		entries, err := repo.FetchAndLockForProcessing(ctx, "lock-svc", 10)
+		require.NoError(t, err)
+		assert.Len(t, entries, 3)
+
+		// Verify entries are now in processing state.
+		var processingCount int
+		err = repo.pool.QueryRow(ctx, "SELECT COUNT(*) FROM event_outbox WHERE status = $1 AND service_name = $2", StatusProcessing, "lock-svc").Scan(&processingCount)
+		require.NoError(t, err)
+		assert.Equal(t, 3, processingCount)
+	})
+
+	t.Run("returns empty when no pending entries", func(t *testing.T) {
+		entries, err := repo.FetchAndLockForProcessing(ctx, "lock-svc", 10)
+		require.NoError(t, err)
+		assert.Empty(t, entries)
+	})
+}
+
+func TestPgxOutboxRepository_MarkProcessing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	repo, cleanup := setupPgxOutboxRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	entry := NewEventOutbox("event.type", "agg", "Type", []byte(`{}`), "topic", "mark-svc", "", "")
+	_, err := repo.pool.Exec(ctx,
+		`INSERT INTO event_outbox (id, event_type, aggregate_id, aggregate_type, event_payload, status, topic, created_at, retry_count, service_name, tenant_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+		entry.ID, entry.EventType, entry.AggregateID, entry.AggregateType, entry.EventPayload,
+		StatusPending, entry.Topic, entry.CreatedAt, 0, entry.ServiceName, "",
+	)
+	require.NoError(t, err)
+
+	t.Run("marks pending entries as processing", func(t *testing.T) {
+		count, err := repo.MarkProcessing(ctx, []uuid.UUID{entry.ID})
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), count)
+	})
+
+	t.Run("empty ids returns zero", func(t *testing.T) {
+		count, err := repo.MarkProcessing(ctx, []uuid.UUID{})
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), count)
+	})
+}
+
+func TestPgxOutboxRepository_MarkCompleted(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	repo, cleanup := setupPgxOutboxRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	entry := NewEventOutbox("event.type", "agg", "Type", []byte(`{}`), "topic", "svc", "", "")
+	_, err := repo.pool.Exec(ctx,
+		`INSERT INTO event_outbox (id, event_type, aggregate_id, aggregate_type, event_payload, status, topic, created_at, retry_count, service_name, tenant_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+		entry.ID, entry.EventType, entry.AggregateID, entry.AggregateType, entry.EventPayload,
+		StatusProcessing, entry.Topic, entry.CreatedAt, 0, entry.ServiceName, "",
+	)
+	require.NoError(t, err)
+
+	t.Run("marks entry as completed", func(t *testing.T) {
+		err := repo.MarkCompleted(ctx, entry.ID)
+		require.NoError(t, err)
+
+		var status string
+		err = repo.pool.QueryRow(ctx, "SELECT status FROM event_outbox WHERE id = $1", entry.ID).Scan(&status)
+		require.NoError(t, err)
+		assert.Equal(t, StatusCompleted, status)
+	})
+
+	t.Run("non-existent entry returns error", func(t *testing.T) {
+		err := repo.MarkCompleted(ctx, uuid.New())
+		assert.ErrorIs(t, err, ErrOutboxEntryNotFound)
+	})
+}
+
+func TestPgxOutboxRepository_MarkFailed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	repo, cleanup := setupPgxOutboxRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	t.Run("increments retry and resets to pending", func(t *testing.T) {
+		entry := NewEventOutbox("event.type", "agg", "Type", []byte(`{}`), "topic", "svc", "", "")
+		_, err := repo.pool.Exec(ctx,
+			`INSERT INTO event_outbox (id, event_type, aggregate_id, aggregate_type, event_payload, status, topic, created_at, retry_count, service_name, tenant_id)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+			entry.ID, entry.EventType, entry.AggregateID, entry.AggregateType, entry.EventPayload,
+			StatusProcessing, entry.Topic, entry.CreatedAt, 0, entry.ServiceName, "",
+		)
+		require.NoError(t, err)
+
+		err = repo.MarkFailed(ctx, entry.ID, errors.New("test error"), 5)
+		require.NoError(t, err)
+
+		var status string
+		var retryCount int
+		err = repo.pool.QueryRow(ctx, "SELECT status, retry_count FROM event_outbox WHERE id = $1", entry.ID).Scan(&status, &retryCount)
+		require.NoError(t, err)
+		assert.Equal(t, StatusPending, status)
+		assert.Equal(t, 1, retryCount)
+	})
+
+	t.Run("marks as failed when retries exhausted", func(t *testing.T) {
+		entry := NewEventOutbox("event.type", "agg", "Type", []byte(`{}`), "topic", "svc", "", "")
+		_, err := repo.pool.Exec(ctx,
+			`INSERT INTO event_outbox (id, event_type, aggregate_id, aggregate_type, event_payload, status, topic, created_at, retry_count, service_name, tenant_id)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+			entry.ID, entry.EventType, entry.AggregateID, entry.AggregateType, entry.EventPayload,
+			StatusProcessing, entry.Topic, entry.CreatedAt, 4, entry.ServiceName, "",
+		)
+		require.NoError(t, err)
+
+		err = repo.MarkFailed(ctx, entry.ID, errors.New("final error"), 5)
+		require.NoError(t, err)
+
+		var status string
+		err = repo.pool.QueryRow(ctx, "SELECT status FROM event_outbox WHERE id = $1", entry.ID).Scan(&status)
+		require.NoError(t, err)
+		assert.Equal(t, StatusFailed, status)
+	})
+
+	t.Run("non-existent entry returns error", func(t *testing.T) {
+		err := repo.MarkFailed(ctx, uuid.New(), errors.New("err"), 5)
+		assert.ErrorIs(t, err, ErrOutboxEntryNotFound)
+	})
+}
+
+func TestPgxOutboxRepository_GetPendingCount(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	repo, cleanup := setupPgxOutboxRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Insert mixed entries.
+	for i := 0; i < 3; i++ {
+		entry := NewEventOutbox("event.type", "agg", "Type", []byte(`{}`), "topic", "count-svc", "", "")
+		_, err := repo.pool.Exec(ctx,
+			`INSERT INTO event_outbox (id, event_type, aggregate_id, aggregate_type, event_payload, status, topic, created_at, retry_count, service_name, tenant_id)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+			entry.ID, entry.EventType, entry.AggregateID, entry.AggregateType, entry.EventPayload,
+			StatusPending, entry.Topic, entry.CreatedAt, 0, entry.ServiceName, "",
+		)
+		require.NoError(t, err)
+	}
+
+	// Insert one completed entry.
+	entry := NewEventOutbox("event.type", "agg", "Type", []byte(`{}`), "topic", "count-svc", "", "")
+	_, err := repo.pool.Exec(ctx,
+		`INSERT INTO event_outbox (id, event_type, aggregate_id, aggregate_type, event_payload, status, topic, created_at, retry_count, service_name, tenant_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+		entry.ID, entry.EventType, entry.AggregateID, entry.AggregateType, entry.EventPayload,
+		StatusCompleted, entry.Topic, entry.CreatedAt, 0, entry.ServiceName, "",
+	)
+	require.NoError(t, err)
+
+	count, err := repo.GetPendingCount(ctx, "count-svc")
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), count)
+}
+
+func TestPgxOutboxRepository_ResetStuckEntries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	repo, cleanup := setupPgxOutboxRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Old stuck entry.
+	oldEntry := NewEventOutbox("event.type", "agg-old", "Type", []byte(`{}`), "topic", "stuck-svc", "", "")
+	_, err := repo.pool.Exec(ctx,
+		`INSERT INTO event_outbox (id, event_type, aggregate_id, aggregate_type, event_payload, status, topic, created_at, retry_count, service_name, tenant_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+		oldEntry.ID, oldEntry.EventType, oldEntry.AggregateID, oldEntry.AggregateType, oldEntry.EventPayload,
+		StatusProcessing, oldEntry.Topic, time.Now().Add(-10*time.Minute), 0, oldEntry.ServiceName, "",
+	)
+	require.NoError(t, err)
+
+	// Recent processing entry (should NOT be reset).
+	newEntry := NewEventOutbox("event.type", "agg-new", "Type", []byte(`{}`), "topic", "stuck-svc", "", "")
+	_, err = repo.pool.Exec(ctx,
+		`INSERT INTO event_outbox (id, event_type, aggregate_id, aggregate_type, event_payload, status, topic, created_at, retry_count, service_name, tenant_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+		newEntry.ID, newEntry.EventType, newEntry.AggregateID, newEntry.AggregateType, newEntry.EventPayload,
+		StatusProcessing, newEntry.Topic, time.Now(), 0, newEntry.ServiceName, "",
+	)
+	require.NoError(t, err)
+
+	count, err := repo.ResetStuckEntries(ctx, "stuck-svc", 5*time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+
+	// Verify old entry was reset.
+	var oldStatus string
+	err = repo.pool.QueryRow(ctx, "SELECT status FROM event_outbox WHERE id = $1", oldEntry.ID).Scan(&oldStatus)
+	require.NoError(t, err)
+	assert.Equal(t, StatusPending, oldStatus)
+
+	// Verify new entry was NOT reset.
+	var newStatus string
+	err = repo.pool.QueryRow(ctx, "SELECT status FROM event_outbox WHERE id = $1", newEntry.ID).Scan(&newStatus)
+	require.NoError(t, err)
+	assert.Equal(t, StatusProcessing, newStatus)
+}
+
+func TestPgxOutboxPublisher_Publish_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testdb.NewTestPool(t)
+	ctx := context.Background()
+
+	_, err := pool.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS event_outbox (
+			id UUID PRIMARY KEY,
+			event_type VARCHAR(200) NOT NULL,
+			aggregate_id VARCHAR(100) NOT NULL,
+			aggregate_type VARCHAR(100) NOT NULL,
+			event_payload BYTEA NOT NULL,
+			correlation_id VARCHAR(100),
+			causation_id VARCHAR(100),
+			status VARCHAR(20) NOT NULL,
+			topic VARCHAR(200) NOT NULL,
+			partition_key VARCHAR(200),
+			created_at TIMESTAMPTZ NOT NULL,
+			processed_at TIMESTAMPTZ,
+			retry_count INT NOT NULL DEFAULT 0,
+			last_error TEXT,
+			service_name VARCHAR(100) NOT NULL,
+			tenant_id VARCHAR(100) NOT NULL DEFAULT ''
+		)
+	`)
+	require.NoError(t, err)
+
+	publisher := NewPgxOutboxPublisher("test-service")
+
+	t.Run("successful publish with all fields", func(t *testing.T) {
+		tenantCtx := tenant.WithTenant(ctx, "test-tenant")
+
+		tx, err := pool.Begin(tenantCtx)
+		require.NoError(t, err)
+
+		event := timestamppb.Now()
+		err = publisher.Publish(tenantCtx, tx, event, PublishConfig{
+			EventType:     "test.event.v1",
+			AggregateID:   "agg-1",
+			AggregateType: "TestAggregate",
+			Topic:         "test-topic",
+			CorrelationID: "corr-1",
+			CausationID:   "cause-1",
+			PartitionKey:  "custom-key",
+		})
+		require.NoError(t, err)
+
+		err = tx.Commit(tenantCtx)
+		require.NoError(t, err)
+
+		var count int
+		err = pool.QueryRow(ctx, "SELECT COUNT(*) FROM event_outbox WHERE aggregate_id = $1", "agg-1").Scan(&count)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+	})
+
+	t.Run("nil event returns error", func(t *testing.T) {
+		tx, err := pool.Begin(ctx)
+		require.NoError(t, err)
+		defer tx.Rollback(ctx) //nolint:errcheck
+
+		err = publisher.Publish(ctx, tx, nil, PublishConfig{
+			EventType:     "test.event.v1",
+			AggregateID:   "agg-1",
+			AggregateType: "Type",
+			Topic:         "topic",
+		})
+		assert.ErrorIs(t, err, ErrNilEvent)
+	})
+
+	t.Run("empty event type returns error", func(t *testing.T) {
+		tx, err := pool.Begin(ctx)
+		require.NoError(t, err)
+		defer tx.Rollback(ctx) //nolint:errcheck
+
+		err = publisher.Publish(ctx, tx, timestamppb.Now(), PublishConfig{
+			AggregateID:   "agg-1",
+			AggregateType: "Type",
+			Topic:         "topic",
+		})
+		assert.ErrorIs(t, err, ErrInvalidEventType)
+	})
+
+	t.Run("empty topic returns error", func(t *testing.T) {
+		tx, err := pool.Begin(ctx)
+		require.NoError(t, err)
+		defer tx.Rollback(ctx) //nolint:errcheck
+
+		err = publisher.Publish(ctx, tx, timestamppb.Now(), PublishConfig{
+			EventType:     "test.event.v1",
+			AggregateID:   "agg-1",
+			AggregateType: "Type",
+		})
+		assert.ErrorIs(t, err, ErrEmptyTopic)
+	})
+
+	t.Run("empty aggregate ID returns error", func(t *testing.T) {
+		tx, err := pool.Begin(ctx)
+		require.NoError(t, err)
+		defer tx.Rollback(ctx) //nolint:errcheck
+
+		err = publisher.Publish(ctx, tx, timestamppb.Now(), PublishConfig{
+			EventType:     "test.event.v1",
+			AggregateType: "Type",
+			Topic:         "topic",
+		})
+		assert.ErrorIs(t, err, ErrEmptyAggregateID)
+	})
+
+	t.Run("empty aggregate type returns error", func(t *testing.T) {
+		tx, err := pool.Begin(ctx)
+		require.NoError(t, err)
+		defer tx.Rollback(ctx) //nolint:errcheck
+
+		err = publisher.Publish(ctx, tx, timestamppb.Now(), PublishConfig{
+			EventType:   "test.event.v1",
+			AggregateID: "agg-1",
+			Topic:       "topic",
+		})
+		assert.ErrorIs(t, err, ErrEmptyAggregateType)
+	})
+
+	t.Run("defaults partition key to aggregate ID", func(t *testing.T) {
+		tx, err := pool.Begin(ctx)
+		require.NoError(t, err)
+
+		err = publisher.Publish(ctx, tx, timestamppb.Now(), PublishConfig{
+			EventType:     "test.default.v1",
+			AggregateID:   "agg-default",
+			AggregateType: "Type",
+			Topic:         "topic",
+		})
+		require.NoError(t, err)
+
+		err = tx.Commit(ctx)
+		require.NoError(t, err)
+
+		var partitionKey *string
+		err = pool.QueryRow(ctx, "SELECT partition_key FROM event_outbox WHERE aggregate_id = $1", "agg-default").Scan(&partitionKey)
+		require.NoError(t, err)
+		require.NotNil(t, partitionKey)
+		assert.Equal(t, "agg-default", *partitionKey)
+	})
+}
+
+// NOTE: GORM FetchAndLockForProcessing is not tested here because GORM's Raw().Scan()
+// with SELECT * has compatibility issues with CockroachDB column mapping in testcontainers.
+// The pgx version of FetchAndLockForProcessing is tested above and covers the same logic.

--- a/shared/platform/events/outbox_pgx_integration_test.go
+++ b/shared/platform/events/outbox_pgx_integration_test.go
@@ -184,7 +184,6 @@ func TestPgxOutboxRepository_FetchAndLockForProcessing(t *testing.T) {
 	ctx := context.Background()
 
 	// Insert entries.
-	var ids []uuid.UUID
 	for i := 0; i < 3; i++ {
 		entry := NewEventOutbox("event.type", "agg", "Type", []byte(`{}`), "topic", "lock-svc", "", "")
 		_, err := repo.pool.Exec(ctx,
@@ -194,7 +193,6 @@ func TestPgxOutboxRepository_FetchAndLockForProcessing(t *testing.T) {
 			StatusPending, entry.Topic, entry.CreatedAt, 0, entry.ServiceName, "",
 		)
 		require.NoError(t, err)
-		ids = append(ids, entry.ID)
 	}
 
 	t.Run("fetches and marks as processing", func(t *testing.T) {

--- a/shared/platform/events/worker_unit_test.go
+++ b/shared/platform/events/worker_unit_test.go
@@ -1,0 +1,370 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+func TestNewWorker_AppliesDefaults(t *testing.T) {
+	repo := newMockOutboxRepository()
+	publisher := newMockKafkaPublisher()
+
+	// All zero/negative values should get defaults applied.
+	config := WorkerConfig{
+		ServiceName: "test-service",
+	}
+
+	worker := NewWorker(repo, publisher, config, nil)
+
+	assert.Equal(t, defaultBatchSize, worker.config.BatchSize)
+	assert.Equal(t, defaultPollInterval, worker.config.PollInterval)
+	assert.Equal(t, defaultMaxRetries, worker.config.MaxRetries)
+	assert.Equal(t, defaultProcessingAge, worker.config.ProcessingAge)
+	assert.Equal(t, defaultPublishTimeoutMs, worker.config.PublishTimeoutMs)
+}
+
+func TestNewWorker_PreservesCustomConfig(t *testing.T) {
+	repo := newMockOutboxRepository()
+	publisher := newMockKafkaPublisher()
+
+	config := WorkerConfig{
+		ServiceName:      "test-service",
+		BatchSize:        50,
+		PollInterval:     10 * time.Second,
+		MaxRetries:       3,
+		ProcessingAge:    2 * time.Minute,
+		PublishTimeoutMs: 3000,
+	}
+
+	worker := NewWorker(repo, publisher, config, nil)
+
+	assert.Equal(t, 50, worker.config.BatchSize)
+	assert.Equal(t, 10*time.Second, worker.config.PollInterval)
+	assert.Equal(t, 3, worker.config.MaxRetries)
+	assert.Equal(t, 2*time.Minute, worker.config.ProcessingAge)
+	assert.Equal(t, 3000, worker.config.PublishTimeoutMs)
+}
+
+func TestDefaultWorkerConfig(t *testing.T) {
+	config := DefaultWorkerConfig("my-service")
+
+	assert.Equal(t, "my-service", config.ServiceName)
+	assert.Equal(t, defaultBatchSize, config.BatchSize)
+	assert.Equal(t, defaultPollInterval, config.PollInterval)
+	assert.Equal(t, defaultMaxRetries, config.MaxRetries)
+	assert.Equal(t, defaultProcessingAge, config.ProcessingAge)
+	assert.Equal(t, defaultPublishTimeoutMs, config.PublishTimeoutMs)
+}
+
+func TestWorker_ResetStuckEntries_RecordsMetric(t *testing.T) {
+	repo := newMockOutboxRepository()
+	publisher := newMockKafkaPublisher()
+
+	config := DefaultWorkerConfig("test-service")
+	config.ProcessingAge = 1 * time.Millisecond // Very short for testing
+
+	worker := NewWorker(repo, publisher, config, nil)
+
+	// Add an entry that's "stuck" in processing state with old created_at.
+	entry := NewEventOutbox("event.type", "agg-1", "Type", []byte(`{}`), "topic", "test-service", "", "")
+	entry.Status = StatusProcessing
+	entry.CreatedAt = time.Now().Add(-10 * time.Minute)
+	repo.addEntry(entry)
+
+	// Call resetStuckEntries directly.
+	err := worker.resetStuckEntries(context.Background())
+	require.NoError(t, err)
+
+	// Verify the entry was reset to pending.
+	e := repo.getEntry(entry.ID)
+	assert.Equal(t, StatusPending, e.Status)
+}
+
+func TestWorker_ResetStuckEntries_NoStuckEntries(t *testing.T) {
+	repo := newMockOutboxRepository()
+	publisher := newMockKafkaPublisher()
+
+	config := DefaultWorkerConfig("test-service")
+	worker := NewWorker(repo, publisher, config, nil)
+
+	// No stuck entries - should succeed without error.
+	err := worker.resetStuckEntries(context.Background())
+	require.NoError(t, err)
+}
+
+func TestWorker_ResetStuckEntries_RepoError(t *testing.T) {
+	repo := &errorOutboxRepository{
+		resetErr: errors.New("db connection lost"),
+	}
+	publisher := newMockKafkaPublisher()
+
+	config := DefaultWorkerConfig("test-service")
+	worker := NewWorker(repo, publisher, config, nil)
+
+	err := worker.resetStuckEntries(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to reset stuck entries")
+}
+
+func TestWorker_ProcessBatch_FetchError(t *testing.T) {
+	repo := &errorOutboxRepository{
+		fetchErr: errors.New("database unavailable"),
+	}
+	publisher := newMockKafkaPublisher()
+
+	config := DefaultWorkerConfig("test-service")
+	worker := NewWorker(repo, publisher, config, nil)
+
+	err := worker.processBatch(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch and lock entries")
+}
+
+func TestWorker_ProcessBatch_EmptyBatch(t *testing.T) {
+	repo := newMockOutboxRepository()
+	publisher := newMockKafkaPublisher()
+
+	config := DefaultWorkerConfig("test-service")
+	worker := NewWorker(repo, publisher, config, nil)
+
+	// No entries - should return nil.
+	err := worker.processBatch(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestWorker_ProcessEntry_MarkCompletedError(t *testing.T) {
+	repo := &errorOutboxRepository{
+		markCompletedErr: errors.New("mark completed failed"),
+	}
+	publisher := newMockKafkaPublisher()
+
+	config := DefaultWorkerConfig("test-service")
+	worker := NewWorker(repo, publisher, config, nil)
+
+	entry := NewEventOutbox("event.type", "agg-1", "Type", []byte(`{}`), "topic", "test-service", "", "")
+
+	err := worker.processEntry(context.Background(), entry)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to mark entry as completed")
+}
+
+func TestWorker_ProcessEntry_MarkFailedError(t *testing.T) {
+	publisher := newMockKafkaPublisher()
+	publisher.setProduceError(errors.New("kafka down"))
+
+	repo := &errorOutboxRepository{
+		markFailedErr: errors.New("db error on mark failed"),
+	}
+
+	config := DefaultWorkerConfig("test-service")
+	worker := NewWorker(repo, publisher, config, nil)
+
+	entry := NewEventOutbox("event.type", "agg-1", "Type", []byte(`{}`), "topic", "test-service", "", "")
+
+	err := worker.processEntry(context.Background(), entry)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "publish failed")
+}
+
+func TestWorker_PublishToKafka_Timeout(t *testing.T) {
+	publisher := &timeoutKafkaPublisher{}
+
+	repo := newMockOutboxRepository()
+
+	config := DefaultWorkerConfig("test-service")
+	config.PublishTimeoutMs = 50 // Short timeout
+	worker := NewWorker(repo, publisher, config, nil)
+
+	entry := NewEventOutbox("event.type", "agg-1", "Type", []byte(`{}`), "topic", "test-service", "", "")
+
+	err := worker.publishToKafka(context.Background(), entry)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrPublishTimeout)
+}
+
+func TestWorker_PublishToKafka_HeadersWithoutOptionalFields(t *testing.T) {
+	publisher := newMockKafkaPublisher()
+	repo := newMockOutboxRepository()
+
+	config := DefaultWorkerConfig("test-service")
+	worker := NewWorker(repo, publisher, config, nil)
+
+	// Entry without correlation, causation, or tenant.
+	entry := NewEventOutbox("event.type", "agg-1", "Type", []byte(`{}`), "topic", "test-service", "", "")
+
+	err := worker.publishToKafka(context.Background(), entry)
+	require.NoError(t, err)
+
+	records := publisher.getRecords()
+	require.Len(t, records, 1)
+
+	// Verify only required headers are present (no correlation, causation, tenant).
+	headerMap := make(map[string]string)
+	for _, h := range records[0].Headers {
+		headerMap[h.Key] = string(h.Value)
+	}
+
+	assert.NotEmpty(t, headerMap["event_id"])
+	assert.Equal(t, "event.type", headerMap["event_type"])
+	assert.Equal(t, "Type", headerMap["aggregate_type"])
+	assert.Equal(t, "agg-1", headerMap["aggregate_id"])
+
+	_, hasCorrelation := headerMap["correlation_id"]
+	_, hasCausation := headerMap["causation_id"]
+	_, hasTenant := headerMap["X-Tenant-ID"]
+	assert.False(t, hasCorrelation, "should not have correlation_id header")
+	assert.False(t, hasCausation, "should not have causation_id header")
+	assert.False(t, hasTenant, "should not have X-Tenant-ID header")
+}
+
+func TestWorker_ProcessEntry_RetriesExhausted(t *testing.T) {
+	publisher := newMockKafkaPublisher()
+	publisher.setProduceError(errors.New("permanent failure"))
+
+	repo := newMockOutboxRepository()
+
+	config := DefaultWorkerConfig("test-service")
+	config.MaxRetries = 3
+	worker := NewWorker(repo, publisher, config, nil)
+
+	// Entry already at max retries - 1.
+	entry := NewEventOutbox("event.type", "agg-1", "Type", []byte(`{}`), "topic", "test-service", "", "")
+	entry.RetryCount = 2 // Next failure will exhaust retries.
+	repo.addEntry(entry)
+
+	err := worker.processEntry(context.Background(), entry)
+	assert.Error(t, err)
+
+	// Verify DLQ path was hit (entry marked failed).
+	e := repo.getEntry(entry.ID)
+	assert.Equal(t, StatusFailed, e.Status)
+}
+
+func TestWorker_ProcessEntry_RetryNotExhausted(t *testing.T) {
+	publisher := newMockKafkaPublisher()
+	publisher.setProduceError(errors.New("temporary failure"))
+
+	repo := newMockOutboxRepository()
+
+	config := DefaultWorkerConfig("test-service")
+	config.MaxRetries = 5
+	worker := NewWorker(repo, publisher, config, nil)
+
+	// Entry with room for retries.
+	entry := NewEventOutbox("event.type", "agg-1", "Type", []byte(`{}`), "topic", "test-service", "", "")
+	entry.RetryCount = 1
+	repo.addEntry(entry)
+
+	err := worker.processEntry(context.Background(), entry)
+	assert.Error(t, err)
+
+	// Entry should be back to pending for retry.
+	e := repo.getEntry(entry.ID)
+	assert.Equal(t, StatusPending, e.Status)
+}
+
+func TestWorker_Stop_MultipleCallsSafe(t *testing.T) {
+	repo := newMockOutboxRepository()
+	publisher := newMockKafkaPublisher()
+
+	config := DefaultWorkerConfig("test-service")
+	config.PollInterval = 100 * time.Millisecond
+
+	worker := NewWorker(repo, publisher, config, nil)
+	worker.Start(context.Background())
+
+	// Multiple stops should not panic.
+	done := make(chan struct{})
+	go func() {
+		worker.Stop()
+		worker.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(3 * time.Second):
+		t.Fatal("double Stop() timed out")
+	}
+}
+
+func TestWorker_Stop_UnflushedMessages(t *testing.T) {
+	repo := newMockOutboxRepository()
+	publisher := newMockKafkaPublisher()
+	publisher.flushError = errors.New("flush failed") // Causes FlushWithTimeout to return >0
+
+	config := DefaultWorkerConfig("test-service")
+	config.PollInterval = 100 * time.Millisecond
+
+	worker := NewWorker(repo, publisher, config, nil)
+	worker.Start(context.Background())
+
+	// Stop should complete even with unflushed messages (just logs warning).
+	done := make(chan struct{})
+	go func() {
+		worker.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success - worker stopped despite flush issues
+	case <-time.After(3 * time.Second):
+		t.Fatal("Stop() with unflushed messages timed out")
+	}
+}
+
+// errorOutboxRepository is a mock that returns configurable errors.
+type errorOutboxRepository struct {
+	fetchErr         error
+	resetErr         error
+	markCompletedErr error
+	markFailedErr    error
+}
+
+func (r *errorOutboxRepository) FetchAndLockForProcessing(_ context.Context, _ string, _ int) ([]EventOutbox, error) {
+	if r.fetchErr != nil {
+		return nil, r.fetchErr
+	}
+	return nil, nil
+}
+
+func (r *errorOutboxRepository) MarkCompleted(_ context.Context, _ uuid.UUID) error {
+	return r.markCompletedErr
+}
+
+func (r *errorOutboxRepository) MarkFailed(_ context.Context, _ uuid.UUID, _ error, _ int) error {
+	return r.markFailedErr
+}
+
+func (r *errorOutboxRepository) GetPendingCount(_ context.Context, _ string) (int64, error) {
+	return 0, nil
+}
+
+func (r *errorOutboxRepository) ResetStuckEntries(_ context.Context, _ string, _ time.Duration) (int64, error) {
+	if r.resetErr != nil {
+		return 0, r.resetErr
+	}
+	return 0, nil
+}
+
+// timeoutKafkaPublisher simulates a producer that always times out.
+type timeoutKafkaPublisher struct{}
+
+func (t *timeoutKafkaPublisher) ProduceRecord(ctx context.Context, _ *kgo.Record) error {
+	// Wait for context to expire.
+	<-ctx.Done()
+	return context.DeadlineExceeded
+}
+
+func (t *timeoutKafkaPublisher) Flush(_ context.Context) error { return nil }
+func (t *timeoutKafkaPublisher) FlushWithTimeout(_ int) int    { return 0 }
+func (t *timeoutKafkaPublisher) Close()                        {}

--- a/shared/platform/kafka/config_unit_test.go
+++ b/shared/platform/kafka/config_unit_test.go
@@ -1,0 +1,294 @@
+package kafka
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestDefaultAuditTopicConfig(t *testing.T) {
+	config := DefaultAuditTopicConfig()
+
+	if config.EventsTopic != AuditEventsTopic {
+		t.Errorf("EventsTopic: got %q, want %q", config.EventsTopic, AuditEventsTopic)
+	}
+	if config.DLQTopic != AuditEventsDLQTopic {
+		t.Errorf("DLQTopic: got %q, want %q", config.DLQTopic, AuditEventsDLQTopic)
+	}
+	if config.ConsumerGroup != AuditConsumerGroup {
+		t.Errorf("ConsumerGroup: got %q, want %q", config.ConsumerGroup, AuditConsumerGroup)
+	}
+	if config.RetentionDays != DefaultAuditRetentionDays {
+		t.Errorf("RetentionDays: got %d, want %d", config.RetentionDays, DefaultAuditRetentionDays)
+	}
+	if config.Partitions != 6 {
+		t.Errorf("Partitions: got %d, want 6", config.Partitions)
+	}
+	if config.ReplicationFactor != 3 {
+		t.Errorf("ReplicationFactor: got %d, want 3", config.ReplicationFactor)
+	}
+}
+
+func TestAuditTopicConfigFromEnv(t *testing.T) {
+	t.Run("defaults when env not set", func(t *testing.T) {
+		// Clear env vars
+		os.Unsetenv("AUDIT_KAFKA_TOPIC")
+		os.Unsetenv("AUDIT_KAFKA_DLQ_TOPIC")
+		os.Unsetenv("AUDIT_KAFKA_CONSUMER_GROUP")
+
+		config := AuditTopicConfigFromEnv()
+		if config.EventsTopic != AuditEventsTopic {
+			t.Errorf("EventsTopic: got %q, want default", config.EventsTopic)
+		}
+		if config.DLQTopic != AuditEventsDLQTopic {
+			t.Errorf("DLQTopic: got %q, want default", config.DLQTopic)
+		}
+		if config.ConsumerGroup != AuditConsumerGroup {
+			t.Errorf("ConsumerGroup: got %q, want default", config.ConsumerGroup)
+		}
+	})
+
+	t.Run("custom env overrides", func(t *testing.T) {
+		t.Setenv("AUDIT_KAFKA_TOPIC", "custom-audit-topic")
+		t.Setenv("AUDIT_KAFKA_DLQ_TOPIC", "custom-dlq-topic")
+		t.Setenv("AUDIT_KAFKA_CONSUMER_GROUP", "custom-group")
+
+		config := AuditTopicConfigFromEnv()
+		if config.EventsTopic != "custom-audit-topic" {
+			t.Errorf("EventsTopic: got %q, want %q", config.EventsTopic, "custom-audit-topic")
+		}
+		if config.DLQTopic != "custom-dlq-topic" {
+			t.Errorf("DLQTopic: got %q, want %q", config.DLQTopic, "custom-dlq-topic")
+		}
+		if config.ConsumerGroup != "custom-group" {
+			t.Errorf("ConsumerGroup: got %q, want %q", config.ConsumerGroup, "custom-group")
+		}
+	})
+}
+
+func TestSplitString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		sep      rune
+		expected []string
+	}{
+		{"single item", "localhost:9092", ',', []string{"localhost:9092"}},
+		{"multiple items", "a,b,c", ',', []string{"a", "b", "c"}},
+		{"empty string", "", ',', nil},
+		{"trailing separator", "a,b,", ',', []string{"a", "b"}},
+		{"leading separator", ",a,b", ',', []string{"", "a", "b"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := splitString(tt.input, tt.sep)
+			if len(result) != len(tt.expected) {
+				t.Errorf("splitString(%q, %q) = %v (len %d), want %v (len %d)",
+					tt.input, string(tt.sep), result, len(result), tt.expected, len(tt.expected))
+				return
+			}
+			for i, v := range result {
+				if v != tt.expected[i] {
+					t.Errorf("splitString(%q, %q)[%d] = %q, want %q", tt.input, string(tt.sep), i, v, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSplitBrokers(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{"single broker", "localhost:9092", []string{"localhost:9092"}},
+		{"multiple brokers", "broker1:9092,broker2:9092,broker3:9092", []string{"broker1:9092", "broker2:9092", "broker3:9092"}},
+		{"empty string", "", nil},
+		{"trailing comma filters empty", "a,b,", []string{"a", "b"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := splitBrokers(tt.input)
+			if len(result) != len(tt.expected) {
+				t.Errorf("splitBrokers(%q) = %v (len %d), want %v (len %d)",
+					tt.input, result, len(result), tt.expected, len(tt.expected))
+				return
+			}
+			for i, v := range result {
+				if v != tt.expected[i] {
+					t.Errorf("splitBrokers(%q)[%d] = %q, want %q", tt.input, i, v, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestNewProtoProducer_ConfigOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  ProducerConfig
+		wantErr bool
+	}{
+		{
+			name: "acks all",
+			config: ProducerConfig{
+				BootstrapServers: "localhost:9092",
+				Acks:             "all",
+			},
+		},
+		{
+			name: "acks minus one",
+			config: ProducerConfig{
+				BootstrapServers: "localhost:9092",
+				Acks:             "-1",
+			},
+		},
+		{
+			name: "acks leader rejected by idempotency",
+			config: ProducerConfig{
+				BootstrapServers: "localhost:9092",
+				Acks:             "1",
+			},
+			wantErr: true,
+		},
+		{
+			name: "acks none rejected by idempotency",
+			config: ProducerConfig{
+				BootstrapServers: "localhost:9092",
+				Acks:             "0",
+			},
+			wantErr: true,
+		},
+		{
+			name: "acks unknown defaults to all",
+			config: ProducerConfig{
+				BootstrapServers: "localhost:9092",
+				Acks:             "unknown",
+			},
+		},
+		{
+			name: "compression gzip",
+			config: ProducerConfig{
+				BootstrapServers: "localhost:9092",
+				Compression:      "gzip",
+			},
+		},
+		{
+			name: "compression lz4",
+			config: ProducerConfig{
+				BootstrapServers: "localhost:9092",
+				Compression:      "lz4",
+			},
+		},
+		{
+			name: "compression zstd",
+			config: ProducerConfig{
+				BootstrapServers: "localhost:9092",
+				Compression:      "zstd",
+			},
+		},
+		{
+			name: "compression none",
+			config: ProducerConfig{
+				BootstrapServers: "localhost:9092",
+				Compression:      "none",
+			},
+		},
+		{
+			name: "compression unknown defaults to snappy",
+			config: ProducerConfig{
+				BootstrapServers: "localhost:9092",
+				Compression:      "unknown-codec",
+			},
+		},
+		{
+			name: "with client ID",
+			config: ProducerConfig{
+				BootstrapServers: "localhost:9092",
+				ClientID:         "my-producer",
+			},
+		},
+		{
+			name: "custom retries",
+			config: ProducerConfig{
+				BootstrapServers: "localhost:9092",
+				Retries:          10,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			producer, err := NewProtoProducer(tt.config)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewProtoProducer() error = %v", err)
+			}
+			defer producer.Close()
+		})
+	}
+}
+
+func TestNewProtoConsumer_ConfigOptions(t *testing.T) {
+	msgFactory := func() proto.Message { return &timestamppb.Timestamp{} }
+	handler := func(_ context.Context, _ []byte, _ proto.Message) error { return nil }
+
+	tests := []struct {
+		name   string
+		config ConsumerConfig
+	}{
+		{
+			name: "auto offset reset latest",
+			config: ConsumerConfig{
+				BootstrapServers: "localhost:9092",
+				GroupID:          "test",
+				AutoOffsetReset:  "latest",
+			},
+		},
+		{
+			name: "auto offset reset unknown defaults to earliest",
+			config: ConsumerConfig{
+				BootstrapServers: "localhost:9092",
+				GroupID:          "test",
+				AutoOffsetReset:  "unknown",
+			},
+		},
+		{
+			name: "with client ID",
+			config: ConsumerConfig{
+				BootstrapServers: "localhost:9092",
+				GroupID:          "test",
+				ClientID:         "my-consumer",
+			},
+		},
+		{
+			name: "auto commit enabled",
+			config: ConsumerConfig{
+				BootstrapServers: "localhost:9092",
+				GroupID:          "test",
+				EnableAutoCommit: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			consumer, err := NewProtoConsumer(tt.config, msgFactory, handler)
+			if err != nil {
+				t.Fatalf("NewProtoConsumer() error = %v", err)
+			}
+			defer consumer.Close()
+		})
+	}
+}

--- a/shared/platform/kafka/consumer_unit_test.go
+++ b/shared/platform/kafka/consumer_unit_test.go
@@ -1,0 +1,238 @@
+package kafka
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// createTestConsumer creates a ProtoConsumer with custom handler for unit testing.
+// This bypasses Kafka by directly creating the struct.
+func createTestConsumer(handler MessageHandler, dlqProducer *DLQProducer, dlqConfig *DLQConfig) *ProtoConsumer {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &ProtoConsumer{
+		client:         nil, // Not used in processMessage tests
+		msgFactory:     func() proto.Message { return &timestamppb.Timestamp{} },
+		handler:        handler,
+		pollTimeout:    100 * time.Millisecond,
+		handlerTimeout: 5 * time.Second,
+		dlqProducer:    dlqProducer,
+		dlqConfig:      dlqConfig,
+		ctx:            ctx,
+		cancel:         cancel,
+	}
+}
+
+func TestProcessMessage_Success(t *testing.T) {
+	var receivedKey []byte
+	var receivedMsg proto.Message
+	var receivedTenant tenant.TenantID
+
+	handler := func(ctx context.Context, key []byte, msg proto.Message) error {
+		receivedKey = key
+		receivedMsg = msg
+		tid, _ := tenant.RequireFromContext(ctx)
+		receivedTenant = tid
+		return nil
+	}
+
+	consumer := createTestConsumer(handler, nil, nil)
+	defer consumer.cancel()
+
+	// Create a valid protobuf message
+	ts := timestamppb.Now()
+	data, err := proto.Marshal(ts)
+	if err != nil {
+		t.Fatalf("failed to marshal test message: %v", err)
+	}
+
+	record := &kgo.Record{
+		Topic: "test-topic",
+		Key:   []byte("test-key"),
+		Value: data,
+		Headers: []kgo.RecordHeader{
+			{Key: tenant.TenantIDKey, Value: []byte("acme_bank")},
+		},
+	}
+
+	err = consumer.processMessage(record)
+	if err != nil {
+		t.Fatalf("processMessage() error = %v", err)
+	}
+
+	if string(receivedKey) != "test-key" {
+		t.Errorf("key: got %q, want %q", receivedKey, "test-key")
+	}
+	if receivedMsg == nil {
+		t.Error("message should not be nil")
+	}
+	if receivedTenant.String() != "acme_bank" {
+		t.Errorf("tenant: got %q, want %q", receivedTenant, "acme_bank")
+	}
+}
+
+func TestProcessMessage_MissingTenantHeader(t *testing.T) {
+	handler := func(_ context.Context, _ []byte, _ proto.Message) error {
+		return nil
+	}
+	consumer := createTestConsumer(handler, nil, nil)
+	defer consumer.cancel()
+
+	record := &kgo.Record{
+		Topic: "test-topic",
+		Key:   []byte("key"),
+		Value: []byte("data"),
+	}
+
+	err := consumer.processMessage(record)
+	if err == nil {
+		t.Fatal("expected error for missing tenant header")
+	}
+	if !errors.Is(err, ErrMissingTenantHeader) {
+		t.Errorf("expected ErrMissingTenantHeader in error chain, got: %v", err)
+	}
+}
+
+func TestProcessMessage_InvalidProtobuf(t *testing.T) {
+	handler := func(_ context.Context, _ []byte, _ proto.Message) error {
+		return nil
+	}
+	consumer := createTestConsumer(handler, nil, nil)
+	defer consumer.cancel()
+
+	record := &kgo.Record{
+		Topic: "test-topic",
+		Key:   []byte("key"),
+		Value: []byte("not-valid-protobuf\xff\xfe"),
+		Headers: []kgo.RecordHeader{
+			{Key: tenant.TenantIDKey, Value: []byte("acme_bank")},
+		},
+	}
+
+	err := consumer.processMessage(record)
+	if err == nil {
+		t.Fatal("expected error for invalid protobuf")
+	}
+	// Error should mention unmarshal failure
+	if err.Error() == "" {
+		t.Error("expected non-empty error message")
+	}
+}
+
+func TestProcessMessage_HandlerError(t *testing.T) {
+	handlerErr := errors.New("handler failed")
+	handler := func(_ context.Context, _ []byte, _ proto.Message) error {
+		return handlerErr
+	}
+	consumer := createTestConsumer(handler, nil, nil)
+	defer consumer.cancel()
+
+	ts := timestamppb.Now()
+	data, _ := proto.Marshal(ts)
+
+	record := &kgo.Record{
+		Topic: "test-topic",
+		Key:   []byte("key"),
+		Value: data,
+		Headers: []kgo.RecordHeader{
+			{Key: tenant.TenantIDKey, Value: []byte("acme_bank")},
+		},
+	}
+
+	err := consumer.processMessage(record)
+	if err == nil {
+		t.Fatal("expected handler error to propagate")
+	}
+	if !errors.Is(err, handlerErr) {
+		t.Errorf("expected handler error in chain, got: %v", err)
+	}
+}
+
+func TestProcessMessageWithRetry_NoDLQ(t *testing.T) {
+	handlerErr := errors.New("processing failed")
+	handler := func(_ context.Context, _ []byte, _ proto.Message) error {
+		return handlerErr
+	}
+	consumer := createTestConsumer(handler, nil, nil)
+	defer consumer.cancel()
+
+	ts := timestamppb.Now()
+	data, _ := proto.Marshal(ts)
+
+	record := &kgo.Record{
+		Topic: "test-topic",
+		Key:   []byte("key"),
+		Value: data,
+		Headers: []kgo.RecordHeader{
+			{Key: tenant.TenantIDKey, Value: []byte("acme_bank")},
+		},
+	}
+
+	// Without DLQ, should attempt once and return error
+	err := consumer.processMessageWithRetry(record)
+	if err == nil {
+		t.Fatal("expected error when DLQ not configured")
+	}
+}
+
+func TestProcessMessageWithRetry_ShutdownDuringBackoff(t *testing.T) {
+	callCount := 0
+	handler := func(_ context.Context, _ []byte, _ proto.Message) error {
+		callCount++
+		return errors.New("always fails")
+	}
+
+	dlqConfig := &DLQConfig{
+		MaxRetries:        5,
+		RetryBackoffMs:    10000, // Long backoff
+		BackoffMultiplier: 1.0,
+		ConsumerGroupID:   "test",
+	}
+
+	// We can't create a real DLQ producer without Kafka, but we need non-nil
+	// to trigger the retry path. Create consumer directly.
+	ctx, cancel := context.WithCancel(context.Background())
+	consumer := &ProtoConsumer{
+		msgFactory:     func() proto.Message { return &timestamppb.Timestamp{} },
+		handler:        handler,
+		pollTimeout:    100 * time.Millisecond,
+		handlerTimeout: 5 * time.Second,
+		dlqProducer:    &DLQProducer{}, // Non-nil to trigger retry path
+		dlqConfig:      dlqConfig,
+		ctx:            ctx,
+		cancel:         cancel,
+	}
+
+	ts := timestamppb.Now()
+	data, _ := proto.Marshal(ts)
+	record := &kgo.Record{
+		Topic: "test-topic",
+		Key:   []byte("key"),
+		Value: data,
+		Headers: []kgo.RecordHeader{
+			{Key: tenant.TenantIDKey, Value: []byte("acme_bank")},
+		},
+	}
+
+	// Cancel context during retry backoff
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	err := consumer.processMessageWithRetry(record)
+	if err == nil {
+		t.Fatal("expected error from shutdown during backoff")
+	}
+
+	// Should have attempted at least once before shutdown
+	if callCount < 1 {
+		t.Errorf("expected at least 1 attempt, got %d", callCount)
+	}
+}

--- a/shared/platform/kafka/consumer_unit_test.go
+++ b/shared/platform/kafka/consumer_unit_test.go
@@ -37,7 +37,10 @@ func TestProcessMessage_Success(t *testing.T) {
 	handler := func(ctx context.Context, key []byte, msg proto.Message) error {
 		receivedKey = key
 		receivedMsg = msg
-		tid, _ := tenant.RequireFromContext(ctx)
+		tid, err := tenant.RequireFromContext(ctx)
+		if err != nil {
+			return err
+		}
 		receivedTenant = tid
 		return nil
 	}

--- a/shared/platform/kafka/dlq_admin_test.go
+++ b/shared/platform/kafka/dlq_admin_test.go
@@ -1,0 +1,378 @@
+package kafka
+
+import (
+	"testing"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+func TestParseDLQMetadata(t *testing.T) {
+	now := time.Now().Truncate(time.Second) // RFC3339 truncates to seconds
+
+	tests := []struct {
+		name     string
+		headers  []kgo.RecordHeader
+		expected DLQMetadata
+	}{
+		{
+			name: "all fields present",
+			headers: []kgo.RecordHeader{
+				{Key: "dlq.original_topic", Value: []byte("orders")},
+				{Key: "dlq.original_partition", Value: []byte("5")},
+				{Key: "dlq.original_offset", Value: []byte("100")},
+				{Key: "dlq.error_message", Value: []byte("processing failed")},
+				{Key: "dlq.error_stack_trace", Value: []byte("stack trace")},
+				{Key: "dlq.retry_count", Value: []byte("3")},
+				{Key: "dlq.first_failure_time", Value: []byte(now.Add(-10 * time.Minute).Format(time.RFC3339))},
+				{Key: "dlq.last_failure_time", Value: []byte(now.Format(time.RFC3339))},
+				{Key: "dlq.consumer_group_id", Value: []byte("test-group")},
+				{Key: "dlq.correlation_id", Value: []byte("corr-123")},
+				{Key: "dlq.causation_id", Value: []byte("cause-456")},
+			},
+			expected: DLQMetadata{
+				OriginalTopic:     "orders",
+				OriginalPartition: 5,
+				OriginalOffset:    100,
+				ErrorMessage:      "processing failed",
+				ErrorStackTrace:   "stack trace",
+				RetryCount:        3,
+				FirstFailureTime:  now.Add(-10 * time.Minute),
+				LastFailureTime:   now,
+				ConsumerGroupID:   "test-group",
+				CorrelationID:     "corr-123",
+				CausationID:       "cause-456",
+			},
+		},
+		{
+			name:     "empty headers",
+			headers:  nil,
+			expected: DLQMetadata{},
+		},
+		{
+			name: "invalid numeric fields ignored",
+			headers: []kgo.RecordHeader{
+				{Key: "dlq.original_partition", Value: []byte("not-a-number")},
+				{Key: "dlq.original_offset", Value: []byte("also-not")},
+				{Key: "dlq.retry_count", Value: []byte("nope")},
+				{Key: "dlq.original_topic", Value: []byte("test-topic")},
+			},
+			expected: DLQMetadata{
+				OriginalTopic: "test-topic",
+			},
+		},
+		{
+			name: "invalid timestamps ignored",
+			headers: []kgo.RecordHeader{
+				{Key: "dlq.first_failure_time", Value: []byte("not-a-timestamp")},
+				{Key: "dlq.last_failure_time", Value: []byte("also-invalid")},
+				{Key: "dlq.error_message", Value: []byte("some error")},
+			},
+			expected: DLQMetadata{
+				ErrorMessage: "some error",
+			},
+		},
+		{
+			name: "unknown headers ignored",
+			headers: []kgo.RecordHeader{
+				{Key: "unknown.header", Value: []byte("value")},
+				{Key: "dlq.original_topic", Value: []byte("my-topic")},
+			},
+			expected: DLQMetadata{
+				OriginalTopic: "my-topic",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			record := &kgo.Record{Headers: tt.headers}
+			result := parseDLQMetadata(record)
+
+			if result.OriginalTopic != tt.expected.OriginalTopic {
+				t.Errorf("OriginalTopic: got %q, want %q", result.OriginalTopic, tt.expected.OriginalTopic)
+			}
+			if result.OriginalPartition != tt.expected.OriginalPartition {
+				t.Errorf("OriginalPartition: got %d, want %d", result.OriginalPartition, tt.expected.OriginalPartition)
+			}
+			if result.OriginalOffset != tt.expected.OriginalOffset {
+				t.Errorf("OriginalOffset: got %d, want %d", result.OriginalOffset, tt.expected.OriginalOffset)
+			}
+			if result.ErrorMessage != tt.expected.ErrorMessage {
+				t.Errorf("ErrorMessage: got %q, want %q", result.ErrorMessage, tt.expected.ErrorMessage)
+			}
+			if result.ErrorStackTrace != tt.expected.ErrorStackTrace {
+				t.Errorf("ErrorStackTrace: got %q, want %q", result.ErrorStackTrace, tt.expected.ErrorStackTrace)
+			}
+			if result.RetryCount != tt.expected.RetryCount {
+				t.Errorf("RetryCount: got %d, want %d", result.RetryCount, tt.expected.RetryCount)
+			}
+			if !result.FirstFailureTime.Equal(tt.expected.FirstFailureTime) {
+				t.Errorf("FirstFailureTime: got %v, want %v", result.FirstFailureTime, tt.expected.FirstFailureTime)
+			}
+			if !result.LastFailureTime.Equal(tt.expected.LastFailureTime) {
+				t.Errorf("LastFailureTime: got %v, want %v", result.LastFailureTime, tt.expected.LastFailureTime)
+			}
+			if result.ConsumerGroupID != tt.expected.ConsumerGroupID {
+				t.Errorf("ConsumerGroupID: got %q, want %q", result.ConsumerGroupID, tt.expected.ConsumerGroupID)
+			}
+			if result.CorrelationID != tt.expected.CorrelationID {
+				t.Errorf("CorrelationID: got %q, want %q", result.CorrelationID, tt.expected.CorrelationID)
+			}
+			if result.CausationID != tt.expected.CausationID {
+				t.Errorf("CausationID: got %q, want %q", result.CausationID, tt.expected.CausationID)
+			}
+		})
+	}
+}
+
+func TestFilterByErrorType(t *testing.T) {
+	msg := DLQMessage{
+		Metadata: DLQMetadata{ErrorMessage: "Connection Timeout: failed to reach broker"},
+	}
+
+	tests := []struct {
+		name     string
+		text     string
+		expected bool
+	}{
+		{"exact match", "Connection Timeout", true},
+		{"case insensitive", "connection timeout", true},
+		{"partial match", "timeout", true},
+		{"no match", "serialization error", false},
+		{"empty filter matches all", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter := FilterByErrorType(tt.text)
+			if got := filter(msg); got != tt.expected {
+				t.Errorf("FilterByErrorType(%q) = %v, want %v", tt.text, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFilterByOriginalTopic(t *testing.T) {
+	msg := DLQMessage{
+		Metadata: DLQMetadata{OriginalTopic: "orders.events.v1"},
+	}
+
+	if !FilterByOriginalTopic("orders.events.v1")(msg) {
+		t.Error("expected match for exact topic")
+	}
+	if FilterByOriginalTopic("users.events.v1")(msg) {
+		t.Error("expected no match for different topic")
+	}
+	if FilterByOriginalTopic("")(msg) {
+		t.Error("expected no match for empty topic")
+	}
+}
+
+func TestFilterByTimeRange(t *testing.T) {
+	now := time.Now()
+	msg := DLQMessage{
+		Metadata: DLQMetadata{LastFailureTime: now},
+	}
+
+	t.Run("within range", func(t *testing.T) {
+		filter := FilterByTimeRange(now.Add(-1*time.Hour), now.Add(1*time.Hour))
+		if !filter(msg) {
+			t.Error("expected message within range to match")
+		}
+	})
+
+	t.Run("before range", func(t *testing.T) {
+		filter := FilterByTimeRange(now.Add(1*time.Hour), now.Add(2*time.Hour))
+		if filter(msg) {
+			t.Error("expected message before range to not match")
+		}
+	})
+
+	t.Run("after range", func(t *testing.T) {
+		filter := FilterByTimeRange(now.Add(-2*time.Hour), now.Add(-1*time.Hour))
+		if filter(msg) {
+			t.Error("expected message after range to not match")
+		}
+	})
+
+	t.Run("exact boundary start", func(t *testing.T) {
+		filter := FilterByTimeRange(now, now.Add(1*time.Hour))
+		if !filter(msg) {
+			t.Error("expected message at start boundary to match")
+		}
+	})
+
+	t.Run("exact boundary end", func(t *testing.T) {
+		filter := FilterByTimeRange(now.Add(-1*time.Hour), now)
+		if !filter(msg) {
+			t.Error("expected message at end boundary to match")
+		}
+	})
+}
+
+func TestFilterByConsumerGroup(t *testing.T) {
+	msg := DLQMessage{
+		Metadata: DLQMetadata{ConsumerGroupID: "audit-consumer-group"},
+	}
+
+	if !FilterByConsumerGroup("audit-consumer-group")(msg) {
+		t.Error("expected match for exact group")
+	}
+	if FilterByConsumerGroup("other-group")(msg) {
+		t.Error("expected no match for different group")
+	}
+}
+
+func TestCombineFilters(t *testing.T) {
+	msg := DLQMessage{
+		Metadata: DLQMetadata{
+			OriginalTopic:   "orders.events.v1",
+			ErrorMessage:    "timeout error",
+			ConsumerGroupID: "order-group",
+		},
+	}
+
+	t.Run("all pass", func(t *testing.T) {
+		combined := CombineFilters(
+			FilterByOriginalTopic("orders.events.v1"),
+			FilterByErrorType("timeout"),
+			FilterByConsumerGroup("order-group"),
+		)
+		if !combined(msg) {
+			t.Error("expected combined filter to pass when all sub-filters pass")
+		}
+	})
+
+	t.Run("one fails", func(t *testing.T) {
+		combined := CombineFilters(
+			FilterByOriginalTopic("orders.events.v1"),
+			FilterByErrorType("serialization"), // won't match
+			FilterByConsumerGroup("order-group"),
+		)
+		if combined(msg) {
+			t.Error("expected combined filter to fail when one sub-filter fails")
+		}
+	})
+
+	t.Run("empty filters pass", func(t *testing.T) {
+		combined := CombineFilters()
+		if !combined(msg) {
+			t.Error("expected empty combined filter to pass")
+		}
+	})
+}
+
+func TestNewDLQInspector_Validation(t *testing.T) {
+	t.Run("empty bootstrap servers", func(t *testing.T) {
+		_, err := NewDLQInspector(DLQInspectorConfig{
+			DLQTopics: []string{"test-dlq"},
+		})
+		if err != ErrEmptyBootstrapServers {
+			t.Errorf("expected ErrEmptyBootstrapServers, got %v", err)
+		}
+	})
+
+	t.Run("empty topics", func(t *testing.T) {
+		_, err := NewDLQInspector(DLQInspectorConfig{
+			BootstrapServers: "localhost:9092",
+			DLQTopics:        []string{},
+		})
+		if err != ErrEmptyTopics {
+			t.Errorf("expected ErrEmptyTopics, got %v", err)
+		}
+	})
+}
+
+func TestNewDLQReplay_Validation(t *testing.T) {
+	t.Run("empty bootstrap servers", func(t *testing.T) {
+		_, err := NewDLQReplay(DLQReplayConfig{})
+		if err == nil {
+			t.Error("expected error for empty bootstrap servers")
+		}
+	})
+}
+
+func TestDLQStatistics_Aggregation(t *testing.T) {
+	// Test the statistics aggregation logic with mocked messages
+	now := time.Now()
+	messages := []DLQMessage{
+		{
+			Metadata: DLQMetadata{
+				OriginalTopic:    "orders",
+				ErrorMessage:     "timeout\ndetails here",
+				ConsumerGroupID:  "group-1",
+				FirstFailureTime: now.Add(-2 * time.Hour),
+				LastFailureTime:  now.Add(-1 * time.Hour),
+			},
+		},
+		{
+			Metadata: DLQMetadata{
+				OriginalTopic:    "orders",
+				ErrorMessage:     "serialization error",
+				ConsumerGroupID:  "group-1",
+				FirstFailureTime: now.Add(-3 * time.Hour),
+				LastFailureTime:  now,
+			},
+		},
+		{
+			Metadata: DLQMetadata{
+				OriginalTopic:    "users",
+				ErrorMessage:     "timeout\nother details",
+				ConsumerGroupID:  "group-2",
+				FirstFailureTime: now.Add(-1 * time.Hour),
+				LastFailureTime:  now.Add(-30 * time.Minute),
+			},
+		},
+	}
+
+	// Simulate the aggregation logic from GetStatistics
+	stats := DLQStatistics{
+		TotalMessages:           len(messages),
+		MessagesByTopic:         make(map[string]int),
+		MessagesByErrorType:     make(map[string]int),
+		MessagesByConsumerGroup: make(map[string]int),
+	}
+
+	for _, msg := range messages {
+		stats.MessagesByTopic[msg.Metadata.OriginalTopic]++
+		errorType := msg.Metadata.ErrorMessage
+		if idx := len(errorType); idx > 100 {
+			errorType = errorType[:100] + "..."
+		}
+		// Extract first line
+		for i, c := range errorType {
+			if c == '\n' {
+				errorType = errorType[:i]
+				break
+			}
+		}
+		stats.MessagesByErrorType[errorType]++
+		stats.MessagesByConsumerGroup[msg.Metadata.ConsumerGroupID]++
+		if stats.OldestFailure.IsZero() || msg.Metadata.FirstFailureTime.Before(stats.OldestFailure) {
+			stats.OldestFailure = msg.Metadata.FirstFailureTime
+		}
+		if msg.Metadata.LastFailureTime.After(stats.NewestFailure) {
+			stats.NewestFailure = msg.Metadata.LastFailureTime
+		}
+	}
+
+	if stats.TotalMessages != 3 {
+		t.Errorf("TotalMessages: got %d, want 3", stats.TotalMessages)
+	}
+	if stats.MessagesByTopic["orders"] != 2 {
+		t.Errorf("MessagesByTopic[orders]: got %d, want 2", stats.MessagesByTopic["orders"])
+	}
+	if stats.MessagesByTopic["users"] != 1 {
+		t.Errorf("MessagesByTopic[users]: got %d, want 1", stats.MessagesByTopic["users"])
+	}
+	if stats.MessagesByConsumerGroup["group-1"] != 2 {
+		t.Errorf("MessagesByConsumerGroup[group-1]: got %d, want 2", stats.MessagesByConsumerGroup["group-1"])
+	}
+	if !stats.OldestFailure.Equal(now.Add(-3 * time.Hour)) {
+		t.Errorf("OldestFailure: got %v, want %v", stats.OldestFailure, now.Add(-3*time.Hour))
+	}
+	if !stats.NewestFailure.Equal(now) {
+		t.Errorf("NewestFailure: got %v, want %v", stats.NewestFailure, now)
+	}
+}

--- a/shared/platform/kafka/dlq_admin_test.go
+++ b/shared/platform/kafka/dlq_admin_test.go
@@ -279,7 +279,7 @@ func TestNewDLQInspector_Validation(t *testing.T) {
 			BootstrapServers: "localhost:9092",
 			DLQTopics:        []string{},
 		})
-		if err != ErrEmptyTopics {
+		if !errors.Is(err, ErrEmptyTopics) {
 			t.Errorf("expected ErrEmptyTopics, got %v", err)
 		}
 	})

--- a/shared/platform/kafka/dlq_admin_test.go
+++ b/shared/platform/kafka/dlq_admin_test.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -268,7 +269,7 @@ func TestNewDLQInspector_Validation(t *testing.T) {
 		_, err := NewDLQInspector(DLQInspectorConfig{
 			DLQTopics: []string{"test-dlq"},
 		})
-		if err != ErrEmptyBootstrapServers {
+		if !errors.Is(err, ErrEmptyBootstrapServers) {
 			t.Errorf("expected ErrEmptyBootstrapServers, got %v", err)
 		}
 	})

--- a/shared/platform/observability/grpc_test.go
+++ b/shared/platform/observability/grpc_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/meridianhub/meridian/shared/platform/observability"
-	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -31,7 +30,7 @@ func TestUnaryServerInterceptor_Success(t *testing.T) {
 
 	interceptor := tracer.UnaryServerInterceptor()
 
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(_ context.Context, _ interface{}) (interface{}, error) {
 		return "ok", nil
 	}
 
@@ -52,7 +51,7 @@ func TestUnaryServerInterceptor_Error(t *testing.T) {
 	interceptor := tracer.UnaryServerInterceptor()
 
 	handlerErr := errors.New("handler failed")
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(_ context.Context, _ interface{}) (interface{}, error) {
 		return nil, handlerErr
 	}
 
@@ -72,9 +71,7 @@ func TestUnaryServerInterceptor_WithTenant(t *testing.T) {
 
 	interceptor := tracer.UnaryServerInterceptor()
 
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		// Simulate auth middleware setting tenant
-		ctx = tenant.WithTenant(ctx, "acme_bank")
+	handler := func(_ context.Context, _ interface{}) (interface{}, error) {
 		return "ok", nil
 	}
 
@@ -94,7 +91,7 @@ func TestUnaryServerInterceptor_UnparsableMethod(t *testing.T) {
 
 	interceptor := tracer.UnaryServerInterceptor()
 
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	handler := func(_ context.Context, _ interface{}) (interface{}, error) {
 		return "ok", nil
 	}
 
@@ -123,7 +120,7 @@ type mockServerStream struct {
 func (s *mockServerStream) SetHeader(metadata.MD) error  { return nil }
 func (s *mockServerStream) SendHeader(metadata.MD) error { return nil }
 func (s *mockServerStream) SetTrailer(metadata.MD)       {}
-func (s *mockServerStream) Context() context.Context      { return s.ctx }
+func (s *mockServerStream) Context() context.Context     { return s.ctx }
 
 func (s *mockServerStream) SendMsg(m interface{}) error {
 	if s.sendErr != nil {
@@ -149,7 +146,7 @@ func TestStreamServerInterceptor_Success(t *testing.T) {
 
 	interceptor := tracer.StreamServerInterceptor()
 
-	handler := func(_ interface{}, stream grpc.ServerStream) error {
+	handler := func(_ interface{}, _ grpc.ServerStream) error {
 		return nil
 	}
 
@@ -170,7 +167,7 @@ func TestStreamServerInterceptor_Error(t *testing.T) {
 	interceptor := tracer.StreamServerInterceptor()
 
 	handlerErr := errors.New("stream handler failed")
-	handler := func(_ interface{}, stream grpc.ServerStream) error {
+	handler := func(_ interface{}, _ grpc.ServerStream) error {
 		return handlerErr
 	}
 

--- a/shared/platform/observability/grpc_test.go
+++ b/shared/platform/observability/grpc_test.go
@@ -194,7 +194,10 @@ func TestStreamServerInterceptor_SendRecv(t *testing.T) {
 		}
 		// Receive a message (will get EOF from mock)
 		var msg interface{}
-		_ = stream.RecvMsg(&msg)
+		err := stream.RecvMsg(&msg)
+		if err != nil && err != io.EOF {
+			return err
+		}
 		return nil
 	}
 

--- a/shared/platform/observability/grpc_test.go
+++ b/shared/platform/observability/grpc_test.go
@@ -1,0 +1,388 @@
+package observability_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/platform/observability"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func newTestTracer(t *testing.T) *observability.Tracer {
+	t.Helper()
+	tracer, err := observability.NewTracer(context.Background(), observability.TracerConfig{
+		ServiceName:  "test-grpc",
+		OTLPEndpoint: "localhost:4317",
+		SamplingRate: 1.0,
+		Enabled:      false,
+	})
+	require.NoError(t, err)
+	return tracer
+}
+
+func TestUnaryServerInterceptor_Success(t *testing.T) {
+	tracer := newTestTracer(t)
+
+	interceptor := tracer.UnaryServerInterceptor()
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "ok", nil
+	}
+
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "/package.Service/Method",
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.MD{})
+	resp, err := interceptor(ctx, "request", info, handler)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+}
+
+func TestUnaryServerInterceptor_Error(t *testing.T) {
+	tracer := newTestTracer(t)
+
+	interceptor := tracer.UnaryServerInterceptor()
+
+	handlerErr := errors.New("handler failed")
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return nil, handlerErr
+	}
+
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "/package.Service/Method",
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.MD{})
+	resp, err := interceptor(ctx, "request", info, handler)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestUnaryServerInterceptor_WithTenant(t *testing.T) {
+	tracer := newTestTracer(t)
+
+	interceptor := tracer.UnaryServerInterceptor()
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		// Simulate auth middleware setting tenant
+		ctx = tenant.WithTenant(ctx, "acme_bank")
+		return "ok", nil
+	}
+
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "/package.Service/Method",
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.MD{})
+	resp, err := interceptor(ctx, "request", info, handler)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+}
+
+func TestUnaryServerInterceptor_UnparsableMethod(t *testing.T) {
+	tracer := newTestTracer(t)
+
+	interceptor := tracer.UnaryServerInterceptor()
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "ok", nil
+	}
+
+	// Unparsable method (no slash separator after removing leading /)
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "no-slash",
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.MD{})
+	resp, err := interceptor(ctx, "request", info, handler)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+}
+
+// mockServerStream implements grpc.ServerStream for testing.
+type mockServerStream struct {
+	ctx      context.Context
+	sentMsgs []interface{}
+	recvMsgs []interface{}
+	recvIdx  int
+	recvErr  error
+	sendErr  error
+}
+
+func (s *mockServerStream) SetHeader(metadata.MD) error  { return nil }
+func (s *mockServerStream) SendHeader(metadata.MD) error { return nil }
+func (s *mockServerStream) SetTrailer(metadata.MD)       {}
+func (s *mockServerStream) Context() context.Context      { return s.ctx }
+
+func (s *mockServerStream) SendMsg(m interface{}) error {
+	if s.sendErr != nil {
+		return s.sendErr
+	}
+	s.sentMsgs = append(s.sentMsgs, m)
+	return nil
+}
+
+func (s *mockServerStream) RecvMsg(m interface{}) error {
+	if s.recvErr != nil {
+		return s.recvErr
+	}
+	if s.recvIdx >= len(s.recvMsgs) {
+		return io.EOF
+	}
+	s.recvIdx++
+	return nil
+}
+
+func TestStreamServerInterceptor_Success(t *testing.T) {
+	tracer := newTestTracer(t)
+
+	interceptor := tracer.StreamServerInterceptor()
+
+	handler := func(srv interface{}, stream grpc.ServerStream) error {
+		return nil
+	}
+
+	info := &grpc.StreamServerInfo{
+		FullMethod: "/package.Service/StreamMethod",
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.MD{})
+	stream := &mockServerStream{ctx: ctx}
+
+	err := interceptor(nil, stream, info, handler)
+	assert.NoError(t, err)
+}
+
+func TestStreamServerInterceptor_Error(t *testing.T) {
+	tracer := newTestTracer(t)
+
+	interceptor := tracer.StreamServerInterceptor()
+
+	handlerErr := errors.New("stream handler failed")
+	handler := func(srv interface{}, stream grpc.ServerStream) error {
+		return handlerErr
+	}
+
+	info := &grpc.StreamServerInfo{
+		FullMethod: "/package.Service/StreamMethod",
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.MD{})
+	stream := &mockServerStream{ctx: ctx}
+
+	err := interceptor(nil, stream, info, handler)
+	assert.Error(t, err)
+}
+
+func TestStreamServerInterceptor_SendRecv(t *testing.T) {
+	tracer := newTestTracer(t)
+
+	interceptor := tracer.StreamServerInterceptor()
+
+	handler := func(srv interface{}, stream grpc.ServerStream) error {
+		// Send a message
+		if err := stream.SendMsg("hello"); err != nil {
+			return err
+		}
+		// Receive a message (will get EOF from mock)
+		var msg interface{}
+		_ = stream.RecvMsg(&msg)
+		return nil
+	}
+
+	info := &grpc.StreamServerInfo{
+		FullMethod: "/package.Service/StreamMethod",
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.MD{})
+	stream := &mockServerStream{ctx: ctx}
+
+	err := interceptor(nil, stream, info, handler)
+	assert.NoError(t, err)
+}
+
+func TestStreamServerInterceptor_RecvError(t *testing.T) {
+	tracer := newTestTracer(t)
+
+	interceptor := tracer.StreamServerInterceptor()
+
+	handler := func(srv interface{}, stream grpc.ServerStream) error {
+		var msg interface{}
+		return stream.RecvMsg(&msg)
+	}
+
+	info := &grpc.StreamServerInfo{
+		FullMethod: "/package.Service/StreamMethod",
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.MD{})
+	stream := &mockServerStream{
+		ctx:     ctx,
+		recvErr: errors.New("recv failed"),
+	}
+
+	err := interceptor(nil, stream, info, handler)
+	assert.Error(t, err)
+}
+
+func TestUnaryClientInterceptor_Success(t *testing.T) {
+	tracer := newTestTracer(t)
+
+	interceptor := tracer.UnaryClientInterceptor()
+
+	invoker := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+		return nil
+	}
+
+	err := interceptor(context.Background(), "/package.Service/Method", "req", "reply", nil, invoker)
+	assert.NoError(t, err)
+}
+
+func TestUnaryClientInterceptor_Error(t *testing.T) {
+	tracer := newTestTracer(t)
+
+	interceptor := tracer.UnaryClientInterceptor()
+
+	invokeErr := errors.New("rpc failed")
+	invoker := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+		return invokeErr
+	}
+
+	err := interceptor(context.Background(), "/package.Service/Method", "req", "reply", nil, invoker)
+	assert.Error(t, err)
+}
+
+// mockClientStream implements grpc.ClientStream for testing.
+type mockClientStream struct {
+	ctx      context.Context
+	sendErr  error
+	recvMsgs []interface{}
+	recvIdx  int
+	recvErr  error
+	closed   bool
+}
+
+func (s *mockClientStream) Header() (metadata.MD, error) { return nil, nil }
+func (s *mockClientStream) Trailer() metadata.MD         { return nil }
+func (s *mockClientStream) CloseSend() error {
+	s.closed = true
+	return nil
+}
+func (s *mockClientStream) Context() context.Context { return s.ctx }
+
+func (s *mockClientStream) SendMsg(m interface{}) error {
+	return s.sendErr
+}
+
+func (s *mockClientStream) RecvMsg(m interface{}) error {
+	if s.recvErr != nil {
+		return s.recvErr
+	}
+	if s.recvIdx >= len(s.recvMsgs) {
+		return io.EOF
+	}
+	s.recvIdx++
+	return nil
+}
+
+func TestStreamClientInterceptor_Success(t *testing.T) {
+	tracer := newTestTracer(t)
+
+	interceptor := tracer.StreamClientInterceptor()
+
+	mockStream := &mockClientStream{ctx: context.Background()}
+	streamer := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		return mockStream, nil
+	}
+
+	stream, err := interceptor(context.Background(), nil, nil, "/package.Service/Stream", streamer)
+	assert.NoError(t, err)
+	assert.NotNil(t, stream)
+
+	// Test SendMsg through wrapped stream.
+	err = stream.SendMsg("hello")
+	assert.NoError(t, err)
+
+	// Test RecvMsg - should get EOF from mock.
+	var msg interface{}
+	err = stream.RecvMsg(&msg)
+	assert.ErrorIs(t, err, io.EOF)
+
+	// Test CloseSend.
+	err = stream.CloseSend()
+	assert.NoError(t, err)
+}
+
+func TestStreamClientInterceptor_StreamerError(t *testing.T) {
+	tracer := newTestTracer(t)
+
+	interceptor := tracer.StreamClientInterceptor()
+
+	streamer := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		return nil, errors.New("connection failed")
+	}
+
+	stream, err := interceptor(context.Background(), nil, nil, "/package.Service/Stream", streamer)
+	assert.Error(t, err)
+	assert.Nil(t, stream)
+}
+
+func TestStreamClientInterceptor_RecvError(t *testing.T) {
+	tracer := newTestTracer(t)
+
+	interceptor := tracer.StreamClientInterceptor()
+
+	recvErr := errors.New("receive failed")
+	mockStream := &mockClientStream{ctx: context.Background(), recvErr: recvErr}
+	streamer := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		return mockStream, nil
+	}
+
+	stream, err := interceptor(context.Background(), nil, nil, "/package.Service/Stream", streamer)
+	require.NoError(t, err)
+
+	var msg interface{}
+	err = stream.RecvMsg(&msg)
+	assert.Error(t, err)
+}
+
+func TestStreamClientInterceptor_RecvSuccess(t *testing.T) {
+	tracer := newTestTracer(t)
+
+	interceptor := tracer.StreamClientInterceptor()
+
+	mockStream := &mockClientStream{
+		ctx:      context.Background(),
+		recvMsgs: []interface{}{"msg1", "msg2"},
+	}
+	streamer := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		return mockStream, nil
+	}
+
+	stream, err := interceptor(context.Background(), nil, nil, "/package.Service/Stream", streamer)
+	require.NoError(t, err)
+
+	// First recv should succeed.
+	var msg interface{}
+	err = stream.RecvMsg(&msg)
+	assert.NoError(t, err)
+
+	// Second recv should succeed.
+	err = stream.RecvMsg(&msg)
+	assert.NoError(t, err)
+
+	// Third recv should get EOF.
+	err = stream.RecvMsg(&msg)
+	assert.ErrorIs(t, err, io.EOF)
+}

--- a/shared/platform/observability/grpc_test.go
+++ b/shared/platform/observability/grpc_test.go
@@ -238,7 +238,7 @@ func TestUnaryClientInterceptor_Success(t *testing.T) {
 
 	interceptor := tracer.UnaryClientInterceptor()
 
-	invoker := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+	invoker := func(_ context.Context, _ string, _, _ interface{}, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
 		return nil
 	}
 
@@ -252,7 +252,7 @@ func TestUnaryClientInterceptor_Error(t *testing.T) {
 	interceptor := tracer.UnaryClientInterceptor()
 
 	invokeErr := errors.New("rpc failed")
-	invoker := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+	invoker := func(_ context.Context, _ string, _, _ interface{}, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
 		return invokeErr
 	}
 
@@ -299,7 +299,7 @@ func TestStreamClientInterceptor_Success(t *testing.T) {
 	interceptor := tracer.StreamClientInterceptor()
 
 	mockStream := &mockClientStream{ctx: context.Background()}
-	streamer := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	streamer := func(_ context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
 		return mockStream, nil
 	}
 
@@ -326,7 +326,7 @@ func TestStreamClientInterceptor_StreamerError(t *testing.T) {
 
 	interceptor := tracer.StreamClientInterceptor()
 
-	streamer := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	streamer := func(_ context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
 		return nil, errors.New("connection failed")
 	}
 
@@ -342,7 +342,7 @@ func TestStreamClientInterceptor_RecvError(t *testing.T) {
 
 	recvErr := errors.New("receive failed")
 	mockStream := &mockClientStream{ctx: context.Background(), recvErr: recvErr}
-	streamer := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	streamer := func(_ context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
 		return mockStream, nil
 	}
 
@@ -363,7 +363,7 @@ func TestStreamClientInterceptor_RecvSuccess(t *testing.T) {
 		ctx:      context.Background(),
 		recvMsgs: []interface{}{"msg1", "msg2"},
 	}
-	streamer := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	streamer := func(_ context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
 		return mockStream, nil
 	}
 

--- a/shared/platform/observability/grpc_test.go
+++ b/shared/platform/observability/grpc_test.go
@@ -133,7 +133,7 @@ func (s *mockServerStream) SendMsg(m interface{}) error {
 	return nil
 }
 
-func (s *mockServerStream) RecvMsg(m interface{}) error {
+func (s *mockServerStream) RecvMsg(_ interface{}) error {
 	if s.recvErr != nil {
 		return s.recvErr
 	}
@@ -149,7 +149,7 @@ func TestStreamServerInterceptor_Success(t *testing.T) {
 
 	interceptor := tracer.StreamServerInterceptor()
 
-	handler := func(srv interface{}, stream grpc.ServerStream) error {
+	handler := func(_ interface{}, stream grpc.ServerStream) error {
 		return nil
 	}
 
@@ -170,7 +170,7 @@ func TestStreamServerInterceptor_Error(t *testing.T) {
 	interceptor := tracer.StreamServerInterceptor()
 
 	handlerErr := errors.New("stream handler failed")
-	handler := func(srv interface{}, stream grpc.ServerStream) error {
+	handler := func(_ interface{}, stream grpc.ServerStream) error {
 		return handlerErr
 	}
 
@@ -190,7 +190,7 @@ func TestStreamServerInterceptor_SendRecv(t *testing.T) {
 
 	interceptor := tracer.StreamServerInterceptor()
 
-	handler := func(srv interface{}, stream grpc.ServerStream) error {
+	handler := func(_ interface{}, stream grpc.ServerStream) error {
 		// Send a message
 		if err := stream.SendMsg("hello"); err != nil {
 			return err
@@ -217,7 +217,7 @@ func TestStreamServerInterceptor_RecvError(t *testing.T) {
 
 	interceptor := tracer.StreamServerInterceptor()
 
-	handler := func(srv interface{}, stream grpc.ServerStream) error {
+	handler := func(_ interface{}, stream grpc.ServerStream) error {
 		var msg interface{}
 		return stream.RecvMsg(&msg)
 	}
@@ -281,11 +281,11 @@ func (s *mockClientStream) CloseSend() error {
 }
 func (s *mockClientStream) Context() context.Context { return s.ctx }
 
-func (s *mockClientStream) SendMsg(m interface{}) error {
+func (s *mockClientStream) SendMsg(_ interface{}) error {
 	return s.sendErr
 }
 
-func (s *mockClientStream) RecvMsg(m interface{}) error {
+func (s *mockClientStream) RecvMsg(_ interface{}) error {
 	if s.recvErr != nil {
 		return s.recvErr
 	}

--- a/shared/platform/observability/grpc_test.go
+++ b/shared/platform/observability/grpc_test.go
@@ -195,7 +195,7 @@ func TestStreamServerInterceptor_SendRecv(t *testing.T) {
 		// Receive a message (will get EOF from mock)
 		var msg interface{}
 		err := stream.RecvMsg(&msg)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return err
 		}
 		return nil

--- a/shared/platform/observability/logging_unit_test.go
+++ b/shared/platform/observability/logging_unit_test.go
@@ -1,0 +1,100 @@
+package observability_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/platform/observability"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogger_DebugContext(t *testing.T) {
+	var buf bytes.Buffer
+	logger := observability.NewLogger(&buf, observability.LogLevelDebug)
+
+	ctx := context.Background()
+	logger.DebugContext(ctx, "debug message")
+
+	var entry observability.LogEntry
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+	assert.Equal(t, observability.LogLevelDebug, entry.Level)
+	assert.Equal(t, "debug message", entry.Message)
+}
+
+func TestLogger_WarnContext(t *testing.T) {
+	var buf bytes.Buffer
+	logger := observability.NewLogger(&buf, observability.LogLevelDebug)
+
+	ctx := context.Background()
+	logger.WarnContext(ctx, "warn message")
+
+	var entry observability.LogEntry
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+	assert.Equal(t, observability.LogLevelWarn, entry.Level)
+}
+
+func TestLogger_ErrorContext(t *testing.T) {
+	var buf bytes.Buffer
+	logger := observability.NewLogger(&buf, observability.LogLevelDebug)
+
+	ctx := context.Background()
+	logger.ErrorContext(ctx, "error message")
+
+	var entry observability.LogEntry
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+	assert.Equal(t, observability.LogLevelError, entry.Level)
+}
+
+func TestLogger_ContextWithTenant(t *testing.T) {
+	var buf bytes.Buffer
+	logger := observability.NewLogger(&buf, observability.LogLevelDebug)
+
+	ctx := tenant.WithTenant(context.Background(), "acme_bank")
+	logger.InfoContext(ctx, "tenant message")
+
+	var entry observability.LogEntry
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+	assert.Equal(t, "acme_bank", entry.TenantID)
+}
+
+func TestLogger_ContextWithCorrelationID(t *testing.T) {
+	var buf bytes.Buffer
+	logger := observability.NewLogger(&buf, observability.LogLevelDebug)
+
+	ctx := observability.WithCorrelationID(context.Background(), "corr-123")
+	logger.InfoContext(ctx, "correlated message")
+
+	var entry observability.LogEntry
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+	assert.Equal(t, "corr-123", entry.CorrelationID)
+}
+
+func TestLogger_ShouldLog_UnknownLevel(t *testing.T) {
+	var buf bytes.Buffer
+	logger := observability.NewLogger(&buf, "unknown-level")
+
+	// Unknown configured level should default to info behavior.
+	logger.Debug("should not appear") // debug < info
+	assert.Empty(t, buf.String())
+
+	logger.Info("should appear")
+	assert.NotEmpty(t, buf.String())
+}
+
+func TestLogger_ShouldLog_FiltersBelowLevel(t *testing.T) {
+	var buf bytes.Buffer
+	logger := observability.NewLogger(&buf, observability.LogLevelWarn)
+
+	logger.Debug("should not appear")
+	assert.Empty(t, buf.String())
+
+	logger.Info("should not appear")
+	assert.Empty(t, buf.String())
+
+	logger.Warn("should appear")
+	assert.NotEmpty(t, buf.String())
+}

--- a/shared/platform/observability/tracing_unit_test.go
+++ b/shared/platform/observability/tracing_unit_test.go
@@ -57,4 +57,3 @@ func TestNewTracer_EnabledWithInvalidEndpoint(t *testing.T) {
 	err = tracer.Shutdown(context.Background())
 	assert.NoError(t, err)
 }
-

--- a/shared/platform/observability/tracing_unit_test.go
+++ b/shared/platform/observability/tracing_unit_test.go
@@ -1,0 +1,60 @@
+package observability_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/platform/observability"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestTracer_RecordError_NoSpan(t *testing.T) {
+	tracer := newTestTracer(t)
+
+	// Context with no span - should not panic.
+	tracer.RecordError(context.Background(), assert.AnError)
+}
+
+func TestTracer_AddEvent_NoSpan(t *testing.T) {
+	tracer := newTestTracer(t)
+
+	// Context with no span - should not panic.
+	tracer.AddEvent(context.Background(), "test-event")
+}
+
+func TestTracer_SetAttributes_NoSpan(t *testing.T) {
+	tracer := newTestTracer(t)
+
+	// Context with no span - should not panic.
+	tracer.SetAttributes(context.Background(), attribute.String("key", "value"))
+}
+
+func TestTracer_Shutdown_WithoutDeadline(t *testing.T) {
+	tracer := newTestTracer(t)
+
+	// Context without deadline - shutdown should add one internally.
+	err := tracer.Shutdown(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestNewTracer_EnabledWithInvalidEndpoint(t *testing.T) {
+	// Enabled tracer with a non-existent endpoint - should still create
+	// (connection errors happen at export time, not creation time).
+	cfg := observability.TracerConfig{
+		ServiceName:  "test-service",
+		OTLPEndpoint: "localhost:99999",
+		SamplingRate: 1.0,
+		Enabled:      true,
+	}
+
+	tracer, err := observability.NewTracer(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.NotNil(t, tracer)
+
+	// Shutdown should work even with bad endpoint.
+	err = tracer.Shutdown(context.Background())
+	assert.NoError(t, err)
+}
+

--- a/shared/platform/testdb/integration_test.go
+++ b/shared/platform/testdb/integration_test.go
@@ -50,7 +50,7 @@ func TestPostgresSetupFunctions(t *testing.T) {
 
 	t.Run("CreateTable", func(t *testing.T) {
 		// Reset search_path for clean slate
-		_ = db.Exec("SET search_path TO public")
+		require.NoError(t, db.Exec("SET search_path TO public").Error)
 		tc := SetupTenantSchema(t, db, "tbl_tenant")
 		defer tc.Cleanup()
 
@@ -65,7 +65,7 @@ func TestPostgresSetupFunctions(t *testing.T) {
 	})
 
 	t.Run("CreateAuditTables", func(t *testing.T) {
-		_ = db.Exec("SET search_path TO public")
+		require.NoError(t, db.Exec("SET search_path TO public").Error)
 		CreateAuditTables(t, db)
 
 		err := db.Exec(`INSERT INTO audit_outbox (table_name, operation, record_id) VALUES ('test', 'INSERT', '1')`).Error

--- a/shared/platform/testdb/integration_test.go
+++ b/shared/platform/testdb/integration_test.go
@@ -1,0 +1,263 @@
+package testdb
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm/logger"
+)
+
+// Integration tests that require testcontainers (PostgreSQL).
+// Skipped when running with -short flag.
+// Tests are consolidated to minimize container startup overhead.
+
+func TestPostgresSetupFunctions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Single container for multiple subtests via SetupPostgres.
+	db, cleanup := SetupPostgres(t, nil, WithLogLevel(logger.Silent))
+	defer cleanup()
+
+	t.Run("BasicQuery", func(t *testing.T) {
+		var result int
+		err := db.Raw("SELECT 1").Scan(&result).Error
+		require.NoError(t, err)
+		assert.Equal(t, 1, result)
+	})
+
+	t.Run("CreateSchemas", func(t *testing.T) {
+		createSchemas(t, db, map[string]bool{"test_schema": true})
+		var count int64
+		err := db.Raw("SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name = 'test_schema'").Scan(&count).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), count)
+	})
+
+	t.Run("SetupTenantSchema", func(t *testing.T) {
+		tc := SetupTenantSchema(t, db, "my_tenant")
+		defer tc.Cleanup()
+
+		tid, ok := tenant.FromContext(tc.Ctx)
+		assert.True(t, ok)
+		assert.Equal(t, tenant.TenantID("my_tenant"), tid)
+	})
+
+	t.Run("CreateTable", func(t *testing.T) {
+		// Reset search_path for clean slate
+		_ = db.Exec("SET search_path TO public")
+		tc := SetupTenantSchema(t, db, "tbl_tenant")
+		defer tc.Cleanup()
+
+		CreateTable(t, tc.DB, tc.Tenant, `CREATE TABLE IF NOT EXISTS %s.test_items (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			name VARCHAR(100) NOT NULL
+		)`)
+
+		schemaName := tc.Tenant.SchemaName()
+		err := db.Exec("INSERT INTO " + schemaName + ".test_items (id, name) VALUES (gen_random_uuid(), 'hello')").Error
+		require.NoError(t, err)
+	})
+
+	t.Run("CreateAuditTables", func(t *testing.T) {
+		_ = db.Exec("SET search_path TO public")
+		CreateAuditTables(t, db)
+
+		err := db.Exec(`INSERT INTO audit_outbox (table_name, operation, record_id) VALUES ('test', 'INSERT', '1')`).Error
+		require.NoError(t, err)
+
+		err = db.Exec(`INSERT INTO audit_log (table_name, operation, record_id) VALUES ('test', 'UPDATE', '2')`).Error
+		require.NoError(t, err)
+	})
+}
+
+func TestSetupTestDB_AllOptions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	type TestEntity struct {
+		ID   uint   `gorm:"primaryKey"`
+		Name string `gorm:"size:100"`
+	}
+
+	// Test with tenant, models, and audit tables all at once to minimize containers.
+	db, ctx, cleanup := SetupTestDB(t,
+		WithModels(&TestEntity{}),
+		WithTenant("acme_bank"),
+		WithAuditTables(),
+		WithSetupLogLevel(logger.Silent),
+	)
+	defer cleanup()
+
+	// Context should have tenant
+	tid, ok := tenant.FromContext(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, tenant.TenantID("acme_bank"), tid)
+
+	// Should be able to write to tenant schema
+	err := db.Create(&TestEntity{ID: 1, Name: "acme"}).Error
+	require.NoError(t, err)
+
+	// Audit tables should exist
+	var result int
+	err = db.Raw("SELECT 1 FROM audit_outbox LIMIT 1").Scan(&result).Error
+	require.NoError(t, err)
+}
+
+// setupTempMigrations creates a temporary services/<name>/migrations/ directory
+// with simple SQL migration files for testing pgx migration functions.
+func setupTempMigrations(t *testing.T) (baseDir string) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	migrationsDir := filepath.Join(tmpDir, "services", "test-svc", "migrations")
+	require.NoError(t, os.MkdirAll(migrationsDir, 0o755))
+
+	migration1 := `CREATE TABLE IF NOT EXISTS test_items (
+		id SERIAL PRIMARY KEY,
+		name VARCHAR(100) NOT NULL
+	);`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(migrationsDir, "001_create_test_items.sql"),
+		[]byte(migration1), 0o644))
+
+	// Non-SQL file that should be skipped
+	require.NoError(t, os.WriteFile(
+		filepath.Join(migrationsDir, "README.md"),
+		[]byte("# Migrations"), 0o644))
+
+	// Subdirectory that should be skipped
+	require.NoError(t, os.MkdirAll(filepath.Join(migrationsDir, "subdir"), 0o755))
+
+	migration2 := `ALTER TABLE test_items ADD COLUMN IF NOT EXISTS description TEXT;`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(migrationsDir, "002_add_description.sql"),
+		[]byte(migration2), 0o644))
+
+	return tmpDir
+}
+
+func TestSetupTestDB_NoOptions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	db, ctx, cleanup := SetupTestDB(t)
+	defer cleanup()
+
+	var result int
+	err := db.Raw("SELECT 1").Scan(&result).Error
+	require.NoError(t, err)
+	assert.Equal(t, 1, result)
+
+	// No tenant in context
+	_, ok := tenant.FromContext(ctx)
+	assert.False(t, ok)
+}
+
+func TestStartSharedPostgres(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	connStr, cleanup := StartSharedPostgres()
+	defer cleanup()
+
+	assert.NotEmpty(t, connStr)
+	assert.Contains(t, connStr, "postgres")
+}
+
+func TestCockroachDBSetup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	type CRDBModel struct {
+		ID   uint   `gorm:"primaryKey"`
+		Name string `gorm:"size:100"`
+	}
+
+	// Test StartCockroachContainer + CockroachDSN
+	t.Run("StartContainerAndDSN", func(t *testing.T) {
+		container, cleanup := StartCockroachContainer(t, "crdb_dsn_test")
+		defer cleanup()
+
+		dsn := CockroachDSN(t, container)
+		assert.Contains(t, dsn, "postgres://")
+		assert.Contains(t, dsn, "crdb_dsn_test")
+	})
+
+	// Test SetupCockroachDB end-to-end
+	t.Run("SetupWithModels", func(t *testing.T) {
+		db, dbCleanup := SetupCockroachDB(t, []interface{}{&CRDBModel{}}, WithLogLevel(logger.Silent))
+		defer dbCleanup()
+
+		err := db.Create(&CRDBModel{ID: 1, Name: "crdb"}).Error
+		require.NoError(t, err)
+
+		var found CRDBModel
+		err = db.First(&found, 1).Error
+		require.NoError(t, err)
+		assert.Equal(t, "crdb", found.Name)
+	})
+}
+
+func TestPgxMigrationFunctions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	baseDir := setupTempMigrations(t)
+
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(baseDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Single pool for migration tests
+	pool := NewTestPool(t, WithMigrations("test-svc"))
+
+	t.Run("MigrationsApplied", func(t *testing.T) {
+		var count int
+		err := pool.QueryRow(t.Context(), "SELECT COUNT(*) FROM test_items").Scan(&count)
+		require.NoError(t, err)
+		assert.Equal(t, 0, count)
+
+		// Second migration added column
+		_, err = pool.Exec(t.Context(), "INSERT INTO test_items (name, description) VALUES ('a', 'b')")
+		require.NoError(t, err)
+	})
+
+	t.Run("SetupTenantSchemaForPgx", func(t *testing.T) {
+		ctx, cleanup := SetupTenantSchemaForPgx(t, pool, "pgx-tenant", "test-svc")
+		defer cleanup()
+
+		tid, ok := tenant.FromContext(ctx)
+		assert.True(t, ok)
+		assert.Equal(t, tenant.TenantID("pgx-tenant"), tid)
+
+		// Table should exist in tenant schema
+		schemaName := tenant.TenantID("pgx-tenant").SchemaName()
+		var exists bool
+		err := pool.QueryRow(t.Context(),
+			"SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_schema = $1 AND table_name = 'test_items')",
+			schemaName).Scan(&exists)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("SetupTenantSchemaForPgx_NoMigrations", func(t *testing.T) {
+		ctx, cleanup := SetupTenantSchemaForPgx(t, pool, "empty-tenant", "")
+		defer cleanup()
+
+		tid, ok := tenant.FromContext(ctx)
+		assert.True(t, ok)
+		assert.Equal(t, tenant.TenantID("empty-tenant"), tid)
+	})
+}

--- a/shared/platform/testdb/unit_test.go
+++ b/shared/platform/testdb/unit_test.go
@@ -1,0 +1,170 @@
+package testdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm/logger"
+)
+
+// --- adaptCockroachDDLForPostgres tests ---
+
+func TestAdaptCockroachDDLForPostgres_NoChanges(t *testing.T) {
+	input := `CREATE TABLE foo (id UUID PRIMARY KEY);`
+	result := adaptCockroachDDLForPostgres(input)
+	assert.Equal(t, input, result)
+}
+
+func TestAdaptCockroachDDLForPostgres_DropIndexCascade(t *testing.T) {
+	input := `DROP INDEX IF EXISTS "public"."uq_platform_saga_definition_name" CASCADE;`
+	result := adaptCockroachDDLForPostgres(input)
+	assert.Contains(t, result, `ALTER TABLE "public"."platform_saga_definition" DROP CONSTRAINT IF EXISTS "uq_platform_saga_definition_name"`)
+	assert.NotContains(t, result, "DROP INDEX")
+}
+
+func TestAdaptCockroachDDLForPostgres_AddConstraintCheck(t *testing.T) {
+	input := `ALTER TABLE public.my_table ADD CONSTRAINT chk_status CHECK (status IN ('a','b'));`
+	result := adaptCockroachDDLForPostgres(input)
+	assert.Contains(t, result, "DO $compat$ BEGIN")
+	assert.Contains(t, result, "EXCEPTION WHEN duplicate_object THEN NULL")
+	assert.Contains(t, result, "END $compat$;")
+	assert.Contains(t, result, "ADD CONSTRAINT chk_status CHECK")
+}
+
+func TestAdaptCockroachDDLForPostgres_AddConstraintIfNotExists(t *testing.T) {
+	// CockroachDB extension form: ADD CONSTRAINT IF NOT EXISTS
+	input := `ALTER TABLE public.my_table ADD CONSTRAINT IF NOT EXISTS chk_val CHECK (val > 0);`
+	result := adaptCockroachDDLForPostgres(input)
+	assert.Contains(t, result, "DO $compat$ BEGIN")
+	// "IF NOT EXISTS" should be stripped
+	assert.NotContains(t, result, "IF NOT EXISTS")
+	assert.Contains(t, result, "ADD CONSTRAINT chk_val CHECK")
+}
+
+func TestAdaptCockroachDDLForPostgres_BothTransformations(t *testing.T) {
+	input := `DROP INDEX IF EXISTS "public"."uq_platform_saga_definition_name" CASCADE;
+ALTER TABLE public.my_table ADD CONSTRAINT chk_foo CHECK (foo > 0);`
+	result := adaptCockroachDDLForPostgres(input)
+	assert.Contains(t, result, "DROP CONSTRAINT IF EXISTS")
+	assert.Contains(t, result, "DO $compat$ BEGIN")
+}
+
+func TestAdaptCockroachDDLForPostgres_MultipleConstraints(t *testing.T) {
+	input := `ALTER TABLE public.t1 ADD CONSTRAINT chk_a CHECK (a > 0);
+ALTER TABLE public.t2 ADD CONSTRAINT chk_b CHECK (b > 0);`
+	result := adaptCockroachDDLForPostgres(input)
+	// Both should be wrapped
+	assert.Equal(t, 2, countOccurrences(result, "DO $compat$ BEGIN"))
+}
+
+func countOccurrences(s, sub string) int {
+	count := 0
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			count++
+		}
+	}
+	return count
+}
+
+// --- extractSchemasFromModels tests ---
+
+type modelWithSchema struct{}
+
+func (m *modelWithSchema) TableName() string { return "myschema.my_table" }
+
+type modelWithoutSchema struct{}
+
+func (m *modelWithoutSchema) TableName() string { return "my_table" }
+
+type modelNoTableName struct {
+	ID int
+}
+
+func TestExtractSchemasFromModels_WithSchema(t *testing.T) {
+	models := []interface{}{&modelWithSchema{}}
+	schemas := extractSchemasFromModels(models)
+	assert.True(t, schemas["myschema"])
+	assert.Len(t, schemas, 1)
+}
+
+func TestExtractSchemasFromModels_WithoutSchema(t *testing.T) {
+	models := []interface{}{&modelWithoutSchema{}}
+	schemas := extractSchemasFromModels(models)
+	assert.Len(t, schemas, 0)
+}
+
+func TestExtractSchemasFromModels_NoTableNameMethod(t *testing.T) {
+	models := []interface{}{&modelNoTableName{}}
+	schemas := extractSchemasFromModels(models)
+	assert.Len(t, schemas, 0)
+}
+
+func TestExtractSchemasFromModels_Mixed(t *testing.T) {
+	models := []interface{}{&modelWithSchema{}, &modelWithoutSchema{}, &modelNoTableName{}}
+	schemas := extractSchemasFromModels(models)
+	assert.True(t, schemas["myschema"])
+	assert.Len(t, schemas, 1)
+}
+
+func TestExtractSchemasFromModels_Empty(t *testing.T) {
+	schemas := extractSchemasFromModels(nil)
+	assert.Len(t, schemas, 0)
+}
+
+func TestExtractSchemasFromModels_DuplicateSchemas(t *testing.T) {
+	models := []interface{}{&modelWithSchema{}, &modelWithSchema{}}
+	schemas := extractSchemasFromModels(models)
+	assert.Len(t, schemas, 1)
+}
+
+// --- Option function tests ---
+
+func TestWithMigrations(t *testing.T) {
+	cfg := &poolConfig{}
+	opt := WithMigrations("reference-data")
+	opt(cfg)
+	assert.Equal(t, "reference-data", cfg.migrations)
+}
+
+func TestWithLogLevel(t *testing.T) {
+	cfg := &postgresConfig{}
+	opt := WithLogLevel(logger.Info)
+	opt(cfg)
+	assert.Equal(t, logger.Info, cfg.logLevel)
+}
+
+func TestWithModels(t *testing.T) {
+	cfg := &setupConfig{}
+	m := &modelWithSchema{}
+	opt := WithModels(m)
+	opt(cfg)
+	assert.Len(t, cfg.models, 1)
+
+	// Append more
+	opt2 := WithModels(&modelNoTableName{})
+	opt2(cfg)
+	assert.Len(t, cfg.models, 2)
+}
+
+func TestWithTenant(t *testing.T) {
+	cfg := &setupConfig{}
+	opt := WithTenant("acme_bank")
+	opt(cfg)
+	assert.Equal(t, "acme_bank", cfg.tenantID)
+}
+
+func TestWithAuditTables(t *testing.T) {
+	cfg := &setupConfig{}
+	opt := WithAuditTables()
+	opt(cfg)
+	assert.True(t, cfg.auditTables)
+}
+
+func TestWithSetupLogLevel(t *testing.T) {
+	cfg := &setupConfig{}
+	opt := WithSetupLogLevel(logger.Warn)
+	opt(cfg)
+	assert.Equal(t, logger.Warn, cfg.logLevel)
+}
+

--- a/shared/platform/testdb/unit_test.go
+++ b/shared/platform/testdb/unit_test.go
@@ -167,4 +167,3 @@ func TestWithSetupLogLevel(t *testing.T) {
 	opt(cfg)
 	assert.Equal(t, logger.Warn, cfg.logLevel)
 }
-


### PR DESCRIPTION
## Summary

- Add unit and integration tests across `shared/platform/` foundational packages to improve test coverage
- Focus on unhappy paths: error handling, edge cases, timeout behavior, retry exhaustion, DLQ publishing

## Coverage Improvements

| Package | Before | After |
|---------|--------|-------|
| kafka/ | 32.0% | 55% |
| events/ | 47.6% | 84.6% |
| audit/ | 52.5% | 57.4% |
| observability/ | 56.9% | 90.3% |
| testdb/ | 1.3% | 80.6% |

## Changes Made

- **kafka/**: Config defaults, env overrides, DLQ metadata parsing, consumer message processing (missing tenant, invalid protobuf, retry logic)
- **audit/**: Schema validation, identifier quoting, proto conversion, consumer validation, publisher error paths
- **events/**: Worker config defaults, stuck entry reset, batch processing errors, publish timeout, retry exhaustion, Kafka header generation, outbox pgx integration tests, metrics recording
- **observability/**: gRPC interceptors (unary/stream, server/client), logging level filtering and context extraction, tracing no-span safety, shutdown behavior
- **testdb/**: CockroachDB DDL adaptation, schema extraction, option functions, PostgreSQL/CockroachDB setup, pgx migration application, tenant schema setup

## Test plan

- [x] All new tests pass locally with `go test -short` (unit tests)
- [x] Integration tests pass with testcontainers (events, testdb)
- [ ] CI pipeline passes