### PR TITLE
test: add tests for payment-order and current-account services

### DIFF
--- a/services/current-account/service/server_coverage_test.go
+++ b/services/current-account/service/server_coverage_test.go
@@ -1,0 +1,100 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// NewService constructor
+// =============================================================================
+
+func TestNewService_NilRepo(t *testing.T) {
+	_, err := NewService(nil, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrRepositoryNil)
+}
+
+func TestNewService_ValidRepo(t *testing.T) {
+	db, _, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := newTestRepo(db)
+	svc, err := NewService(repo, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, svc)
+}
+
+// =============================================================================
+// NewServiceWithIdempotency constructor
+// =============================================================================
+
+func TestNewServiceWithIdempotency_NilRepo(t *testing.T) {
+	_, err := NewServiceWithIdempotency(nil, nil, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrRepositoryNil)
+}
+
+func TestNewServiceWithIdempotency_ValidRepo(t *testing.T) {
+	db, _, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := newTestRepo(db)
+	mockIdemp := &mockIdempotencyService{}
+	svc, err := NewServiceWithIdempotency(repo, nil, mockIdemp)
+	require.NoError(t, err)
+	assert.NotNil(t, svc)
+}
+
+// =============================================================================
+// NewServiceWithValuationFeatures constructor
+// =============================================================================
+
+func TestNewServiceWithValuationFeatures_ValidRepo(t *testing.T) {
+	db, _, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := newTestRepo(db)
+	svc, err := NewServiceWithValuationFeatures(repo, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, svc)
+}
+
+// =============================================================================
+// loadSagaAsset - fallback to executable directory
+// =============================================================================
+
+func TestLoadSagaAsset_FallbackToExecutable(t *testing.T) {
+	// Clear the env var to force executable fallback
+	t.Setenv("SAGA_ASSET_DIR", "")
+
+	// The file won't exist relative to the test executable, so we expect an error
+	_, err := loadSagaAsset("nonexistent/path/script.star")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read saga asset")
+}
+
+func TestLoadSagaAsset_EnvVarSet_FileExists(t *testing.T) {
+	tmpDir := t.TempDir()
+	scriptPath := filepath.Join(tmpDir, "test.star")
+	require.NoError(t, os.WriteFile(scriptPath, []byte("print('hello')"), 0o644))
+
+	t.Setenv("SAGA_ASSET_DIR", tmpDir)
+
+	content, err := loadSagaAsset("test.star")
+	require.NoError(t, err)
+	assert.Equal(t, "print('hello')", content)
+}
+
+func TestLoadSagaAsset_EnvVarSet_FileNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("SAGA_ASSET_DIR", tmpDir)
+
+	_, err := loadSagaAsset("missing.star")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read saga asset")
+}

