### PR TITLE
test: Add unit tests for shared/pkg/mapping and shared/pkg/money

### DIFF
--- a/shared/pkg/mapping/dryrun_test.go
+++ b/shared/pkg/mapping/dryrun_test.go
@@ -1,0 +1,175 @@
+package mapping
+
+import (
+	"testing"
+
+	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDryRunInbound_Success(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "name", InternalPath: "full_name"},
+		},
+	}
+	result := e.DryRunInbound(def, []byte(`{"name":"Alice"}`))
+	assert.True(t, result.ValidationPassed)
+	assert.Empty(t, result.TransformError)
+	assert.Contains(t, result.TransformedJSON, "Alice")
+	assert.GreaterOrEqual(t, result.ExecutionTimeMs, int64(0))
+	require.Len(t, result.FieldTraces, 1)
+	assert.Equal(t, "name", result.FieldTraces[0].SourcePath)
+	assert.Equal(t, "full_name", result.FieldTraces[0].TargetPath)
+	assert.Equal(t, "none", result.FieldTraces[0].TransformType)
+}
+
+func TestDryRunInbound_ValidationFails(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		InboundValidationCel: `payload.amount > 0`,
+	}
+	result := e.DryRunInbound(def, []byte(`{"amount":-1}`))
+	assert.False(t, result.ValidationPassed)
+	assert.NotEmpty(t, result.ValidationErrors)
+	assert.Empty(t, result.TransformedJSON)
+}
+
+func TestDryRunInbound_TransformError(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "status",
+				InternalPath: "status",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_EnumMapping{
+						EnumMapping: &mappingv1.EnumMapping{
+							Values: map[string]string{"a": "A"},
+						},
+					},
+				},
+			},
+		},
+	}
+	result := e.DryRunInbound(def, []byte(`{"status":"unmapped"}`))
+	assert.True(t, result.ValidationPassed) // Validation passed, transform failed
+	assert.NotEmpty(t, result.TransformError)
+}
+
+func TestDryRunInbound_WithIdempotency(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "id", InternalPath: "id"},
+		},
+		Idempotency: &mappingv1.IdempotencyConfig{
+			SourceSelector: "id",
+		},
+	}
+	result := e.DryRunInbound(def, []byte(`{"id":"key-1"}`))
+	assert.True(t, result.ValidationPassed)
+	assert.Equal(t, "key-1", result.IdempotencyKey)
+}
+
+func TestDryRunOutbound_Success(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{InternalPath: "full_name", ExternalPath: "name"},
+		},
+	}
+	result := e.DryRunOutbound(def, []byte(`{"full_name":"Bob"}`))
+	assert.True(t, result.ValidationPassed)
+	assert.Empty(t, result.TransformError)
+	assert.Contains(t, result.TransformedJSON, "Bob")
+	require.Len(t, result.FieldTraces, 1)
+	assert.Equal(t, "full_name", result.FieldTraces[0].SourcePath)
+	assert.Equal(t, "name", result.FieldTraces[0].TargetPath)
+}
+
+func TestDryRunOutbound_ValidationFails(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		OutboundValidationCel: `payload.amount > 0`,
+	}
+	result := e.DryRunOutbound(def, []byte(`{"amount":-1}`))
+	assert.False(t, result.ValidationPassed)
+	assert.NotEmpty(t, result.ValidationErrors)
+}
+
+func TestDryRunOutbound_TransformError(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				InternalPath: "date",
+				ExternalPath: "date",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_DateFormat{
+						DateFormat: "02/01/2006",
+					},
+				},
+			},
+		},
+	}
+	result := e.DryRunOutbound(def, []byte(`{"date":"bad-date"}`))
+	assert.True(t, result.ValidationPassed)
+	assert.NotEmpty(t, result.TransformError)
+}
+
+func TestTransformTypeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		ft       *mappingv1.FieldTransform
+		expected string
+	}{
+		{"nil", nil, "none"},
+		{"cel", &mappingv1.FieldTransform{Transform: &mappingv1.FieldTransform_Cel{Cel: &mappingv1.CelTransform{}}}, "cel"},
+		{"enum", &mappingv1.FieldTransform{Transform: &mappingv1.FieldTransform_EnumMapping{EnumMapping: &mappingv1.EnumMapping{}}}, "enum_mapping"},
+		{"date", &mappingv1.FieldTransform{Transform: &mappingv1.FieldTransform_DateFormat{DateFormat: "2006"}}, "date_format"},
+		{"default", &mappingv1.FieldTransform{Transform: &mappingv1.FieldTransform_DefaultValue{DefaultValue: "x"}}, "default_value"},
+		{"flatten", &mappingv1.FieldTransform{Transform: &mappingv1.FieldTransform_AttributeFlatten{AttributeFlatten: &mappingv1.AttributeFlatten{}}}, "attribute_flatten"},
+		{"empty", &mappingv1.FieldTransform{}, "none"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, transformTypeName(tt.ft))
+		})
+	}
+}
+
+func TestRawOrEmpty(t *testing.T) {
+	assert.Equal(t, "", rawOrEmpty(Extract(`{}`, "missing")))
+	assert.Equal(t, `"hello"`, rawOrEmpty(Extract(`{"a":"hello"}`, "a")))
+}
+
+func TestToJSONString(t *testing.T) {
+	assert.Equal(t, "null", toJSONString(nil))
+	assert.Equal(t, `"hello"`, toJSONString("hello"))
+	assert.Equal(t, "42", toJSONString(42))
+	assert.Equal(t, "true", toJSONString(true))
+}
+
+func TestDryRunInbound_FieldTraceWithTransformError(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "date",
+				InternalPath: "date",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_DateFormat{
+						DateFormat: "02/01/2006",
+					},
+				},
+			},
+		},
+	}
+	result := e.DryRunInbound(def, []byte(`{"date":"bad"}`))
+	require.Len(t, result.FieldTraces, 1)
+	assert.Contains(t, result.FieldTraces[0].TransformedValue, "<error:")
+	assert.Equal(t, "date_format", result.FieldTraces[0].TransformType)
+}

