### PR TITLE
test: close control-plane coverage gap (77.5% -> 80%)

### DIFF
--- a/services/control-plane/internal/differ/safety_test.go
+++ b/services/control-plane/internal/differ/safety_test.go
@@ -1,0 +1,92 @@
+package differ
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoOpSafetyChecker_CheckAccountTypeDeletion(t *testing.T) {
+	checker := &NoOpSafetyChecker{}
+	blocked, err := checker.CheckAccountTypeDeletion(context.Background(), "CURRENT")
+	assert.NoError(t, err)
+	assert.Nil(t, blocked)
+}
+
+func TestNoOpSafetyChecker_CheckInstrumentDeletion(t *testing.T) {
+	checker := &NoOpSafetyChecker{}
+	blocked, err := checker.CheckInstrumentDeletion(context.Background(), "GBP")
+	assert.NoError(t, err)
+	assert.Nil(t, blocked)
+}
+
+func TestNoOpSafetyChecker_CheckSagaDeletion(t *testing.T) {
+	checker := &NoOpSafetyChecker{}
+	blocked, err := checker.CheckSagaDeletion(context.Background(), "process_settlement")
+	assert.NoError(t, err)
+	assert.Nil(t, blocked)
+}
+
+func TestNoOpDriftDetector_DetectDrift(t *testing.T) {
+	detector := &NoOpDriftDetector{}
+	warnings, err := detector.DetectDrift(context.Background(), nil)
+	assert.NoError(t, err)
+	assert.Nil(t, warnings)
+}
+
+func TestDiffPlan_HasBlockedDeletions_Empty(t *testing.T) {
+	plan := &DiffPlan{}
+	assert.False(t, plan.HasBlockedDeletions())
+}
+
+func TestDiffPlan_HasBlockedDeletions_WithEntries(t *testing.T) {
+	plan := &DiffPlan{
+		BlockedDeletions: []BlockedDeletion{
+			{ResourceType: ResourceInstrument, ResourceCode: "GBP", Reason: "in use"},
+		},
+	}
+	assert.True(t, plan.HasBlockedDeletions())
+}
+
+func TestDiffPlan_Summary_Empty(t *testing.T) {
+	plan := &DiffPlan{}
+	assert.Equal(t, "0 to create, 0 to update, 0 to delete, 0 no-change", plan.Summary())
+}
+
+func TestDiffPlan_Summary_Mixed(t *testing.T) {
+	plan := &DiffPlan{
+		Actions: []PlannedAction{
+			{Action: ActionCreate},
+			{Action: ActionCreate},
+			{Action: ActionUpdate},
+			{Action: ActionDelete},
+			{Action: ActionNoChange},
+			{Action: ActionNoChange},
+			{Action: ActionNoChange},
+		},
+	}
+	assert.Equal(t, "2 to create, 1 to update, 1 to delete, 3 no-change", plan.Summary())
+}
+
+func TestDiffPlan_BlockedDeletionErrors_Empty(t *testing.T) {
+	plan := &DiffPlan{}
+	assert.Empty(t, plan.BlockedDeletionErrors())
+}
+
+func TestDiffPlan_BlockedDeletionErrors_Formatted(t *testing.T) {
+	plan := &DiffPlan{
+		BlockedDeletions: []BlockedDeletion{
+			{ResourceType: ResourceInstrument, ResourceCode: "GBP", Reason: "has active positions"},
+			{ResourceType: ResourceAccountType, ResourceCode: "CURRENT", Reason: "in use by customers"},
+		},
+	}
+	errors := plan.BlockedDeletionErrors()
+	assert.Len(t, errors, 2)
+	assert.Equal(t, "Cannot delete instrument GBP: has active positions", errors[0])
+	assert.Equal(t, "Cannot delete account_type CURRENT: in use by customers", errors[1])
+}
+
+func TestErrNilManifest(t *testing.T) {
+	assert.EqualError(t, ErrNilManifest, "new manifest cannot be nil")
+}

