### PR TITLE
test: add tests for untested frontend features

### DIFF
--- a/frontend/src/features/cookbook/components/filter-bar.test.tsx
+++ b/frontend/src/features/cookbook/components/filter-bar.test.tsx
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FilterBar } from './filter-bar'
+import type { CookbookItem, PatternMeta } from '../hooks/use-cookbook'
+import type { FilterState } from '../hooks/use-filter-state'
+
+function makeItem(overrides: Partial<CookbookItem> = {}): CookbookItem {
+  return {
+    name: 'test-item',
+    type: 'registry:pattern',
+    title: 'Test Item',
+    ...overrides,
+  }
+}
+
+const emptyFilters: FilterState = { search: '', type: '', category: '', industry: '', kind: '' }
+
+const items: CookbookItem[] = [
+  makeItem({
+    name: 'banking',
+    title: 'Banking Pattern',
+    categories: ['finance', 'banking'],
+    meta: { industries: ['banking', 'fintech'] } as PatternMeta,
+  }),
+  makeItem({
+    name: 'energy',
+    title: 'Energy',
+    type: 'registry:ui',
+    categories: ['energy'],
+    meta: { industries: ['utilities'] } as PatternMeta,
+  }),
+]
+
+describe('FilterBar', () => {
+  it('renders search input', () => {
+    render(
+      <FilterBar items={items} filters={emptyFilters} onFilterChange={vi.fn()} />,
+    )
+
+    expect(screen.getByPlaceholderText('Search patterns and components...')).toBeDefined()
+  })
+
+  it('renders type filter chips', () => {
+    render(
+      <FilterBar items={items} filters={emptyFilters} onFilterChange={vi.fn()} />,
+    )
+
+    expect(screen.getByText('Patterns')).toBeDefined()
+    expect(screen.getByText('UI Components')).toBeDefined()
+  })
+
+  it('hides type filter when hideTypeFilter is true', () => {
+    render(
+      <FilterBar items={items} filters={emptyFilters} onFilterChange={vi.fn()} hideTypeFilter />,
+    )
+
+    expect(screen.queryByText('Patterns')).toBeNull()
+    expect(screen.queryByText('UI Components')).toBeNull()
+  })
+
+  it('renders category chips from items', () => {
+    render(
+      <FilterBar items={items} filters={emptyFilters} onFilterChange={vi.fn()} />,
+    )
+
+    // Categories include: banking, energy, finance (sorted)
+    const categoryGroup = screen.getByRole('group', { name: 'Category filter' })
+    expect(categoryGroup).toBeDefined()
+    expect(screen.getByText('energy')).toBeDefined()
+    expect(screen.getByText('finance')).toBeDefined()
+  })
+
+  it('renders industry chips from items', () => {
+    render(
+      <FilterBar items={items} filters={emptyFilters} onFilterChange={vi.fn()} />,
+    )
+
+    // Industries include: banking, fintech, utilities
+    const industryGroup = screen.getByRole('group', { name: 'Industry filter' })
+    expect(industryGroup).toBeDefined()
+    expect(screen.getByText('fintech')).toBeDefined()
+    expect(screen.getByText('utilities')).toBeDefined()
+  })
+
+  it('calls onFilterChange when search input changes', async () => {
+    const user = userEvent.setup()
+    const onFilterChange = vi.fn()
+    render(
+      <FilterBar items={items} filters={emptyFilters} onFilterChange={onFilterChange} />,
+    )
+
+    const input = screen.getByPlaceholderText('Search patterns and components...')
+    await user.type(input, 'a')
+
+    expect(onFilterChange).toHaveBeenCalledWith({ search: 'a' })
+  })
+
+  it('calls onFilterChange when type chip is clicked', async () => {
+    const user = userEvent.setup()
+    const onFilterChange = vi.fn()
+    render(
+      <FilterBar items={items} filters={emptyFilters} onFilterChange={onFilterChange} />,
+    )
+
+    await user.click(screen.getByText('Patterns'))
+
+    expect(onFilterChange).toHaveBeenCalledWith({ type: 'pattern' })
+  })
+
+  it('deselects type chip when already selected', async () => {
+    const user = userEvent.setup()
+    const onFilterChange = vi.fn()
+    render(
+      <FilterBar
+        items={items}
+        filters={{ ...emptyFilters, type: 'pattern' }}
+        onFilterChange={onFilterChange}
+      />,
+    )
+
+    await user.click(screen.getByText('Patterns'))
+
+    expect(onFilterChange).toHaveBeenCalledWith({ type: '' })
+  })
+
+  it('shows Clear button when filters are active', () => {
+    render(
+      <FilterBar
+        items={items}
+        filters={{ ...emptyFilters, search: 'test' }}
+        onFilterChange={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Clear')).toBeDefined()
+  })
+
+  it('does not show Clear button when no filters are active', () => {
+    render(
+      <FilterBar items={items} filters={emptyFilters} onFilterChange={vi.fn()} />,
+    )
+
+    expect(screen.queryByText('Clear')).toBeNull()
+  })
+
+  it('clears all filters when Clear button is clicked', async () => {
+    const user = userEvent.setup()
+    const onFilterChange = vi.fn()
+    render(
+      <FilterBar
+        items={items}
+        filters={{ ...emptyFilters, search: 'test', type: 'pattern' }}
+        onFilterChange={onFilterChange}
+      />,
+    )
+
+    await user.click(screen.getByText('Clear'))
+
+    expect(onFilterChange).toHaveBeenCalledWith({
+      search: '',
+      type: '',
+      category: '',
+      industry: '',
+      kind: '',
+    })
+  })
+
+  it('renders kind filter chips when showKindFilter is true and items have kinds', () => {
+    const patternItems: CookbookItem[] = [
+      makeItem({
+        name: 'p1',
+        type: 'registry:pattern',
+        meta: { provides: { sagas: ['s1'] } } as PatternMeta,
+      }),
+      makeItem({
+        name: 'p2',
+        type: 'registry:pattern',
+        categories: ['gateway'],
+      }),
+    ]
+
+    render(
+      <FilterBar
+        items={patternItems}
+        filters={emptyFilters}
+        onFilterChange={vi.fn()}
+        showKindFilter
+      />,
+    )
+
+    expect(screen.getByText('Economy')).toBeDefined()
+    expect(screen.getByText('Integration')).toBeDefined()
+  })
+
+  it('does not show kind filter when showKindFilter is false', () => {
+    const patternItems: CookbookItem[] = [
+      makeItem({
+        name: 'p1',
+        type: 'registry:pattern',
+        meta: { provides: { sagas: ['s1'] } } as PatternMeta,
+      }),
+    ]
+
+    render(
+      <FilterBar
+        items={patternItems}
+        filters={emptyFilters}
+        onFilterChange={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByText('Economy')).toBeNull()
+  })
+
+  it('sets aria-pressed on selected filter chip', () => {
+    render(
+      <FilterBar
+        items={items}
+        filters={{ ...emptyFilters, type: 'pattern' }}
+        onFilterChange={vi.fn()}
+      />,
+    )
+
+    const button = screen.getByText('Patterns').closest('button')
+    expect(button?.getAttribute('aria-pressed')).toBe('true')
+
+    const uiButton = screen.getByText('UI Components').closest('button')
+    expect(uiButton?.getAttribute('aria-pressed')).toBe('false')
+  })
+})

--- a/frontend/src/features/cookbook/hooks/use-filter-state.test.ts
+++ b/frontend/src/features/cookbook/hooks/use-filter-state.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest'
+import type { CookbookItem, PatternMeta } from './use-cookbook'
+import { derivePatternKind, applyFilters } from './use-filter-state'
+import type { FilterState } from './use-filter-state'
+
+function makeItem(overrides: Partial<CookbookItem> = {}): CookbookItem {
+  return {
+    name: 'test-item',
+    type: 'registry:pattern',
+    title: 'Test Item',
+    ...overrides,
+  }
+}
+
+const emptyFilters: FilterState = { search: '', type: '', category: '', industry: '', kind: '' }
+
+describe('derivePatternKind', () => {
+  it('returns null for non-pattern items', () => {
+    const item = makeItem({ type: 'registry:ui' })
+    expect(derivePatternKind(item)).toBeNull()
+  })
+
+  it('returns "foundation" when design_pattern starts with "foundation"', () => {
+    const item = makeItem({
+      meta: { design_pattern: 'foundation-core' } as PatternMeta,
+    })
+    expect(derivePatternKind(item)).toBe('foundation')
+  })
+
+  it('returns "integration" for gateway category', () => {
+    const item = makeItem({ categories: ['gateway'] })
+    expect(derivePatternKind(item)).toBe('integration')
+  })
+
+  it('returns "integration" for integration category', () => {
+    const item = makeItem({ categories: ['integration'] })
+    expect(derivePatternKind(item)).toBe('integration')
+  })
+
+  it('returns "integration" for payments category', () => {
+    const item = makeItem({ categories: ['payments'] })
+    expect(derivePatternKind(item)).toBe('integration')
+  })
+
+  it('returns "integration" for compliance category', () => {
+    const item = makeItem({ categories: ['compliance'] })
+    expect(derivePatternKind(item)).toBe('integration')
+  })
+
+  it('returns "economy" when item has sagas', () => {
+    const item = makeItem({
+      meta: { provides: { sagas: ['saga1'] } } as PatternMeta,
+    })
+    expect(derivePatternKind(item)).toBe('economy')
+  })
+
+  it('returns "definition" for pattern without special markers', () => {
+    const item = makeItem({ categories: ['general'] })
+    expect(derivePatternKind(item)).toBe('definition')
+  })
+
+  it('prioritizes foundation over integration', () => {
+    const item = makeItem({
+      categories: ['gateway'],
+      meta: { design_pattern: 'foundation-base' } as PatternMeta,
+    })
+    expect(derivePatternKind(item)).toBe('foundation')
+  })
+})
+
+describe('applyFilters', () => {
+  const items: CookbookItem[] = [
+    makeItem({ name: 'banking', title: 'Banking Pattern', type: 'registry:pattern', categories: ['finance'], meta: { industries: ['banking'] } as PatternMeta }),
+    makeItem({ name: 'energy-ui', title: 'Energy Dashboard', type: 'registry:ui', categories: ['energy'] }),
+    makeItem({ name: 'carbon', title: 'Carbon Credits', type: 'registry:pattern', categories: ['compliance'], meta: { industries: ['energy'], provides: { sagas: ['saga1'] } } as PatternMeta }),
+  ]
+
+  it('returns all items with empty filters', () => {
+    expect(applyFilters(items, emptyFilters)).toHaveLength(3)
+  })
+
+  it('filters by type: pattern', () => {
+    const result = applyFilters(items, { ...emptyFilters, type: 'pattern' })
+    expect(result).toHaveLength(2)
+    expect(result.every((i) => i.type === 'registry:pattern')).toBe(true)
+  })
+
+  it('filters by type: ui', () => {
+    const result = applyFilters(items, { ...emptyFilters, type: 'ui' })
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('energy-ui')
+  })
+
+  it('filters by category', () => {
+    const result = applyFilters(items, { ...emptyFilters, category: 'finance' })
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('banking')
+  })
+
+  it('filters by industry', () => {
+    const result = applyFilters(items, { ...emptyFilters, industry: 'energy' })
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('carbon')
+  })
+
+  it('filters by search term (case insensitive)', () => {
+    const result = applyFilters(items, { ...emptyFilters, search: 'carbon' })
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('carbon')
+  })
+
+  it('search matches against name, title, and description', () => {
+    const result = applyFilters(items, { ...emptyFilters, search: 'Dashboard' })
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('energy-ui')
+  })
+
+  it('filters by kind (integration)', () => {
+    const result = applyFilters(items, { ...emptyFilters, kind: 'integration' })
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('carbon')
+  })
+
+  it('combines multiple filters', () => {
+    const result = applyFilters(items, {
+      ...emptyFilters,
+      type: 'pattern',
+      industry: 'banking',
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('banking')
+  })
+
+  it('returns empty when no items match', () => {
+    const result = applyFilters(items, { ...emptyFilters, search: 'nonexistent' })
+    expect(result).toHaveLength(0)
+  })
+
+  it('filters by unknown type returns empty', () => {
+    const result = applyFilters(items, { ...emptyFilters, type: 'unknown' })
+    expect(result).toHaveLength(0)
+  })
+})

--- a/frontend/src/features/economy/hooks/use-manifest-plan.test.tsx
+++ b/frontend/src/features/economy/hooks/use-manifest-plan.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { useManifestPlan } from './use-manifest-plan'
+
+const mockApplyManifest = vi.fn()
+
+vi.mock('@/api/context', () => ({
+  useApiClients: () => ({
+    manifestApplier: {
+      applyManifest: mockApplyManifest,
+    },
+  }),
+}))
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('useManifestPlan', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns initial state with null plan', () => {
+    const { result } = renderHook(() => useManifestPlan(), { wrapper: createWrapper() })
+
+    expect(result.current.plan).toBeNull()
+    expect(result.current.isPlanning).toBe(false)
+    expect(result.current.error).toBeNull()
+    expect(typeof result.current.planManifest).toBe('function')
+    expect(typeof result.current.planManifestAsync).toBe('function')
+  })
+
+  it('calls applyManifest with dryRun=true and maps response', async () => {
+    const mockResponse = {
+      status: 1,
+      diffSummary: '3 add, 2 modify, 1 remove',
+      stepResults: [{ stepName: 'step1', status: 1 }],
+      validationErrors: [{ severity: 'WARNING', message: 'warn' }],
+    }
+    mockApplyManifest.mockResolvedValue(mockResponse)
+
+    const { result } = renderHook(() => useManifestPlan(), { wrapper: createWrapper() })
+
+    act(() => {
+      result.current.planManifest({} as never)
+    })
+
+    await waitFor(() => {
+      expect(result.current.plan).not.toBeNull()
+    })
+
+    expect(mockApplyManifest).toHaveBeenCalledWith({
+      manifest: {},
+      dryRun: true,
+      force: false,
+      appliedBy: '',
+    })
+
+    expect(result.current.plan).toEqual({
+      status: 1,
+      diffSummary: '3 add, 2 modify, 1 remove',
+      stepResults: [{ stepName: 'step1', status: 1 }],
+      validationErrors: [{ severity: 'WARNING', message: 'warn' }],
+      counts: { add: 3, modify: 2, remove: 1 },
+    })
+  })
+
+  it('parses diff counts with various formats', async () => {
+    mockApplyManifest.mockResolvedValue({
+      status: 1,
+      diffSummary: '10 additions, 5 modifications, 2 deletions',
+      stepResults: [],
+      validationErrors: [],
+    })
+
+    const { result } = renderHook(() => useManifestPlan(), { wrapper: createWrapper() })
+
+    act(() => {
+      result.current.planManifest({} as never)
+    })
+
+    await waitFor(() => {
+      expect(result.current.plan).not.toBeNull()
+    })
+
+    expect(result.current.plan!.counts).toEqual({ add: 10, modify: 5, remove: 2 })
+  })
+
+  it('returns zeros for empty diff summary', async () => {
+    mockApplyManifest.mockResolvedValue({
+      status: 1,
+      diffSummary: 'No changes',
+      stepResults: [],
+      validationErrors: [],
+    })
+
+    const { result } = renderHook(() => useManifestPlan(), { wrapper: createWrapper() })
+
+    act(() => {
+      result.current.planManifest({} as never)
+    })
+
+    await waitFor(() => {
+      expect(result.current.plan).not.toBeNull()
+    })
+
+    expect(result.current.plan!.counts).toEqual({ add: 0, modify: 0, remove: 0 })
+  })
+
+  it('sets error on failure', async () => {
+    mockApplyManifest.mockRejectedValue(new Error('Plan failed'))
+
+    const { result } = renderHook(() => useManifestPlan(), { wrapper: createWrapper() })
+
+    act(() => {
+      result.current.planManifest({} as never)
+    })
+
+    await waitFor(() => {
+      expect(result.current.error).not.toBeNull()
+    })
+
+    expect(result.current.error).toBeInstanceOf(Error)
+    expect((result.current.error as Error).message).toBe('Plan failed')
+    expect(result.current.plan).toBeNull()
+  })
+})

--- a/frontend/src/features/economy/hooks/use-manifest-validate.test.ts
+++ b/frontend/src/features/economy/hooks/use-manifest-validate.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useManifestValidate } from './use-manifest-validate'
+
+// Mock the protobuf create function
+vi.mock('@bufbuild/protobuf', () => ({
+  create: (_schema: unknown, fields: Record<string, unknown>) => fields,
+}))
+
+const mockApplyManifest = vi.fn()
+
+vi.mock('@/api/context', () => ({
+  useApiClients: () => ({
+    manifestApplier: {
+      applyManifest: mockApplyManifest,
+    },
+  }),
+}))
+
+// Stub the generated proto imports
+vi.mock('@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb', () => ({
+  ApplyManifestStatus: { VALIDATION_FAILED: 3, DRY_RUN: 1 },
+  StepResultStatus: { SUCCESS: 1 },
+  ValidationErrorSchema: { typeName: 'ValidationError' },
+}))
+
+describe('useManifestValidate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns initial state', () => {
+    const { result } = renderHook(() => useManifestValidate())
+
+    expect(result.current.isValidating).toBe(false)
+    expect(result.current.result).toBeNull()
+    expect(typeof result.current.validate).toBe('function')
+  })
+
+  it('debounces validation calls by 500ms', async () => {
+    const manifest = { yaml: 'test' } as never
+    mockApplyManifest.mockResolvedValue({
+      validationErrors: [],
+      stepResults: [],
+      status: 1,
+    })
+
+    const { result } = renderHook(() => useManifestValidate())
+
+    act(() => {
+      result.current.validate(manifest)
+    })
+
+    // Not yet called - still within debounce period
+    expect(mockApplyManifest).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    // Now it should be called
+    expect(mockApplyManifest).toHaveBeenCalledTimes(1)
+    expect(mockApplyManifest).toHaveBeenCalledWith(
+      { manifest, dryRun: true, force: false, appliedBy: '' },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+  })
+
+  it('cancels previous debounce when validate is called again', async () => {
+    const manifest1 = { yaml: 'first' } as never
+    const manifest2 = { yaml: 'second' } as never
+    mockApplyManifest.mockResolvedValue({
+      validationErrors: [],
+      stepResults: [],
+      status: 1,
+    })
+
+    const { result } = renderHook(() => useManifestValidate())
+
+    act(() => {
+      result.current.validate(manifest1)
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300)
+    })
+
+    act(() => {
+      result.current.validate(manifest2)
+    })
+
+    // Advance past original debounce but not new one
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300)
+    })
+
+    // First call should have been cancelled
+    expect(mockApplyManifest).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200)
+    })
+
+    expect(mockApplyManifest).toHaveBeenCalledTimes(1)
+    expect(mockApplyManifest).toHaveBeenCalledWith(
+      expect.objectContaining({ manifest: manifest2 }),
+      expect.any(Object),
+    )
+  })
+
+  it('separates errors and warnings from response', async () => {
+    mockApplyManifest.mockResolvedValue({
+      validationErrors: [
+        { severity: 'ERROR', code: 'E1', message: 'err1' },
+        { severity: 'WARNING', code: 'W1', message: 'warn1' },
+        { severity: 'ERROR', code: 'E2', message: 'err2' },
+      ],
+      stepResults: [],
+      status: 1,
+    })
+
+    const { result } = renderHook(() => useManifestValidate())
+
+    act(() => {
+      result.current.validate({} as never)
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    expect(result.current.result).not.toBeNull()
+    expect(result.current.result!.errors).toHaveLength(2)
+    expect(result.current.result!.warnings).toHaveLength(1)
+  })
+
+  it('extracts step-level errors when VALIDATION_FAILED but no structured errors', async () => {
+    mockApplyManifest.mockResolvedValue({
+      validationErrors: [],
+      stepResults: [
+        { stepName: 'step1', status: 0, message: 'Step failed' },
+        { stepName: 'step2', status: 1, message: 'OK' },
+      ],
+      status: 3, // VALIDATION_FAILED
+    })
+
+    const { result } = renderHook(() => useManifestValidate())
+
+    act(() => {
+      result.current.validate({} as never)
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    expect(result.current.result).not.toBeNull()
+    expect(result.current.result!.errors).toHaveLength(1)
+    expect(result.current.result!.errors[0]).toEqual(
+      expect.objectContaining({ code: 'step1', message: 'Step failed' }),
+    )
+  })
+
+  it('handles network errors', async () => {
+    mockApplyManifest.mockRejectedValue(new Error('Network down'))
+
+    const { result } = renderHook(() => useManifestValidate())
+
+    act(() => {
+      result.current.validate({} as never)
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    expect(result.current.result).not.toBeNull()
+    expect(result.current.result!.errors).toHaveLength(1)
+    expect(result.current.result!.errors[0]).toEqual(
+      expect.objectContaining({ code: 'NETWORK_ERROR', message: 'Network down' }),
+    )
+    expect(result.current.result!.warnings).toHaveLength(0)
+  })
+
+  it('handles non-Error rejection', async () => {
+    mockApplyManifest.mockRejectedValue('string error')
+
+    const { result } = renderHook(() => useManifestValidate())
+
+    act(() => {
+      result.current.validate({} as never)
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    expect(result.current.result).not.toBeNull()
+    expect(result.current.result!.errors[0]).toEqual(
+      expect.objectContaining({ message: 'Validation request failed' }),
+    )
+  })
+
+  it('ignores AbortError', async () => {
+    const abortError = new DOMException('Aborted', 'AbortError')
+    mockApplyManifest.mockRejectedValue(abortError)
+
+    const { result } = renderHook(() => useManifestValidate())
+
+    act(() => {
+      result.current.validate({} as never)
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600)
+    })
+
+    // result should remain null since abort errors are ignored
+    expect(result.current.result).toBeNull()
+  })
+
+  it('sets isValidating during request', async () => {
+    let resolvePromise: (value: unknown) => void
+    mockApplyManifest.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePromise = resolve
+      }),
+    )
+
+    const { result } = renderHook(() => useManifestValidate())
+
+    act(() => {
+      result.current.validate({} as never)
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    expect(result.current.isValidating).toBe(true)
+
+    await act(async () => {
+      resolvePromise!({
+        validationErrors: [],
+        stepResults: [],
+        status: 1,
+      })
+    })
+
+    expect(result.current.isValidating).toBe(false)
+  })
+})

--- a/frontend/src/features/payments/hooks/use-payments.test.tsx
+++ b/frontend/src/features/payments/hooks/use-payments.test.tsx
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ConnectError, Code } from '@connectrpc/connect'
+import type { ReactNode } from 'react'
+import { usePaymentsTable, usePaymentDetail } from './use-payments'
+
+const mockListPaymentOrders = vi.fn()
+const mockRetrievePaymentOrder = vi.fn()
+
+vi.mock('@/api/context', () => ({
+  useApiClients: () => ({
+    paymentOrder: {
+      listPaymentOrders: mockListPaymentOrders,
+      retrievePaymentOrder: mockRetrievePaymentOrder,
+    },
+  }),
+}))
+
+vi.mock('@/hooks/use-tenant-context', () => ({
+  useTenantSlug: () => 'test-tenant',
+}))
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('usePaymentsTable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns queryKey and queryFn', () => {
+    const { result } = renderHook(() => usePaymentsTable(), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.queryKey).toEqual(['tenants', 'test-tenant', 'payments'])
+    expect(typeof result.current.queryFn).toBe('function')
+    expect(result.current.tenantSlug).toBe('test-tenant')
+  })
+
+  it('queryFn maps response correctly', async () => {
+    mockListPaymentOrders.mockResolvedValue({
+      paymentOrders: [
+        {
+          paymentOrderId: 'po-1',
+          debtorAccountId: 'acc-1',
+          creditorReference: 'CR001',
+          amount: '100.00',
+          currency: 'GBP',
+          status: 'COMPLETED',
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      pagination: { nextPageToken: 'next-page' },
+    })
+
+    const { result } = renderHook(() => usePaymentsTable(), {
+      wrapper: createWrapper(),
+    })
+
+    const data = await result.current.queryFn({ pageSize: 10 })
+
+    expect(data.items).toHaveLength(1)
+    expect(data.items[0]).toEqual({
+      paymentOrderId: 'po-1',
+      debtorAccountId: 'acc-1',
+      creditorReference: 'CR001',
+      amount: '100.00',
+      currency: 'GBP',
+      status: 'COMPLETED',
+      createdAt: '2025-01-15T10:00:00Z',
+    })
+    expect(data.nextPageToken).toBe('next-page')
+  })
+
+  it('queryFn passes pagination and filters', async () => {
+    mockListPaymentOrders.mockResolvedValue({
+      paymentOrders: [],
+      pagination: { nextPageToken: '' },
+    })
+
+    const { result } = renderHook(() => usePaymentsTable(), {
+      wrapper: createWrapper(),
+    })
+
+    await result.current.queryFn({
+      pageSize: 25,
+      pageToken: 'tok',
+      filters: { status: 'PENDING' },
+    })
+
+    expect(mockListPaymentOrders).toHaveBeenCalledWith({
+      pagination: { pageSize: 25, pageToken: 'tok' },
+      status: 'PENDING',
+    })
+  })
+
+  it('queryFn handles null fields gracefully', async () => {
+    mockListPaymentOrders.mockResolvedValue({
+      paymentOrders: [
+        {
+          paymentOrderId: null,
+          debtorAccountId: null,
+          creditorReference: null,
+          amount: null,
+          currency: null,
+          status: null,
+          createdAt: null,
+        },
+      ],
+      pagination: { nextPageToken: '' },
+    })
+
+    const { result } = renderHook(() => usePaymentsTable(), {
+      wrapper: createWrapper(),
+    })
+
+    const data = await result.current.queryFn({ pageSize: 10 })
+
+    expect(data.items[0]).toEqual({
+      paymentOrderId: '',
+      debtorAccountId: '',
+      creditorReference: '',
+      amount: '',
+      currency: '',
+      status: '',
+      createdAt: null,
+    })
+  })
+
+  it('queryFn returns empty on NotFound error', async () => {
+    mockListPaymentOrders.mockRejectedValue(new ConnectError('not found', Code.NotFound))
+
+    const { result } = renderHook(() => usePaymentsTable(), {
+      wrapper: createWrapper(),
+    })
+
+    const data = await result.current.queryFn({ pageSize: 10 })
+    expect(data).toEqual({ items: [] })
+  })
+
+  it('queryFn returns empty on Unimplemented error', async () => {
+    mockListPaymentOrders.mockRejectedValue(
+      new ConnectError('unimplemented', Code.Unimplemented),
+    )
+
+    const { result } = renderHook(() => usePaymentsTable(), {
+      wrapper: createWrapper(),
+    })
+
+    const data = await result.current.queryFn({ pageSize: 10 })
+    expect(data).toEqual({ items: [] })
+  })
+
+  it('queryFn rethrows other errors', async () => {
+    mockListPaymentOrders.mockRejectedValue(new Error('Internal error'))
+
+    const { result } = renderHook(() => usePaymentsTable(), {
+      wrapper: createWrapper(),
+    })
+
+    await expect(result.current.queryFn({ pageSize: 10 })).rejects.toThrow('Internal error')
+  })
+
+  it('queryFn returns empty when no nextPageToken in pagination', async () => {
+    mockListPaymentOrders.mockResolvedValue({
+      paymentOrders: [],
+      pagination: { nextPageToken: '' },
+    })
+
+    const { result } = renderHook(() => usePaymentsTable(), {
+      wrapper: createWrapper(),
+    })
+
+    const data = await result.current.queryFn({ pageSize: 10 })
+    expect(data.nextPageToken).toBeUndefined()
+  })
+})
+
+describe('usePaymentDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fetches and maps payment detail', async () => {
+    mockRetrievePaymentOrder.mockResolvedValue({
+      paymentOrder: {
+        paymentOrderId: 'po-1',
+        debtorAccountId: 'acc-1',
+        creditorReference: 'CR001',
+        amount: '250.00',
+        currency: 'GBP',
+        status: 'COMPLETED',
+        reference: 'REF-123',
+        createdAt: { seconds: BigInt(1700000000), nanos: 0 },
+        sagaSteps: [{ name: 'step1', status: 'SUCCESS' }],
+        compensationSteps: [],
+      },
+    })
+
+    const { result } = renderHook(() => usePaymentDetail('po-1'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.data).toBeDefined()
+    })
+
+    expect(result.current.data).toEqual({
+      paymentOrderId: 'po-1',
+      debtorAccountId: 'acc-1',
+      creditorReference: 'CR001',
+      amount: '250.00',
+      currency: 'GBP',
+      status: 'COMPLETED',
+      reference: 'REF-123',
+      createdAt: { seconds: BigInt(1700000000), nanos: 0 },
+      sagaSteps: [{ name: 'step1', status: 'SUCCESS' }],
+      compensationSteps: [],
+    })
+  })
+
+  it('returns null when paymentOrder is missing from response', async () => {
+    mockRetrievePaymentOrder.mockResolvedValue({
+      paymentOrder: undefined,
+    })
+
+    const { result } = renderHook(() => usePaymentDetail('po-1'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(result.current.data).toBeNull()
+  })
+
+  it('does not fetch when paymentOrderId is undefined', () => {
+    renderHook(() => usePaymentDetail(undefined), {
+      wrapper: createWrapper(),
+    })
+
+    expect(mockRetrievePaymentOrder).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/features/reconciliation/hooks/use-reconciliation.test.tsx
+++ b/frontend/src/features/reconciliation/hooks/use-reconciliation.test.tsx
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ConnectError, Code } from '@connectrpc/connect'
+import type { ReactNode } from 'react'
+import { useReconciliationRunsTable, useReconciliationRunDetail } from './use-reconciliation'
+
+const mockListReconciliationRuns = vi.fn()
+const mockGetReconciliationRun = vi.fn()
+
+vi.mock('@/api/context', () => ({
+  useApiClients: () => ({
+    accountReconciliation: {
+      listReconciliationRuns: mockListReconciliationRuns,
+      getReconciliationRun: mockGetReconciliationRun,
+    },
+  }),
+}))
+
+vi.mock('@/hooks/use-tenant-context', () => ({
+  useTenantSlug: () => 'test-tenant',
+}))
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('useReconciliationRunsTable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns queryKey and queryFn', () => {
+    const { result } = renderHook(() => useReconciliationRunsTable(), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.queryKey).toEqual(['tenants', 'test-tenant', 'reconciliation-runs'])
+    expect(typeof result.current.queryFn).toBe('function')
+    expect(result.current.tenantSlug).toBe('test-tenant')
+  })
+
+  it('queryFn maps response and strips prefixes', async () => {
+    mockListReconciliationRuns.mockResolvedValue({
+      runs: [
+        {
+          runId: 'run-1',
+          accountId: 'acc-1',
+          scope: 'RECONCILIATION_SCOPE_DAILY',
+          settlementType: 'SETTLEMENT_TYPE_NET',
+          status: 'RUN_STATUS_COMPLETED',
+          varianceCount: 3,
+          periodStart: '2025-01-01',
+          periodEnd: '2025-01-31',
+        },
+      ],
+      nextPageToken: 'next-tok',
+    })
+
+    const { result } = renderHook(() => useReconciliationRunsTable(), {
+      wrapper: createWrapper(),
+    })
+
+    const data = await result.current.queryFn({ pageSize: 10 })
+
+    expect(data.items).toHaveLength(1)
+    expect(data.items[0]).toEqual({
+      runId: 'run-1',
+      accountId: 'acc-1',
+      scope: 'DAILY',
+      settlementType: 'NET',
+      status: 'COMPLETED',
+      varianceCount: 3,
+      periodStart: '2025-01-01',
+      periodEnd: '2025-01-31',
+    })
+    expect(data.nextPageToken).toBe('next-tok')
+  })
+
+  it('queryFn passes filters to API', async () => {
+    mockListReconciliationRuns.mockResolvedValue({ runs: [], nextPageToken: '' })
+
+    const { result } = renderHook(() => useReconciliationRunsTable(), {
+      wrapper: createWrapper(),
+    })
+
+    await result.current.queryFn({
+      pageSize: 20,
+      pageToken: 'tok',
+      filters: { status: 'COMPLETED', account_id: 'acc-1' },
+    })
+
+    expect(mockListReconciliationRuns).toHaveBeenCalledWith({
+      pageSize: 20,
+      pageToken: 'tok',
+      status: 'COMPLETED',
+      accountId: 'acc-1',
+    })
+  })
+
+  it('queryFn handles null fields gracefully', async () => {
+    mockListReconciliationRuns.mockResolvedValue({
+      runs: [
+        {
+          runId: null,
+          accountId: null,
+          scope: null,
+          settlementType: null,
+          status: null,
+          varianceCount: null,
+          periodStart: null,
+          periodEnd: null,
+        },
+      ],
+      nextPageToken: '',
+    })
+
+    const { result } = renderHook(() => useReconciliationRunsTable(), {
+      wrapper: createWrapper(),
+    })
+
+    const data = await result.current.queryFn({ pageSize: 10 })
+
+    expect(data.items[0]).toEqual({
+      runId: '',
+      accountId: '',
+      scope: '',
+      settlementType: '',
+      status: '',
+      varianceCount: 0,
+      periodStart: '',
+      periodEnd: '',
+    })
+  })
+
+  it('queryFn returns empty on NotFound error', async () => {
+    mockListReconciliationRuns.mockRejectedValue(new ConnectError('not found', Code.NotFound))
+
+    const { result } = renderHook(() => useReconciliationRunsTable(), {
+      wrapper: createWrapper(),
+    })
+
+    const data = await result.current.queryFn({ pageSize: 10 })
+    expect(data).toEqual({ items: [] })
+  })
+
+  it('queryFn returns empty on Unimplemented error', async () => {
+    mockListReconciliationRuns.mockRejectedValue(
+      new ConnectError('unimplemented', Code.Unimplemented),
+    )
+
+    const { result } = renderHook(() => useReconciliationRunsTable(), {
+      wrapper: createWrapper(),
+    })
+
+    const data = await result.current.queryFn({ pageSize: 10 })
+    expect(data).toEqual({ items: [] })
+  })
+
+  it('queryFn rethrows other errors', async () => {
+    mockListReconciliationRuns.mockRejectedValue(new Error('Server error'))
+
+    const { result } = renderHook(() => useReconciliationRunsTable(), {
+      wrapper: createWrapper(),
+    })
+
+    await expect(result.current.queryFn({ pageSize: 10 })).rejects.toThrow('Server error')
+  })
+})
+
+describe('useReconciliationRunDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fetches and maps run detail', async () => {
+    mockGetReconciliationRun.mockResolvedValue({
+      runId: 'run-1',
+      accountId: 'acc-1',
+      scope: 'RECONCILIATION_SCOPE_MONTHLY',
+      settlementType: 'SETTLEMENT_TYPE_GROSS',
+      status: 'RUN_STATUS_FAILED',
+      varianceCount: 5,
+      periodStart: '2025-01-01',
+      periodEnd: '2025-01-31',
+    })
+
+    const { result } = renderHook(() => useReconciliationRunDetail('run-1'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.data).toBeDefined()
+    })
+
+    expect(result.current.data).toEqual({
+      runId: 'run-1',
+      accountId: 'acc-1',
+      scope: 'MONTHLY',
+      settlementType: 'GROSS',
+      status: 'FAILED',
+      varianceCount: 5,
+      periodStart: '2025-01-01',
+      periodEnd: '2025-01-31',
+    })
+  })
+
+  it('does not fetch when runId is undefined', () => {
+    renderHook(() => useReconciliationRunDetail(undefined), {
+      wrapper: createWrapper(),
+    })
+
+    expect(mockGetReconciliationRun).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- Add tests for 6 frontend features at 0% coverage (hooks and components)
- 74 new tests across 6 test files, ~1239 lines of test code
- All 2391 frontend tests passing

## Changes Made

| File | Tests | Coverage Target |
|------|-------|----------------|
| `use-manifest-validate.test.ts` | 9 | Debounce, abort, error handling, stale response logic |
| `use-manifest-plan.test.tsx` | 5 | Diff parsing, mutation lifecycle, error states |
| `use-reconciliation.test.tsx` | 9 | Response mapping, prefix stripping, error fallbacks |
| `use-payments.test.tsx` | 11 | Response mapping, pagination, error fallbacks |
| `filter-bar.test.tsx` | 14 | Rendering, interaction, filter chips, clear button |
| `use-filter-state.test.ts` | 20 | derivePatternKind and applyFilters pure functions |

## Test plan

- [x] All 74 new tests pass
- [x] Full frontend test suite passes (2391 tests, 190 files)
- [x] No changes to production code