--- a/shared/pkg/mapping/engine_batch_test.go
+++ b/shared/pkg/mapping/engine_batch_test.go
@@ -1,0 +1,138 @@
+package mapping
+
+import (
+	"testing"
+
+	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransformInboundBatch_Simple(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		IsBatch:         true,
+		BatchTargetPath: "items",
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "name", InternalPath: "name"},
+		},
+	}
+	input := `[{"name":"Alice"},{"name":"Bob"}]`
+	results, err := e.TransformInboundBatch(def, []byte(input))
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Contains(t, string(results[0].ProtoJSON), "Alice")
+	assert.Contains(t, string(results[1].ProtoJSON), "Bob")
+}
+
+func TestTransformInboundBatch_InvalidJSON(t *testing.T) {
+	e := newTestEngine(t)
+	_, err := e.TransformInboundBatch(&mappingv1.MappingDefinition{}, []byte(`not json`))
+	require.ErrorIs(t, err, ErrInvalidJSON)
+}
+
+func TestTransformInboundBatch_NotArray(t *testing.T) {
+	e := newTestEngine(t)
+	_, err := e.TransformInboundBatch(&mappingv1.MappingDefinition{}, []byte(`{"key":"value"}`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidJSON)
+}
+
+func TestTransformInboundBatch_EmptyArray(t *testing.T) {
+	e := newTestEngine(t)
+	results, err := e.TransformInboundBatch(&mappingv1.MappingDefinition{}, []byte(`[]`))
+	require.NoError(t, err)
+	assert.Nil(t, results)
+}
+
+func TestTransformInboundBatch_WithIdempotency(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		IsBatch:         true,
+		BatchTargetPath: "items",
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "id", InternalPath: "id"},
+		},
+		Idempotency: &mappingv1.IdempotencyConfig{
+			SourceSelector: "id",
+		},
+	}
+	input := `[{"id":"a"},{"id":"b"}]`
+	results, err := e.TransformInboundBatch(def, []byte(input))
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, "a:0", results[0].IdempotencyKey)
+	assert.Equal(t, "b:1", results[1].IdempotencyKey)
+}
+
+func TestTransformInboundBatch_NoIdempotency(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		IsBatch:         true,
+		BatchTargetPath: "items",
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "x", InternalPath: "x"},
+		},
+	}
+	results, err := e.TransformInboundBatch(def, []byte(`[{"x":1}]`))
+	require.NoError(t, err)
+	assert.Empty(t, results[0].IdempotencyKey)
+}
+
+func TestTransformInboundBatch_ValidationFailure(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		IsBatch:              true,
+		BatchTargetPath:      "items",
+		InboundValidationCel: `payload.amount > 0`,
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "amount", InternalPath: "amount"},
+		},
+	}
+	input := `[{"amount":10},{"amount":-1}]`
+	_, err := e.TransformInboundBatch(def, []byte(input))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "element 1")
+}
+
+func TestTransformOutboundBatch_Simple(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		IsBatch:         true,
+		BatchTargetPath: "items",
+		Fields: []*mappingv1.FieldCorrespondence{
+			{InternalPath: "name", ExternalPath: "display_name"},
+		},
+	}
+	input := `{"items":[{"name":"Alice"},{"name":"Bob"}]}`
+	result, err := e.TransformOutboundBatch(def, []byte(input))
+	require.NoError(t, err)
+	assert.Contains(t, string(result), "display_name")
+	assert.Contains(t, string(result), "Alice")
+}
+
+func TestTransformOutboundBatch_InvalidJSON(t *testing.T) {
+	e := newTestEngine(t)
+	_, err := e.TransformOutboundBatch(&mappingv1.MappingDefinition{}, []byte(`bad`))
+	require.ErrorIs(t, err, ErrInvalidJSON)
+}
+
+func TestTransformOutboundBatch_MissingPath(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		BatchTargetPath: "items",
+	}
+	result, err := e.TransformOutboundBatch(def, []byte(`{"other":"val"}`))
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(result))
+}
+
+func TestTransformOutboundBatch_NotArray(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		BatchTargetPath: "items",
+	}
+	result, err := e.TransformOutboundBatch(def, []byte(`{"items":"not_array"}`))
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(result))
+}

--- a/shared/pkg/mapping/engine_test.go
+++ b/shared/pkg/mapping/engine_test.go
@@ -413,8 +413,11 @@ func TestTransformInbound_AttributeFlatten(t *testing.T) {
 	}
 	result, err := e.TransformInbound(def, []byte(`{"color":"red","size":"large"}`))
 	require.NoError(t, err)
-	assert.Contains(t, string(result.ProtoJSON), "color")
-	assert.Contains(t, string(result.ProtoJSON), "red")
+	assert.Contains(t, string(result.ProtoJSON), `"attributes":`)
+	assert.Contains(t, string(result.ProtoJSON), `"key":"color"`)
+	assert.Contains(t, string(result.ProtoJSON), `"value":"red"`)
+	assert.Contains(t, string(result.ProtoJSON), `"key":"size"`)
+	assert.Contains(t, string(result.ProtoJSON), `"value":"large"`)
 }
 
 // --- TransformOutbound ---
