### PR TITLE
test: Add Go architecture tests for size, naming, layers, and structure

### DIFF
--- a/tests/architecture/helpers_test.go
+++ b/tests/architecture/helpers_test.go
@@ -1,0 +1,83 @@
+package architecture_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// findRepoRoot walks up from the test directory to find the directory containing go.mod.
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find go.mod in any parent directory")
+		}
+		dir = parent
+	}
+}
+
+// shouldSkipDir returns true for directories that should be excluded from analysis.
+func shouldSkipDir(name string) bool {
+	switch name {
+	case "vendor", ".git", "node_modules", "gen", "frontend":
+		return true
+	}
+	return false
+}
+
+// isGeneratedFile returns true for generated Go files that should be excluded from analysis.
+func isGeneratedFile(path string) bool {
+	base := filepath.Base(path)
+	return strings.HasSuffix(base, ".pb.go") ||
+		strings.HasSuffix(base, "_grpc.pb.go") ||
+		strings.HasSuffix(base, ".pb.gw.go") ||
+		strings.HasSuffix(base, ".connect.go")
+}
+
+// isTestFile returns true for Go test files.
+func isTestFile(path string) bool {
+	return strings.HasSuffix(filepath.Base(path), "_test.go")
+}
+
+// walkGoFiles walks the directory tree starting at root, calling fn for each
+// non-generated, non-test .go file. Directories matching shouldSkipDir are skipped.
+func walkGoFiles(t *testing.T, root string, fn func(path string, relPath string)) {
+	t.Helper()
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() && shouldSkipDir(info.Name()) {
+			return filepath.SkipDir
+		}
+		if info.IsDir() || !strings.HasSuffix(info.Name(), ".go") {
+			return nil
+		}
+		if isGeneratedFile(path) || isTestFile(path) {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		fn(path, relPath)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to walk directory %s: %v", root, err)
+	}
+}

--- a/tests/architecture/helpers_test.go
+++ b/tests/architecture/helpers_test.go
@@ -74,6 +74,8 @@ func walkGoFiles(t *testing.T, root string, fn func(path string, relPath string)
 		if err != nil {
 			return err
 		}
+		// Normalize to forward slashes so allowlist keys work cross-platform.
+		relPath = filepath.ToSlash(relPath)
 		fn(path, relPath)
 		return nil
 	})

