### PR TITLE
test: Add unhappy path tests for reference-data service

### DIFF
--- a/services/reference-data/accounttype/postgres_registry_test.go
+++ b/services/reference-data/accounttype/postgres_registry_test.go
@@ -582,6 +582,214 @@ func TestPostgresAccountTypeRegistry_GetProductFeatures(t *testing.T) {
 	assert.Equal(t, 0.05, features["interest_rate"])
 }
 
+func TestPostgresRegistry_GetDefinitionByID(t *testing.T) {
+	reg, pool := setupTestAccountTypeRegistry(t)
+	ctx := setupAccountTypeTenantContext(t, pool, "test-tenant-at-getbyid")
+
+	t.Run("returns existing definition by ID", func(t *testing.T) {
+		def := newTestDefinition("GETBYID_OK", "GBP")
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		result, err := reg.GetDefinitionByID(ctx, def.ID)
+		require.NoError(t, err)
+		assert.Equal(t, def.ID, result.ID)
+		assert.Equal(t, "GETBYID_OK", result.Code)
+		assert.Equal(t, 1, result.Version)
+		assert.Equal(t, accounttype.StatusDraft, result.Status)
+	})
+
+	t.Run("returns ErrNotFound for non-existent ID", func(t *testing.T) {
+		_, err := reg.GetDefinitionByID(ctx, uuid.New())
+		require.ErrorIs(t, err, accounttype.ErrNotFound)
+	})
+}
+
+func TestPostgresRegistry_ActivateWithValuationMethods(t *testing.T) {
+	reg, pool := setupTestAccountTypeRegistry(t)
+	ctx := setupAccountTypeTenantContext(t, pool, "test-tenant-at-valmethod")
+
+	seedInstrument(t, pool, ctx, "GBP")
+	seedInstrument(t, pool, ctx, "USD")
+
+	// Seed a valuation method so the activation pre-check succeeds
+	seedValuationMethod(t, pool, ctx)
+
+	t.Run("creates draft with valuation method templates and activates", func(t *testing.T) {
+		vmID := getSeededValuationMethodID(t, pool, ctx)
+
+		def := newTestDefinition("VM_ACTIVATE", "GBP")
+		def.ValuationMethods = []accounttype.ValuationMethodTemplate{
+			{
+				InputInstrument:        "USD",
+				ValuationMethodID:      vmID,
+				ValuationMethodVersion: 1,
+				Parameters:             map[string]any{"margin": 0.01},
+			},
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		// Activate should succeed (valuation method and instruments are valid)
+		err := reg.ActivateAccountType(ctx, "VM_ACTIVATE", 1)
+		require.NoError(t, err)
+
+		// Fetch and verify valuation methods are present and ACTIVE
+		result, err := reg.GetDefinitionByID(ctx, def.ID)
+		require.NoError(t, err)
+		assert.Equal(t, accounttype.StatusActive, result.Status)
+		require.Len(t, result.ValuationMethods, 1)
+		assert.Equal(t, accounttype.StatusActive, result.ValuationMethods[0].Status)
+		assert.Equal(t, "USD", result.ValuationMethods[0].InputInstrument)
+	})
+
+	t.Run("activation fails when valuation method does not exist", func(t *testing.T) {
+		def := newTestDefinition("VM_BAD_METHOD", "GBP")
+		def.ValuationMethods = []accounttype.ValuationMethodTemplate{
+			{
+				InputInstrument:        "USD",
+				ValuationMethodID:      uuid.New(), // non-existent
+				ValuationMethodVersion: 1,
+			},
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		err := reg.ActivateAccountType(ctx, "VM_BAD_METHOD", 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "valuation method")
+	})
+
+	t.Run("activation fails when valuation method instrument is not active", func(t *testing.T) {
+		vmID := getSeededValuationMethodID(t, pool, ctx)
+
+		def := newTestDefinition("VM_BAD_INST", "GBP")
+		def.ValuationMethods = []accounttype.ValuationMethodTemplate{
+			{
+				InputInstrument:        "NONEXISTENT_CURRENCY",
+				ValuationMethodID:      vmID,
+				ValuationMethodVersion: 1,
+			},
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		err := reg.ActivateAccountType(ctx, "VM_BAD_INST", 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "instrument")
+	})
+}
+
+func TestPostgresRegistry_SchemaValidation(t *testing.T) {
+	reg, pool := setupTestAccountTypeRegistry(t)
+	ctx := setupAccountTypeTenantContext(t, pool, "test-tenant-at-schema")
+
+	seedInstrument(t, pool, ctx, "GBP")
+
+	t.Run("valid schema and matching attributes pass activation", func(t *testing.T) {
+		def := newTestDefinition("SCHEMA_OK", "GBP")
+		def.AttributeSchema = json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"tier": {"type": "string"},
+				"limit": {"type": "number"}
+			},
+			"required": ["tier"]
+		}`)
+		def.Attributes = map[string]any{
+			"tier":  "GOLD",
+			"limit": float64(5000),
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		err := reg.ActivateAccountType(ctx, "SCHEMA_OK", 1)
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid JSON schema is rejected at draft creation", func(t *testing.T) {
+		def := newTestDefinition("SCHEMA_BAD", "GBP")
+		def.AttributeSchema = json.RawMessage(`{"type": "not-a-real-type"}`)
+
+		err := reg.CreateDraft(ctx, def)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, accounttype.ErrInvalidAttributeSchema)
+	})
+
+	t.Run("attributes not matching schema fail activation", func(t *testing.T) {
+		def := newTestDefinition("SCHEMA_MISMATCH", "GBP")
+		def.AttributeSchema = json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"tier": {"type": "string"}
+			},
+			"required": ["tier"]
+		}`)
+		// Missing required "tier" field
+		def.Attributes = map[string]any{
+			"other_field": "value",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		err := reg.ActivateAccountType(ctx, "SCHEMA_MISMATCH", 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "attribute")
+	})
+
+	t.Run("empty schema allows activation without attribute validation", func(t *testing.T) {
+		def := newTestDefinition("SCHEMA_EMPTY", "GBP")
+		def.AttributeSchema = json.RawMessage(`{}`)
+		def.Attributes = map[string]any{"anything": "goes"}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		err := reg.ActivateAccountType(ctx, "SCHEMA_EMPTY", 1)
+		require.NoError(t, err)
+	})
+}
+
+// seedValuationMethod inserts a minimal valuation method record so activation pre-checks pass.
+func seedValuationMethod(t *testing.T, pool *pgxpool.Pool, ctx context.Context) {
+	t.Helper()
+	tenantID, _ := tenant.FromContext(ctx)
+	schemaName := tenantID.SchemaName()
+
+	tx, err := pool.Begin(ctx)
+	require.NoError(t, err)
+
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	require.NoError(t, err)
+
+	query := `
+		INSERT INTO valuation_method (
+			id, name, version, input_instrument, output_instrument,
+			logic_script, logic_hash, lifecycle_status, is_system,
+			created_at, valid_from
+		) VALUES (
+			gen_random_uuid(), 'TEST_VM', 1, 'USD', 'GBP',
+			'return input', 'abc123', 'ACTIVE', false,
+			NOW(), NOW()
+		) ON CONFLICT DO NOTHING`
+
+	_, err = tx.Exec(ctx, query)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit(ctx))
+}
+
+// getSeededValuationMethodID retrieves the ID of the seeded valuation method.
+func getSeededValuationMethodID(t *testing.T, pool *pgxpool.Pool, ctx context.Context) uuid.UUID {
+	t.Helper()
+	tenantID, _ := tenant.FromContext(ctx)
+	schemaName := tenantID.SchemaName()
+
+	tx, err := pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	require.NoError(t, err)
+
+	var vmID uuid.UUID
+	err = tx.QueryRow(ctx, `SELECT id FROM valuation_method WHERE name = 'TEST_VM' AND version = 1`).Scan(&vmID)
+	require.NoError(t, err)
+
+	return vmID
+}
+
 func TestPostgresAccountTypeRegistry_LifecycleTimestamps(t *testing.T) {
 	reg, pool := setupTestAccountTypeRegistry(t)
 	ctx := setupAccountTypeTenantContext(t, pool, "test-tenant-at-timestamps")

--- a/services/reference-data/accounttype/types_test.go
+++ b/services/reference-data/accounttype/types_test.go
@@ -1,0 +1,85 @@
+package accounttype_test
+
+import (
+	"testing"
+
+	"github.com/meridianhub/meridian/services/reference-data/accounttype"
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// BehaviorClass.String
+// ---------------------------------------------------------------------------
+
+func TestBehaviorClass_String(t *testing.T) {
+	tests := []struct {
+		name   string
+		bc     accounttype.BehaviorClass
+		expect string
+	}{
+		{"CUSTOMER", accounttype.BehaviorClassCustomer, "CUSTOMER"},
+		{"CLEARING", accounttype.BehaviorClassClearing, "CLEARING"},
+		{"NOSTRO", accounttype.BehaviorClassNostro, "NOSTRO"},
+		{"VOSTRO", accounttype.BehaviorClassVostro, "VOSTRO"},
+		{"HOLDING", accounttype.BehaviorClassHolding, "HOLDING"},
+		{"SUSPENSE", accounttype.BehaviorClassSuspense, "SUSPENSE"},
+		{"REVENUE", accounttype.BehaviorClassRevenue, "REVENUE"},
+		{"EXPENSE", accounttype.BehaviorClassExpense, "EXPENSE"},
+		{"INVENTORY", accounttype.BehaviorClassInventory, "INVENTORY"},
+		{"unknown", accounttype.BehaviorClass("UNKNOWN"), "UNKNOWN"},
+		{"empty", accounttype.BehaviorClass(""), ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expect, tt.bc.String())
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NormalBalance.String
+// ---------------------------------------------------------------------------
+
+func TestNormalBalance_String(t *testing.T) {
+	tests := []struct {
+		name   string
+		nb     accounttype.NormalBalance
+		expect string
+	}{
+		{"DEBIT", accounttype.NormalBalanceDebit, "DEBIT"},
+		{"CREDIT", accounttype.NormalBalanceCredit, "CREDIT"},
+		{"unknown", accounttype.NormalBalance("UNKNOWN"), "UNKNOWN"},
+		{"empty", accounttype.NormalBalance(""), ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expect, tt.nb.String())
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AccountTypeStatus.String
+// ---------------------------------------------------------------------------
+
+func TestAccountTypeStatus_String(t *testing.T) {
+	tests := []struct {
+		name   string
+		s      accounttype.Status
+		expect string
+	}{
+		{"DRAFT", accounttype.StatusDraft, "DRAFT"},
+		{"ACTIVE", accounttype.StatusActive, "ACTIVE"},
+		{"DEPRECATED", accounttype.StatusDeprecated, "DEPRECATED"},
+		{"unknown", accounttype.Status("UNKNOWN"), "UNKNOWN"},
+		{"empty", accounttype.Status(""), ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expect, tt.s.String())
+		})
+	}
+}

--- a/services/reference-data/client/conversions_test.go
+++ b/services/reference-data/client/conversions_test.go
@@ -1,0 +1,91 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	"github.com/meridianhub/meridian/services/reference-data/registry"
+)
+
+func TestDimensionToString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    referencedatav1.Dimension
+		expected string
+	}{
+		{"UNSPECIFIED", referencedatav1.Dimension_DIMENSION_UNSPECIFIED, "UNSPECIFIED"},
+		{"CURRENCY", referencedatav1.Dimension_DIMENSION_CURRENCY, "CURRENCY"},
+		{"ENERGY", referencedatav1.Dimension_DIMENSION_ENERGY, "ENERGY"},
+		{"MASS", referencedatav1.Dimension_DIMENSION_MASS, "MASS"},
+		{"VOLUME", referencedatav1.Dimension_DIMENSION_VOLUME, "VOLUME"},
+		{"TIME", referencedatav1.Dimension_DIMENSION_TIME, "TIME"},
+		{"COMPUTE", referencedatav1.Dimension_DIMENSION_COMPUTE, "COMPUTE"},
+		{"CARBON", referencedatav1.Dimension_DIMENSION_CARBON, "CARBON"},
+		{"DATA", referencedatav1.Dimension_DIMENSION_DATA, "DATA"},
+		{"COUNT", referencedatav1.Dimension_DIMENSION_COUNT, "COUNT"},
+		{"unknown value defaults to UNSPECIFIED", referencedatav1.Dimension(999), "UNSPECIFIED"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, dimensionToString(tc.input))
+		})
+	}
+}
+
+func TestStatusFromProto(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    referencedatav1.InstrumentStatus
+		expected registry.Status
+	}{
+		{"DRAFT", referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_DRAFT, registry.StatusDraft},
+		{"ACTIVE", referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE, registry.StatusActive},
+		{"DEPRECATED", referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_DEPRECATED, registry.StatusDeprecated},
+		{"UNSPECIFIED", referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_UNSPECIFIED, ""},
+		{"unknown value defaults to empty", referencedatav1.InstrumentStatus(999), ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, statusFromProto(tc.input))
+		})
+	}
+}
+
+func TestDimensionFromProto(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    referencedatav1.Dimension
+		expected registry.Dimension
+	}{
+		{"CURRENCY maps to DimensionMonetary", referencedatav1.Dimension_DIMENSION_CURRENCY, registry.DimensionMonetary},
+		{"ENERGY maps to DimensionEnergy", referencedatav1.Dimension_DIMENSION_ENERGY, registry.DimensionEnergy},
+		{"MASS maps to DimensionMass", referencedatav1.Dimension_DIMENSION_MASS, registry.DimensionMass},
+		{"VOLUME maps to DimensionVolume", referencedatav1.Dimension_DIMENSION_VOLUME, registry.DimensionVolume},
+		{"TIME maps to DimensionTime", referencedatav1.Dimension_DIMENSION_TIME, registry.DimensionTime},
+		{"COMPUTE maps to DimensionCompute", referencedatav1.Dimension_DIMENSION_COMPUTE, registry.DimensionCompute},
+		{"COUNT maps to DimensionQuantity", referencedatav1.Dimension_DIMENSION_COUNT, registry.DimensionQuantity},
+		{"UNSPECIFIED maps to empty", referencedatav1.Dimension_DIMENSION_UNSPECIFIED, ""},
+		{"CARBON maps to empty", referencedatav1.Dimension_DIMENSION_CARBON, ""},
+		{"DATA maps to empty", referencedatav1.Dimension_DIMENSION_DATA, ""},
+		{"unknown value maps to empty", referencedatav1.Dimension(999), ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, dimensionFromProto(tc.input))
+		})
+	}
+}

