### PR TITLE
test: close position-keeping coverage gaps toward 80%

### DIFF
--- a/services/position-keeping/observability/metrics_test.go
+++ b/services/position-keeping/observability/metrics_test.go
@@ -1,0 +1,35 @@
+package observability
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetNoopIdempotencyActive(t *testing.T) {
+	t.Run("set active", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			SetNoopIdempotencyActive(true)
+		})
+	})
+	t.Run("set inactive", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			SetNoopIdempotencyActive(false)
+		})
+	})
+}
+
+func TestRecordServiceDegradation(t *testing.T) {
+	require.NotPanics(t, func() {
+		RecordServiceDegradation(ComponentIdempotency, DegradationReasonStartupFallback)
+	})
+}
+
+func TestComponentConstants(t *testing.T) {
+	assert.Equal(t, "idempotency", ComponentIdempotency)
+}
+
+func TestDegradationReasonConstants(t *testing.T) {
+	assert.Equal(t, "startup_fallback", DegradationReasonStartupFallback)
+}

--- a/services/position-keeping/service/export_test.go
+++ b/services/position-keeping/service/export_test.go
@@ -1,0 +1,16 @@
+package service
+
+// ExtractIPAddressForTesting exposes extractIPAddress for testing.
+var ExtractIPAddressForTesting = extractIPAddress
+
+// ExtractSystemContextForTesting exposes extractSystemContext for testing.
+var ExtractSystemContextForTesting = extractSystemContext
+
+// FromProtoTransactionStatusForTesting exposes fromProtoTransactionStatus for testing.
+var FromProtoTransactionStatusForTesting = fromProtoTransactionStatus
+
+// ValidateUpdateRequestForTesting exposes validateUpdateRequest for testing.
+var ValidateUpdateRequestForTesting = validateUpdateRequest
+
+// ProtoAuditEntryToDomainForTesting exposes protoAuditEntryToDomain for testing.
+var ProtoAuditEntryToDomainForTesting = protoAuditEntryToDomain

--- a/services/position-keeping/service/metrics_coverage_test.go
+++ b/services/position-keeping/service/metrics_coverage_test.go
@@ -1,0 +1,52 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/position-keeping/service"
+)
+
+func TestRecordValidationFailure(t *testing.T) {
+	// Should not panic when called with valid arguments
+	require.NotPanics(t, func() {
+		service.RecordValidationFailure("KWH", service.ValidationFailureReasonCELRejected)
+	})
+	require.NotPanics(t, func() {
+		service.RecordValidationFailure("GBP", service.ValidationFailureReasonCELError)
+	})
+	require.NotPanics(t, func() {
+		service.RecordValidationFailure("USD", service.ValidationFailureReasonInstrumentNotFound)
+	})
+	require.NotPanics(t, func() {
+		service.RecordValidationFailure("EUR", service.ValidationFailureReasonBucketKeyError)
+	})
+}
+
+func TestRecordCardinalityViolation(t *testing.T) {
+	require.NotPanics(t, func() {
+		service.RecordCardinalityViolation("KWH")
+	})
+}
+
+func TestRecordOpeningBalanceValidationFailure(t *testing.T) {
+	require.NotPanics(t, func() {
+		service.RecordOpeningBalanceValidationFailure("GBP", service.ValidationFailureReasonCELRejected)
+	})
+}
+
+func TestExposeMetricsForTesting(t *testing.T) {
+	metrics := service.ExposeMetricsForTesting
+	assert.NotNil(t, metrics.MeasurementValidationFailuresTotal)
+	assert.NotNil(t, metrics.BucketCardinalityViolationsTotal)
+	assert.NotNil(t, metrics.OpeningBalanceValidationFailuresTotal)
+}
+
+func TestValidationFailureReasonConstants(t *testing.T) {
+	assert.Equal(t, "cel_rejected", service.ValidationFailureReasonCELRejected)
+	assert.Equal(t, "cel_error", service.ValidationFailureReasonCELError)
+	assert.Equal(t, "instrument_not_found", service.ValidationFailureReasonInstrumentNotFound)
+	assert.Equal(t, "bucket_key_error", service.ValidationFailureReasonBucketKeyError)
+}

--- a/services/position-keeping/service/server_coverage_test.go
+++ b/services/position-keeping/service/server_coverage_test.go
@@ -142,6 +142,7 @@ func TestListFinancialPositionLogs_NextPageToken(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, resp.Logs, 10)
 	assert.Equal(t, "10", resp.Pagination.NextPageToken)
