### PR TITLE
test: increase shared/platform coverage targeting partial hits

### DIFF
--- a/shared/platform/audit/hooks_test.go
+++ b/shared/platform/audit/hooks_test.go
@@ -403,3 +403,51 @@ func TestAuditOutboxTableName(t *testing.T) {
 	outbox := AuditOutbox{}
 	assert.Equal(t, "audit_outbox", outbox.TableName())
 }
+
+func TestRecordUpdateManual(t *testing.T) {
+	db := setupHooksTestDB(t)
+
+	t.Run("records UPDATE with explicit old and new values", func(t *testing.T) {
+		oldEntity := testEntity{
+			ID:     uuid.New(),
+			Name:   "Old Name",
+			Status: "pending",
+		}
+		newEntity := testEntity{
+			ID:     oldEntity.ID,
+			Name:   "New Name",
+			Status: "active",
+		}
+
+		err := db.Transaction(func(tx *gorm.DB) error {
+			return RecordUpdateManual(tx, oldEntity, newEntity)
+		})
+		require.NoError(t, err)
+
+		var outbox testAuditOutbox
+		err = db.Order("created_at DESC").First(&outbox).Error
+		require.NoError(t, err)
+
+		assert.Equal(t, "test_entity", outbox.Table)
+		assert.Equal(t, OperationUpdate, outbox.Operation)
+		assert.Equal(t, oldEntity.ID.String(), outbox.RecordID)
+		assert.NotEmpty(t, outbox.OldValues)
+		assert.NotEmpty(t, outbox.NewValues)
+
+		var oldVals map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(outbox.OldValues), &oldVals))
+		assert.Equal(t, "Old Name", oldVals["Name"])
+
+		var newVals map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(outbox.NewValues), &newVals))
+		assert.Equal(t, "New Name", newVals["Name"])
+	})
+
+	t.Run("returns error on nil transaction", func(t *testing.T) {
+		oldEntity := testEntity{ID: uuid.New(), Name: "Old"}
+		newEntity := testEntity{ID: oldEntity.ID, Name: "New"}
+
+		err := RecordUpdateManual[testEntity](nil, oldEntity, newEntity)
+		assert.ErrorIs(t, err, ErrNilTransaction)
+	})
+}

--- a/shared/platform/audit/metrics_test.go
+++ b/shared/platform/audit/metrics_test.go
@@ -11,6 +11,11 @@ func TestRecordKafkaMetrics(t *testing.T) {
 		RecordPollInterval("test_schema", 5.0)
 	})
 