--- a/services/reference-data/handler/account_type_helpers_test.go
+++ b/services/reference-data/handler/account_type_helpers_test.go
@@ -1,0 +1,263 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	"github.com/meridianhub/meridian/services/reference-data/accounttype"
+)
+
+func TestFilterByBehaviorClass(t *testing.T) {
+	t.Parallel()
+
+	defs := []*accounttype.Definition{
+		{Code: "CUSTOMER_1", BehaviorClass: accounttype.BehaviorClassCustomer},
+		{Code: "CLEARING_1", BehaviorClass: accounttype.BehaviorClassClearing},
+		{Code: "CUSTOMER_2", BehaviorClass: accounttype.BehaviorClassCustomer},
+		{Code: "NOSTRO_1", BehaviorClass: accounttype.BehaviorClassNostro},
+	}
+
+	t.Run("UNSPECIFIED returns all definitions", func(t *testing.T) {
+		t.Parallel()
+		result := filterByBehaviorClass(defs, pb.BehaviorClass_BEHAVIOR_CLASS_UNSPECIFIED)
+		assert.Len(t, result, 4)
+	})
+
+	t.Run("CUSTOMER filters to customer only", func(t *testing.T) {
+		t.Parallel()
+		result := filterByBehaviorClass(defs, pb.BehaviorClass_BEHAVIOR_CLASS_CUSTOMER)
+		assert.Len(t, result, 2)
+		for _, d := range result {
+			assert.Equal(t, accounttype.BehaviorClassCustomer, d.BehaviorClass)
+		}
+	})
+
+	t.Run("CLEARING filters to clearing only", func(t *testing.T) {
+		t.Parallel()
+		result := filterByBehaviorClass(defs, pb.BehaviorClass_BEHAVIOR_CLASS_CLEARING)
+		assert.Len(t, result, 1)
+		assert.Equal(t, "CLEARING_1", result[0].Code)
+	})
+
+	t.Run("HOLDING returns empty when no matches", func(t *testing.T) {
+		t.Parallel()
+		result := filterByBehaviorClass(defs, pb.BehaviorClass_BEHAVIOR_CLASS_HOLDING)
+		assert.Empty(t, result)
+	})
+
+	t.Run("empty input returns empty", func(t *testing.T) {
+		t.Parallel()
+		result := filterByBehaviorClass(nil, pb.BehaviorClass_BEHAVIOR_CLASS_CUSTOMER)
+		assert.Empty(t, result)
+	})
+}
+
+func TestPaginateDefinitions(t *testing.T) {
+	t.Parallel()
+
+	makeDefs := func(codes ...string) []*accounttype.Definition {
+		defs := make([]*accounttype.Definition, len(codes))
+		for i, c := range codes {
+			defs[i] = &accounttype.Definition{Code: c}
+		}
+		return defs
+	}
+
+	t.Run("empty list returns nil", func(t *testing.T) {
+		t.Parallel()
+		page, token := paginateDefinitions(nil, 10, "")
+		assert.Nil(t, page)
+		assert.Empty(t, token)
+	})
+
+	t.Run("all items fit in one page", func(t *testing.T) {
+		t.Parallel()
+		defs := makeDefs("A", "B", "C")
+		page, token := paginateDefinitions(defs, 10, "")
+		assert.Len(t, page, 3)
+		assert.Empty(t, token, "no next page token when all fit")
+	})
+
+	t.Run("items exceed page size", func(t *testing.T) {
+		t.Parallel()
+		defs := makeDefs("A", "B", "C", "D", "E")
+		page, token := paginateDefinitions(defs, 2, "")
+		assert.Len(t, page, 2)
+		assert.Equal(t, "B", token, "next page token is last item's code")
+	})
+
+	t.Run("page token skips past earlier items", func(t *testing.T) {
+		t.Parallel()
+		defs := makeDefs("A", "B", "C", "D", "E")
+		page, token := paginateDefinitions(defs, 2, "B")
+		assert.Len(t, page, 2)
+		assert.Equal(t, "C", page[0].Code)
+		assert.Equal(t, "D", page[1].Code)
+		assert.Equal(t, "D", token)
+	})
+
+	t.Run("page token past all items returns nil", func(t *testing.T) {
+		t.Parallel()
+		defs := makeDefs("A", "B", "C")
+		page, token := paginateDefinitions(defs, 10, "Z")
+		assert.Nil(t, page)
+		assert.Empty(t, token)
+	})
+
+	t.Run("exact boundary with page size", func(t *testing.T) {
+		t.Parallel()
+		defs := makeDefs("A", "B", "C")
+		page, token := paginateDefinitions(defs, 3, "")
+		assert.Len(t, page, 3)
+		assert.Empty(t, token, "no next page when exactly full")
+	})
+}
+
+func TestNormalizeAccountTypePageSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    int
+		expected int
+	}{
+		{"zero returns default", 0, DefaultPageSize},
+		{"negative returns default", -1, DefaultPageSize},
+		{"valid value passes through", 25, 25},
+		{"max value passes through", MaxPageSize, MaxPageSize},
+		{"above max clamped to max", MaxPageSize + 1, MaxPageSize},
+		{"one returns one", 1, 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, normalizeAccountTypePageSize(tc.input))
+		})
+	}
+}
+
+func TestDomainBehaviorClassToProto(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		domain   accounttype.BehaviorClass
+		expected pb.BehaviorClass
+	}{
+		{"CUSTOMER", accounttype.BehaviorClassCustomer, pb.BehaviorClass_BEHAVIOR_CLASS_CUSTOMER},
+		{"CLEARING", accounttype.BehaviorClassClearing, pb.BehaviorClass_BEHAVIOR_CLASS_CLEARING},
+		{"NOSTRO", accounttype.BehaviorClassNostro, pb.BehaviorClass_BEHAVIOR_CLASS_NOSTRO},
+		{"VOSTRO", accounttype.BehaviorClassVostro, pb.BehaviorClass_BEHAVIOR_CLASS_VOSTRO},
+		{"HOLDING", accounttype.BehaviorClassHolding, pb.BehaviorClass_BEHAVIOR_CLASS_HOLDING},
+		{"SUSPENSE", accounttype.BehaviorClassSuspense, pb.BehaviorClass_BEHAVIOR_CLASS_SUSPENSE},
+		{"REVENUE", accounttype.BehaviorClassRevenue, pb.BehaviorClass_BEHAVIOR_CLASS_REVENUE},
+		{"EXPENSE", accounttype.BehaviorClassExpense, pb.BehaviorClass_BEHAVIOR_CLASS_EXPENSE},
+		{"INVENTORY", accounttype.BehaviorClassInventory, pb.BehaviorClass_BEHAVIOR_CLASS_INVENTORY},
+		{"unknown defaults to UNSPECIFIED", accounttype.BehaviorClass("UNKNOWN"), pb.BehaviorClass_BEHAVIOR_CLASS_UNSPECIFIED},
+		{"empty defaults to UNSPECIFIED", accounttype.BehaviorClass(""), pb.BehaviorClass_BEHAVIOR_CLASS_UNSPECIFIED},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, domainBehaviorClassToProto(tc.domain))
+		})
+	}
+}
+
+func TestProtoBehaviorClassToDomain(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		proto    pb.BehaviorClass
+		expected accounttype.BehaviorClass
+	}{
+		{"UNSPECIFIED", pb.BehaviorClass_BEHAVIOR_CLASS_UNSPECIFIED, ""},
+		{"CUSTOMER", pb.BehaviorClass_BEHAVIOR_CLASS_CUSTOMER, accounttype.BehaviorClassCustomer},
+		{"CLEARING", pb.BehaviorClass_BEHAVIOR_CLASS_CLEARING, accounttype.BehaviorClassClearing},
+		{"NOSTRO", pb.BehaviorClass_BEHAVIOR_CLASS_NOSTRO, accounttype.BehaviorClassNostro},
+		{"VOSTRO", pb.BehaviorClass_BEHAVIOR_CLASS_VOSTRO, accounttype.BehaviorClassVostro},
+		{"HOLDING", pb.BehaviorClass_BEHAVIOR_CLASS_HOLDING, accounttype.BehaviorClassHolding},
+		{"SUSPENSE", pb.BehaviorClass_BEHAVIOR_CLASS_SUSPENSE, accounttype.BehaviorClassSuspense},
+		{"REVENUE", pb.BehaviorClass_BEHAVIOR_CLASS_REVENUE, accounttype.BehaviorClassRevenue},
+		{"EXPENSE", pb.BehaviorClass_BEHAVIOR_CLASS_EXPENSE, accounttype.BehaviorClassExpense},
+		{"INVENTORY", pb.BehaviorClass_BEHAVIOR_CLASS_INVENTORY, accounttype.BehaviorClassInventory},
+		{"unknown value defaults to empty", pb.BehaviorClass(999), ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, protoBehaviorClassToDomain(tc.proto))
+		})
+	}
+}
+
+func TestParseConversionMethodPair(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty ID returns nil pointers", func(t *testing.T) {
+		t.Parallel()
+		id, version, err := parseConversionMethodPair("", 0)
+		assert.NoError(t, err)
+		assert.Nil(t, id)
+		assert.Nil(t, version)
+	})
+
+	t.Run("valid ID and version", func(t *testing.T) {
+		t.Parallel()
+		testID := uuid.New()
+		id, version, err := parseConversionMethodPair(testID.String(), 5)
+		require.NoError(t, err)
+		assert.Equal(t, testID, *id)
+		assert.Equal(t, 5, *version)
+	})
+
+	t.Run("invalid UUID returns InvalidArgument", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := parseConversionMethodPair("not-a-uuid", 1)
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "invalid default_conversion_method_id")
+	})
+
+	t.Run("version zero returns InvalidArgument", func(t *testing.T) {
+		t.Parallel()
+		testID := uuid.New()
+		_, _, err := parseConversionMethodPair(testID.String(), 0)
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "must be >= 1")
+	})
+
+	t.Run("negative version returns InvalidArgument", func(t *testing.T) {
+		t.Parallel()
+		testID := uuid.New()
+		_, _, err := parseConversionMethodPair(testID.String(), -1)
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("version 1 is minimum valid", func(t *testing.T) {
+		t.Parallel()
+		testID := uuid.New()
+		id, version, err := parseConversionMethodPair(testID.String(), 1)
+		require.NoError(t, err)
+		assert.Equal(t, testID, *id)
+		assert.Equal(t, 1, *version)
+	})
+}

--- a/services/reference-data/handler/mapping_conversions_test.go
+++ b/services/reference-data/handler/mapping_conversions_test.go
@@ -1,0 +1,153 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	mappb "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+	"github.com/meridianhub/meridian/services/reference-data/mapping"
+)
+
+func TestProtoStatusToDomainMapping_AllStatuses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		proto    mappb.MappingStatus
+		expected mapping.Status
+	}{
+		{
+			name:     "UNSPECIFIED maps to empty",
+			proto:    mappb.MappingStatus_MAPPING_STATUS_UNSPECIFIED,
+			expected: "",
+		},
+		{
+			name:     "DRAFT maps to StatusDraft",
+			proto:    mappb.MappingStatus_MAPPING_STATUS_DRAFT,
+			expected: mapping.StatusDraft,
+		},
+		{
+			name:     "ACTIVE maps to StatusActive",
+			proto:    mappb.MappingStatus_MAPPING_STATUS_ACTIVE,
+			expected: mapping.StatusActive,
+		},
+		{
+			name:     "DEPRECATED maps to StatusDeprecated",
+			proto:    mappb.MappingStatus_MAPPING_STATUS_DEPRECATED,
+			expected: mapping.StatusDeprecated,
+		},
+		{
+			name:     "unknown value maps to empty",
+			proto:    mappb.MappingStatus(999),
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, protoStatusToDomainMapping(tc.proto))
+		})
+	}
+}
+
+func TestDomainStatusToProtoMapping_AllStatuses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		domain   mapping.Status
+		expected mappb.MappingStatus
+	}{
+		{
+			name:     "StatusDraft maps to DRAFT",
+			domain:   mapping.StatusDraft,
+			expected: mappb.MappingStatus_MAPPING_STATUS_DRAFT,
+		},
+		{
+			name:     "StatusActive maps to ACTIVE",
+			domain:   mapping.StatusActive,
+			expected: mappb.MappingStatus_MAPPING_STATUS_ACTIVE,
+		},
+		{
+			name:     "StatusDeprecated maps to DEPRECATED",
+			domain:   mapping.StatusDeprecated,
+			expected: mappb.MappingStatus_MAPPING_STATUS_DEPRECATED,
+		},
+		{
+			name:     "unknown domain status maps to UNSPECIFIED",
+			domain:   mapping.Status("UNKNOWN"),
+			expected: mappb.MappingStatus_MAPPING_STATUS_UNSPECIFIED,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, domainStatusToProtoMapping(tc.domain))
+		})
+	}
+}
+
+func TestProtoComputedFieldsToDomain(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil input returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, protoComputedFieldsToDomain(nil))
+	})
+
+	t.Run("empty slice returns empty slice", func(t *testing.T) {
+		t.Parallel()
+		result := protoComputedFieldsToDomain([]*mappb.ComputedField{})
+		assert.NotNil(t, result)
+		assert.Empty(t, result)
+	})
+
+	t.Run("populated fields convert correctly", func(t *testing.T) {
+		t.Parallel()
+		input := []*mappb.ComputedField{
+			{TargetPath: "amount", CelExpression: "parse_decimal(raw_amount)"},
+			{TargetPath: "status", CelExpression: `"ACTIVE"`},
+		}
+
+		result := protoComputedFieldsToDomain(input)
+		assert.Len(t, result, 2)
+		assert.Equal(t, "amount", result[0].TargetPath)
+		assert.Equal(t, "parse_decimal(raw_amount)", result[0].CELExpression)
+		assert.Equal(t, "status", result[1].TargetPath)
+		assert.Equal(t, `"ACTIVE"`, result[1].CELExpression)
+	})
+}
+
+func TestComputedFieldsToProto(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil input returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, computedFieldsToProto(nil))
+	})
+
+	t.Run("empty slice returns empty slice", func(t *testing.T) {
+		t.Parallel()
+		result := computedFieldsToProto([]mapping.ComputedField{})
+		assert.NotNil(t, result)
+		assert.Empty(t, result)
+	})
+
+	t.Run("populated fields convert correctly", func(t *testing.T) {
+		t.Parallel()
+		input := []mapping.ComputedField{
+			{TargetPath: "total", CELExpression: "quantity * price"},
+			{TargetPath: "timestamp", CELExpression: "now()"},
+		}
+
+		result := computedFieldsToProto(input)
+		assert.Len(t, result, 2)
+		assert.Equal(t, "total", result[0].TargetPath)
+		assert.Equal(t, "quantity * price", result[0].CelExpression)
+		assert.Equal(t, "timestamp", result[1].TargetPath)
+		assert.Equal(t, "now()", result[1].CelExpression)
+	})
+}

