### PR TITLE
feat: Enhance validate-manifests CI to include handler parameter validation

### DIFF
--- a/.github/workflows/control-plane-ci.yml
+++ b/.github/workflows/control-plane-ci.yml
@@ -8,6 +8,7 @@ on:
       - 'api/jsonschema/**'
       - 'services/control-plane/**'
       - 'examples/manifests/**'
+      - 'cookbook/**'
       - 'buf.gen.jsonschema.yaml'
       - 'scripts/validate-manifest-jsonschema.sh'
       - '.github/workflows/control-plane-ci.yml'
@@ -18,6 +19,7 @@ on:
       - 'api/jsonschema/**'
       - 'services/control-plane/**'
       - 'examples/manifests/**'
+      - 'cookbook/**'
       - 'buf.gen.jsonschema.yaml'
       - 'scripts/validate-manifest-jsonschema.sh'
       - '.github/workflows/control-plane-ci.yml'
@@ -133,14 +135,19 @@ jobs:
       - name: Report validation failures
         if: failure()
         run: |
-          echo "::error::Example manifest validation failed."
+          echo "::error::Manifest or cookbook pattern validation failed."
           echo "::error::Check the output above for specific validation errors."
           echo ""
           echo "Manifests are validated against:"
           echo "  - Protobuf schema constraints (field types, required fields)"
           echo "  - CEL expression type-checking (policy expressions)"
           echo "  - Starlark script compilation (saga scripts)"
+          echo "  - Handler parameter validation (required params, types, enum values)"
           echo "  - Cross-reference integrity (instrument code references)"
+          echo ""
+          echo "Cookbook patterns (.star files) are validated against:"
+          echo "  - Starlark syntax"
+          echo "  - Handler parameter validation via schema-derived service modules"
 
   unit-tests:
     name: Control Plane Unit Tests

--- a/Makefile
+++ b/Makefile
@@ -519,11 +519,11 @@ asyncapi-validate:
 gen-event-publishers:
 	@$(GOCMD) run ./tools/gen-event-publishers
 
-## validate-manifests: Validate example manifests against protobuf schema, CEL, and Starlark
+## validate-manifests: Validate example manifests and cookbook patterns against schema
 validate-manifests:
-	@echo "Validating example manifests..."
-	@$(GOCMD) run ./services/control-plane/cmd/validate/ -manifest='examples/manifests/*.json'
-	@echo "All example manifests validated successfully"
+	@echo "Validating example manifests and cookbook patterns..."
+	@$(GOCMD) run ./services/control-plane/cmd/validate/ -manifest='examples/manifests/*.json' -starlark='cookbook/patterns/**/*.star'
+	@echo "All example manifests and cookbook patterns validated successfully"
 
 ## test-control-plane: Run control plane service unit tests
 test-control-plane:

