### PR TITLE
test: close party service coverage gap toward 80%

### DIFF
--- a/services/party/service/association_handlers_test.go
+++ b/services/party/service/association_handlers_test.go
@@ -1,0 +1,473 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	"github.com/meridianhub/meridian/services/party/adapters/persistence"
+	"github.com/meridianhub/meridian/services/party/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+)
+
+// associationMockRepository extends mockRepository with configurable association behavior.
+type associationMockRepository struct {
+	mockRepository
+	checkCircularResult bool
+	checkCircularErr    error
+	saveAssocErr        error
+	findAssocResult     []persistence.PartyAssociationEntity
+	findAssocErr        error
+	updateAssocResult   *persistence.PartyAssociationEntity
+	updateAssocErr      error
+	listParticipantsResult []persistence.PartyAssociationEntity
+	listParticipantsErr    error
+	getStructuringResult   map[string]interface{}
+	getStructuringErr      error
+}
+
+func (m *associationMockRepository) CheckCircularAssociation(_ context.Context, _, _ uuid.UUID) (bool, error) {
+	return m.checkCircularResult, m.checkCircularErr
+}
+
+func (m *associationMockRepository) SaveAssociationWithInput(_ context.Context, _, _ uuid.UUID, _ string, _ *persistence.AssociationInput) (uuid.UUID, error) {
+	if m.saveAssocErr != nil {
+		return uuid.Nil, m.saveAssocErr
+	}
+	return uuid.New(), nil
+}
+
+func (m *associationMockRepository) FindAssociations(_ context.Context, _ uuid.UUID) ([]persistence.PartyAssociationEntity, error) {
+	return m.findAssocResult, m.findAssocErr
+}
+
+func (m *associationMockRepository) UpdateAssociation(_ context.Context, associationID uuid.UUID, relationshipType string) (*persistence.PartyAssociationEntity, error) {
+	if m.updateAssocErr != nil {
+		return nil, m.updateAssocErr
+	}
+	if m.updateAssocResult != nil {
+		return m.updateAssocResult, nil
+	}
+	return &persistence.PartyAssociationEntity{
+		ID:               associationID,
+		PartyID:          uuid.New(),
+		RelatedPartyID:   uuid.New(),
+		RelationshipType: relationshipType,
+	}, nil
+}
+
+func (m *associationMockRepository) ListParticipants(_ context.Context, _ uuid.UUID, _ string) ([]persistence.PartyAssociationEntity, error) {
+	return m.listParticipantsResult, m.listParticipantsErr
+}
+
+func (m *associationMockRepository) GetStructuringData(_ context.Context, _, _ uuid.UUID, _ string) (map[string]interface{}, error) {
+	if m.getStructuringErr != nil {
+		return nil, m.getStructuringErr
+	}
+	if m.getStructuringResult != nil {
+		return m.getStructuringResult, nil
+	}
+	return map[string]interface{}{}, nil
+}
+
+func newAssociationMock() *associationMockRepository {
+	return &associationMockRepository{
+		mockRepository: *newMockRepository(),
+	}
+}
+
+func TestRegisterAssociations(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("registers association between two parties", func(t *testing.T) {
+		mock := newAssociationMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		party1, err := domain.NewParty(domain.PartyTypeOrganization, "Org1")
+		require.NoError(t, err)
+		party2, err := domain.NewParty(domain.PartyTypeOrganization, "Org2")
+		require.NoError(t, err)
+		mock.parties[party1.ID()] = party1
+		mock.parties[party2.ID()] = party2
+
+		resp, err := svc.RegisterAssociations(ctx, &pb.RegisterAssociationsRequest{
+			PartyId:          party1.ID().String(),
+			RelatedPartyId:   party2.ID().String(),
+			RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_BUSINESS_PARTNER,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.NotEmpty(t, resp.AssociationId)
+		assert.Equal(t, party1.ID().String(), resp.PartyId)
+		assert.Equal(t, party2.ID().String(), resp.RelatedPartyId)
+		// Default status should be ACTIVE when unspecified
+		assert.Equal(t, pb.AssociationStatus_ASSOCIATION_STATUS_ACTIVE, resp.Status)
+	})
+
+	t.Run("returns InvalidArgument for invalid party ID", func(t *testing.T) {
+		mock := newAssociationMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.RegisterAssociations(ctx, &pb.RegisterAssociationsRequest{
+			PartyId:          "bad-uuid",
+			RelatedPartyId:   uuid.New().String(),
+			RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SPOUSE,
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("returns InvalidArgument for invalid related party ID", func(t *testing.T) {
+		mock := newAssociationMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.RegisterAssociations(ctx, &pb.RegisterAssociationsRequest{
+			PartyId:          uuid.New().String(),
+			RelatedPartyId:   "bad-uuid",
+			RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SPOUSE,
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("returns NotFound when party does not exist", func(t *testing.T) {
+		mock := newAssociationMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.RegisterAssociations(ctx, &pb.RegisterAssociationsRequest{
+			PartyId:          uuid.New().String(),
+			RelatedPartyId:   uuid.New().String(),
+			RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SPOUSE,
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.NotFound, st.Code())
+	})
+
+	t.Run("returns Internal when find party fails with db error", func(t *testing.T) {
+		mock := newAssociationMock()
+		mock.findByIDForUpdateErr = errDatabaseFailed
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.RegisterAssociations(ctx, &pb.RegisterAssociationsRequest{
+			PartyId:          uuid.New().String(),
+			RelatedPartyId:   uuid.New().String(),
+			RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SPOUSE,
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+
+	t.Run("returns InvalidArgument for circular association", func(t *testing.T) {
+		mock := newAssociationMock()
+		mock.checkCircularResult = true
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		party1, err := domain.NewParty(domain.PartyTypePerson, "A")
+		require.NoError(t, err)
+		party2, err := domain.NewParty(domain.PartyTypePerson, "B")
+		require.NoError(t, err)
+		mock.parties[party1.ID()] = party1
+		mock.parties[party2.ID()] = party2
+
+		resp, err := svc.RegisterAssociations(ctx, &pb.RegisterAssociationsRequest{
+			PartyId:          party1.ID().String(),
+			RelatedPartyId:   party2.ID().String(),
+			RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SPOUSE,
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "circular")
+	})
+
+	t.Run("returns Internal when circular check fails", func(t *testing.T) {
+		mock := newAssociationMock()
+		mock.checkCircularErr = errors.New("db error")
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		party1, err := domain.NewParty(domain.PartyTypePerson, "A")
+		require.NoError(t, err)
+		party2, err := domain.NewParty(domain.PartyTypePerson, "B")
+		require.NoError(t, err)
+		mock.parties[party1.ID()] = party1
+		mock.parties[party2.ID()] = party2
+
+		resp, err := svc.RegisterAssociations(ctx, &pb.RegisterAssociationsRequest{
+			PartyId:          party1.ID().String(),
+			RelatedPartyId:   party2.ID().String(),
+			RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SPOUSE,
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+
+	t.Run("returns AlreadyExists on duplicate association", func(t *testing.T) {
+		mock := newAssociationMock()
+		mock.saveAssocErr = persistence.ErrAssociationExists
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		party1, err := domain.NewParty(domain.PartyTypePerson, "A")
+		require.NoError(t, err)
+		party2, err := domain.NewParty(domain.PartyTypePerson, "B")
+		require.NoError(t, err)
+		mock.parties[party1.ID()] = party1
+		mock.parties[party2.ID()] = party2
+
+		resp, err := svc.RegisterAssociations(ctx, &pb.RegisterAssociationsRequest{
+			PartyId:          party1.ID().String(),
+			RelatedPartyId:   party2.ID().String(),
+			RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SPOUSE,
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.AlreadyExists, st.Code())
+	})
+
+	t.Run("returns Internal on save error", func(t *testing.T) {
+		mock := newAssociationMock()
+		mock.saveAssocErr = errors.New("unexpected")
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		party1, err := domain.NewParty(domain.PartyTypePerson, "A")
+		require.NoError(t, err)
+		party2, err := domain.NewParty(domain.PartyTypePerson, "B")
+		require.NoError(t, err)
+		mock.parties[party1.ID()] = party1
+		mock.parties[party2.ID()] = party2
+
+		resp, err := svc.RegisterAssociations(ctx, &pb.RegisterAssociationsRequest{
+			PartyId:          party1.ID().String(),
+			RelatedPartyId:   party2.ID().String(),
+			RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SPOUSE,
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+}
+
+func TestUpdateAssociations(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("updates association successfully", func(t *testing.T) {
+		mock := newAssociationMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		assocID := uuid.New()
+		resp, err := svc.UpdateAssociations(ctx, &pb.UpdateAssociationsRequest{
+			AssociationId:    assocID.String(),
+			RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_GUARANTOR,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, assocID.String(), resp.AssociationId)
+		assert.NotNil(t, resp.UpdatedAt)
+	})
+
+	t.Run("returns InvalidArgument for invalid association ID", func(t *testing.T) {
+		mock := newAssociationMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.UpdateAssociations(ctx, &pb.UpdateAssociationsRequest{
+			AssociationId:    "bad",
+			RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SPOUSE,
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("returns NotFound when association not found", func(t *testing.T) {
+		mock := newAssociationMock()
+		mock.updateAssocErr = gorm.ErrRecordNotFound
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.UpdateAssociations(ctx, &pb.UpdateAssociationsRequest{
+			AssociationId:    uuid.New().String(),
+			RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SPOUSE,
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.NotFound, st.Code())
+	})
+
+	t.Run("returns Internal on update error", func(t *testing.T) {
+		mock := newAssociationMock()
+		mock.updateAssocErr = errors.New("db error")
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.UpdateAssociations(ctx, &pb.UpdateAssociationsRequest{
+			AssociationId:    uuid.New().String(),
+			RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SPOUSE,
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+}
+
+func TestRetrieveAssociations(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("retrieves associations successfully", func(t *testing.T) {
+		mock := newAssociationMock()
+		mock.findAssocResult = []persistence.PartyAssociationEntity{
+			{
+				ID:               uuid.New(),
+				PartyID:          uuid.New(),
+				RelatedPartyID:   uuid.New(),
+				RelationshipType: "SPOUSE",
+				Status:           "ACTIVE",
+			},
+		}
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.RetrieveAssociations(ctx, &pb.RetrieveAssociationsRequest{
+			PartyId: uuid.New().String(),
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Associations, 1)
+	})
+
+	t.Run("returns InvalidArgument for invalid party ID", func(t *testing.T) {
+		mock := newAssociationMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.RetrieveAssociations(ctx, &pb.RetrieveAssociationsRequest{
+			PartyId: "bad",
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("returns Internal on repository error", func(t *testing.T) {
+		mock := newAssociationMock()
+		mock.findAssocErr = errDatabaseFailed
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.RetrieveAssociations(ctx, &pb.RetrieveAssociationsRequest{
+			PartyId: uuid.New().String(),
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+}
+
+func TestListParticipants_Unit(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("returns InvalidArgument for invalid relationship type", func(t *testing.T) {
+		mock := newAssociationMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.ListParticipants(ctx, &pb.ListParticipantsRequest{
+			OrgPartyId:       uuid.New().String(),
+			RelationshipType: pb.RelationshipType(999),
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("returns Internal on repository error", func(t *testing.T) {
+		mock := newAssociationMock()
+		mock.listParticipantsErr = errDatabaseFailed
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.ListParticipants(ctx, &pb.ListParticipantsRequest{
+			OrgPartyId:       uuid.New().String(),
+			RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT,
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+}
+
+func TestGetStructuringData_Unit(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("returns InvalidArgument for invalid relationship type", func(t *testing.T) {
+		mock := newAssociationMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.GetStructuringData(ctx, &pb.GetStructuringDataRequest{
+			PartyId:          uuid.New().String(),
+			OrgPartyId:       uuid.New().String(),
+			RelationshipType: pb.RelationshipType(999),
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("returns Internal on repository error", func(t *testing.T) {
+		mock := newAssociationMock()
+		mock.getStructuringErr = errDatabaseFailed
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.GetStructuringData(ctx, &pb.GetStructuringDataRequest{
+			PartyId:          uuid.New().String(),
+			OrgPartyId:       uuid.New().String(),
+			RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT,
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+}

--- a/services/party/service/association_handlers_test.go
+++ b/services/party/service/association_handlers_test.go
@@ -19,13 +19,13 @@ import (
 // associationMockRepository extends mockRepository with configurable association behavior.
 type associationMockRepository struct {
 	mockRepository
-	checkCircularResult bool
-	checkCircularErr    error
-	saveAssocErr        error
-	findAssocResult     []persistence.PartyAssociationEntity
-	findAssocErr        error
-	updateAssocResult   *persistence.PartyAssociationEntity
-	updateAssocErr      error
+	checkCircularResult    bool
+	checkCircularErr       error
+	saveAssocErr           error
+	findAssocResult        []persistence.PartyAssociationEntity
+	findAssocErr           error
+	updateAssocResult      *persistence.PartyAssociationEntity
+	updateAssocErr         error
 	listParticipantsResult []persistence.PartyAssociationEntity
 	listParticipantsErr    error
 	getStructuringResult   map[string]interface{}

--- a/services/party/service/demographics_handlers_test.go
+++ b/services/party/service/demographics_handlers_test.go
@@ -1,0 +1,450 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	"github.com/meridianhub/meridian/services/party/adapters/persistence"
+	"github.com/meridianhub/meridian/services/party/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// demographicMockRepository extends mockRepository with configurable demographic behavior.
+type demographicMockRepository struct {
+	mockRepository
+	saveDemoErr    error
+	findDemoResult *persistence.PartyDemographicEntity
+	findDemoErr    error
+	saveBankErr    error
+	findBankResult *persistence.PartyBankRelationEntity
+	findBankErr    error
+}
+
+func (m *demographicMockRepository) SaveDemographic(_ context.Context, _ uuid.UUID, _, _ string) error {
+	return m.saveDemoErr
+}
+
+func (m *demographicMockRepository) FindDemographic(_ context.Context, _ uuid.UUID) (*persistence.PartyDemographicEntity, error) {
+	return m.findDemoResult, m.findDemoErr
+}
+
+func (m *demographicMockRepository) SaveBankRelation(_ context.Context, _ uuid.UUID, _, _, _ string) error {
+	return m.saveBankErr
+}
+
+func (m *demographicMockRepository) FindBankRelation(_ context.Context, _ uuid.UUID) (*persistence.PartyBankRelationEntity, error) {
+	return m.findBankResult, m.findBankErr
+}
+
+func newDemographicMock() *demographicMockRepository {
+	return &demographicMockRepository{
+		mockRepository: *newMockRepository(),
+	}
+}
+
+func TestUpdateDemographics(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("updates demographics successfully", func(t *testing.T) {
+		mock := newDemographicMock()
+		svc := newTestService(&mock.mockRepository)
+		// Rewire the svc to use the demographic mock
+		svc.repo = mock
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Alice")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+
+		resp, err := svc.UpdateDemographics(ctx, &pb.UpdateDemographicsRequest{
+			PartyId:           party.ID().String(),
+			SocioEconomicData: `{"income": "HIGH"}`,
+			EmploymentHistory: `{"current": "Engineer"}`,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, party.ID().String(), resp.PartyId)
+		assert.Equal(t, `{"income": "HIGH"}`, resp.SocioEconomicData)
+		assert.Equal(t, `{"current": "Engineer"}`, resp.EmploymentHistory)
+		assert.NotNil(t, resp.UpdatedAt)
+	})
+
+	t.Run("returns InvalidArgument for invalid party ID", func(t *testing.T) {
+		mock := newDemographicMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.UpdateDemographics(ctx, &pb.UpdateDemographicsRequest{
+			PartyId: "bad-uuid",
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("returns NotFound for non-existent party", func(t *testing.T) {
+		mock := newDemographicMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.UpdateDemographics(ctx, &pb.UpdateDemographicsRequest{
+			PartyId:           uuid.New().String(),
+			SocioEconomicData: "data",
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.NotFound, st.Code())
+	})
+
+	t.Run("returns Internal on find error", func(t *testing.T) {
+		mock := newDemographicMock()
+		mock.findByIDForUpdateErr = errDatabaseFailed
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.UpdateDemographics(ctx, &pb.UpdateDemographicsRequest{
+			PartyId: uuid.New().String(),
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+
+	t.Run("returns Internal on save error", func(t *testing.T) {
+		mock := newDemographicMock()
+		mock.saveDemoErr = errors.New("db write error")
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Bob")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+
+		resp, err := svc.UpdateDemographics(ctx, &pb.UpdateDemographicsRequest{
+			PartyId:           party.ID().String(),
+			SocioEconomicData: "data",
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+}
+
+func TestRetrieveDemographics(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("retrieves demographics with data", func(t *testing.T) {
+		mock := newDemographicMock()
+		socioData := `"HIGH_INCOME"`
+		employData := `"Software Engineer"`
+		mock.findDemoResult = &persistence.PartyDemographicEntity{
+			SocioEconomicData: &socioData,
+			EmploymentHistory: &employData,
+			UpdatedAt:         time.Now(),
+		}
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.RetrieveDemographics(ctx, &pb.RetrieveDemographicsRequest{
+			PartyId: uuid.New().String(),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "HIGH_INCOME", resp.SocioEconomicData)
+		assert.Equal(t, "Software Engineer", resp.EmploymentHistory)
+		assert.NotNil(t, resp.UpdatedAt)
+	})
+
+	t.Run("retrieves empty demographics when none exist", func(t *testing.T) {
+		mock := newDemographicMock()
+		mock.findDemoResult = nil
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.RetrieveDemographics(ctx, &pb.RetrieveDemographicsRequest{
+			PartyId: uuid.New().String(),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Empty(t, resp.SocioEconomicData)
+		assert.Empty(t, resp.EmploymentHistory)
+	})
+
+	t.Run("returns InvalidArgument for invalid party ID", func(t *testing.T) {
+		mock := newDemographicMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.RetrieveDemographics(ctx, &pb.RetrieveDemographicsRequest{
+			PartyId: "invalid",
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("returns Internal on repository error", func(t *testing.T) {
+		mock := newDemographicMock()
+		mock.findDemoErr = errDatabaseFailed
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.RetrieveDemographics(ctx, &pb.RetrieveDemographicsRequest{
+			PartyId: uuid.New().String(),
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+}
+
+func TestUpdateBankRelations(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("updates bank relations successfully", func(t *testing.T) {
+		mock := newDemographicMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Alice")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+
+		resp, err := svc.UpdateBankRelations(ctx, &pb.UpdateBankRelationsRequest{
+			PartyId:               party.ID().String(),
+			AccountOfficerId:      "officer-1",
+			RelationshipManagerId: "rm-1",
+			AssignedBranch:        "LONDON-HQ",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "officer-1", resp.AccountOfficerId)
+		assert.Equal(t, "rm-1", resp.RelationshipManagerId)
+		assert.Equal(t, "LONDON-HQ", resp.AssignedBranch)
+		assert.NotNil(t, resp.UpdatedAt)
+	})
+
+	t.Run("returns InvalidArgument for invalid party ID", func(t *testing.T) {
+		mock := newDemographicMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.UpdateBankRelations(ctx, &pb.UpdateBankRelationsRequest{
+			PartyId: "bad",
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("returns NotFound for non-existent party", func(t *testing.T) {
+		mock := newDemographicMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.UpdateBankRelations(ctx, &pb.UpdateBankRelationsRequest{
+			PartyId: uuid.New().String(),
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.NotFound, st.Code())
+	})
+
+	t.Run("returns Internal on find error", func(t *testing.T) {
+		mock := newDemographicMock()
+		mock.findByIDForUpdateErr = errDatabaseFailed
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.UpdateBankRelations(ctx, &pb.UpdateBankRelationsRequest{
+			PartyId: uuid.New().String(),
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+
+	t.Run("returns Internal on save error", func(t *testing.T) {
+		mock := newDemographicMock()
+		mock.saveBankErr = errors.New("db error")
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Bob")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+
+		resp, err := svc.UpdateBankRelations(ctx, &pb.UpdateBankRelationsRequest{
+			PartyId:          party.ID().String(),
+			AccountOfficerId: "officer",
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+}
+
+func TestRetrieveBankRelations(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("retrieves bank relations with data", func(t *testing.T) {
+		mock := newDemographicMock()
+		officer := "officer-1"
+		rm := "rm-1"
+		branch := "LONDON"
+		mock.findBankResult = &persistence.PartyBankRelationEntity{
+			AccountOfficerID:      &officer,
+			RelationshipManagerID: &rm,
+			AssignedBranch:        &branch,
+			UpdatedAt:             time.Now(),
+		}
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.RetrieveBankRelations(ctx, &pb.RetrieveBankRelationsRequest{
+			PartyId: uuid.New().String(),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "officer-1", resp.AccountOfficerId)
+		assert.Equal(t, "rm-1", resp.RelationshipManagerId)
+		assert.Equal(t, "LONDON", resp.AssignedBranch)
+		assert.NotNil(t, resp.UpdatedAt)
+	})
+
+	t.Run("retrieves empty when no bank relation exists", func(t *testing.T) {
+		mock := newDemographicMock()
+		mock.findBankResult = nil
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.RetrieveBankRelations(ctx, &pb.RetrieveBankRelationsRequest{
+			PartyId: uuid.New().String(),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Empty(t, resp.AccountOfficerId)
+	})
+
+	t.Run("retrieves bank relation with partial data", func(t *testing.T) {
+		mock := newDemographicMock()
+		officer := "officer-only"
+		mock.findBankResult = &persistence.PartyBankRelationEntity{
+			AccountOfficerID: &officer,
+			UpdatedAt:        time.Now(),
+		}
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.RetrieveBankRelations(ctx, &pb.RetrieveBankRelationsRequest{
+			PartyId: uuid.New().String(),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "officer-only", resp.AccountOfficerId)
+		assert.Empty(t, resp.RelationshipManagerId)
+		assert.Empty(t, resp.AssignedBranch)
+	})
+
+	t.Run("returns InvalidArgument for invalid party ID", func(t *testing.T) {
+		mock := newDemographicMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.RetrieveBankRelations(ctx, &pb.RetrieveBankRelationsRequest{
+			PartyId: "nope",
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("returns Internal on repository error", func(t *testing.T) {
+		mock := newDemographicMock()
+		mock.findBankErr = errDatabaseFailed
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.RetrieveBankRelations(ctx, &pb.RetrieveBankRelationsRequest{
+			PartyId: uuid.New().String(),
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+}
+
+func TestExchangeDemographicsStub(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("stub returns VERIFIED in test environment", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Test")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+
+		t.Setenv("ENVIRONMENT", "test")
+
+		resp, err := svc.ExchangeDemographics(ctx, &pb.ExchangeDemographicsRequest{
+			PartyId: party.ID().String(),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "VERIFIED", resp.VerificationStatus)
+	})
+
+	t.Run("stub returns Unimplemented in unknown environment", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Test")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+
+		t.Setenv("ENVIRONMENT", "staging")
+
+		resp, err := svc.ExchangeDemographics(ctx, &pb.ExchangeDemographicsRequest{
+			PartyId: party.ID().String(),
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Unimplemented, st.Code())
+	})
+
+	t.Run("returns Internal on find error", func(t *testing.T) {
+		mock := newMockRepository()
+		mock.findByIDErr = errDatabaseFailed
+		svc := newTestService(mock)
+
+		resp, err := svc.ExchangeDemographics(ctx, &pb.ExchangeDemographicsRequest{
+			PartyId: uuid.New().String(),
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+}

--- a/services/party/service/health_test.go
+++ b/services/party/service/health_test.go
@@ -1,0 +1,143 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/pkg/health"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+func TestMapStatusToGRPC(t *testing.T) {
+	t.Parallel()
+
+	// We need a minimal HealthChecker to call mapStatusToGRPC
+	// Since NewHealthChecker panics on nil repo, create one directly
+	hc := &HealthChecker{}
+
+	tests := []struct {
+		name     string
+		status   health.Status
+		expected grpc_health_v1.HealthCheckResponse_ServingStatus
+	}{
+		{"healthy maps to SERVING", health.StatusHealthy, grpc_health_v1.HealthCheckResponse_SERVING},
+		{"degraded maps to SERVING", health.StatusDegraded, grpc_health_v1.HealthCheckResponse_SERVING},
+		{"unhealthy maps to NOT_SERVING", health.StatusUnhealthy, grpc_health_v1.HealthCheckResponse_NOT_SERVING},
+		{"unknown maps to UNKNOWN", health.StatusUnknown, grpc_health_v1.HealthCheckResponse_UNKNOWN},
+		{"unrecognized maps to UNKNOWN", health.Status(99), grpc_health_v1.HealthCheckResponse_UNKNOWN},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hc.mapStatusToGRPC(tt.status)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestLogHealthCheck(t *testing.T) {
+	t.Parallel()
+
+	hc := &HealthChecker{
+		logger: newTestService(newMockRepository()).logger,
+	}
+
+	tests := []struct {
+		name   string
+		status health.Status
+	}{
+		{"logs healthy status", health.StatusHealthy},
+		{"logs degraded status", health.StatusDegraded},
+		{"logs unhealthy status", health.StatusUnhealthy},
+		{"logs unknown status", health.StatusUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := &health.Report{
+				Components: []health.ComponentResult{
+					{Name: "database", Status: tt.status, Message: "test"},
+				},
+			}
+			grpcStatus := hc.mapStatusToGRPC(tt.status)
+			// Should not panic
+			hc.logHealthCheck(report, tt.status, grpcStatus)
+		})
+	}
+
+	t.Run("logs component failures for unhealthy", func(t *testing.T) {
+		report := &health.Report{
+			Components: []health.ComponentResult{
+				{Name: "database", Status: health.StatusUnhealthy, Message: "connection refused"},
+				{Name: "cache", Status: health.StatusHealthy, Message: "ok"},
+			},
+		}
+		// Should not panic
+		hc.logHealthCheck(report, health.StatusUnhealthy, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+	})
+}
+
+func TestDatabaseHealthChecker_Name(t *testing.T) {
+	t.Parallel()
+	dhc := NewDatabaseHealthChecker(nil, 0)
+	assert.Equal(t, "database", dhc.Name())
+}
+
+func TestNewHealthChecker_PanicsOnNilRepo(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() {
+		NewHealthChecker(HealthCheckerConfig{
+			Repository: nil,
+		})
+	})
+}
+
+func TestNewHealthChecker_Defaults(t *testing.T) {
+	t.Parallel()
+
+	// We need a real repository to avoid panic - but we can't use a nil one.
+	// This test verifies the defaults are applied.
+	// We'll use a test that just checks the config defaults logic.
+	// Since NewHealthChecker requires non-nil repo, and repo is *persistence.Repository,
+	// we need an actual one. Skip if can't construct without DB.
+	t.Skip("requires persistence.Repository which needs DB connection")
+}
+
+func TestHealthChecker_Check_UnknownService(t *testing.T) {
+	t.Parallel()
+
+	// Create a minimal health checker using direct struct init for unit testing
+	// This tests the "unknown service" path
+	checkers := []health.Checker{}
+	aggregator := health.NewAggregator(checkers)
+
+	hc := &HealthChecker{
+		logger:       newTestService(newMockRepository()).logger,
+		aggregator:   aggregator,
+		serviceName:  "party",
+		checkTimeout: 0,
+	}
+
+	// Test 1: Empty service name should check all components
+	resp, err := hc.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
+		Service: "",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
+
+	// Test 2: Matching service name
+	resp, err = hc.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
+		Service: "party",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
+
+	// Test 3: Unknown service name returns UNKNOWN
+	resp, err = hc.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
+		Service: "nonexistent-service",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_UNKNOWN, resp.Status)
+}

--- a/services/party/service/health_test.go
+++ b/services/party/service/health_test.go
@@ -55,7 +55,7 @@ func TestLogHealthCheck(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(_ *testing.T) {
 			report := &health.Report{
 				Components: []health.ComponentResult{
 					{Name: "database", Status: tt.status, Message: "test"},
@@ -67,7 +67,7 @@ func TestLogHealthCheck(t *testing.T) {
 		})
 	}
 
-	t.Run("logs component failures for unhealthy", func(t *testing.T) {
+	t.Run("logs component failures for unhealthy", func(_ *testing.T) {
 		report := &health.Report{
 			Components: []health.ComponentResult{
 				{Name: "database", Status: health.StatusUnhealthy, Message: "connection refused"},

--- a/services/party/service/reference_handlers_test.go
+++ b/services/party/service/reference_handlers_test.go
@@ -1,0 +1,290 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	"github.com/meridianhub/meridian/services/party/adapters/persistence"
+	"github.com/meridianhub/meridian/services/party/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// referenceMockRepository extends mockRepository with configurable reference behavior.
+type referenceMockRepository struct {
+	mockRepository
+	saveRefsErr    error
+	findRefsResult []persistence.PartyReferenceEntity
+	findRefsErr    error
+}
+
+func (m *referenceMockRepository) SaveReferences(_ context.Context, _ uuid.UUID, _ []persistence.ReferenceInput) error {
+	return m.saveRefsErr
+}
+
+func (m *referenceMockRepository) FindReferences(_ context.Context, _ uuid.UUID) ([]persistence.PartyReferenceEntity, error) {
+	return m.findRefsResult, m.findRefsErr
+}
+
+func newReferenceMock() *referenceMockRepository {
+	return &referenceMockRepository{
+		mockRepository: *newMockRepository(),
+	}
+}
+
+func TestUpdateReference(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("saves government ID and tax reference", func(t *testing.T) {
+		mock := newReferenceMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Alice")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+
+		resp, err := svc.UpdateReference(ctx, &pb.UpdateReferenceRequest{
+			PartyId:          party.ID().String(),
+			GovernmentId:     "AB123456",
+			TaxReference:     "UTR123456789",
+			IssuingAuthority: "HMRC",
+			ExpiryDate:       "2030-12-31",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "AB123456", resp.GovernmentId)
+		assert.Equal(t, "UTR123456789", resp.TaxReference)
+		assert.Equal(t, "HMRC", resp.IssuingAuthority)
+		assert.Equal(t, "2030-12-31", resp.ExpiryDate)
+		assert.NotNil(t, resp.UpdatedAt)
+	})
+
+	t.Run("saves government ID only", func(t *testing.T) {
+		mock := newReferenceMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Bob")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+
+		resp, err := svc.UpdateReference(ctx, &pb.UpdateReferenceRequest{
+			PartyId:      party.ID().String(),
+			GovernmentId: "CD987654",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "CD987654", resp.GovernmentId)
+		assert.Empty(t, resp.TaxReference)
+	})
+
+	t.Run("no-op when no references provided", func(t *testing.T) {
+		mock := newReferenceMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Carol")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+
+		resp, err := svc.UpdateReference(ctx, &pb.UpdateReferenceRequest{
+			PartyId: party.ID().String(),
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+	})
+
+	t.Run("returns InvalidArgument for invalid party ID", func(t *testing.T) {
+		mock := newReferenceMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.UpdateReference(ctx, &pb.UpdateReferenceRequest{
+			PartyId: "bad",
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("returns NotFound for non-existent party", func(t *testing.T) {
+		mock := newReferenceMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.UpdateReference(ctx, &pb.UpdateReferenceRequest{
+			PartyId:      uuid.New().String(),
+			GovernmentId: "ABC",
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.NotFound, st.Code())
+	})
+
+	t.Run("returns Internal on find error", func(t *testing.T) {
+		mock := newReferenceMock()
+		mock.findByIDForUpdateErr = errDatabaseFailed
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.UpdateReference(ctx, &pb.UpdateReferenceRequest{
+			PartyId: uuid.New().String(),
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+
+	t.Run("returns InvalidArgument for bad expiry date", func(t *testing.T) {
+		mock := newReferenceMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Dave")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+
+		resp, err := svc.UpdateReference(ctx, &pb.UpdateReferenceRequest{
+			PartyId:      party.ID().String(),
+			GovernmentId: "ABC",
+			ExpiryDate:   "31/12/2030", // Bad format
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "expiry_date")
+	})
+
+	t.Run("returns Internal on save error", func(t *testing.T) {
+		mock := newReferenceMock()
+		mock.saveRefsErr = errors.New("write failed")
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Eve")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+
+		resp, err := svc.UpdateReference(ctx, &pb.UpdateReferenceRequest{
+			PartyId:      party.ID().String(),
+			GovernmentId: "XY123",
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+}
+
+func TestRetrieveReference(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("retrieves government ID and tax reference", func(t *testing.T) {
+		mock := newReferenceMock()
+		issuingAuth := "HMRC"
+		expiryDate := time.Date(2030, 12, 31, 0, 0, 0, 0, time.UTC)
+		mock.findRefsResult = []persistence.PartyReferenceEntity{
+			{
+				ReferenceType:    "GOVERNMENT_ID",
+				ReferenceValue:   "AB123456",
+				IssuingAuthority: &issuingAuth,
+				ExpiryDate:       &expiryDate,
+				CreatedAt:        time.Now(),
+			},
+			{
+				ReferenceType:  "TAX_REFERENCE",
+				ReferenceValue: "UTR123456789",
+				CreatedAt:      time.Now(),
+			},
+		}
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.RetrieveReference(ctx, &pb.RetrieveReferenceRequest{
+			PartyId: uuid.New().String(),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "AB123456", resp.GovernmentId)
+		assert.Equal(t, "HMRC", resp.IssuingAuthority)
+		assert.Equal(t, "2030-12-31", resp.ExpiryDate)
+		assert.Equal(t, "UTR123456789", resp.TaxReference)
+		assert.NotNil(t, resp.UpdatedAt)
+	})
+
+	t.Run("retrieves empty when no references", func(t *testing.T) {
+		mock := newReferenceMock()
+		mock.findRefsResult = []persistence.PartyReferenceEntity{}
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.RetrieveReference(ctx, &pb.RetrieveReferenceRequest{
+			PartyId: uuid.New().String(),
+		})
+		require.NoError(t, err)
+		assert.Empty(t, resp.GovernmentId)
+		assert.Empty(t, resp.TaxReference)
+	})
+
+	t.Run("handles government ID without optional fields", func(t *testing.T) {
+		mock := newReferenceMock()
+		mock.findRefsResult = []persistence.PartyReferenceEntity{
+			{
+				ReferenceType:  "GOVERNMENT_ID",
+				ReferenceValue: "XY789",
+				CreatedAt:      time.Now(),
+			},
+		}
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.RetrieveReference(ctx, &pb.RetrieveReferenceRequest{
+			PartyId: uuid.New().String(),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "XY789", resp.GovernmentId)
+		assert.Empty(t, resp.IssuingAuthority)
+		assert.Empty(t, resp.ExpiryDate)
+	})
+
+	t.Run("returns InvalidArgument for invalid party ID", func(t *testing.T) {
+		mock := newReferenceMock()
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.RetrieveReference(ctx, &pb.RetrieveReferenceRequest{
+			PartyId: "nope",
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("returns Internal on repository error", func(t *testing.T) {
+		mock := newReferenceMock()
+		mock.findRefsErr = errDatabaseFailed
+		svc := newTestService(&mock.mockRepository)
+		svc.repo = mock
+
+		resp, err := svc.RetrieveReference(ctx, &pb.RetrieveReferenceRequest{
+			PartyId: uuid.New().String(),
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+}

--- a/services/party/service/update_control_test.go
+++ b/services/party/service/update_control_test.go
@@ -1,0 +1,517 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
+	"github.com/meridianhub/meridian/services/party/adapters/persistence"
+	"github.com/meridianhub/meridian/services/party/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
+
+func TestUpdateParty(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("updates display name without field mask", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Alice Smith")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+
+		resp, err := svc.UpdateParty(ctx, &pb.UpdatePartyRequest{
+			PartyId:     party.ID().String(),
+			DisplayName: "Ali",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "Ali", resp.Party.DisplayName)
+	})
+
+	t.Run("updates display name with field mask", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Bob Jones")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+
+		resp, err := svc.UpdateParty(ctx, &pb.UpdatePartyRequest{
+			PartyId:     party.ID().String(),
+			DisplayName: "Bobby",
+			UpdateMask:  &fieldmaskpb.FieldMask{Paths: []string{"display_name"}},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "Bobby", resp.Party.DisplayName)
+	})
+
+	t.Run("updates attributes with field mask", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		party, err := domain.NewParty(domain.PartyTypeOrganization, "Acme Corp")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+
+		resp, err := svc.UpdateParty(ctx, &pb.UpdatePartyRequest{
+			PartyId: party.ID().String(),
+			Attributes: []*quantityv1.AttributeEntry{
+				{Key: "tier", Value: "gold"},
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"attributes"}},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Len(t, resp.Party.Attributes, 1)
+		assert.Equal(t, "tier", resp.Party.Attributes[0].Key)
+		assert.Equal(t, "gold", resp.Party.Attributes[0].Value)
+	})
+
+	t.Run("updates attributes without field mask", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		party, err := domain.NewParty(domain.PartyTypeOrganization, "Corp Ltd")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+
+		resp, err := svc.UpdateParty(ctx, &pb.UpdatePartyRequest{
+			PartyId: party.ID().String(),
+			Attributes: []*quantityv1.AttributeEntry{
+				{Key: "region", Value: "EU"},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Party.Attributes, 1)
+		assert.Equal(t, "region", resp.Party.Attributes[0].Key)
+	})
+
+	t.Run("returns InvalidArgument for invalid party ID", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		resp, err := svc.UpdateParty(ctx, &pb.UpdatePartyRequest{
+			PartyId: "not-a-uuid",
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("returns NotFound for non-existent party", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		resp, err := svc.UpdateParty(ctx, &pb.UpdatePartyRequest{
+			PartyId:     uuid.New().String(),
+			DisplayName: "Test",
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.NotFound, st.Code())
+	})
+
+	t.Run("returns Internal on find error", func(t *testing.T) {
+		mock := newMockRepository()
+		mock.findByIDForUpdateErr = errDatabaseFailed
+		svc := newTestService(mock)
+
+		resp, err := svc.UpdateParty(ctx, &pb.UpdatePartyRequest{
+			PartyId: uuid.New().String(),
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+
+	t.Run("returns Aborted on version conflict check", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Carol")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+
+		resp, err := svc.UpdateParty(ctx, &pb.UpdatePartyRequest{
+			PartyId: party.ID().String(),
+			Version: 999, // Wrong version
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Aborted, st.Code())
+	})
+
+	t.Run("returns InvalidArgument for unsupported field mask path", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Dave")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+
+		resp, err := svc.UpdateParty(ctx, &pb.UpdatePartyRequest{
+			PartyId:    party.ID().String(),
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"unsupported_field"}},
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("returns Internal on save error", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Eve")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+		mock.saveErr = errDatabaseFailed
+
+		resp, err := svc.UpdateParty(ctx, &pb.UpdatePartyRequest{
+			PartyId:     party.ID().String(),
+			DisplayName: "Evie",
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+
+	t.Run("returns Aborted on version conflict during save", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Frank")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+		mock.saveErr = persistence.ErrVersionConflict
+
+		resp, err := svc.UpdateParty(ctx, &pb.UpdatePartyRequest{
+			PartyId:     party.ID().String(),
+			DisplayName: "Frankie",
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Aborted, st.Code())
+	})
+}
+
+func TestControlParty(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("suspends active party", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Alice Smith")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+
+		resp, err := svc.ControlParty(ctx, &pb.ControlPartyRequest{
+			PartyId:       party.ID().String(),
+			ControlAction: pb.ControlAction_CONTROL_ACTION_SUSPEND,
+			Reason:        "suspicious activity",
+			ActorId:       "admin-123",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, pb.PartyStatus_PARTY_STATUS_SUSPENDED, resp.Party.Status)
+		assert.NotNil(t, resp.ActionTimestamp)
+		assert.True(t, resp.ActionTimestamp.AsTime().Before(time.Now().Add(time.Second)))
+	})
+
+	t.Run("restricts active party", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Bob")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+
+		resp, err := svc.ControlParty(ctx, &pb.ControlPartyRequest{
+			PartyId:       party.ID().String(),
+			ControlAction: pb.ControlAction_CONTROL_ACTION_RESTRICT,
+			Reason:        "under review",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, pb.PartyStatus_PARTY_STATUS_RESTRICTED, resp.Party.Status)
+	})
+
+	t.Run("terminates suspended party", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Carol")
+		require.NoError(t, err)
+		require.NoError(t, party.ControlParty(domain.ControlActionSuspend, "test"))
+		mock.parties[party.ID()] = party
+
+		resp, err := svc.ControlParty(ctx, &pb.ControlPartyRequest{
+			PartyId:       party.ID().String(),
+			ControlAction: pb.ControlAction_CONTROL_ACTION_TERMINATE,
+			Reason:        "account closure",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, pb.PartyStatus_PARTY_STATUS_TERMINATED, resp.Party.Status)
+	})
+
+	t.Run("reactivates suspended party", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Dave")
+		require.NoError(t, err)
+		require.NoError(t, party.ControlParty(domain.ControlActionSuspend, "test"))
+		mock.parties[party.ID()] = party
+
+		resp, err := svc.ControlParty(ctx, &pb.ControlPartyRequest{
+			PartyId:       party.ID().String(),
+			ControlAction: pb.ControlAction_CONTROL_ACTION_ACTIVATE,
+			Reason:        "cleared",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, pb.PartyStatus_PARTY_STATUS_ACTIVE, resp.Party.Status)
+	})
+
+	t.Run("returns InvalidArgument for invalid party ID", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		resp, err := svc.ControlParty(ctx, &pb.ControlPartyRequest{
+			PartyId:       "bad-uuid",
+			ControlAction: pb.ControlAction_CONTROL_ACTION_SUSPEND,
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("returns InvalidArgument for unspecified action", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		resp, err := svc.ControlParty(ctx, &pb.ControlPartyRequest{
+			PartyId:       uuid.New().String(),
+			ControlAction: pb.ControlAction_CONTROL_ACTION_UNSPECIFIED,
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("returns NotFound for non-existent party", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		resp, err := svc.ControlParty(ctx, &pb.ControlPartyRequest{
+			PartyId:       uuid.New().String(),
+			ControlAction: pb.ControlAction_CONTROL_ACTION_SUSPEND,
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.NotFound, st.Code())
+	})
+
+	t.Run("returns Internal on find error", func(t *testing.T) {
+		mock := newMockRepository()
+		mock.findByIDForUpdateErr = errDatabaseFailed
+		svc := newTestService(mock)
+
+		resp, err := svc.ControlParty(ctx, &pb.ControlPartyRequest{
+			PartyId:       uuid.New().String(),
+			ControlAction: pb.ControlAction_CONTROL_ACTION_SUSPEND,
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+
+	t.Run("returns FailedPrecondition for invalid transition", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Terminated")
+		require.NoError(t, err)
+		require.NoError(t, party.ControlParty(domain.ControlActionSuspend, "test"))
+		require.NoError(t, party.ControlParty(domain.ControlActionTerminate, "test"))
+		mock.parties[party.ID()] = party
+
+		resp, err := svc.ControlParty(ctx, &pb.ControlPartyRequest{
+			PartyId:       party.ID().String(),
+			ControlAction: pb.ControlAction_CONTROL_ACTION_ACTIVATE,
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.FailedPrecondition, st.Code())
+	})
+
+	t.Run("returns Internal on save error", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Grace")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+		mock.saveErr = errDatabaseFailed
+
+		resp, err := svc.ControlParty(ctx, &pb.ControlPartyRequest{
+			PartyId:       party.ID().String(),
+			ControlAction: pb.ControlAction_CONTROL_ACTION_SUSPEND,
+			Reason:        "test",
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+
+	t.Run("returns Aborted on version conflict save", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Heidi")
+		require.NoError(t, err)
+		mock.parties[party.ID()] = party
+		mock.saveErr = persistence.ErrVersionConflict
+
+		resp, err := svc.ControlParty(ctx, &pb.ControlPartyRequest{
+			PartyId:       party.ID().String(),
+			ControlAction: pb.ControlAction_CONTROL_ACTION_SUSPEND,
+			Reason:        "test",
+		})
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Aborted, st.Code())
+	})
+}
+
+func TestApplyFieldUpdate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("updates display_name", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Alice")
+		require.NoError(t, err)
+
+		err = svc.applyFieldUpdate(party, "display_name", &pb.UpdatePartyRequest{
+			DisplayName: "Ali",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "Ali", party.DisplayName())
+	})
+
+	t.Run("no-op for empty display_name", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Alice")
+		require.NoError(t, err)
+
+		err = svc.applyFieldUpdate(party, "display_name", &pb.UpdatePartyRequest{
+			DisplayName: "",
+		})
+		require.NoError(t, err)
+		assert.Empty(t, party.DisplayName())
+	})
+
+	t.Run("updates attributes", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		party, err := domain.NewParty(domain.PartyTypeOrganization, "Corp")
+		require.NoError(t, err)
+
+		err = svc.applyFieldUpdate(party, "attributes", &pb.UpdatePartyRequest{
+			Attributes: []*quantityv1.AttributeEntry{
+				{Key: "k", Value: "v"},
+			},
+		})
+		require.NoError(t, err)
+		assert.Len(t, party.Attributes(), 1)
+	})
+
+	t.Run("returns error for unsupported field", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		party, err := domain.NewParty(domain.PartyTypePerson, "Alice")
+		require.NoError(t, err)
+
+		err = svc.applyFieldUpdate(party, "legal_name", &pb.UpdatePartyRequest{})
+		assert.ErrorIs(t, err, ErrUnsupportedFieldUpdate)
+	})
+}
+
+func TestWithBuilders(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WithPaymentMethodRepository", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+		result := svc.WithPaymentMethodRepository(nil)
+		assert.Same(t, svc, result)
+	})
+
+	t.Run("WithVerificationProvider", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+		result := svc.WithVerificationProvider(nil)
+		assert.Same(t, svc, result)
+	})
+
+	t.Run("WithAttributeValidator", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+		result := svc.WithAttributeValidator(nil)
+		assert.Same(t, svc, result)
+	})
+
+	t.Run("WithOutboxPublisher", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+		result := svc.WithOutboxPublisher(nil, nil)
+		assert.Same(t, svc, result)
+	})
+}
+
+func TestSavePartyWithEvent_NoOutbox(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	mock := newMockRepository()
+	svc := newTestService(mock)
+
+	party, err := domain.NewParty(domain.PartyTypePerson, "Test")
+	require.NoError(t, err)
+
+	// Without outbox, should fall back to plain save
+	err = svc.savePartyWithEvent(ctx, party, nil)
+	require.NoError(t, err)
+	assert.Contains(t, mock.parties, party.ID())
+}


### PR DESCRIPTION
## Summary

- Add unit tests for party service handlers that were previously untested
- Target: close the gap from 74.2% toward 80% on Codecov for the party service

## Changes Made

New test files covering previously uncovered service-layer handlers:

| File | Covers |
|------|--------|
| `update_control_test.go` | `UpdateParty`, `ControlParty`, `applyFieldUpdate`, `With*` builders, `savePartyWithEvent` |
| `demographics_handlers_test.go` | `UpdateDemographics`, `RetrieveDemographics`, `UpdateBankRelations`, `RetrieveBankRelations`, `exchangeDemographicsStub` |
| `reference_handlers_test.go` | `UpdateReference`, `RetrieveReference` |
| `association_handlers_test.go` | `RegisterAssociations`, `UpdateAssociations`, `RetrieveAssociations`, `ListParticipants`, `GetStructuringData` |
| `health_test.go` | `mapStatusToGRPC`, `logHealthCheck`, `DatabaseHealthChecker.Name`, `HealthChecker.Check` |

All tests use the existing mock repository pattern from `grpc_service_test.go`. Extended mocks are defined per-file for handlers that need configurable return values (demographics, references, associations).

## Test plan

- [ ] All new unit tests pass locally
- [ ] CI passes
- [ ] Codecov coverage for party service improves toward 80%