### PR TITLE
Fix ApplyManifest: use getattr for handler result access

### DIFF
--- a/services/control-plane/internal/applier/defaults/apply_manifest/v1.3.0.star
+++ b/services/control-plane/internal/applier/defaults/apply_manifest/v1.3.0.star
@@ -146,7 +146,7 @@ def execute_apply_manifest():
         step(name="activate_data_set_" + dataset["code"])
         market_information.activate_data_set(
             code=dataset["code"],
-            version=ds_result.get("version", 1),
+            version=getattr(ds_result, "version", 1),
         )
 
         registered_market_data_sets.append({
@@ -246,7 +246,7 @@ def execute_apply_manifest():
         )
         registered_connections.append({
             "connection_id": conn["connection_id"],
-            "status": result.get("status", "UPSERTED"),
+            "status": getattr(result, "status", "UPSERTED"),
         })
 
     for route in instruction_routes:
@@ -262,7 +262,7 @@ def execute_apply_manifest():
         )
         registered_routes.append({
             "instruction_type": route["instruction_type"],
-            "status": result.get("status", "UPSERTED"),
+            "status": getattr(result, "status", "UPSERTED"),
         })
 
     result = {


### PR DESCRIPTION
## Summary

- Replace `result.get("field", default)` with `getattr(result, "field", default)` in ApplyManifest saga script — handler results are Starlark structs, not dicts

## Context

Sixth PR in the reproducible demo seeding chain. Handler results are converted to `starlarkstruct.Struct` (branded with `handlerName.Result`), which uses attribute access, not dict `.get()`. This was masked because the ApplyManifest saga was never executed end-to-end against a fresh database until now.

## Test Plan

- [x] `TestSagaScriptExecution` and `TestApplyManifest*` pass
- [ ] Deploy to demo, full reset completes