### PR TITLE
test: close party service coverage gap toward 80%

### DIFF
--- a/services/party/adapters/persistence/repository_test.go
+++ b/services/party/adapters/persistence/repository_test.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"testing"
 	"time"
@@ -978,4 +979,51 @@ func TestAudit_DeleteParty_WritesAuditOutboxEntry(t *testing.T) {
 	assert.Equal(t, "party", deleteEntry.Table)
 	assert.NotEmpty(t, deleteEntry.OldValues, "Old values should contain deleted party data")
 	assert.Empty(t, deleteEntry.NewValues, "New values should be empty for DELETE")
+}
+
+// Unit tests for DecodePartyCursor
+
+func TestDecodePartyCursor_InvalidBase64(t *testing.T) {
+	_, err := DecodePartyCursor("!!!not-valid-base64!!!")
+	assert.ErrorIs(t, err, ErrInvalidCursor)
+}
+
+func TestDecodePartyCursor_InvalidFormat(t *testing.T) {
+	// Valid base64url but decoded content has no pipe separator
+	token := base64.URLEncoding.EncodeToString([]byte("nopipe"))
+	_, err := DecodePartyCursor(token)
+	assert.ErrorIs(t, err, ErrInvalidCursor)
+}
+
+func TestDecodePartyCursor_InvalidTimestamp(t *testing.T) {
+	// Valid format (has pipe) but timestamp portion is not parseable
+	token := base64.URLEncoding.EncodeToString([]byte("notadate|" + uuid.New().String()))
+	_, err := DecodePartyCursor(token)
+	assert.ErrorIs(t, err, ErrInvalidCursor)
+}
+
+func TestDecodePartyCursor_InvalidUUID(t *testing.T) {
+	// Valid timestamp but UUID portion is malformed
+	token := base64.URLEncoding.EncodeToString([]byte(time.Now().Format(time.RFC3339Nano) + "|notauuid"))
+	_, err := DecodePartyCursor(token)
+	assert.ErrorIs(t, err, ErrInvalidCursor)
+}
+
+// Unit tests for Repository helper methods
+
+func TestIsInTransaction_NilStatement(t *testing.T) {
+	// A fresh gorm.DB with nil Statement (no query chain started) is not in a transaction.
+	repo := &Repository{db: &gorm.DB{}}
+	assert.False(t, repo.isInTransaction())
+}
+
+func TestWithTx_ReturnsNewInstance(t *testing.T) {
+	original := &gorm.DB{}
+	tx := &gorm.DB{}
+	repo := &Repository{db: original}
+
+	txRepo := repo.WithTx(tx)
+
+	assert.NotSame(t, repo, txRepo)
+	assert.Equal(t, tx, txRepo.db)
 }

--- a/services/party/adapters/persistence/verification_repository_test.go
+++ b/services/party/adapters/persistence/verification_repository_test.go
@@ -431,3 +431,13 @@ func TestUpdateVerificationMetadata_NotFound(t *testing.T) {
 	err := repo.UpdateVerificationMetadata(ctx, uuid.New(), `{"test": "data"}`)
 	assert.ErrorIs(t, err, ErrVerificationNotFound)
 }
+
+func TestGetVerificationByID_NotFound(t *testing.T) {
+	db, ctx, cleanup := setupVerificationTestDB(t)
+	defer cleanup()
+
+	repo := NewVerificationRepository(db)
+
+	_, err := repo.GetVerificationByID(ctx, uuid.New())
+	assert.ErrorIs(t, err, ErrVerificationNotFound)
+}

--- a/services/party/service/grpc_service_test.go
+++ b/services/party/service/grpc_service_test.go
@@ -1050,4 +1050,32 @@ func TestListParties(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, codes.Internal, st.Code())
 	})
+
+	t.Run("returns InvalidArgument for unrecognized party_type enum", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		resp, err := svc.ListParties(ctx, &pb.ListPartiesRequest{
+			PartyType: pb.PartyType(999),
+		})
+		assert.Nil(t, resp)
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("returns InvalidArgument for unrecognized status enum", func(t *testing.T) {
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		resp, err := svc.ListParties(ctx, &pb.ListPartiesRequest{
+			Status: pb.PartyStatus(999),
+		})
+		assert.Nil(t, resp)
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
 }


### PR DESCRIPTION
## Summary

- Add `DecodePartyCursor` error path tests (invalid base64, missing pipe separator, bad timestamp, bad UUID)
- Add `Repository` helper unit tests: `isInTransaction` with nil statement, `WithTx` returns new instance
- Add `VerificationRepository.GetVerificationByID` not-found path test
- Add `ListParties` invalid enum filter tests (unrecognized party type and status enums return `InvalidArgument`)

## Test plan

- All new unit tests pass locally (pure unit tests with no testcontainer dependency)
- Integration tests verified to follow existing patterns in the file
- `go vet ./services/party/...` passes cleanly