### PR TITLE
test: close reference-data coverage gap to 80%

### DIFF
--- a/services/reference-data/registry/instrument_status_test.go
+++ b/services/reference-data/registry/instrument_status_test.go
@@ -1,0 +1,79 @@
+package registry_test
+
+import (
+	"testing"
+
+	"github.com/meridianhub/meridian/services/reference-data/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstrumentStatus_IsValid(t *testing.T) {
+	assert.True(t, registry.StatusDraft.IsValid())
+	assert.True(t, registry.StatusActive.IsValid())
+	assert.True(t, registry.StatusDeprecated.IsValid())
+	assert.False(t, registry.Status("UNKNOWN").IsValid())
+	assert.False(t, registry.Status("").IsValid())
+}
+
+func TestInstrumentStatus_CanTransitionTo(t *testing.T) {
+	tests := []struct {
+		name   string
+		from   registry.Status
+		to     registry.Status
+		expect bool
+	}{
+		{"DRAFT to ACTIVE", registry.StatusDraft, registry.StatusActive, true},
+		{"DRAFT to DEPRECATED", registry.StatusDraft, registry.StatusDeprecated, false},
+		{"DRAFT to DRAFT", registry.StatusDraft, registry.StatusDraft, false},
+		{"ACTIVE to DEPRECATED", registry.StatusActive, registry.StatusDeprecated, true},
+		{"ACTIVE to DRAFT", registry.StatusActive, registry.StatusDraft, false},
+		{"ACTIVE to ACTIVE", registry.StatusActive, registry.StatusActive, false},
+		{"DEPRECATED to DRAFT", registry.StatusDeprecated, registry.StatusDraft, false},
+		{"DEPRECATED to ACTIVE", registry.StatusDeprecated, registry.StatusActive, false},
+		{"DEPRECATED to DEPRECATED", registry.StatusDeprecated, registry.StatusDeprecated, false},
+		{"unknown to ACTIVE", registry.Status("UNKNOWN"), registry.StatusActive, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expect, tt.from.CanTransitionTo(tt.to))
+		})
+	}
+}
+
+func TestValidateStatusTransition(t *testing.T) {
+	t.Run("valid DRAFT to ACTIVE", func(t *testing.T) {
+		err := registry.ValidateStatusTransition(registry.StatusDraft, registry.StatusActive)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid ACTIVE to DEPRECATED", func(t *testing.T) {
+		err := registry.ValidateStatusTransition(registry.StatusActive, registry.StatusDeprecated)
+		require.NoError(t, err)
+	})
+
+	t.Run("same status returns error", func(t *testing.T) {
+		err := registry.ValidateStatusTransition(registry.StatusDraft, registry.StatusDraft)
+		require.ErrorIs(t, err, registry.ErrInvalidStateTransition)
+		assert.Contains(t, err.Error(), "same")
+	})
+
+	t.Run("invalid transition returns error", func(t *testing.T) {
+		err := registry.ValidateStatusTransition(registry.StatusDraft, registry.StatusDeprecated)
+		require.ErrorIs(t, err, registry.ErrInvalidStateTransition)
+		assert.Contains(t, err.Error(), "cannot transition")
+	})
+
+	t.Run("DEPRECATED is terminal", func(t *testing.T) {
+		err := registry.ValidateStatusTransition(registry.StatusDeprecated, registry.StatusActive)
+		require.ErrorIs(t, err, registry.ErrInvalidStateTransition)
+	})
+}
+
+func TestInstrumentStatus_String(t *testing.T) {
+	assert.Equal(t, "DRAFT", registry.StatusDraft.String())
+	assert.Equal(t, "ACTIVE", registry.StatusActive.String())
+	assert.Equal(t, "DEPRECATED", registry.StatusDeprecated.String())
+	assert.Equal(t, "UNKNOWN", registry.Status("UNKNOWN").String())
+}