@@ -648,8 +651,10 @@ func TestTransformOutbound_AttributeFlatten(t *testing.T) {
 	input := `{"attributes":[{"key":"color","value":"red"},{"key":"size","value":"L"}]}`
 	result, err := e.TransformOutbound(def, []byte(input))
 	require.NoError(t, err)
-	assert.Contains(t, string(result), "color")
-	assert.Contains(t, string(result), "red")
+	assert.Contains(t, string(result), `"attrs":`)
+	assert.Contains(t, string(result), `"color":"red"`)
+	assert.Contains(t, string(result), `"size":"L"`)
+	assert.NotContains(t, string(result), `"attributes":`)
 }
 
 func TestTransformOutbound_MissingFieldSkipped(t *testing.T) {
@@ -661,8 +666,8 @@ func TestTransformOutbound_MissingFieldSkipped(t *testing.T) {
 	}
 	result, err := e.TransformOutbound(def, []byte(`{"other":"val"}`))
 	require.NoError(t, err)
-	// Field is skipped, original value preserved
 	assert.Contains(t, string(result), `"other":"val"`)
+	assert.NotContains(t, string(result), `"out":`)
 }
 
 // --- CEL cache ---

--- a/shared/pkg/mapping/engine_test.go
+++ b/shared/pkg/mapping/engine_test.go
@@ -721,4 +721,3 @@ func TestGjsonToInterface_Types(t *testing.T) {
 		})
 	}
 }
-

