### PR TITLE
test: add persistence and domain tests for position-keeping service

### DIFF
--- a/services/position-keeping/adapters/persistence/outbox_repository_test.go
+++ b/services/position-keeping/adapters/persistence/outbox_repository_test.go
@@ -22,7 +22,7 @@ func TestPostgresRepository_CreateWithOutbox(t *testing.T) {
 		log := createTestLog(t, testAccountID)
 		postFnCalled := false
 
-		err := tc.repo.CreateWithOutbox(ctx, log, func(tx pgx.Tx) error {
+		err := tc.repo.CreateWithOutbox(ctx, log, func(_ pgx.Tx) error {
 			postFnCalled = true
 			return nil
 		})
@@ -63,7 +63,7 @@ func TestPostgresRepository_CreateWithOutbox(t *testing.T) {
 		log := createTestLog(t, testAccountID)
 		expectedErr := fmt.Errorf("outbox write failed")
 
-		err := tc.repo.CreateWithOutbox(ctx, log, func(tx pgx.Tx) error {
+		err := tc.repo.CreateWithOutbox(ctx, log, func(_ pgx.Tx) error {
 			return expectedErr
 		})
 		require.Error(t, err)
@@ -90,7 +90,7 @@ func TestPostgresRepository_UpdateWithOutbox(t *testing.T) {
 		require.NoError(t, err)
 
 		postFnCalled := false
-		err = tc.repo.UpdateWithOutbox(ctx, log, func(tx pgx.Tx) error {
+		err = tc.repo.UpdateWithOutbox(ctx, log, func(_ pgx.Tx) error {
 			postFnCalled = true
 			return nil
 		})
@@ -150,7 +150,7 @@ func TestPostgresRepository_UpdateWithOutbox(t *testing.T) {
 		err = log.MarkPosted("Posted", nil)
 		require.NoError(t, err)
 
-		err = tc.repo.UpdateWithOutbox(ctx, log, func(tx pgx.Tx) error {
+		err = tc.repo.UpdateWithOutbox(ctx, log, func(_ pgx.Tx) error {
 			return fmt.Errorf("outbox error")
 		})
 		require.Error(t, err)

--- a/services/position-keeping/adapters/persistence/outbox_repository_test.go
+++ b/services/position-keeping/adapters/persistence/outbox_repository_test.go
@@ -1,0 +1,163 @@
+package persistence_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/meridianhub/meridian/services/position-keeping/adapters/persistence"
+	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgresRepository_CreateWithOutbox(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+
+	t.Run("creates log and calls postFn", func(t *testing.T) {
+		log := createTestLog(t, testAccountID)
+		postFnCalled := false
+
+		err := tc.repo.CreateWithOutbox(ctx, log, func(tx pgx.Tx) error {
+			postFnCalled = true
+			return nil
+		})
+		require.NoError(t, err)
+		assert.True(t, postFnCalled)
+
+		// Verify the log was persisted
+		retrieved, err := tc.repo.FindByID(ctx, log.LogID)
+		require.NoError(t, err)
+		assert.Equal(t, log.LogID, retrieved.LogID)
+	})
+
+	t.Run("nil postFn succeeds", func(t *testing.T) {
+		log := createTestLog(t, testAccountID)
+		err := tc.repo.CreateWithOutbox(ctx, log, nil)
+		require.NoError(t, err)
+
+		retrieved, err := tc.repo.FindByID(ctx, log.LogID)
+		require.NoError(t, err)
+		assert.Equal(t, log.LogID, retrieved.LogID)
+	})
+
+	t.Run("nil log returns error", func(t *testing.T) {
+		err := tc.repo.CreateWithOutbox(ctx, nil, nil)
+		assert.ErrorIs(t, err, persistence.ErrNilLog)
+	})
+
+	t.Run("duplicate log returns conflict", func(t *testing.T) {
+		log := createTestLog(t, testAccountID)
+		err := tc.repo.CreateWithOutbox(ctx, log, nil)
+		require.NoError(t, err)
+
+		err = tc.repo.CreateWithOutbox(ctx, log, nil)
+		assert.ErrorIs(t, err, domain.ErrConflict)
+	})
+
+	t.Run("postFn error rolls back log creation", func(t *testing.T) {
+		log := createTestLog(t, testAccountID)
+		expectedErr := fmt.Errorf("outbox write failed")
+
+		err := tc.repo.CreateWithOutbox(ctx, log, func(tx pgx.Tx) error {
+			return expectedErr
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "outbox write failed")
+
+		// Verify the log was NOT persisted
+		_, err = tc.repo.FindByID(ctx, log.LogID)
+		assert.ErrorIs(t, err, domain.ErrNotFound)
+	})
+}
+
+func TestPostgresRepository_UpdateWithOutbox(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+
+	t.Run("updates log and calls postFn", func(t *testing.T) {
+		log := createTestLog(t, testAccountID)
+		err := tc.repo.Create(ctx, log)
+		require.NoError(t, err)
+
+		err = log.MarkPosted("Posted", nil)
+		require.NoError(t, err)
+
+		postFnCalled := false
+		err = tc.repo.UpdateWithOutbox(ctx, log, func(tx pgx.Tx) error {
+			postFnCalled = true
+			return nil
+		})
+		require.NoError(t, err)
+		assert.True(t, postFnCalled)
+
+		retrieved, err := tc.repo.FindByID(ctx, log.LogID)
+		require.NoError(t, err)
+		assert.Equal(t, domain.TransactionStatusPosted, retrieved.StatusTracking.CurrentStatus)
+	})
+
+	t.Run("nil postFn succeeds", func(t *testing.T) {
+		log := createTestLog(t, testAccountID)
+		err := tc.repo.Create(ctx, log)
+		require.NoError(t, err)
+
+		err = log.MarkPosted("Posted", nil)
+		require.NoError(t, err)
+
+		err = tc.repo.UpdateWithOutbox(ctx, log, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("nil log returns error", func(t *testing.T) {
+		err := tc.repo.UpdateWithOutbox(ctx, nil, nil)
+		assert.ErrorIs(t, err, persistence.ErrNilLog)
+	})
+
+	t.Run("not found log returns error", func(t *testing.T) {
+		log := createTestLog(t, testAccountID)
+		err := tc.repo.UpdateWithOutbox(ctx, log, nil)
+		assert.ErrorIs(t, err, domain.ErrNotFound)
+	})
+
+	t.Run("optimistic lock failure", func(t *testing.T) {
+		log := createTestLog(t, testAccountID)
+		err := tc.repo.Create(ctx, log)
+		require.NoError(t, err)
+
+		err = log.MarkPosted("Posted", nil)
+		require.NoError(t, err)
+
+		err = tc.repo.UpdateWithOutbox(ctx, log, nil)
+		require.NoError(t, err)
+
+		// Try to update with stale version
+		log.Version = 1
+		err = tc.repo.UpdateWithOutbox(ctx, log, nil)
+		assert.ErrorIs(t, err, domain.ErrOptimisticLock)
+	})
+
+	t.Run("postFn error rolls back update", func(t *testing.T) {
+		log := createTestLog(t, testAccountID)
+		err := tc.repo.Create(ctx, log)
+		require.NoError(t, err)
+
+		err = log.MarkPosted("Posted", nil)
+		require.NoError(t, err)
+
+		err = tc.repo.UpdateWithOutbox(ctx, log, func(tx pgx.Tx) error {
+			return fmt.Errorf("outbox error")
+		})
+		require.Error(t, err)
+
+		// Verify the update was rolled back
+		retrieved, err := tc.repo.FindByID(ctx, log.LogID)
+		require.NoError(t, err)
+		assert.Equal(t, domain.TransactionStatusPending, retrieved.StatusTracking.CurrentStatus)
+	})
+}

--- a/services/position-keeping/adapters/persistence/outbox_repository_test.go
+++ b/services/position-keeping/adapters/persistence/outbox_repository_test.go
@@ -13,6 +13,10 @@ import (
 )
 
 func TestPostgresRepository_CreateWithOutbox(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
 	tc := setupTestContainer(t)
 	defer tc.cleanup(t)
 
@@ -76,6 +80,10 @@ func TestPostgresRepository_CreateWithOutbox(t *testing.T) {
 }
 
 func TestPostgresRepository_UpdateWithOutbox(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
 	tc := setupTestContainer(t)
 	defer tc.cleanup(t)
 

--- a/services/position-keeping/adapters/persistence/position_repository_tx_test.go
+++ b/services/position-keeping/adapters/persistence/position_repository_tx_test.go
@@ -1,0 +1,133 @@
+package persistence_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/position-keeping/adapters/persistence"
+	"github.com/meridianhub/meridian/services/position-keeping/adapters/persistence/testhelpers"
+	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPositionRepository_InsertWithTx(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	t.Run("insert within transaction and commit", func(t *testing.T) {
+		tx, err := tc.PositionRepo.BeginTx(ctx)
+		require.NoError(t, err)
+
+		pos, err := domain.NewPosition(
+			"ACC-TX-001",
+			"GBP",
+			"default",
+			decimal.NewFromFloat(250.00),
+			"Monetary",
+			map[string]string{"via": "tx"},
+			uuid.New(),
+			"system",
+		)
+		require.NoError(t, err)
+
+		err = tc.PositionRepo.InsertWithTx(ctx, tx, pos)
+		require.NoError(t, err)
+
+		err = tx.Commit(ctx)
+		require.NoError(t, err)
+
+		// Verify via FindByID
+		found, err := tc.PositionRepo.FindByID(ctx, pos.ID)
+		require.NoError(t, err)
+		assert.Equal(t, pos.ID, found.ID)
+		assert.True(t, decimal.NewFromFloat(250.00).Equal(found.Amount))
+		assert.Equal(t, "tx", found.Attributes["via"])
+	})
+
+	t.Run("insert within transaction and rollback", func(t *testing.T) {
+		tx, err := tc.PositionRepo.BeginTx(ctx)
+		require.NoError(t, err)
+
+		pos, err := domain.NewPosition(
+			"ACC-TX-002",
+			"USD",
+			"default",
+			decimal.NewFromFloat(100.00),
+			"Monetary",
+			nil,
+			uuid.Nil,
+			"system",
+		)
+		require.NoError(t, err)
+
+		err = tc.PositionRepo.InsertWithTx(ctx, tx, pos)
+		require.NoError(t, err)
+
+		// Rollback instead of commit
+		err = tx.Rollback(ctx)
+		require.NoError(t, err)
+
+		// Should NOT be found
+		_, err = tc.PositionRepo.FindByID(ctx, pos.ID)
+		assert.ErrorIs(t, err, domain.ErrNotFound)
+	})
+
+	t.Run("nil position returns error", func(t *testing.T) {
+		tx, err := tc.PositionRepo.BeginTx(ctx)
+		require.NoError(t, err)
+		defer func() { _ = tx.Rollback(ctx) }()
+
+		err = tc.PositionRepo.InsertWithTx(ctx, tx, nil)
+		assert.ErrorIs(t, err, persistence.ErrNilPosition)
+	})
+
+	t.Run("duplicate ID within tx returns conflict", func(t *testing.T) {
+		tx, err := tc.PositionRepo.BeginTx(ctx)
+		require.NoError(t, err)
+		defer func() { _ = tx.Rollback(ctx) }()
+
+		pos, err := domain.NewPosition(
+			"ACC-TX-DUP",
+			"EUR",
+			"default",
+			decimal.NewFromFloat(50.00),
+			"Monetary",
+			nil,
+			uuid.Nil,
+			"system",
+		)
+		require.NoError(t, err)
+
+		err = tc.PositionRepo.InsertWithTx(ctx, tx, pos)
+		require.NoError(t, err)
+
+		// Insert same position again
+		err = tc.PositionRepo.InsertWithTx(ctx, tx, pos)
+		assert.ErrorIs(t, err, domain.ErrConflict)
+	})
+}
+
+func TestPositionRepository_BeginTx(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	tx, err := tc.PositionRepo.BeginTx(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, tx)
+	_ = tx.Rollback(ctx)
+}

--- a/services/position-keeping/adapters/persistence/reservation_repository_extra_test.go
+++ b/services/position-keeping/adapters/persistence/reservation_repository_extra_test.go
@@ -1,0 +1,49 @@
+package persistence_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/position-keeping/adapters/persistence/testhelpers"
+	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReservationRepository_UpdateStatus_ActiveReturnsInvalid(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Trying to transition to ACTIVE is invalid
+	lienID := uuid.New()
+	r, err := domain.NewReservation(lienID, "ACC-001", "GBP", "", decimal.NewFromInt(100))
+	require.NoError(t, err)
+
+	err = tc.ReservationRepo.Create(ctx, r)
+	require.NoError(t, err)
+
+	err = tc.ReservationRepo.UpdateStatus(ctx, lienID, domain.ReservationStatusActive)
+	assert.ErrorIs(t, err, domain.ErrInvalidReservationState)
+}
+
+func TestReservationRepository_CreateNilReservation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	err := tc.ReservationRepo.Create(ctx, nil)
+	require.Error(t, err)
+}

--- a/services/position-keeping/domain/measurement_test.go
+++ b/services/position-keeping/domain/measurement_test.go
@@ -1,0 +1,163 @@
+package domain_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMeasurementType_String(t *testing.T) {
+	assert.Equal(t, "kWh", domain.MeasurementTypeKWh.String())
+	assert.Equal(t, "GPU-Hours", domain.MeasurementTypeGPUHours.String())
+	assert.Equal(t, "Custom", domain.MeasurementTypeCustom.String())
+}
+
+func TestMeasurementType_IsValid(t *testing.T) {
+	validTypes := []domain.MeasurementType{
+		domain.MeasurementTypeKWh,
+		domain.MeasurementTypeGPUHours,
+		domain.MeasurementTypeCPUHours,
+		domain.MeasurementTypeStorageGB,
+		domain.MeasurementTypeBandwidthGB,
+		domain.MeasurementTypeCarbonTonnes,
+		domain.MeasurementTypeWaterLitres,
+		domain.MeasurementTypeCustom,
+	}
+	for _, mt := range validTypes {
+		assert.True(t, mt.IsValid(), "expected %q to be valid", mt)
+	}
+
+	assert.False(t, domain.MeasurementType("invalid").IsValid())
+	assert.False(t, domain.MeasurementType("").IsValid())
+}
+
+func TestParseMeasurementType(t *testing.T) {
+	assert.Equal(t, domain.MeasurementTypeKWh, domain.ParseMeasurementType("kWh"))
+	assert.Equal(t, domain.MeasurementTypeGPUHours, domain.ParseMeasurementType("GPU-Hours"))
+	assert.Equal(t, domain.MeasurementTypeCustom, domain.ParseMeasurementType("unknown-type"))
+	assert.Equal(t, domain.MeasurementTypeCustom, domain.ParseMeasurementType(""))
+}
+
+func TestNewMeasurement(t *testing.T) {
+	validLogID := uuid.New()
+	pastTime := time.Now().UTC().Add(-1 * time.Hour)
+
+	t.Run("valid measurement", func(t *testing.T) {
+		m, err := domain.NewMeasurement(
+			validLogID,
+			domain.MeasurementTypeKWh,
+			decimal.NewFromFloat(42.5),
+			"kWh",
+			pastTime,
+			map[string]string{"source": "meter"},
+			"bucket-1",
+			"test-user",
+		)
+		require.NoError(t, err)
+		require.NotNil(t, m)
+
+		assert.Equal(t, validLogID, m.FinancialPositionLogID)
+		assert.Equal(t, domain.MeasurementTypeKWh, m.MeasurementType)
+		assert.True(t, decimal.NewFromFloat(42.5).Equal(m.Value))
+		assert.Equal(t, "kWh", m.Unit)
+		assert.Equal(t, pastTime, m.Timestamp)
+		assert.Equal(t, "meter", m.Metadata["source"])
+		assert.Equal(t, "bucket-1", m.BucketID)
+		assert.Equal(t, "test-user", m.CreatedBy)
+		assert.Equal(t, "test-user", m.UpdatedBy)
+		assert.NotEqual(t, uuid.Nil, m.ID)
+		assert.False(t, m.CreatedAt.IsZero())
+	})
+
+	t.Run("zero value is valid", func(t *testing.T) {
+		m, err := domain.NewMeasurement(
+			validLogID,
+			domain.MeasurementTypeKWh,
+			decimal.Zero,
+			"kWh",
+			pastTime,
+			nil,
+			"",
+			"system",
+		)
+		require.NoError(t, err)
+		assert.True(t, m.Value.IsZero())
+		assert.Empty(t, m.BucketID)
+	})
+
+	t.Run("nil position log ID returns error", func(t *testing.T) {
+		_, err := domain.NewMeasurement(
+			uuid.Nil,
+			domain.MeasurementTypeKWh,
+			decimal.NewFromFloat(1.0),
+			"kWh",
+			pastTime,
+			nil,
+			"",
+			"user",
+		)
+		assert.ErrorIs(t, err, domain.ErrEmptyPositionStateID)
+	})
+
+	t.Run("invalid measurement type returns error", func(t *testing.T) {
+		_, err := domain.NewMeasurement(
+			validLogID,
+			domain.MeasurementType("bogus"),
+			decimal.NewFromFloat(1.0),
+			"kWh",
+			pastTime,
+			nil,
+			"",
+			"user",
+		)
+		assert.ErrorIs(t, err, domain.ErrInvalidMeasurementType)
+	})
+
+	t.Run("negative value returns error", func(t *testing.T) {
+		_, err := domain.NewMeasurement(
+			validLogID,
+			domain.MeasurementTypeKWh,
+			decimal.NewFromFloat(-1.0),
+			"kWh",
+			pastTime,
+			nil,
+			"",
+			"user",
+		)
+		assert.ErrorIs(t, err, domain.ErrNegativeMeasurementValue)
+	})
+
+	t.Run("empty unit returns error", func(t *testing.T) {
+		_, err := domain.NewMeasurement(
+			validLogID,
+			domain.MeasurementTypeKWh,
+			decimal.NewFromFloat(1.0),
+			"",
+			pastTime,
+			nil,
+			"",
+			"user",
+		)
+		assert.ErrorIs(t, err, domain.ErrInvalidUnit)
+	})
+
+	t.Run("future timestamp returns error", func(t *testing.T) {
+		futureTime := time.Now().UTC().Add(10 * time.Minute)
+		_, err := domain.NewMeasurement(
+			validLogID,
+			domain.MeasurementTypeKWh,
+			decimal.NewFromFloat(1.0),
+			"kWh",
+			futureTime,
+			nil,
+			"",
+			"user",
+		)
+		assert.ErrorIs(t, err, domain.ErrFutureTimestamp)
+	})
+}


### PR DESCRIPTION
## Summary

- Add unit tests for `domain/measurement.go` covering MeasurementType enum, ParseMeasurementType, and NewMeasurement validation paths
- Add integration tests for CreateWithOutbox and UpdateWithOutbox (outbox pattern, rollback on postFn error, optimistic locking)
- Add integration tests for PositionRepository InsertWithTx/BeginTx (commit, rollback, nil position, duplicate conflict)
- Add integration tests for ReservationRepository UpdateStatus with ACTIVE status (invalid state transition) and Create with nil

## Test plan
- [x] All 4 new test files compile and pass individually
- [x] Domain measurement tests cover all validation error paths (nil ID, invalid type, negative value, empty unit, future timestamp)
- [x] Outbox tests verify atomic commit/rollback semantics with postFn callbacks
- [x] Position tx tests verify commit persistence, rollback non-persistence, and error cases
- [x] Reservation tests cover previously untested error branches

## Coverage impact
Targets position-keeping service coverage improvement from 74.9% toward 80% by testing previously uncovered code paths in:
- `domain/measurement.go` (was 0%)
- `adapters/persistence/position_log_write.go` (CreateWithOutbox/UpdateWithOutbox were untested)
- `adapters/persistence/position_repository.go` (InsertWithTx/BeginTx were untested)
- `adapters/persistence/reservation_repository.go` (ACTIVE status path was untested)

Task: test-coverage-80.38