+	t.Run("RecordEmptyPolls", func(_ *testing.T) {
+		RecordEmptyPolls("test_schema", 0)
+		RecordEmptyPolls("test_schema", 5)
+	})
+
 	t.Run("RecordKafkaPublished", func(_ *testing.T) {
 		RecordKafkaPublished("test_schema", "INSERT", "success")
 		RecordKafkaPublished("test_schema", "UPDATE", "failure")

--- a/shared/platform/audit/worker_unit_test.go
+++ b/shared/platform/audit/worker_unit_test.go
@@ -1,0 +1,158 @@
+package audit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/defaults"
+	"github.com/stretchr/testify/assert"
+)
+
+// newTestWorker creates a Worker with nil db for unit testing option functions.
+// Do not call Start/Stop on this worker.
+func newTestWorker() *Worker {
+	return &Worker{
+		batchSize:       defaultBatchSize,
+		pollInterval:    defaultPollInterval,
+		maxRetries:      defaultMaxRetries,
+		minPollInterval: defaultMinPollInterval,
+		maxPollInterval: defaultMaxPollInterval,
+		shutdown:        make(chan struct{}),
+	}
+}
+
+func TestWithBatchSize(t *testing.T) {
+	t.Run("positive value is applied", func(t *testing.T) {
+		w := newTestWorker()
+		WithBatchSize(50)(w)
+		assert.Equal(t, 50, w.batchSize)
+	})
+
+	t.Run("zero value is ignored", func(t *testing.T) {
+		w := newTestWorker()
+		WithBatchSize(0)(w)
+		assert.Equal(t, defaultBatchSize, w.batchSize)
+	})
+
+	t.Run("negative value is ignored", func(t *testing.T) {
+		w := newTestWorker()
+		WithBatchSize(-10)(w)
+		assert.Equal(t, defaultBatchSize, w.batchSize)
+	})
+}
+
+func TestWithPollInterval(t *testing.T) {
+	t.Run("positive duration is applied", func(t *testing.T) {
+		w := newTestWorker()
+		WithPollInterval(10 * time.Second)(w)
+		assert.Equal(t, 10*time.Second, w.pollInterval)
+	})
+
+	t.Run("zero duration is ignored", func(t *testing.T) {
+		w := newTestWorker()
+		WithPollInterval(0)(w)
+		assert.Equal(t, defaultPollInterval, w.pollInterval)
+	})
+
+	t.Run("negative duration is ignored", func(t *testing.T) {
+		w := newTestWorker()
+		WithPollInterval(-1 * time.Second)(w)
+		assert.Equal(t, defaultPollInterval, w.pollInterval)
+	})
+}
+
+func TestWithMaxRetries(t *testing.T) {
+	t.Run("positive value is applied", func(t *testing.T) {
+		w := newTestWorker()
+		WithMaxRetries(5)(w)
+		assert.Equal(t, 5, w.maxRetries)
+	})
+
+	t.Run("zero is accepted", func(t *testing.T) {
+		w := newTestWorker()
+		WithMaxRetries(0)(w)
+		assert.Equal(t, 0, w.maxRetries)
+	})
+
+	t.Run("negative value is ignored", func(t *testing.T) {
+		w := newTestWorker()
+		WithMaxRetries(-1)(w)
+		assert.Equal(t, defaultMaxRetries, w.maxRetries)
+	})
+}
+
+func TestWithAdaptivePolling(t *testing.T) {
+	t.Run("valid min and max are applied", func(t *testing.T) {
+		w := newTestWorker()
+		WithAdaptivePolling(100*time.Millisecond, 30*time.Second)(w)
+		assert.True(t, w.adaptivePolling)
+		assert.Equal(t, 100*time.Millisecond, w.minPollInterval)
+		assert.Equal(t, 30*time.Second, w.maxPollInterval)
+	})
+
+	t.Run("inverted min/max are swapped", func(t *testing.T) {
+		w := newTestWorker()
+		WithAdaptivePolling(30*time.Second, 100*time.Millisecond)(w)
+		assert.True(t, w.adaptivePolling)
+		assert.Equal(t, 100*time.Millisecond, w.minPollInterval)
+		assert.Equal(t, 30*time.Second, w.maxPollInterval)
+	})
+
+	t.Run("zero min interval is ignored", func(t *testing.T) {
+		w := newTestWorker()
+		WithAdaptivePolling(0, 30*time.Second)(w)
+		assert.True(t, w.adaptivePolling)
+		assert.Equal(t, defaultMinPollInterval, w.minPollInterval)
+		assert.Equal(t, 30*time.Second, w.maxPollInterval)
+	})
+
+	t.Run("zero max interval is ignored", func(t *testing.T) {
+		w := newTestWorker()
+		WithAdaptivePolling(100*time.Millisecond, 0)(w)
+		assert.True(t, w.adaptivePolling)
+		assert.Equal(t, 100*time.Millisecond, w.minPollInterval)
+		assert.Equal(t, defaultMaxPollInterval, w.maxPollInterval)
+	})
+}
+
+func TestCalculateAdaptiveInterval(t *testing.T) {
+	min := defaults.DefaultRetryDelay  // 100ms
+	max := defaults.DefaultRPCTimeout  // 30s
+
+	t.Run("work found resets to min interval", func(t *testing.T) {
+		w := newTestWorker()
+		w.minPollInterval = min
+		w.maxPollInterval = max
+		w.emptyPollCount = 5 // simulate previous idle state
+
+		interval := w.calculateAdaptiveInterval(10)
+		assert.Equal(t, min, interval)
+		assert.Equal(t, 0, w.emptyPollCount)
+	})
+
+	t.Run("no work increases interval exponentially", func(t *testing.T) {
+		w := newTestWorker()
+		w.minPollInterval = min
+		w.maxPollInterval = max
+
+		// First empty poll: emptyPollCount becomes 1, multiplier = 2^1 = 2
+		interval := w.calculateAdaptiveInterval(0)
+		assert.Equal(t, 1, w.emptyPollCount)
+		assert.Equal(t, 2*min, interval)
+
+		// Second empty poll: emptyPollCount becomes 2, multiplier = 2^2 = 4
+		interval = w.calculateAdaptiveInterval(0)
+		assert.Equal(t, 2, w.emptyPollCount)
+		assert.Equal(t, 4*min, interval)
+	})
+
+	t.Run("interval is capped at max", func(t *testing.T) {
+		w := newTestWorker()
+		w.minPollInterval = min
+		w.maxPollInterval = 200 * time.Millisecond // very small max
+		w.emptyPollCount = 20                      // large count to exceed max
+
+		interval := w.calculateAdaptiveInterval(0)
+		assert.Equal(t, 200*time.Millisecond, interval)
+	})
+}

--- a/shared/platform/gateway/tenant_resolver_test.go
+++ b/shared/platform/gateway/tenant_resolver_test.go
@@ -1417,6 +1417,80 @@ func TestHandlerOptionalTenant_TenantNotFoundInDB(t *testing.T) {
 	mockRepo.AssertExpectations(t)
 }
 
+func TestHandlerOptionalTenant_LocalDevMode_ValidSlugFromHeader(t *testing.T) {
+	ctx := context.Background()
+	baseDomain := "api.meridian.io"
+	testSlug := "acme"
+	testTenantID := tenant.MustNewTenantID("tenant_abc")
+	logger := slog.Default()
+
+	mockCache := new(MockSlugCache)
+	mockRepo := new(MockTenantRepository)
+
+	mockCache.On("Get", ctx, testSlug).Return(testTenantID, nil)
+
+	middleware := &TenantResolverMiddleware{
+		slugCache:    mockCache,
+		tenantRepo:   mockRepo,
+		baseDomain:   baseDomain,
+		logger:       logger,
+		localDevMode: true,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "http://"+baseDomain+"/api/test", nil)
+	req.Header.Set(TenantSlugHeader, testSlug)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	var capturedTenantOk bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, capturedTenantOk = tenant.FromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := middleware.HandlerOptionalTenant(next)
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, capturedTenantOk, "tenant should be resolved from header slug in local dev mode")
+	mockCache.AssertExpectations(t)
+}
+
+func TestHandlerOptionalTenant_LocalDevMode_InvalidSlugFromHeader(t *testing.T) {
+	ctx := context.Background()
+	baseDomain := "api.meridian.io"
+	logger := slog.Default()
+
+	mockCache := new(MockSlugCache)
+	mockRepo := new(MockTenantRepository)
+
+	middleware := &TenantResolverMiddleware{
+		slugCache:    mockCache,
+		tenantRepo:   mockRepo,
+		baseDomain:   baseDomain,
+		logger:       logger,
+		localDevMode: true,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "http://"+baseDomain+"/api/test", nil)
+	req.Header.Set(TenantSlugHeader, "INVALID SLUG!!!")
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	var capturedTenantOk bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, capturedTenantOk = tenant.FromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := middleware.HandlerOptionalTenant(next)
+	handler.ServeHTTP(rec, req)
+
+	// Invalid slug: falls through to subdomain extraction, which also returns empty, so no tenant
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.False(t, capturedTenantOk, "no tenant should be resolved with invalid slug")
+}
+
 func TestPlatformPathsDoesNotIncludeDex(t *testing.T) {
 	assert.False(t, IsPlatformPath("/dex/auth"), "/dex/auth should not be a platform path")
 	assert.False(t, IsPlatformPath("/dex/callback"), "/dex/callback should not be a platform path")

--- a/shared/platform/quantity/value_test.go
+++ b/shared/platform/quantity/value_test.go
@@ -607,3 +607,18 @@ func TestValue_HighPrecision(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "1.123456789012345678", result.Amount.String())
 }