--- a/services/reference-data/handler/node_error_mapping_test.go
+++ b/services/reference-data/handler/node_error_mapping_test.go
@@ -1,0 +1,126 @@
+package handler
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/meridianhub/meridian/services/reference-data/node"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+func TestMapNodeError_AllCases(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	svc := &NodeService{logger: logger}
+
+	tests := []struct {
+		name         string
+		err          error
+		expectedCode codes.Code
+		expectedMsg  string
+	}{
+		{
+			name:         "ErrNotFound maps to NotFound",
+			err:          node.ErrNotFound,
+			expectedCode: codes.NotFound,
+			expectedMsg:  "node not found",
+		},
+		{
+			name:         "ErrAlreadyExists maps to AlreadyExists",
+			err:          node.ErrAlreadyExists,
+			expectedCode: codes.AlreadyExists,
+			expectedMsg:  "active node with this resolution key already exists",
+		},
+		{
+			name:         "ErrParentNotFound maps to NotFound",
+			err:          node.ErrParentNotFound,
+			expectedCode: codes.NotFound,
+			expectedMsg:  "parent node not found",
+		},
+		{
+			name:         "ErrParentNotActive maps to FailedPrecondition",
+			err:          node.ErrParentNotActive,
+			expectedCode: codes.FailedPrecondition,
+			expectedMsg:  "parent node is not active",
+		},
+		{
+			name:         "ErrCrossTenantParent maps to PermissionDenied",
+			err:          node.ErrCrossTenantParent,
+			expectedCode: codes.PermissionDenied,
+			expectedMsg:  "parent node belongs to a different tenant",
+		},
+		{
+			name:         "ErrImmutableIdentity maps to FailedPrecondition",
+			err:          node.ErrImmutableIdentity,
+			expectedCode: codes.FailedPrecondition,
+			expectedMsg:  "cannot change identity fields on active node",
+		},
+		{
+			name:         "ErrOptimisticLock maps to Aborted",
+			err:          node.ErrOptimisticLock,
+			expectedCode: codes.Aborted,
+			expectedMsg:  "node was modified by another transaction",
+		},
+		{
+			name:         "ErrCircularHierarchy maps to FailedPrecondition",
+			err:          node.ErrCircularHierarchy,
+			expectedCode: codes.FailedPrecondition,
+			expectedMsg:  "circular hierarchy detected",
+		},
+		{
+			name:         "ErrMaxDepthExceeded maps to FailedPrecondition",
+			err:          node.ErrMaxDepthExceeded,
+			expectedCode: codes.FailedPrecondition,
+			expectedMsg:  "maximum hierarchy depth exceeded",
+		},
+		{
+			name:         "ErrInvalidTimeRange maps to InvalidArgument",
+			err:          node.ErrInvalidTimeRange,
+			expectedCode: codes.InvalidArgument,
+			expectedMsg:  "valid_to must be after valid_from",
+		},
+		{
+			name:         "ErrAlreadySuperseded maps to FailedPrecondition",
+			err:          node.ErrAlreadySuperseded,
+			expectedCode: codes.FailedPrecondition,
+			expectedMsg:  "node has already been superseded",
+		},
+		{
+			name:         "ErrInvalidNode maps to InvalidArgument",
+			err:          node.ErrInvalidNode,
+			expectedCode: codes.InvalidArgument,
+			expectedMsg:  "invalid node",
+		},
+		{
+			name:         "ErrMissingTenantContext maps to Unauthenticated",
+			err:          tenant.ErrMissingTenantContext,
+			expectedCode: codes.Unauthenticated,
+			expectedMsg:  "missing tenant context",
+		},
+		{
+			name:         "unknown error maps to Internal",
+			err:          assert.AnError,
+			expectedCode: codes.Internal,
+			expectedMsg:  "internal error",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := svc.mapNodeError(tc.err, "TestOp", "test-id")
+
+			st, ok := status.FromError(result)
+			assert.True(t, ok, "expected gRPC status error")
+			assert.Equal(t, tc.expectedCode, st.Code())
+			assert.Contains(t, st.Message(), tc.expectedMsg)
+		})
+	}
+}

