### PR TITLE
fix: upgrade flatted to 3.4.2 (CVE-2026-33228)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7584,9 +7584,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,7 +56,8 @@
   },
   "overrides": {
     "hono": "^4.12.4",
-    "@hono/node-server": "^1.19.10"
+    "@hono/node-server": "^1.19.10",
+    "flatted": "^3.4.2"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.65.0",


### PR DESCRIPTION
## Summary

- Pins `flatted` >= 3.4.2 via npm overrides to resolve high-severity prototype pollution vulnerability (CVE-2026-33228 / GHSA-rf6f-7fwh-wjgh)
- `flatted` is a transitive dev dependency via `flat-cache` (ESLint)
- No application code changes - lockfile-only update

## Security Advisory

- **CVE**: CVE-2026-33228
- **GHSA**: GHSA-rf6f-7fwh-wjgh
- **Severity**: High
- **Vulnerable**: flatted <= 3.4.1
- **Fixed**: flatted >= 3.4.2
- **Vector**: Prototype pollution via `parse()`

## Test plan

- [x] `npm audit` reports 0 vulnerabilities
- [ ] CI passes (no runtime dependency changes)