--- a/shared/pkg/mapping/engine_test.go
+++ b/shared/pkg/mapping/engine_test.go
@@ -1,0 +1,729 @@
+package mapping
+
+import (
+	"testing"
+
+	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestEngine(t *testing.T) *Engine {
+	t.Helper()
+	e, err := NewEngine()
+	require.NoError(t, err)
+	return e
+}
+
+// --- Engine creation ---
+
+func TestNewEngine(t *testing.T) {
+	e, err := NewEngine()
+	require.NoError(t, err)
+	assert.NotNil(t, e)
+	assert.Equal(t, 0, e.CacheLen())
+}
+
+func TestNewEngineWithCacheSize(t *testing.T) {
+	e, err := NewEngineWithCacheSize(10)
+	require.NoError(t, err)
+	assert.NotNil(t, e)
+}
+
+func TestNewEngineWithCacheSize_Invalid(t *testing.T) {
+	_, err := NewEngineWithCacheSize(0)
+	require.Error(t, err)
+}
+
+// --- TransformInbound ---
+
+func TestTransformInbound_SimpleFields(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "name", InternalPath: "full_name"},
+			{ExternalPath: "age", InternalPath: "user_age"},
+		},
+	}
+
+	result, err := e.TransformInbound(def, []byte(`{"name":"Alice","age":30}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(result.ProtoJSON), `"full_name":"Alice"`)
+	assert.Contains(t, string(result.ProtoJSON), `"user_age":30`)
+}
+
+func TestTransformInbound_InvalidJSON(t *testing.T) {
+	e := newTestEngine(t)
+	_, err := e.TransformInbound(&mappingv1.MappingDefinition{}, []byte(`not json`))
+	require.ErrorIs(t, err, ErrInvalidJSON)
+}
+
+func TestTransformInbound_NestedPath(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "user.email", InternalPath: "email"},
+		},
+	}
+	result, err := e.TransformInbound(def, []byte(`{"user":{"email":"a@b.com"}}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(result.ProtoJSON), `"email":"a@b.com"`)
+}
+
+func TestTransformInbound_MissingFieldSkipped(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "missing_field", InternalPath: "target"},
+		},
+	}
+	result, err := e.TransformInbound(def, []byte(`{"other":"value"}`))
+	require.NoError(t, err)
+	assert.Equal(t, "{}", string(result.ProtoJSON))
+}
+
+func TestTransformInbound_DefaultValue(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "missing",
+				InternalPath: "status",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_DefaultValue{DefaultValue: "PENDING"},
+				},
+			},
+		},
+	}
+	result, err := e.TransformInbound(def, []byte(`{}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(result.ProtoJSON), `"status":"PENDING"`)
+}
+
+func TestTransformInbound_ValidationCEL_Pass(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		InboundValidationCel: `payload.amount > 0`,
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "amount", InternalPath: "amount"},
+		},
+	}
+	result, err := e.TransformInbound(def, []byte(`{"amount":100}`))
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+func TestTransformInbound_ValidationCEL_Fail(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		InboundValidationCel: `payload.amount > 0`,
+	}
+	_, err := e.TransformInbound(def, []byte(`{"amount":-1}`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrValidation)
+}
+
+func TestTransformInbound_ValidationCEL_CompileError(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		InboundValidationCel: `invalid %%% expression`,
+	}
+	_, err := e.TransformInbound(def, []byte(`{}`))
+	require.Error(t, err)
+}
+
+func TestTransformInbound_EnumMapping(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "status",
+				InternalPath: "internal_status",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_EnumMapping{
+						EnumMapping: &mappingv1.EnumMapping{
+							Values: map[string]string{
+								"active":   "ACTIVE",
+								"inactive": "INACTIVE",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	result, err := e.TransformInbound(def, []byte(`{"status":"active"}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(result.ProtoJSON), `"internal_status":"ACTIVE"`)
+}
+
+func TestTransformInbound_EnumMapping_Fallback(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "status",
+				InternalPath: "internal_status",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_EnumMapping{
+						EnumMapping: &mappingv1.EnumMapping{
+							Values:   map[string]string{"a": "A"},
+							Fallback: "UNKNOWN",
+						},
+					},
+				},
+			},
+		},
+	}
+	result, err := e.TransformInbound(def, []byte(`{"status":"unmapped"}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(result.ProtoJSON), `"internal_status":"UNKNOWN"`)
+}
+
+func TestTransformInbound_EnumMapping_NoMapping(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "status",
+				InternalPath: "internal_status",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_EnumMapping{
+						EnumMapping: &mappingv1.EnumMapping{
+							Values: map[string]string{"a": "A"},
+						},
+					},
+				},
+			},
+		},
+	}
+	_, err := e.TransformInbound(def, []byte(`{"status":"unmapped"}`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEnumNotMapped)
+}
+
+func TestTransformInbound_DateFormat(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "date",
+				InternalPath: "created_at",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_DateFormat{
+						DateFormat: "02/01/2006",
+					},
+				},
+			},
+		},
+	}
+	result, err := e.TransformInbound(def, []byte(`{"date":"15/03/2024"}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(result.ProtoJSON), "2024-03-15T00:00:00Z")
+}
+
+func TestTransformInbound_DateFormat_Invalid(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "date",
+				InternalPath: "created_at",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_DateFormat{
+						DateFormat: "02/01/2006",
+					},
+				},
+			},
+		},
+	}
+	_, err := e.TransformInbound(def, []byte(`{"date":"not-a-date"}`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrDateParse)
+}
+
+func TestTransformInbound_CELTransform(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "name",
+				InternalPath: "upper_name",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_Cel{
+						Cel: &mappingv1.CelTransform{
+							InboundCel: `value.upperAscii()`,
+						},
+					},
+				},
+			},
+		},
+	}
+	result, err := e.TransformInbound(def, []byte(`{"name":"alice"}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(result.ProtoJSON), `"upper_name":"ALICE"`)
+}
+
+func TestTransformInbound_CELTransform_EmptyExpr(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "name",
+				InternalPath: "name",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_Cel{
+						Cel: &mappingv1.CelTransform{InboundCel: ""},
+					},
+				},
+			},
+		},
+	}
+	result, err := e.TransformInbound(def, []byte(`{"name":"alice"}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(result.ProtoJSON), `"name":"alice"`)
+}
+
+func TestTransformInbound_ComputedField(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "first", InternalPath: "first"},
+			{ExternalPath: "last", InternalPath: "last"},
+		},
+		InboundComputedFields: []*mappingv1.ComputedField{
+			{
+				TargetPath:    "full_name",
+				CelExpression: `mapped.first + " " + mapped.last`,
+			},
+		},
+	}
+	result, err := e.TransformInbound(def, []byte(`{"first":"John","last":"Doe"}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(result.ProtoJSON), `"full_name":"John Doe"`)
+}
+
+func TestTransformInbound_Idempotency_Selector(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "id", InternalPath: "id"},
+		},
+		Idempotency: &mappingv1.IdempotencyConfig{
+			SourceSelector: "id",
+		},
+	}
+	result, err := e.TransformInbound(def, []byte(`{"id":"tx-123"}`))
+	require.NoError(t, err)
+	assert.Equal(t, "tx-123", result.IdempotencyKey)
+}
+
+func TestTransformInbound_Idempotency_ContentHash(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "a", InternalPath: "a"},
+		},
+		Idempotency: &mappingv1.IdempotencyConfig{
+			UseContentHash:    true,
+			ContentHashFields: []string{"a", "b"},
+		},
+	}
+	result, err := e.TransformInbound(def, []byte(`{"a":"1","b":"2"}`))
+	require.NoError(t, err)
+	assert.NotEmpty(t, result.IdempotencyKey)
+	assert.Len(t, result.IdempotencyKey, 64) // SHA256 hex
+}
+
+func TestTransformInbound_Idempotency_ContentHash_MissingField(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Idempotency: &mappingv1.IdempotencyConfig{
+			UseContentHash:    true,
+			ContentHashFields: []string{"missing"},
+		},
+	}
+	_, err := e.TransformInbound(def, []byte(`{}`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrIdempotencyKey)
+}
+
+func TestTransformInbound_Idempotency_ContentHash_NoFields(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Idempotency: &mappingv1.IdempotencyConfig{
+			UseContentHash: true,
+		},
+	}
+	_, err := e.TransformInbound(def, []byte(`{}`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrIdempotencyKey)
+}
+
+func TestTransformInbound_Idempotency_SelectorMissing(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Idempotency: &mappingv1.IdempotencyConfig{
+			SourceSelector: "missing",
+		},
+	}
+	_, err := e.TransformInbound(def, []byte(`{}`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrIdempotencyKey)
+}
+
+func TestTransformInbound_Idempotency_EmptySelector(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Idempotency: &mappingv1.IdempotencyConfig{},
+	}
+	_, err := e.TransformInbound(def, []byte(`{}`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrIdempotencyKey)
+}
+
+func TestTransformInbound_NoIdempotency(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "x", InternalPath: "x"},
+		},
+	}
+	result, err := e.TransformInbound(def, []byte(`{"x":1}`))
+	require.NoError(t, err)
+	assert.Empty(t, result.IdempotencyKey)
+}
+
+func TestTransformInbound_AttributeFlatten(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "",
+				InternalPath: "attributes",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_AttributeFlatten{
+						AttributeFlatten: &mappingv1.AttributeFlatten{
+							SourceKeys: []string{"color", "size"},
+						},
+					},
+				},
+			},
+		},
+	}
+	result, err := e.TransformInbound(def, []byte(`{"color":"red","size":"large"}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(result.ProtoJSON), "color")
+	assert.Contains(t, string(result.ProtoJSON), "red")
+}
+
+// --- TransformOutbound ---
+
+func TestTransformOutbound_SimpleFields(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{InternalPath: "full_name", ExternalPath: "name"},
+		},
+	}
+	result, err := e.TransformOutbound(def, []byte(`{"full_name":"Alice"}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(result), `"name":"Alice"`)
+	// Internal path should be removed when different from external
+	assert.NotContains(t, string(result), `"full_name"`)
+}
+
+func TestTransformOutbound_SamePathNotRemoved(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{InternalPath: "name", ExternalPath: "name"},
+		},
+	}
+	result, err := e.TransformOutbound(def, []byte(`{"name":"Alice"}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(result), `"name":"Alice"`)
+}
+
+func TestTransformOutbound_InvalidJSON(t *testing.T) {
+	e := newTestEngine(t)
+	_, err := e.TransformOutbound(&mappingv1.MappingDefinition{}, []byte(`bad`))
+	require.ErrorIs(t, err, ErrInvalidJSON)
+}
+
+func TestTransformOutbound_EnumMapping(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				InternalPath: "status",
+				ExternalPath: "ext_status",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_EnumMapping{
+						EnumMapping: &mappingv1.EnumMapping{
+							Values: map[string]string{
+								"active": "ACTIVE",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	result, err := e.TransformOutbound(def, []byte(`{"status":"ACTIVE"}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(result), `"ext_status":"active"`)
+}
+
+func TestTransformOutbound_EnumMapping_OutboundFallback(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				InternalPath: "status",
+				ExternalPath: "ext_status",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_EnumMapping{
+						EnumMapping: &mappingv1.EnumMapping{
+							Values:           map[string]string{"a": "A"},
+							OutboundFallback: "unknown",
+						},
+					},
+				},
+			},
+		},
+	}
+	result, err := e.TransformOutbound(def, []byte(`{"status":"UNMAPPED"}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(result), `"ext_status":"unknown"`)
+}
+
+func TestTransformOutbound_EnumMapping_NoMapping(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				InternalPath: "status",
+				ExternalPath: "ext_status",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_EnumMapping{
+						EnumMapping: &mappingv1.EnumMapping{
+							Values: map[string]string{"a": "A"},
+						},
+					},
+				},
+			},
+		},
+	}
+	_, err := e.TransformOutbound(def, []byte(`{"status":"UNKNOWN"}`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEnumNotMapped)
+}
+
+func TestTransformOutbound_DateFormat(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				InternalPath: "created_at",
+				ExternalPath: "date",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_DateFormat{
+						DateFormat: "02/01/2006",
+					},
+				},
+			},
+		},
+	}
+	result, err := e.TransformOutbound(def, []byte(`{"created_at":"2024-03-15T00:00:00Z"}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(result), `"date":"15/03/2024"`)
+}
+
+func TestTransformOutbound_DateFormat_Invalid(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				InternalPath: "created_at",
+				ExternalPath: "date",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_DateFormat{
+						DateFormat: "02/01/2006",
+					},
+				},
+			},
+		},
+	}
+	_, err := e.TransformOutbound(def, []byte(`{"created_at":"not-rfc3339"}`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrDateParse)
+}
+
+func TestTransformOutbound_CELTransform(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				InternalPath: "name",
+				ExternalPath: "display",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_Cel{
+						Cel: &mappingv1.CelTransform{
+							OutboundCel: `value.upperAscii()`,
+						},
+					},
+				},
+			},
+		},
+	}
+	result, err := e.TransformOutbound(def, []byte(`{"name":"alice"}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(result), `"display":"ALICE"`)
+}
+
+func TestTransformOutbound_CELTransform_EmptyExpr(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				InternalPath: "name",
+				ExternalPath: "name",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_Cel{
+						Cel: &mappingv1.CelTransform{OutboundCel: ""},
+					},
+				},
+			},
+		},
+	}
+	result, err := e.TransformOutbound(def, []byte(`{"name":"alice"}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(result), `"name":"alice"`)
+}
+
+func TestTransformOutbound_ValidationCEL_Fail(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		OutboundValidationCel: `payload.amount > 0`,
+	}
+	_, err := e.TransformOutbound(def, []byte(`{"amount":-1}`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrValidation)
+}
+
+func TestTransformOutbound_ComputedField(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{InternalPath: "price", ExternalPath: "price"},
+		},
+		OutboundComputedFields: []*mappingv1.ComputedField{
+			{
+				TargetPath:    "formatted",
+				CelExpression: `"$" + string(input.price)`,
+			},
+		},
+	}
+	result, err := e.TransformOutbound(def, []byte(`{"price":42}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(result), `"formatted":"$42"`)
+}
+
+func TestTransformOutbound_AttributeFlatten(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				InternalPath: "attributes",
+				ExternalPath: "attrs",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_AttributeFlatten{
+						AttributeFlatten: &mappingv1.AttributeFlatten{
+							SourceKeys: []string{"k1"},
+						},
+					},
+				},
+			},
+		},
+	}
+	input := `{"attributes":[{"key":"color","value":"red"},{"key":"size","value":"L"}]}`
+	result, err := e.TransformOutbound(def, []byte(input))
+	require.NoError(t, err)
+	assert.Contains(t, string(result), "color")
+	assert.Contains(t, string(result), "red")
+}
+
+func TestTransformOutbound_MissingFieldSkipped(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{InternalPath: "nonexistent", ExternalPath: "out"},
+		},
+	}
+	result, err := e.TransformOutbound(def, []byte(`{"other":"val"}`))
+	require.NoError(t, err)
+	// Field is skipped, original value preserved
+	assert.Contains(t, string(result), `"other":"val"`)
+}
+
+// --- CEL cache ---
+
+func TestCELCache(t *testing.T) {
+	e := newTestEngine(t)
+	def := &mappingv1.MappingDefinition{
+		InboundValidationCel: `payload.x > 0`,
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "x", InternalPath: "x"},
+		},
+	}
+	_, err := e.TransformInbound(def, []byte(`{"x":1}`))
+	require.NoError(t, err)
+	assert.True(t, e.CacheContains(`payload.x > 0`))
+	assert.Equal(t, 1, e.CacheLen())
+
+	// Second call uses cache
+	_, err = e.TransformInbound(def, []byte(`{"x":2}`))
+	require.NoError(t, err)
+	assert.Equal(t, 1, e.CacheLen())
+}
+
+// --- EscapeJSONPath ---
+
+func TestEscapeJSONPath(t *testing.T) {
+	assert.Equal(t, `a\.b\.c`, EscapeJSONPath("a.b.c"))
+	assert.Equal(t, "simple", EscapeJSONPath("simple"))
+}
+
+// --- gjsonToInterface ---
+
+func TestGjsonToInterface_Types(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		path     string
+		expected any
+	}{
+		{"null", `{"a":null}`, "a", nil},
+		{"true", `{"a":true}`, "a", true},
+		{"false", `{"a":false}`, "a", false},
+		{"integer", `{"a":42}`, "a", int64(42)},
+		{"float", `{"a":3.14}`, "a", 3.14},
+		{"string", `{"a":"hello"}`, "a", "hello"},
+		{"array", `{"a":[1,2]}`, "a", []any{int64(1), int64(2)}},
+		{"object", `{"a":{"b":"c"}}`, "a", map[string]any{"b": "c"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Extract(tt.json, tt.path)
+			val := gjsonToInterface(result)
+			assert.Equal(t, tt.expected, val)
+		})
+	}
+}
+
+// --- Helpers ---
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/shared/pkg/mapping/engine_test.go
+++ b/shared/pkg/mapping/engine_test.go
@@ -639,9 +639,7 @@ func TestTransformOutbound_AttributeFlatten(t *testing.T) {
 				ExternalPath: "attrs",
 				Transform: &mappingv1.FieldTransform{
 					Transform: &mappingv1.FieldTransform_AttributeFlatten{
-						AttributeFlatten: &mappingv1.AttributeFlatten{
-							SourceKeys: []string{"k1"},
-						},
+						AttributeFlatten: &mappingv1.AttributeFlatten{},
 					},
 				},
 			},

