### PR TITLE
chore: exclude testhelpers from Codecov coverage reporting

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,6 +15,7 @@ ignore:
   - "**/*.pb.validate.go"
   - "**/*_grpc.pb.go"
   - "**/mocks/**"
+  - "**/testhelpers/**"
   - "utilities/**"
   - "frontend/src/api/gen/**"
   - "services/mcp-server/cmd/wire.go"


### PR DESCRIPTION
## Summary

- Adds `**/testhelpers/**` to the `ignore` list in `codecov.yml`
- Excludes test infrastructure files (testcontainer setup helpers) that execute only during tests but are incorrectly counted as uncovered production code

## Files being excluded

- `services/market-information/adapters/persistence/testhelpers/testcontainer.go` (326 lines, 0% coverage)
- `services/position-keeping/adapters/persistence/testhelpers/testcontainer.go` (232 lines, 0% coverage)
- Any other testhelpers directories that may exist

This recovers ~558 lines from the miss count, improving per-service coverage metrics.