### PR TITLE
Fix ApplyManifest: pass validation_expression for market data sets

### DIFF
--- a/services/control-plane/internal/applier/defaults/apply_manifest/v1.3.0.star
+++ b/services/control-plane/internal/applier/defaults/apply_manifest/v1.3.0.star
@@ -139,6 +139,7 @@ def execute_apply_manifest():
             source_code=dataset.get("source_code", ""),
             display_name=dataset.get("display_name", dataset["code"]),
             description=dataset.get("description", ""),
+            validation_expression=dataset.get("validation_expression", "true"),
         )
 
         step(name="activate_data_set_" + dataset["code"])


### PR DESCRIPTION
## Summary

- Add `validation_expression` parameter to `register_data_set` call in the ApplyManifest saga script, defaulting to `"true"` when not specified in the manifest

## Context

Fourth PR in the reproducible demo seeding chain (#1776, #1804, #1806). The `register_data_set` gRPC handler requires a `validation_expression` (CEL expression for validating observation values), but the ApplyManifest Starlark script wasn't passing one. This caused `APPLY_MANIFEST_STATUS_PARTIAL` with phases 1-3 and 9 succeeding but dataset registration failing.

One-line fix in the Starlark script.

## Test Plan

- [x] `TestSagaScriptExecution` passes
- [x] All ApplyManifest unit tests pass
- [ ] Deploy to demo, run `reset-demo.sh` — full pipeline should complete