### PR TITLE
test: increase shared/pkg coverage targeting partial hits

### DIFF
--- a/shared/pkg/cel/validate_cel_test.go
+++ b/shared/pkg/cel/validate_cel_test.go
@@ -1,0 +1,75 @@
+package cel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateValidationCEL(t *testing.T) {
+	c, err := NewCompiler()
+	require.NoError(t, err)
+
+	t.Run("valid expression", func(t *testing.T) {
+		err := c.ValidateValidationCEL("amount != ''")
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid expression", func(t *testing.T) {
+		err := c.ValidateValidationCEL("invalid !! syntax")
+		assert.Error(t, err)
+	})
+}
+
+func TestValidateBucketingCEL(t *testing.T) {
+	c, err := NewCompiler()
+	require.NoError(t, err)
+
+	t.Run("valid expression", func(t *testing.T) {
+		err := c.ValidateBucketingCEL("bucket_key(['METERING'])")
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid expression", func(t *testing.T) {
+		err := c.ValidateBucketingCEL("!!!bad")
+		assert.Error(t, err)
+	})
+}
+
+func TestValidateEligibilityCEL(t *testing.T) {
+	c, err := NewCompiler()
+	require.NoError(t, err)
+
+	t.Run("valid expression", func(t *testing.T) {
+		err := c.ValidateEligibilityCEL("party.type == 'INDIVIDUAL'")
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid expression", func(t *testing.T) {
+		err := c.ValidateEligibilityCEL("not valid >><< cel")
+		assert.Error(t, err)
+	})
+}
+
+func TestCompileValueExpression_ValidAndInvalid(t *testing.T) {
+	c, err := NewCompiler()
+	require.NoError(t, err)
+
+	t.Run("simple expression", func(t *testing.T) {
+		prog, err := c.CompileValueExpression("amount")
+		assert.NoError(t, err)
+		assert.NotNil(t, prog)
+	})
+
+	t.Run("string comparison expression", func(t *testing.T) {
+		prog, err := c.CompileValueExpression("source")
+		assert.NoError(t, err)
+		assert.NotNil(t, prog)
+	})
+
+	t.Run("invalid expression", func(t *testing.T) {
+		_, err := c.CompileValueExpression("!!!bad")
+		assert.Error(t, err)
+	})
+}

--- a/shared/pkg/idempotency/executor_error_test.go
+++ b/shared/pkg/idempotency/executor_error_test.go
@@ -1,0 +1,38 @@
+package idempotency
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecutorError_Error(t *testing.T) {
+	key := Key{
+		Namespace: "test-ns",
+		Operation: "deposit",
+		EntityID:  "acct-123",
+	}
+	execErr := &ExecutorError{
+		Op:  "check",
+		Key: key,
+		Err: ErrResultNotFound,
+	}
+
+	msg := execErr.Error()
+	assert.Contains(t, msg, "check")
+	assert.Contains(t, msg, "test-ns")
+	assert.Contains(t, msg, "result not found")
+}
+
+func TestExecutorError_UnwrapChain(t *testing.T) {
+	inner := ErrOperationAlreadyProcessed
+	execErr := &ExecutorError{
+		Op:  "store",
+		Key: Key{Namespace: "ns", Operation: "op", EntityID: "id"},
+		Err: inner,
+	}
+
+	assert.ErrorIs(t, execErr, ErrOperationAlreadyProcessed)
+	assert.Contains(t, execErr.Error(), "store")
+	assert.Contains(t, execErr.Error(), "ns")
+}

--- a/shared/pkg/idempotency/noop_service_test.go
+++ b/shared/pkg/idempotency/noop_service_test.go
@@ -1,0 +1,66 @@
+package idempotency
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoopService(t *testing.T) {
+	logger := slog.Default()
+	svc := NewNoopService(logger)
+	require.NotNil(t, svc)
+
+	ctx := context.Background()
+	key := Key{
+		Namespace: "test",
+		Operation: "op",
+		EntityID:  "123",
+	}
+
+	t.Run("Check returns ErrResultNotFound", func(t *testing.T) {
+		result, err := svc.Check(ctx, key)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, ErrResultNotFound)
+	})
+
+	t.Run("MarkPending is no-op", func(t *testing.T) {
+		err := svc.MarkPending(ctx, key, 30*time.Second)
+		assert.NoError(t, err)
+	})
+
+	t.Run("StoreResult is no-op", func(t *testing.T) {
+		err := svc.StoreResult(ctx, Result{Key: key, Status: StatusCompleted})
+		assert.NoError(t, err)
+	})
+
+	t.Run("Delete is no-op", func(t *testing.T) {
+		err := svc.Delete(ctx, key)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Acquire always succeeds", func(t *testing.T) {
+		err := svc.Acquire(ctx, key, LockOptions{TTL: 10 * time.Second})
+		assert.NoError(t, err)
+	})
+
+	t.Run("Release is no-op", func(t *testing.T) {
+		err := svc.Release(ctx, key, "token")
+		assert.NoError(t, err)
+	})
+
+	t.Run("Refresh is no-op", func(t *testing.T) {
+		err := svc.Refresh(ctx, key, "token", 10*time.Second)
+		assert.NoError(t, err)
+	})
+
+	t.Run("IsHeld always returns false", func(t *testing.T) {
+		held, err := svc.IsHeld(ctx, key)
+		assert.NoError(t, err)
+		assert.False(t, held)
+	})
+}