--- a/tests/architecture/layers_test.go
+++ b/tests/architecture/layers_test.go
@@ -102,12 +102,15 @@ func TestNoInternalCrossServiceImports(t *testing.T) {
 			if !strings.HasPrefix(importPath, modulePath+"/services/") {
 				continue
 			}
-			if !strings.Contains(importPath, "/internal/") && !strings.Contains(importPath, "/internal") {
+
+			// Check if import path contains /internal/ as a full path segment
+			// (not just a prefix like "internal-account").
+			remainder := strings.TrimPrefix(importPath, modulePath+"/services/")
+			parts := strings.SplitN(remainder, "/", 2)
+			importedService := parts[0]
+			if len(parts) < 2 || !hasInternalSegment(parts[1]) {
 				continue
 			}
-
-			remainder := strings.TrimPrefix(importPath, modulePath+"/services/")
-			importedService := strings.SplitN(remainder, "/", 2)[0]
 
 			if importedService != ownerService {
 				if knownCrossServiceInternalImports[relPath] {
@@ -206,6 +209,7 @@ func TestSharedNeverImportsServices(t *testing.T) {
 		}
 
 		relPath, _ := filepath.Rel(root, path)
+		relPath = filepath.ToSlash(relPath)
 		for _, imp := range file.Imports {
 			importPath := strings.Trim(imp.Path.Value, `"`)
 			if strings.HasPrefix(importPath, modulePath+"/services/") {
@@ -259,6 +263,7 @@ func TestAdaptersNeverImportService(t *testing.T) {
 			}
 
 			relPath, _ := filepath.Rel(root, path)
+			relPath = filepath.ToSlash(relPath)
 			for _, imp := range file.Imports {
 				importPath := strings.Trim(imp.Path.Value, `"`)
 				if strings.HasPrefix(importPath, serviceImportPrefix) {
@@ -292,4 +297,14 @@ func listServiceDirs(t *testing.T, servicesDir string) []string {
 		}
 	}
 	return services
+}
+
+// hasInternalSegment returns true if the path contains "internal" as a full path segment.
+func hasInternalSegment(subPath string) bool {
+	for _, seg := range strings.Split(subPath, "/") {
+		if seg == "internal" {
+			return true
+		}
+	}
+	return false
 }

--- a/tests/architecture/layers_test.go
+++ b/tests/architecture/layers_test.go
@@ -1,0 +1,295 @@
+package architecture_test
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const modulePath = "github.com/meridianhub/meridian"
+
+// compositionRootAllowlist contains files that are allowed to import across services
+// because they wire the application together.
+var compositionRootAllowlist = map[string]bool{
+	"cmd/meridian/wire_services.go": true,
+	"cmd/meridian/main.go":         true,
+}
+
+// knownCrossServiceInternalImports tracks existing cross-service internal/ imports.
+// Do NOT add new entries — use gRPC clients instead of direct imports.
+var knownCrossServiceInternalImports = map[string]bool{
+	"cmd/ibactl/cmd/provision_defaults.go":       true,
+	"cmd/ibactl/cmd/root.go":                     true,
+	"services/control-plane/cmd/validate/main.go": true,
+	"services/current-account/cmd/main.go":        true,
+	"services/financial-accounting/cmd/main.go":   true,
+	"services/payment-order/cmd/clients.go":       true,
+}
+
+// knownCrossServiceDomainImports tracks existing cross-service domain imports.
+// Do NOT add new entries — use gRPC clients instead of direct imports.
+var knownCrossServiceDomainImports = map[string]bool{
+	"services/api-gateway/auth_handler.go":                                   true,
+	"services/api-gateway/auth_sso_handler.go":                               true,
+	"services/api-gateway/cmd/main.go":                                       true,
+	"services/current-account/service/deposit_orchestrator.go":               true,
+	"services/current-account/service/fungibility_validator.go":              true,
+	"services/current-account/service/grpc_account_endpoints.go":            true,
+	"services/current-account/service/server.go":                            true,
+	"services/current-account/service/withdrawal_orchestrator.go":           true,
+	"services/event-router/adapters/grpc/position_keeping_client.go":        true,
+	"services/event-router/adapters/messaging/audit_consumer.go":            true,
+	"services/event-router/adapters/messaging/platform_metering_handler.go": true,
+	"services/event-router/cmd/main.go":                                     true,
+	"services/event-router/domain/measurement.go":                           true,
+	"services/event-router/domain/position_keeping_client.go":               true,
+	"services/event-router/internal/correlation/extractor.go":               true,
+	"services/financial-accounting/cmd/main.go":                             true,
+	"services/internal-account/service/server.go":                           true,
+}
+
+// knownSharedImportsServices tracks shared/ files that currently import services/.
+// Do NOT add new entries — shared packages must never depend on services.
+var knownSharedImportsServices = map[string]bool{
+	"shared/pkg/valuationfeature/resolution.go": true,
+	"shared/pkg/valuationfeature/seeder.go":     true,
+	"shared/platform/gateway/tenant_resolver.go": true,
+}
+
+// knownAdapterImportsService tracks adapter files that import their service layer.
+// Do NOT add new entries — adapters should depend on domain, not service.
+var knownAdapterImportsService = map[string]bool{
+	"services/financial-accounting/adapters/messaging/deposit_consumer.go":    true,
+	"services/internal-account/adapters/grpc/position_keeping_client.go":     true,
+	"services/party/adapters/http/verification_webhook.go":                   true,
+	"services/payment-order/adapters/clients/reference_data_client.go":      true,
+	"services/payment-order/adapters/lock/redis_lock_client.go":             true,
+}
+
+// TestNoInternalCrossServiceImports validates that no service imports another service's
+// internal/ package. The composition root (cmd/meridian/) is allowlisted.
+func TestNoInternalCrossServiceImports(t *testing.T) {
+	root := findRepoRoot(t)
+	fset := token.NewFileSet()
+
+	servicesDir := filepath.Join(root, "services")
+	services := listServiceDirs(t, servicesDir)
+
+	walkGoFiles(t, root, func(path string, relPath string) {
+		if compositionRootAllowlist[relPath] {
+			return
+		}
+
+		ownerService := ""
+		for _, svc := range services {
+			prefix := filepath.Join("services", svc) + "/"
+			if strings.HasPrefix(relPath, prefix) {
+				ownerService = svc
+				break
+			}
+		}
+
+		file, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if err != nil {
+			return
+		}
+
+		for _, imp := range file.Imports {
+			importPath := strings.Trim(imp.Path.Value, `"`)
+			if !strings.HasPrefix(importPath, modulePath+"/services/") {
+				continue
+			}
+			if !strings.Contains(importPath, "/internal/") && !strings.Contains(importPath, "/internal") {
+				continue
+			}
+
+			remainder := strings.TrimPrefix(importPath, modulePath+"/services/")
+			importedService := strings.SplitN(remainder, "/", 2)[0]
+
+			if importedService != ownerService {
+				if knownCrossServiceInternalImports[relPath] {
+					t.Logf("KNOWN: %s: imports internal package of service %q", relPath, importedService)
+					continue
+				}
+				pos := fset.Position(imp.Pos())
+				t.Errorf("%s:%d: imports internal package of service %q: %s",
+					relPath, pos.Line, importedService, importPath)
+			}
+		}
+	})
+}
+
+// TestNoCrossServiceDomainImports validates that services communicate via gRPC, not by
+// importing each other's domain packages directly. Test files and composition root are excluded.
+func TestNoCrossServiceDomainImports(t *testing.T) {
+	root := findRepoRoot(t)
+	fset := token.NewFileSet()
+
+	servicesDir := filepath.Join(root, "services")
+	services := listServiceDirs(t, servicesDir)
+
+	walkGoFiles(t, root, func(path string, relPath string) {
+		if compositionRootAllowlist[relPath] {
+			return
+		}
+
+		ownerService := ""
+		for _, svc := range services {
+			prefix := filepath.Join("services", svc) + "/"
+			if strings.HasPrefix(relPath, prefix) {
+				ownerService = svc
+				break
+			}
+		}
+		if ownerService == "" {
+			return
+		}
+
+		file, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if err != nil {
+			return
+		}
+
+		for _, imp := range file.Imports {
+			importPath := strings.Trim(imp.Path.Value, `"`)
+			if !strings.HasPrefix(importPath, modulePath+"/services/") {
+				continue
+			}
+
+			remainder := strings.TrimPrefix(importPath, modulePath+"/services/")
+			importedService := strings.SplitN(remainder, "/", 2)[0]
+
+			if importedService == ownerService {
+				continue
+			}
+
+			// Allow importing another service's client/ package (generated gRPC stubs).
+			parts := strings.SplitN(remainder, "/", 2)
+			if len(parts) > 1 && strings.HasPrefix(parts[1], "client") {
+				continue
+			}
+
+			if knownCrossServiceDomainImports[relPath] {
+				t.Logf("KNOWN: %s: service %q imports service %q", relPath, ownerService, importedService)
+				continue
+			}
+			pos := fset.Position(imp.Pos())
+			t.Errorf("%s:%d: service %q imports service %q directly (%s). Use gRPC client instead.",
+				relPath, pos.Line, ownerService, importedService, importPath)
+		}
+	})
+}
+
+// TestSharedNeverImportsServices validates that shared/ packages never import services/.
+func TestSharedNeverImportsServices(t *testing.T) {
+	root := findRepoRoot(t)
+	fset := token.NewFileSet()
+
+	sharedDir := filepath.Join(root, "shared")
+	err := filepath.Walk(sharedDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() && shouldSkipDir(info.Name()) {
+			return filepath.SkipDir
+		}
+		if info.IsDir() || !strings.HasSuffix(info.Name(), ".go") || isTestFile(path) || isGeneratedFile(path) {
+			return nil
+		}
+
+		file, parseErr := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if parseErr != nil {
+			return nil
+		}
+
+		relPath, _ := filepath.Rel(root, path)
+		for _, imp := range file.Imports {
+			importPath := strings.Trim(imp.Path.Value, `"`)
+			if strings.HasPrefix(importPath, modulePath+"/services/") {
+				if knownSharedImportsServices[relPath] {
+					t.Logf("KNOWN: %s: shared package imports service: %s", relPath, importPath)
+					continue
+				}
+				pos := fset.Position(imp.Pos())
+				t.Errorf("%s:%d: shared package imports service: %s",
+					relPath, pos.Line, importPath)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to walk shared/: %v", err)
+	}
+}
+
+// TestAdaptersNeverImportService validates that within each service, the adapters/ layer
+// does not import the service/ layer.
+func TestAdaptersNeverImportService(t *testing.T) {
+	root := findRepoRoot(t)
+	fset := token.NewFileSet()
+
+	servicesDir := filepath.Join(root, "services")
+	services := listServiceDirs(t, servicesDir)
+
+	for _, svc := range services {
+		adaptersDir := filepath.Join(servicesDir, svc, "adapters")
+		if _, err := os.Stat(adaptersDir); os.IsNotExist(err) {
+			continue
+		}
+
+		serviceImportPrefix := modulePath + "/services/" + svc + "/service"
+
+		err := filepath.Walk(adaptersDir, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() && shouldSkipDir(info.Name()) {
+				return filepath.SkipDir
+			}
+			if info.IsDir() || !strings.HasSuffix(info.Name(), ".go") || isTestFile(path) || isGeneratedFile(path) {
+				return nil
+			}
+
+			file, parseErr := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+			if parseErr != nil {
+				return nil
+			}
+
+			relPath, _ := filepath.Rel(root, path)
+			for _, imp := range file.Imports {
+				importPath := strings.Trim(imp.Path.Value, `"`)
+				if strings.HasPrefix(importPath, serviceImportPrefix) {
+					if knownAdapterImportsService[relPath] {
+						t.Logf("KNOWN: %s: adapter in %q imports service layer", relPath, svc)
+						continue
+					}
+					pos := fset.Position(imp.Pos())
+					t.Errorf("%s:%d: adapter in %q imports service layer: %s",
+						relPath, pos.Line, svc, importPath)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Errorf("failed to walk adapters for %s: %v", svc, err)
+		}
+	}
+}
+
+func listServiceDirs(t *testing.T, servicesDir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(servicesDir)
+	if err != nil {
+		t.Fatalf("failed to read services directory: %v", err)
+	}
+	var services []string
+	for _, e := range entries {
+		if e.IsDir() {
+			services = append(services, e.Name())
+		}
+	}
+	return services
+}

--- a/tests/architecture/layers_test.go
+++ b/tests/architecture/layers_test.go
@@ -253,9 +253,9 @@ func TestAdaptersNeverImportService(t *testing.T) {
 				return nil
 			}
 
-			file, parseErr := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
-			if parseErr != nil {
-				return nil
+			file, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+			if err != nil {
+				return nil //nolint:nilerr // intentionally skip unparseable files
 			}
 
 			relPath, _ := filepath.Rel(root, path)

--- a/tests/architecture/layers_test.go
+++ b/tests/architecture/layers_test.go
@@ -15,14 +15,14 @@ const modulePath = "github.com/meridianhub/meridian"
 // because they wire the application together.
 var compositionRootAllowlist = map[string]bool{
 	"cmd/meridian/wire_services.go": true,
-	"cmd/meridian/main.go":         true,
+	"cmd/meridian/main.go":          true,
 }
 
 // knownCrossServiceInternalImports tracks existing cross-service internal/ imports.
 // Do NOT add new entries — use gRPC clients instead of direct imports.
 var knownCrossServiceInternalImports = map[string]bool{
-	"cmd/ibactl/cmd/provision_defaults.go":       true,
-	"cmd/ibactl/cmd/root.go":                     true,
+	"cmd/ibactl/cmd/provision_defaults.go":        true,
+	"cmd/ibactl/cmd/root.go":                      true,
 	"services/control-plane/cmd/validate/main.go": true,
 	"services/current-account/cmd/main.go":        true,
 	"services/financial-accounting/cmd/main.go":   true,
@@ -32,11 +32,11 @@ var knownCrossServiceInternalImports = map[string]bool{
 // knownCrossServiceDomainImports tracks existing cross-service domain imports.
 // Do NOT add new entries — use gRPC clients instead of direct imports.
 var knownCrossServiceDomainImports = map[string]bool{
-	"services/api-gateway/auth_handler.go":                                   true,
-	"services/api-gateway/auth_sso_handler.go":                               true,
-	"services/api-gateway/cmd/main.go":                                       true,
-	"services/current-account/service/deposit_orchestrator.go":               true,
-	"services/current-account/service/fungibility_validator.go":              true,
+	"services/api-gateway/auth_handler.go":                                  true,
+	"services/api-gateway/auth_sso_handler.go":                              true,
+	"services/api-gateway/cmd/main.go":                                      true,
+	"services/current-account/service/deposit_orchestrator.go":              true,
+	"services/current-account/service/fungibility_validator.go":             true,
 	"services/current-account/service/grpc_account_endpoints.go":            true,
 	"services/current-account/service/server.go":                            true,
 	"services/current-account/service/withdrawal_orchestrator.go":           true,
@@ -54,19 +54,19 @@ var knownCrossServiceDomainImports = map[string]bool{
 // knownSharedImportsServices tracks shared/ files that currently import services/.
 // Do NOT add new entries — shared packages must never depend on services.
 var knownSharedImportsServices = map[string]bool{
-	"shared/pkg/valuationfeature/resolution.go": true,
-	"shared/pkg/valuationfeature/seeder.go":     true,
+	"shared/pkg/valuationfeature/resolution.go":  true,
+	"shared/pkg/valuationfeature/seeder.go":      true,
 	"shared/platform/gateway/tenant_resolver.go": true,
 }
 
 // knownAdapterImportsService tracks adapter files that import their service layer.
 // Do NOT add new entries — adapters should depend on domain, not service.
 var knownAdapterImportsService = map[string]bool{
-	"services/financial-accounting/adapters/messaging/deposit_consumer.go":    true,
-	"services/internal-account/adapters/grpc/position_keeping_client.go":     true,
-	"services/party/adapters/http/verification_webhook.go":                   true,
-	"services/payment-order/adapters/clients/reference_data_client.go":      true,
-	"services/payment-order/adapters/lock/redis_lock_client.go":             true,
+	"services/financial-accounting/adapters/messaging/deposit_consumer.go": true,
+	"services/internal-account/adapters/grpc/position_keeping_client.go":   true,
+	"services/party/adapters/http/verification_webhook.go":                 true,
+	"services/payment-order/adapters/clients/reference_data_client.go":     true,
+	"services/payment-order/adapters/lock/redis_lock_client.go":            true,
 }
 
 // TestNoInternalCrossServiceImports validates that no service imports another service's
@@ -200,9 +200,9 @@ func TestSharedNeverImportsServices(t *testing.T) {
 			return nil
 		}
 
-		file, parseErr := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
-		if parseErr != nil {
-			return nil
+		file, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if err != nil {
+			return nil //nolint:nilerr // intentionally skip unparseable files
 		}
 
 		relPath, _ := filepath.Rel(root, path)

--- a/tests/architecture/naming_test.go
+++ b/tests/architecture/naming_test.go
@@ -97,9 +97,9 @@ func TestRepositoryMethodVerbs(t *testing.T) {
 			return nil
 		}
 
-		file, parseErr := parser.ParseFile(fset, path, nil, 0)
-		if parseErr != nil {
-			return nil
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return nil //nolint:nilerr // intentionally skip unparseable files
 		}
 
 		for _, decl := range file.Decls {
@@ -149,22 +149,22 @@ func TestRepositoryMethodVerbs(t *testing.T) {
 // knownMissingComplianceDeclarations tracks repository structs that are currently
 // missing interface compliance declarations. Do NOT add new entries.
 var knownMissingComplianceDeclarations = map[string]bool{
-	"services/current-account/adapters/persistence/lien_repository.go::LienRepository":                     true,
-	"services/current-account/adapters/persistence/repository.go::Repository":                              true,
-	"services/current-account/adapters/persistence/withdrawal_repository.go::WithdrawalRepository":         true,
-	"services/financial-accounting/adapters/persistence/repository.go::LedgerRepository":                   true,
-	"services/identity/adapters/persistence/repository.go::Repository":                                     true,
-	"services/internal-account/adapters/persistence/lien_repository.go::LienRepository":                    true,
-	"services/market-information/adapters/persistence/base_repository.go::baseRepository":                  true,
-	"services/operational-gateway/adapters/persistence/connection_repository.go::ConnectionRepository":     true,
-	"services/operational-gateway/adapters/persistence/instruction_repository.go::InstructionRepository":   true,
-	"services/operational-gateway/adapters/persistence/route_repository.go::RouteRepository":               true,
+	"services/current-account/adapters/persistence/lien_repository.go::LienRepository":                       true,
+	"services/current-account/adapters/persistence/repository.go::Repository":                                true,
+	"services/current-account/adapters/persistence/withdrawal_repository.go::WithdrawalRepository":           true,
+	"services/financial-accounting/adapters/persistence/repository.go::LedgerRepository":                     true,
+	"services/identity/adapters/persistence/repository.go::Repository":                                       true,
+	"services/internal-account/adapters/persistence/lien_repository.go::LienRepository":                      true,
+	"services/market-information/adapters/persistence/base_repository.go::baseRepository":                    true,
+	"services/operational-gateway/adapters/persistence/connection_repository.go::ConnectionRepository":       true,
+	"services/operational-gateway/adapters/persistence/instruction_repository.go::InstructionRepository":     true,
+	"services/operational-gateway/adapters/persistence/route_repository.go::RouteRepository":                 true,
 	"services/party/adapters/persistence/party_type_definition_repository.go::PartyTypeDefinitionRepository": true,
-	"services/party/adapters/persistence/payment_method_repository.go::PaymentMethodRepository":            true,
-	"services/party/adapters/persistence/repository.go::Repository":                                        true,
-	"services/party/adapters/persistence/verification_repository.go::VerificationRepository":               true,
-	"services/payment-order/adapters/persistence/saga_execution_repository.go::SagaExecutionRepository":   true,
-	"services/position-keeping/adapters/persistence/postgres_repository.go::PostgresRepository":            true,
+	"services/party/adapters/persistence/payment_method_repository.go::PaymentMethodRepository":              true,
+	"services/party/adapters/persistence/repository.go::Repository":                                          true,
+	"services/party/adapters/persistence/verification_repository.go::VerificationRepository":                 true,
+	"services/payment-order/adapters/persistence/saga_execution_repository.go::SagaExecutionRepository":      true,
+	"services/position-keeping/adapters/persistence/postgres_repository.go::PostgresRepository":              true,
 }
 
 // TestInterfaceComplianceDeclarations validates that persistence repository implementations
@@ -191,9 +191,9 @@ func TestInterfaceComplianceDeclarations(t *testing.T) {
 			return nil
 		}
 
-		file, parseErr := parser.ParseFile(fset, path, nil, 0)
-		if parseErr != nil {
-			return nil
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return nil //nolint:nilerr // intentionally skip unparseable files
 		}
 
 		// Find struct types that look like repository implementations.

--- a/tests/architecture/naming_test.go
+++ b/tests/architecture/naming_test.go
@@ -1,0 +1,323 @@
+package architecture_test
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// errPattern matches exported error variables following ErrEntityAction or ErrEntity convention.
+var errPattern = regexp.MustCompile(`^Err[A-Z][a-zA-Z]*$`)
+
+// TestDomainErrorNaming validates that exported error variables in domain/errors.go files
+// follow the ErrEntityAction naming pattern.
+func TestDomainErrorNaming(t *testing.T) {
+	root := findRepoRoot(t)
+	fset := token.NewFileSet()
+
+	errFiles := findDomainErrorFiles(t, root)
+	if len(errFiles) == 0 {
+		t.Fatal("found no domain/errors.go files — something is wrong with the search")
+	}
+
+	for _, path := range errFiles {
+		relPath, _ := filepath.Rel(root, path)
+
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Errorf("could not parse %s: %v", relPath, err)
+			continue
+		}
+
+		for _, decl := range file.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+			if !ok || genDecl.Tok != token.VAR {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for _, name := range vs.Names {
+					if !name.IsExported() {
+						continue
+					}
+					if !strings.HasPrefix(name.Name, "Err") {
+						continue
+					}
+					if !errPattern.MatchString(name.Name) {
+						pos := fset.Position(name.Pos())
+						t.Errorf("%s:%d: error variable %q does not follow ErrEntityAction pattern. See docs/guides/service-file-conventions.md",
+							relPath, pos.Line, name.Name)
+					}
+				}
+			}
+		}
+	}
+}
+
+// repositoryMethodVerbs are the standard verb prefixes for repository methods.
+var repositoryMethodVerbs = []string{
+	"Create", "Find", "Update", "List", "Delete",
+	"Save", "Count", "Exists", "Get", "Remove", "Upsert",
+	// Domain-specific verbs common in this codebase.
+	"Insert", "Record", "Query", "Retrieve", "Load",
+	"Mark", "Sum", "Is", "Soft",
+}
+
+// TestRepositoryMethodVerbs validates that methods on types ending in "Repository"
+// use standard verb prefixes.
+func TestRepositoryMethodVerbs(t *testing.T) {
+	root := findRepoRoot(t)
+	fset := token.NewFileSet()
+	var violations []string
+
+	servicesDir := filepath.Join(root, "services")
+	err := filepath.Walk(servicesDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if shouldSkipDir(info.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(info.Name(), ".go") || isTestFile(path) || isGeneratedFile(path) {
+			return nil
+		}
+		if !strings.Contains(path, "/domain/") {
+			return nil
+		}
+
+		file, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return nil
+		}
+
+		for _, decl := range file.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+			if !ok || genDecl.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok || !strings.HasSuffix(ts.Name.Name, "Repository") {
+					continue
+				}
+				iface, ok := ts.Type.(*ast.InterfaceType)
+				if !ok || iface.Methods == nil {
+					continue
+				}
+				for _, method := range iface.Methods.List {
+					if len(method.Names) == 0 {
+						continue // embedded interface
+					}
+					methodName := method.Names[0].Name
+					if !method.Names[0].IsExported() {
+						continue
+					}
+					if !hasStandardVerb(methodName) {
+						pos := fset.Position(method.Pos())
+						relPath, _ := filepath.Rel(root, path)
+						violations = append(violations, fmt.Sprintf(
+							"%s:%d: repository method %s.%s does not start with a standard verb (%s). See docs/guides/service-file-conventions.md",
+							relPath, pos.Line, ts.Name.Name, methodName, strings.Join(repositoryMethodVerbs, "/"),
+						))
+					}
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to walk services: %v", err)
+	}
+
+	for _, v := range violations {
+		t.Error(v)
+	}
+}
+
+// knownMissingComplianceDeclarations tracks repository structs that are currently
+// missing interface compliance declarations. Do NOT add new entries.
+var knownMissingComplianceDeclarations = map[string]bool{
+	"services/current-account/adapters/persistence/lien_repository.go::LienRepository":                     true,
+	"services/current-account/adapters/persistence/repository.go::Repository":                              true,
+	"services/current-account/adapters/persistence/withdrawal_repository.go::WithdrawalRepository":         true,
+	"services/financial-accounting/adapters/persistence/repository.go::LedgerRepository":                   true,
+	"services/identity/adapters/persistence/repository.go::Repository":                                     true,
+	"services/internal-account/adapters/persistence/lien_repository.go::LienRepository":                    true,
+	"services/market-information/adapters/persistence/base_repository.go::baseRepository":                  true,
+	"services/operational-gateway/adapters/persistence/connection_repository.go::ConnectionRepository":     true,
+	"services/operational-gateway/adapters/persistence/instruction_repository.go::InstructionRepository":   true,
+	"services/operational-gateway/adapters/persistence/route_repository.go::RouteRepository":               true,
+	"services/party/adapters/persistence/party_type_definition_repository.go::PartyTypeDefinitionRepository": true,
+	"services/party/adapters/persistence/payment_method_repository.go::PaymentMethodRepository":            true,
+	"services/party/adapters/persistence/repository.go::Repository":                                        true,
+	"services/party/adapters/persistence/verification_repository.go::VerificationRepository":               true,
+	"services/payment-order/adapters/persistence/saga_execution_repository.go::SagaExecutionRepository":   true,
+	"services/position-keeping/adapters/persistence/postgres_repository.go::PostgresRepository":            true,
+}
+
+// TestInterfaceComplianceDeclarations validates that persistence repository implementations
+// include a compile-time interface compliance check: var _ domain.XxxRepository = (*XxxRepository)(nil)
+func TestInterfaceComplianceDeclarations(t *testing.T) {
+	root := findRepoRoot(t)
+	fset := token.NewFileSet()
+
+	servicesDir := filepath.Join(root, "services")
+	err := filepath.Walk(servicesDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if shouldSkipDir(info.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(info.Name(), ".go") || isTestFile(path) || isGeneratedFile(path) {
+			return nil
+		}
+		if !strings.Contains(path, "/adapters/persistence/") {
+			return nil
+		}
+
+		file, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return nil
+		}
+
+		// Find struct types that look like repository implementations.
+		structNames := map[string]bool{}
+		for _, decl := range file.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+			if !ok || genDecl.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				if _, ok := ts.Type.(*ast.StructType); ok && strings.HasSuffix(ts.Name.Name, "Repository") {
+					structNames[ts.Name.Name] = true
+				}
+			}
+		}
+
+		if len(structNames) == 0 {
+			return nil
+		}
+
+		// Check for var _ SomeType = (*StructName)(nil) declarations.
+		hasComplianceCheck := map[string]bool{}
+		for _, decl := range file.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+			if !ok || genDecl.Tok != token.VAR {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok || len(vs.Names) != 1 || vs.Names[0].Name != "_" {
+					continue
+				}
+				for _, val := range vs.Values {
+					call, ok := val.(*ast.CallExpr)
+					if !ok || len(call.Args) != 1 {
+						continue
+					}
+					ident, ok := call.Args[0].(*ast.Ident)
+					if !ok || ident.Name != "nil" {
+						continue
+					}
+					paren, ok := call.Fun.(*ast.ParenExpr)
+					if !ok {
+						continue
+					}
+					star, ok := paren.X.(*ast.StarExpr)
+					if !ok {
+						continue
+					}
+					if id, ok := star.X.(*ast.Ident); ok {
+						hasComplianceCheck[id.Name] = true
+					}
+				}
+			}
+		}
+
+		relPath, _ := filepath.Rel(root, path)
+		for name := range structNames {
+			if hasComplianceCheck[name] {
+				continue
+			}
+			key := relPath + "::" + name
+			if knownMissingComplianceDeclarations[key] {
+				t.Logf("KNOWN: %s: repository struct %s missing interface compliance declaration", relPath, name)
+				continue
+			}
+			t.Errorf("%s: repository struct %s is missing interface compliance declaration (var _ SomeInterface = (*%s)(nil)). See docs/guides/service-file-conventions.md",
+				relPath, name, name)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to walk services: %v", err)
+	}
+}
+
+func hasStandardVerb(methodName string) bool {
+	for _, verb := range repositoryMethodVerbs {
+		if strings.HasPrefix(methodName, verb) {
+			return true
+		}
+	}
+	return false
+}
+
+func findDomainErrorFiles(t *testing.T, root string) []string {
+	t.Helper()
+	var files []string
+	servicesDir := filepath.Join(root, "services")
+	err := filepath.Walk(servicesDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() && shouldSkipDir(info.Name()) {
+			return filepath.SkipDir
+		}
+		if info.Name() == "errors.go" && strings.Contains(filepath.Dir(path), "/domain") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to walk services for error files: %v", err)
+	}
+
+	// Also check shared packages.
+	sharedDir := filepath.Join(root, "shared")
+	_ = filepath.Walk(sharedDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() && shouldSkipDir(info.Name()) {
+			return filepath.SkipDir
+		}
+		if info.Name() == "errors.go" {
+			files = append(files, path)
+		}
+		return nil
+	})
+
+	return files
+}

--- a/tests/architecture/naming_test.go
+++ b/tests/architecture/naming_test.go
@@ -28,6 +28,7 @@ func TestDomainErrorNaming(t *testing.T) {
 
 	for _, path := range errFiles {
 		relPath, _ := filepath.Rel(root, path)
+		relPath = filepath.ToSlash(relPath)
 
 		file, err := parser.ParseFile(fset, path, nil, 0)
 		if err != nil {
@@ -127,6 +128,7 @@ func TestRepositoryMethodVerbs(t *testing.T) {
 					if !hasStandardVerb(methodName) {
 						pos := fset.Position(method.Pos())
 						relPath, _ := filepath.Rel(root, path)
+						relPath = filepath.ToSlash(relPath)
 						violations = append(violations, fmt.Sprintf(
 							"%s:%d: repository method %s.%s does not start with a standard verb (%s). See docs/guides/service-file-conventions.md",
 							relPath, pos.Line, ts.Name.Name, methodName, strings.Join(repositoryMethodVerbs, "/"),
@@ -255,6 +257,7 @@ func TestInterfaceComplianceDeclarations(t *testing.T) {
 		}
 
 		relPath, _ := filepath.Rel(root, path)
+		relPath = filepath.ToSlash(relPath)
 		for name := range structNames {
 			if hasComplianceCheck[name] {
 				continue
@@ -277,8 +280,16 @@ func TestInterfaceComplianceDeclarations(t *testing.T) {
 
 func hasStandardVerb(methodName string) bool {
 	for _, verb := range repositoryMethodVerbs {
-		if strings.HasPrefix(methodName, verb) {
+		if methodName == verb {
 			return true
+		}
+		if strings.HasPrefix(methodName, verb) {
+			// Verify the character after the verb is uppercase (word boundary).
+			// This prevents "Is" from matching "Issue" or "Soft" from matching "Software".
+			rest := methodName[len(verb):]
+			if len(rest) > 0 && rest[0] >= 'A' && rest[0] <= 'Z' {
+				return true
+			}
 		}
 	}
 	return false

--- a/tests/architecture/size_test.go
+++ b/tests/architecture/size_test.go
@@ -1,0 +1,185 @@
+package architecture_test
+
+import (
+	"bufio"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"testing"
+)
+
+const (
+	maxFileLines     = 800
+	maxFunctionLines = 60
+
+	// baselineOversizedFunctions is the number of functions exceeding maxFunctionLines
+	// at the time this test was introduced. The test fails if this count increases,
+	// preventing new violations while allowing gradual cleanup.
+	// Last measured: 2025-03-19 (develop branch at 6d7d1003)
+	baselineOversizedFunctions = 455
+)
+
+// knownOversizedFiles tracks files that currently exceed the size limit.
+// Each entry must be removed when the file is split to comply.
+// Do NOT add new entries — split large files instead.
+var knownOversizedFiles = map[string]bool{
+	"services/control-plane/internal/applier/grpc_handler.go":               true,
+	"services/control-plane/internal/generator/validate_fix.go":             true,
+	"services/current-account/service/saga_handlers.go":                     true,
+	"services/identity/service/server.go":                                   true,
+	"services/internal-account/service/server.go":                           true,
+	"services/market-information/service/observation_service.go":            true,
+	"services/mcp-server/internal/tools/economy.go":                         true,
+	"services/mcp-server/internal/tools/refdata.go":                         true,
+	"services/party/adapters/persistence/repository.go":                     true,
+	"services/position-keeping/adapters/persistence/position_repository.go": true,
+	"services/reconciliation/service/server.go":                             true,
+	"services/reference-data/handler/account_type_handler.go":               true,
+	"services/reference-data/registry/postgres_registry.go":                 true,
+	"services/reference-data/saga/grpc_handler.go":                          true,
+	"services/reference-data/saga/postgres_registry.go":                     true,
+	"shared/pkg/saga/schema/schema.go":                                      true,
+}
+
+// TestFileSize validates that no non-test, non-generated Go file exceeds maxFileLines.
+// Known violations are tracked in knownOversizedFiles — the test fails only on NEW violations.
+// See docs/guides/service-file-conventions.md for guidance on splitting large files.
+func TestFileSize(t *testing.T) {
+	root := findRepoRoot(t)
+
+	walkGoFiles(t, root, func(path string, relPath string) {
+		lines := countLines(t, path)
+		if lines > maxFileLines {
+			if knownOversizedFiles[relPath] {
+				t.Logf("KNOWN: %s: %d lines (max %d)", relPath, lines, maxFileLines)
+				return
+			}
+			t.Errorf("%s: %d lines (max %d). See docs/guides/service-file-conventions.md",
+				relPath, lines, maxFileLines)
+		}
+	})
+}
+
+// TestFileSizeAllowlistAccuracy checks that every entry in knownOversizedFiles still exists
+// and is still over the limit. Stale entries should be removed.
+func TestFileSizeAllowlistAccuracy(t *testing.T) {
+	root := findRepoRoot(t)
+
+	for relPath := range knownOversizedFiles {
+		absPath := root + "/" + relPath
+		info, err := os.Stat(absPath)
+		if os.IsNotExist(err) {
+			t.Errorf("allowlist entry %q: file no longer exists — remove from knownOversizedFiles", relPath)
+			continue
+		}
+		if err != nil || info.IsDir() {
+			t.Errorf("allowlist entry %q: not a regular file — remove from knownOversizedFiles", relPath)
+			continue
+		}
+		lines := countLines(t, absPath)
+		if lines <= maxFileLines {
+			t.Errorf("allowlist entry %q: now %d lines (limit %d) — remove from knownOversizedFiles", relPath, lines, maxFileLines)
+		}
+	}
+}
+
+// TestFunctionSize uses a ratchet approach: it counts the total number of functions
+// exceeding maxFunctionLines and fails if the count exceeds the baseline.
+// This prevents new violations while allowing gradual cleanup without maintaining
+// an individual allowlist for 400+ existing violations.
+//
+// To reduce the baseline: refactor oversized functions, then lower baselineOversizedFunctions.
+// See docs/guides/service-file-conventions.md for guidance.
+func TestFunctionSize(t *testing.T) {
+	root := findRepoRoot(t)
+	fset := token.NewFileSet()
+
+	type violation struct {
+		relPath string
+		line    int
+		name    string
+		lines   int
+	}
+	var violations []violation
+
+	walkGoFiles(t, root, func(path string, relPath string) {
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Logf("WARNING: could not parse %s: %v", relPath, err)
+			return
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			fd, ok := n.(*ast.FuncDecl)
+			if !ok {
+				return true
+			}
+
+			start := fset.Position(fd.Pos())
+			end := fset.Position(fd.End())
+			lines := end.Line - start.Line + 1
+
+			if lines > maxFunctionLines {
+				name := fd.Name.Name
+				if fd.Recv != nil && len(fd.Recv.List) > 0 {
+					name = fmt.Sprintf("(%s).%s", exprName(fd.Recv.List[0].Type), fd.Name.Name)
+				}
+				violations = append(violations, violation{relPath, start.Line, name, lines})
+			}
+			return true
+		})
+	})
+
+	t.Logf("Functions exceeding %d lines: %d (baseline: %d)", maxFunctionLines, len(violations), baselineOversizedFunctions)
+
+	if len(violations) > baselineOversizedFunctions {
+		t.Errorf("Function size violations increased from %d to %d. New oversized functions:",
+			baselineOversizedFunctions, len(violations))
+		// Log all violations to help identify the new ones.
+		for _, v := range violations {
+			t.Logf("  %s:%d: %s (%d lines)", v.relPath, v.line, v.name, v.lines)
+		}
+	}
+
+	if len(violations) < baselineOversizedFunctions-5 {
+		t.Logf("HINT: Baseline can be reduced from %d to %d — update baselineOversizedFunctions in size_test.go",
+			baselineOversizedFunctions, len(violations))
+	}
+}
+
+func countLines(t *testing.T, path string) int {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("failed to open %s: %v", path, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	count := 0
+	for scanner.Scan() {
+		count++
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("failed to scan %s: %v", path, err)
+	}
+	return count
+}
+
+// exprName returns a human-readable name for a receiver type expression.
+func exprName(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.StarExpr:
+		return "*" + exprName(e.X)
+	case *ast.IndexExpr:
+		return exprName(e.X)
+	case *ast.IndexListExpr:
+		return exprName(e.X)
+	default:
+		return "?"
+	}
+}

--- a/tests/architecture/structure_test.go
+++ b/tests/architecture/structure_test.go
@@ -51,6 +51,16 @@ func TestServiceServerGoExists(t *testing.T) {
 	}
 }
 
+// knownMissingDocGo tracks shared packages that currently lack doc.go.
+// Do NOT add new entries — create doc.go for new packages.
+var knownMissingDocGo = map[string]bool{
+	"shared/pkg/saga/schema":                 true,
+	"shared/pkg/saga/validation":             true,
+	"shared/pkg/valuation/internal/builtins": true,
+	"shared/platform/events/topics":          true,
+	"shared/platform/quantity/currency":      true,
+}
+
 // TestSharedPackagesHaveDocGo validates that all shared/pkg/ and shared/platform/
 // packages have a doc.go file for package documentation.
 func TestSharedPackagesHaveDocGo(t *testing.T) {
@@ -91,44 +101,50 @@ func TestServiceDirectoryLayout(t *testing.T) {
 func checkDocGo(t *testing.T, root string, dir string) {
 	t.Helper()
 
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
 		}
-		t.Fatalf("failed to read directory %s: %v", dir, err)
-	}
-
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
+		if !info.IsDir() {
+			return nil
 		}
-		if shouldSkipDir(e.Name()) {
-			continue
+		if shouldSkipDir(info.Name()) {
+			return filepath.SkipDir
 		}
-
-		pkgDir := filepath.Join(dir, e.Name())
+		// Skip the root directory itself.
+		if path == dir {
+			return nil
+		}
 
 		// Only check directories that contain .go files (are Go packages).
-		hasGoFiles := false
-		subEntries, err := os.ReadDir(pkgDir)
-		if err != nil {
-			continue
+		entries, readErr := os.ReadDir(path)
+		if readErr != nil {
+			return readErr
 		}
-		for _, sub := range subEntries {
-			if !sub.IsDir() && filepath.Ext(sub.Name()) == ".go" {
+		hasGoFiles := false
+		for _, e := range entries {
+			if !e.IsDir() && filepath.Ext(e.Name()) == ".go" {
 				hasGoFiles = true
 				break
 			}
 		}
 		if !hasGoFiles {
-			continue
+			return nil
 		}
 
-		docPath := filepath.Join(pkgDir, "doc.go")
-		if _, err := os.Stat(docPath); os.IsNotExist(err) {
-			relPath, _ := filepath.Rel(root, pkgDir)
+		docPath := filepath.Join(path, "doc.go")
+		if _, statErr := os.Stat(docPath); os.IsNotExist(statErr) {
+			relPath, _ := filepath.Rel(root, path)
+			relPath = filepath.ToSlash(relPath)
+			if knownMissingDocGo[relPath] {
+				t.Logf("KNOWN: %s: missing doc.go", relPath)
+				return nil
+			}
 			t.Errorf("%s: missing doc.go", relPath)
 		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to walk %s: %v", dir, err)
 	}
 }

--- a/tests/architecture/structure_test.go
+++ b/tests/architecture/structure_test.go
@@ -1,0 +1,134 @@
+package architecture_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// nonStandardServices are excluded from standard service layout checks
+// because they follow different architectural patterns.
+var nonStandardServices = map[string]bool{
+	"api-gateway":   true,
+	"event-router":  true,
+	"control-plane": true,
+	"mcp-server":    true,
+}
+
+// servicesWithoutServerGo tracks services that lack service/server.go.
+// Do NOT add new entries — all gRPC services should have server.go.
+var servicesWithoutServerGo = map[string]bool{
+	"forecasting":    true,
+	"reference-data": true,
+}
+
+// servicesWithNonStandardLayout tracks services that don't follow standard layout.
+// Do NOT add new entries.
+var servicesWithNonStandardLayout = map[string]bool{
+	"financial-gateway": true,
+	"forecasting":       true,
+	"reference-data":    true,
+}
+
+// TestServiceServerGoExists validates that all gRPC services have a service/server.go file.
+func TestServiceServerGoExists(t *testing.T) {
+	root := findRepoRoot(t)
+	servicesDir := filepath.Join(root, "services")
+	services := listServiceDirs(t, servicesDir)
+
+	for _, svc := range services {
+		if nonStandardServices[svc] {
+			continue
+		}
+		serverPath := filepath.Join(servicesDir, svc, "service", "server.go")
+		if _, err := os.Stat(serverPath); os.IsNotExist(err) {
+			if servicesWithoutServerGo[svc] {
+				t.Logf("KNOWN: services/%s: missing service/server.go", svc)
+				continue
+			}
+			t.Errorf("services/%s: missing service/server.go", svc)
+		}
+	}
+}
+
+// TestSharedPackagesHaveDocGo validates that all shared/pkg/ and shared/platform/
+// packages have a doc.go file for package documentation.
+func TestSharedPackagesHaveDocGo(t *testing.T) {
+	root := findRepoRoot(t)
+
+	dirs := []string{
+		filepath.Join(root, "shared", "pkg"),
+		filepath.Join(root, "shared", "platform"),
+	}
+
+	for _, dir := range dirs {
+		checkDocGo(t, root, dir)
+	}
+}
+
+// TestServiceDirectoryLayout validates that standard services have the expected
+// directory structure: domain/, adapters/persistence/, service/.
+func TestServiceDirectoryLayout(t *testing.T) {
+	root := findRepoRoot(t)
+	servicesDir := filepath.Join(root, "services")
+	services := listServiceDirs(t, servicesDir)
+
+	requiredDirs := []string{"domain", "adapters/persistence", "service"}
+
+	for _, svc := range services {
+		if nonStandardServices[svc] || servicesWithNonStandardLayout[svc] {
+			continue
+		}
+		for _, dir := range requiredDirs {
+			dirPath := filepath.Join(servicesDir, svc, dir)
+			if _, err := os.Stat(dirPath); os.IsNotExist(err) {
+				t.Errorf("services/%s: missing required directory %s/", svc, dir)
+			}
+		}
+	}
+}
+
+func checkDocGo(t *testing.T, root string, dir string) {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return
+		}
+		t.Fatalf("failed to read directory %s: %v", dir, err)
+	}
+
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if shouldSkipDir(e.Name()) {
+			continue
+		}
+
+		pkgDir := filepath.Join(dir, e.Name())
+
+		// Only check directories that contain .go files (are Go packages).
+		hasGoFiles := false
+		subEntries, err := os.ReadDir(pkgDir)
+		if err != nil {
+			continue
+		}
+		for _, sub := range subEntries {
+			if !sub.IsDir() && filepath.Ext(sub.Name()) == ".go" {
+				hasGoFiles = true
+				break
+			}
+		}
+		if !hasGoFiles {
+			continue
+		}
+
+		docPath := filepath.Join(pkgDir, "doc.go")
+		if _, err := os.Stat(docPath); os.IsNotExist(err) {
+			relPath, _ := filepath.Rel(root, pkgDir)
+			t.Errorf("%s: missing doc.go", relPath)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `tests/architecture/` package with 13 automated tests enforcing codebase conventions as contracts
- Covers file/function size limits, naming conventions, layer dependency rules, and service structure
- Uses known-violation allowlists for existing violations — tests pass today, fail on new violations
- Function size uses ratcheting baseline (455 violations) instead of individual allowlist

## Task Master

049-codebase-consistency tasks 24, 25, 26, 28.

## Test Files

| File | Tests | Approach |
|------|-------|----------|
| `size_test.go` | TestFileSize, TestFileSizeAllowlistAccuracy, TestFunctionSize | File: individual allowlist (16 files). Function: ratcheting baseline count |
| `naming_test.go` | TestDomainErrorNaming, TestRepositoryMethodVerbs, TestInterfaceComplianceDeclarations | Pattern matching via go/ast. Interface compliance has allowlist (16 repos) |
| `layers_test.go` | TestNoInternalCrossServiceImports, TestNoCrossServiceDomainImports, TestSharedNeverImportsServices, TestAdaptersNeverImportService | Import analysis via go/parser. All have known-violation allowlists |
| `structure_test.go` | TestServiceServerGoExists, TestSharedPackagesHaveDocGo, TestServiceDirectoryLayout | Directory existence checks with exclusion lists for non-standard services |
| `helpers_test.go` | Shared utilities | findRepoRoot, shouldSkipDir, isGeneratedFile, walkGoFiles |

## Test plan

- [x] `go test ./tests/architecture/... -v` — all 13 tests pass
- [ ] CI passes