### PR TITLE
Fix ApplyManifest: use valid external_reference_type for orgs

### DIFF
--- a/services/control-plane/internal/applier/defaults/apply_manifest/v1.3.0.star
+++ b/services/control-plane/internal/applier/defaults/apply_manifest/v1.3.0.star
@@ -179,7 +179,7 @@ def execute_apply_manifest():
             display_name=org_name,
             party_type=org.get("party_type", "ORGANIZATION"),
             external_reference=org.get("code", ""),
-            external_reference_type="CUSTOM",
+            external_reference_type=org.get("external_reference_type", ""),
             attributes=org.get("attributes", {}),
         )
         registered_organizations.append({

--- a/services/control-plane/internal/applier/party_client.go
+++ b/services/control-plane/internal/applier/party_client.go
@@ -61,12 +61,18 @@ func (c *PartyClient) RegisterOrganization(ctx *saga.StarlarkContext, params map
 }
 
 // parseExternalReferenceType converts a string to the proto ExternalReferenceType enum.
+// Accepts both prefixed ("EXTERNAL_REFERENCE_TYPE_LEI") and stripped ("LEI") forms,
+// since the Starlark handler schema uses stripped names while proto uses prefixed names.
 // Returns an error for non-empty strings that do not match a known type.
 func parseExternalReferenceType(s string) (partyv1.ExternalReferenceType, error) {
 	if s == "" {
 		return partyv1.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_UNSPECIFIED, nil
 	}
 	if v, ok := partyv1.ExternalReferenceType_value[s]; ok {
+		return partyv1.ExternalReferenceType(v), nil
+	}
+	// Try with prefix added (handles stripped form like "LEI").
+	if v, ok := partyv1.ExternalReferenceType_value["EXTERNAL_REFERENCE_TYPE_"+s]; ok {
 		return partyv1.ExternalReferenceType(v), nil
 	}
 	return 0, fmt.Errorf("%w: %q", ErrUnknownExternalReferenceType, s)


### PR DESCRIPTION
## Summary

- Replace hardcoded `"CUSTOM"` (invalid proto enum) with manifest-provided value, defaulting to empty string (UNSPECIFIED)
- Add prefix-fallback to `parseExternalReferenceType` so stripped names like `"LEI"` resolve to `EXTERNAL_REFERENCE_TYPE_LEI`

## Context

Addresses claude-review feedback from #1817. The `CUSTOM` value was not a valid `ExternalReferenceType` proto enum variant and would fail at runtime.

## Test Plan

- [x] ApplyManifest unit tests pass
- [ ] Deploy to demo, full reset completes