### PR TITLE
fix: derive provisioner DSNs from base DSN in bootstrap command

### DIFF
--- a/cmd/meridian/connections.go
+++ b/cmd/meridian/connections.go
@@ -15,6 +15,7 @@ import (
 	misclient "github.com/meridianhub/meridian/services/market-information/client"
 	partyclient "github.com/meridianhub/meridian/services/party/client"
 	pkclient "github.com/meridianhub/meridian/services/position-keeping/client"
+	tenantprovisioner "github.com/meridianhub/meridian/services/tenant/provisioner"
 
 	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
@@ -25,6 +26,27 @@ import (
 )
 
 // ─── Per-Service Database Connections ────────────────────────────────────────
+
+// DeriveProvisionerConfig returns a provisioner config with each service's DatabaseURL
+// derived from baseDSN by replacing the database component. If baseDSN is empty,
+// DefaultConfig() is returned unchanged (preserving env-var fallback behaviour).
+func DeriveProvisionerConfig(baseDSN string) (*tenantprovisioner.Config, error) {
+	config := tenantprovisioner.DefaultConfig()
+	if baseDSN == "" {
+		return config, nil
+	}
+	for i := range config.Services {
+		svc := &config.Services[i]
+		if sdb, ok := migrations.ServiceDatabases[svc.Name]; ok {
+			dsn, err := replaceDSNDatabase(baseDSN, sdb.Database)
+			if err != nil {
+				return nil, fmt.Errorf("derive DSN for %s: %w", svc.Name, err)
+			}
+			svc.DatabaseURL = dsn
+		}
+	}
+	return config, nil
+}
 
 // replaceDSNDatabase replaces the database name in a PostgreSQL/CockroachDB DSN URL.
 func replaceDSNDatabase(baseDSN, database string) (string, error) {

--- a/cmd/meridian/connections.go
+++ b/cmd/meridian/connections.go
@@ -29,7 +29,7 @@ import (
 
 // DeriveProvisionerConfig returns a provisioner config with each service's DatabaseURL
 // derived from baseDSN by replacing the database component. If baseDSN is empty,
-// DefaultConfig() is returned unchanged (preserving env-var fallback behaviour).
+// DefaultConfig() is returned unchanged (preserving env-var fallback behavior).
 func DeriveProvisionerConfig(baseDSN string) (*tenantprovisioner.Config, error) {
 	config := tenantprovisioner.DefaultConfig()
 	if baseDSN == "" {

--- a/cmd/meridian/connections_test.go
+++ b/cmd/meridian/connections_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeriveProvisionerConfig_EmptyDSN(t *testing.T) {
+	config, err := DeriveProvisionerConfig("")
+	require.NoError(t, err)
+	// Empty DSN returns DefaultConfig unchanged - all services present.
+	assert.NotEmpty(t, config.Services)
+	for _, svc := range config.Services {
+		assert.NotEmpty(t, svc.Name)
+	}
+}
+
+func TestDeriveProvisionerConfig_PostgresDSN(t *testing.T) {
+	config, err := DeriveProvisionerConfig("postgres://root:pass@myhost:5432/defaultdb?sslmode=disable")
+	require.NoError(t, err)
+	require.NotEmpty(t, config.Services)
+	for _, svc := range config.Services {
+		assert.Contains(t, svc.DatabaseURL, "myhost:5432", "service %s should use provided host", svc.Name)
+		assert.NotContains(t, svc.DatabaseURL, "defaultdb", "service %s should not use base database name", svc.Name)
+	}
+}
+
+func TestDeriveProvisionerConfig_CockroachDBDSN(t *testing.T) {
+	config, err := DeriveProvisionerConfig("postgres://root@cockroachdb:26257/defaultdb?sslmode=disable")
+	require.NoError(t, err)
+	require.NotEmpty(t, config.Services)
+	for _, svc := range config.Services {
+		assert.Contains(t, svc.DatabaseURL, "cockroachdb:26257", "service %s should use cockroachdb host", svc.Name)
+	}
+}
+
+func TestDeriveProvisionerConfig_LocalhostDSN(t *testing.T) {
+	config, err := DeriveProvisionerConfig("postgres://root@localhost:26257/defaultdb?sslmode=disable")
+	require.NoError(t, err)
+	require.NotEmpty(t, config.Services)
+
+	// Verify a known service gets the correct derived database name.
+	var partyURL string
+	for _, svc := range config.Services {
+		if svc.Name == "party" {
+			partyURL = svc.DatabaseURL
+		}
+	}
+	assert.Contains(t, partyURL, "localhost:26257")
+	assert.Contains(t, partyURL, "/meridian_party")
+}

--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -342,9 +342,15 @@ func runBootstrap(baseDSN string, logger *slog.Logger) error {
 	}
 	defer platformPool.Close()
 
+	provConfig, err := DeriveProvisionerConfig(baseDSN)
+	if err != nil {
+		return fmt.Errorf("provisioner config: %w", err)
+	}
+
 	return masterbootstrap.Run(ctx, masterbootstrap.Config{
-		PlatformDB:       platformDB,
-		ControlPlanePool: platformPool,
-		Logger:           logger,
+		PlatformDB:        platformDB,
+		ControlPlanePool:  platformPool,
+		ProvisionerConfig: provConfig,
+		Logger:            logger,
 	})
 }

--- a/cmd/meridian/wire_services.go
+++ b/cmd/meridian/wire_services.go
@@ -78,7 +78,6 @@ import (
 	gateway "github.com/meridianhub/meridian/services/api-gateway"
 
 	// Shared platform
-	"github.com/meridianhub/meridian/internal/migrations"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/defaults"
@@ -327,18 +326,9 @@ func startProvisioningWorker(ctx context.Context, baseDSN string, platformDB *go
 	// DefaultConfig() falls back to cockroachdb:26257 when per-service env vars
 	// are unset. The unified binary derives all connections from a single base DSN,
 	// so we override each service's DatabaseURL to match.
-	config := tenantprovisioner.DefaultConfig()
-	if baseDSN != "" {
-		for i := range config.Services {
-			svc := &config.Services[i]
-			if sdb, ok := migrations.ServiceDatabases[svc.Name]; ok {
-				dsn, dsnErr := replaceDSNDatabase(baseDSN, sdb.Database)
-				if dsnErr != nil {
-					return nil, nil, fmt.Errorf("provisioner dsn for %s: %w", svc.Name, dsnErr)
-				}
-				svc.DatabaseURL = dsn
-			}
-		}
+	config, err := DeriveProvisionerConfig(baseDSN)
+	if err != nil {
+		return nil, nil, fmt.Errorf("provisioner config: %w", err)
 	}
 	prov, err := tenantprovisioner.NewPostgresProvisioner(platformDB, config)
 	if err != nil {


### PR DESCRIPTION
## Summary

- The `--bootstrap` command's schema provisioner used `DefaultConfig()` which falls back to hardcoded `cockroachdb:26257` hostnames when per-service `DATABASE_URL` env vars are not set
- Extracts `DeriveProvisionerConfig(baseDSN string)` helper into `connections.go` - the pattern already existed inline in `startProvisioningWorker()`
- Updates `runBootstrap()` to call the helper and pass `ProvisionerConfig` to `masterbootstrap.Run()`
- Refactors `startProvisioningWorker()` to use the shared helper, eliminating inline duplication

## Changes Made

| File | Change |
|------|--------|
| `cmd/meridian/connections.go` | Added `DeriveProvisionerConfig()` helper and `tenantprovisioner` import |
| `cmd/meridian/main.go` | Updated `runBootstrap()` to pass derived config as `ProvisionerConfig` |
| `cmd/meridian/wire_services.go` | Refactored to use `DeriveProvisionerConfig()`, removed now-unused `migrations` import |
| `cmd/meridian/connections_test.go` | Added unit tests for all four DSN cases |

## Testing

Unit tests cover:
- Empty DSN: returns `DefaultConfig()` unchanged (preserves env-var fallback)
- Postgres DSN: derived URLs use provided host/port
- CockroachDB DSN: derived URLs use cockroachdb host
- Localhost DSN: verifies correct database name substitution (e.g., `meridian_party`)