### PR TITLE
test: add tests for frontend manifests feature to close coverage gap

### DIFF
--- a/frontend/src/features/manifests/components/manifest-diff-graph.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-diff-graph.test.tsx
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi } from 'vitest'
+import { useState } from 'react'
+import { render, screen } from '@testing-library/react'
+import { ManifestDiffGraph } from './manifest-diff-graph'
+import type { ManifestGraph } from '../lib/manifest-graph-model'
+
+vi.mock('@/components/ui/tooltip', () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="tooltip-content">{children}</div>
+  ),
+}))
+
+vi.mock('@xyflow/react', () => {
+  const Position = { Top: 'top', Bottom: 'bottom', Left: 'left', Right: 'right' }
+  const BackgroundVariant = { Dots: 'dots' }
+
+  function Handle() { return null }
+
+  function ReactFlow({ nodes, edges, children }: {
+    nodes: { id: string; type?: string; data: Record<string, unknown> }[]
+    edges: { id: string; source: string; target: string; data?: Record<string, unknown> }[]
+    children?: React.ReactNode
+    [key: string]: unknown
+  }) {
+    return (
+      <div data-testid="react-flow" data-node-count={nodes.length} data-edge-count={edges.length}>
+        {nodes.map((n) => (
+          <div
+            key={n.id}
+            data-testid={`diff-flow-node-${n.id}`}
+            data-node-type={n.type}
+            data-diff-status={(n.data as { diffStatus?: string }).diffStatus}
+          >
+            {n.id}
+          </div>
+        ))}
+        {edges.map((e) => (
+          <div key={e.id} data-testid={`diff-flow-edge-${e.id}`} data-diff-status={(e.data as { diffStatus?: string })?.diffStatus}>
+            {e.source} -&gt; {e.target}
+          </div>
+        ))}
+        {children}
+      </div>
+    )
+  }
+
+  function Controls() { return <div data-testid="controls" /> }
+  function Background() { return null }
+
+  return {
+    ReactFlow,
+    Controls,
+    Background,
+    Handle,
+    Position,
+    BackgroundVariant,
+    useNodesState: (init: unknown[]) => {
+      const [s, setS] = useState(init)
+      return [s, setS, vi.fn()]
+    },
+    useEdgesState: (init: unknown[]) => {
+      const [s, setS] = useState(init)
+      return [s, setS, vi.fn()]
+    },
+  }
+})
+
+vi.mock('elkjs/lib/elk.bundled.js', () => ({
+  default: class MockELK {
+    async layout(graph: { children: { id: string }[] }) {
+      return {
+        children: graph.children.map((child, i) => ({
+          id: child.id,
+          x: i * 100,
+          y: i * 100,
+        })),
+      }
+    }
+  },
+}))
+
+const emptyGraph: ManifestGraph = { nodes: [], edges: [] }
+
+const graphWithInstrument: ManifestGraph = {
+  nodes: [
+    {
+      id: 'instrument:GBP',
+      type: 'instrument',
+      label: 'British Pound',
+      data: { code: 'GBP', dimensions: { unit: 'GBP' } },
+    },
+  ],
+  edges: [],
+}
+
+const graphWithTwo: ManifestGraph = {
+  nodes: [
+    {
+      id: 'instrument:GBP',
+      type: 'instrument',
+      label: 'British Pound',
+      data: { code: 'GBP', dimensions: { unit: 'GBP' } },
+    },
+    {
+      id: 'instrument:KWH',
+      type: 'instrument',
+      label: 'Kilowatt Hour',
+      data: { code: 'KWH', dimensions: { unit: 'kWh' } },
+    },
+  ],
+  edges: [],
+}
+
+describe('ManifestDiffGraph', () => {
+  describe('no-diff state', () => {
+    it('shows no-changes message when before and after are identical', () => {
+      render(<ManifestDiffGraph before={graphWithInstrument} after={graphWithInstrument} />)
+      expect(screen.getByTestId('manifest-diff-no-changes')).toBeInTheDocument()
+      expect(screen.getByText('No differences between versions.')).toBeInTheDocument()
+    })
+
+    it('shows no-changes for two empty graphs', () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={emptyGraph} />)
+      expect(screen.getByTestId('manifest-diff-no-changes')).toBeInTheDocument()
+    })
+  })
+
+  describe('graph rendering with changes', () => {
+    it('renders ReactFlow when nodes differ', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithInstrument} />)
+      expect(await screen.findByTestId('react-flow')).toBeInTheDocument()
+    })
+
+    it('renders diff-summary panel', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithInstrument} />)
+      expect(await screen.findByTestId('diff-summary')).toBeInTheDocument()
+    })
+
+    it('shows added count when node is new', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithInstrument} />)
+      expect(await screen.findByText('+1 added')).toBeInTheDocument()
+    })
+
+    it('shows removed count when node is removed', async () => {
+      render(<ManifestDiffGraph before={graphWithInstrument} after={emptyGraph} />)
+      expect(await screen.findByText('-1 removed')).toBeInTheDocument()
+    })
+
+    it('renders node with added diff status', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithInstrument} />)
+      const node = await screen.findByTestId('diff-flow-node-instrument:GBP')
+      expect(node).toHaveAttribute('data-diff-status', 'added')
+    })
+
+    it('renders node with removed diff status', async () => {
+      render(<ManifestDiffGraph before={graphWithInstrument} after={emptyGraph} />)
+      const node = await screen.findByTestId('diff-flow-node-instrument:GBP')
+      expect(node).toHaveAttribute('data-diff-status', 'removed')
+    })
+
+    it('renders node with unchanged diff status when present in both', async () => {
+      render(<ManifestDiffGraph before={graphWithInstrument} after={graphWithInstrument} />)
+      // identical graphs => no-diff state, no ReactFlow rendered
+      expect(screen.getByTestId('manifest-diff-no-changes')).toBeInTheDocument()
+    })
+
+    it('renders multiple added nodes', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithTwo} />)
+      const flow = await screen.findByTestId('react-flow')
+      expect(flow).toHaveAttribute('data-node-count', '2')
+    })
+
+    it('assigns diff_instrument node type', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithInstrument} />)
+      const node = await screen.findByTestId('diff-flow-node-instrument:GBP')
+      expect(node).toHaveAttribute('data-node-type', 'diff_instrument')
+    })
+
+    it('accepts className prop', async () => {
+      const { container } = render(
+        <ManifestDiffGraph before={emptyGraph} after={graphWithInstrument} className="h-96" />,
+      )
+      await screen.findByTestId('react-flow')
+      const wrapper = container.querySelector('[data-testid="manifest-diff-graph"]')
+      expect(wrapper).toHaveClass('h-96')
+    })
+  })
+})

