### PR TITLE
Fix ApplyManifest dataset category enum prefix stripping

### DIFF
--- a/services/control-plane/internal/applier/grpc_handler.go
+++ b/services/control-plane/internal/applier/grpc_handler.go
@@ -800,7 +800,7 @@ func extractMarketData(mf *controlplanev1.Manifest, input *ApplyManifestInput) {
 	for _, ds := range md.GetDatasets() {
 		input.MarketDataSets = append(input.MarketDataSets, MarketDataSetInput{
 			Code:        ds.GetCode(),
-			Category:    ds.GetCategory().String(),
+			Category:    stripEnumPrefix(ds.GetCategory().String(), "DATA_CATEGORY_"),
 			Unit:        ds.GetUnit(),
 			SourceCode:  ds.GetSourceCode(),
 			DisplayName: ds.GetDisplayName(),

--- a/services/control-plane/internal/applier/handlers_test.go
+++ b/services/control-plane/internal/applier/handlers_test.go
@@ -802,7 +802,7 @@ func TestRegisterDataSetHandler(t *testing.T) {
 	ctx := newTestStarlarkContext()
 	params := map[string]any{
 		"code":     "USD_EUR_FX",
-		"category": "DATA_CATEGORY_FX_RATE",
+		"category": "FX_RATE",
 		"unit":     "USD/EUR",
 	}
 

--- a/services/control-plane/internal/applier/market_information_client.go
+++ b/services/control-plane/internal/applier/market_information_client.go
@@ -123,12 +123,19 @@ func (c *MarketInformationClient) ActivateDataSet(ctx *saga.StarlarkContext, par
 }
 
 // parseDataCategory converts a string category name to the proto enum value.
+// Accepts both prefixed ("DATA_CATEGORY_ENERGY_PRICE") and stripped ("ENERGY_PRICE") forms,
+// since the Starlark handler schema uses stripped names while proto uses prefixed names.
 // Returns an error for non-empty strings that do not match a known category.
 func parseDataCategory(s string) (marketinformationv1.DataCategory, error) {
 	if s == "" {
 		return marketinformationv1.DataCategory_DATA_CATEGORY_UNSPECIFIED, nil
 	}
+	// Try the value as-is first (handles both prefixed and stripped forms).
 	if v, ok := marketinformationv1.DataCategory_value[s]; ok {
+		return marketinformationv1.DataCategory(v), nil
+	}
+	// Try with the DATA_CATEGORY_ prefix added (handles stripped form like "ENERGY_PRICE").
+	if v, ok := marketinformationv1.DataCategory_value["DATA_CATEGORY_"+s]; ok {
 		return marketinformationv1.DataCategory(v), nil
 	}
 	return 0, fmt.Errorf("%w: %q", ErrUnknownDataCategory, s)


### PR DESCRIPTION
## Summary

- Strip `DATA_CATEGORY_` prefix when converting manifest proto enum to Starlark handler input, matching the existing pattern for `NORMAL_BALANCE_`
- Make `parseDataCategory` accept both prefixed (`DATA_CATEGORY_ENERGY_PRICE`) and stripped (`ENERGY_PRICE`) forms

## Context

Third PR in the reproducible demo seeding chain (#1776, #1804). The Starlark handler schema uses `derive.go:StripEnumPrefix()` to remove proto enum prefixes for cleaner Starlark code, but `grpc_handler.go` was passing the raw proto enum name for dataset categories. This caused `ApplyManifest` to fail when registering market data sets with `ENERGY_PRICE` or `CARBON_PRICE` categories.

The same pattern (`stripEnumPrefix`) was already used for `NORMAL_BALANCE_` on account types (line 744) but was missing for `DATA_CATEGORY_` on datasets.

## Test Plan

- [x] `TestRegisterDataSetHandler` passes with stripped enum
- [x] `TestBuildSagaInput` passes
- [x] Full `./services/control-plane/internal/applier/...` test suite passes
- [ ] Deploy to demo, run `reset-demo.sh` — manifest should apply successfully