--- a/services/reference-data/saga/migrate_platform_ref_test.go
+++ b/services/reference-data/saga/migrate_platform_ref_test.go
@@ -1,0 +1,92 @@
+package saga
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTenantMigrationSummary_Counts(t *testing.T) {
+	t.Run("empty results", func(t *testing.T) {
+		s := &TenantMigrationSummary{}
+		m, sk, wm := s.Counts()
+		assert.Equal(t, 0, m)
+		assert.Equal(t, 0, sk)
+		assert.Equal(t, 0, wm)
+	})
+
+	t.Run("mixed actions", func(t *testing.T) {
+		s := &TenantMigrationSummary{
+			Results: []MigrationResult{
+				{Action: MigrationActionMigrated},
+				{Action: MigrationActionMigrated},
+				{Action: MigrationActionSkipped},
+				{Action: MigrationActionWouldMigrate},
+				{Action: MigrationActionWouldMigrate},
+				{Action: MigrationActionWouldMigrate},
+				{Action: "unknown_action"},
+			},
+		}
+		m, sk, wm := s.Counts()
+		assert.Equal(t, 2, m)
+		assert.Equal(t, 1, sk)
+		assert.Equal(t, 3, wm)
+	})
+}
+
+func TestFormatReport(t *testing.T) {
+	refID := uuid.New()
+
+	t.Run("dry run report", func(t *testing.T) {
+		summaries := []TenantMigrationSummary{
+			{
+				TenantID: "tenant-1",
+				Results: []MigrationResult{
+					{Action: MigrationActionWouldMigrate, SagaName: "payment.initiate", Reason: "95% similar", PlatformRefID: &refID},
+					{Action: MigrationActionSkipped, SagaName: "custom.workflow", Reason: "no match"},
+				},
+			},
+		}
+		report := FormatReport(summaries, true)
+		assert.Contains(t, report, "DRY RUN")
+		assert.Contains(t, report, "tenant-1")
+		assert.Contains(t, report, "payment.initiate")
+		assert.Contains(t, report, "Would migrate: 1")
+		assert.Contains(t, report, "Skipped: 1")
+		assert.Contains(t, report, "platform_ref=")
+	})
+
+	t.Run("apply report with error", func(t *testing.T) {
+		summaries := []TenantMigrationSummary{
+			{
+				TenantID: "tenant-ok",
+				Results: []MigrationResult{
+					{Action: MigrationActionMigrated, SagaName: "payment.settle", Reason: "matched"},
+				},
+			},
+			{
+				TenantID: "tenant-fail",
+				Error:    errors.New("db connection lost"),
+			},
+		}
+		report := FormatReport(summaries, false)
+		assert.NotContains(t, report, "DRY RUN")
+		assert.Contains(t, report, "Migrated: 1")
+		assert.Contains(t, report, "Errors: 1")
+		assert.Contains(t, report, "db connection lost")
+	})
+
+	t.Run("empty summaries", func(t *testing.T) {
+		report := FormatReport(nil, false)
+		assert.Contains(t, report, "Tenants processed: 0")
+	})
+}
+
+func TestErrPartialMigrationFailure(t *testing.T) {
+	err := ErrPartialMigrationFailure
+	require.Error(t, err)
+	assert.Equal(t, "some tenant migrations failed", err.Error())
+}

