### PR TITLE
fix: Seed platform manifest during bootstrap for Economy pages

### DIFF
--- a/internal/bootstrap/master_tenant.go
+++ b/internal/bootstrap/master_tenant.go
@@ -81,6 +81,11 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("manifest validation: %w", err)
 	}
 
+	// Step 4: Seed platform manifest into master tenant schema
+	if err := seedPlatformManifest(ctx, cfg.PlatformDB, logger); err != nil {
+		return fmt.Errorf("seed platform manifest: %w", err)
+	}
+
 	logger.Info("master tenant bootstrap completed successfully")
 	return nil
 }
@@ -165,6 +170,37 @@ func validatePlatformManifest(logger *slog.Logger) error {
 		"account_types", len(mf.AccountTypes),
 		"valuation_rules", len(mf.ValuationRules),
 		"warnings", len(result.Warnings))
+	return nil
+}
+
+// seedPlatformManifest stores the platform manifest in the master tenant's
+// manifest_versions table so the Economy and Starlark Config pages display
+// content immediately after bootstrap. Idempotent - skips if a manifest
+// version already exists.
+func seedPlatformManifest(ctx context.Context, db *gorm.DB, logger *slog.Logger) error {
+	logger.Info("seeding platform manifest into master tenant schema")
+
+	tenantID := tenant.TenantID(MasterTenantID)
+	tenantCtx := tenant.WithTenant(ctx, tenantID)
+
+	mf, err := LoadPlatformManifest()
+	if err != nil {
+		return fmt.Errorf("load platform manifest: %w", err)
+	}
+
+	seeded, err := controlplaneservice.SeedManifestVersion(tenantCtx, db, mf, "system:bootstrap")
+	if err != nil {
+		return fmt.Errorf("seed manifest version: %w", err)
+	}
+
+	if !seeded {
+		logger.Info("platform manifest already seeded, skipping")
+		return nil
+	}
+
+	logger.Info("platform manifest seeded successfully",
+		"tenant_id", MasterTenantID,
+		"version", mf.Version)
 	return nil
 }
 

--- a/services/control-plane/internal/differ/persistence/manifest_version_store.go
+++ b/services/control-plane/internal/differ/persistence/manifest_version_store.go
@@ -110,10 +110,11 @@ func (s *PostgresManifestVersionStore) Save(ctx context.Context, manifest *contr
 }
 
 // setSearchPath sets the PostgreSQL search_path for tenant isolation.
+// Returns tenant.ErrMissingTenantContext if the context has no tenant ID.
 func (s *PostgresManifestVersionStore) setSearchPath(ctx context.Context, tx pgx.Tx) error {
 	tenantID, ok := tenant.FromContext(ctx)
 	if !ok {
-		return nil
+		return tenant.ErrMissingTenantContext
 	}
 
 	schemaName := pgx.Identifier{tenantID.SchemaName()}.Sanitize()

--- a/services/control-plane/internal/differ/persistence/manifest_version_store_test.go
+++ b/services/control-plane/internal/differ/persistence/manifest_version_store_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -105,15 +106,14 @@ func TestGetLatestApplied_WithoutTenant(t *testing.T) {
 	pool := testdb.NewTestPool(t, testdb.WithMigrations("control-plane"))
 	store := NewPostgresManifestVersionStore(pool)
 
-	// Use plain context without tenant - should still work (no search_path set)
+	// Use plain context without tenant - should return error
 	ctx := context.Background()
 
-	// Save and retrieve without tenant context
 	err := store.Save(ctx, testManifest(), "no-tenant-user")
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, tenant.ErrMissingTenantContext)
 
-	result, err := store.GetLatestApplied(ctx)
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	assert.Equal(t, 1, result.Version)
+	_, err = store.GetLatestApplied(ctx)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, tenant.ErrMissingTenantContext)
 }

--- a/services/control-plane/service/bootstrap_test.go
+++ b/services/control-plane/service/bootstrap_test.go
@@ -230,6 +230,82 @@ func (f *fakeManifestValidator) ValidateDryRun(_ context.Context, _ string) (*ge
 }
 
 // ---------------------------------------------------------------------------
