### PR TITLE
chore: add frontend feature components to Codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -136,3 +136,107 @@ component_management:
       name: Shared Domain
       paths:
         - shared/domain/**
+    - component_id: fe-accounts
+      name: Frontend - Accounts
+      paths:
+        - frontend/src/features/accounts/**
+    - component_id: fe-audit
+      name: Frontend - Audit
+      paths:
+        - frontend/src/features/audit/**
+    - component_id: fe-cookbook
+      name: Frontend - Cookbook
+      paths:
+        - frontend/src/features/cookbook/**
+    - component_id: fe-dashboard
+      name: Frontend - Dashboard
+      paths:
+        - frontend/src/features/dashboard/**
+    - component_id: fe-economy
+      name: Frontend - Economy
+      paths:
+        - frontend/src/features/economy/**
+    - component_id: fe-forecasting
+      name: Frontend - Forecasting
+      paths:
+        - frontend/src/features/forecasting/**
+    - component_id: fe-identity
+      name: Frontend - Identity
+      paths:
+        - frontend/src/features/identity/**
+    - component_id: fe-internal-accounts
+      name: Frontend - Internal Accounts
+      paths:
+        - frontend/src/features/internal-accounts/**
+    - component_id: fe-ledger
+      name: Frontend - Ledger
+      paths:
+        - frontend/src/features/ledger/**
+    - component_id: fe-manifests
+      name: Frontend - Manifests
+      paths:
+        - frontend/src/features/manifests/**
+    - component_id: fe-mappings
+      name: Frontend - Mappings
+      paths:
+        - frontend/src/features/mappings/**
+    - component_id: fe-market-data
+      name: Frontend - Market Data
+      paths:
+        - frontend/src/features/market-data/**
+    - component_id: fe-mcp-config
+      name: Frontend - MCP Config
+      paths:
+        - frontend/src/features/mcp-config/**
+    - component_id: fe-parties
+      name: Frontend - Parties
+      paths:
+        - frontend/src/features/parties/**
+    - component_id: fe-payments
+      name: Frontend - Payments
+      paths:
+        - frontend/src/features/payments/**
+    - component_id: fe-positions
+      name: Frontend - Positions
+      paths:
+        - frontend/src/features/positions/**
+    - component_id: fe-reconciliation
+      name: Frontend - Reconciliation
+      paths:
+        - frontend/src/features/reconciliation/**
+    - component_id: fe-reference-data
+      name: Frontend - Reference Data
+      paths:
+        - frontend/src/features/reference-data/**
+    - component_id: fe-sagas
+      name: Frontend - Sagas
+      paths:
+        - frontend/src/features/sagas/**
+    - component_id: fe-tenants
+      name: Frontend - Tenants
+      paths:
+        - frontend/src/features/tenants/**
+    - component_id: fe-transactions
+      name: Frontend - Transactions
+      paths:
+        - frontend/src/features/transactions/**
+    - component_id: fe-components
+      name: Frontend - Components
+      paths:
+        - frontend/src/components/**
+    - component_id: fe-contexts
+      name: Frontend - Contexts
+      paths:
+        - frontend/src/contexts/**
+    - component_id: fe-hooks
+      name: Frontend - Hooks
+      paths:
+        - frontend/src/hooks/**
+    - component_id: fe-lib
+      name: Frontend - Lib
+      paths:
+        - frontend/src/lib/**
+    - component_id: fe-shared
+      name: Frontend - Shared
+      paths:
+        - frontend/src/shared/**


### PR DESCRIPTION
## Summary

- Adds 21 frontend feature component definitions to `codecov.yml` mirroring the backend per-service structure added in PR #1815
- Adds 5 shared frontend component definitions (`components`, `contexts`, `hooks`, `lib`, `shared`)
- All components inherit the 80% coverage target from `default_rules`

## Changes Made

Extended `component_management.individual_components` in `codecov.yml` with:

**Feature components** (21): `fe-accounts`, `fe-audit`, `fe-cookbook`, `fe-dashboard`, `fe-economy`, `fe-forecasting`, `fe-identity`, `fe-internal-accounts`, `fe-ledger`, `fe-manifests`, `fe-mappings`, `fe-market-data`, `fe-mcp-config`, `fe-parties`, `fe-payments`, `fe-positions`, `fe-reconciliation`, `fe-reference-data`, `fe-sagas`, `fe-tenants`, `fe-transactions`

**Shared components** (5): `fe-components`, `fe-contexts`, `fe-hooks`, `fe-lib`, `fe-shared`

Each component path maps to `frontend/src/features/<name>/**` or `frontend/src/<name>/**` for shared directories.

## Verification

- All directory paths verified to exist before adding
- YAML syntax validated via `python3 -c "import yaml; yaml.safe_load(...)"`