--- a/services/reference-data/saga/reference_helpers_test.go
+++ b/services/reference-data/saga/reference_helpers_test.go
@@ -1,0 +1,107 @@
+package saga
+
+import (
+	"testing"
+
+	pkgsaga "github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSimilarity_IdenticalStrings(t *testing.T) {
+	score := similarity("hello", "hello")
+	assert.Equal(t, 10, score) // len("hello") * 2
+}
+
+func TestSimilarity_EmptyStrings(t *testing.T) {
+	score := similarity("", "")
+	assert.Equal(t, 0, score) // len("") * 2 = 0
+}
+
+func TestSimilarity_CommonPrefix(t *testing.T) {
+	score := similarity("hello_world", "hello_earth")
+	assert.Greater(t, score, 0, "common prefix should contribute to score")
+}
+
+func TestSimilarity_CommonSuffix(t *testing.T) {
+	score := similarity("foo_handler", "bar_handler")
+	assert.Greater(t, score, 0, "common suffix should contribute to score")
+}
+
+func TestSimilarity_SubstringMatch(t *testing.T) {
+	score := similarity("handler", "step_handler_v2")
+	assert.Greater(t, score, 0, "substring match should increase score")
+}
+
+func TestSimilarity_CompletelyDifferent(t *testing.T) {
+	score := similarity("abc", "xyz")
+	assert.Equal(t, 0, score, "no common prefix/suffix/substring should yield 0")
+}
+
+func TestFindSimilar_EmptyCandidates(t *testing.T) {
+	result := findSimilar("hello", nil)
+	assert.Equal(t, "", result)
+
+	result = findSimilar("hello", []string{})
+	assert.Equal(t, "", result)
+}
+
+func TestFindSimilar_ExactMatch(t *testing.T) {
+	result := findSimilar("hello", []string{"world", "hello", "hi"})
+	assert.Equal(t, "hello", result)
+}
+
+func TestFindSimilar_CaseInsensitive(t *testing.T) {
+	result := findSimilar("Hello", []string{"world", "hello", "hi"})
+	assert.Equal(t, "hello", result)
+}
+
+func TestFindSimilar_NoGoodMatch(t *testing.T) {
+	result := findSimilar("xyz", []string{"abcdefgh", "ijklmnop"})
+	assert.Equal(t, "", result, "no sufficiently similar candidate should return empty")
+}
+
+func TestFindSimilar_BestMatchSelected(t *testing.T) {
+	result := findSimilar("position_keeping", []string{
+		"position_taking",
+		"account_keeping",
+		"totally_different",
+	})
+	// "position_taking" shares more prefix with "position_keeping"
+	assert.Equal(t, "position_taking", result)
+}
+
+func TestSuggestAttribute_EmptySchema(t *testing.T) {
+	v := &ReferenceValidator{}
+	result := v.suggestAttribute(map[string]interface{}{}, "key")
+	assert.Equal(t, "", result)
+}
+
+func TestSuggestAttribute_HasMatch(t *testing.T) {
+	v := &ReferenceValidator{}
+	schema := map[string]interface{}{
+		"status":     "string",
+		"balance":    "decimal",
+		"created_at": "timestamp",
+	}
+	result := v.suggestAttribute(schema, "statu") // close to "status"
+	assert.Contains(t, result, "status")
+}
+
+func TestSuggestHandler_EmptyRegistry(t *testing.T) {
+	reg := pkgsaga.NewHandlerRegistry()
+	v := &ReferenceValidator{handlerRegistry: reg}
+	result := v.suggestHandler("nonexistent_handler")
+	assert.Equal(t, "", result)
+}
+
+func TestSuggestInstrument_NilChecker(t *testing.T) {
+	v := &ReferenceValidator{instrumentChecker: nil}
+	result := v.suggestInstrument(nil, "GBX")
+	assert.Equal(t, "", result)
+}
+
+func TestSuggestSaga_NilChecker(t *testing.T) {
+	v := &ReferenceValidator{definitionChecker: nil}
+	result := v.suggestSaga(nil, "payment.initiate")
+	assert.Equal(t, "", result)
+}