+	mockRepo.AssertExpectations(t)
 }
 
 func TestListFinancialPositionLogs_CanceledContext(t *testing.T) {
@@ -181,6 +182,7 @@ func TestListFinancialPositionLogs_ContextCancelledDuringQuery(t *testing.T) {
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.Canceled, st.Code())
+	mockRepo.AssertExpectations(t)
 }
 
 func TestListFinancialPositionLogs_DeadlineExceeded(t *testing.T) {
@@ -202,4 +204,5 @@ func TestListFinancialPositionLogs_DeadlineExceeded(t *testing.T) {
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.DeadlineExceeded, st.Code())
+	mockRepo.AssertExpectations(t)
 }

--- a/services/position-keeping/service/server_coverage_test.go
+++ b/services/position-keeping/service/server_coverage_test.go
@@ -1,0 +1,205 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/meridianhub/meridian/services/position-keeping/service"
+)
+
+func TestFromProtoTransactionStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		proto    commonv1.TransactionStatus
+		expected domain.TransactionStatus
+	}{
+		{"pending", commonv1.TransactionStatus_TRANSACTION_STATUS_PENDING, domain.TransactionStatusPending},
+		{"posted", commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED, domain.TransactionStatusPosted},
+		{"failed", commonv1.TransactionStatus_TRANSACTION_STATUS_FAILED, domain.TransactionStatusFailed},
+		{"cancelled", commonv1.TransactionStatus_TRANSACTION_STATUS_CANCELLED, domain.TransactionStatusCancelled},
+		{"reversed", commonv1.TransactionStatus_TRANSACTION_STATUS_REVERSED, domain.TransactionStatusReversed},
+		{"unspecified defaults to pending", commonv1.TransactionStatus_TRANSACTION_STATUS_UNSPECIFIED, domain.TransactionStatusPending},
+		{"unknown defaults to pending", commonv1.TransactionStatus(999), domain.TransactionStatusPending},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := service.FromProtoTransactionStatusForTesting(tt.proto)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestListFinancialPositionLogs_InvalidPageToken(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	publisher := domain.NewInMemoryEventPublisher()
+	idempotency := new(MockIdempotencyService)
+	svc := mustNewPositionKeepingService(t, mockRepo, publisher, idempotency)
+
+	resp, err := svc.ListFinancialPositionLogs(ctx, &positionkeepingv1.ListFinancialPositionLogsRequest{
+		Pagination: &commonv1.Pagination{
+			PageSize:  10,
+			PageToken: "not-a-number",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "invalid page_token")
+}
+
+func TestListFinancialPositionLogs_NegativePageToken(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	publisher := domain.NewInMemoryEventPublisher()
+	idempotency := new(MockIdempotencyService)
+	svc := mustNewPositionKeepingService(t, mockRepo, publisher, idempotency)
+
+	resp, err := svc.ListFinancialPositionLogs(ctx, &positionkeepingv1.ListFinancialPositionLogsRequest{
+		Pagination: &commonv1.Pagination{
+			PageSize:  10,
+			PageToken: "-5",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "page_token cannot be negative")
+}
+
+func TestListFinancialPositionLogs_InvalidEndDate(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	publisher := domain.NewInMemoryEventPublisher()
+	idempotency := new(MockIdempotencyService)
+	svc := mustNewPositionKeepingService(t, mockRepo, publisher, idempotency)
+
+	resp, err := svc.ListFinancialPositionLogs(ctx, &positionkeepingv1.ListFinancialPositionLogsRequest{
+		DateRange: &commonv1.DateRange{
+			StartDate: "2025-01-01",
+			EndDate:   "invalid-date",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "invalid end_date")
+}
+
+func TestListFinancialPositionLogs_NextPageToken(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	publisher := domain.NewInMemoryEventPublisher()
+	idempotency := new(MockIdempotencyService)
+	svc := mustNewPositionKeepingService(t, mockRepo, publisher, idempotency)
+
+	now := time.Now().UTC()
+
+	// Return exactly page_size logs so NextPageToken is set
+	logs := make([]*domain.FinancialPositionLog, 10)
+	for i := range logs {
+		logs[i] = &domain.FinancialPositionLog{
+			LogID:                 uuid.New(),
+			AccountID:             "ACC-001",
+			TransactionLogEntries: []*domain.TransactionLogEntry{},
+			AuditTrail:            []*domain.AuditTrailEntry{},
+			StatusTracking:        domain.NewStatusTracking(),
+			CreatedAt:             now,
+			UpdatedAt:             now,
+			Version:               1,
+		}
+	}
+
+	mockRepo.On("List", ctx, domain.PositionLogFilter{
+		Limit:  10,
+		Offset: 0,
+	}).Return(logs, nil)
+
+	resp, err := svc.ListFinancialPositionLogs(ctx, &positionkeepingv1.ListFinancialPositionLogsRequest{
+		Pagination: &commonv1.Pagination{PageSize: 10},
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, resp.Logs, 10)
+	assert.Equal(t, "10", resp.Pagination.NextPageToken)
+}
+
+func TestListFinancialPositionLogs_CanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	mockRepo := new(MockRepository)
+	publisher := domain.NewInMemoryEventPublisher()
+	idempotency := new(MockIdempotencyService)
+	svc := mustNewPositionKeepingService(t, mockRepo, publisher, idempotency)
+
+	resp, err := svc.ListFinancialPositionLogs(ctx, &positionkeepingv1.ListFinancialPositionLogsRequest{})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Canceled, st.Code())
+}
+
+func TestListFinancialPositionLogs_ContextCancelledDuringQuery(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	publisher := domain.NewInMemoryEventPublisher()
+	idempotency := new(MockIdempotencyService)
+	svc := mustNewPositionKeepingService(t, mockRepo, publisher, idempotency)
+
+	mockRepo.On("List", ctx, domain.PositionLogFilter{
+		Limit:  50,
+		Offset: 0,
+	}).Return(nil, context.Canceled)
+
+	resp, err := svc.ListFinancialPositionLogs(ctx, &positionkeepingv1.ListFinancialPositionLogsRequest{})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Canceled, st.Code())
+}
+
+func TestListFinancialPositionLogs_DeadlineExceeded(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	publisher := domain.NewInMemoryEventPublisher()
+	idempotency := new(MockIdempotencyService)
+	svc := mustNewPositionKeepingService(t, mockRepo, publisher, idempotency)
+
+	mockRepo.On("List", ctx, domain.PositionLogFilter{
+		Limit:  50,
+		Offset: 0,
+	}).Return(nil, context.DeadlineExceeded)
+
+	resp, err := svc.ListFinancialPositionLogs(ctx, &positionkeepingv1.ListFinancialPositionLogsRequest{})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.DeadlineExceeded, st.Code())
+}

--- a/services/position-keeping/service/update_context_test.go
+++ b/services/position-keeping/service/update_context_test.go
@@ -1,0 +1,177 @@
+package service_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+
+	"github.com/meridianhub/meridian/services/position-keeping/service"
+)
+
+func TestExtractIPAddress(t *testing.T) {
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		expected string
+	}{
+		{
+			name:     "nil context",
+			ctx:      nil,
+			expected: "",
+		},
+		{
+			name:     "empty context",
+			ctx:      context.Background(),
+			expected: "",
+		},
+		{
+			name: "x-forwarded-for header",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+				"x-forwarded-for", "203.0.113.50, 70.41.3.18, 150.172.238.178",
+			)),
+			expected: "203.0.113.50",
+		},
+		{
+			name: "x-forwarded-for single IP",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+				"x-forwarded-for", "10.0.0.1",
+			)),
+			expected: "10.0.0.1",
+		},
+		{
+			name: "x-real-ip header",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+				"x-real-ip", "192.168.1.100",
+			)),
+			expected: "192.168.1.100",
+		},
+		{
+			name: "x-forwarded-for takes priority over x-real-ip",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+				"x-forwarded-for", "10.0.0.1",
+				"x-real-ip", "192.168.1.100",
+			)),
+			expected: "10.0.0.1",
+		},
+		{
+			name: "peer address fallback",
+			ctx: peer.NewContext(context.Background(), &peer.Peer{
+				Addr: &net.TCPAddr{IP: net.ParseIP("192.168.1.1"), Port: 50051},
+			}),
+			expected: "192.168.1.1",
+		},
+		{
+			name: "empty x-forwarded-for falls back to x-real-ip",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+				"x-forwarded-for", "",
+				"x-real-ip", "10.0.0.2",
+			)),
+			expected: "10.0.0.2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := service.ExtractIPAddressForTesting(tt.ctx)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractSystemContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		expected map[string]string
+	}{
+		{
+			name: "nil context returns service only",
+			ctx:  nil,
+			expected: map[string]string{
+				"service": "position-keeping",
+			},
+		},
+		{
+			name: "empty context returns service only",
+			ctx:  context.Background(),
+			expected: map[string]string{
+				"service": "position-keeping",
+			},
+		},
+		{
+			name: "x-correlation-id extracted",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+				"x-correlation-id", "corr-123",
+			)),
+			expected: map[string]string{
+				"service":        "position-keeping",
+				"correlation_id": "corr-123",
+			},
+		},
+		{
+			name: "correlation-id fallback",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+				"correlation-id", "corr-456",
+			)),
+			expected: map[string]string{
+				"service":        "position-keeping",
+				"correlation_id": "corr-456",
+			},
+		},
+		{
+			name: "x-request-id fallback",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+				"x-request-id", "req-789",
+			)),
+			expected: map[string]string{
+				"service":        "position-keeping",
+				"correlation_id": "req-789",
+			},
+		},
+		{
+			name: "tenant ID extracted",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+				"x-tenant-id", "tenant-abc",
+			)),
+			expected: map[string]string{
+				"service":   "position-keeping",
+				"tenant_id": "tenant-abc",
+			},
+		},
+		{
+			name: "user-agent extracted",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+				"user-agent", "grpc-go/1.50.0",
+			)),
+			expected: map[string]string{
+				"service":    "position-keeping",
+				"user_agent": "grpc-go/1.50.0",
+			},
+		},
+		{
+			name: "all headers extracted",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+				"x-correlation-id", "corr-all",
+				"x-tenant-id", "tenant-all",
+				"user-agent", "test-agent",
+			)),
+			expected: map[string]string{
+				"service":        "position-keeping",
+				"correlation_id": "corr-all",
+				"tenant_id":      "tenant-all",
+				"user_agent":     "test-agent",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := service.ExtractSystemContextForTesting(tt.ctx)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/services/position-keeping/service/update_status_transitions_test.go
+++ b/services/position-keeping/service/update_status_transitions_test.go
@@ -1,0 +1,309 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	"github.com/meridianhub/meridian/services/position-keeping/domain"
+)
+
+func makeExistingLog(logID uuid.UUID) *domain.FinancialPositionLog {
+	return &domain.FinancialPositionLog{
+		LogID:                 logID,
+		AccountID:             "ACC-001",
+		TransactionLogEntries: []*domain.TransactionLogEntry{},
+		AuditTrail:            []*domain.AuditTrailEntry{},
+		StatusTracking:        domain.NewStatusTracking(),
+		CreatedAt:             time.Now().UTC().Add(-1 * time.Hour),
+		UpdatedAt:             time.Now().UTC().Add(-1 * time.Hour),
+		Version:               1,
+	}
+}
+
+func TestUpdateFinancialPositionLog_StatusFailed(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	publisher := domain.NewInMemoryEventPublisher()
+	idempotency := new(MockIdempotencyService)
+	svc := mustNewPositionKeepingService(t, mockRepo, publisher, idempotency)
+
+	logID := uuid.New()
+	existingLog := makeExistingLog(logID)
+
+	mockRepo.On("FindByID", ctx, logID).Return(existingLog, nil)
+	mockRepo.On("UpdateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+
+	resp, err := svc.UpdateFinancialPositionLog(ctx, &positionkeepingv1.UpdateFinancialPositionLogRequest{
+		LogId:   logID.String(),
+		Version: 1,
+		StatusUpdate: &positionkeepingv1.StatusTracking{
+			CurrentStatus: commonv1.TransactionStatus_TRANSACTION_STATUS_FAILED,
+			StatusReason:  "Processing error",
+		},
+		AuditEntry: &positionkeepingv1.AuditTrailEntry{
+			Action: "fail_transaction", Details: "System failure", UserId: "system",
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, commonv1.TransactionStatus_TRANSACTION_STATUS_FAILED, resp.Log.StatusTracking.CurrentStatus)
+}
+
+func TestUpdateFinancialPositionLog_StatusCancelled(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	publisher := domain.NewInMemoryEventPublisher()
+	idempotency := new(MockIdempotencyService)
+	svc := mustNewPositionKeepingService(t, mockRepo, publisher, idempotency)
+
+	logID := uuid.New()
+	existingLog := makeExistingLog(logID)
+
+	mockRepo.On("FindByID", ctx, logID).Return(existingLog, nil)
+	mockRepo.On("UpdateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+
+	resp, err := svc.UpdateFinancialPositionLog(ctx, &positionkeepingv1.UpdateFinancialPositionLogRequest{
+		LogId:   logID.String(),
+		Version: 1,
+		StatusUpdate: &positionkeepingv1.StatusTracking{
+			CurrentStatus: commonv1.TransactionStatus_TRANSACTION_STATUS_CANCELLED,
+			StatusReason:  "User requested cancellation",
+		},
+		AuditEntry: &positionkeepingv1.AuditTrailEntry{
+			Action: "cancel_transaction", Details: "User cancellation", UserId: "user@example.com",
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, commonv1.TransactionStatus_TRANSACTION_STATUS_CANCELLED, resp.Log.StatusTracking.CurrentStatus)
+}
+
+func TestUpdateFinancialPositionLog_StatusPendingNotAllowed(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	publisher := domain.NewInMemoryEventPublisher()
+	idempotency := new(MockIdempotencyService)
+	svc := mustNewPositionKeepingService(t, mockRepo, publisher, idempotency)
+
+	logID := uuid.New()
+	existingLog := makeExistingLog(logID)
+
+	mockRepo.On("FindByID", ctx, logID).Return(existingLog, nil)
+
+	resp, err := svc.UpdateFinancialPositionLog(ctx, &positionkeepingv1.UpdateFinancialPositionLogRequest{
+		LogId:   logID.String(),
+		Version: 1,
+		StatusUpdate: &positionkeepingv1.StatusTracking{
+			CurrentStatus: commonv1.TransactionStatus_TRANSACTION_STATUS_PENDING,
+			StatusReason:  "Reset to pending",
+		},
+		AuditEntry: &positionkeepingv1.AuditTrailEntry{
+			Action: "reset", Details: "Reset", UserId: "user",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "cannot be directly set")
+}
+
+func TestUpdateFinancialPositionLog_StatusReversedNotAllowed(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	publisher := domain.NewInMemoryEventPublisher()
+	idempotency := new(MockIdempotencyService)
+	svc := mustNewPositionKeepingService(t, mockRepo, publisher, idempotency)
+
+	logID := uuid.New()
+	existingLog := makeExistingLog(logID)
+
+	mockRepo.On("FindByID", ctx, logID).Return(existingLog, nil)
+
+	resp, err := svc.UpdateFinancialPositionLog(ctx, &positionkeepingv1.UpdateFinancialPositionLogRequest{
+		LogId:   logID.String(),
+		Version: 1,
+		StatusUpdate: &positionkeepingv1.StatusTracking{
+			CurrentStatus: commonv1.TransactionStatus_TRANSACTION_STATUS_REVERSED,
+			StatusReason:  "Reverse",
+		},
+		AuditEntry: &positionkeepingv1.AuditTrailEntry{
+			Action: "reverse", Details: "Reverse", UserId: "user",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestUpdateFinancialPositionLog_RepositoryUpdateNotFound(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	publisher := domain.NewInMemoryEventPublisher()
+	idempotency := new(MockIdempotencyService)
+	svc := mustNewPositionKeepingService(t, mockRepo, publisher, idempotency)
+
+	logID := uuid.New()
+	existingLog := makeExistingLog(logID)
+
+	mockRepo.On("FindByID", ctx, logID).Return(existingLog, nil)
+	mockRepo.On("UpdateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
+		Return(domain.ErrNotFound)
+
+	resp, err := svc.UpdateFinancialPositionLog(ctx, &positionkeepingv1.UpdateFinancialPositionLogRequest{
+		LogId:   logID.String(),
+		Version: 1,
+		StatusUpdate: &positionkeepingv1.StatusTracking{
+			CurrentStatus: commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+			StatusReason:  "Posted",
+		},
+		AuditEntry: &positionkeepingv1.AuditTrailEntry{
+			Action: "post", Details: "Post", UserId: "user",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestUpdateFinancialPositionLog_RepositoryOptimisticLock(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	publisher := domain.NewInMemoryEventPublisher()
+	idempotency := new(MockIdempotencyService)
+	svc := mustNewPositionKeepingService(t, mockRepo, publisher, idempotency)
+
+	logID := uuid.New()
+	existingLog := makeExistingLog(logID)
+
+	mockRepo.On("FindByID", ctx, logID).Return(existingLog, nil)
+	mockRepo.On("UpdateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
+		Return(domain.ErrOptimisticLock)
+
+	resp, err := svc.UpdateFinancialPositionLog(ctx, &positionkeepingv1.UpdateFinancialPositionLogRequest{
+		LogId:   logID.String(),
+		Version: 1,
+		StatusUpdate: &positionkeepingv1.StatusTracking{
+			CurrentStatus: commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+			StatusReason:  "Posted",
+		},
+		AuditEntry: &positionkeepingv1.AuditTrailEntry{
+			Action: "post", Details: "Post", UserId: "user",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Aborted, st.Code())
+}
+
+func TestUpdateFinancialPositionLog_RepositoryInternalError(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	publisher := domain.NewInMemoryEventPublisher()
+	idempotency := new(MockIdempotencyService)
+	svc := mustNewPositionKeepingService(t, mockRepo, publisher, idempotency)
+
+	logID := uuid.New()
+	existingLog := makeExistingLog(logID)
+
+	mockRepo.On("FindByID", ctx, logID).Return(existingLog, nil)
+	mockRepo.On("UpdateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
+		Return(assert.AnError)
+
+	resp, err := svc.UpdateFinancialPositionLog(ctx, &positionkeepingv1.UpdateFinancialPositionLogRequest{
+		LogId:   logID.String(),
+		Version: 1,
+		StatusUpdate: &positionkeepingv1.StatusTracking{
+			CurrentStatus: commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+			StatusReason:  "Posted",
+		},
+		AuditEntry: &positionkeepingv1.AuditTrailEntry{
+			Action: "post", Details: "Post", UserId: "user",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
+func TestUpdateFinancialPositionLog_FindByIDInternalError(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	publisher := domain.NewInMemoryEventPublisher()
+	idempotency := new(MockIdempotencyService)
+	svc := mustNewPositionKeepingService(t, mockRepo, publisher, idempotency)
+
+	logID := uuid.New()
+	mockRepo.On("FindByID", ctx, logID).Return(nil, assert.AnError)
+
+	resp, err := svc.UpdateFinancialPositionLog(ctx, &positionkeepingv1.UpdateFinancialPositionLogRequest{
+		LogId:   logID.String(),
+		Version: 1,
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
+func TestUpdateFinancialPositionLog_NoIdempotencyKey(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	publisher := domain.NewInMemoryEventPublisher()
+	idempotency := new(MockIdempotencyService)
+	svc := mustNewPositionKeepingService(t, mockRepo, publisher, idempotency)
+
+	logID := uuid.New()
+	existingLog := makeExistingLog(logID)
+
+	mockRepo.On("FindByID", ctx, logID).Return(existingLog, nil)
+	mockRepo.On("UpdateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+
+	resp, err := svc.UpdateFinancialPositionLog(ctx, &positionkeepingv1.UpdateFinancialPositionLogRequest{
+		LogId:   logID.String(),
+		Version: 1,
+		StatusUpdate: &positionkeepingv1.StatusTracking{
+			CurrentStatus: commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+			StatusReason:  "Posted",
+		},
+		AuditEntry: &positionkeepingv1.AuditTrailEntry{
+			Action: "post", Details: "Post", UserId: "user",
+		},
+		// No IdempotencyKey
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	// No idempotency calls should be made
+	idempotency.AssertNotCalled(t, "Check")
+	idempotency.AssertNotCalled(t, "MarkPending")
+	idempotency.AssertNotCalled(t, "StoreResult")
+}


### PR DESCRIPTION
## Summary

- Add 6 new test files targeting position-keeping service and observability packages
- Service package coverage: 86.3% (up from ~73.7%)
- Tests cover: status transitions, context extraction (IP/system metadata), proto conversion, List edge cases, metrics recording, observability degradation tracking

## Test Files Added

| File | Package | What it tests |
|------|---------|---------------|
| `export_test.go` | service | Exposes internal functions for external test package |
| `server_coverage_test.go` | service_test | `fromProtoTransactionStatus`, `List` pagination/cancellation edge cases |
| `update_context_test.go` | service_test | `extractIPAddress` (forwarded-for, real-ip, peer), `extractSystemContext` (correlation-id, tenant, user-agent) |
| `update_status_transitions_test.go` | service_test | Failed/Cancelled/Pending(blocked)/Reversed(blocked) transitions, repo error mapping (NotFound, OptimisticLock, Internal), no-idempotency-key path |
| `metrics_coverage_test.go` | service_test | Validation failure metrics, cardinality violations, opening balance failures, constant values |
| `observability/metrics_test.go` | observability | `SetNoopIdempotencyActive`, `RecordServiceDegradation`, component constants |

## Test plan

- [x] All new tests pass locally with `-short` flag
- [ ] CI passes