+
+func TestParseQuantity_InvalidNonEmptyDimension(t *testing.T) {
+	// Create an instrument with a non-empty dimension that is not in ValidDimensions.
+	// This bypasses the empty-string case and exercises the ValidDimensions check.
+	invalidInst := quantity.Instrument{
+		Code:      "BOGUS",
+		Version:   1,
+		Dimension: "NOT_A_VALID_DIMENSION",
+		Precision: 2,
+	}
+
+	_, err := quantity.ParseQuantity(decimal.NewFromInt(42), invalidInst)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, quantity.ErrUnknownDimension)
+}

--- a/shared/platform/ratelimit/interceptor_test.go
+++ b/shared/platform/ratelimit/interceptor_test.go
@@ -322,3 +322,32 @@ func TestInterceptor_NilMetrics(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
 }
+
+func TestNewMetrics_AlreadyRegistered(t *testing.T) {
+	// Register metrics once
+	registry := testRegistry()
+	m1 := NewMetrics("dedupe_test", registry)
+	assert.NotNil(t, m1)
+
+	// Registering again with the same registry should not panic
+	// (AlreadyRegisteredError is handled gracefully)
+	assert.NotPanics(t, func() {
+		m2 := NewMetrics("dedupe_test", registry)
+		assert.NotNil(t, m2)
+	})
+}
+
+func TestNewMetrics_NilRegistry(t *testing.T) {
+	// nil registry falls back to prometheus.DefaultRegisterer
+	// This should not panic
+	assert.NotPanics(t, func() {
+		_ = NewMetrics("nil_reg_test", nil)
+	})
+}
+
+func TestNewMetrics_EmptyNamespace(t *testing.T) {
+	registry := testRegistry()
+	// Empty namespace falls back to "grpc"
+	m := NewMetrics("", registry)
+	assert.NotNil(t, m)
+}

