### PR TITLE
test: close coverage gaps for tenant, financial-accounting, and market-information

### DIFF
--- a/services/financial-accounting/cmd/main_test.go
+++ b/services/financial-accounting/cmd/main_test.go
@@ -1,11 +1,41 @@
 package main
 
 import (
+	"log/slog"
 	"testing"
 
 	"github.com/meridianhub/meridian/shared/platform/env"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestParseLogLevel(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected slog.Level
+	}{
+		{"debug", slog.LevelDebug},
+		{"DEBUG", slog.LevelDebug},
+		{"Debug", slog.LevelDebug},
+		{"info", slog.LevelInfo},
+		{"INFO", slog.LevelInfo},
+		{"warn", slog.LevelWarn},
+		{"WARN", slog.LevelWarn},
+		{"warning", slog.LevelWarn},
+		{"WARNING", slog.LevelWarn},
+		{"error", slog.LevelError},
+		{"ERROR", slog.LevelError},
+		{"", slog.LevelInfo},
+		{"unknown", slog.LevelInfo},
+		{"trace", slog.LevelInfo},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseLogLevel(tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
 
 // TestIsProductionEnvironmentDetection tests that environment detection works correctly
 // via the shared env package.

--- a/services/market-information/cmd/main_test.go
+++ b/services/market-information/cmd/main_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseLogLevel(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected slog.Level
+	}{
+		{"debug", slog.LevelDebug},
+		{"DEBUG", slog.LevelDebug},
+		{"Debug", slog.LevelDebug},
+		{"info", slog.LevelInfo},
+		{"INFO", slog.LevelInfo},
+		{"warn", slog.LevelWarn},
+		{"WARN", slog.LevelWarn},
+		{"warning", slog.LevelWarn},
+		{"WARNING", slog.LevelWarn},
+		{"error", slog.LevelError},
+		{"ERROR", slog.LevelError},
+		{"", slog.LevelInfo},
+		{"unknown", slog.LevelInfo},
+		{"trace", slog.LevelInfo},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseLogLevel(tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/services/tenant/client/client_methods_test.go
+++ b/services/tenant/client/client_methods_test.go
@@ -1,0 +1,259 @@
+package client
+
+import (
+	"context"
+	"testing"
+
+	tenantv1 "github.com/meridianhub/meridian/api/proto/meridian/tenant/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// mockTenantServiceClient implements tenantv1.TenantServiceClient for testing.
+type mockTenantServiceClient struct {
+	InitiateTenantFunc              func(ctx context.Context, in *tenantv1.InitiateTenantRequest, opts ...grpc.CallOption) (*tenantv1.InitiateTenantResponse, error)
+	RetrieveTenantFunc              func(ctx context.Context, in *tenantv1.RetrieveTenantRequest, opts ...grpc.CallOption) (*tenantv1.RetrieveTenantResponse, error)
+	UpdateTenantStatusFunc          func(ctx context.Context, in *tenantv1.UpdateTenantStatusRequest, opts ...grpc.CallOption) (*tenantv1.UpdateTenantStatusResponse, error)
+	ListTenantsFunc                 func(ctx context.Context, in *tenantv1.ListTenantsRequest, opts ...grpc.CallOption) (*tenantv1.ListTenantsResponse, error)
+	ReconcileMigrationsFunc         func(ctx context.Context, in *tenantv1.ReconcileMigrationsRequest, opts ...grpc.CallOption) (*tenantv1.ReconcileMigrationsResponse, error)
+	GetTenantProvisioningStatusFunc func(ctx context.Context, in *tenantv1.GetTenantProvisioningStatusRequest, opts ...grpc.CallOption) (*tenantv1.GetTenantProvisioningStatusResponse, error)
+}
+
+func (m *mockTenantServiceClient) InitiateTenant(ctx context.Context, in *tenantv1.InitiateTenantRequest, opts ...grpc.CallOption) (*tenantv1.InitiateTenantResponse, error) {
+	if m.InitiateTenantFunc != nil {
+		return m.InitiateTenantFunc(ctx, in, opts...)
+	}
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockTenantServiceClient) RetrieveTenant(ctx context.Context, in *tenantv1.RetrieveTenantRequest, opts ...grpc.CallOption) (*tenantv1.RetrieveTenantResponse, error) {
+	if m.RetrieveTenantFunc != nil {
+		return m.RetrieveTenantFunc(ctx, in, opts...)
+	}
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockTenantServiceClient) UpdateTenantStatus(ctx context.Context, in *tenantv1.UpdateTenantStatusRequest, opts ...grpc.CallOption) (*tenantv1.UpdateTenantStatusResponse, error) {
+	if m.UpdateTenantStatusFunc != nil {
+		return m.UpdateTenantStatusFunc(ctx, in, opts...)
+	}
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockTenantServiceClient) ListTenants(ctx context.Context, in *tenantv1.ListTenantsRequest, opts ...grpc.CallOption) (*tenantv1.ListTenantsResponse, error) {
+	if m.ListTenantsFunc != nil {
+		return m.ListTenantsFunc(ctx, in, opts...)
+	}
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockTenantServiceClient) ReconcileMigrations(ctx context.Context, in *tenantv1.ReconcileMigrationsRequest, opts ...grpc.CallOption) (*tenantv1.ReconcileMigrationsResponse, error) {
+	if m.ReconcileMigrationsFunc != nil {
+		return m.ReconcileMigrationsFunc(ctx, in, opts...)
+	}
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockTenantServiceClient) GetTenantProvisioningStatus(ctx context.Context, in *tenantv1.GetTenantProvisioningStatusRequest, opts ...grpc.CallOption) (*tenantv1.GetTenantProvisioningStatusResponse, error) {
+	if m.GetTenantProvisioningStatusFunc != nil {
+		return m.GetTenantProvisioningStatusFunc(ctx, in, opts...)
+	}
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+// newTestClient creates a Client with an injected mock for unit testing.
+func newTestClient(mock tenantv1.TenantServiceClient) *Client {
+	return &Client{
+		tenant:  mock,
+		timeout: DefaultTimeout,
+	}
+}
+
+// =============================================================================
+// InitiateTenant Tests
+// =============================================================================
+
+func TestInitiateTenant_Success(t *testing.T) {
+	expected := &tenantv1.InitiateTenantResponse{}
+	mock := &mockTenantServiceClient{
+		InitiateTenantFunc: func(_ context.Context, _ *tenantv1.InitiateTenantRequest, _ ...grpc.CallOption) (*tenantv1.InitiateTenantResponse, error) {
+			return expected, nil
+		},
+	}
+	c := newTestClient(mock)
+
+	resp, err := c.InitiateTenant(context.Background(), &tenantv1.InitiateTenantRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, expected, resp)
+}
+
+func TestInitiateTenant_Error(t *testing.T) {
+	mock := &mockTenantServiceClient{
+		InitiateTenantFunc: func(_ context.Context, _ *tenantv1.InitiateTenantRequest, _ ...grpc.CallOption) (*tenantv1.InitiateTenantResponse, error) {
+			return nil, status.Error(codes.Internal, "db error")
+		},
+	}
+	c := newTestClient(mock)
+
+	_, err := c.InitiateTenant(context.Background(), &tenantv1.InitiateTenantRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "initiate tenant")
+}
+
+// =============================================================================
+// RetrieveTenant Tests
+// =============================================================================
+
+func TestRetrieveTenant_Success(t *testing.T) {
+	expected := &tenantv1.RetrieveTenantResponse{}
+	mock := &mockTenantServiceClient{
+		RetrieveTenantFunc: func(_ context.Context, _ *tenantv1.RetrieveTenantRequest, _ ...grpc.CallOption) (*tenantv1.RetrieveTenantResponse, error) {
+			return expected, nil
+		},
+	}
+	c := newTestClient(mock)
+
+	resp, err := c.RetrieveTenant(context.Background(), &tenantv1.RetrieveTenantRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, expected, resp)
+}
+
+func TestRetrieveTenant_Error(t *testing.T) {
+	mock := &mockTenantServiceClient{
+		RetrieveTenantFunc: func(_ context.Context, _ *tenantv1.RetrieveTenantRequest, _ ...grpc.CallOption) (*tenantv1.RetrieveTenantResponse, error) {
+			return nil, status.Error(codes.NotFound, "not found")
+		},
+	}
+	c := newTestClient(mock)
+
+	_, err := c.RetrieveTenant(context.Background(), &tenantv1.RetrieveTenantRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "retrieve tenant")
+}
+
+// =============================================================================
+// UpdateTenantStatus Tests
+// =============================================================================
+
+func TestUpdateTenantStatus_Success(t *testing.T) {
+	expected := &tenantv1.UpdateTenantStatusResponse{}
+	mock := &mockTenantServiceClient{
+		UpdateTenantStatusFunc: func(_ context.Context, _ *tenantv1.UpdateTenantStatusRequest, _ ...grpc.CallOption) (*tenantv1.UpdateTenantStatusResponse, error) {
+			return expected, nil
+		},
+	}
+	c := newTestClient(mock)
+
+	resp, err := c.UpdateTenantStatus(context.Background(), &tenantv1.UpdateTenantStatusRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, expected, resp)
+}
+
+func TestUpdateTenantStatus_Error(t *testing.T) {
+	mock := &mockTenantServiceClient{
+		UpdateTenantStatusFunc: func(_ context.Context, _ *tenantv1.UpdateTenantStatusRequest, _ ...grpc.CallOption) (*tenantv1.UpdateTenantStatusResponse, error) {
+			return nil, status.Error(codes.FailedPrecondition, "invalid transition")
+		},
+	}
+	c := newTestClient(mock)
+
+	_, err := c.UpdateTenantStatus(context.Background(), &tenantv1.UpdateTenantStatusRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "update tenant status")
+}
+
+// =============================================================================
+// ListTenants Tests
+// =============================================================================
+
+func TestListTenants_Success(t *testing.T) {
+	expected := &tenantv1.ListTenantsResponse{}
+	mock := &mockTenantServiceClient{
+		ListTenantsFunc: func(_ context.Context, _ *tenantv1.ListTenantsRequest, _ ...grpc.CallOption) (*tenantv1.ListTenantsResponse, error) {
+			return expected, nil
+		},
+	}
+	c := newTestClient(mock)
+
+	resp, err := c.ListTenants(context.Background(), &tenantv1.ListTenantsRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, expected, resp)
+}
+
+func TestListTenants_Error(t *testing.T) {
+	mock := &mockTenantServiceClient{
+		ListTenantsFunc: func(_ context.Context, _ *tenantv1.ListTenantsRequest, _ ...grpc.CallOption) (*tenantv1.ListTenantsResponse, error) {
+			return nil, status.Error(codes.Internal, "db error")
+		},
+	}
+	c := newTestClient(mock)
+
+	_, err := c.ListTenants(context.Background(), &tenantv1.ListTenantsRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list tenants")
+}
+
+// =============================================================================
+// ReconcileMigrations Tests
+// =============================================================================
+
+func TestReconcileMigrations_Success(t *testing.T) {
+	expected := &tenantv1.ReconcileMigrationsResponse{}
+	mock := &mockTenantServiceClient{
+		ReconcileMigrationsFunc: func(_ context.Context, _ *tenantv1.ReconcileMigrationsRequest, _ ...grpc.CallOption) (*tenantv1.ReconcileMigrationsResponse, error) {
+			return expected, nil
+		},
+	}
+	c := newTestClient(mock)
+
+	resp, err := c.ReconcileMigrations(context.Background(), &tenantv1.ReconcileMigrationsRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, expected, resp)
+}
+
+func TestReconcileMigrations_Error(t *testing.T) {
+	mock := &mockTenantServiceClient{
+		ReconcileMigrationsFunc: func(_ context.Context, _ *tenantv1.ReconcileMigrationsRequest, _ ...grpc.CallOption) (*tenantv1.ReconcileMigrationsResponse, error) {
+			return nil, status.Error(codes.Internal, "migration error")
+		},
+	}
+	c := newTestClient(mock)
+
+	_, err := c.ReconcileMigrations(context.Background(), &tenantv1.ReconcileMigrationsRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reconcile migrations")
+}
+
+// =============================================================================
+// GetTenantProvisioningStatus Tests
+// =============================================================================
+
+func TestGetTenantProvisioningStatus_Success(t *testing.T) {
+	expected := &tenantv1.GetTenantProvisioningStatusResponse{}
+	mock := &mockTenantServiceClient{
+		GetTenantProvisioningStatusFunc: func(_ context.Context, _ *tenantv1.GetTenantProvisioningStatusRequest, _ ...grpc.CallOption) (*tenantv1.GetTenantProvisioningStatusResponse, error) {
+			return expected, nil
+		},
+	}
+	c := newTestClient(mock)
+
+	resp, err := c.GetTenantProvisioningStatus(context.Background(), &tenantv1.GetTenantProvisioningStatusRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, expected, resp)
+}
+
+func TestGetTenantProvisioningStatus_Error(t *testing.T) {
+	mock := &mockTenantServiceClient{
+		GetTenantProvisioningStatusFunc: func(_ context.Context, _ *tenantv1.GetTenantProvisioningStatusRequest, _ ...grpc.CallOption) (*tenantv1.GetTenantProvisioningStatusResponse, error) {
+			return nil, status.Error(codes.NotFound, "not found")
+		},
+	}
+	c := newTestClient(mock)
+
+	_, err := c.GetTenantProvisioningStatus(context.Background(), &tenantv1.GetTenantProvisioningStatusRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "get tenant provisioning status")
+}

--- a/services/tenant/provisioner/provisioner_helpers_test.go
+++ b/services/tenant/provisioner/provisioner_helpers_test.go
@@ -1,0 +1,106 @@
+package provisioner
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaskDatabaseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "URL with password gets masked",
+			input:    "postgres://admin:secretpass@localhost:5432/mydb",
+			expected: "postgres://admin:%2A%2A%2A@localhost:5432/mydb",
+		},
+		{
+			name:     "URL without password unchanged",
+			input:    "postgres://admin@localhost:5432/mydb",
+			expected: "postgres://admin@localhost:5432/mydb",
+		},
+		{
+			name:     "URL with no user info unchanged",
+			input:    "postgres://localhost:5432/mydb",
+			expected: "postgres://localhost:5432/mydb",
+		},
+		{
+			name:     "empty string returned as-is",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "non-URL string returned as-is",
+			input:    "not-a-url",
+			expected: "not-a-url",
+		},
+		{
+			name:     "URL with query params preserves params",
+			input:    "postgres://user:pass@host:5432/db?sslmode=require",
+			expected: "postgres://user:%2A%2A%2A@host:5432/db?sslmode=require",
+		},
+		{
+			name:     "URL with empty password gets masked",
+			input:    "postgres://user:@localhost:5432/db",
+			expected: "postgres://user:%2A%2A%2A@localhost:5432/db",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := maskDatabaseURL(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsAlreadyExistsError(t *testing.T) {
+	t.Run("nil error returns false", func(t *testing.T) {
+		assert.False(t, isAlreadyExistsError(nil))
+	})
+
+	t.Run("PgError duplicate_table (42P07) returns true", func(t *testing.T) {
+		pgErr := &pgconn.PgError{Code: "42P07", Message: "relation already exists"}
+		assert.True(t, isAlreadyExistsError(pgErr))
+	})
+
+	t.Run("PgError duplicate_schema (42P06) returns true", func(t *testing.T) {
+		pgErr := &pgconn.PgError{Code: "42P06", Message: "schema already exists"}
+		assert.True(t, isAlreadyExistsError(pgErr))
+	})
+
+	t.Run("PgError duplicate_object (42710) returns true", func(t *testing.T) {
+		pgErr := &pgconn.PgError{Code: "42710", Message: "index already exists"}
+		assert.True(t, isAlreadyExistsError(pgErr))
+	})
+
+	t.Run("PgError unique_violation (23505) returns false", func(t *testing.T) {
+		pgErr := &pgconn.PgError{Code: "23505", Message: "unique constraint violated"}
+		assert.False(t, isAlreadyExistsError(pgErr))
+	})
+
+	t.Run("error containing already exists returns true", func(t *testing.T) {
+		err := errors.New("table already exists in schema")
+		assert.True(t, isAlreadyExistsError(err))
+	})
+
+	t.Run("error containing ALREADY EXISTS uppercase returns true", func(t *testing.T) {
+		err := errors.New("TABLE ALREADY EXISTS")
+		assert.True(t, isAlreadyExistsError(err))
+	})
+
+	t.Run("error containing duplicate returns true", func(t *testing.T) {
+		err := errors.New("duplicate key value")
+		assert.True(t, isAlreadyExistsError(err))
+	})
+
+	t.Run("generic error returns false", func(t *testing.T) {
+		err := errors.New("connection refused")
+		assert.False(t, isAlreadyExistsError(err))
+	})
+}

--- a/services/tenant/provisioner/provisioner_helpers_test.go
+++ b/services/tenant/provisioner/provisioner_helpers_test.go
@@ -99,6 +99,11 @@ func TestIsAlreadyExistsError(t *testing.T) {
 		assert.True(t, isAlreadyExistsError(err))
 	})
 
+	t.Run("PgError with unrecognized code falls through to string matching", func(t *testing.T) {
+		pgErr := &pgconn.PgError{Code: "23505", Message: "duplicate key value"}
+		assert.True(t, isAlreadyExistsError(pgErr))
+	})
+
 	t.Run("generic error returns false", func(t *testing.T) {
 		err := errors.New("connection refused")
 		assert.False(t, isAlreadyExistsError(err))


### PR DESCRIPTION
## Summary

- Add unit tests for tenant service client RPC methods (6 methods, success + error paths) and provisioner helper functions (maskDatabaseURL, isAlreadyExistsError)
- Add parseLogLevel unit tests for financial-accounting and market-information cmd packages
- Targets services near 80% on Codecov: financial-accounting (78.4%), tenant (78.4%), market-information (79.6%)

## Test plan

- [x] All new tests pass locally
- [ ] CI passes (lint, build, unit tests)
- [ ] Codecov coverage improves for all three services