### PR TITLE
test: add tests for reference-data saga cache and account type handler

### DIFF
--- a/services/reference-data/handler/account_type_handler_error_test.go
+++ b/services/reference-data/handler/account_type_handler_error_test.go
@@ -523,4 +523,5 @@ func TestFindSuggestions_ExactMatchExcluded(t *testing.T) {
 	// When there are close alternatives too, those are returned
 	result = findSuggestions("GBP", []string{"GBP", "GBQ"})
 	assert.NotContains(t, result, "GBP") // exact match excluded
+	assert.Contains(t, result, "GBQ")    // close alternative included
 }

--- a/services/reference-data/handler/account_type_handler_error_test.go
+++ b/services/reference-data/handler/account_type_handler_error_test.go
@@ -1,0 +1,526 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	"github.com/meridianhub/meridian/services/reference-data/accounttype"
+)
+
+// --- NewAccountTypeService error paths ---
+
+func TestNewAccountTypeService_NilRegistry(t *testing.T) {
+	_, err := NewAccountTypeService(nil, nil, nil, nil)
+	require.ErrorIs(t, err, ErrAccountTypeRegistryNil)
+}
+
+func TestNewAccountTypeService_NilCompiler(t *testing.T) {
+	reg := newMockAccountTypeRegistry()
+	_, err := NewAccountTypeService(reg, nil, nil, nil)
+	require.ErrorIs(t, err, ErrCompilerNil)
+}
+
+// --- GetDefinition error paths ---
+
+func TestAccountTypeService_GetDefinition_InvalidID(t *testing.T) {
+	svc, _ := newTestAccountTypeService(t)
+	_, err := svc.GetDefinition(context.Background(), &pb.GetDefinitionRequest{
+		Id: "not-a-uuid",
+	})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+// --- GetActiveDefinition error paths ---
+
+func TestAccountTypeService_GetActiveDefinition_EmptyCode(t *testing.T) {
+	svc, _ := newTestAccountTypeService(t)
+	_, err := svc.GetActiveDefinition(context.Background(), &pb.GetActiveDefinitionRequest{
+		Code: "",
+	})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestAccountTypeService_GetActiveDefinition_NotFound(t *testing.T) {
+	svc, _ := newTestAccountTypeService(t)
+	_, err := svc.GetActiveDefinition(context.Background(), &pb.GetActiveDefinitionRequest{
+		Code: "NONEXISTENT",
+	})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+// --- ListActive ---
+
+func TestAccountTypeService_ListActive_Pagination(t *testing.T) {
+	svc, reg := newTestAccountTypeService(t)
+	ctx := context.Background()
+
+	for _, code := range []string{"A_TYPE", "B_TYPE", "C_TYPE", "D_TYPE", "E_TYPE"} {
+		def := makeDraftDef(code)
+		def.Status = accounttype.StatusActive
+		reg.definitions[def.ID] = def
+	}
+
+	resp, err := svc.ListActive(ctx, &pb.ListActiveRequest{PageSize: 2})
+	require.NoError(t, err)
+	assert.Len(t, resp.Definitions, 2)
+	assert.NotEmpty(t, resp.NextPageToken)
+
+	resp2, err := svc.ListActive(ctx, &pb.ListActiveRequest{
+		PageSize:  2,
+		PageToken: resp.NextPageToken,
+	})
+	require.NoError(t, err)
+	assert.Len(t, resp2.Definitions, 2)
+}
+
+func TestAccountTypeService_ListActive_BehaviorClassFilter(t *testing.T) {
+	svc, reg := newTestAccountTypeService(t)
+	ctx := context.Background()
+
+	def1 := makeDraftDef("CUSTOMER")
+	def1.Status = accounttype.StatusActive
+	def1.BehaviorClass = accounttype.BehaviorClassCustomer
+	reg.definitions[def1.ID] = def1
+
+	def2 := makeDraftDef("CLEARING")
+	def2.Status = accounttype.StatusActive
+	def2.BehaviorClass = accounttype.BehaviorClassClearing
+	reg.definitions[def2.ID] = def2
+
+	resp, err := svc.ListActive(ctx, &pb.ListActiveRequest{
+		BehaviorClassFilter: pb.BehaviorClass_BEHAVIOR_CLASS_CUSTOMER,
+	})
+	require.NoError(t, err)
+	assert.Len(t, resp.Definitions, 1)
+	assert.Equal(t, "CUSTOMER", resp.Definitions[0].Code)
+}
+
+// --- UpdateDefinition error paths ---
+
+func TestAccountTypeService_UpdateDefinition_InvalidID(t *testing.T) {
+	svc, _ := newTestAccountTypeService(t)
+	_, err := svc.UpdateDefinition(context.Background(), &pb.UpdateDefinitionRequest{
+		Id: "invalid",
+	})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestAccountTypeService_UpdateDefinition_NotFound(t *testing.T) {
+	svc, _ := newTestAccountTypeService(t)
+	_, err := svc.UpdateDefinition(context.Background(), &pb.UpdateDefinitionRequest{
+		Id: uuid.New().String(),
+	})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestAccountTypeService_UpdateDefinition_InvalidConversionMethodID(t *testing.T) {
+	svc, reg := newTestAccountTypeService(t)
+	def := makeDraftDef("UPDATE_TEST")
+	reg.definitions[def.ID] = def
+
+	_, err := svc.UpdateDefinition(context.Background(), &pb.UpdateDefinitionRequest{
+		Id:                             def.ID.String(),
+		DefaultConversionMethodId:      "not-a-uuid",
+		DefaultConversionMethodVersion: 1,
+	})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+// --- ActivateAccountType error paths ---
+
+func TestAccountTypeService_ActivateAccountType_InvalidID(t *testing.T) {
+	svc, _ := newTestAccountTypeService(t)
+	_, err := svc.ActivateAccountType(context.Background(), &pb.ActivateAccountTypeRequest{
+		Id: "bad-uuid",
+	})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestAccountTypeService_ActivateAccountType_NotFound(t *testing.T) {
+	svc, _ := newTestAccountTypeService(t)
+	_, err := svc.ActivateAccountType(context.Background(), &pb.ActivateAccountTypeRequest{
+		Id: uuid.New().String(),
+	})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+// --- DeprecateAccountType error paths ---
+
+func TestAccountTypeService_DeprecateAccountType_InvalidID(t *testing.T) {
+	svc, _ := newTestAccountTypeService(t)
+	_, err := svc.DeprecateAccountType(context.Background(), &pb.DeprecateAccountTypeRequest{
+		Id: "bad-uuid",
+	})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestAccountTypeService_DeprecateAccountType_NotFound(t *testing.T) {
+	svc, _ := newTestAccountTypeService(t)
+	_, err := svc.DeprecateAccountType(context.Background(), &pb.DeprecateAccountTypeRequest{
+		Id: uuid.New().String(),
+	})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestAccountTypeService_DeprecateAccountType_InvalidSuccessorID(t *testing.T) {
+	svc, reg := newTestAccountTypeService(t)
+	def := makeDraftDef("DEP_TEST")
+	def.Status = accounttype.StatusActive
+	reg.definitions[def.ID] = def
+
+	_, err := svc.DeprecateAccountType(context.Background(), &pb.DeprecateAccountTypeRequest{
+		Id:          def.ID.String(),
+		SuccessorId: "not-a-uuid",
+	})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestAccountTypeService_DeprecateAccountType_DeprecateError(t *testing.T) {
+	svc, reg := newTestAccountTypeService(t)
+	def := makeDraftDef("DEP_ERR_TEST")
+	def.Status = accounttype.StatusActive
+	reg.definitions[def.ID] = def
+	reg.deprecateErr = accounttype.ErrNotActive
+
+	_, err := svc.DeprecateAccountType(context.Background(), &pb.DeprecateAccountTypeRequest{
+		Id: def.ID.String(),
+	})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+// --- ValidateProductDefinition error paths ---
+
+func TestAccountTypeService_ValidateProductDefinition_NilDefinition(t *testing.T) {
+	svc, _ := newTestAccountTypeService(t)
+	_, err := svc.ValidateProductDefinition(context.Background(), &pb.ValidateProductDefinitionRequest{
+		Definition: nil,
+	})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestAccountTypeService_ValidateProductDefinition_AllCELInvalid(t *testing.T) {
+	svc, _ := newTestAccountTypeService(t)
+	resp, err := svc.ValidateProductDefinition(context.Background(), &pb.ValidateProductDefinitionRequest{
+		Definition: &pb.AccountTypeDefinition{
+			Code:           "TEST",
+			ValidationCel:  "!!! invalid !!!",
+			BucketingCel:   "!!! also invalid !!!",
+			EligibilityCel: "!!! very invalid !!!",
+		},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Valid)
+	assert.Len(t, resp.Errors, 3)
+	for _, e := range resp.Errors {
+		assert.Equal(t, "CEL_COMPILE_ERROR", e.ErrorCode)
+	}
+}
+
+func TestAccountTypeService_ValidateProductDefinition_SchemaValidationFails(t *testing.T) {
+	svc, _ := newTestAccountTypeService(t)
+	resp, err := svc.ValidateProductDefinition(context.Background(), &pb.ValidateProductDefinitionRequest{
+		Definition: &pb.AccountTypeDefinition{
+			Code:            "TEST",
+			AttributeSchema: `{"type":"object","properties":{"tier":{"type":"string"}},"required":["tier"]}`,
+			Attributes:      map[string]string{"wrong_field": "value"},
+		},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Valid)
+	found := false
+	for _, e := range resp.Errors {
+		if e.ErrorCode == "SCHEMA_VALIDATION_FAILED" {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected SCHEMA_VALIDATION_FAILED error")
+}
+
+func TestAccountTypeService_ValidateProductDefinition_ValuationMethodInstrumentRef(t *testing.T) {
+	svc, _, _ := newTestAccountTypeServiceWithInstruments(t)
+
+	resp, err := svc.ValidateProductDefinition(context.Background(), &pb.ValidateProductDefinitionRequest{
+		Definition: &pb.AccountTypeDefinition{
+			Code:           "TEST",
+			InstrumentCode: "GBP",
+			ValuationMethods: []*pb.ValuationMethodTemplate{
+				{InputInstrument: "INVALID_INSTR"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Valid)
+	found := false
+	for _, e := range resp.Errors {
+		if e.Field == "valuation_methods[0].input_instrument" {
+			found = true
+			assert.Equal(t, "UNRESOLVABLE_REFERENCE", e.ErrorCode)
+		}
+	}
+	assert.True(t, found)
+}
+
+// --- mapDomainError ---
+
+func TestMapDomainError_AllSentinels(t *testing.T) {
+	svc, _ := newTestAccountTypeService(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		err      error
+		expected codes.Code
+	}{
+		{accounttype.ErrNotFound, codes.NotFound},
+		{accounttype.ErrOptimisticLock, codes.Aborted},
+		{accounttype.ErrNotDraft, codes.FailedPrecondition},
+		{accounttype.ErrNotActive, codes.FailedPrecondition},
+		{accounttype.ErrFieldImmutable, codes.InvalidArgument},
+		{accounttype.ErrInvalidCEL, codes.InvalidArgument},
+		{accounttype.ErrActiveCodeExists, codes.AlreadyExists},
+		{accounttype.ErrInvalidBehaviorClass, codes.InvalidArgument},
+		{accounttype.ErrInvalidNormalBalance, codes.InvalidArgument},
+		{accounttype.ErrConversionMethodPair, codes.InvalidArgument},
+		{accounttype.ErrSuccessorWriteOnce, codes.FailedPrecondition},
+		{accounttype.ErrInvalidInstrument, codes.FailedPrecondition},
+		{accounttype.ErrInvalidConversionMethod, codes.FailedPrecondition},
+		{accounttype.ErrInvalidValuationMethod, codes.FailedPrecondition},
+		{accounttype.ErrInvalidAttributeSchema, codes.InvalidArgument},
+		{accounttype.ErrAttributesInvalid, codes.InvalidArgument},
+	}
+
+	for _, tt := range tests {
+		grpcErr := svc.mapDomainError(ctx, tt.err, "TestOp", "test-id")
+		st, ok := status.FromError(grpcErr)
+		require.True(t, ok, "error %v should be gRPC status", tt.err)
+		assert.Equal(t, tt.expected, st.Code(), "error %v should map to %v", tt.err, tt.expected)
+	}
+}
+
+func TestMapDomainError_UnknownError(t *testing.T) {
+	svc, _ := newTestAccountTypeService(t)
+	grpcErr := svc.mapDomainError(context.Background(), errors.New("unexpected"), "TestOp", "id")
+	st, ok := status.FromError(grpcErr)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
+func TestMapDomainError_WrappedError(t *testing.T) {
+	svc, _ := newTestAccountTypeService(t)
+	wrapped := errors.Join(accounttype.ErrNotFound, errors.New("extra context"))
+	grpcErr := svc.mapDomainError(context.Background(), wrapped, "TestOp", "id")
+	st, ok := status.FromError(grpcErr)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+// --- Proto mapping edge cases ---
+
+func TestDomainNormalBalanceToProto_AllValues(t *testing.T) {
+	assert.Equal(t, pb.NormalBalance_NORMAL_BALANCE_DEBIT, domainNormalBalanceToProto(accounttype.NormalBalanceDebit))
+	assert.Equal(t, pb.NormalBalance_NORMAL_BALANCE_CREDIT, domainNormalBalanceToProto(accounttype.NormalBalanceCredit))
+	assert.Equal(t, pb.NormalBalance_NORMAL_BALANCE_UNSPECIFIED, domainNormalBalanceToProto(accounttype.NormalBalance("UNKNOWN")))
+}
+
+func TestProtoBehaviorNormalBalanceToDomainString(t *testing.T) {
+	assert.Equal(t, "", protoBehaviorNormalBalanceToDomainString(pb.NormalBalance_NORMAL_BALANCE_UNSPECIFIED))
+	assert.Equal(t, "DEBIT", protoBehaviorNormalBalanceToDomainString(pb.NormalBalance_NORMAL_BALANCE_DEBIT))
+	assert.Equal(t, "CREDIT", protoBehaviorNormalBalanceToDomainString(pb.NormalBalance_NORMAL_BALANCE_CREDIT))
+	assert.Equal(t, "", protoBehaviorNormalBalanceToDomainString(pb.NormalBalance(999)))
+}
+
+func TestDomainAccountTypeStatusToProto_AllValues(t *testing.T) {
+	assert.Equal(t, pb.AccountTypeStatus_ACCOUNT_TYPE_STATUS_DRAFT, domainAccountTypeStatusToProto(accounttype.StatusDraft))
+	assert.Equal(t, pb.AccountTypeStatus_ACCOUNT_TYPE_STATUS_ACTIVE, domainAccountTypeStatusToProto(accounttype.StatusActive))
+	assert.Equal(t, pb.AccountTypeStatus_ACCOUNT_TYPE_STATUS_DEPRECATED, domainAccountTypeStatusToProto(accounttype.StatusDeprecated))
+	assert.Equal(t, pb.AccountTypeStatus_ACCOUNT_TYPE_STATUS_UNSPECIFIED, domainAccountTypeStatusToProto(accounttype.Status("UNKNOWN")))
+}
+
+func TestAccountTypeToProto_Nil(t *testing.T) {
+	assert.Nil(t, accountTypeToProto(nil))
+}
+
+func TestAccountTypeToProto_MinimalFields(t *testing.T) {
+	now := time.Now()
+	def := &accounttype.Definition{
+		ID:        uuid.New(),
+		Code:      "BASIC",
+		Version:   1,
+		Status:    accounttype.StatusDraft,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	proto := accountTypeToProto(def)
+	require.NotNil(t, proto)
+	assert.Equal(t, "BASIC", proto.Code)
+	assert.Empty(t, proto.DefaultConversionMethodId)
+	assert.Empty(t, proto.SuccessorId)
+	assert.Nil(t, proto.ActivatedAt)
+	assert.Nil(t, proto.DeprecatedAt)
+	assert.Empty(t, proto.ValuationMethods)
+}
+
+func TestValuationMethodToProto_WithSuccessor(t *testing.T) {
+	successorID := uuid.New()
+	vmt := &accounttype.ValuationMethodTemplate{
+		ID:                     uuid.New(),
+		AccountTypeID:          uuid.New(),
+		InputInstrument:        "GBP",
+		ValuationMethodID:      uuid.New(),
+		ValuationMethodVersion: 1,
+		Status:                 accounttype.StatusActive,
+		SuccessorID:            &successorID,
+	}
+	proto := valuationMethodToProto(vmt)
+	assert.Equal(t, successorID.String(), proto.SuccessorId)
+}
+
+// --- validateInstrumentRefs with nil instrumentRegistry ---
+
+func TestValidateInstrumentRefs_NilInstrumentRegistry(t *testing.T) {
+	svc, _ := newTestAccountTypeService(t)
+	errs := svc.validateInstrumentRefs(context.Background(), &pb.AccountTypeDefinition{
+		InstrumentCode: "GBP",
+	})
+	assert.Empty(t, errs)
+}
+
+// --- instrumentSuggestions ---
+
+func TestInstrumentSuggestions_NilRegistry(t *testing.T) {
+	svc, _ := newTestAccountTypeService(t)
+	suggestions := svc.instrumentSuggestions(context.Background(), "GBP")
+	assert.Nil(t, suggestions)
+}
+
+// --- CreateDraft error paths ---
+
+func TestAccountTypeService_CreateDraft_InvalidConversionMethodPair(t *testing.T) {
+	svc, _ := newTestAccountTypeService(t)
+	_, err := svc.CreateDraft(context.Background(), &pb.CreateDraftRequest{
+		Code:                           "TEST",
+		NormalBalance:                  pb.NormalBalance_NORMAL_BALANCE_DEBIT,
+		BehaviorClass:                  pb.BehaviorClass_BEHAVIOR_CLASS_CUSTOMER,
+		DefaultConversionMethodId:      "bad-uuid",
+		DefaultConversionMethodVersion: 1,
+	})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestAccountTypeService_CreateDraft_RegistryError(t *testing.T) {
+	svc, reg := newTestAccountTypeService(t)
+	reg.createErr = accounttype.ErrActiveCodeExists
+
+	_, err := svc.CreateDraft(context.Background(), &pb.CreateDraftRequest{
+		Code:          "DUPLICATE",
+		NormalBalance: pb.NormalBalance_NORMAL_BALANCE_DEBIT,
+		BehaviorClass: pb.BehaviorClass_BEHAVIOR_CLASS_CUSTOMER,
+	})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.AlreadyExists, st.Code())
+}
+
+// --- Utility functions ---
+
+func TestToRawJSON(t *testing.T) {
+	assert.Nil(t, toRawJSON(""))
+	assert.Equal(t, `{"key":"val"}`, string(toRawJSON(`{"key":"val"}`)))
+}
+
+func TestStringMapToAnyMap(t *testing.T) {
+	assert.Nil(t, stringMapToAnyMap(nil))
+	result := stringMapToAnyMap(map[string]string{"a": "1", "b": "2"})
+	assert.Equal(t, "1", result["a"])
+	assert.Equal(t, "2", result["b"])
+}
+
+func TestAnyMapToStringMap(t *testing.T) {
+	assert.Nil(t, anyMapToStringMap(nil))
+	result := anyMapToStringMap(map[string]any{"a": 1, "b": "text"})
+	assert.Equal(t, "1", result["a"])
+	assert.Equal(t, "text", result["b"])
+}
+
+// --- validateAttributeSchema ---
+
+func TestValidateAttributeSchema_Empty(t *testing.T) {
+	valid, errs := validateAttributeSchema("")
+	assert.False(t, valid)
+	assert.Nil(t, errs)
+}
+
+func TestValidateAttributeSchema_InvalidJSON(t *testing.T) {
+	valid, errs := validateAttributeSchema("not json")
+	assert.False(t, valid)
+	require.Len(t, errs, 1)
+	assert.Equal(t, "INVALID_JSON", errs[0].ErrorCode)
+}
+
+func TestValidateAttributeSchema_ValidSchema(t *testing.T) {
+	valid, errs := validateAttributeSchema(`{"type":"object","properties":{"name":{"type":"string"}}}`)
+	assert.True(t, valid)
+	assert.Empty(t, errs)
+}
+
+// --- validateAttrsAgainstSchema ---
+
+func TestValidateAttrsAgainstSchema_SchemaInvalid(t *testing.T) {
+	errs := validateAttrsAgainstSchema(&pb.AccountTypeDefinition{
+		Attributes: map[string]string{"key": "val"},
+	}, false)
+	assert.Nil(t, errs)
+}
+
+func TestValidateAttrsAgainstSchema_NoAttributes(t *testing.T) {
+	errs := validateAttrsAgainstSchema(&pb.AccountTypeDefinition{}, true)
+	assert.Nil(t, errs)
+}
+
+// --- findSuggestions edge case ---
+
+func TestFindSuggestions_ExactMatchExcluded(t *testing.T) {
+	// Exact match (distance 0) is excluded, but close matches are included
+	result := findSuggestions("GBP", []string{"GBP"})
+	assert.Empty(t, result) // only the exact match, no close alternatives
+
+	// When there are close alternatives too, those are returned
+	result = findSuggestions("GBP", []string{"GBP", "GBQ"})
+	assert.NotContains(t, result, "GBP") // exact match excluded
+}

--- a/services/reference-data/saga/cache_test.go
+++ b/services/reference-data/saga/cache_test.go
@@ -1,0 +1,474 @@
+package saga
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupMiniRedis(t *testing.T) *redis.Client {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	return redis.NewClient(&redis.Options{Addr: mr.Addr()})
+}
+
+func tenantCtx(tenantID string) context.Context {
+	return tenant.WithTenant(context.Background(), tenant.TenantID(tenantID))
+}
+
+func testDefinition() *Definition {
+	now := time.Now().UTC().Truncate(time.Second)
+	activated := now.Add(-time.Hour)
+	successorID := uuid.New()
+	return &Definition{
+		ID:                      uuid.New(),
+		Name:                    "test-saga",
+		Version:                 1,
+		Script:                  "def run(): pass",
+		Status:                  StatusActive,
+		IsSystem:                false,
+		PreconditionsExpression: "amount > 0",
+		DisplayName:             "Test Saga",
+		Description:             "A test saga definition",
+		CreatedAt:               now,
+		UpdatedAt:               now,
+		ActivatedAt:             &activated,
+		SuccessorID:             &successorID,
+	}
+}
+
+// --- NewCache tests ---
+
+func TestNewCache_NilClient(t *testing.T) {
+	_, err := NewCache(nil)
+	require.ErrorIs(t, err, ErrCacheClientRequired)
+}
+
+func TestNewCache_Defaults(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client)
+	require.NoError(t, err)
+	assert.Equal(t, DefaultCacheKeyPrefix, c.keyPrefix)
+	assert.Equal(t, DefaultCacheTTL, c.baseTTL)
+	assert.Equal(t, DefaultCacheTTLJitter, c.ttlJitter)
+}
+
+func TestNewCache_WithOptions(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client,
+		WithCacheKeyPrefix("custom"),
+		WithCacheTTL(30*time.Minute, 2*time.Minute),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "custom", c.keyPrefix)
+	assert.Equal(t, 30*time.Minute, c.baseTTL)
+	assert.Equal(t, 2*time.Minute, c.ttlJitter)
+}
+
+// --- Serialize/Deserialize round-trip ---
+
+func TestSerializeDeserialize_RoundTrip(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client)
+	require.NoError(t, err)
+
+	def := testDefinition()
+	data := c.serialize(def)
+	require.NotNil(t, data)
+
+	result := c.deserialize(data)
+	require.NotNil(t, result)
+
+	assert.Equal(t, def.ID, result.ID)
+	assert.Equal(t, def.Name, result.Name)
+	assert.Equal(t, def.Version, result.Version)
+	assert.Equal(t, def.Script, result.Script)
+	assert.Equal(t, def.Status, result.Status)
+	assert.Equal(t, def.IsSystem, result.IsSystem)
+	assert.Equal(t, def.PreconditionsExpression, result.PreconditionsExpression)
+	assert.Equal(t, def.DisplayName, result.DisplayName)
+	assert.Equal(t, def.Description, result.Description)
+	assert.Equal(t, def.CreatedAt.Unix(), result.CreatedAt.Unix())
+	assert.Equal(t, def.UpdatedAt.Unix(), result.UpdatedAt.Unix())
+	require.NotNil(t, result.ActivatedAt)
+	assert.Equal(t, def.ActivatedAt.Unix(), result.ActivatedAt.Unix())
+	assert.Nil(t, result.DeprecatedAt)
+	require.NotNil(t, result.SuccessorID)
+	assert.Equal(t, *def.SuccessorID, *result.SuccessorID)
+}
+
+func TestSerialize_NilSuccessorID(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client)
+	require.NoError(t, err)
+
+	def := testDefinition()
+	def.SuccessorID = nil
+
+	data := c.serialize(def)
+	require.NotNil(t, data)
+
+	result := c.deserialize(data)
+	require.NotNil(t, result)
+	assert.Nil(t, result.SuccessorID)
+}
+
+func TestDeserialize_InvalidJSON(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client)
+	require.NoError(t, err)
+
+	result := c.deserialize([]byte("not json"))
+	assert.Nil(t, result)
+}
+
+func TestDeserialize_InvalidUUID(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client)
+	require.NoError(t, err)
+
+	// Invalid ID should be parsed as zero UUID
+	data := []byte(`{"id":"not-a-uuid","name":"test","version":1,"status":"ACTIVE","created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z"}`)
+	result := c.deserialize(data)
+	require.NotNil(t, result)
+	assert.Equal(t, uuid.Nil, result.ID)
+}
+
+func TestDeserialize_InvalidSuccessorUUID(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client)
+	require.NoError(t, err)
+
+	data := []byte(`{"id":"` + uuid.New().String() + `","name":"test","version":1,"status":"ACTIVE","successor_id":"bad-uuid","created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z"}`)
+	result := c.deserialize(data)
+	require.NotNil(t, result)
+	assert.Nil(t, result.SuccessorID)
+}
+
+// --- GetByID / PutByID ---
+
+func TestGetByID_CacheMiss(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client)
+	require.NoError(t, err)
+
+	ctx := tenantCtx("tenant-1")
+	result := c.GetByID(ctx, uuid.New())
+	assert.Nil(t, result)
+}
+
+func TestGetByID_NoTenantContext(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client)
+	require.NoError(t, err)
+
+	result := c.GetByID(context.Background(), uuid.New())
+	assert.Nil(t, result)
+}
+
+func TestPutByID_AndGetByID(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client, WithCacheTTL(time.Hour, 0))
+	require.NoError(t, err)
+
+	ctx := tenantCtx("tenant-1")
+	def := testDefinition()
+
+	c.PutByID(ctx, def)
+	result := c.GetByID(ctx, def.ID)
+	require.NotNil(t, result)
+	assert.Equal(t, def.ID, result.ID)
+	assert.Equal(t, def.Name, result.Name)
+}
+
+func TestPutByID_NilDefinition(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client)
+	require.NoError(t, err)
+
+	ctx := tenantCtx("tenant-1")
+	c.PutByID(ctx, nil) // should not panic
+}
+
+func TestPutByID_NoTenantContext(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client)
+	require.NoError(t, err)
+
+	c.PutByID(context.Background(), testDefinition()) // should not panic
+}
+
+// --- Get / Put (by name+version) ---
+
+func TestPut_AndGet(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client, WithCacheTTL(time.Hour, 0))
+	require.NoError(t, err)
+
+	ctx := tenantCtx("tenant-1")
+	def := testDefinition()
+
+	c.Put(ctx, def)
+	result := c.Get(ctx, def.Name, def.Version)
+	require.NotNil(t, result)
+	assert.Equal(t, def.Name, result.Name)
+	assert.Equal(t, def.Version, result.Version)
+}
+
+func TestGet_NoTenantContext(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client)
+	require.NoError(t, err)
+
+	result := c.Get(context.Background(), "test", 1)
+	assert.Nil(t, result)
+}
+
+func TestPut_NilDefinition(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client)
+	require.NoError(t, err)
+
+	ctx := tenantCtx("tenant-1")
+	c.Put(ctx, nil) // should not panic
+}
+
+func TestPut_NoTenantContext(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client)
+	require.NoError(t, err)
+
+	c.Put(context.Background(), testDefinition()) // should not panic
+}
+
+// --- GetActive / PutActive ---
+
+func TestPutActive_AndGetActive(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client, WithCacheTTL(time.Hour, 0))
+	require.NoError(t, err)
+
+	ctx := tenantCtx("tenant-1")
+	def := testDefinition()
+
+	c.PutActive(ctx, def)
+	result := c.GetActive(ctx, def.Name)
+	require.NotNil(t, result)
+	assert.Equal(t, def.Name, result.Name)
+}
+
+func TestGetActive_NoTenantContext(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client)
+	require.NoError(t, err)
+
+	result := c.GetActive(context.Background(), "test")
+	assert.Nil(t, result)
+}
+
+func TestPutActive_NilDefinition(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client)
+	require.NoError(t, err)
+
+	ctx := tenantCtx("tenant-1")
+	c.PutActive(ctx, nil) // should not panic
+}
+
+func TestPutActive_NoTenantContext(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client)
+	require.NoError(t, err)
+
+	c.PutActive(context.Background(), testDefinition()) // should not panic
+}
+
+// --- Invalidation ---
+
+func TestInvalidateByID(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client, WithCacheTTL(time.Hour, 0))
+	require.NoError(t, err)
+
+	ctx := tenantCtx("tenant-1")
+	def := testDefinition()
+
+	c.PutByID(ctx, def)
+	require.NotNil(t, c.GetByID(ctx, def.ID))
+
+	c.InvalidateByID(ctx, def.ID)
+	assert.Nil(t, c.GetByID(ctx, def.ID))
+}
+
+func TestInvalidateByID_NoTenantContext(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client)
+	require.NoError(t, err)
+
+	c.InvalidateByID(context.Background(), uuid.New()) // should not panic
+}
+
+func TestInvalidate(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client, WithCacheTTL(time.Hour, 0))
+	require.NoError(t, err)
+
+	ctx := tenantCtx("tenant-1")
+	def := testDefinition()
+
+	c.Put(ctx, def)
+	require.NotNil(t, c.Get(ctx, def.Name, def.Version))
+
+	c.Invalidate(ctx, def.Name, def.Version)
+	assert.Nil(t, c.Get(ctx, def.Name, def.Version))
+}
+
+func TestInvalidate_NoTenantContext(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client)
+	require.NoError(t, err)
+
+	c.Invalidate(context.Background(), "test", 1) // should not panic
+}
+
+func TestInvalidateName(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client, WithCacheTTL(time.Hour, 0))
+	require.NoError(t, err)
+
+	ctx := tenantCtx("tenant-1")
+
+	// Store multiple versions + active
+	def1 := testDefinition()
+	def1.Name = "multi-version"
+	def1.Version = 1
+
+	def2 := testDefinition()
+	def2.Name = "multi-version"
+	def2.Version = 2
+
+	c.Put(ctx, def1)
+	c.Put(ctx, def2)
+	c.PutActive(ctx, def2)
+
+	require.NotNil(t, c.Get(ctx, "multi-version", 1))
+	require.NotNil(t, c.Get(ctx, "multi-version", 2))
+	require.NotNil(t, c.GetActive(ctx, "multi-version"))
+
+	c.InvalidateName(ctx, "multi-version")
+
+	assert.Nil(t, c.Get(ctx, "multi-version", 1))
+	assert.Nil(t, c.Get(ctx, "multi-version", 2))
+	assert.Nil(t, c.GetActive(ctx, "multi-version"))
+}
+
+func TestInvalidateName_NoTenantContext(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client)
+	require.NoError(t, err)
+
+	c.InvalidateName(context.Background(), "test") // should not panic
+}
+
+func TestInvalidateAll(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client, WithCacheTTL(time.Hour, 0))
+	require.NoError(t, err)
+
+	ctx := tenantCtx("tenant-1")
+	def := testDefinition()
+
+	c.PutByID(ctx, def)
+	c.Put(ctx, def)
+	c.PutActive(ctx, def)
+
+	require.NotNil(t, c.GetByID(ctx, def.ID))
+	require.NotNil(t, c.Get(ctx, def.Name, def.Version))
+	require.NotNil(t, c.GetActive(ctx, def.Name))
+
+	c.InvalidateAll(ctx)
+
+	assert.Nil(t, c.GetByID(ctx, def.ID))
+	assert.Nil(t, c.Get(ctx, def.Name, def.Version))
+	assert.Nil(t, c.GetActive(ctx, def.Name))
+}
+
+func TestInvalidateAll_NoTenantContext(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client)
+	require.NoError(t, err)
+
+	c.InvalidateAll(context.Background()) // should not panic
+}
+
+// --- Tenant isolation ---
+
+func TestTenantIsolation(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client, WithCacheTTL(time.Hour, 0))
+	require.NoError(t, err)
+
+	ctx1 := tenantCtx("tenant-1")
+	ctx2 := tenantCtx("tenant-2")
+
+	def := testDefinition()
+	c.PutByID(ctx1, def)
+	c.Put(ctx1, def)
+	c.PutActive(ctx1, def)
+
+	// tenant-2 should not see tenant-1's data
+	assert.Nil(t, c.GetByID(ctx2, def.ID))
+	assert.Nil(t, c.Get(ctx2, def.Name, def.Version))
+	assert.Nil(t, c.GetActive(ctx2, def.Name))
+
+	// tenant-1 should still see its data
+	assert.NotNil(t, c.GetByID(ctx1, def.ID))
+	assert.NotNil(t, c.Get(ctx1, def.Name, def.Version))
+	assert.NotNil(t, c.GetActive(ctx1, def.Name))
+}
+
+// --- Key format tests ---
+
+func TestKeyFormats(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client, WithCacheKeyPrefix("test"))
+	require.NoError(t, err)
+
+	tid := tenant.TenantID("t1")
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	assert.Equal(t, "test:id:t1:11111111-1111-1111-1111-111111111111", c.idKey(tid, id))
+	assert.Equal(t, "test:def:t1:saga-name:3", c.definitionKey(tid, "saga-name", 3))
+	assert.Equal(t, "test:active:t1:saga-name", c.activeKey(tid, "saga-name"))
+	assert.Equal(t, "test:def:t1:saga-name:*", c.definitionKeyPattern(tid, "saga-name"))
+	assert.Equal(t, "test:id:t1:*", c.tenantKeyPattern(tid, "id"))
+}
+
+// --- Jittered TTL ---
+
+func TestJitteredTTL_NoJitter(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client, WithCacheTTL(time.Hour, 0))
+	require.NoError(t, err)
+
+	assert.Equal(t, time.Hour, c.jitteredTTL())
+}
+
+func TestJitteredTTL_WithJitter(t *testing.T) {
+	client := setupMiniRedis(t)
+	c, err := NewCache(client, WithCacheTTL(time.Hour, 5*time.Minute))
+	require.NoError(t, err)
+
+	for i := 0; i < 100; i++ {
+		ttl := c.jitteredTTL()
+		assert.GreaterOrEqual(t, ttl, 55*time.Minute)
+		assert.LessOrEqual(t, ttl, 65*time.Minute)
+	}
+}

