### PR TITLE
fix: balance retrieval for non-fiat instruments (KWH, CARBON_CREDIT)

### DIFF
--- a/services/current-account/service/coverage_unit_test.go
+++ b/services/current-account/service/coverage_unit_test.go
@@ -5301,10 +5301,10 @@ func TestRetrieveWithdrawal_MissingBothIDs(t *testing.T) {
 // =============================================================================
 
 // =============================================================================
-// getAccountBalanceCents: various response shapes
+// getAccountBalanceMinorUnits: various response shapes
 // =============================================================================
 
-func TestGetAccountBalanceCents_NilAmount(t *testing.T) {
+func TestGetAccountBalanceMinorUnits_NilAmount(t *testing.T) {
 	mockPK := &stubPKClient{
 		getBalanceResp: &positionkeepingv1.GetAccountBalanceResponse{
 			Amount: nil,
@@ -5314,12 +5314,12 @@ func TestGetAccountBalanceCents_NilAmount(t *testing.T) {
 		posKeepingClient: mockPK,
 		logger:           slog.New(slog.NewJSONHandler(os.Stdout, nil)),
 	}
-	cents, err := svc.getAccountBalanceCents(context.Background(), "ACC-001")
+	cents, err := svc.getAccountBalanceMinorUnits(context.Background(), "ACC-001", "GBP", 2)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), cents)
 }
 
-func TestGetAccountBalanceCents_EmptyAmount(t *testing.T) {
+func TestGetAccountBalanceMinorUnits_EmptyAmount(t *testing.T) {
 	mockPK := &stubPKClient{
 		getBalanceResp: &positionkeepingv1.GetAccountBalanceResponse{
 			Amount: &quantityv1.InstrumentAmount{
@@ -5331,12 +5331,12 @@ func TestGetAccountBalanceCents_EmptyAmount(t *testing.T) {
 		posKeepingClient: mockPK,
 		logger:           slog.New(slog.NewJSONHandler(os.Stdout, nil)),
 	}
-	cents, err := svc.getAccountBalanceCents(context.Background(), "ACC-001")
+	cents, err := svc.getAccountBalanceMinorUnits(context.Background(), "ACC-001", "GBP", 2)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), cents)
 }
 
-func TestGetAccountBalanceCents_InstrumentCodeMismatch(t *testing.T) {
+func TestGetAccountBalanceMinorUnits_InstrumentCodeMismatch(t *testing.T) {
 	mockPK := &stubPKClient{
 		getBalanceResp: &positionkeepingv1.GetAccountBalanceResponse{
 			Amount: &quantityv1.InstrumentAmount{
@@ -5349,12 +5349,12 @@ func TestGetAccountBalanceCents_InstrumentCodeMismatch(t *testing.T) {
 		posKeepingClient: mockPK,
 		logger:           slog.New(slog.NewJSONHandler(os.Stdout, nil)),
 	}
-	_, err := svc.getAccountBalanceCents(context.Background(), "ACC-001")
+	_, err := svc.getAccountBalanceMinorUnits(context.Background(), "ACC-001", "GBP", 2)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrInstrumentCodeMismatch)
 }
 
-func TestGetAccountBalanceCents_InvalidAmountString(t *testing.T) {
+func TestGetAccountBalanceMinorUnits_InvalidAmountString(t *testing.T) {
 	mockPK := &stubPKClient{
 		getBalanceResp: &positionkeepingv1.GetAccountBalanceResponse{
 			Amount: &quantityv1.InstrumentAmount{
@@ -5367,12 +5367,12 @@ func TestGetAccountBalanceCents_InvalidAmountString(t *testing.T) {
 		posKeepingClient: mockPK,
 		logger:           slog.New(slog.NewJSONHandler(os.Stdout, nil)),
 	}
-	_, err := svc.getAccountBalanceCents(context.Background(), "ACC-001")
+	_, err := svc.getAccountBalanceMinorUnits(context.Background(), "ACC-001", "GBP", 2)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse balance amount")
 }
 
-func TestGetAccountBalanceCents_Success(t *testing.T) {
+func TestGetAccountBalanceMinorUnits_Success(t *testing.T) {
 	mockPK := &stubPKClient{
 		getBalanceResp: &positionkeepingv1.GetAccountBalanceResponse{
 			Amount: &quantityv1.InstrumentAmount{
@@ -5385,12 +5385,12 @@ func TestGetAccountBalanceCents_Success(t *testing.T) {
 		posKeepingClient: mockPK,
 		logger:           slog.New(slog.NewJSONHandler(os.Stdout, nil)),
 	}
-	cents, err := svc.getAccountBalanceCents(context.Background(), "ACC-001")
+	cents, err := svc.getAccountBalanceMinorUnits(context.Background(), "ACC-001", "GBP", 2)
 	require.NoError(t, err)
 	assert.Equal(t, int64(12345), cents)
 }
 
-func TestGetAccountBalanceCents_Error(t *testing.T) {
+func TestGetAccountBalanceMinorUnits_Error(t *testing.T) {
 	mockPK := &stubPKClient{
 		getBalanceErr: fmt.Errorf("connection refused"),
 	}
@@ -5398,9 +5398,150 @@ func TestGetAccountBalanceCents_Error(t *testing.T) {
 		posKeepingClient: mockPK,
 		logger:           slog.New(slog.NewJSONHandler(os.Stdout, nil)),
 	}
-	_, err := svc.getAccountBalanceCents(context.Background(), "ACC-001")
+	_, err := svc.getAccountBalanceMinorUnits(context.Background(), "ACC-001", "GBP", 2)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "connection refused")
+}
+
+func TestGetAccountBalanceMinorUnits_KWH_Precision0(t *testing.T) {
+	mockPK := &stubPKClient{
+		getBalanceResp: &positionkeepingv1.GetAccountBalanceResponse{
+			Amount: &quantityv1.InstrumentAmount{
+				Amount:         "1500",
+				InstrumentCode: "KWH",
+			},
+		},
+	}
+	svc := &Service{
+		posKeepingClient: mockPK,
+		logger:           slog.New(slog.NewJSONHandler(os.Stdout, nil)),
+	}
+	minorUnits, err := svc.getAccountBalanceMinorUnits(context.Background(), "ACC-KWH-001", "KWH", 0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1500), minorUnits)
+}
+
+func TestGetAccountBalanceMinorUnits_KWH_Precision3(t *testing.T) {
+	mockPK := &stubPKClient{
+		getBalanceResp: &positionkeepingv1.GetAccountBalanceResponse{
+			Amount: &quantityv1.InstrumentAmount{
+				Amount:         "1.500",
+				InstrumentCode: "KWH",
+			},
+		},
+	}
+	svc := &Service{
+		posKeepingClient: mockPK,
+		logger:           slog.New(slog.NewJSONHandler(os.Stdout, nil)),
+	}
+	minorUnits, err := svc.getAccountBalanceMinorUnits(context.Background(), "ACC-KWH-001", "KWH", 3)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1500), minorUnits)
+}
+
+func TestGetAccountBalanceMinorUnits_CarbonCredit(t *testing.T) {
+	mockPK := &stubPKClient{
+		getBalanceResp: &positionkeepingv1.GetAccountBalanceResponse{
+			Amount: &quantityv1.InstrumentAmount{
+				Amount:         "100",
+				InstrumentCode: "CARBON_CREDIT",
+			},
+		},
+	}
+	svc := &Service{
+		posKeepingClient: mockPK,
+		logger:           slog.New(slog.NewJSONHandler(os.Stdout, nil)),
+	}
+	minorUnits, err := svc.getAccountBalanceMinorUnits(context.Background(), "ACC-CC-001", "CARBON_CREDIT", 0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(100), minorUnits)
+}
+
+func TestGetAccountBalanceMinorUnits_InstrumentMismatch_NonFiat(t *testing.T) {
+	mockPK := &stubPKClient{
+		getBalanceResp: &positionkeepingv1.GetAccountBalanceResponse{
+			Amount: &quantityv1.InstrumentAmount{
+				Amount:         "100",
+				InstrumentCode: "GBP",
+			},
+		},
+	}
+	svc := &Service{
+		posKeepingClient: mockPK,
+		logger:           slog.New(slog.NewJSONHandler(os.Stdout, nil)),
+	}
+	_, err := svc.getAccountBalanceMinorUnits(context.Background(), "ACC-KWH-001", "KWH", 0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInstrumentCodeMismatch)
+}
+
+// =============================================================================
+// hydrateAccountWithBalance: non-fiat instruments
+// =============================================================================
+
+func TestHydrateAccountWithBalance_KWH_Success(t *testing.T) {
+	mockPK := &stubPKClient{
+		getBalanceResp: &positionkeepingv1.GetAccountBalanceResponse{
+			Amount: &quantityv1.InstrumentAmount{
+				Amount:         "1500",
+				InstrumentCode: "KWH",
+			},
+		},
+	}
+	db := openSharedDB(t)
+	repo := persistence.NewRepository(db)
+	svc := &Service{
+		repo:             repo,
+		posKeepingClient: mockPK,
+		logger:           slog.New(slog.NewJSONHandler(os.Stdout, nil)),
+	}
+
+	account, err := domain.NewCurrentAccountWithDimension("ACC-KWH-001", "KWH-001", uuid.New().String(), "KWH", "ENERGY", 0)
+	require.NoError(t, err)
+	hydrated, err := svc.hydrateAccountWithBalance(context.Background(), account)
+	require.NoError(t, err)
+	balanceMinor, _ := hydrated.Balance().ToMinorUnits()
+	assert.Equal(t, int64(1500), balanceMinor)
+	assert.Equal(t, "KWH", hydrated.Balance().InstrumentCode())
+	assert.Equal(t, "ENERGY", hydrated.Balance().Dimension())
+}
+
+func TestHydrateAccountWithBalance_CarbonCredit_Success(t *testing.T) {
+	mockPK := &stubPKClient{
+		getBalanceResp: &positionkeepingv1.GetAccountBalanceResponse{
+			Amount: &quantityv1.InstrumentAmount{
+				Amount:         "50",
+				InstrumentCode: "CARBON_CREDIT",
+			},
+		},
+	}
+	db := openSharedDB(t)
+	repo := persistence.NewRepository(db)
+	svc := &Service{
+		repo:             repo,
+		posKeepingClient: mockPK,
+		logger:           slog.New(slog.NewJSONHandler(os.Stdout, nil)),
+	}
+
+	account, err := domain.NewCurrentAccountWithDimension("ACC-CC-001", "CC-001", uuid.New().String(), "CARBON_CREDIT", "CARBON", 0)
+	require.NoError(t, err)
+	hydrated, err := svc.hydrateAccountWithBalance(context.Background(), account)
+	require.NoError(t, err)
+	balanceMinor, _ := hydrated.Balance().ToMinorUnits()
+	assert.Equal(t, int64(50), balanceMinor)
+	assert.Equal(t, "CARBON_CREDIT", hydrated.Balance().InstrumentCode())
+	assert.Equal(t, "CARBON", hydrated.Balance().Dimension())
+}
+
+func TestHydrateAccountWithPrefetchedBalance_KWH_Success(t *testing.T) {
+	svc := &Service{logger: slog.New(slog.NewJSONHandler(os.Stdout, nil))}
+	account, err := domain.NewCurrentAccountWithDimension("ACC-KWH-PREF-001", "KWH-PREF-001", uuid.New().String(), "KWH", "ENERGY", 0)
+	require.NoError(t, err)
+	hydrated, err := svc.hydrateAccountWithPrefetchedBalance(account, 5000)
+	require.NoError(t, err)
+	balanceMinor, _ := hydrated.Balance().ToMinorUnits()
+	assert.Equal(t, int64(5000), balanceMinor)
+	assert.Equal(t, "KWH", hydrated.Balance().InstrumentCode())
 }
 
 // =============================================================================

--- a/services/current-account/service/coverage_unit_test.go
+++ b/services/current-account/service/coverage_unit_test.go
@@ -5506,6 +5506,36 @@ func TestHydrateAccountWithBalance_KWH_Success(t *testing.T) {
 	assert.Equal(t, "ENERGY", hydrated.Balance().Dimension())
 }
 
+func TestHydrateAccountWithBalance_KWH_Precision3_Success(t *testing.T) {
+	// PK returns "1.500" (major units). With precision=3, minor units = 1500.
+	// Hydration must reconstruct Amount with precision=3 so 1500 minor -> 1.500 KWH.
+	mockPK := &stubPKClient{
+		getBalanceResp: &positionkeepingv1.GetAccountBalanceResponse{
+			Amount: &quantityv1.InstrumentAmount{
+				Amount:         "1.500",
+				InstrumentCode: "KWH",
+			},
+		},
+	}
+	db := openSharedDB(t)
+	repo := persistence.NewRepository(db)
+	svc := &Service{
+		repo:             repo,
+		posKeepingClient: mockPK,
+		logger:           slog.New(slog.NewJSONHandler(os.Stdout, nil)),
+	}
+
+	account, err := domain.NewCurrentAccountWithDimension("ACC-KWH-P3", "KWH-P3-001", uuid.New().String(), "KWH", "ENERGY", 3)
+	require.NoError(t, err)
+	hydrated, err := svc.hydrateAccountWithBalance(context.Background(), account)
+	require.NoError(t, err)
+	balanceMinor, _ := hydrated.Balance().ToMinorUnits()
+	assert.Equal(t, int64(1500), balanceMinor)
+	assert.Equal(t, 3, hydrated.Balance().Precision())
+	// Verify major units display correctly
+	assert.Equal(t, "1.500 KWH", hydrated.Balance().String())
+}
+
 func TestHydrateAccountWithBalance_CarbonCredit_Success(t *testing.T) {
 	mockPK := &stubPKClient{
 		getBalanceResp: &positionkeepingv1.GetAccountBalanceResponse{

--- a/services/current-account/service/lien_helpers.go
+++ b/services/current-account/service/lien_helpers.go
@@ -158,13 +158,14 @@ func (s *Service) checkLienIdempotency(ctx context.Context, paymentOrderRef stri
 // Position Keeping is the source of truth for account balances - this method MUST be called
 // before any operation that requires the current balance.
 func (s *Service) hydrateAccountWithBalance(ctx context.Context, account domain.CurrentAccount) (domain.CurrentAccount, error) {
-	balanceCents, err := s.getAccountBalanceMinorUnits(ctx, account.AccountID(), account.InstrumentCode(), account.Balance().Precision())
+	precision := account.Balance().Precision()
+	balanceCents, err := s.getAccountBalanceMinorUnits(ctx, account.AccountID(), account.InstrumentCode(), precision)
 	if err != nil {
 		return domain.CurrentAccount{}, fmt.Errorf("failed to get balance from Position Keeping: %w", err)
 	}
 
-	// Create balance Money object
-	balance, err := domain.NewAmountFromInstrument(account.InstrumentCode(), account.Dimension(), 0, balanceCents)
+	// Create balance Amount using the account's instrument precision.
+	balance, err := domain.NewAmountFromInstrument(account.InstrumentCode(), account.Dimension(), precision, balanceCents)
 	if err != nil {
 		return domain.CurrentAccount{}, fmt.Errorf("failed to create balance: %w", err)
 	}
@@ -199,8 +200,8 @@ func (s *Service) hydrateAccountWithBalance(ctx context.Context, account domain.
 // Use this inside transactions to avoid making external service calls while holding database locks.
 // The balanceCents parameter should be fetched from Position Keeping BEFORE entering the transaction.
 func (s *Service) hydrateAccountWithPrefetchedBalance(account domain.CurrentAccount, balanceCents int64) (domain.CurrentAccount, error) {
-	// Create balance Money object
-	balance, err := domain.NewAmountFromInstrument(account.InstrumentCode(), account.Dimension(), 0, balanceCents)
+	// Create balance Amount using the account's instrument precision.
+	balance, err := domain.NewAmountFromInstrument(account.InstrumentCode(), account.Dimension(), account.Balance().Precision(), balanceCents)
 	if err != nil {
 		return domain.CurrentAccount{}, fmt.Errorf("failed to create balance: %w", err)
 	}

--- a/services/current-account/service/lien_helpers.go
+++ b/services/current-account/service/lien_helpers.go
@@ -158,7 +158,7 @@ func (s *Service) checkLienIdempotency(ctx context.Context, paymentOrderRef stri
 // Position Keeping is the source of truth for account balances - this method MUST be called
 // before any operation that requires the current balance.
 func (s *Service) hydrateAccountWithBalance(ctx context.Context, account domain.CurrentAccount) (domain.CurrentAccount, error) {
-	balanceCents, err := s.getAccountBalanceCents(ctx, account.AccountID())
+	balanceCents, err := s.getAccountBalanceMinorUnits(ctx, account.AccountID(), account.InstrumentCode(), account.Balance().Precision())
 	if err != nil {
 		return domain.CurrentAccount{}, fmt.Errorf("failed to get balance from Position Keeping: %w", err)
 	}
@@ -232,24 +232,19 @@ func (s *Service) hydrateAccountWithPrefetchedBalance(account domain.CurrentAcco
 		Build(), nil
 }
 
-// currentAccountInstrumentCode is the instrument code used for Current Account balance queries.
-// Current Account operates exclusively with GBP currency (CURRENCY dimension).
-// The Internal Account service will use different instrument codes for multi-asset support.
-const currentAccountInstrumentCode = "GBP"
-
-// getAccountBalanceCents gets the account balance in cents from Position Keeping service.
+// getAccountBalanceMinorUnits gets the account balance from Position Keeping service.
 // Position Keeping is the mandatory source of truth for all account balances.
-// Uses the multi-asset API with explicit instrument_code="GBP" for currency operations.
-// Returns balance in minor units (cents/pence).
-func (s *Service) getAccountBalanceCents(ctx context.Context, accountID string) (int64, error) {
+// Uses the multi-asset API with the account's instrument code and precision.
+// Returns balance in minor units (e.g., cents for GBP precision=2, whole units for KWH precision=0).
+func (s *Service) getAccountBalanceMinorUnits(ctx context.Context, accountID, instrumentCode string, precision int) (int64, error) {
 	resp, err := s.posKeepingClient.GetAccountBalance(ctx, &positionkeepingv1.GetAccountBalanceRequest{
 		AccountId:      accountID,
 		BalanceType:    positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
-		InstrumentCode: currentAccountInstrumentCode, // Explicit instrument for multi-asset API
+		InstrumentCode: instrumentCode,
 	})
 	if err != nil {
 		s.logger.Error("failed to get balance from Position Keeping",
-			"account_id", accountID, "instrument_code", currentAccountInstrumentCode, "error", err)
+			"account_id", accountID, "instrument_code", instrumentCode, "error", err)
 		return 0, fmt.Errorf("failed to get balance from Position Keeping: %w", err)
 	}
 
@@ -259,14 +254,14 @@ func (s *Service) getAccountBalanceCents(ctx context.Context, accountID string) 
 
 	// Validate that the response instrument matches the requested instrument.
 	// This guards against configuration mismatches where Position Keeping might
-	// return a different currency than expected.
-	if resp.Amount.InstrumentCode != currentAccountInstrumentCode {
+	// return a different instrument than expected.
+	if resp.Amount.InstrumentCode != instrumentCode {
 		s.logger.Error("instrument code mismatch in balance response",
 			"account_id", accountID,
-			"expected", currentAccountInstrumentCode,
+			"expected", instrumentCode,
 			"received", resp.Amount.InstrumentCode)
 		return 0, fmt.Errorf("%w: expected %s, got %s",
-			ErrInstrumentCodeMismatch, currentAccountInstrumentCode, resp.Amount.InstrumentCode)
+			ErrInstrumentCodeMismatch, instrumentCode, resp.Amount.InstrumentCode)
 	}
 
 	// Parse InstrumentAmount as decimal
@@ -277,19 +272,21 @@ func (s *Service) getAccountBalanceCents(ctx context.Context, accountID string) 
 		return 0, fmt.Errorf("failed to parse balance amount: %w", err)
 	}
 
-	// Convert to minor units (cents/pence) - multiply by 100 for 2 decimal currencies.
+	// Convert to minor units using the instrument's precision.
+	// For GBP (precision=2): multiply by 100. For KWH (precision=0): multiply by 1.
 	// Uses banker's rounding (round-to-even) which differs from half-up at .5 boundaries:
 	// e.g., 0.015 -> 2 (rounds to even), 0.025 -> 2 (rounds to even), 0.035 -> 4 (rounds to even)
-	cents := amount.Mul(decimal.NewFromInt(100)).RoundBank(0)
+	// #nosec G115 - precision is bounded by instrument definition (0-9 in practice)
+	minorUnits := amount.Shift(int32(precision)).RoundBank(0)
 
 	// Check for overflow using int64 bounds
 	maxInt64 := decimal.NewFromInt(math.MaxInt64)
 	minInt64 := decimal.NewFromInt(math.MinInt64)
-	if cents.GreaterThan(maxInt64) || cents.LessThan(minInt64) {
+	if minorUnits.GreaterThan(maxInt64) || minorUnits.LessThan(minInt64) {
 		return 0, ErrAmountOverflow
 	}
 
-	return cents.IntPart(), nil
+	return minorUnits.IntPart(), nil
 }
 
 // calculateAvailableBalance calculates available balance with active liens.

--- a/services/current-account/service/lien_helpers.go
+++ b/services/current-account/service/lien_helpers.go
@@ -235,7 +235,7 @@ func (s *Service) hydrateAccountWithPrefetchedBalance(account domain.CurrentAcco
 // getAccountBalanceMinorUnits gets the account balance from Position Keeping service.
 // Position Keeping is the mandatory source of truth for all account balances.
 // Uses the multi-asset API with the account's instrument code and precision.
-// Returns balance in minor units (e.g., cents for GBP precision=2, whole units for KWH precision=0).
+// Returns balance in minor units scaled by the given precision.
 func (s *Service) getAccountBalanceMinorUnits(ctx context.Context, accountID, instrumentCode string, precision int) (int64, error) {
 	resp, err := s.posKeepingClient.GetAccountBalance(ctx, &positionkeepingv1.GetAccountBalanceRequest{
 		AccountId:      accountID,
@@ -272,10 +272,8 @@ func (s *Service) getAccountBalanceMinorUnits(ctx context.Context, accountID, in
 		return 0, fmt.Errorf("failed to parse balance amount: %w", err)
 	}
 
-	// Convert to minor units using the instrument's precision.
-	// For GBP (precision=2): multiply by 100. For KWH (precision=0): multiply by 1.
-	// Uses banker's rounding (round-to-even) which differs from half-up at .5 boundaries:
-	// e.g., 0.015 -> 2 (rounds to even), 0.025 -> 2 (rounds to even), 0.035 -> 4 (rounds to even)
+	// Convert to minor units using the instrument's precision (Shift by precision digits).
+	// Uses banker's rounding (round-to-even) which differs from half-up at .5 boundaries.
 	// #nosec G115 - precision is bounded by instrument definition (0-9 in practice)
 	minorUnits := amount.Shift(int32(precision)).RoundBank(0)
 

--- a/services/current-account/service/lien_lifecycle.go
+++ b/services/current-account/service/lien_lifecycle.go
@@ -161,7 +161,7 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 
 	bucketID := req.BucketId
 
-	prefetchedBalanceCents, err := s.getAccountBalanceCents(ctx, req.AccountId)
+	prefetchedBalanceCents, err := s.getAccountBalanceMinorUnits(ctx, req.AccountId, prefetchedAccount.InstrumentCode(), prefetchedAccount.Balance().Precision())
 	if err != nil {
 		operationStatus = opStatusRetrieveFailed
 		s.logger.Error("failed to prefetch balance from Position Keeping",
@@ -437,7 +437,7 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 	// Note: Currently Position Keeping returns total balance regardless of bucket.
 	// The lien's bucket_id is used for bucket-scoped lien calculations within Current Account,
 	// but the balance comes from total Position Keeping balance.
-	prefetchedBalanceCents, err := s.getAccountBalanceCents(ctx, prefetchAccount.AccountID())
+	prefetchedBalanceCents, err := s.getAccountBalanceMinorUnits(ctx, prefetchAccount.AccountID(), prefetchAccount.InstrumentCode(), prefetchAccount.Balance().Precision())
 	if err != nil {
 		operationStatus = opStatusRetrieveFailed
 		s.logger.Error("failed to prefetch balance from Position Keeping",


### PR DESCRIPTION
## Summary

- Fix `getAccountBalanceCents` which hardcoded GBP as the instrument code and used a fixed `* 100` multiplier for minor unit conversion, breaking non-fiat instruments (KWH, CARBON_CREDIT)
- Rename to `getAccountBalanceMinorUnits` accepting `instrumentCode` and `precision` parameters
- Use `decimal.Shift(precision)` for dimension-agnostic minor unit conversion
- Update all three callers (`hydrateAccountWithBalance`, `InitiateLien`, `ExecuteLien`) to pass the account's instrument metadata

## Root Cause

The `getAccountBalanceCents` function in `lien_helpers.go` had three hardcoded GBP assumptions:
1. Queried Position Keeping with `instrument_code="GBP"` regardless of account type
2. Validated response instrument against hardcoded "GBP"
3. Converted to minor units using `amount * 100` (2 decimal places)

For non-fiat accounts (e.g., KWH with dimension ENERGY, CARBON_CREDIT with dimension CARBON), this caused instrument mismatch errors from Position Keeping or incorrect balance values.

## Task Master

Task: manifest-integrity.8 - Fix balance creation for non-fiat instruments

## Test Plan

- [x] Existing GBP balance retrieval tests updated and passing
- [x] New tests for KWH (precision 0 and 3) balance retrieval
- [x] New tests for CARBON_CREDIT balance retrieval
- [x] New test for instrument mismatch with non-fiat instrument
- [x] New tests for hydrating KWH and CARBON_CREDIT accounts with balance
- [x] New test for prefetched balance with KWH accounts
- [x] All current-account service tests passing