### PR TITLE
Fix ApplyManifest: pass resolution_key_expression for market data sets

### DIFF
--- a/services/control-plane/internal/applier/defaults/apply_manifest/v1.3.0.star
+++ b/services/control-plane/internal/applier/defaults/apply_manifest/v1.3.0.star
@@ -140,6 +140,7 @@ def execute_apply_manifest():
             display_name=dataset.get("display_name", dataset["code"]),
             description=dataset.get("description", ""),
             validation_expression=dataset.get("validation_expression", "true"),
+            resolution_key_expression=dataset.get("resolution_key_expression", "observed_at"),
         )
 
         step(name="activate_data_set_" + dataset["code"])


### PR DESCRIPTION
## Summary

- Add `resolution_key_expression` parameter to `register_data_set` in ApplyManifest saga, defaulting to `"observed_at"`

## Context

Fifth PR in the reproducible demo seeding chain. Same pattern as #1809 — the `register_data_set` handler requires this field but the saga script wasn't passing it.

## Test Plan

- [x] ApplyManifest unit tests pass
- [ ] Deploy to demo, full reset-demo.sh completes