--- a/services/control-plane/internal/manifest/export_test.go
+++ b/services/control-plane/internal/manifest/export_test.go
@@ -611,6 +611,188 @@ func TestExportService_Export_FallbackOnlySections(t *testing.T) {
 	})
 }
 
+func TestExportService_Export_AccountTypeCollectorError(t *testing.T) {
+	fb := testFallbackManifest()
+
+	t.Run("account type collector error falls back with warning", func(t *testing.T) {
+		svc := &ExportService{
+			collectors: &ExportCollectors{
+				AccountTypes: &mockAccountTypeCollector{err: errors.New("db connection lost")},
+			},
+		}
+
+		result := &ExportResult{
+			Manifest:       &controlplanev1.Manifest{},
+			SectionSources: make(map[string]string),
+		}
+
+		svc.collectAccountTypes(context.Background(), result, fb, "1.0")
+		assert.Equal(t, fb.AccountTypes, result.Manifest.AccountTypes)
+		assert.Equal(t, "fallback:manifest-v1.0", result.SectionSources["account_types"])
+		require.Len(t, result.Warnings, 1)
+		assert.Contains(t, result.Warnings[0], "db connection lost")
+	})
+
+	t.Run("account type collector error without fallback", func(t *testing.T) {
+		svc := &ExportService{
+			collectors: &ExportCollectors{
+				AccountTypes: &mockAccountTypeCollector{err: errors.New("fail")},
+			},
+		}
+
+		result := &ExportResult{
+			Manifest:       &controlplanev1.Manifest{},
+			SectionSources: make(map[string]string),
+		}
+
+		svc.collectAccountTypes(context.Background(), result, nil, "")
+		assert.Nil(t, result.Manifest.AccountTypes)
+		require.Len(t, result.Warnings, 1)
+	})
+}
+
+func TestExportService_Export_OrganizationCollectorError(t *testing.T) {
+	fb := testFallbackManifest()
+	fb.Organizations = []*controlplanev1.OrganizationDefinition{
+		{Code: "ACME", Name: "Acme Corp"},
+	}
+
+	svc := &ExportService{
+		collectors: &ExportCollectors{
+			Organizations: &mockOrganizationCollector{err: errors.New("timeout")},
+		},
+	}
+
+	result := &ExportResult{
+		Manifest:       &controlplanev1.Manifest{},
+		SectionSources: make(map[string]string),
+	}
+
+	svc.collectOrganizations(context.Background(), result, fb, "1.0")
+	assert.Equal(t, fb.Organizations, result.Manifest.Organizations)
+	assert.Equal(t, "fallback:manifest-v1.0", result.SectionSources["organizations"])
+	require.Len(t, result.Warnings, 1)
+	assert.Contains(t, result.Warnings[0], "timeout")
+}
+
+func TestExportService_Export_InternalAccountCollectorError(t *testing.T) {
+	fb := testFallbackManifest()
+	fb.InternalAccounts = []*controlplanev1.InternalAccountDefinition{
+		{Code: "REVENUE_GBP", AccountType: "REVENUE"},
+	}
+
+	svc := &ExportService{
+		collectors: &ExportCollectors{
+			InternalAccounts: &mockInternalAccountCollector{err: errors.New("service unavailable")},
+		},
+	}
+
+	result := &ExportResult{
+		Manifest:       &controlplanev1.Manifest{},
+		SectionSources: make(map[string]string),
+	}
+
+	svc.collectInternalAccounts(context.Background(), result, fb, "1.0")
+	assert.Equal(t, fb.InternalAccounts, result.Manifest.InternalAccounts)
+	assert.Equal(t, "fallback:manifest-v1.0", result.SectionSources["internal_accounts"])
+	require.Len(t, result.Warnings, 1)
+	assert.Contains(t, result.Warnings[0], "service unavailable")
+}
+
+func TestExportService_Export_MarketDataDatasetError(t *testing.T) {
+	fb := testFallbackManifest()
+	fb.MarketData = &controlplanev1.MarketDataConfig{
+		Datasets: []*controlplanev1.MarketDataSetDefinition{{Code: "FB_DS"}},
+	}
+
+	svc := &ExportService{
+		collectors: &ExportCollectors{
+			MarketData: &mockMarketDataCollector{dsErr: errors.New("dataset fail")},
+		},
+	}
+
+	result := &ExportResult{
+		Manifest:       &controlplanev1.Manifest{},
+		SectionSources: make(map[string]string),
+	}
+
+	svc.collectMarketData(context.Background(), result, fb, "1.0")
+	assert.Equal(t, fb.MarketData, result.Manifest.MarketData)
+	require.Len(t, result.Warnings, 1)
+	assert.Contains(t, result.Warnings[0], "dataset fail")
+}
+
+func TestExportService_Export_MarketDataBothErrors(t *testing.T) {
+	svc := &ExportService{
+		collectors: &ExportCollectors{
+			MarketData: &mockMarketDataCollector{
+				srcErr: errors.New("src fail"),
+				dsErr:  errors.New("ds fail"),
+			},
+		},
+	}
+
+	result := &ExportResult{
+		Manifest:       &controlplanev1.Manifest{},
+		SectionSources: make(map[string]string),
+	}
+
+	svc.collectMarketData(context.Background(), result, nil, "")
+	require.Len(t, result.Warnings, 1)
+	assert.Contains(t, result.Warnings[0], "src fail")
+	assert.Contains(t, result.Warnings[0], "ds fail")
+}
+
+func TestExportService_Export_OperationalGatewayRouteError(t *testing.T) {
+	fb := testFallbackManifest()
+	fb.OperationalGateway = &controlplanev1.OperationalGatewayConfig{
+		InstructionRoutes: []*controlplanev1.InstructionRouteConfig{{InstructionType: "pay"}},
+	}
+
+	svc := &ExportService{
+		collectors: &ExportCollectors{
+			OperationalGateway: &mockOperationalGatewayCollector{routeErr: errors.New("route fail")},
+		},
+	}
+
+	result := &ExportResult{
+		Manifest:       &controlplanev1.Manifest{},
+		SectionSources: make(map[string]string),
+	}
+
+	svc.collectOperationalGateway(context.Background(), result, fb, "1.0")
+	assert.Equal(t, fb.OperationalGateway, result.Manifest.OperationalGateway)
+	require.Len(t, result.Warnings, 1)
+	assert.Contains(t, result.Warnings[0], "route fail")
+}
+
+func TestExportService_Export_OperationalGatewayBothErrors(t *testing.T) {
+	svc := &ExportService{
+		collectors: &ExportCollectors{
+			OperationalGateway: &mockOperationalGatewayCollector{
+				connErr:  errors.New("conn fail"),
+				routeErr: errors.New("route fail"),
+			},
+		},
+	}
+
+	result := &ExportResult{
+		Manifest:       &controlplanev1.Manifest{},
+		SectionSources: make(map[string]string),
+	}
+
+	svc.collectOperationalGateway(context.Background(), result, nil, "")
+	require.Len(t, result.Warnings, 1)
+	assert.Contains(t, result.Warnings[0], "conn fail")
+	assert.Contains(t, result.Warnings[0], "route fail")
+}
+
+func TestIsNotFound(t *testing.T) {
+	assert.True(t, isNotFound(ErrVersionNotFound))
+	assert.False(t, isNotFound(nil))
+	assert.False(t, isNotFound(errors.New("other error")))
+}
+
 func TestExportService_Export_SectionFiltering(t *testing.T) {
 	t.Run("include only instruments section", func(t *testing.T) {
 		liveInstruments := []*controlplanev1.InstrumentDefinition{
@@ -645,4 +827,35 @@ func TestExportService_Export_SectionFiltering(t *testing.T) {
 		assert.Equal(t, liveInstruments, result.Manifest.Instruments)
 		assert.Nil(t, result.Manifest.Sagas) // Sagas not included.
 	})
+}
+
+func TestParseSections_Empty(t *testing.T) {
+	sections := parseSections(nil)
+	assert.Len(t, sections, len(allSections))
+	for name := range allSections {
+		assert.True(t, sections[name], "expected %s in result", name)
+	}
+}
+
+func TestParseSections_ValidSubset(t *testing.T) {
+	sections := parseSections([]string{"instruments", "sagas"})
+	assert.Len(t, sections, 2)
+	assert.True(t, sections[SectionInstruments])
+	assert.True(t, sections[SectionSagas])
+}
+
+func TestParseSections_UnknownIgnored(t *testing.T) {
+	sections := parseSections([]string{"instruments", "nonexistent"})
+	assert.Len(t, sections, 1)
+	assert.True(t, sections[SectionInstruments])
+}
+
+func TestParseSections_AllUnknown(t *testing.T) {
+	sections := parseSections([]string{"bogus", "fake"})
+	assert.Empty(t, sections)
+}
+
+func TestParseSections_EmptySlice(t *testing.T) {
+	sections := parseSections([]string{})
+	assert.Len(t, sections, len(allSections))
 }

--- a/services/control-plane/internal/manifest/history_test.go
+++ b/services/control-plane/internal/manifest/history_test.go
@@ -476,3 +476,28 @@ func testManifest(version string) *controlplanev1.Manifest {
 		},
 	}
 }
