### PR TITLE
fix: Rename min/max variables to avoid shadowing Go builtins

### DIFF
--- a/shared/platform/audit/worker_unit_test.go
+++ b/shared/platform/audit/worker_unit_test.go
@@ -116,39 +116,39 @@ func TestWithAdaptivePolling(t *testing.T) {
 }
 
 func TestCalculateAdaptiveInterval(t *testing.T) {
-	min := defaults.DefaultRetryDelay  // 100ms
-	max := defaults.DefaultRPCTimeout  // 30s
+	minInterval := defaults.DefaultRetryDelay // 100ms
+	maxInterval := defaults.DefaultRPCTimeout // 30s
 
 	t.Run("work found resets to min interval", func(t *testing.T) {
 		w := newTestWorker()
-		w.minPollInterval = min
-		w.maxPollInterval = max
+		w.minPollInterval = minInterval
+		w.maxPollInterval = maxInterval
 		w.emptyPollCount = 5 // simulate previous idle state
 
 		interval := w.calculateAdaptiveInterval(10)
-		assert.Equal(t, min, interval)
+		assert.Equal(t, minInterval, interval)
 		assert.Equal(t, 0, w.emptyPollCount)
 	})
 
 	t.Run("no work increases interval exponentially", func(t *testing.T) {
 		w := newTestWorker()
-		w.minPollInterval = min
-		w.maxPollInterval = max
+		w.minPollInterval = minInterval
+		w.maxPollInterval = maxInterval
 
 		// First empty poll: emptyPollCount becomes 1, multiplier = 2^1 = 2
 		interval := w.calculateAdaptiveInterval(0)
 		assert.Equal(t, 1, w.emptyPollCount)
-		assert.Equal(t, 2*min, interval)
+		assert.Equal(t, 2*minInterval, interval)
 
 		// Second empty poll: emptyPollCount becomes 2, multiplier = 2^2 = 4
 		interval = w.calculateAdaptiveInterval(0)
 		assert.Equal(t, 2, w.emptyPollCount)
-		assert.Equal(t, 4*min, interval)
+		assert.Equal(t, 4*minInterval, interval)
 	})
 
 	t.Run("interval is capped at max", func(t *testing.T) {
 		w := newTestWorker()
-		w.minPollInterval = min
+		w.minPollInterval = minInterval
 		w.maxPollInterval = 200 * time.Millisecond // very small max
 		w.emptyPollCount = 20                      // large count to exceed max
 


### PR DESCRIPTION
## Summary
- Code Quality CI on develop is failing due to revive linter flagging `min` and `max` variable names in `shared/platform/audit/worker_unit_test.go` as shadowing Go built-in functions
- Renamed to `minInterval` and `maxInterval`

## Evidence
- Failing run: https://github.com/meridianhub/meridian/actions/runs/23382961670
- Error: `redefines-builtin-id: redefinition of the built-in function min/max (revive)`

## Note on test failures
Separate `TestInstructionRepository_FetchDispatchable_*` test failures appear flaky (different tests fail in different runs). Monitoring in this CI run.