### PR TITLE
chore: exclude cmd/main.go entry points from Codecov coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -19,6 +19,7 @@ ignore:
   - "utilities/**"
   - "frontend/src/api/gen/**"
   - "services/mcp-server/cmd/wire.go"
+  - "**/cmd/main.go"
 
 comment:
   layout: "condensed_header, condensed_files, components, condensed_footer"


### PR DESCRIPTION
## Summary

- Adds `**/cmd/main.go` to the `ignore` list in `codecov.yml`

## Rationale

Service entry points (`cmd/main.go`) contain infrastructure wiring - dependency injection, server startup, and signal handling. These cannot be meaningfully unit tested. Excluding them (~3,509 lines across 15 services) gives a more accurate picture of testable business logic coverage.

Same rationale as the existing `**/testhelpers/**` exclusion.

## Changes

- `codecov.yml`: Added `"**/cmd/main.go"` to the `ignore` array