--- a/services/reference-data/mapping/domain_test.go
+++ b/services/reference-data/mapping/domain_test.go
@@ -1,0 +1,273 @@
+package mapping_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/reference-data/mapping"
+)
+
+// ---------------------------------------------------------------------------
+// MappingStatus.CanTransitionTo
+// ---------------------------------------------------------------------------
+
+func TestMappingStatus_CanTransitionTo(t *testing.T) {
+	tests := []struct {
+		name   string
+		from   mapping.Status
+		to     mapping.Status
+		expect bool
+	}{
+		{"DRAFT to ACTIVE is allowed", mapping.StatusDraft, mapping.StatusActive, true},
+		{"DRAFT to DEPRECATED is forbidden", mapping.StatusDraft, mapping.StatusDeprecated, false},
+		{"DRAFT to DRAFT is forbidden", mapping.StatusDraft, mapping.StatusDraft, false},
+		{"ACTIVE to DEPRECATED is allowed", mapping.StatusActive, mapping.StatusDeprecated, true},
+		{"ACTIVE to DRAFT is forbidden", mapping.StatusActive, mapping.StatusDraft, false},
+		{"ACTIVE to ACTIVE is forbidden", mapping.StatusActive, mapping.StatusActive, false},
+		{"DEPRECATED to DRAFT is forbidden", mapping.StatusDeprecated, mapping.StatusDraft, false},
+		{"DEPRECATED to ACTIVE is forbidden", mapping.StatusDeprecated, mapping.StatusActive, false},
+		{"DEPRECATED to DEPRECATED is forbidden", mapping.StatusDeprecated, mapping.StatusDeprecated, false},
+		{"unknown status to ACTIVE is forbidden", mapping.Status("UNKNOWN"), mapping.StatusActive, false},
+		{"ACTIVE to unknown status is forbidden", mapping.StatusActive, mapping.Status("UNKNOWN"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expect, tt.from.CanTransitionTo(tt.to))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MarshalComputedFields / UnmarshalComputedFields
+// ---------------------------------------------------------------------------
+
+func TestMarshalComputedFields_NilInput(t *testing.T) {
+	data, err := mapping.MarshalComputedFields(nil)
+	require.NoError(t, err)
+	assert.JSONEq(t, "[]", string(data))
+}
+
+func TestMarshalComputedFields_EmptySlice(t *testing.T) {
+	data, err := mapping.MarshalComputedFields([]mapping.ComputedField{})
+	require.NoError(t, err)
+	assert.JSONEq(t, "[]", string(data))
+}
+
+func TestMarshalComputedFields_Populated(t *testing.T) {
+	fields := []mapping.ComputedField{
+		{TargetPath: "created_at", CELExpression: "now()"},
+		{TargetPath: "status", CELExpression: "'ACTIVE'"},
+	}
+	data, err := mapping.MarshalComputedFields(fields)
+	require.NoError(t, err)
+
+	var roundtrip []mapping.ComputedField
+	require.NoError(t, json.Unmarshal(data, &roundtrip))
+	assert.Len(t, roundtrip, 2)
+	assert.Equal(t, "created_at", roundtrip[0].TargetPath)
+}
+
+func TestUnmarshalComputedFields_NilInput(t *testing.T) {
+	fields, err := mapping.UnmarshalComputedFields(nil)
+	require.NoError(t, err)
+	assert.Nil(t, fields)
+}
+
+func TestUnmarshalComputedFields_EmptyInput(t *testing.T) {
+	fields, err := mapping.UnmarshalComputedFields([]byte{})
+	require.NoError(t, err)
+	assert.Nil(t, fields)
+}
+
+func TestUnmarshalComputedFields_Populated(t *testing.T) {
+	input := `[{"target_path":"foo","cel_expression":"bar"}]`
+	fields, err := mapping.UnmarshalComputedFields([]byte(input))
+	require.NoError(t, err)
+	require.Len(t, fields, 1)
+	assert.Equal(t, "foo", fields[0].TargetPath)
+	assert.Equal(t, "bar", fields[0].CELExpression)
+}
+
+func TestUnmarshalComputedFields_InvalidJSON(t *testing.T) {
+	_, err := mapping.UnmarshalComputedFields([]byte(`{not json`))
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// MarshalIdempotency / UnmarshalIdempotency
+// ---------------------------------------------------------------------------
+
+func TestMarshalIdempotency_NilInput(t *testing.T) {
+	data, err := mapping.MarshalIdempotency(nil)
+	require.NoError(t, err)
+	assert.Equal(t, "null", string(data))
+}
+
+func TestMarshalIdempotency_Populated(t *testing.T) {
+	cfg := &mapping.IdempotencyConfig{
+		SourceSelector:    "header.key",
+		UseContentHash:    true,
+		ContentHashFields: []string{"amount", "reference"},
+	}
+	data, err := mapping.MarshalIdempotency(cfg)
+	require.NoError(t, err)
+
+	var roundtrip mapping.IdempotencyConfig
+	require.NoError(t, json.Unmarshal(data, &roundtrip))
+	assert.Equal(t, "header.key", roundtrip.SourceSelector)
+	assert.True(t, roundtrip.UseContentHash)
+	assert.Equal(t, []string{"amount", "reference"}, roundtrip.ContentHashFields)
+}
+
+func TestUnmarshalIdempotency_NilInput(t *testing.T) {
+	cfg, err := mapping.UnmarshalIdempotency(nil)
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestUnmarshalIdempotency_EmptyInput(t *testing.T) {
+	cfg, err := mapping.UnmarshalIdempotency([]byte{})
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestUnmarshalIdempotency_NullLiteral(t *testing.T) {
+	cfg, err := mapping.UnmarshalIdempotency([]byte("null"))
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestUnmarshalIdempotency_NullLiteralWithWhitespace(t *testing.T) {
+	cfg, err := mapping.UnmarshalIdempotency([]byte("  null  "))
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestUnmarshalIdempotency_Populated(t *testing.T) {
+	input := `{"source_selector":"ref","use_content_hash":false}`
+	cfg, err := mapping.UnmarshalIdempotency([]byte(input))
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "ref", cfg.SourceSelector)
+	assert.False(t, cfg.UseContentHash)
+}
+
+func TestUnmarshalIdempotency_InvalidJSON(t *testing.T) {
+	_, err := mapping.UnmarshalIdempotency([]byte(`{broken`))
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// MarshalFields / UnmarshalFields round-trip
+// ---------------------------------------------------------------------------
+
+func TestMarshalFields_NilInput(t *testing.T) {
+	data, err := mapping.MarshalFields(nil)
+	require.NoError(t, err)
+	assert.JSONEq(t, "[]", string(data))
+}
+
+func TestMarshalFields_EmptySlice(t *testing.T) {
+	data, err := mapping.MarshalFields([]mapping.FieldCorrespondence{})
+	require.NoError(t, err)
+	assert.JSONEq(t, "[]", string(data))
+}
+
+func TestMarshalFields_Populated(t *testing.T) {
+	fields := []mapping.FieldCorrespondence{
+		{ExternalPath: "ext", InternalPath: "int"},
+	}
+	data, err := mapping.MarshalFields(fields)
+	require.NoError(t, err)
+
+	roundtrip, err := mapping.UnmarshalFields(data)
+	require.NoError(t, err)
+	require.Len(t, roundtrip, 1)
+	assert.Equal(t, "ext", roundtrip[0].ExternalPath)
+}
+
+func TestUnmarshalFields_NilInput(t *testing.T) {
+	fields, err := mapping.UnmarshalFields(nil)
+	require.NoError(t, err)
+	assert.Nil(t, fields)
+}
+
+func TestUnmarshalFields_EmptyInput(t *testing.T) {
+	fields, err := mapping.UnmarshalFields([]byte{})
+	require.NoError(t, err)
+	assert.Nil(t, fields)
+}
+
+func TestUnmarshalFields_InvalidJSON(t *testing.T) {
+	_, err := mapping.UnmarshalFields([]byte(`not-json`))
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// Marshal/Unmarshal idempotency (round-trip stability)
+// ---------------------------------------------------------------------------
+
+func TestMarshalIdempotency_RoundTrip_Nil(t *testing.T) {
+	data, err := mapping.MarshalIdempotency(nil)
+	require.NoError(t, err)
+
+	cfg, err := mapping.UnmarshalIdempotency(data)
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestMarshalIdempotency_RoundTrip_Empty(t *testing.T) {
+	cfg := &mapping.IdempotencyConfig{}
+	data, err := mapping.MarshalIdempotency(cfg)
+	require.NoError(t, err)
+
+	result, err := mapping.UnmarshalIdempotency(data)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "", result.SourceSelector)
+	assert.False(t, result.UseContentHash)
+}
+
+func TestMarshalIdempotency_RoundTrip_Populated(t *testing.T) {
+	cfg := &mapping.IdempotencyConfig{
+		SourceSelector:    "x.y",
+		UseContentHash:    true,
+		ContentHashFields: []string{"a", "b"},
+	}
+	data, err := mapping.MarshalIdempotency(cfg)
+	require.NoError(t, err)
+
+	result, err := mapping.UnmarshalIdempotency(data)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, cfg.SourceSelector, result.SourceSelector)
+	assert.Equal(t, cfg.UseContentHash, result.UseContentHash)
+	assert.Equal(t, cfg.ContentHashFields, result.ContentHashFields)
+}
+
+func TestMarshalComputedFields_RoundTrip_Nil(t *testing.T) {
+	data, err := mapping.MarshalComputedFields(nil)
+	require.NoError(t, err)
+
+	result, err := mapping.UnmarshalComputedFields(data)
+	require.NoError(t, err)
+	// "[]" unmarshals to an empty slice, not nil
+	assert.Empty(t, result)
+}
+
+func TestMarshalComputedFields_RoundTrip_Populated(t *testing.T) {
+	fields := []mapping.ComputedField{
+		{TargetPath: "a", CELExpression: "b"},
+	}
+	data, err := mapping.MarshalComputedFields(fields)
+	require.NoError(t, err)
+
+	result, err := mapping.UnmarshalComputedFields(data)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, fields[0], result[0])
+}

--- a/services/reference-data/mapping/repository_test.go
+++ b/services/reference-data/mapping/repository_test.go
@@ -218,6 +218,35 @@ func TestRepository_GetLatestActive(t *testing.T) {
 	assert.Equal(t, mapping.StatusActive, got.Status)
 }
 
+func TestRepository_GetByNameAndVersion(t *testing.T) {
+	pool := testdb.NewTestPool(t, testdb.WithMigrations("reference-data"))
+	ctx, cleanup := testdb.SetupTenantSchemaForPgx(t, pool, "testtenant13", "reference-data")
+	defer cleanup()
+
+	repo := mapping.NewPostgresRepository(pool)
+
+	t.Run("returns existing definition", func(t *testing.T) {
+		def := newTestDef()
+		require.NoError(t, repo.Create(ctx, def))
+
+		got, err := repo.GetByNameAndVersion(ctx, "test-mapping", 1)
+		require.NoError(t, err)
+		assert.Equal(t, def.ID, got.ID)
+		assert.Equal(t, "test-mapping", got.Name)
+		assert.Equal(t, 1, got.Version)
+	})
+
+	t.Run("returns ErrNotFound for non-existent name", func(t *testing.T) {
+		_, err := repo.GetByNameAndVersion(ctx, "does-not-exist", 1)
+		assert.ErrorIs(t, err, mapping.ErrNotFound)
+	})
+
+	t.Run("returns ErrNotFound for non-existent version", func(t *testing.T) {
+		_, err := repo.GetByNameAndVersion(ctx, "test-mapping", 999)
+		assert.ErrorIs(t, err, mapping.ErrNotFound)
+	})
+}
+
 func TestRepository_OptimisticLock(t *testing.T) {
 	pool := testdb.NewTestPool(t, testdb.WithMigrations("reference-data"))
 	ctx, cleanup := testdb.SetupTenantSchemaForPgx(t, pool, "testtenant12", "reference-data")

--- a/services/reference-data/mapping/validator_test.go
+++ b/services/reference-data/mapping/validator_test.go
@@ -238,3 +238,257 @@ func TestValidator_MultipleTransformVariants_Rejected(t *testing.T) {
 	err := v.Validate(def)
 	assert.ErrorIs(t, err, mapping.ErrTransformVariantConflict)
 }
+
+func TestValidator_AttributeFlatten_ValidSourceKeys(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		Fields: []mapping.FieldCorrespondence{
+			{
+				ExternalPath: "data",
+				InternalPath: "attributes",
+				Transform: &mapping.FieldTransform{
+					AttributeFlatten: &mapping.AttributeFlatten{
+						SourceKeys:  []string{"key1", "nested.key2", "array.0.value"},
+						TargetField: "merged_attrs",
+					},
+				},
+			},
+		},
+	}
+	assert.NoError(t, v.Validate(def))
+}
+
+func TestValidator_AttributeFlatten_InvalidSourceKey(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		Fields: []mapping.FieldCorrespondence{
+			{
+				ExternalPath: "data",
+				InternalPath: "attributes",
+				Transform: &mapping.FieldTransform{
+					AttributeFlatten: &mapping.AttributeFlatten{
+						SourceKeys:  []string{"valid_key", "[unbalanced"},
+						TargetField: "merged",
+					},
+				},
+			},
+		},
+	}
+	err := v.Validate(def)
+	assert.ErrorIs(t, err, mapping.ErrInvalidGjsonPath)
+}
+
+func TestValidator_AttributeFlatten_EmptyTargetField(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		Fields: []mapping.FieldCorrespondence{
+			{
+				ExternalPath: "data",
+				InternalPath: "attributes",
+				Transform: &mapping.FieldTransform{
+					AttributeFlatten: &mapping.AttributeFlatten{
+						SourceKeys:  []string{"key1"},
+						TargetField: "",
+					},
+				},
+			},
+		},
+	}
+	err := v.Validate(def)
+	assert.ErrorIs(t, err, mapping.ErrRequiredField)
+}
+
+func TestValidator_AttributeFlatten_EmptySourceKey(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		Fields: []mapping.FieldCorrespondence{
+			{
+				ExternalPath: "data",
+				InternalPath: "attributes",
+				Transform: &mapping.FieldTransform{
+					AttributeFlatten: &mapping.AttributeFlatten{
+						SourceKeys:  []string{""},
+						TargetField: "merged",
+					},
+				},
+			},
+		},
+	}
+	err := v.Validate(def)
+	assert.ErrorIs(t, err, mapping.ErrInvalidGjsonPath)
+}
+
+func TestValidator_GjsonPathSyntax(t *testing.T) {
+	v := newTestValidator(t)
+
+	tests := []struct {
+		name      string
+		path      string
+		expectErr bool
+	}{
+		{"simple key", "amount", false},
+		{"nested key", "data.amount", false},
+		{"array index", "items.0.name", false},
+		{"balanced brackets", "items[0].name", false},
+		{"unbalanced open bracket", "items[0.name", true},
+		{"unbalanced close bracket", "items]0.name", true},
+		{"mismatched brackets", "items[0}", true},
+		{"mismatched braces", "items{0]", true},
+		{"empty string", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			def := &mapping.Definition{
+				Fields: []mapping.FieldCorrespondence{
+					{ExternalPath: tt.path, InternalPath: "target"},
+				},
+			}
+			err := v.Validate(def)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidator_NilDefinition(t *testing.T) {
+	v := newTestValidator(t)
+	err := v.Validate(nil)
+	assert.ErrorIs(t, err, mapping.ErrRequiredField)
+}
+
+func TestValidator_EmptyTransform_Rejected(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		Fields: []mapping.FieldCorrespondence{
+			{
+				ExternalPath: "amount",
+				InternalPath: "amount",
+				Transform:    &mapping.FieldTransform{},
+			},
+		},
+	}
+	err := v.Validate(def)
+	assert.ErrorIs(t, err, mapping.ErrTransformVariantRequired)
+}
+
+func TestValidator_NewValidator_NilCompiler(t *testing.T) {
+	_, err := mapping.NewValidator(nil)
+	assert.ErrorIs(t, err, mapping.ErrCELCompilerNil)
+}
+
+func TestValidator_OutboundValidationCEL_Invalid(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		OutboundValidationCEL: "this is not valid CEL !!!",
+	}
+	err := v.Validate(def)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, mapping.ErrInvalidCEL)
+}
+
+func TestValidator_OutboundComputedField_Invalid(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		OutboundComputed: []mapping.ComputedField{
+			{TargetPath: "out_field", CELExpression: "not valid !!!"},
+		},
+	}
+	err := v.Validate(def)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, mapping.ErrInvalidCEL)
+}
+
+func TestValidator_BatchTargetPath_InvalidGjson(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		IsBatch:         true,
+		BatchTargetPath: "[unbalanced",
+	}
+	err := v.Validate(def)
+	assert.Error(t, err)
+}
+
+func TestValidator_IdempotencyConfig_InvalidSourceSelectorGjson(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		Idempotency: &mapping.IdempotencyConfig{
+			SourceSelector: "[invalid",
+		},
+	}
+	err := v.Validate(def)
+	assert.ErrorIs(t, err, mapping.ErrInvalidGjsonPath)
+}
+
+func TestValidator_IdempotencyConfig_InvalidContentHashFieldGjson(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		Idempotency: &mapping.IdempotencyConfig{
+			UseContentHash:    true,
+			ContentHashFields: []string{"valid_key", "[broken"},
+		},
+	}
+	err := v.Validate(def)
+	assert.ErrorIs(t, err, mapping.ErrInvalidGjsonPath)
+}
+
+func TestValidator_ComputedField_EmptyTargetPath(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		InboundComputed: []mapping.ComputedField{
+			{TargetPath: "", CELExpression: "true"},
+		},
+	}
+	err := v.Validate(def)
+	assert.ErrorIs(t, err, mapping.ErrRequiredField)
+}
+
+func TestValidator_ComputedField_InvalidTargetPathGjson(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		InboundComputed: []mapping.ComputedField{
+			{TargetPath: "[unbalanced", CELExpression: "true"},
+		},
+	}
+	err := v.Validate(def)
+	assert.ErrorIs(t, err, mapping.ErrInvalidGjsonPath)
+}
+
+func TestValidator_InternalPath_Empty(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		Fields: []mapping.FieldCorrespondence{
+			{ExternalPath: "amount", InternalPath: ""},
+		},
+	}
+	err := v.Validate(def)
+	assert.ErrorIs(t, err, mapping.ErrInvalidGjsonPath)
+}
+
+func TestValidator_InternalPath_InvalidGjson(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		Fields: []mapping.FieldCorrespondence{
+			{ExternalPath: "amount", InternalPath: "[broken"},
+		},
+	}
+	err := v.Validate(def)
+	assert.ErrorIs(t, err, mapping.ErrInvalidGjsonPath)
+}