+
+func TestVersionEntity_TableName(t *testing.T) {
+	entity := VersionEntity{}
+	assert.Equal(t, "manifest_versions", entity.TableName())
+}
+
+func TestVersionEntity_GetPhaseStatus_InvalidJSON(t *testing.T) {
+	bad := "not json"
+	entity := &VersionEntity{PhaseStatus: &bad}
+	_, err := entity.GetPhaseStatus()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal phase_status")
+}
+
+func TestUnmarshalManifest_Valid(t *testing.T) {
+	m, err := unmarshalManifest(`{"version":"1.0"}`)
+	require.NoError(t, err)
+	assert.Equal(t, "1.0", m.GetVersion())
+}
+
+func TestUnmarshalManifest_Invalid(t *testing.T) {
+	_, err := unmarshalManifest(`not valid json`)
+	assert.Error(t, err)
+}
+

--- a/services/control-plane/internal/manifest/history_test.go
+++ b/services/control-plane/internal/manifest/history_test.go
@@ -500,4 +500,3 @@ func TestUnmarshalManifest_Invalid(t *testing.T) {
 	_, err := unmarshalManifest(`not valid json`)
 	assert.Error(t, err)
 }
-


### PR DESCRIPTION
## Summary

- Add unit tests for previously uncovered code paths in the control-plane service
- Target: close ~2.5% coverage gap to reach 80% threshold
- All new tests are pure unit tests (no testcontainer/DB dependencies)

### New test coverage

**differ package** (`safety_test.go` - new file):
- `NoOpSafetyChecker` methods (CheckAccountTypeDeletion, CheckInstrumentDeletion, CheckSagaDeletion)
- `NoOpDriftDetector.DetectDrift`
- `DiffPlan.HasBlockedDeletions`, `Summary`, `BlockedDeletionErrors`
- `ErrNilManifest` sentinel

**manifest/export package** (`export_test.go` - additions):
- Collector error paths: account types, organizations, internal accounts
- Market data: dataset-only errors, both source+dataset errors
- Operational gateway: route-only errors, both connection+route errors
- `parseSections`: empty input, valid subset, unknown sections, all unknown
- `isNotFound` helper

**manifest/history package** (`history_test.go` - additions):
- `VersionEntity.TableName()`
- `VersionEntity.GetPhaseStatus` with invalid JSON
- `unmarshalManifest` valid and invalid JSON paths

## Test plan

- [x] All new tests pass locally (`go test -short`)
- [ ] CI passes