--- a/shared/platform/scheduler/metrics_config_test.go
+++ b/shared/platform/scheduler/metrics_config_test.go
@@ -1,0 +1,47 @@
+package scheduler_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/defaults"
+	"github.com/meridianhub/meridian/shared/platform/scheduler"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := scheduler.DefaultConfig()
+
+	assert.Equal(t, defaults.DefaultHealthCheckTimeout, cfg.PollInterval)
+	assert.Equal(t, defaults.DefaultGracefulShutdown, cfg.ShutdownTimeout)
+	assert.Equal(t, 5*time.Minute, cfg.MaxCatchUpAge)
+}
+
+// TestSchedulerMetrics verifies that the scheduler metric functions do not panic.
+// These are thin prometheus wrappers - the test validates correct invocation.
+func TestSchedulerMetrics(t *testing.T) {
+	t.Run("RecordWorkerStart", func(_ *testing.T) {
+		scheduler.RecordWorkerStart("test-worker")
+	})
+
+	t.Run("RecordWorkerStop", func(_ *testing.T) {
+		scheduler.RecordWorkerStop("test-worker")
+	})
+
+	t.Run("RecordShutdownDuration", func(_ *testing.T) {
+		scheduler.RecordShutdownDuration("test-worker", 0.5)
+	})
+
+	t.Run("RecordShutdownTimeout", func(_ *testing.T) {
+		scheduler.RecordShutdownTimeout("test-worker")
+	})
+
+	t.Run("RecordInFlightWork", func(_ *testing.T) {
+		scheduler.RecordInFlightWork("test-worker", 3.0)
+		scheduler.RecordInFlightWork("test-worker", 0.0)
+	})
+
+	t.Run("RecordPoll", func(_ *testing.T) {
+		scheduler.RecordPoll("test-worker")
+	})
+}


### PR DESCRIPTION
## Summary

Increases test coverage across `shared/platform` by targeting uncovered and partially-covered code paths. Adds ~376 lines of tests across 7 files.

## Changes Made

| Package | Functions Covered |
|---------|-------------------|
| `audit/worker` | `WithBatchSize`, `WithPollInterval`, `WithMaxRetries`, `WithAdaptivePolling` (all branches including inverted ranges), `calculateAdaptiveInterval` (reset, exponential growth, cap) |
| `audit/hooks` | `RecordUpdateManual` (happy path + nil transaction error) |
| `audit/metrics` | `RecordEmptyPolls` |
| `scheduler` | `DefaultConfig`, `RecordWorkerStart/Stop`, `RecordShutdownDuration/Timeout`, `RecordInFlightWork`, `RecordPoll` |
| `ratelimit` | `NewMetrics` `AlreadyRegisteredError` branch, nil registry fallback, empty namespace fallback |
| `gateway` | `extractSlugFromRequestOptional` local-dev mode paths (valid and invalid header slug) |
| `quantity` | `ParseQuantity` non-empty invalid dimension branch (exercises `ValidDimensions` map check) |

## Test Plan

- [x] All new tests pass locally with `go test -run <TestName> ./shared/platform/<pkg>/`
- [x] No new test files introduce container dependencies (all unit tests)
- [x] Scheduler tests verified with `-short` flag (skips CockroachDB container setup)