+// SeedManifestVersion tests
+// ---------------------------------------------------------------------------
+
+func TestSeedManifestVersion_NilDB(t *testing.T) {
+	_, err := SeedManifestVersion(context.Background(), nil, &controlplanev1.Manifest{}, "test")
+	require.ErrorIs(t, err, ErrDBRequired)
+}
+
+func TestSeedManifestVersion_StoresManifest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires testcontainer")
+	}
+
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+	defer cleanup()
+
+	tc := testdb.SetupTenantSchema(t, db, "test_tenant")
+	defer tc.Cleanup()
+	testdb.CreateTable(t, tc.DB, tc.Tenant, manifestVersionsDDL)
+
+	mf := &controlplanev1.Manifest{
+		Version:  "1.0",
+		Metadata: &controlplanev1.ManifestMetadata{Name: "Test", Industry: "platform"},
+	}
+
+	seeded, err := SeedManifestVersion(tc.Ctx, tc.DB, mf, "system:bootstrap")
+	require.NoError(t, err)
+	assert.True(t, seeded, "expected manifest to be seeded on first call")
+}
+
+func TestSeedManifestVersion_Idempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires testcontainer")
+	}
+
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+	defer cleanup()
+
+	tc := testdb.SetupTenantSchema(t, db, "test_tenant")
+	defer tc.Cleanup()
+	testdb.CreateTable(t, tc.DB, tc.Tenant, manifestVersionsDDL)
+
+	mf := &controlplanev1.Manifest{
+		Version:  "1.0",
+		Metadata: &controlplanev1.ManifestMetadata{Name: "Test", Industry: "platform"},
+	}
+
+	seeded1, err := SeedManifestVersion(tc.Ctx, tc.DB, mf, "system:bootstrap")
+	require.NoError(t, err)
+	assert.True(t, seeded1)
+
+	seeded2, err := SeedManifestVersion(tc.Ctx, tc.DB, mf, "system:bootstrap")
+	require.NoError(t, err)
+	assert.False(t, seeded2, "expected second call to skip seeding")
+}
+
+const manifestVersionsDDL = `CREATE TABLE IF NOT EXISTS %s.manifest_versions (
+	id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+	version VARCHAR(50) NOT NULL,
+	manifest_json JSONB NOT NULL,
+	applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+	applied_by VARCHAR(255) NOT NULL,
+	apply_status VARCHAR(20) NOT NULL DEFAULT 'APPLIED',
+	apply_job_id UUID,
+	diff_summary TEXT,
+	relationship_graph JSONB,
+	sequence_number BIGINT NOT NULL DEFAULT 0,
+	checksum VARCHAR(64),
+	source VARCHAR(20),
+	resource_path VARCHAR(255),
+	phase_status JSONB,
+	created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+	CONSTRAINT valid_apply_status CHECK (apply_status IN ('APPLIED', 'FAILED', 'ROLLED_BACK', 'PARTIAL'))
+)`
+
+// ---------------------------------------------------------------------------
 // NewHandlerDeps test
 // ---------------------------------------------------------------------------
 

--- a/services/control-plane/service/manifest_history.go
+++ b/services/control-plane/service/manifest_history.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -65,4 +66,40 @@ func RegisterManifestHistoryService(server *grpc.Server, cfg ManifestHistoryServ
 
 	controlplanev1.RegisterManifestHistoryServiceServer(server, handler)
 	return nil
+}
+
+// SeedManifestVersion stores a manifest as the initial applied version in the
+// tenant's manifest_versions table. Idempotent - returns (false, nil) if a
+// manifest version already exists. The context must carry tenant identity via
+// tenant.WithTenant. Returns (true, nil) when a new version was stored.
+func SeedManifestVersion(ctx context.Context, db *gorm.DB, mf *controlplanev1.Manifest, appliedBy string) (bool, error) {
+	if db == nil {
+		return false, ErrDBRequired
+	}
+
+	repo, err := manifest.NewRepository(db)
+	if err != nil {
+		return false, fmt.Errorf("manifest repository: %w", err)
+	}
+
+	historySvc, err := manifest.NewHistoryService(repo)
+	if err != nil {
+		return false, fmt.Errorf("manifest history service: %w", err)
+	}
+
+	// Check if a manifest already exists - skip if so (idempotent)
+	_, err = historySvc.GetCurrentManifest(ctx)
+	if err == nil {
+		return false, nil
+	}
+	if !errors.Is(err, manifest.ErrVersionNotFound) {
+		return false, fmt.Errorf("check existing manifest: %w", err)
+	}
+
+	_, err = historySvc.StoreManifestVersion(ctx, mf, appliedBy, nil, manifest.ApplyStatusApplied, nil, 0)
+	if err != nil {
+		return false, fmt.Errorf("store manifest version: %w", err)
+	}
+
+	return true, nil
 }


### PR DESCRIPTION
## Summary

- After a DB reset, the Economy page (/economy) and Starlark Config page (/starlark-config) showed empty content because bootstrap only validated the platform manifest without storing it in `manifest_versions`
- Added `seedPlatformManifest` step to bootstrap that stores the embedded platform manifest as an applied version in the master tenant schema (idempotent - skips if already seeded)
- Fixed `PostgresManifestVersionStore.setSearchPath()` to return `tenant.ErrMissingTenantContext` when tenant context is missing, consistent with all other tenant-scoped stores. Previously it silently succeeded, causing data to be written to the public schema instead of the tenant schema

## Changes

| File | Change |
|------|--------|
| `internal/bootstrap/master_tenant.go` | Added step 4: `seedPlatformManifest` using `SeedManifestVersion` from control-plane service |
| `services/control-plane/service/manifest_history.go` | Added `SeedManifestVersion()` public API for storing initial manifest version with idempotency |
| `services/control-plane/internal/differ/persistence/manifest_version_store.go` | Fixed `setSearchPath` to return error on missing tenant context |
| `services/control-plane/internal/differ/persistence/manifest_version_store_test.go` | Updated test to verify error on missing tenant context |
| `services/control-plane/service/bootstrap_test.go` | Added integration tests for `SeedManifestVersion` (stores + idempotency) |

## Root Cause

The bootstrap process had three steps:
1. Provision org_meridian_master schemas
2. Ensure platform saga definition exists
3. Validate embedded platform manifest

Step 3 only validated the manifest JSON but never persisted it. The frontend calls `getCurrentManifest()` which queries `manifest_versions` - an empty table after DB reset returns NotFound, rendering empty pages.

Additionally, `PostgresManifestVersionStore.setSearchPath()` silently returned nil when tenant context was missing (line 116: `return nil`), which meant any writes without proper tenant context would silently go to the public schema instead of failing.

## Test Plan

- [x] Unit tests pass (`go test -short`)
- [x] `TestSeedManifestVersion_StoresManifest` - verifies manifest is stored on first call
- [x] `TestSeedManifestVersion_Idempotent` - verifies second call returns false (already seeded)
- [x] `TestGetLatestApplied_WithoutTenant` - updated to verify error on missing tenant context
- [x] All existing differ persistence integration tests pass
- [ ] CI passes