--- a/services/reference-data/saga/reference_helpers_test.go
+++ b/services/reference-data/saga/reference_helpers_test.go
@@ -1,6 +1,7 @@
 package saga
 
 import (
+	"context"
 	"testing"
 
 	pkgsaga "github.com/meridianhub/meridian/shared/pkg/saga"
@@ -96,12 +97,12 @@ func TestSuggestHandler_EmptyRegistry(t *testing.T) {
 
 func TestSuggestInstrument_NilChecker(t *testing.T) {
 	v := &ReferenceValidator{instrumentChecker: nil}
-	result := v.suggestInstrument(nil, "GBX")
+	result := v.suggestInstrument(context.TODO(), "GBX")
 	assert.Equal(t, "", result)
 }
 
 func TestSuggestSaga_NilChecker(t *testing.T) {
 	v := &ReferenceValidator{definitionChecker: nil}
-	result := v.suggestSaga(nil, "payment.initiate")
+	result := v.suggestSaga(context.TODO(), "payment.initiate")
 	assert.Equal(t, "", result)
 }

--- a/services/reference-data/valuation/helpers_test.go
+++ b/services/reference-data/valuation/helpers_test.go
@@ -1,0 +1,84 @@
+package valuation
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEstimateCELCost(t *testing.T) {
+	tests := []struct {
+		name     string
+		expr     string
+		expected int
+	}{
+		{"empty expression returns 1", "", 1},
+		{"short expression", "a > 0", 1},
+		{"medium expression", "amount > 0 && amount <= 1000000 && currency == 'GBP'", 5},
+		{"very long expression clamps at 9999", string(make([]byte, 200000)), 9999},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, estimateCELCost(tt.expr))
+		})
+	}
+}
+
+func TestComputeHash(t *testing.T) {
+	t.Run("deterministic", func(t *testing.T) {
+		h1 := computeHash("hello")
+		h2 := computeHash("hello")
+		assert.Equal(t, h1, h2)
+	})
+
+	t.Run("different inputs produce different hashes", func(t *testing.T) {
+		h1 := computeHash("hello")
+		h2 := computeHash("world")
+		assert.NotEqual(t, h1, h2)
+	})
+
+	t.Run("returns 64 char hex string", func(t *testing.T) {
+		h := computeHash("test")
+		assert.Len(t, h, 64) // SHA-256 = 32 bytes = 64 hex chars
+	})
+}
+
+func TestNullString(t *testing.T) {
+	t.Run("empty string returns invalid", func(t *testing.T) {
+		ns := nullString("")
+		assert.Equal(t, sql.NullString{Valid: false}, ns)
+	})
+
+	t.Run("non-empty string returns valid", func(t *testing.T) {
+		ns := nullString("hello")
+		assert.Equal(t, sql.NullString{String: "hello", Valid: true}, ns)
+	})
+}
+
+func TestBuildDryRunInput(t *testing.T) {
+	t.Run("nil inputs", func(t *testing.T) {
+		result := buildDryRunInput(nil)
+		assert.NotNil(t, result["attributes"])
+		assert.Equal(t, "", result["amount"])
+		assert.Equal(t, "", result["source"])
+	})
+
+	t.Run("with amount", func(t *testing.T) {
+		result := buildDryRunInput(map[string]string{"amount": "100.50"})
+		assert.Equal(t, "100.50", result["amount"])
+	})
+
+	t.Run("without amount", func(t *testing.T) {
+		result := buildDryRunInput(map[string]string{"currency": "GBP"})
+		assert.Equal(t, "", result["amount"])
+	})
+}
+
+func TestFailedDryRun(t *testing.T) {
+	result := failedDryRun(42, "compilation error")
+	assert.False(t, result.Success)
+	assert.Equal(t, 42, result.EstimatedCost)
+	assert.Equal(t, []string{"compilation error"}, result.Errors)
+}


### PR DESCRIPTION
## Summary

- Add pure unit tests for previously untested reference-data code across 4 packages
- Cover instrument status transitions (registry), similarity/suggestion helpers (saga), migration report formatting (saga), and valuation helper functions (valuation)
- 362 lines of new test code targeting functions with zero prior coverage

## Test plan

- [x] All new tests pass locally (`go test` per package)
- [ ] CI passes
- [ ] Codecov confirms coverage improvement