### PR TITLE
Fix ApplyManifest: use NATIONAL_ID type for org external references

### DIFF
--- a/services/control-plane/internal/applier/defaults/apply_manifest/v1.3.0.star
+++ b/services/control-plane/internal/applier/defaults/apply_manifest/v1.3.0.star
@@ -174,13 +174,16 @@ def execute_apply_manifest():
     for org in organizations:
         step(name="register_organization_" + org["code"])
         org_name = org.get("name", org["code"])
+        org_attrs = org.get("attributes", {})
+        # Use external_reference from attributes if present, otherwise fall back to org code.
+        ext_ref = org_attrs.get("external_reference", org["code"])
         party.register_organization(
             legal_name=org_name,
             display_name=org_name,
             party_type=org.get("party_type", "ORGANIZATION"),
-            external_reference=org.get("code", ""),
-            external_reference_type=org.get("external_reference_type", "COMPANIES_HOUSE"),
-            attributes=org.get("attributes", {}),
+            external_reference=ext_ref,
+            external_reference_type=org.get("external_reference_type", "NATIONAL_ID"),
+            attributes=org_attrs,
         )
         registered_organizations.append({
             "code": org["code"],


### PR DESCRIPTION
## Summary

- Use `NATIONAL_ID` instead of `COMPANIES_HOUSE` as default `external_reference_type` (regex accepts alphanumeric org codes)
- Extract `external_reference` from org `attributes` where the manifest defines it (e.g., `"UKPNDNO001"`)

## Context

Tenth PR in the demo seeding chain. `COMPANIES_HOUSE` regex (`^[A-Z]{0,2}\d{6,8}$`) rejected org codes like "UKPNDNO001". `NATIONAL_ID` regex (`^[A-Z0-9]{5,20}$`) accepts them.

## Test Plan

- [x] ApplyManifest unit tests pass
- [ ] Deploy to demo, full reset completes