--- a/shared/pkg/mapping/engine_test.go
+++ b/shared/pkg/mapping/engine_test.go
@@ -722,8 +722,3 @@ func TestGjsonToInterface_Types(t *testing.T) {
 	}
 }
 
-// --- Helpers ---
-
-func strPtr(s string) *string {
-	return &s
-}

--- a/shared/pkg/mapping/gjson_test.go
+++ b/shared/pkg/mapping/gjson_test.go
@@ -1,0 +1,68 @@
+package mapping
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtract(t *testing.T) {
+	json := `{"user":{"name":"Alice","age":30},"tags":["go","rust"]}`
+
+	t.Run("nested field", func(t *testing.T) {
+		r := Extract(json, "user.name")
+		assert.True(t, r.Exists())
+		assert.Equal(t, "Alice", r.String())
+	})
+
+	t.Run("missing path", func(t *testing.T) {
+		r := Extract(json, "user.missing")
+		assert.False(t, r.Exists())
+	})
+
+	t.Run("array path", func(t *testing.T) {
+		r := Extract(json, "tags.0")
+		assert.Equal(t, "go", r.String())
+	})
+
+	t.Run("invalid json returns zero result", func(t *testing.T) {
+		r := Extract("not json", "any")
+		assert.False(t, r.Exists())
+	})
+
+	t.Run("empty path returns whole doc", func(t *testing.T) {
+		r := Extract(json, "")
+		// gjson with empty path returns nothing
+		assert.False(t, r.Exists())
+	})
+}
+
+func TestExtractString(t *testing.T) {
+	json := `{"name":"Bob","count":42}`
+
+	assert.Equal(t, "Bob", ExtractString(json, "name"))
+	assert.Equal(t, "42", ExtractString(json, "count"))
+	assert.Equal(t, "", ExtractString(json, "missing"))
+}
+
+func TestExtractAll(t *testing.T) {
+	json := `{"items":[{"id":1},{"id":2},{"id":3}]}`
+
+	t.Run("array iteration", func(t *testing.T) {
+		results := ExtractAll(json, "items.#.id")
+		assert.Len(t, results, 3)
+		assert.Equal(t, int64(1), results[0].Int())
+		assert.Equal(t, int64(3), results[2].Int())
+	})
+
+	t.Run("non-array returns empty", func(t *testing.T) {
+		results := ExtractAll(json, "missing")
+		assert.Empty(t, results)
+	})
+
+	t.Run("scalar wrapped in array", func(t *testing.T) {
+		results := ExtractAll(`{"a":"single"}`, "a")
+		// gjson wraps a scalar in a single-element array when .Array() is called
+		assert.Len(t, results, 1)
+	})
+}