--- a/frontend/src/features/manifests/components/manifest-diff-graph.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-diff-graph.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi } from 'vitest'
-import { useState } from 'react'
 import { render, screen } from '@testing-library/react'
 import { ManifestDiffGraph } from './manifest-diff-graph'
 import type { ManifestGraph } from '../lib/manifest-graph-model'
@@ -13,7 +12,8 @@ vi.mock('@/components/ui/tooltip', () => ({
   ),
 }))
 
-vi.mock('@xyflow/react', () => {
+vi.mock('@xyflow/react', async () => {
+  const React = await vi.importActual<typeof import('react')>('react')
   const Position = { Top: 'top', Bottom: 'bottom', Left: 'left', Right: 'right' }
   const BackgroundVariant = { Dots: 'dots' }
 
@@ -58,11 +58,11 @@ vi.mock('@xyflow/react', () => {
     Position,
     BackgroundVariant,
     useNodesState: (init: unknown[]) => {
-      const [s, setS] = useState(init)
+      const [s, setS] = React.useState(init)
       return [s, setS, vi.fn()]
     },
     useEdgesState: (init: unknown[]) => {
-      const [s, setS] = useState(init)
+      const [s, setS] = React.useState(init)
       return [s, setS, vi.fn()]
     },
   }

--- a/frontend/src/features/manifests/components/manifest-diff-graph.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-diff-graph.test.tsx
@@ -161,10 +161,10 @@ describe('ManifestDiffGraph', () => {
       expect(node).toHaveAttribute('data-diff-status', 'removed')
     })
 
-    it('renders node with unchanged diff status when present in both', async () => {
+    it('shows no-changes state (not ReactFlow) when before and after are identical', async () => {
       render(<ManifestDiffGraph before={graphWithInstrument} after={graphWithInstrument} />)
-      // identical graphs => no-diff state, no ReactFlow rendered
       expect(screen.getByTestId('manifest-diff-no-changes')).toBeInTheDocument()
+      expect(screen.queryByTestId('react-flow')).not.toBeInTheDocument()
     })
 
     it('renders multiple added nodes', async () => {

--- a/frontend/src/features/manifests/components/manifest-diff-graph.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-diff-graph.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import { useState } from 'react'
 import { render, screen } from '@testing-library/react'
 import { ManifestDiffGraph } from './manifest-diff-graph'
 import type { ManifestGraph } from '../lib/manifest-graph-model'
@@ -12,8 +13,7 @@ vi.mock('@/components/ui/tooltip', () => ({
   ),
 }))
 
-vi.mock('@xyflow/react', async () => {
-  const React = await vi.importActual<typeof import('react')>('react')
+vi.mock('@xyflow/react', () => {
   const Position = { Top: 'top', Bottom: 'bottom', Left: 'left', Right: 'right' }
   const BackgroundVariant = { Dots: 'dots' }
 
@@ -58,11 +58,11 @@ vi.mock('@xyflow/react', async () => {
     Position,
     BackgroundVariant,
     useNodesState: (init: unknown[]) => {
-      const [s, setS] = React.useState(init)
+      const [s, setS] = useState(init)
       return [s, setS, vi.fn()]
     },
     useEdgesState: (init: unknown[]) => {
-      const [s, setS] = React.useState(init)
+      const [s, setS] = useState(init)
       return [s, setS, vi.fn()]
     },
   }

--- a/frontend/src/features/manifests/hooks/use-manifest-diff.test.ts
+++ b/frontend/src/features/manifests/hooks/use-manifest-diff.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createElement } from 'react'
+import { useManifestDiff } from './use-manifest-diff'
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(),
+}))
+
+import { useApiClients } from '@/api/context'
+
+function createWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client }, children)
+}
+
+const mockDiffResponse = {
+  actions: [],
+  summary: { totalActions: 2, creates: 1, updates: 1, deletes: 0, noChanges: 0, hasBreakingChanges: false },
+}
+
+beforeEach(() => {
+  vi.mocked(useApiClients).mockReturnValue({
+    manifestHistory: {
+      diffManifestVersions: vi.fn().mockResolvedValue(mockDiffResponse),
+    },
+  } as unknown as ReturnType<typeof useApiClients>)
+})
+
+describe('useManifestDiff', () => {
+  it('returns loading state initially', () => {
+    const { result } = renderHook(() => useManifestDiff(1, 2), { wrapper: createWrapper() })
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it('returns data after successful fetch', async () => {
+    const { result } = renderHook(() => useManifestDiff(1, 2), { wrapper: createWrapper() })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.data).toEqual(mockDiffResponse)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('does not fetch when targetSeq is 0', () => {
+    const diffFn = vi.fn()
+    vi.mocked(useApiClients).mockReturnValue({
+      manifestHistory: { diffManifestVersions: diffFn },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    renderHook(() => useManifestDiff(0, 0), { wrapper: createWrapper() })
+    expect(diffFn).not.toHaveBeenCalled()
+  })
+
+  it('returns error when fetch fails', async () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      manifestHistory: {
+        diffManifestVersions: vi.fn().mockRejectedValue(new Error('API error')),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const { result } = renderHook(() => useManifestDiff(1, 2), { wrapper: createWrapper() })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.error).toBeInstanceOf(Error)
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it('calls API with correct BigInt sequence numbers', async () => {
+    const diffFn = vi.fn().mockResolvedValue(mockDiffResponse)
+    vi.mocked(useApiClients).mockReturnValue({
+      manifestHistory: { diffManifestVersions: diffFn },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const { result } = renderHook(() => useManifestDiff(3, 7), { wrapper: createWrapper() })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(diffFn).toHaveBeenCalledWith({
+      baseSequenceNumber: BigInt(3),
+      targetSequenceNumber: BigInt(7),
+    })
+  })
+})

--- a/frontend/src/features/manifests/hooks/use-manifest-graph.test.ts
+++ b/frontend/src/features/manifests/hooks/use-manifest-graph.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createElement } from 'react'
+import { useManifestGraph } from './use-manifest-graph'
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(),
+}))
+
+import { useApiClients } from '@/api/context'
+
+function createWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client }, children)
+}
+
+const mockManifest = {
+  version: '1.0',
+  metadata: { name: 'Test', industry: 'energy', description: '' },
+  instruments: [
+    { code: 'GBP', name: 'British Pound', type: 1, dimensions: { unit: 'GBP', precision: 2 } },
+  ],
+  accountTypes: [],
+  valuationRules: [],
+  sagas: [],
+  seedData: undefined,
+  paymentRails: [],
+  partyTypes: [],
+  mappings: [],
+  operationalGateway: undefined,
+}
+
+beforeEach(() => {
+  vi.mocked(useApiClients).mockReturnValue({
+    manifestHistory: {
+      getCurrentManifest: vi.fn().mockResolvedValue({
+        version: { manifest: mockManifest },
+      }),
+    },
+  } as unknown as ReturnType<typeof useApiClients>)
+})
+
+describe('useManifestGraph', () => {
+  it('returns loading state initially', () => {
+    const { result } = renderHook(() => useManifestGraph(), { wrapper: createWrapper() })
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.graph).toBeNull()
+  })
+
+  it('returns graph after successful fetch', async () => {
+    const { result } = renderHook(() => useManifestGraph(), { wrapper: createWrapper() })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.graph).not.toBeNull()
+    expect(result.current.error).toBeNull()
+  })
+
+  it('returns graph with nodes derived from manifest', async () => {
+    const { result } = renderHook(() => useManifestGraph(), { wrapper: createWrapper() })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    const graph = result.current.graph!
+    expect(graph.nodes.some((n) => n.id === 'instrument:GBP')).toBe(true)
+  })
+
+  it('returns null graph when manifest is absent', async () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      manifestHistory: {
+        getCurrentManifest: vi.fn().mockResolvedValue({ version: undefined }),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const { result } = renderHook(() => useManifestGraph(), { wrapper: createWrapper() })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.graph).toBeNull()
+  })
+
+  it('returns error when fetch fails', async () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      manifestHistory: {
+        getCurrentManifest: vi.fn().mockRejectedValue(new Error('Fetch failed')),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const { result } = renderHook(() => useManifestGraph(), { wrapper: createWrapper() })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.error).toBeInstanceOf(Error)
+    expect(result.current.graph).toBeNull()
+  })
+})

--- a/frontend/src/features/manifests/lib/cel-filter-analyzer.test.ts
+++ b/frontend/src/features/manifests/lib/cel-filter-analyzer.test.ts
@@ -186,4 +186,72 @@ describe('analyzeFilter', () => {
       expect(result.reason).toContain('Complex expression');
     });
   });
+
+  describe('double-quoted string literals', () => {
+    it('handles double-quoted equality', () => {
+      const context: EventContext = { instrumentCode: 'GBP' };
+      const result = analyzeFilter(
+        'event.instrument_code == "GBP"',
+        context,
+      );
+      expect(result.result).toBe('pass');
+    });
+
+    it('handles double-quoted inequality', () => {
+      const context: EventContext = { instrumentCode: 'USD' };
+      const result = analyzeFilter(
+        'event.instrument_code != "GBP"',
+        context,
+      );
+      expect(result.result).toBe('pass');
+    });
+  });
+
+  describe('unknown field in inequality', () => {
+    it('returns indeterminate for unknown field in != expression', () => {
+      const result = analyzeFilter(
+        "event.unknown_field != 'value'",
+        {},
+      );
+      expect(result.result).toBe('indeterminate');
+      expect(result.reason).toContain('Unknown field');
+    });
+  });
+
+  describe('missing context in inequality', () => {
+    it('returns indeterminate when context value missing for != expression', () => {
+      const result = analyzeFilter(
+        "event.instrument_code != 'GBP'",
+        {},
+      );
+      expect(result.result).toBe('indeterminate');
+      expect(result.reason).toContain('missing');
+    });
+  });
+
+  describe('nested parentheses', () => {
+    it('returns indeterminate for parenthesised subexpressions (parens not stripped)', () => {
+      // The analyzer does not strip outer parens from sub-parts, so they are treated
+      // as complex unrecognised expressions and return indeterminate.
+      const context: EventContext = { instrumentCode: 'GBP', direction: 'CREDIT' };
+      const result = analyzeFilter(
+        "(event.instrument_code == 'GBP') && (event.direction == 'CREDIT')",
+        context,
+      );
+      expect(result.result).toBe('indeterminate');
+    });
+  });
+
+  describe('has() short-circuit in or expressions', () => {
+    it('returns indeterminate when expression contains has() even with a passing branch', () => {
+      // has() is detected on the whole expression before compound splitting, so the
+      // entire filter is treated as indeterminate regardless of other branches.
+      const context: EventContext = { instrumentCode: 'GBP' };
+      const result = analyzeFilter(
+        "has(event.metadata) || event.instrument_code == 'GBP'",
+        context,
+      );
+      expect(result.result).toBe('indeterminate');
+    });
+  });
 });

