### PR TITLE
Fix ApplyManifest: default external_reference_type for organizations

### DIFF
--- a/services/control-plane/internal/applier/defaults/apply_manifest/v1.3.0.star
+++ b/services/control-plane/internal/applier/defaults/apply_manifest/v1.3.0.star
@@ -179,7 +179,7 @@ def execute_apply_manifest():
             display_name=org_name,
             party_type=org.get("party_type", "ORGANIZATION"),
             external_reference=org.get("code", ""),
-            external_reference_type=org.get("external_reference_type", ""),
+            external_reference_type=org.get("external_reference_type", "COMPANIES_HOUSE"),
             attributes=org.get("attributes", {}),
         )
         registered_organizations.append({


### PR DESCRIPTION
## Summary

- Default `external_reference_type` to `"COMPANIES_HOUSE"` when not specified in manifest (empty string is rejected by Starlark enum validation since UNSPECIFIED is stripped)

## Context

Ninth PR in the reproducible demo seeding chain. The Starlark handler schema strips the 0-valued UNSPECIFIED entry from enum allowed values, so empty string fails validation. Manifests can override with any valid type.

## Test Plan

- [x] ApplyManifest unit tests pass
- [ ] Deploy to demo, full reset completes