--- a/services/reference-data/saga/cache_test.go
+++ b/services/reference-data/saga/cache_test.go
@@ -466,9 +466,14 @@ func TestJitteredTTL_WithJitter(t *testing.T) {
 	c, err := NewCache(client, WithCacheTTL(time.Hour, 5*time.Minute))
 	require.NoError(t, err)
 
+	seenDifferent := false
 	for i := 0; i < 100; i++ {
 		ttl := c.jitteredTTL()
 		assert.GreaterOrEqual(t, ttl, 55*time.Minute)
 		assert.LessOrEqual(t, ttl, 65*time.Minute)
+		if ttl != time.Hour {
+			seenDifferent = true
+		}
 	}
+	assert.True(t, seenDifferent, "jitter should produce at least one value != base TTL over 100 samples")
 }

--- a/services/reference-data/saga/cached_registry_test.go
+++ b/services/reference-data/saga/cached_registry_test.go
@@ -341,15 +341,18 @@ func TestCachedRegistry_UpdateDefinition_InvalidatesCache(t *testing.T) {
 	def := makeTestDef("updatable", StatusDraft)
 	reg.definitions[def.ID] = def
 
-	// Populate cache
+	// Populate all cache paths
 	_, _ = cr.GetByID(ctx, def.ID)
+	_, _ = cr.GetDefinition(ctx, def.Name, def.Version)
 	require.NotNil(t, cache.GetByID(ctx, def.ID))
+	require.NotNil(t, cache.Get(ctx, def.Name, def.Version))
 
 	err := cr.UpdateDefinition(ctx, def.ID, &Definition{DisplayName: "Updated"})
 	require.NoError(t, err)
 
-	// Cache should be invalidated
+	// Both cache paths should be invalidated
 	assert.Nil(t, cache.GetByID(ctx, def.ID))
+	assert.Nil(t, cache.Get(ctx, def.Name, def.Version))
 }
 
 func TestCachedRegistry_UpdateDefinition_GetByIDError(t *testing.T) {
@@ -380,14 +383,18 @@ func TestCachedRegistry_ActivateSaga_InvalidatesCache(t *testing.T) {
 	def := makeTestDef("activatable", StatusDraft)
 	reg.definitions[def.ID] = def
 
-	// Populate cache
+	// Populate all cache paths
 	_, _ = cr.GetByID(ctx, def.ID)
+	_, _ = cr.GetDefinition(ctx, def.Name, def.Version)
 	require.NotNil(t, cache.GetByID(ctx, def.ID))
+	require.NotNil(t, cache.Get(ctx, def.Name, def.Version))
 
 	err := cr.ActivateSaga(ctx, def.ID)
 	require.NoError(t, err)
 
+	// All cache paths should be invalidated (InvalidateName clears def keys too)
 	assert.Nil(t, cache.GetByID(ctx, def.ID))
+	assert.Nil(t, cache.Get(ctx, def.Name, def.Version))
 }
 
 func TestCachedRegistry_ActivateSaga_GetByIDError(t *testing.T) {
@@ -418,15 +425,22 @@ func TestCachedRegistry_DeprecateSaga_InvalidatesCache(t *testing.T) {
 	def := makeTestDef("deprecatable", StatusActive)
 	reg.definitions[def.ID] = def
 
-	// Populate cache
+	// Populate all cache paths
 	_, _ = cr.GetByID(ctx, def.ID)
+	_, _ = cr.GetDefinition(ctx, def.Name, def.Version)
+	_, _ = cr.GetActive(ctx, def.Name)
 	require.NotNil(t, cache.GetByID(ctx, def.ID))
+	require.NotNil(t, cache.Get(ctx, def.Name, def.Version))
+	require.NotNil(t, cache.GetActive(ctx, def.Name))
 
 	successorID := uuid.New()
 	err := cr.DeprecateSaga(ctx, def.ID, &successorID)
 	require.NoError(t, err)
 
+	// All cache paths should be invalidated
 	assert.Nil(t, cache.GetByID(ctx, def.ID))
+	assert.Nil(t, cache.Get(ctx, def.Name, def.Version))
+	assert.Nil(t, cache.GetActive(ctx, def.Name))
 }
 
 func TestCachedRegistry_DeprecateSaga_GetByIDError(t *testing.T) {

--- a/services/reference-data/saga/cached_registry_test.go
+++ b/services/reference-data/saga/cached_registry_test.go
@@ -1,0 +1,450 @@
+package saga
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Mock Registry ---
+
+type mockSagaRegistry struct {
+	definitions  map[uuid.UUID]*Definition
+	getByIDErr   error
+	getDefErr    error
+	getActiveErr error
+	listErr      error
+	createErr    error
+	updateErr    error
+	activateErr  error
+	deprecateErr error
+}
+
+func newMockSagaRegistry() *mockSagaRegistry {
+	return &mockSagaRegistry{
+		definitions: make(map[uuid.UUID]*Definition),
+	}
+}
+
+func (m *mockSagaRegistry) GetByID(_ context.Context, id uuid.UUID) (*Definition, error) {
+	if m.getByIDErr != nil {
+		return nil, m.getByIDErr
+	}
+	def, ok := m.definitions[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return def, nil
+}
+
+func (m *mockSagaRegistry) GetDefinition(_ context.Context, name string, version int) (*Definition, error) {
+	if m.getDefErr != nil {
+		return nil, m.getDefErr
+	}
+	for _, def := range m.definitions {
+		if def.Name == name && def.Version == version {
+			return def, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+func (m *mockSagaRegistry) GetActive(_ context.Context, name string) (*Definition, error) {
+	if m.getActiveErr != nil {
+		return nil, m.getActiveErr
+	}
+	for _, def := range m.definitions {
+		if def.Name == name && def.Status == StatusActive {
+			return def, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+func (m *mockSagaRegistry) ListByStatus(_ context.Context, status Status) ([]*Definition, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	var result []*Definition
+	for _, def := range m.definitions {
+		if def.Status == status {
+			result = append(result, def)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockSagaRegistry) CreateDraft(_ context.Context, def *Definition) error {
+	if m.createErr != nil {
+		return m.createErr
+	}
+	m.definitions[def.ID] = def
+	return nil
+}
+
+func (m *mockSagaRegistry) UpdateDefinition(_ context.Context, id uuid.UUID, updates *Definition) error {
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	def, ok := m.definitions[id]
+	if !ok {
+		return ErrNotFound
+	}
+	if updates.DisplayName != "" {
+		def.DisplayName = updates.DisplayName
+	}
+	def.UpdatedAt = time.Now()
+	return nil
+}
+
+func (m *mockSagaRegistry) ActivateSaga(_ context.Context, id uuid.UUID) error {
+	if m.activateErr != nil {
+		return m.activateErr
+	}
+	def, ok := m.definitions[id]
+	if !ok {
+		return ErrNotFound
+	}
+	def.Status = StatusActive
+	now := time.Now()
+	def.ActivatedAt = &now
+	return nil
+}
+
+func (m *mockSagaRegistry) DeprecateSaga(_ context.Context, id uuid.UUID, successorID *uuid.UUID) error {
+	if m.deprecateErr != nil {
+		return m.deprecateErr
+	}
+	def, ok := m.definitions[id]
+	if !ok {
+		return ErrNotFound
+	}
+	def.Status = StatusDeprecated
+	now := time.Now()
+	def.DeprecatedAt = &now
+	def.SuccessorID = successorID
+	return nil
+}
+
+// --- Helpers ---
+
+func setupCachedRegistry(t *testing.T) (*CachedRegistry, *mockSagaRegistry, *Cache) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	cache, err := NewCache(client, WithCacheTTL(time.Hour, 0))
+	require.NoError(t, err)
+	reg := newMockSagaRegistry()
+	return NewCachedRegistry(reg, cache), reg, cache
+}
+
+func cachedCtx() context.Context {
+	return tenant.WithTenant(context.Background(), "test-tenant")
+}
+
+func makeTestDef(name string, status Status) *Definition {
+	now := time.Now()
+	return &Definition{
+		ID:        uuid.New(),
+		Name:      name,
+		Version:   1,
+		Script:    "def run(): pass",
+		Status:    status,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+// --- GetByID ---
+
+func TestCachedRegistry_GetByID_CacheMiss_FetchesFromRegistry(t *testing.T) {
+	cr, reg, _ := setupCachedRegistry(t)
+	ctx := cachedCtx()
+	def := makeTestDef("deposit", StatusActive)
+	reg.definitions[def.ID] = def
+
+	result, err := cr.GetByID(ctx, def.ID)
+	require.NoError(t, err)
+	assert.Equal(t, def.ID, result.ID)
+}
+
+func TestCachedRegistry_GetByID_CacheHit(t *testing.T) {
+	cr, reg, cache := setupCachedRegistry(t)
+	ctx := cachedCtx()
+	def := makeTestDef("deposit", StatusActive)
+	reg.definitions[def.ID] = def
+
+	// First call populates cache
+	_, err := cr.GetByID(ctx, def.ID)
+	require.NoError(t, err)
+
+	// Remove from underlying registry to prove cache serves it
+	delete(reg.definitions, def.ID)
+
+	result, err := cr.GetByID(ctx, def.ID)
+	require.NoError(t, err)
+	assert.Equal(t, def.ID, result.ID)
+
+	// Verify cache has it
+	assert.NotNil(t, cache.GetByID(ctx, def.ID))
+}
+
+func TestCachedRegistry_GetByID_RegistryError(t *testing.T) {
+	cr, reg, _ := setupCachedRegistry(t)
+	ctx := cachedCtx()
+	reg.getByIDErr = errors.New("db connection failed")
+
+	_, err := cr.GetByID(ctx, uuid.New())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "db connection failed")
+}
+
+// --- GetDefinition ---
+
+func TestCachedRegistry_GetDefinition_CacheMiss(t *testing.T) {
+	cr, reg, _ := setupCachedRegistry(t)
+	ctx := cachedCtx()
+	def := makeTestDef("withdrawal", StatusDraft)
+	reg.definitions[def.ID] = def
+
+	result, err := cr.GetDefinition(ctx, "withdrawal", 1)
+	require.NoError(t, err)
+	assert.Equal(t, "withdrawal", result.Name)
+}
+
+func TestCachedRegistry_GetDefinition_CacheHit(t *testing.T) {
+	cr, reg, _ := setupCachedRegistry(t)
+	ctx := cachedCtx()
+	def := makeTestDef("withdrawal", StatusDraft)
+	reg.definitions[def.ID] = def
+
+	// Populate cache
+	_, err := cr.GetDefinition(ctx, "withdrawal", 1)
+	require.NoError(t, err)
+
+	// Remove from registry
+	delete(reg.definitions, def.ID)
+
+	result, err := cr.GetDefinition(ctx, "withdrawal", 1)
+	require.NoError(t, err)
+	assert.Equal(t, "withdrawal", result.Name)
+}
+
+func TestCachedRegistry_GetDefinition_RegistryError(t *testing.T) {
+	cr, reg, _ := setupCachedRegistry(t)
+	ctx := cachedCtx()
+	reg.getDefErr = ErrNotFound
+
+	_, err := cr.GetDefinition(ctx, "nonexistent", 1)
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+// --- GetActive ---
+
+func TestCachedRegistry_GetActive_CacheMiss(t *testing.T) {
+	cr, reg, _ := setupCachedRegistry(t)
+	ctx := cachedCtx()
+	def := makeTestDef("transfer", StatusActive)
+	reg.definitions[def.ID] = def
+
+	result, err := cr.GetActive(ctx, "transfer")
+	require.NoError(t, err)
+	assert.Equal(t, "transfer", result.Name)
+}
+
+func TestCachedRegistry_GetActive_CacheHit(t *testing.T) {
+	cr, reg, _ := setupCachedRegistry(t)
+	ctx := cachedCtx()
+	def := makeTestDef("transfer", StatusActive)
+	reg.definitions[def.ID] = def
+
+	// Populate cache
+	_, err := cr.GetActive(ctx, "transfer")
+	require.NoError(t, err)
+
+	// Remove from registry
+	delete(reg.definitions, def.ID)
+
+	result, err := cr.GetActive(ctx, "transfer")
+	require.NoError(t, err)
+	assert.Equal(t, "transfer", result.Name)
+}
+
+func TestCachedRegistry_GetActive_RegistryError(t *testing.T) {
+	cr, reg, _ := setupCachedRegistry(t)
+	ctx := cachedCtx()
+	reg.getActiveErr = ErrNotFound
+
+	_, err := cr.GetActive(ctx, "nonexistent")
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+// --- ListByStatus (passthrough, no cache) ---
+
+func TestCachedRegistry_ListByStatus_Delegates(t *testing.T) {
+	cr, reg, _ := setupCachedRegistry(t)
+	ctx := cachedCtx()
+
+	def1 := makeTestDef("saga-1", StatusActive)
+	def2 := makeTestDef("saga-2", StatusActive)
+	reg.definitions[def1.ID] = def1
+	reg.definitions[def2.ID] = def2
+
+	result, err := cr.ListByStatus(ctx, StatusActive)
+	require.NoError(t, err)
+	assert.Len(t, result, 2)
+}
+
+func TestCachedRegistry_ListByStatus_Error(t *testing.T) {
+	cr, reg, _ := setupCachedRegistry(t)
+	ctx := cachedCtx()
+	reg.listErr = errors.New("list failed")
+
+	_, err := cr.ListByStatus(ctx, StatusActive)
+	require.Error(t, err)
+}
+
+// --- CreateDraft (passthrough) ---
+
+func TestCachedRegistry_CreateDraft_Delegates(t *testing.T) {
+	cr, reg, _ := setupCachedRegistry(t)
+	ctx := cachedCtx()
+	def := makeTestDef("new-saga", StatusDraft)
+
+	err := cr.CreateDraft(ctx, def)
+	require.NoError(t, err)
+	assert.Contains(t, reg.definitions, def.ID)
+}
+
+func TestCachedRegistry_CreateDraft_Error(t *testing.T) {
+	cr, reg, _ := setupCachedRegistry(t)
+	ctx := cachedCtx()
+	reg.createErr = ErrAlreadyExists
+
+	err := cr.CreateDraft(ctx, makeTestDef("dup", StatusDraft))
+	require.ErrorIs(t, err, ErrAlreadyExists)
+}
+
+// --- UpdateDefinition (invalidates cache) ---
+
+func TestCachedRegistry_UpdateDefinition_InvalidatesCache(t *testing.T) {
+	cr, reg, cache := setupCachedRegistry(t)
+	ctx := cachedCtx()
+	def := makeTestDef("updatable", StatusDraft)
+	reg.definitions[def.ID] = def
+
+	// Populate cache
+	_, _ = cr.GetByID(ctx, def.ID)
+	require.NotNil(t, cache.GetByID(ctx, def.ID))
+
+	err := cr.UpdateDefinition(ctx, def.ID, &Definition{DisplayName: "Updated"})
+	require.NoError(t, err)
+
+	// Cache should be invalidated
+	assert.Nil(t, cache.GetByID(ctx, def.ID))
+}
+
+func TestCachedRegistry_UpdateDefinition_GetByIDError(t *testing.T) {
+	cr, reg, _ := setupCachedRegistry(t)
+	ctx := cachedCtx()
+	reg.getByIDErr = ErrNotFound
+
+	err := cr.UpdateDefinition(ctx, uuid.New(), &Definition{DisplayName: "X"})
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestCachedRegistry_UpdateDefinition_RegistryError(t *testing.T) {
+	cr, reg, _ := setupCachedRegistry(t)
+	ctx := cachedCtx()
+	def := makeTestDef("update-fail", StatusDraft)
+	reg.definitions[def.ID] = def
+	reg.updateErr = ErrNotDraft
+
+	err := cr.UpdateDefinition(ctx, def.ID, &Definition{DisplayName: "X"})
+	require.ErrorIs(t, err, ErrNotDraft)
+}
+
+// --- ActivateSaga (invalidates cache) ---
+
+func TestCachedRegistry_ActivateSaga_InvalidatesCache(t *testing.T) {
+	cr, reg, cache := setupCachedRegistry(t)
+	ctx := cachedCtx()
+	def := makeTestDef("activatable", StatusDraft)
+	reg.definitions[def.ID] = def
+
+	// Populate cache
+	_, _ = cr.GetByID(ctx, def.ID)
+	require.NotNil(t, cache.GetByID(ctx, def.ID))
+
+	err := cr.ActivateSaga(ctx, def.ID)
+	require.NoError(t, err)
+
+	assert.Nil(t, cache.GetByID(ctx, def.ID))
+}
+
+func TestCachedRegistry_ActivateSaga_GetByIDError(t *testing.T) {
+	cr, reg, _ := setupCachedRegistry(t)
+	ctx := cachedCtx()
+	reg.getByIDErr = ErrNotFound
+
+	err := cr.ActivateSaga(ctx, uuid.New())
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestCachedRegistry_ActivateSaga_RegistryError(t *testing.T) {
+	cr, reg, _ := setupCachedRegistry(t)
+	ctx := cachedCtx()
+	def := makeTestDef("activate-fail", StatusActive)
+	reg.definitions[def.ID] = def
+	reg.activateErr = ErrNotDraft
+
+	err := cr.ActivateSaga(ctx, def.ID)
+	require.ErrorIs(t, err, ErrNotDraft)
+}
+
+// --- DeprecateSaga (invalidates cache) ---
+
+func TestCachedRegistry_DeprecateSaga_InvalidatesCache(t *testing.T) {
+	cr, reg, cache := setupCachedRegistry(t)
+	ctx := cachedCtx()
+	def := makeTestDef("deprecatable", StatusActive)
+	reg.definitions[def.ID] = def
+
+	// Populate cache
+	_, _ = cr.GetByID(ctx, def.ID)
+	require.NotNil(t, cache.GetByID(ctx, def.ID))
+
+	successorID := uuid.New()
+	err := cr.DeprecateSaga(ctx, def.ID, &successorID)
+	require.NoError(t, err)
+
+	assert.Nil(t, cache.GetByID(ctx, def.ID))
+}
+
+func TestCachedRegistry_DeprecateSaga_GetByIDError(t *testing.T) {
+	cr, reg, _ := setupCachedRegistry(t)
+	ctx := cachedCtx()
+	reg.getByIDErr = ErrNotFound
+
+	err := cr.DeprecateSaga(ctx, uuid.New(), nil)
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestCachedRegistry_DeprecateSaga_RegistryError(t *testing.T) {
+	cr, reg, _ := setupCachedRegistry(t)
+	ctx := cachedCtx()
+	def := makeTestDef("deprecate-fail", StatusDraft)
+	reg.definitions[def.ID] = def
+	reg.deprecateErr = ErrNotActive
+
+	err := cr.DeprecateSaga(ctx, def.ID, nil)
+	require.ErrorIs(t, err, ErrNotActive)
+}


### PR DESCRIPTION
## Summary
- Add unit tests for `saga/cache.go` and `saga/cached_registry.go` (previously 0% coverage) using miniredis
- Add error-path tests for `handler/account_type_handler.go` covering constructor validation, invalid inputs, domain-to-gRPC error mapping, proto enum conversions, pagination, and validation logic

## Test plan
- [x] All new saga cache tests pass (`go test ./services/reference-data/saga/...`)
- [x] All new handler error tests pass (`go test ./services/reference-data/handler/...`)
- [ ] CI green