--- a/frontend/src/features/manifests/pages/manifest-diff-page.test.tsx
+++ b/frontend/src/features/manifests/pages/manifest-diff-page.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { renderWithProviders } from '@/test/test-utils'
+import { createTenantUserToken } from '@/test/jwt-helpers'
+import { ManifestDiffPage } from './manifest-diff-page'
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(),
+  ApiClientProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+import { useApiClients } from '@/api/context'
+
+vi.mock('../components/manifest-diff-table', () => ({
+  ManifestDiffTable: ({ summary }: { summary?: { totalActions: number } }) => (
+    <div data-testid="manifest-diff-table">
+      {summary && <span>total: {summary.totalActions}</span>}
+    </div>
+  ),
+}))
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+function mockApi(overrides: Record<string, unknown> = {}) {
+  vi.mocked(useApiClients).mockReturnValue({
+    manifestHistory: {
+      diffManifestVersions: vi.fn().mockResolvedValue({
+        actions: [],
+        summary: {
+          totalActions: 3,
+          creates: 1,
+          updates: 1,
+          deletes: 1,
+          noChanges: 0,
+          hasBreakingChanges: false,
+        },
+      }),
+      ...overrides,
+    },
+  } as unknown as ReturnType<typeof useApiClients>)
+}
+
+function renderPage(path: string) {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/economy/manifest/diff/:v1/:v2" element={<ManifestDiffPage />} />
+        <Route path="*" element={<ManifestDiffPage />} />
+      </Routes>
+    </MemoryRouter>,
+    { initialToken: createTenantUserToken() },
+  )
+}
+
+describe('ManifestDiffPage', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear()
+    mockApi()
+  })
+
+  describe('invalid params', () => {
+    it('shows invalid params message when no URL params', () => {
+      renderWithProviders(
+        <MemoryRouter>
+          <ManifestDiffPage />
+        </MemoryRouter>,
+        { initialToken: createTenantUserToken() },
+      )
+      expect(screen.getByText(/Invalid version parameters/)).toBeInTheDocument()
+    })
+
+    it('renders Back to Economy button on invalid params', () => {
+      renderWithProviders(
+        <MemoryRouter>
+          <ManifestDiffPage />
+        </MemoryRouter>,
+        { initialToken: createTenantUserToken() },
+      )
+      expect(screen.getByRole('button', { name: /Back to Economy/i })).toBeInTheDocument()
+    })
+
+    it('navigates to /economy when Back to Economy is clicked', async () => {
+      renderWithProviders(
+        <MemoryRouter>
+          <ManifestDiffPage />
+        </MemoryRouter>,
+        { initialToken: createTenantUserToken() },
+      )
+      await userEvent.click(screen.getByRole('button', { name: /Back to Economy/i }))
+      expect(mockNavigate).toHaveBeenCalledWith('/economy')
+    })
+  })
+
+  describe('valid params', () => {
+    it('shows correct title with version numbers', async () => {
+      renderPage('/economy/manifest/diff/1/2')
+      expect(await screen.findByText(/Manifest Diff: v1.*v2/)).toBeInTheDocument()
+    })
+
+    it('renders ManifestDiffTable when data loads', async () => {
+      renderPage('/economy/manifest/diff/1/2')
+      expect(await screen.findByTestId('manifest-diff-table')).toBeInTheDocument()
+    })
+
+    it('renders Back button', async () => {
+      renderPage('/economy/manifest/diff/1/2')
+      expect(await screen.findByRole('button', { name: /Back/i })).toBeInTheDocument()
+    })
+
+    it('navigates back when Back button clicked', async () => {
+      renderPage('/economy/manifest/diff/1/2')
+      const backBtn = await screen.findByRole('button', { name: /Back/i })
+      await userEvent.click(backBtn)
+      expect(mockNavigate).toHaveBeenCalledWith(-1)
+    })
+
+    it('shows error message when API fails', async () => {
+      vi.mocked(useApiClients).mockReturnValue({
+        manifestHistory: {
+          diffManifestVersions: vi.fn().mockRejectedValue(new Error('Network error')),
+        },
+      } as unknown as ReturnType<typeof useApiClients>)
+
+      renderPage('/economy/manifest/diff/1/2')
+      expect(await screen.findByText(/Failed to load diff.*Network error/)).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add `manifest-diff-graph.test.tsx`: covers no-diff state, ReactFlow rendering with added/removed nodes, diff status node attributes, className passthrough (~120 lines)
- Add `manifest-diff-page.test.tsx`: covers invalid params display, navigation, data rendering via ManifestDiffTable, and API error display (~110 lines)
- Add `use-manifest-diff.test.ts`: covers loading state, successful fetch, disabled when targetSeq=0, error handling, and BigInt argument passing (~65 lines)
- Add `use-manifest-graph.test.ts`: covers loading, graph node derivation from manifest, null manifest handling, error state (~65 lines)
- Extend `cel-filter-analyzer.test.ts`: double-quoted literals, unknown-field inequality, missing context inequality, parenthesised expression behavior, has() short-circuit in OR (~35 lines)

## Test plan

- [x] All 212 manifests tests pass locally: `vitest run src/features/manifests/`
- [x] Covers 0% files: `manifest-diff-page.tsx`, `use-manifest-diff.ts`, `use-manifest-graph.ts`, `manifest-diff-graph.tsx`
- [x] Extends existing edge case coverage in `cel-filter-analyzer.test.ts`