--- a/shared/pkg/proto/mappers/currency_test.go
+++ b/shared/pkg/proto/mappers/currency_test.go
@@ -11,7 +11,7 @@ import (
 func TestCurrencyCodeToProto(t *testing.T) {
 	tests := []struct {
 		code string
-		want commonpb.Currency
+		want commonpb.Currency //nolint:staticcheck // testing deprecated mapper
 	}{
 		{"GBP", commonpb.Currency_CURRENCY_GBP},
 		{"USD", commonpb.Currency_CURRENCY_USD},
@@ -35,7 +35,7 @@ func TestCurrencyCodeToProto(t *testing.T) {
 func TestDomainCurrencyToProto(t *testing.T) {
 	tests := []struct {
 		currency money.Currency
-		want     commonpb.Currency
+		want     commonpb.Currency //nolint:staticcheck // testing deprecated mapper
 	}{
 		{money.CurrencyGBP, commonpb.Currency_CURRENCY_GBP},
 		{money.CurrencyUSD, commonpb.Currency_CURRENCY_USD},

--- a/shared/pkg/proto/mappers/currency_test.go
+++ b/shared/pkg/proto/mappers/currency_test.go
@@ -1,0 +1,51 @@
+package mappers
+
+import (
+	"testing"
+
+	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	"github.com/meridianhub/meridian/shared/domain/money"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCurrencyCodeToProto(t *testing.T) {
+	tests := []struct {
+		code string
+		want commonpb.Currency
+	}{
+		{"GBP", commonpb.Currency_CURRENCY_GBP},
+		{"USD", commonpb.Currency_CURRENCY_USD},
+		{"EUR", commonpb.Currency_CURRENCY_EUR},
+		{"JPY", commonpb.Currency_CURRENCY_JPY},
+		{"CHF", commonpb.Currency_CURRENCY_CHF},
+		{"CAD", commonpb.Currency_CURRENCY_CAD},
+		{"AUD", commonpb.Currency_CURRENCY_AUD},
+		{"UNKNOWN", commonpb.Currency_CURRENCY_UNSPECIFIED},
+		{"", commonpb.Currency_CURRENCY_UNSPECIFIED},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.code, func(t *testing.T) {
+			got := CurrencyCodeToProto(tt.code)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDomainCurrencyToProto(t *testing.T) {
+	tests := []struct {
+		currency money.Currency
+		want     commonpb.Currency
+	}{
+		{money.CurrencyGBP, commonpb.Currency_CURRENCY_GBP},
+		{money.CurrencyUSD, commonpb.Currency_CURRENCY_USD},
+		{money.CurrencyEUR, commonpb.Currency_CURRENCY_EUR},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.currency), func(t *testing.T) {
+			got := DomainCurrencyToProto(tt.currency)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/shared/pkg/saga/clone_test.go
+++ b/shared/pkg/saga/clone_test.go
@@ -1,0 +1,125 @@
+package saga
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloneStringMap(t *testing.T) {
+	t.Run("nil map returns nil", func(t *testing.T) {
+		result := cloneStringMap(nil)
+		assert.Nil(t, result)
+	})
+
+	t.Run("empty map returns empty map", func(t *testing.T) {
+		result := cloneStringMap(map[string]string{})
+		require.NotNil(t, result)
+		assert.Empty(t, result)
+	})
+
+	t.Run("populated map is deep copied", func(t *testing.T) {
+		original := map[string]string{"a": "1", "b": "2"}
+		clone := cloneStringMap(original)
+		require.NotNil(t, clone)
+		assert.Equal(t, original, clone)
+
+		// Modify clone - original should not change
+		clone["c"] = "3"
+		assert.NotContains(t, original, "c")
+	})
+}
+
+func TestCloneHandlerConversion(t *testing.T) {
+	t.Run("empty conversion", func(t *testing.T) {
+		conv := HandlerConversion{}
+		clone := cloneHandlerConversion(conv)
+		assert.Equal(t, conv, clone)
+	})
+
+	t.Run("conversion with maps is deep copied", func(t *testing.T) {
+		conv := HandlerConversion{
+			FromVersion:  1,
+			FromName:     "old.handler",
+			ParamMapping: map[string]string{"old_param": "new_param"},
+			Defaults:     map[string]string{"new_field": "default_val"},
+		}
+		clone := cloneHandlerConversion(conv)
+		assert.Equal(t, conv.FromVersion, clone.FromVersion)
+		assert.Equal(t, conv.FromName, clone.FromName)
+		assert.Equal(t, conv.ParamMapping, clone.ParamMapping)
+		assert.Equal(t, conv.Defaults, clone.Defaults)
+
+		// Modify clone maps - original should not change
+		clone.ParamMapping["extra"] = "value"
+		assert.NotContains(t, conv.ParamMapping, "extra")
+		clone.Defaults["extra"] = "value"
+		assert.NotContains(t, conv.Defaults, "extra")
+	})
+
+	t.Run("conversion with nil maps", func(t *testing.T) {
+		conv := HandlerConversion{
+			FromVersion:  2,
+			ParamMapping: nil,
+			Defaults:     nil,
+		}
+		clone := cloneHandlerConversion(conv)
+		assert.Nil(t, clone.ParamMapping)
+		assert.Nil(t, clone.Defaults)
+	})
+}
+
+func TestCloneHandlerMetadata(t *testing.T) {
+	t.Run("nil metadata returns nil", func(t *testing.T) {
+		result := cloneHandlerMetadata(nil)
+		assert.Nil(t, result)
+	})
+
+	t.Run("metadata with all fields", func(t *testing.T) {
+		reqTrue := true
+		meta := &HandlerMetadata{
+			ProducesInstruments: []string{"GBP", "USD"},
+			ParamOverrides: map[string]ParamOverride{
+				"amount": {
+					Type:     "Decimal",
+					Required: &reqTrue,
+				},
+			},
+			Conversions: []HandlerConversion{
+				{
+					FromVersion:  1,
+					ParamMapping: map[string]string{"old": "new"},
+					Defaults:     map[string]string{"field": "val"},
+				},
+			},
+		}
+		clone := cloneHandlerMetadata(meta)
+		require.NotNil(t, clone)
+
+		// Verify deep copy
+		assert.Equal(t, meta.ProducesInstruments, clone.ProducesInstruments)
+		assert.Equal(t, meta.ParamOverrides, clone.ParamOverrides)
+		assert.Len(t, clone.Conversions, 1)
+
+		// Modify clone - original should not change
+		clone.ProducesInstruments = append(clone.ProducesInstruments, "EUR")
+		assert.Len(t, meta.ProducesInstruments, 2)
+
+		clone.Conversions[0].ParamMapping["extra"] = "val"
+		assert.NotContains(t, meta.Conversions[0].ParamMapping, "extra")
+
+		// Verify Required pointer is deep copied
+		*clone.ParamOverrides["amount"].Required = false
+		assert.True(t, *meta.ParamOverrides["amount"].Required)
+	})
+
+	t.Run("metadata with nil slices", func(t *testing.T) {
+		meta := &HandlerMetadata{}
+		clone := cloneHandlerMetadata(meta)
+		require.NotNil(t, clone)
+		assert.Nil(t, clone.ProducesInstruments)
+		assert.Nil(t, clone.ParamOverrides)
+		assert.Nil(t, clone.Conversions)
+	})
+}

--- a/shared/pkg/saga/schema/service_modules_gaps_test.go
+++ b/shared/pkg/saga/schema/service_modules_gaps_test.go
@@ -1,0 +1,131 @@
+package schema
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+func TestStarlarkToGoValue_DictWithNestedValues(t *testing.T) {
+	dict := starlark.NewDict(2)
+	require.NoError(t, dict.SetKey(starlark.String("nested"), starlark.String("val")))
+	innerList := starlark.NewList([]starlark.Value{starlark.MakeInt(1)})
+	require.NoError(t, dict.SetKey(starlark.String("list"), innerList))
+
+	val, err := starlarkToGoValue(dict)
+	require.NoError(t, err)
+	m, ok := val.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "val", m["nested"])
+	innerSlice, ok := m["list"].([]any)
+	require.True(t, ok)
+	assert.Equal(t, int64(1), innerSlice[0])
+}
+
+func TestStarlarkToGoValue_StructWithNestedTypes(t *testing.T) {
+	inner := starlarkstruct.FromStringDict(starlark.String("inner"), starlark.StringDict{
+		"deep": starlark.String("value"),
+	})
+	outer := starlarkstruct.FromStringDict(starlark.String("outer"), starlark.StringDict{
+		"child": inner,
+		"num":   starlark.Float(3.14),
+	})
+	val, err := starlarkToGoValue(outer)
+	require.NoError(t, err)
+	m, ok := val.(map[string]any)
+	require.True(t, ok)
+	childMap, ok := m["child"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "value", childMap["deep"])
+	assert.InDelta(t, 3.14, m["num"], 0.001)
+}
+
+func TestStarlarkIntToGo_VeryLargeInt(t *testing.T) {
+	bigInt := new(big.Int).SetUint64(1)
+	bigInt.Lsh(bigInt, 128)
+	val := starlarkIntToGo(starlark.MakeBigInt(bigInt))
+	s, ok := val.(string)
+	require.True(t, ok)
+	assert.Contains(t, s, "3402823669209384")
+}
+
+func TestGoToStarlarkResult_VariousNonMapTypes(t *testing.T) {
+	t.Run("boolean result", func(t *testing.T) {
+		val, err := goToStarlarkResult("test.handler", true)
+		require.NoError(t, err)
+		assert.Equal(t, starlark.Bool(true), val)
+	})
+
+	t.Run("decimal result", func(t *testing.T) {
+		d := decimal.NewFromFloat(99.99)
+		val, err := goToStarlarkResult("test.handler", d)
+		require.NoError(t, err)
+		assert.Equal(t, starlark.String(d.String()), val)
+	})
+
+	t.Run("slice result", func(t *testing.T) {
+		val, err := goToStarlarkResult("test.handler", []any{"a", "b"})
+		require.NoError(t, err)
+		list, ok := val.(*starlark.List)
+		require.True(t, ok)
+		assert.Equal(t, 2, list.Len())
+	})
+}
+
+func TestGoToStarlarkValue_EmptyCollections(t *testing.T) {
+	t.Run("empty map", func(t *testing.T) {
+		val, err := goToStarlarkValue(map[string]any{})
+		require.NoError(t, err)
+		dict, ok := val.(*starlark.Dict)
+		require.True(t, ok)
+		assert.Equal(t, 0, dict.Len())
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		val, err := goToStarlarkValue([]any{})
+		require.NoError(t, err)
+		list, ok := val.(*starlark.List)
+		require.True(t, ok)
+		assert.Equal(t, 0, list.Len())
+	})
+}
+
+func TestBuildServiceModulesFromSchema_HandlerNotInRegistry(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	s := &Schema{
+		Handlers: map[string]*HandlerDef{
+			"svc.missing": {
+				Params:  map[string]*FieldDef{},
+				Returns: map[string]*FieldDef{},
+			},
+		},
+	}
+	_, err := BuildServiceModulesFromSchema(registry, s)
+	require.Error(t, err)
+}
+
+func TestBuildServiceModulesFromSchema_BothRBACFieldsSet(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	registry.Register("svc.action", func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+		return nil, nil
+	})
+	s := &Schema{
+		Handlers: map[string]*HandlerDef{
+			"svc.action": {
+				ResourceType:       "payment_order",
+				RequiredPermission: "write",
+				Params:             map[string]*FieldDef{},
+				Returns:            map[string]*FieldDef{},
+			},
+		},
+	}
+	modules, err := BuildServiceModulesFromSchema(registry, s)
+	require.NoError(t, err)
+	assert.Contains(t, modules, "svc")
+}


### PR DESCRIPTION
## Summary

- Add ~486 lines of test code across 6 files to close coverage gaps in `shared/pkg`
- Target: push overall repo coverage toward 80% by covering previously untested functions

## Changes

| Package | File | Coverage Gain |
|---------|------|---------------|
| saga | clone_test.go | cloneStringMap, cloneHandlerConversion, cloneHandlerMetadata (0% -> 100%) |
| saga/schema | service_modules_gaps_test.go | starlarkStructToGo (0% -> covered), starlarkIntToGo large int path, goToStarlarkResult non-map types, RBAC validation paths |
| idempotency | noop_service_test.go | All NoopService methods (0% -> 100%) |
| idempotency | executor_error_test.go | ExecutorError.Error() formatting (0% -> 100%) |
| proto/mappers | currency_test.go | All currency conversions (0% -> 100%) |
| cel | validate_cel_test.go | ValidateValidationCEL, ValidateBucketingCEL, ValidateEligibilityCEL, CompileValueExpression (0% -> covered) |

## Test plan

- [x] All new tests pass locally (`go test -count=1`)
- [x] No existing tests broken
- [ ] CI passes