--- a/services/payment-order/adapters/messaging/payment_event_consumer_coverage_test.go
+++ b/services/payment-order/adapters/messaging/payment_event_consumer_coverage_test.go
@@ -44,7 +44,7 @@ func TestPaymentEventConsumer_Start_NotConfigured(t *testing.T) {
 // Stop — no panic on nil consumers
 // =============================================================================
 
-func TestPaymentEventConsumer_Stop_NilConsumers(t *testing.T) {
+func TestPaymentEventConsumer_Stop_NilConsumers(_ *testing.T) {
 	stub := &stubPaymentOrderUpdater{}
 	consumer := messaging.NewPaymentEventConsumer(stub)
 

--- a/services/payment-order/adapters/messaging/payment_event_consumer_coverage_test.go
+++ b/services/payment-order/adapters/messaging/payment_event_consumer_coverage_test.go
@@ -1,0 +1,127 @@
+package messaging_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	financialgatewayeventsv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_gateway_events/v1"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
+	"github.com/meridianhub/meridian/services/payment-order/adapters/messaging"
+)
+
+// =============================================================================
+// Constructor edge cases
+// =============================================================================
+
+func TestNewPaymentEventConsumer_NilSvc_Panics(t *testing.T) {
+	assert.PanicsWithValue(t, messaging.ErrNilPaymentOrderUpdater.Error(), func() {
+		messaging.NewPaymentEventConsumer(nil)
+	})
+}
+
+func TestNewPaymentEventConsumer_ValidSvc(t *testing.T) {
+	stub := &stubPaymentOrderUpdater{}
+	consumer := messaging.NewPaymentEventConsumer(stub)
+	require.NotNil(t, consumer)
+}
+
+// =============================================================================
+// Start — not configured (no Kafka)
+// =============================================================================
+
+func TestPaymentEventConsumer_Start_NotConfigured(t *testing.T) {
+	stub := &stubPaymentOrderUpdater{}
+	consumer := messaging.NewPaymentEventConsumer(stub)
+
+	// Start should return ErrConsumerNotConfigured because no Kafka was wired
+	err := consumer.Start("captured-topic", "failed-topic")
+	assert.ErrorIs(t, err, messaging.ErrConsumerNotConfigured)
+}
+
+// =============================================================================
+// Stop — no panic on nil consumers
+// =============================================================================
+
+func TestPaymentEventConsumer_Stop_NilConsumers(t *testing.T) {
+	stub := &stubPaymentOrderUpdater{}
+	consumer := messaging.NewPaymentEventConsumer(stub)
+
+	// Should not panic when internal consumers are nil
+	consumer.Stop()
+}
+
+// =============================================================================
+// Close — no panic on nil consumers
+// =============================================================================
+
+func TestPaymentEventConsumer_Close_NilConsumers(t *testing.T) {
+	stub := &stubPaymentOrderUpdater{}
+	consumer := messaging.NewPaymentEventConsumer(stub)
+
+	// Should not panic and return nil when internal consumers are nil
+	err := consumer.Close()
+	assert.NoError(t, err)
+}
+
+// =============================================================================
+// IdempotencyKey deterministic format
+// =============================================================================
+
+func TestPaymentEventConsumer_IdempotencyKey_Failed_UsesProviderEventId(t *testing.T) {
+	stub := &stubPaymentOrderUpdater{
+		resp: &pb.UpdatePaymentOrderResponse{},
+	}
+	consumer := messaging.NewPaymentEventConsumer(stub)
+
+	evt := newFailedEvent("evt-1", "po-1", "pi_ref", "declined", "evt-stripe-1")
+
+	require.NoError(t, consumer.HandlePaymentFailedEvent(t.Context(), nil, evt))
+	require.Len(t, stub.calls, 1)
+
+	key := stub.calls[0].GetIdempotencyKey().GetKey()
+	assert.Contains(t, key, "failed")
+	assert.Contains(t, key, "evt-stripe-1")
+	assert.Contains(t, key, "po-1")
+}
+
+func TestPaymentEventConsumer_IdempotencyKey_Captured_Format(t *testing.T) {
+	stub := &stubPaymentOrderUpdater{}
+	consumer := messaging.NewPaymentEventConsumer(stub)
+
+	evt := newCapturedEvent("evt-2", "po-2", "pi_ref_2", "evt-stripe-2")
+
+	require.NoError(t, consumer.HandlePaymentCapturedEvent(t.Context(), nil, evt))
+	require.Len(t, stub.calls, 1)
+
+	key := stub.calls[0].GetIdempotencyKey().GetKey()
+	assert.Contains(t, key, "captured")
+	assert.Contains(t, key, "evt-stripe-2")
+	assert.Contains(t, key, "po-2")
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+func newCapturedEvent(eventID, poID, providerRef, providerEventID string) *financialgatewayeventsv1.PaymentCapturedEvent {
+	return &financialgatewayeventsv1.PaymentCapturedEvent{
+		EventId:             eventID,
+		PaymentOrderId:      poID,
+		ProviderReferenceId: providerRef,
+		ProviderEventId:     providerEventID,
+		Version:             1,
+	}
+}
+
+func newFailedEvent(eventID, poID, providerRef, reason, providerEventID string) *financialgatewayeventsv1.PaymentFailedEvent {
+	return &financialgatewayeventsv1.PaymentFailedEvent{
+		EventId:             eventID,
+		PaymentOrderId:      poID,
+		ProviderReferenceId: providerRef,
+		FailureReason:       reason,
+		ProviderEventId:     providerEventID,
+		Version:             1,
+	}
+}

--- a/services/payment-order/service/payment_orchestrator_lien_test.go
+++ b/services/payment-order/service/payment_orchestrator_lien_test.go
@@ -281,9 +281,9 @@ func TestUpdateLienExecutionStatus_VersionConflict_Retries(t *testing.T) {
 
 	// Create a repo that returns version conflict on the first update, then succeeds
 	repo := &versionConflictMockRepo{
-		inner:            NewMockRepository(),
-		conflictsRemain:  2,
-		mu:               sync.Mutex{},
+		inner:           NewMockRepository(),
+		conflictsRemain: 2,
+		mu:              sync.Mutex{},
 	}
 	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusCompleted)
 	require.NoError(t, repo.inner.Create(context.Background(), po))

--- a/services/payment-order/service/payment_orchestrator_lien_test.go
+++ b/services/payment-order/service/payment_orchestrator_lien_test.go
@@ -1,0 +1,370 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/payment-order/adapters/persistence"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"github.com/meridianhub/meridian/services/payment-order/domain/testfixtures"
+	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockLock implements Lock for testing.
+type mockLock struct {
+	releaseErr error
+}
+
+func (m *mockLock) Release(_ context.Context) error {
+	return m.releaseErr
+}
+
+// mockLockClient implements LockClient for testing.
+type mockLockClient struct {
+	lock Lock
+	err  error
+}
+
+func (m *mockLockClient) Obtain(_ context.Context, _ string, _ time.Duration) (Lock, error) {
+	return m.lock, m.err
+}
+
+// =============================================================================
+// ExecuteLienWithRetry
+// =============================================================================
+
+func TestExecuteLienWithRetry_NilCurrentAccountClient(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockRepository()
+	o := testOrchestrator(repo, nil, nil, nil)
+	// Explicitly nil out the client
+	o.currentAccountClient = nil
+
+	// Should return early without panic
+	o.ExecuteLienWithRetry(context.Background(), uuid.New(), "lien-123")
+}
+
+func TestExecuteLienWithRetry_Success(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockRepository()
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusCompleted)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	mockCA := &MockCurrentAccountClient{}
+	o := testOrchestrator(repo, mockCA, nil, nil)
+	o.lienExecutionRetryConfig = &sharedclients.RetryConfig{
+		MaxRetries:      1,
+		InitialInterval: 1 * time.Millisecond,
+		MaxInterval:     10 * time.Millisecond,
+		Multiplier:      1.0,
+	}
+
+	o.ExecuteLienWithRetry(context.Background(), po.ID, "lien-abc")
+
+	updated, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.LienExecutionStatusSucceeded, updated.LienExecutionStatus)
+	assert.Equal(t, 1, updated.LienExecutionAttempts)
+}
+
+func TestExecuteLienWithRetry_FailureAfterRetries(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockRepository()
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusCompleted)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	mockCA := &MockCurrentAccountClient{
+		executeLienErr: errors.New("service unavailable"),
+	}
+	o := testOrchestrator(repo, mockCA, nil, nil)
+	o.lienExecutionRetryConfig = &sharedclients.RetryConfig{
+		MaxRetries:      2,
+		InitialInterval: 1 * time.Millisecond,
+		MaxInterval:     5 * time.Millisecond,
+		Multiplier:      1.0,
+	}
+
+	o.ExecuteLienWithRetry(context.Background(), po.ID, "lien-fail")
+
+	updated, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.LienExecutionStatusFailed, updated.LienExecutionStatus)
+	assert.Contains(t, updated.LienExecutionError, "service unavailable")
+}
+
+func TestExecuteLienWithRetry_DefaultRetryConfig(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockRepository()
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusCompleted)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	mockCA := &MockCurrentAccountClient{}
+	o := testOrchestrator(repo, mockCA, nil, nil)
+	// Leave lienExecutionRetryConfig nil to trigger default path
+	o.lienExecutionRetryConfig = nil
+
+	// Use a short-lived context to avoid waiting for the full default timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	o.ExecuteLienWithRetry(ctx, po.ID, "lien-default")
+
+	updated, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.LienExecutionStatusSucceeded, updated.LienExecutionStatus)
+}
+
+// =============================================================================
+// updateLienExecutionStatus
+// =============================================================================
+
+func TestUpdateLienExecutionStatus_Success_NoLock(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockRepository()
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusCompleted)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	o := testOrchestrator(repo, &MockCurrentAccountClient{}, nil, nil)
+	// No lock client configured
+
+	o.updateLienExecutionStatus(context.Background(), po.ID, 1, nil, nil, testLogger())
+
+	updated, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.LienExecutionStatusSucceeded, updated.LienExecutionStatus)
+}
+
+func TestUpdateLienExecutionStatus_Failure_RecordsError(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockRepository()
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusCompleted)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	o := testOrchestrator(repo, &MockCurrentAccountClient{}, nil, nil)
+
+	retryErr := errors.New("all retries exhausted")
+	lastErr := errors.New("connection refused")
+
+	o.updateLienExecutionStatus(context.Background(), po.ID, 3, retryErr, lastErr, testLogger())
+
+	updated, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.LienExecutionStatusFailed, updated.LienExecutionStatus)
+	assert.Contains(t, updated.LienExecutionError, "connection refused")
+	assert.Equal(t, 3, updated.LienExecutionAttempts)
+}
+
+func TestUpdateLienExecutionStatus_Failure_FallsBackToRetryErr(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockRepository()
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusCompleted)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	o := testOrchestrator(repo, &MockCurrentAccountClient{}, nil, nil)
+
+	retryErr := errors.New("retry wrapper error")
+
+	o.updateLienExecutionStatus(context.Background(), po.ID, 2, retryErr, nil, testLogger())
+
+	updated, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.LienExecutionStatusFailed, updated.LienExecutionStatus)
+	assert.Contains(t, updated.LienExecutionError, "retry wrapper error")
+}
+
+func TestUpdateLienExecutionStatus_WithLock_Success(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockRepository()
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusCompleted)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	o := testOrchestrator(repo, &MockCurrentAccountClient{}, nil, nil)
+	o.lockClient = &mockLockClient{
+		lock: &mockLock{},
+	}
+
+	o.updateLienExecutionStatus(context.Background(), po.ID, 1, nil, nil, testLogger())
+
+	updated, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.LienExecutionStatusSucceeded, updated.LienExecutionStatus)
+}
+
+func TestUpdateLienExecutionStatus_LockNotObtained_Returns(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockRepository()
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusCompleted)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	o := testOrchestrator(repo, &MockCurrentAccountClient{}, nil, nil)
+	o.lockClient = &mockLockClient{
+		err: LockNotObtainedError{},
+	}
+
+	o.updateLienExecutionStatus(context.Background(), po.ID, 1, nil, nil, testLogger())
+
+	// Should NOT have updated the PO because lock was not obtained
+	updated, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.NotEqual(t, domain.LienExecutionStatusSucceeded, updated.LienExecutionStatus)
+}
+
+func TestUpdateLienExecutionStatus_LockError_ContinuesWithoutLock(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockRepository()
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusCompleted)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	o := testOrchestrator(repo, &MockCurrentAccountClient{}, nil, nil)
+	o.lockClient = &mockLockClient{
+		err: errors.New("redis connection error"),
+	}
+
+	o.updateLienExecutionStatus(context.Background(), po.ID, 1, nil, nil, testLogger())
+
+	// Should still succeed - continues without lock
+	updated, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.LienExecutionStatusSucceeded, updated.LienExecutionStatus)
+}
+
+func TestUpdateLienExecutionStatus_LockReleaseError(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockRepository()
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusCompleted)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	o := testOrchestrator(repo, &MockCurrentAccountClient{}, nil, nil)
+	o.lockClient = &mockLockClient{
+		lock: &mockLock{releaseErr: errors.New("release failed")},
+	}
+
+	// Should not panic despite release error
+	o.updateLienExecutionStatus(context.Background(), po.ID, 1, nil, nil, testLogger())
+
+	updated, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.LienExecutionStatusSucceeded, updated.LienExecutionStatus)
+}
+
+func TestUpdateLienExecutionStatus_FindByIDError(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockRepository()
+	repo.findByIDErr = errors.New("db unavailable")
+
+	o := testOrchestrator(repo, &MockCurrentAccountClient{}, nil, nil)
+
+	// Should not panic - error is logged
+	o.updateLienExecutionStatus(context.Background(), uuid.New(), 1, nil, nil, testLogger())
+}
+
+func TestUpdateLienExecutionStatus_VersionConflict_Retries(t *testing.T) {
+	t.Parallel()
+
+	// Create a repo that returns version conflict on the first update, then succeeds
+	repo := &versionConflictMockRepo{
+		inner:            NewMockRepository(),
+		conflictsRemain:  2,
+		mu:               sync.Mutex{},
+	}
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusCompleted)
+	require.NoError(t, repo.inner.Create(context.Background(), po))
+
+	o := testOrchestrator(repo, &MockCurrentAccountClient{}, nil, nil)
+
+	o.updateLienExecutionStatus(context.Background(), po.ID, 1, nil, nil, testLogger())
+
+	updated, err := repo.inner.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.LienExecutionStatusSucceeded, updated.LienExecutionStatus)
+}
+
+func TestUpdateLienExecutionStatus_NonRecoverableUpdateError(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockRepository()
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusCompleted)
+	require.NoError(t, repo.Create(context.Background(), po))
+	repo.updateErr = errors.New("disk full")
+
+	o := testOrchestrator(repo, &MockCurrentAccountClient{}, nil, nil)
+
+	// Should not panic - error is logged
+	o.updateLienExecutionStatus(context.Background(), po.ID, 1, nil, nil, testLogger())
+}
+
+// =============================================================================
+// isVersionConflict
+// =============================================================================
+
+func TestIsVersionConflict(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isVersionConflict(persistence.ErrPaymentOrderVersionConflict))
+	assert.False(t, isVersionConflict(errors.New("other error")))
+	assert.False(t, isVersionConflict(nil))
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+// versionConflictMockRepo wraps MockRepository and returns version conflict
+// errors for the first N update calls, then delegates to the inner repo.
+type versionConflictMockRepo struct {
+	inner           *MockRepository
+	conflictsRemain int
+	mu              sync.Mutex
+}
+
+func (r *versionConflictMockRepo) Create(ctx context.Context, po *domain.PaymentOrder) error {
+	return r.inner.Create(ctx, po)
+}
+
+func (r *versionConflictMockRepo) FindByID(ctx context.Context, id uuid.UUID) (*domain.PaymentOrder, error) {
+	return r.inner.FindByID(ctx, id)
+}
+
+func (r *versionConflictMockRepo) FindByIdempotencyKey(ctx context.Context, key string) (*domain.PaymentOrder, error) {
+	return r.inner.FindByIdempotencyKey(ctx, key)
+}
+
+func (r *versionConflictMockRepo) FindByGatewayReferenceID(ctx context.Context, ref string) (*domain.PaymentOrder, error) {
+	return r.inner.FindByGatewayReferenceID(ctx, ref)
+}
+
+func (r *versionConflictMockRepo) FindByDebtorAccountID(ctx context.Context, accountID string) ([]*domain.PaymentOrder, error) {
+	return r.inner.FindByDebtorAccountID(ctx, accountID)
+}
+
+func (r *versionConflictMockRepo) FindByDebtorAccountIDWithCursor(ctx context.Context, accountID string, limit int, cursor persistence.Cursor) (*persistence.PaginatedResult, error) {
+	return r.inner.FindByDebtorAccountIDWithCursor(ctx, accountID, limit, cursor)
+}
+
+func (r *versionConflictMockRepo) Update(ctx context.Context, po *domain.PaymentOrder) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.conflictsRemain > 0 {
+		r.conflictsRemain--
+		return persistence.ErrPaymentOrderVersionConflict
+	}
+	return r.inner.Update(ctx, po)
+}


### PR DESCRIPTION
## Summary
- Add unit tests for `payment_orchestrator_lien.go` covering ExecuteLienWithRetry and updateLienExecutionStatus error paths (lock contention, version conflicts, retry fallback, nil client guard)
- Add unit tests for `payment_event_consumer.go` covering Start/Stop/Close nil safety and constructor validation
- Add unit tests for current-account `server.go` covering NewService/NewServiceWithIdempotency constructors, loadSagaAsset fallback paths, and functional options

## Test plan
- [x] All new tests pass locally (`go test` for both services)
- [x] No existing tests broken (verified unit test suites)
- [x] Covers error paths and edge cases in targeted files