--- a/services/control-plane/cmd/validate/main.go
+++ b/services/control-plane/cmd/validate/main.go
@@ -30,25 +30,17 @@ import (
 
 func main() {
 	manifestGlob := flag.String("manifest", "", "glob pattern for manifest files (e.g., examples/manifests/*.json)")
+	starlarkGlob := flag.String("starlark", "", "glob pattern for standalone Starlark files (e.g., cookbook/patterns/**/*.star)")
 	jsonOutput := flag.Bool("json", false, "output results as JSON")
 	flag.Parse()
 
-	if *manifestGlob == "" {
-		fmt.Fprintf(os.Stderr, "Usage: validate -manifest=<glob>\n")
-		fmt.Fprintf(os.Stderr, "  Validates manifest files against the Meridian schema.\n\n")
-		fmt.Fprintf(os.Stderr, "Example:\n")
+	if *manifestGlob == "" && *starlarkGlob == "" {
+		fmt.Fprintf(os.Stderr, "Usage: validate -manifest=<glob> [-starlark=<glob>] [-json]\n")
+		fmt.Fprintf(os.Stderr, "  Validates manifest and/or Starlark files against the Meridian schema.\n\n")
+		fmt.Fprintf(os.Stderr, "Examples:\n")
 		fmt.Fprintf(os.Stderr, "  validate -manifest='examples/manifests/*.json'\n")
-		os.Exit(1)
-	}
-
-	files, err := filepath.Glob(*manifestGlob)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: invalid glob pattern: %v\n", err)
-		os.Exit(1)
-	}
-
-	if len(files) == 0 {
-		fmt.Fprintf(os.Stderr, "Error: no files matched pattern: %s\n", *manifestGlob)
+		fmt.Fprintf(os.Stderr, "  validate -starlark='cookbook/patterns/**/*.star'\n")
+		fmt.Fprintf(os.Stderr, "  validate -manifest='examples/manifests/*.json' -starlark='cookbook/patterns/**/*.star'\n")
 		os.Exit(1)
 	}
 
@@ -59,17 +51,52 @@ func main() {
 		os.Exit(1)
 	}
 
+	hasFailures := false
+
+	// Validate manifest files if glob provided.
+	if *manifestGlob != "" {
+		failed := validateManifests(*manifestGlob, derivedSchema, *jsonOutput)
+		if failed {
+			hasFailures = true
+		}
+	}
+
+	// Validate standalone Starlark files if glob provided.
+	if *starlarkGlob != "" {
+		failed := validateStarlark(*starlarkGlob, derivedSchema, *jsonOutput)
+		if failed {
+			hasFailures = true
+		}
+	}
+
+	if hasFailures {
+		os.Exit(1)
+	}
+}
+
+// validateManifests validates manifest JSON files and returns true if any failures occurred.
+func validateManifests(glob string, derivedSchema *schema.Schema, jsonOut bool) bool {
+	files, err := filepath.Glob(glob)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: invalid manifest glob pattern: %v\n", err)
+		return true
+	}
+	if len(files) == 0 {
+		fmt.Fprintf(os.Stderr, "Error: no files matched manifest pattern: %s\n", glob)
+		return true
+	}
+
 	v, err := validator.New(validator.WithDerivedSchema(derivedSchema))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: failed to create validator: %v\n", err)
-		os.Exit(1)
+		return true
 	}
 
 	hasFailures := false
 	for _, file := range files {
 		result, validErr := validateFile(v, file)
 		if validErr != nil {
-			if *jsonOutput {
+			if jsonOut {
 				out, _ := json.MarshalIndent(map[string]any{
 					"file":  file,
 					"error": validErr.Error(),
@@ -82,7 +109,7 @@ func main() {
 			continue
 		}
 
-		if *jsonOutput {
+		if jsonOut {
 			out, _ := json.MarshalIndent(map[string]any{
 				"file":   file,
 				"result": result,
@@ -96,10 +123,41 @@ func main() {
 			hasFailures = true
 		}
 	}
+	return hasFailures
+}
 
-	if hasFailures {
-		os.Exit(1)
+// validateStarlark validates standalone .star files and returns true if any failures occurred.
+func validateStarlark(glob string, derivedSchema *schema.Schema, jsonOut bool) bool {
+	results, err := validateStarlarkFiles(glob, derivedSchema)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return true
 	}
+
+	hasFailures := false
+	for _, r := range results {
+		if jsonOut {
+			out, _ := json.MarshalIndent(map[string]any{
+				"file":    r.File,
+				"pass":    r.Pass,
+				"skipped": r.Skipped,
+				"error":   r.Error,
+			}, "", "  ")
+			fmt.Println(string(out))
+		} else {
+			if r.Skipped {
+				fmt.Printf("SKIP %s\n", r.File)
+			} else if r.Pass {
+				fmt.Printf("PASS %s\n", r.File)
+			} else {
+				fmt.Fprintf(os.Stderr, "FAIL %s: %s\n", r.File, r.Error)
+			}
+		}
+		if !r.Pass && !r.Skipped {
+			hasFailures = true
+		}
+	}
+	return hasFailures
 }
 
 // buildDerivedSchema registers all service handlers and derives the schema from proto metadata.

--- a/services/control-plane/cmd/validate/starlark.go
+++ b/services/control-plane/cmd/validate/starlark.go
@@ -46,6 +46,12 @@ func collectStarlarkFiles(glob string) ([]string, error) {
 	root := filepath.Clean(strings.TrimRight(parts[0], string(filepath.Separator)))
 	suffix := strings.TrimLeft(parts[1], string(filepath.Separator))
 
+	// Determine whether the suffix contains path separators.
+	// filepath.Match does not match across path separators, so for simple
+	// suffixes like "*.star" we match the basename; for multi-segment suffixes
+	// like "payments/*.star" we match the relative path from root.
+	matchRelative := strings.Contains(suffix, string(filepath.Separator))
+
 	var files []string
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -54,7 +60,17 @@ func collectStarlarkFiles(glob string) ([]string, error) {
 		if d.IsDir() {
 			return nil
 		}
-		matched, matchErr := filepath.Match(suffix, filepath.Base(path))
+		var target string
+		if matchRelative {
+			rel, relErr := filepath.Rel(root, path)
+			if relErr != nil {
+				return relErr
+			}
+			target = rel
+		} else {
+			target = filepath.Base(path)
+		}
+		matched, matchErr := filepath.Match(suffix, target)
 		if matchErr != nil {
 			return matchErr
 		}
@@ -67,6 +83,17 @@ func collectStarlarkFiles(glob string) ([]string, error) {
 		return nil, fmt.Errorf("walking directory %s: %w", root, err)
 	}
 	return files, nil
+}
+
+// hasSkipDirective checks whether a Starlark script contains the skip directive
+// as an actual comment line rather than inside a string literal.
+func hasSkipDirective(content string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		if strings.TrimSpace(line) == skipDirective {
+			return true
+		}
+	}
+	return false
 }
 
 // starlarkValidationResult holds the validation outcome for a single .star file.
@@ -110,8 +137,8 @@ func validateSingleStarlarkFile(path string, schemaReg *schema.Registry) starlar
 	}
 	content := string(data)
 
-	// Honor skip directive
-	if strings.Contains(content, skipDirective) {
+	// Honor skip directive - check actual comment lines only
+	if hasSkipDirective(content) {
 		return starlarkValidationResult{File: path, Pass: true, Skipped: true}
 	}
 

--- a/services/control-plane/cmd/validate/starlark.go
+++ b/services/control-plane/cmd/validate/starlark.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
@@ -30,6 +31,44 @@ var (
 	errHandlerNotAllowed = errors.New("handler not registered and not in open fallback allowlist")
 )
 
+// collectStarlarkFiles resolves a glob pattern into a list of .star file paths.
+// Unlike filepath.Glob, this supports ** for recursive directory matching by
+// using filepath.WalkDir when the pattern contains **.
+func collectStarlarkFiles(glob string) ([]string, error) {
+	if !strings.Contains(glob, "**") {
+		// Simple glob without recursion - filepath.Glob works fine
+		return filepath.Glob(glob)
+	}
+
+	// Split pattern at ** to get the root directory and the file suffix pattern.
+	// E.g., "cookbook/patterns/**/*.star" -> root="cookbook/patterns", suffix="*.star"
+	parts := strings.SplitN(glob, "**", 2)
+	root := filepath.Clean(strings.TrimRight(parts[0], string(filepath.Separator)))
+	suffix := strings.TrimLeft(parts[1], string(filepath.Separator))
+
+	var files []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		matched, matchErr := filepath.Match(suffix, filepath.Base(path))
+		if matchErr != nil {
+			return matchErr
+		}
+		if matched {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walking directory %s: %w", root, err)
+	}
+	return files, nil
+}
+
 // starlarkValidationResult holds the validation outcome for a single .star file.
 type starlarkValidationResult struct {
 	File    string
@@ -41,10 +80,13 @@ type starlarkValidationResult struct {
 // validateStarlarkFiles validates standalone .star files against the handler schema.
 // It builds validation modules from the derived schema and executes each script
 // to catch UNKNOWN_HANDLER, UNKNOWN_PARAM, MISSING_REQUIRED_PARAM, and WRONG_PARAM_TYPE errors.
+//
+// The glob parameter supports ** for recursive matching (e.g., "cookbook/patterns/**/*.star")
+// by using filepath.WalkDir instead of filepath.Glob, which does not support **.
 func validateStarlarkFiles(glob string, derivedSchema *schema.Schema) ([]starlarkValidationResult, error) {
-	files, err := filepath.Glob(glob)
+	files, err := collectStarlarkFiles(glob)
 	if err != nil {
-		return nil, fmt.Errorf("invalid glob pattern: %w", err)
+		return nil, err
 	}
 	if len(files) == 0 {
 		return nil, fmt.Errorf("%w: %s", errNoFilesMatched, glob)
@@ -213,9 +255,8 @@ func decimalBuiltin() *starlark.Builtin {
 			}
 			return starlark.Float(float64(i64)), nil
 		case starlark.String:
-			var f float64
-			n, err := fmt.Sscanf(string(v), "%f", &f)
-			if err != nil || n != 1 {
+			f, err := strconv.ParseFloat(string(v), 64)
+			if err != nil {
 				return nil, fmt.Errorf("%w: %q", errDecimalParse, string(v))
 			}
 			return starlark.Float(f), nil
@@ -440,12 +481,9 @@ func permissiveResultField(contextName, name string) starlark.Value {
 			&permissiveResultValue{name: contextName + "." + name + "[1]"},
 		})
 	}
-	intFields := map[string]bool{"count": true}
+	intFields := map[string]bool{"count": true, "max_members": true}
 	if intFields[name] {
 		return starlark.MakeInt(0)
-	}
-	if name == "max_members" {
-		return starlark.MakeInt(100)
 	}
 	numericFields := map[string]bool{
 		"amount": true, "total": true, "balance": true, "quantity": true,

--- a/services/control-plane/cmd/validate/starlark.go
+++ b/services/control-plane/cmd/validate/starlark.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,6 +15,20 @@ import (
 
 // skipDirective is the comment that opts a .star file out of schema validation.
 const skipDirective = "# schema-validation: skip"
+
+// Sentinel errors for linter compliance.
+var (
+	errNoFilesMatched    = errors.New("no files matched pattern")
+	errDecimalArgCount   = errors.New("decimal: expected exactly 1 argument")
+	errDecimalOverflow   = errors.New("decimal: integer too large to convert")
+	errDecimalParse      = errors.New("decimal: cannot parse as a number")
+	errDecimalType       = errors.New("decimal: unsupported type")
+	errUnhashableDict    = errors.New("unhashable: dict")
+	errUnhashableModule  = errors.New("unhashable: open_service_module")
+	errUnhashableHybrid  = errors.New("unhashable: hybrid_service_module")
+	errUnhashableResult  = errors.New("unhashable: result")
+	errHandlerNotAllowed = errors.New("handler not registered and not in open fallback allowlist")
+)
 
 // starlarkValidationResult holds the validation outcome for a single .star file.
 type starlarkValidationResult struct {
@@ -32,7 +47,7 @@ func validateStarlarkFiles(glob string, derivedSchema *schema.Schema) ([]starlar
 		return nil, fmt.Errorf("invalid glob pattern: %w", err)
 	}
 	if len(files) == 0 {
-		return nil, fmt.Errorf("no files matched pattern: %s", glob)
+		return nil, fmt.Errorf("%w: %s", errNoFilesMatched, glob)
 	}
 
 	schemaReg := schema.NewRegistryFromSchema(derivedSchema)
@@ -174,9 +189,19 @@ func buildStarlarkPredeclared(schemaReg *schema.Registry) (starlark.StringDict, 
 	})
 
 	// Decimal(s) returns a Float for arithmetic compatibility
-	predeclared["Decimal"] = starlark.NewBuiltin("Decimal", func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+	predeclared["Decimal"] = decimalBuiltin()
+
+	// input_data is a permissive dict that returns sensible defaults for any key access.
+	predeclared["input_data"] = &permissiveInputDict{}
+
+	return predeclared, nil
+}
+
+// decimalBuiltin returns a Starlark builtin that converts string/int/float to Float.
+func decimalBuiltin() *starlark.Builtin {
+	return starlark.NewBuiltin("Decimal", func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 		if len(args) != 1 {
-			return nil, fmt.Errorf("Decimal: expected exactly 1 argument, got %d", len(args))
+			return nil, fmt.Errorf("%w: got %d", errDecimalArgCount, len(args))
 		}
 		switch v := args[0].(type) {
 		case starlark.Float:
@@ -184,31 +209,20 @@ func buildStarlarkPredeclared(schemaReg *schema.Registry) (starlark.StringDict, 
 		case starlark.Int:
 			i64, ok := v.Int64()
 			if !ok {
-				return nil, fmt.Errorf("Decimal: integer too large to convert")
+				return nil, errDecimalOverflow
 			}
 			return starlark.Float(float64(i64)), nil
 		case starlark.String:
 			var f float64
 			n, err := fmt.Sscanf(string(v), "%f", &f)
 			if err != nil || n != 1 {
-				return nil, fmt.Errorf("Decimal: cannot parse %q as a number", string(v))
+				return nil, fmt.Errorf("%w: %q", errDecimalParse, string(v))
 			}
 			return starlark.Float(f), nil
 		default:
-			return nil, fmt.Errorf("Decimal: unsupported type %s", args[0].Type())
+			return nil, fmt.Errorf("%w: %s", errDecimalType, args[0].Type())
 		}
 	})
-
-	// input_data is a permissive dict that returns sensible defaults for any key access.
-	predeclared["input_data"] = newPermissiveInputData()
-
-	return predeclared, nil
-}
-
-// newPermissiveInputData creates a permissive input_data mock that returns
-// sensible defaults for any key access pattern used in cookbook scripts.
-func newPermissiveInputData() *permissiveInputDict {
-	return &permissiveInputDict{}
 }
 
 // permissiveInputDict is a Starlark value that responds to both dict-style
@@ -221,7 +235,7 @@ func (d *permissiveInputDict) String() string        { return "input_data{}" }
 func (d *permissiveInputDict) Type() string          { return "dict" }
 func (d *permissiveInputDict) Freeze()               {}
 func (d *permissiveInputDict) Truth() starlark.Bool  { return starlark.True }
-func (d *permissiveInputDict) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: dict") }
+func (d *permissiveInputDict) Hash() (uint32, error) { return 0, errUnhashableDict }
 
 // Get implements starlark.Mapping for x["key"] access.
 func (d *permissiveInputDict) Get(key starlark.Value) (v starlark.Value, found bool, err error) {
@@ -247,7 +261,7 @@ func (d *permissiveInputDict) Attr(name string) (starlark.Value, error) {
 			return starlark.String(""), nil
 		}), nil
 	}
-	return nil, nil
+	return starlark.None, nil
 }
 
 // AttrNames lists the available methods.
@@ -295,7 +309,7 @@ func (m *openServiceModule) Type() string         { return "open_service_module"
 func (m *openServiceModule) Freeze()              {}
 func (m *openServiceModule) Truth() starlark.Bool { return starlark.True }
 func (m *openServiceModule) Hash() (uint32, error) {
-	return 0, fmt.Errorf("unhashable: open_service_module")
+	return 0, errUnhashableModule
 }
 
 func (m *openServiceModule) Attr(name string) (starlark.Value, error) {
@@ -321,7 +335,7 @@ func (h *hybridServiceModule) Type() string         { return "hybrid_service_mod
 func (h *hybridServiceModule) Freeze()              {}
 func (h *hybridServiceModule) Truth() starlark.Bool { return starlark.True }
 func (h *hybridServiceModule) Hash() (uint32, error) {
-	return 0, fmt.Errorf("unhashable: hybrid_service_module")
+	return 0, errUnhashableHybrid
 }
 
 func (h *hybridServiceModule) Attr(name string) (starlark.Value, error) {
@@ -334,7 +348,7 @@ func (h *hybridServiceModule) Attr(name string) (starlark.Value, error) {
 	if _, allowed := h.openHandlers[name]; allowed {
 		return h.open.Attr(name)
 	}
-	return nil, fmt.Errorf("%s.%s: handler not registered and not in open fallback allowlist (possible misspelling?)", h.name, name)
+	return nil, fmt.Errorf("%s.%s: %w (possible misspelling?)", h.name, name, errHandlerNotAllowed)
 }
 
 func (h *hybridServiceModule) AttrNames() []string {
@@ -350,11 +364,14 @@ type permissiveResultValue struct {
 	name string
 }
 
-func (r *permissiveResultValue) String() string        { return r.name + "{}" }
-func (r *permissiveResultValue) Type() string          { return r.name }
-func (r *permissiveResultValue) Freeze()               {}
-func (r *permissiveResultValue) Truth() starlark.Bool  { return starlark.True }
-func (r *permissiveResultValue) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: %s", r.name) }
+func (r *permissiveResultValue) String() string       { return r.name + "{}" }
+func (r *permissiveResultValue) Type() string         { return r.name }
+func (r *permissiveResultValue) Freeze()              {}
+func (r *permissiveResultValue) Truth() starlark.Bool { return starlark.True }
+
+func (r *permissiveResultValue) Hash() (uint32, error) {
+	return 0, errUnhashableResult
+}
 
 func (r *permissiveResultValue) Attr(name string) (starlark.Value, error) {
 	if name == "get" {

--- a/services/control-plane/cmd/validate/starlark.go
+++ b/services/control-plane/cmd/validate/starlark.go
@@ -1,0 +1,447 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+	"go.starlark.net/syntax"
+)
+
+// skipDirective is the comment that opts a .star file out of schema validation.
+const skipDirective = "# schema-validation: skip"
+
+// starlarkValidationResult holds the validation outcome for a single .star file.
+type starlarkValidationResult struct {
+	File    string
+	Pass    bool
+	Skipped bool
+	Error   string
+}
+
+// validateStarlarkFiles validates standalone .star files against the handler schema.
+// It builds validation modules from the derived schema and executes each script
+// to catch UNKNOWN_HANDLER, UNKNOWN_PARAM, MISSING_REQUIRED_PARAM, and WRONG_PARAM_TYPE errors.
+func validateStarlarkFiles(glob string, derivedSchema *schema.Schema) ([]starlarkValidationResult, error) {
+	files, err := filepath.Glob(glob)
+	if err != nil {
+		return nil, fmt.Errorf("invalid glob pattern: %w", err)
+	}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no files matched pattern: %s", glob)
+	}
+
+	schemaReg := schema.NewRegistryFromSchema(derivedSchema)
+
+	var results []starlarkValidationResult
+	for _, file := range files {
+		result := validateSingleStarlarkFile(file, schemaReg)
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+// validateSingleStarlarkFile validates one .star file against the handler schema.
+func validateSingleStarlarkFile(path string, schemaReg *schema.Registry) starlarkValidationResult {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return starlarkValidationResult{File: path, Error: fmt.Sprintf("failed to read file: %v", err)}
+	}
+	content := string(data)
+
+	// Honor skip directive
+	if strings.Contains(content, skipDirective) {
+		return starlarkValidationResult{File: path, Pass: true, Skipped: true}
+	}
+
+	// Syntax check
+	fileOpts := &syntax.FileOptions{}
+	if _, parseErr := fileOpts.Parse(filepath.Base(path), content, 0); parseErr != nil {
+		return starlarkValidationResult{File: path, Error: fmt.Sprintf("syntax error: %v", parseErr)}
+	}
+
+	// Build predeclared environment with schema-validated modules
+	predeclared, err := buildStarlarkPredeclared(schemaReg)
+	if err != nil {
+		return starlarkValidationResult{File: path, Error: fmt.Sprintf("failed to build validation modules: %v", err)}
+	}
+
+	// Execute the script
+	thread := &starlark.Thread{
+		Name:  filepath.Base(path),
+		Print: func(_ *starlark.Thread, _ string) {},
+	}
+	if _, execErr := starlark.ExecFileOptions(fileOpts, thread, filepath.Base(path), content, predeclared); execErr != nil {
+		return starlarkValidationResult{File: path, Error: execErr.Error()}
+	}
+
+	return starlarkValidationResult{File: path, Pass: true}
+}
+
+// buildStarlarkPredeclared constructs the Starlark predeclared environment for
+// validating standalone cookbook scripts. It combines:
+//   - Schema-validated modules for all registered handlers (strict validation)
+//   - Open mock modules for service namespaces not yet in the handler registry
+//   - Standard builtins: saga, step, Decimal, input_data
+func buildStarlarkPredeclared(schemaReg *schema.Registry) (starlark.StringDict, error) {
+	// Build strict validation modules from the schema registry.
+	validationModules, err := schema.BuildValidationModules(schemaReg, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	predeclared := make(starlark.StringDict)
+	for name, module := range validationModules {
+		predeclared[name] = module
+	}
+
+	// Add open mock modules for namespaces not covered by the schema.
+	// These are service namespaces used in cookbook patterns that either:
+	// (a) have no registered handlers yet (experimental/aspirational)
+	// (b) use a different service module name than what's registered
+	cookbookNamespaces := []string{
+		"current_account",
+		"financial_accounting",
+		"financial_gateway",
+		"internal_account",
+		"market_data",
+		"market_information",
+		"operational_gateway",
+		"party",
+		"position_keeping",
+		"reconciliation",
+		"reference_data",
+		"repository",
+		"valuation_engine",
+	}
+
+	// Explicit allowlist of handlers not yet registered but used in cookbook scripts.
+	// Misspelled handler names NOT in this list will still fail validation.
+	openFallbackHandlers := map[string]map[string]struct{}{
+		"current_account": {
+			"evaluate_asset_valuation": {},
+			"execute_withdrawal":       {},
+		},
+		"party": {
+			"get": {},
+		},
+		"position_keeping": {
+			"get_balance":      {},
+			"list_accounts":    {},
+			"query_accounts":   {},
+			"query_logs":       {},
+			"query_positions":  {},
+			"retrieve_balance": {},
+		},
+		"reference_data": {
+			"get_account":      {},
+			"get_account_type": {},
+			"query":            {},
+		},
+	}
+
+	for _, ns := range cookbookNamespaces {
+		if _, registered := predeclared[ns]; !registered {
+			predeclared[ns] = &openServiceModule{name: ns}
+		} else {
+			// Wrap registered modules with hybrid fallback for known unregistered handlers
+			if fallbacks, ok := openFallbackHandlers[ns]; ok {
+				predeclared[ns] = &hybridServiceModule{
+					name:         ns,
+					strict:       predeclared[ns],
+					open:         &openServiceModule{name: ns},
+					openHandlers: fallbacks,
+				}
+			}
+		}
+	}
+
+	// Standard builtins
+
+	// saga(name) returns a mock saga object
+	predeclared["saga"] = starlark.NewBuiltin("saga", func(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+		members := starlark.StringDict{"name": starlark.String("mock_saga")}
+		return starlarkstruct.FromStringDict(starlark.String("Saga"), members), nil
+	})
+
+	// step(name) is a no-op step marker
+	predeclared["step"] = starlark.NewBuiltin("step", func(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+		return starlark.None, nil
+	})
+
+	// Decimal(s) returns a Float for arithmetic compatibility
+	predeclared["Decimal"] = starlark.NewBuiltin("Decimal", func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("Decimal: expected exactly 1 argument, got %d", len(args))
+		}
+		switch v := args[0].(type) {
+		case starlark.Float:
+			return v, nil
+		case starlark.Int:
+			i64, ok := v.Int64()
+			if !ok {
+				return nil, fmt.Errorf("Decimal: integer too large to convert")
+			}
+			return starlark.Float(float64(i64)), nil
+		case starlark.String:
+			var f float64
+			n, err := fmt.Sscanf(string(v), "%f", &f)
+			if err != nil || n != 1 {
+				return nil, fmt.Errorf("Decimal: cannot parse %q as a number", string(v))
+			}
+			return starlark.Float(f), nil
+		default:
+			return nil, fmt.Errorf("Decimal: unsupported type %s", args[0].Type())
+		}
+	})
+
+	// input_data is a permissive dict that returns sensible defaults for any key access.
+	predeclared["input_data"] = newPermissiveInputData()
+
+	return predeclared, nil
+}
+
+// newPermissiveInputData creates a permissive input_data mock that returns
+// sensible defaults for any key access pattern used in cookbook scripts.
+func newPermissiveInputData() *permissiveInputDict {
+	return &permissiveInputDict{}
+}
+
+// permissiveInputDict is a Starlark value that responds to both dict-style
+// access (x["key"]) and attribute access (x.get("key")), returning sensible
+// defaults for any key. This enables cookbook scripts to execute end-to-end
+// so handler parameter validation can fire.
+type permissiveInputDict struct{}
+
+func (d *permissiveInputDict) String() string        { return "input_data{}" }
+func (d *permissiveInputDict) Type() string          { return "dict" }
+func (d *permissiveInputDict) Freeze()               {}
+func (d *permissiveInputDict) Truth() starlark.Bool  { return starlark.True }
+func (d *permissiveInputDict) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: dict") }
+
+// Get implements starlark.Mapping for x["key"] access.
+func (d *permissiveInputDict) Get(key starlark.Value) (v starlark.Value, found bool, err error) {
+	name, ok := key.(starlark.String)
+	if !ok {
+		return starlark.String(""), true, nil
+	}
+	return permissiveValue(string(name)), true, nil
+}
+
+// Attr implements starlark.HasAttrs for x.get("key") access.
+func (d *permissiveInputDict) Attr(name string) (starlark.Value, error) {
+	if name == "get" {
+		return starlark.NewBuiltin("get", func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+			if len(args) >= 2 {
+				return args[1], nil
+			}
+			if len(args) >= 1 {
+				if keyStr, ok := args[0].(starlark.String); ok {
+					return permissiveValue(string(keyStr)), nil
+				}
+			}
+			return starlark.String(""), nil
+		}), nil
+	}
+	return nil, nil
+}
+
+// AttrNames lists the available methods.
+func (d *permissiveInputDict) AttrNames() []string { return []string{"get"} }
+
+// permissiveValue returns a sensible default value for a given key name.
+// Integer fields return Int, decimal fields return Float, nested dicts
+// return a permissive struct, and everything else returns String.
+func permissiveValue(name string) starlark.Value {
+	// Integer fields - used where handlers expect int32/int64/uint32
+	intFields := map[string]bool{
+		"amount_cents": true, "max_members": true, "count": true,
+	}
+	if intFields[name] || strings.HasSuffix(name, "_cents") || strings.HasSuffix(name, "_minor_units") {
+		return starlark.MakeInt(10)
+	}
+	// Decimal/float fields - used where handlers expect TypeDecimal
+	numericFields := map[string]bool{
+		"amount": true, "total": true, "balance": true, "quantity": true,
+		"units": true, "unit_amount": true, "value": true, "stake_amount": true,
+		"gpu_hours": true, "amount_per_unit": true,
+	}
+	if numericFields[name] {
+		return starlark.Float(10.0)
+	}
+
+	nestedFields := map[string]bool{
+		"metadata": true, "instrument_amount": true, "attributes": true,
+	}
+	if nestedFields[name] {
+		return &permissiveResultValue{name: "input_data." + name}
+	}
+
+	return starlark.String("mock-" + name)
+}
+
+// openServiceModule is a Starlark value that responds to any attribute access
+// by returning a callable that accepts any kwargs and returns a permissive result.
+type openServiceModule struct {
+	name string
+}
+
+func (m *openServiceModule) String() string       { return m.name }
+func (m *openServiceModule) Type() string         { return "open_service_module" }
+func (m *openServiceModule) Freeze()              {}
+func (m *openServiceModule) Truth() starlark.Bool { return starlark.True }
+func (m *openServiceModule) Hash() (uint32, error) {
+	return 0, fmt.Errorf("unhashable: open_service_module")
+}
+
+func (m *openServiceModule) Attr(name string) (starlark.Value, error) {
+	fullName := m.name + "." + name
+	return starlark.NewBuiltin(fullName, func(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+		return &permissiveResultValue{name: fullName + ".Result"}, nil
+	}), nil
+}
+
+func (m *openServiceModule) AttrNames() []string { return nil }
+
+// hybridServiceModule delegates to strict schema-validated module for
+// known handlers, falls back to open mock for handlers in openHandlers.
+type hybridServiceModule struct {
+	name         string
+	strict       starlark.Value
+	open         *openServiceModule
+	openHandlers map[string]struct{}
+}
+
+func (h *hybridServiceModule) String() string       { return h.name }
+func (h *hybridServiceModule) Type() string         { return "hybrid_service_module" }
+func (h *hybridServiceModule) Freeze()              {}
+func (h *hybridServiceModule) Truth() starlark.Bool { return starlark.True }
+func (h *hybridServiceModule) Hash() (uint32, error) {
+	return 0, fmt.Errorf("unhashable: hybrid_service_module")
+}
+
+func (h *hybridServiceModule) Attr(name string) (starlark.Value, error) {
+	if hasAttr, ok := h.strict.(starlark.HasAttrs); ok {
+		val, err := hasAttr.Attr(name)
+		if err == nil && val != nil {
+			return val, nil
+		}
+	}
+	if _, allowed := h.openHandlers[name]; allowed {
+		return h.open.Attr(name)
+	}
+	return nil, fmt.Errorf("%s.%s: handler not registered and not in open fallback allowlist (possible misspelling?)", h.name, name)
+}
+
+func (h *hybridServiceModule) AttrNames() []string {
+	if hasAttr, ok := h.strict.(starlark.HasAttrs); ok {
+		return hasAttr.AttrNames()
+	}
+	return nil
+}
+
+// permissiveResultValue is a Starlark value that responds to any attribute access
+// or dict-style key access with a placeholder value. It also supports iteration.
+type permissiveResultValue struct {
+	name string
+}
+
+func (r *permissiveResultValue) String() string        { return r.name + "{}" }
+func (r *permissiveResultValue) Type() string          { return r.name }
+func (r *permissiveResultValue) Freeze()               {}
+func (r *permissiveResultValue) Truth() starlark.Bool  { return starlark.True }
+func (r *permissiveResultValue) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: %s", r.name) }
+
+func (r *permissiveResultValue) Attr(name string) (starlark.Value, error) {
+	if name == "get" {
+		return starlark.NewBuiltin("get", func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+			if len(args) >= 2 {
+				return args[1], nil
+			}
+			return starlark.String(""), nil
+		}), nil
+	}
+	return permissiveResultField(r.name, name), nil
+}
+
+func (r *permissiveResultValue) AttrNames() []string { return nil }
+
+// Get implements starlark.Mapping for x["key"] access.
+func (r *permissiveResultValue) Get(key starlark.Value) (v starlark.Value, found bool, err error) {
+	name, ok := key.(starlark.String)
+	if !ok {
+		return starlark.String(""), true, nil
+	}
+	return permissiveResultField(r.name, string(name)), true, nil
+}
+
+// Len implements starlark.Sequence for len(result).
+func (r *permissiveResultValue) Len() int { return 2 }
+
+// Index implements starlark.Indexable for result[i].
+func (r *permissiveResultValue) Index(i int) starlark.Value {
+	return &permissiveResultValue{name: fmt.Sprintf("%s[%d]", r.name, i)}
+}
+
+// Iterate implements starlark.Iterable for "for x in result".
+func (r *permissiveResultValue) Iterate() starlark.Iterator {
+	items := []starlark.Value{
+		&permissiveResultValue{name: r.name + "[0]"},
+		&permissiveResultValue{name: r.name + "[1]"},
+	}
+	return &resultIterator{items: items}
+}
+
+type resultIterator struct {
+	items []starlark.Value
+	index int
+}
+
+func (it *resultIterator) Next(p *starlark.Value) bool {
+	if it.index >= len(it.items) {
+		return false
+	}
+	*p = it.items[it.index]
+	it.index++
+	return true
+}
+
+func (it *resultIterator) Done() {}
+
+// permissiveResultField returns a placeholder value for a result field.
+func permissiveResultField(contextName, name string) starlark.Value {
+	listFields := map[string]bool{
+		"valuation_methods": true, "items": true, "results": true, "participants": true,
+	}
+	if listFields[name] {
+		return starlark.NewList([]starlark.Value{
+			&permissiveResultValue{name: contextName + "." + name + "[0]"},
+			&permissiveResultValue{name: contextName + "." + name + "[1]"},
+		})
+	}
+	intFields := map[string]bool{"count": true}
+	if intFields[name] {
+		return starlark.MakeInt(0)
+	}
+	if name == "max_members" {
+		return starlark.MakeInt(100)
+	}
+	numericFields := map[string]bool{
+		"amount": true, "total": true, "balance": true, "quantity": true,
+		"units": true, "unit_amount": true, "value": true, "stake_amount": true,
+	}
+	if numericFields[name] {
+		return starlark.Float(0)
+	}
+	nestedFields := map[string]bool{
+		"metadata": true, "instrument_amount": true, "attributes": true,
+	}
+	if nestedFields[name] {
+		return &permissiveResultValue{name: contextName + "." + name}
+	}
+	return starlark.String("")
+}


### PR DESCRIPTION
## Summary

- Add `-starlark` flag to the validate CLI tool for validating standalone `.star` files against the proto-derived handler schema
- Update `make validate-manifests` to also validate `cookbook/patterns/**/*.star` alongside example manifests
- Add `cookbook/**` to control-plane-ci.yml trigger paths so cookbook changes trigger validation
- Catches UNKNOWN_HANDLER, UNKNOWN_PARAM, MISSING_REQUIRED_PARAM, and WRONG_PARAM_TYPE errors in cookbook scripts

## Changes Made

**`services/control-plane/cmd/validate/main.go`** - Refactored to support both `-manifest` and `-starlark` flags. Either or both can be provided.

**`services/control-plane/cmd/validate/starlark.go`** (new) - Standalone Starlark file validation:
- Builds schema-validated modules from the derived handler schema (same as manifest validation)
- Provides open mock modules for unregistered service namespaces (repository, market_data, etc.)
- Hybrid modules for services with partially registered handlers (strict for known, permissive fallback for allowlisted)
- Permissive input_data mock that returns type-appropriate defaults (int for `_cents`/`_minor_units`, float for amounts, string for everything else)
- Honors `# schema-validation: skip` directive in scripts

**`Makefile`** - `validate-manifests` target now passes both `-manifest` and `-starlark` globs

**`.github/workflows/control-plane-ci.yml`** - Added `cookbook/**` to push/PR trigger paths

## Task Master

Task: manifest-integrity.4

## Test plan

- [x] `make validate-manifests` passes - validates 5 manifests + 16 cookbook patterns (12 PASS, 4 SKIP)
- [x] `go build ./services/control-plane/cmd/validate/` compiles cleanly
- [ ] CI pipeline passes on this PR