--- a/shared/pkg/mapping/gjson_test.go
+++ b/shared/pkg/mapping/gjson_test.go
@@ -30,9 +30,8 @@ func TestExtract(t *testing.T) {
 		assert.False(t, r.Exists())
 	})
 
-	t.Run("empty path returns whole doc", func(t *testing.T) {
+	t.Run("empty path returns no result", func(t *testing.T) {
 		r := Extract(json, "")
-		// gjson with empty path returns nothing
 		assert.False(t, r.Exists())
 	})
 }

--- a/shared/pkg/money/money_test.go
+++ b/shared/pkg/money/money_test.go
@@ -1,0 +1,339 @@
+package money
+
+import (
+	"math"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("valid GBP from minor units", func(t *testing.T) {
+		m, err := New("GBP", 10000)
+		require.NoError(t, err)
+		assert.Equal(t, "GBP", m.CurrencyCode())
+		assert.True(t, decimal.NewFromInt(100).Equal(m.Amount()))
+	})
+
+	t.Run("valid USD from minor units", func(t *testing.T) {
+		m, err := New("USD", 4999)
+		require.NoError(t, err)
+		assert.Equal(t, "USD", m.CurrencyCode())
+		assert.True(t, decimal.NewFromFloat(49.99).Equal(m.Amount()))
+	})
+
+	t.Run("JPY zero precision", func(t *testing.T) {
+		m, err := New("JPY", 1000)
+		require.NoError(t, err)
+		assert.Equal(t, "JPY", m.CurrencyCode())
+		assert.True(t, decimal.NewFromInt(1000).Equal(m.Amount()))
+	})
+
+	t.Run("lowercase currency normalised", func(t *testing.T) {
+		m, err := New("gbp", 500)
+		require.NoError(t, err)
+		assert.Equal(t, "GBP", m.CurrencyCode())
+	})
+
+	t.Run("invalid currency returns error", func(t *testing.T) {
+		_, err := New("INVALID", 100)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidCurrency)
+	})
+
+	t.Run("zero amount", func(t *testing.T) {
+		m, err := New("GBP", 0)
+		require.NoError(t, err)
+		assert.True(t, m.IsZero())
+	})
+
+	t.Run("negative amount", func(t *testing.T) {
+		m, err := New("GBP", -500)
+		require.NoError(t, err)
+		assert.True(t, m.IsNegative())
+		assert.True(t, decimal.NewFromFloat(-5.00).Equal(m.Amount()))
+	})
+}
+
+func TestNewFromDecimal(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		m, err := NewFromDecimal(decimal.NewFromFloat(99.99), CurrencyGBP)
+		require.NoError(t, err)
+		assert.Equal(t, CurrencyGBP, m.Currency())
+		assert.True(t, decimal.NewFromFloat(99.99).Equal(m.Amount()))
+	})
+
+	t.Run("invalid currency", func(t *testing.T) {
+		_, err := NewFromDecimal(decimal.NewFromInt(1), Currency("XXX"))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidCurrency)
+	})
+}
+
+func TestMustNewFromDecimal(t *testing.T) {
+	t.Run("valid does not panic", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			m := MustNewFromDecimal(decimal.NewFromInt(50), CurrencyUSD)
+			assert.Equal(t, CurrencyUSD, m.Currency())
+		})
+	})
+
+	t.Run("invalid currency panics", func(t *testing.T) {
+		assert.Panics(t, func() {
+			MustNewFromDecimal(decimal.NewFromInt(1), Currency("NOPE"))
+		})
+	})
+}
+
+func TestNewFromMajorUnits(t *testing.T) {
+	m, err := NewFromMajorUnits("EUR", 250)
+	require.NoError(t, err)
+	assert.True(t, decimal.NewFromInt(250).Equal(m.Amount()))
+	assert.Equal(t, "EUR", m.CurrencyCode())
+}
+
+func TestNewFromMajorUnits_InvalidCurrency(t *testing.T) {
+	_, err := NewFromMajorUnits("FAKE", 1)
+	require.ErrorIs(t, err, ErrInvalidCurrency)
+}
+
+func TestNewFromQuantity(t *testing.T) {
+	m1, _ := New("GBP", 5000)
+	m2 := NewFromQuantity(m1.Quantity())
+	assert.True(t, m1.Equals(m2))
+}
+
+func TestNewFromInstrument(t *testing.T) {
+	t.Run("valid CURRENCY dimension", func(t *testing.T) {
+		m, err := NewFromInstrument("GBP", "CURRENCY", 10000)
+		require.NoError(t, err)
+		assert.Equal(t, "GBP", m.CurrencyCode())
+		assert.True(t, decimal.NewFromInt(100).Equal(m.Amount()))
+	})
+
+	t.Run("lowercase currency dimension accepted", func(t *testing.T) {
+		m, err := NewFromInstrument("USD", "currency", 500)
+		require.NoError(t, err)
+		assert.Equal(t, "USD", m.CurrencyCode())
+	})
+
+	t.Run("non-currency dimension rejected", func(t *testing.T) {
+		_, err := NewFromInstrument("kWh", "ENERGY", 100)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidCurrency)
+	})
+}
+
+func TestZero(t *testing.T) {
+	m, err := Zero("GBP")
+	require.NoError(t, err)
+	assert.True(t, m.IsZero())
+	assert.Equal(t, "GBP", m.CurrencyCode())
+}
+
+func TestZero_InvalidCurrency(t *testing.T) {
+	_, err := Zero("NOPE")
+	require.ErrorIs(t, err, ErrInvalidCurrency)
+}
+
+func TestAccessors(t *testing.T) {
+	m, _ := New("GBP", 12345)
+	assert.Equal(t, "GBP", m.CurrencyCode())
+	assert.Equal(t, CurrencyGBP, m.Currency())
+	assert.Equal(t, "GBP", m.Instrument().Code)
+	assert.NotNil(t, m.Quantity())
+}
+
+func TestAdd(t *testing.T) {
+	t.Run("same currency", func(t *testing.T) {
+		a, _ := New("GBP", 1000)
+		b, _ := New("GBP", 2500)
+		result, err := a.Add(b)
+		require.NoError(t, err)
+		assert.True(t, decimal.NewFromFloat(35.00).Equal(result.Amount()))
+	})
+
+	t.Run("different currencies returns error", func(t *testing.T) {
+		a, _ := New("GBP", 1000)
+		b, _ := New("USD", 2000)
+		_, err := a.Add(b)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrCurrencyMismatch)
+	})
+}
+
+func TestSubtract(t *testing.T) {
+	t.Run("same currency", func(t *testing.T) {
+		a, _ := New("GBP", 5000)
+		b, _ := New("GBP", 2000)
+		result, err := a.Subtract(b)
+		require.NoError(t, err)
+		assert.True(t, decimal.NewFromFloat(30.00).Equal(result.Amount()))
+	})
+
+	t.Run("result can be negative", func(t *testing.T) {
+		a, _ := New("GBP", 1000)
+		b, _ := New("GBP", 5000)
+		result, err := a.Subtract(b)
+		require.NoError(t, err)
+		assert.True(t, result.IsNegative())
+	})
+
+	t.Run("different currencies returns error", func(t *testing.T) {
+		a, _ := New("GBP", 1000)
+		b, _ := New("EUR", 1000)
+		_, err := a.Subtract(b)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrCurrencyMismatch)
+	})
+}
+
+func TestNegate(t *testing.T) {
+	m, _ := New("GBP", 5000)
+	neg := m.Negate()
+	assert.True(t, neg.IsNegative())
+	assert.True(t, decimal.NewFromFloat(-50.00).Equal(neg.Amount()))
+
+	// Double negate returns original
+	assert.True(t, neg.Negate().Equals(m))
+}
+
+func TestAbs(t *testing.T) {
+	neg, _ := New("GBP", -3000)
+	pos := neg.Abs()
+	assert.True(t, pos.IsPositive())
+	assert.True(t, decimal.NewFromFloat(30.00).Equal(pos.Amount()))
+
+	// Abs of positive is unchanged
+	pos2, _ := New("GBP", 3000)
+	assert.True(t, pos2.Abs().Equals(pos2))
+}
+
+func TestMultiply(t *testing.T) {
+	m, _ := New("GBP", 1000) // £10.00
+	result := m.Multiply(decimal.NewFromFloat(2.5))
+	assert.True(t, decimal.NewFromFloat(25.00).Equal(result.Amount()))
+}
+
+func TestDivide(t *testing.T) {
+	t.Run("valid division", func(t *testing.T) {
+		m, _ := New("GBP", 10000) // £100.00
+		result, err := m.Divide(decimal.NewFromInt(4))
+		require.NoError(t, err)
+		assert.True(t, decimal.NewFromFloat(25.00).Equal(result.Amount()))
+	})
+
+	t.Run("divide by zero returns error", func(t *testing.T) {
+		m, _ := New("GBP", 10000)
+		_, err := m.Divide(decimal.Zero)
+		require.Error(t, err)
+	})
+}
+
+func TestPredicates(t *testing.T) {
+	zero, _ := New("GBP", 0)
+	pos, _ := New("GBP", 100)
+	neg, _ := New("GBP", -100)
+
+	assert.True(t, zero.IsZero())
+	assert.False(t, zero.IsPositive())
+	assert.False(t, zero.IsNegative())
+
+	assert.False(t, pos.IsZero())
+	assert.True(t, pos.IsPositive())
+	assert.False(t, pos.IsNegative())
+
+	assert.False(t, neg.IsZero())
+	assert.False(t, neg.IsPositive())
+	assert.True(t, neg.IsNegative())
+}
+
+func TestEquals(t *testing.T) {
+	a, _ := New("GBP", 5000)
+	b, _ := New("GBP", 5000)
+	c, _ := New("GBP", 6000)
+	d, _ := New("USD", 5000)
+
+	assert.True(t, a.Equals(b))
+	assert.False(t, a.Equals(c))
+	assert.False(t, a.Equals(d))
+}
+
+func TestCompare(t *testing.T) {
+	a, _ := New("GBP", 1000)
+	b, _ := New("GBP", 2000)
+	c, _ := New("GBP", 1000)
+
+	cmp, err := a.Compare(b)
+	require.NoError(t, err)
+	assert.Equal(t, -1, cmp)
+
+	cmp, err = b.Compare(a)
+	require.NoError(t, err)
+	assert.Equal(t, 1, cmp)
+
+	cmp, err = a.Compare(c)
+	require.NoError(t, err)
+	assert.Equal(t, 0, cmp)
+}
+
+func TestCompare_DifferentCurrencies(t *testing.T) {
+	a, _ := New("GBP", 1000)
+	b, _ := New("USD", 1000)
+	_, err := a.Compare(b)
+	require.Error(t, err)
+}
+
+func TestString(t *testing.T) {
+	m, _ := New("GBP", 12345)
+	s := m.String()
+	assert.NotEmpty(t, s)
+}
+
+func TestCurrencyString(t *testing.T) {
+	c := CurrencyGBP
+	assert.Equal(t, "GBP", c.String())
+}
+
+func TestToMinorUnits(t *testing.T) {
+	t.Run("normal conversion", func(t *testing.T) {
+		m, _ := New("GBP", 12345)
+		cents, err := m.ToMinorUnits()
+		require.NoError(t, err)
+		assert.Equal(t, int64(12345), cents)
+	})
+
+	t.Run("zero", func(t *testing.T) {
+		m, _ := New("GBP", 0)
+		cents, err := m.ToMinorUnits()
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), cents)
+	})
+
+	t.Run("negative", func(t *testing.T) {
+		m, _ := New("GBP", -500)
+		cents, err := m.ToMinorUnits()
+		require.NoError(t, err)
+		assert.Equal(t, int64(-500), cents)
+	})
+
+	t.Run("overflow returns error", func(t *testing.T) {
+		// Create a huge amount that would overflow int64 when converted to minor units
+		huge := decimal.New(math.MaxInt64, 0)
+		m, _ := NewFromDecimal(huge, CurrencyGBP)
+		_, err := m.ToMinorUnits()
+		require.ErrorIs(t, err, ErrAmountOverflow)
+	})
+}
+
+func TestToMinorUnitsUnchecked(t *testing.T) {
+	m, _ := New("GBP", 9999)
+	assert.Equal(t, int64(9999), m.ToMinorUnitsUnchecked())
+}
+
+func TestAmountCents(t *testing.T) {
+	m, _ := New("USD", 4200)
+	assert.Equal(t, int64(4200), m.AmountCents())
+}


### PR DESCRIPTION
## Summary
- Add unit tests for `shared/pkg/mapping` (engine, batch, dry run, gjson helpers) and `shared/pkg/money` packages
- Coverage: mapping 87.8%, money 100% (combined 89.5%, up from 0%)

## Test plan
- [x] All new tests pass locally
- [ ] CI passes