### PR TITLE
fix: Resolve nightly test failures for deeply nested control-plane tests

### DIFF
--- a/shared/platform/testdb/pgx.go
+++ b/shared/platform/testdb/pgx.go
@@ -123,6 +123,7 @@ func applyMigrationsWithPgx(t *testing.T, pool *pgxpool.Pool, service string) {
 		filepath.Join("..", "..", "services", service, "migrations"),
 		filepath.Join("..", "..", "..", "services", service, "migrations"),
 		filepath.Join("..", "..", "..", "..", "services", service, "migrations"),
+		filepath.Join("..", "..", "..", "..", "..", "services", service, "migrations"),
 	}
 
 	for _, path := range possiblePaths {
@@ -214,6 +215,7 @@ func applyMigrationsToSchema(t *testing.T, pool *pgxpool.Pool, service string, s
 		filepath.Join("..", "..", "services", service, "migrations"),
 		filepath.Join("..", "..", "..", "services", service, "migrations"),
 		filepath.Join("..", "..", "..", "..", "services", service, "migrations"),
+		filepath.Join("..", "..", "..", "..", "..", "services", service, "migrations"),
 	}
 
 	for _, path := range possiblePaths {


### PR DESCRIPTION
## Summary
- The `manifest_version_store_test.go` tests in `services/control-plane/internal/differ/persistence/` consistently fail in nightly CI with "Could not find migrations directory for service control-plane"
- Root cause: `shared/platform/testdb/pgx.go` path resolution only traverses up to 4 parent directories, but these tests are 5 levels deep from the repo root
- Fix: Add a 5th path entry (`../../../../../services/<service>/migrations`) to both `applyMigrationsWithPgx` and `applyMigrationsToSchema`

## Evidence
- Failing nightly runs: https://github.com/meridianhub/meridian/actions/runs/23373485428 and https://github.com/meridianhub/meridian/actions/runs/23371675473
- Tests introduced in 58e7aa69 (#1837), nightly green before that commit

## Note on instruction repo flakiness
The `TestInstructionRepository_FetchDispatchable_SkipsAlreadyDispatching` and `TestInstructionRepository_FetchDispatchable_RespectsScheduledAt` tests also failed intermittently in the same CI window but passed in subsequent runs. This is a separate CockroachDB `FOR UPDATE SKIP LOCKED` flakiness issue and is not addressed in this PR.