--- a/services/reference-data/saga/grpc_handler_test.go
+++ b/services/reference-data/saga/grpc_handler_test.go
@@ -2,6 +2,8 @@ package saga
 
 import (
 	"context"
+	"errors"
+	"strconv"
 	"testing"
 	"time"
 
@@ -876,4 +878,401 @@ func TestRegistryHandler_ExistingTests_StillPass_WithValidator(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, sagav1.SagaStatus_SAGA_STATUS_DEPRECATED, deprecateResp.Saga.Status)
 	})
+}
+
+func TestRegistryHandler_CreateSagaDraft_NegativeVersion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool, tenantID, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	registry := NewPostgresRegistry(pool, nil)
+	handler := NewRegistryHandler(registry, nil, nil, nil)
+	ctx := tenant.WithTenant(context.Background(), tenantID)
+
+	req := &sagav1.CreateSagaDraftRequest{
+		Name:    "negative_version_saga",
+		Version: -1,
+		Script:  `saga(name="negative_version_saga")`,
+	}
+
+	_, err := handler.CreateSagaDraft(ctx, req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "version must be non-negative")
+}
+
+func TestRegistryHandler_DeprecateSaga_InvalidIDs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool, tenantID, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	registry := NewPostgresRegistry(pool, nil)
+	handler := NewRegistryHandler(registry, nil, nil, nil)
+	ctx := tenant.WithTenant(context.Background(), tenantID)
+
+	t.Run("invalid saga UUID", func(t *testing.T) {
+		req := &sagav1.DeprecateSagaRequest{
+			Id: "not-a-uuid",
+		}
+
+		_, err := handler.DeprecateSaga(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "invalid saga id")
+	})
+
+	t.Run("invalid successor UUID", func(t *testing.T) {
+		// Create and activate a saga so we have a valid saga ID
+		createResp, err := handler.CreateSagaDraft(ctx, &sagav1.CreateSagaDraftRequest{
+			Name:   "deprecate_invalid_successor",
+			Script: `saga(name="deprecate_invalid_successor")`,
+		})
+		require.NoError(t, err)
+		_, err = handler.ActivateSaga(ctx, &sagav1.ActivateSagaRequest{Id: createResp.Saga.Id})
+		require.NoError(t, err)
+
+		req := &sagav1.DeprecateSagaRequest{
+			Id:          createResp.Saga.Id,
+			SuccessorId: "not-a-uuid",
+		}
+
+		_, err = handler.DeprecateSaga(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "invalid successor_id")
+	})
+}
+
+func TestRegistryHandler_GetSaga_ErrorPaths(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool, tenantID, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	registry := NewPostgresRegistry(pool, nil)
+	handler := NewRegistryHandler(registry, nil, nil, nil)
+	ctx := tenant.WithTenant(context.Background(), tenantID)
+
+	t.Run("invalid UUID", func(t *testing.T) {
+		req := &sagav1.GetSagaRequest{
+			Id: "not-a-uuid",
+		}
+
+		_, err := handler.GetSaga(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("negative version", func(t *testing.T) {
+		req := &sagav1.GetSagaRequest{
+			Name:    "some_saga",
+			Version: -1,
+		}
+
+		_, err := handler.GetSaga(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "version must be >= 0")
+	})
+
+	t.Run("version zero triggers active lookup", func(t *testing.T) {
+		// Version 0 means "get active version" — non-existent name returns NotFound
+		req := &sagav1.GetSagaRequest{
+			Name:    "nonexistent_active_saga",
+			Version: 0,
+		}
+
+		_, err := handler.GetSaga(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.NotFound, st.Code())
+	})
+
+	t.Run("non-existent saga by name", func(t *testing.T) {
+		req := &sagav1.GetSagaRequest{
+			Name:    "absolutely_does_not_exist",
+			Version: 1,
+		}
+
+		_, err := handler.GetSaga(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.NotFound, st.Code())
+	})
+}
+
+func TestRegistryHandler_ListSagas_Pagination(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool, tenantID, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	registry := NewPostgresRegistry(pool, nil)
+	handler := NewRegistryHandler(registry, nil, nil, nil)
+	ctx := tenant.WithTenant(context.Background(), tenantID)
+
+	// Seed some sagas
+	for i := 0; i < 5; i++ {
+		_, err := handler.CreateSagaDraft(ctx, &sagav1.CreateSagaDraftRequest{
+			Name:   "pagination_saga_" + strconv.Itoa(i),
+			Script: `saga(name="pagination")`,
+		})
+		require.NoError(t, err)
+	}
+
+	t.Run("pageSize 0 defaults to 50", func(t *testing.T) {
+		resp, err := handler.ListSagas(ctx, &sagav1.ListSagasRequest{
+			PageSize: 0,
+		})
+		require.NoError(t, err)
+		// With only 5 sagas, all should be returned (50 > 5) and no next token
+		assert.GreaterOrEqual(t, len(resp.Sagas), 5)
+		assert.Empty(t, resp.NextPageToken)
+	})
+
+	t.Run("pageSize over 100 caps to 100", func(t *testing.T) {
+		resp, err := handler.ListSagas(ctx, &sagav1.ListSagasRequest{
+			PageSize: 200,
+		})
+		require.NoError(t, err)
+		// All 5 sagas fit within the capped page size of 100
+		assert.GreaterOrEqual(t, len(resp.Sagas), 5)
+		assert.Empty(t, resp.NextPageToken)
+	})
+
+	t.Run("invalid page_token", func(t *testing.T) {
+		_, err := handler.ListSagas(ctx, &sagav1.ListSagasRequest{
+			PageToken: "not-a-number",
+		})
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "invalid page_token")
+	})
+
+	t.Run("ExcludeSystem filter", func(t *testing.T) {
+		// Insert a system saga directly
+		schemaName := tenantID.SchemaName()
+		_, err := pool.Exec(ctx, `
+			INSERT INTO `+schemaName+`.saga_definition
+				(name, version, script, status, is_system)
+			VALUES
+				('system_list_test', 1, 'saga(name="system")', 'DRAFT', true)`)
+		require.NoError(t, err)
+
+		// Without ExcludeSystem — system saga should be present
+		allResp, err := handler.ListSagas(ctx, &sagav1.ListSagasRequest{
+			ExcludeSystem: false,
+		})
+		require.NoError(t, err)
+		hasSystem := false
+		for _, s := range allResp.Sagas {
+			if s.Name == "system_list_test" {
+				hasSystem = true
+				break
+			}
+		}
+		assert.True(t, hasSystem, "system saga should be included when ExcludeSystem=false")
+
+		// With ExcludeSystem — system saga should be excluded
+		filteredResp, err := handler.ListSagas(ctx, &sagav1.ListSagasRequest{
+			ExcludeSystem: true,
+		})
+		require.NoError(t, err)
+		for _, s := range filteredResp.Sagas {
+			assert.False(t, s.IsSystem, "no system saga should be returned when ExcludeSystem=true")
+		}
+	})
+}
+
+func TestRegistryHandler_DescribeHandlers(t *testing.T) {
+	t.Run("no schema returns empty response", func(t *testing.T) {
+		handler := NewRegistryHandler(nil, nil, nil, nil)
+
+		resp, err := handler.DescribeHandlers(context.Background(), &sagav1.DescribeHandlersRequest{})
+		require.NoError(t, err)
+		assert.Empty(t, resp.Services)
+	})
+
+	t.Run("with schema returns handlers grouped by service", func(t *testing.T) {
+		reg := schema.NewRegistry()
+		yamlData := []byte(`
+service: test
+version: 1.0
+handlers:
+  position_keeping.initiate_log:
+    description: Initiate a position log entry
+    compensation_strategy: none
+    params:
+      amount:
+        type: Decimal
+        required: true
+      direction:
+        type: enum
+        values: [DEBIT, CREDIT]
+        required: true
+    returns:
+      log_id:
+        type: string
+  payment.create_lien:
+    description: Create payment lien
+    compensation_strategy: none
+    params:
+      amount:
+        type: string
+        required: true
+    returns:
+      lien_id:
+        type: string
+`)
+		require.NoError(t, reg.LoadFromYAML(yamlData))
+
+		handler := NewRegistryHandler(nil, nil, nil, nil).WithSchemaRegistry(reg)
+
+		resp, err := handler.DescribeHandlers(context.Background(), &sagav1.DescribeHandlersRequest{})
+		require.NoError(t, err)
+		require.Len(t, resp.Services, 2)
+
+		// Services should be sorted alphabetically
+		assert.Equal(t, "payment", resp.Services[0].Name)
+		assert.Equal(t, "position_keeping", resp.Services[1].Name)
+
+		// Check payment service handlers
+		require.Len(t, resp.Services[0].Handlers, 1)
+		assert.Equal(t, "create_lien", resp.Services[0].Handlers[0].Name)
+		assert.Equal(t, "Create payment lien", resp.Services[0].Handlers[0].Description)
+
+		// Check position_keeping service handlers
+		require.Len(t, resp.Services[1].Handlers, 1)
+		assert.Equal(t, "initiate_log", resp.Services[1].Handlers[0].Name)
+		require.Len(t, resp.Services[1].Handlers[0].Parameters, 2)
+	})
+}
+
+func TestRegistryHandler_MapDomainError(t *testing.T) {
+	handler := NewRegistryHandler(nil, nil, nil, nil)
+
+	tests := []struct {
+		name         string
+		err          error
+		expectedCode codes.Code
+	}{
+		{"ErrNotFound", ErrNotFound, codes.NotFound},
+		{"ErrSystemSagaReadOnly", ErrSystemSagaReadOnly, codes.PermissionDenied},
+		{"ErrOptimisticLock", ErrOptimisticLock, codes.Aborted},
+		{"ErrValidationFailed", ErrValidationFailed, codes.FailedPrecondition},
+		{"ErrSuccessorInvalid", ErrSuccessorInvalid, codes.FailedPrecondition},
+		{"ErrNotDraft", ErrNotDraft, codes.FailedPrecondition},
+		{"ErrNotActive", ErrNotActive, codes.FailedPrecondition},
+		{"ErrAlreadyExists", ErrAlreadyExists, codes.AlreadyExists},
+		{"ErrInvalidStateTransition", ErrInvalidStateTransition, codes.FailedPrecondition},
+		{"unknown error", errors.New("something unexpected"), codes.Internal},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := handler.mapDomainError(tc.err, "TestOp", "test-id")
+			st, ok := status.FromError(result)
+			require.True(t, ok)
+			assert.Equal(t, tc.expectedCode, st.Code())
+		})
+	}
+}
+
+func TestRegistryHandler_ValidateSagaDraft_ErrorPaths(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool, tenantID, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	registry := NewPostgresRegistry(pool, nil)
+	ctx := tenant.WithTenant(context.Background(), tenantID)
+
+	t.Run("invalid UUID", func(t *testing.T) {
+		handler := NewRegistryHandler(registry, nil, nil, nil)
+
+		_, err := handler.ValidateSagaDraft(ctx, &sagav1.ValidateSagaDraftRequest{
+			Id: "not-a-uuid",
+		})
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("non-existent saga", func(t *testing.T) {
+		handler := NewRegistryHandler(registry, nil, nil, nil)
+
+		_, err := handler.ValidateSagaDraft(ctx, &sagav1.ValidateSagaDraftRequest{
+			Id: uuid.New().String(),
+		})
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.NotFound, st.Code())
+	})
+
+	t.Run("no validator returns READY status", func(t *testing.T) {
+		handler := NewRegistryHandler(registry, nil, nil, nil)
+
+		// Create a saga to validate
+		createResp, err := handler.CreateSagaDraft(ctx, &sagav1.CreateSagaDraftRequest{
+			Name:   "validate_no_validator",
+			Script: `saga(name="validate_no_validator")`,
+		})
+		require.NoError(t, err)
+
+		resp, err := handler.ValidateSagaDraft(ctx, &sagav1.ValidateSagaDraftRequest{
+			Id: createResp.Saga.Id,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "READY", resp.Validation.Status)
+		assert.Equal(t, "No validator configured", resp.Report)
+	})
+}
+
+func TestRegistryHandler_AnalyzeDeprecationImpact_NoValidator(t *testing.T) {
+	handler := NewRegistryHandler(nil, nil, nil, nil)
+
+	resp, err := handler.AnalyzeDeprecationImpact(context.Background(), &sagav1.AnalyzeDeprecationImpactRequest{
+		InstrumentCode: "GBP",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Dependencies)
+	assert.Equal(t, int32(0), resp.TotalCount)
 }


### PR DESCRIPTION
## Summary

- Add unhappy-path and edge-case tests across reference-data sub-packages to increase coverage toward 80%
- Target ~357 uncovered lines across handler, mapping, accounttype, client, and saga packages
- All new tests are unit tests (no additional DB containers) except accounttype registry integration tests

## Coverage Improvements

| Package | Before | After | Delta |
|---------|--------|-------|-------|
| handler | 71.7% | 81.2% | +9.5% |
| mapping | 70.9% | 84.9% | +14.0% |
| accounttype | 68.3% | 81.2% | +12.9% |
| client | 77.0% | 82.8% | +5.8% |
| saga | 42.9% | 51.1% | +8.2% |

## Changes Made

**New test files (6):**
- `accounttype/types_test.go` - BehaviorClass, NormalBalance, AccountTypeStatus String() methods
- `client/conversions_test.go` - Dimension/status proto enum conversions
- `handler/account_type_helpers_test.go` - Pagination, behavior class filtering/conversion helpers
- `handler/mapping_conversions_test.go` - Status/computed field proto conversions
- `handler/node_error_mapping_test.go` - All 14 error sentinel → gRPC code mappings
- `mapping/domain_test.go` - Status transitions, marshal/unmarshal round-trips

**Extended test files (4):**
- `saga/grpc_handler_test.go` - Negative version, invalid IDs, pagination, DescribeHandlers, mapDomainError, ValidateSagaDraft error paths
- `accounttype/postgres_registry_test.go` - GetDefinitionByID, activation with valuation methods, JSON schema validation
- `mapping/repository_test.go` - GetByNameAndVersion success/not-found
- `mapping/validator_test.go` - Attribute flatten, gjson path syntax, nil definition, empty transform

## Test plan

- [x] All new unit tests pass locally
- [x] All existing tests continue to pass
- [ ] CI pipeline passes