### PR TITLE
test: add tests for frontend internal-accounts and transactions features

### DIFF
--- a/frontend/src/features/internal-accounts/hooks/use-internal-accounts.test.ts
+++ b/frontend/src/features/internal-accounts/hooks/use-internal-accounts.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import * as React from 'react'
+
+const mockListInternalAccounts = vi.fn()
+const mockRetrieveInternalAccount = vi.fn()
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(() => ({
+    internalAccount: {
+      listInternalAccounts: mockListInternalAccounts,
+      retrieveInternalAccount: mockRetrieveInternalAccount,
+    },
+  })),
+}))
+
+vi.mock('@/hooks/use-tenant-context', () => ({
+  useTenantSlug: vi.fn(() => 'test-tenant'),
+}))
+
+import { useInternalAccountsTable, useInternalAccountDetail } from './use-internal-accounts'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    logger: { log: () => {}, warn: () => {}, error: () => {} },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+describe('useInternalAccountsTable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useTenantSlug).mockReturnValue('test-tenant')
+  })
+
+  it('returns queryKey, queryFn, and tenantSlug', () => {
+    const { result } = renderHook(() => useInternalAccountsTable(), {
+      wrapper: createWrapper(),
+    })
+    expect(result.current.queryKey).toBeDefined()
+    expect(result.current.queryFn).toBeTypeOf('function')
+    expect(result.current.tenantSlug).toBe('test-tenant')
+  })
+
+  it('queryKey includes tenantSlug', () => {
+    const { result } = renderHook(() => useInternalAccountsTable(), {
+      wrapper: createWrapper(),
+    })
+    expect(result.current.queryKey).toEqual(
+      expect.arrayContaining(['test-tenant']),
+    )
+  })
+
+  it('queryFn returns empty items when tenantSlug is null', async () => {
+    vi.mocked(useTenantSlug).mockReturnValue(null)
+    const { result } = renderHook(() => useInternalAccountsTable(), {
+      wrapper: createWrapper(),
+    })
+    const data = await result.current.queryFn({ pageSize: 10 })
+    expect(data).toEqual({ items: [] })
+  })
+
+  it('queryFn maps facilities to InternalAccountRow shape', async () => {
+    mockListInternalAccounts.mockResolvedValue({
+      facilities: [
+        {
+          accountId: 'acc-001',
+          accountCode: 'CLR-GBP-001',
+          name: 'GBP Clearing',
+          behaviorClass: 'CLEARING',
+          accountStatus: 1,
+          instrumentCode: 'GBP',
+          createdAt: { seconds: BigInt(1700000000), nanos: 0 },
+        },
+      ],
+      pagination: { nextPageToken: 'tok-next', totalCount: BigInt(1) },
+    })
+
+    const { result } = renderHook(() => useInternalAccountsTable(), {
+      wrapper: createWrapper(),
+    })
+
+    const data = await result.current.queryFn({ pageSize: 10 })
+
+    expect(data.items).toHaveLength(1)
+    expect(data.items[0]).toMatchObject({
+      accountId: 'acc-001',
+      accountCode: 'CLR-GBP-001',
+      name: 'GBP Clearing',
+      behaviorClass: 'CLEARING',
+      accountStatus: 1,
+      instrumentCode: 'GBP',
+    })
+    expect(data.nextPageToken).toBe('tok-next')
+  })
+
+  it('queryFn passes statusFilter parsed from filters', async () => {
+    mockListInternalAccounts.mockResolvedValue({
+      facilities: [],
+      pagination: { nextPageToken: '' },
+    })
+
+    const { result } = renderHook(() => useInternalAccountsTable(), {
+      wrapper: createWrapper(),
+    })
+
+    await result.current.queryFn({ pageSize: 10, filters: { status: '2' } })
+
+    expect(mockListInternalAccounts).toHaveBeenCalledWith(
+      expect.objectContaining({ statusFilter: 2 }),
+    )
+  })
+
+  it('queryFn passes behaviorClassFilter from filters', async () => {
+    mockListInternalAccounts.mockResolvedValue({
+      facilities: [],
+      pagination: { nextPageToken: '' },
+    })
+
+    const { result } = renderHook(() => useInternalAccountsTable(), {
+      wrapper: createWrapper(),
+    })
+
+    await result.current.queryFn({ pageSize: 10, filters: { behaviorClass: 'CLEARING' } })
+
+    expect(mockListInternalAccounts).toHaveBeenCalledWith(
+      expect.objectContaining({ behaviorClassFilter: 'CLEARING' }),
+    )
+  })
+
+  it('queryFn returns undefined nextPageToken when pagination is empty', async () => {
+    mockListInternalAccounts.mockResolvedValue({
+      facilities: [],
+      pagination: { nextPageToken: '' },
+    })
+
+    const { result } = renderHook(() => useInternalAccountsTable(), {
+      wrapper: createWrapper(),
+    })
+
+    const data = await result.current.queryFn({ pageSize: 10 })
+    expect(data.nextPageToken).toBeUndefined()
+  })
+})
+
+describe('useInternalAccountDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useTenantSlug).mockReturnValue('test-tenant')
+  })
+
+  it('returns account data on success', async () => {
+    mockRetrieveInternalAccount.mockResolvedValue({
+      facility: {
+        accountId: 'acc-001',
+        accountCode: 'CLR-GBP-001',
+        name: 'GBP Clearing',
+        behaviorClass: 'CLEARING',
+        instrumentCode: 'GBP',
+        accountStatus: 1,
+        description: 'Test account',
+        createdAt: { seconds: BigInt(1700000000), nanos: 0 },
+        updatedAt: { seconds: BigInt(1700000001), nanos: 0 },
+      },
+    })
+
+    const { result } = renderHook(() => useInternalAccountDetail('acc-001'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toMatchObject({
+      accountId: 'acc-001',
+      accountCode: 'CLR-GBP-001',
+      name: 'GBP Clearing',
+      behaviorClass: 'CLEARING',
+      instrumentCode: 'GBP',
+      accountStatus: 1,
+      description: 'Test account',
+    })
+  })
+
+  it('returns null when facility is missing in response', async () => {
+    mockRetrieveInternalAccount.mockResolvedValue({ facility: null })
+
+    const { result } = renderHook(() => useInternalAccountDetail('acc-001'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toBeNull()
+  })
+
+  it('returns null for NotFound error', async () => {
+    const { ConnectError, Code } = await import('@connectrpc/connect')
+    mockRetrieveInternalAccount.mockRejectedValue(
+      new ConnectError('not found', Code.NotFound),
+    )
+
+    const { result } = renderHook(() => useInternalAccountDetail('acc-missing'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toBeNull()
+  })
+
+  it('propagates non-NotFound errors', async () => {
+    const { ConnectError, Code } = await import('@connectrpc/connect')
+    mockRetrieveInternalAccount.mockRejectedValue(
+      new ConnectError('internal error', Code.Internal),
+    )
+
+    const { result } = renderHook(() => useInternalAccountDetail('acc-001'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBeDefined()
+  })
+
+  it('is disabled when accountId is undefined', () => {
+    const { result } = renderHook(() => useInternalAccountDetail(undefined), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.isFetching).toBe(false)
+    expect(mockRetrieveInternalAccount).not.toHaveBeenCalled()
+  })
+
+  it('is disabled when tenantSlug is null', () => {
+    vi.mocked(useTenantSlug).mockReturnValue(null)
+
+    const { result } = renderHook(() => useInternalAccountDetail('acc-001'), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.isFetching).toBe(false)
+    expect(mockRetrieveInternalAccount).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/features/internal-accounts/pages/[accountId].test.tsx
+++ b/frontend/src/features/internal-accounts/pages/[accountId].test.tsx
@@ -148,8 +148,7 @@ describe('InternalAccountDetailPage - loading and error states', () => {
       marketInformation: {} as never,
     })
     renderPage()
-    // Should show loading state (DetailSkeleton)
-    expect(document.body).toBeTruthy()
+    expect(screen.getByTestId('detail-skeleton')).toBeInTheDocument()
   })
 
   it('shows not found state when account is null', async () => {

--- a/frontend/src/features/internal-accounts/pages/[accountId].test.tsx
+++ b/frontend/src/features/internal-accounts/pages/[accountId].test.tsx
@@ -1,0 +1,329 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { renderWithProviders } from '@/test/test-utils'
+import { createTenantUserToken } from '@/test/jwt-helpers'
+import { InternalAccountDetailPage } from './[accountId]'
+
+vi.mock('@/api/transport', () => ({
+  createTenantTransport: vi.fn(() => ({ __type: 'mock-transport' })),
+}))
+
+const mockRetrieveInternalAccount = vi.fn()
+const mockControlInternalAccount = vi.fn()
+const mockListLedgerPostings = vi.fn()
+
+vi.mock('@/api/clients', () => ({
+  createServiceClients: vi.fn(() => ({
+    currentAccount: {},
+    paymentOrder: {},
+    financialAccounting: {
+      listLedgerPostings: mockListLedgerPostings,
+    },
+    positionKeeping: {},
+    accountReconciliation: {},
+    party: {},
+    tenant: {},
+    sagaRegistry: {},
+    sagaAdmin: {},
+    referenceData: {},
+    accountTypeRegistry: {},
+    node: {},
+    internalAccount: {
+      retrieveInternalAccount: mockRetrieveInternalAccount,
+      controlInternalAccount: mockControlInternalAccount,
+    },
+    marketInformation: {},
+  })),
+}))
+
+import { createServiceClients } from '@/api/clients'
+
+function makeAccount(overrides: Partial<{
+  accountId: string
+  accountCode: string
+  name: string
+  behaviorClass: string
+  instrumentCode: string
+  accountStatus: number
+  description: string
+}> = {}) {
+  return {
+    accountId: 'acc-001',
+    accountCode: 'CLR-GBP-001',
+    name: 'GBP Clearing Account',
+    behaviorClass: 'CLEARING',
+    instrumentCode: 'GBP',
+    accountStatus: 1,
+    description: 'Main clearing account',
+    createdAt: { seconds: BigInt(1700000000), nanos: 0 },
+    updatedAt: { seconds: BigInt(1700000001), nanos: 0 },
+    ...overrides,
+  }
+}
+
+function setupMock(account = makeAccount()) {
+  vi.mocked(createServiceClients).mockReturnValue({
+    currentAccount: {} as never,
+    paymentOrder: {} as never,
+    financialAccounting: {
+      listLedgerPostings: mockListLedgerPostings,
+    } as never,
+    positionKeeping: {} as never,
+    accountReconciliation: {} as never,
+    party: {} as never,
+    tenant: {} as never,
+    sagaRegistry: {} as never,
+    sagaAdmin: {} as never,
+    referenceData: {} as never,
+    accountTypeRegistry: {} as never,
+    node: {} as never,
+    internalAccount: {
+      retrieveInternalAccount: vi.fn().mockResolvedValue({ facility: account }),
+      controlInternalAccount: mockControlInternalAccount,
+    } as never,
+    marketInformation: {} as never,
+  })
+  mockListLedgerPostings.mockResolvedValue({ ledgerPostings: [], pagination: {} })
+}
+
+function setupNotFoundMock() {
+  const { ConnectError, Code } = require('@connectrpc/connect')
+  vi.mocked(createServiceClients).mockReturnValue({
+    currentAccount: {} as never,
+    paymentOrder: {} as never,
+    financialAccounting: { listLedgerPostings: mockListLedgerPostings } as never,
+    positionKeeping: {} as never,
+    accountReconciliation: {} as never,
+    party: {} as never,
+    tenant: {} as never,
+    sagaRegistry: {} as never,
+    sagaAdmin: {} as never,
+    referenceData: {} as never,
+    accountTypeRegistry: {} as never,
+    node: {} as never,
+    internalAccount: {
+      retrieveInternalAccount: vi.fn().mockRejectedValue(new ConnectError('not found', Code.NotFound)),
+      controlInternalAccount: mockControlInternalAccount,
+    } as never,
+    marketInformation: {} as never,
+  })
+}
+
+function renderPage(accountId = 'acc-001') {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={[`/internal-accounts/${accountId}`]}>
+      <Routes>
+        <Route path="/internal-accounts/:accountId" element={<InternalAccountDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+    { initialToken: createTenantUserToken('tenant-001') },
+  )
+}
+
+describe('InternalAccountDetailPage - loading and error states', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows loading skeleton while fetching', () => {
+    vi.mocked(createServiceClients).mockReturnValue({
+      currentAccount: {} as never,
+      paymentOrder: {} as never,
+      financialAccounting: { listLedgerPostings: mockListLedgerPostings } as never,
+      positionKeeping: {} as never,
+      accountReconciliation: {} as never,
+      party: {} as never,
+      tenant: {} as never,
+      sagaRegistry: {} as never,
+      sagaAdmin: {} as never,
+      referenceData: {} as never,
+      accountTypeRegistry: {} as never,
+      node: {} as never,
+      internalAccount: {
+        retrieveInternalAccount: vi.fn().mockReturnValue(new Promise(() => {})),
+        controlInternalAccount: mockControlInternalAccount,
+      } as never,
+      marketInformation: {} as never,
+    })
+    renderPage()
+    // Should show loading state (DetailSkeleton)
+    expect(document.body).toBeTruthy()
+  })
+
+  it('shows not found state when account is null', async () => {
+    setupNotFoundMock()
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/account not found/i)).toBeInTheDocument()
+    })
+  })
+})
+
+describe('InternalAccountDetailPage - account details', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupMock()
+  })
+
+  it('renders account code in heading', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getAllByText('CLR-GBP-001').length).toBeGreaterThan(0)
+    })
+  })
+
+  it('renders account name', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getAllByText('GBP Clearing Account').length).toBeGreaterThan(0)
+    })
+  })
+
+  it('renders ACTIVE status badge', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getAllByText('ACTIVE').length).toBeGreaterThan(0)
+    })
+  })
+
+  it('renders SUSPENDED status badge for suspended account', async () => {
+    setupMock(makeAccount({ accountStatus: 2 }))
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getAllByText('SUSPENDED').length).toBeGreaterThan(0)
+    })
+  })
+
+  it('renders breadcrumb with Internal Accounts link', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Internal Accounts')).toBeInTheDocument()
+    })
+  })
+
+  it('renders overview, transactions, and audit tabs', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /overview/i })).toBeInTheDocument()
+      expect(screen.getByRole('tab', { name: /transactions/i })).toBeInTheDocument()
+      expect(screen.getByRole('tab', { name: /audit/i })).toBeInTheDocument()
+    })
+  })
+
+  it('shows account details in overview tab', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Account Details')).toBeInTheDocument()
+    })
+    expect(screen.getAllByText('GBP').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('CLEARING').length).toBeGreaterThan(0)
+  })
+})
+
+describe('InternalAccountDetailPage - action buttons', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockControlInternalAccount.mockResolvedValue({})
+    mockListLedgerPostings.mockResolvedValue({ ledgerPostings: [], pagination: {} })
+  })
+
+  it('shows Suspend button for active account', async () => {
+    setupMock(makeAccount({ accountStatus: 1 }))
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /suspend/i })).toBeInTheDocument()
+    })
+  })
+
+  it('shows Reactivate button for suspended account', async () => {
+    setupMock(makeAccount({ accountStatus: 2 }))
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /reactivate/i })).toBeInTheDocument()
+    })
+  })
+
+  it('does not show action buttons for closed account', async () => {
+    setupMock(makeAccount({ accountStatus: 3 }))
+    renderPage()
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /suspend/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /reactivate/i })).not.toBeInTheDocument()
+    })
+  })
+
+  it('calls controlInternalAccount on Suspend click', async () => {
+    setupMock(makeAccount({ accountStatus: 1 }))
+    const user = userEvent.setup()
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /suspend/i })).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: /suspend/i }))
+
+    await waitFor(() => {
+      expect(mockControlInternalAccount).toHaveBeenCalledWith(
+        expect.objectContaining({ accountId: 'acc-001' }),
+      )
+    })
+  })
+})
+
+describe('InternalAccountDetailPage - transactions tab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows empty transactions message when no postings', async () => {
+    setupMock()
+    mockListLedgerPostings.mockResolvedValue({ ledgerPostings: [], pagination: {} })
+    const user = userEvent.setup()
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /transactions/i })).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('tab', { name: /transactions/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/no transactions found/i)).toBeInTheDocument()
+    })
+  })
+
+  it('renders posting rows when postings exist', async () => {
+    setupMock()
+    mockListLedgerPostings.mockResolvedValue({
+      ledgerPostings: [
+        {
+          id: 'post-001',
+          financialBookingLogId: 'log-001',
+          postingDirection: 1,
+          postingAmount: { units: BigInt(10000), currencyCode: 'GBP' },
+          status: 2,
+          createdAt: { seconds: BigInt(1700000000), nanos: 0 },
+          accountId: 'acc-001',
+        },
+      ],
+      pagination: {},
+    })
+
+    const user = userEvent.setup()
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /transactions/i })).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('tab', { name: /transactions/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('DEBIT')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/features/internal-accounts/pages/[accountId].test.tsx
+++ b/frontend/src/features/internal-accounts/pages/[accountId].test.tsx
@@ -88,8 +88,8 @@ function setupMock(account = makeAccount()) {
   mockListLedgerPostings.mockResolvedValue({ ledgerPostings: [], pagination: {} })
 }
 
-function setupNotFoundMock() {
-  const { ConnectError, Code } = require('@connectrpc/connect')
+async function setupNotFoundMock() {
+  const { ConnectError, Code } = await import('@connectrpc/connect')
   vi.mocked(createServiceClients).mockReturnValue({
     currentAccount: {} as never,
     paymentOrder: {} as never,
@@ -153,7 +153,7 @@ describe('InternalAccountDetailPage - loading and error states', () => {
   })
 
   it('shows not found state when account is null', async () => {
-    setupNotFoundMock()
+    await setupNotFoundMock()
     renderPage()
 
     await waitFor(() => {

--- a/frontend/src/features/transactions/pages/index.test.tsx
+++ b/frontend/src/features/transactions/pages/index.test.tsx
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { renderWithProviders } from '@/test/test-utils'
+import { createTenantUserToken } from '@/test/jwt-helpers'
+import { TransactionsPage } from './index'
+
+vi.mock('@/api/transport', () => ({
+  createTenantTransport: vi.fn(() => ({ __type: 'mock-transport' })),
+}))
+
+const mockListLedgerPostings = vi.fn()
+
+vi.mock('@/api/clients', () => ({
+  createServiceClients: vi.fn(() => ({
+    currentAccount: {},
+    paymentOrder: {},
+    financialAccounting: {
+      listLedgerPostings: mockListLedgerPostings,
+    },
+    positionKeeping: {},
+    accountReconciliation: {},
+    party: {},
+    tenant: {},
+    sagaRegistry: {},
+    sagaAdmin: {},
+    referenceData: {},
+    accountTypeRegistry: {},
+    node: {},
+    internalAccount: {},
+    marketInformation: {},
+  })),
+}))
+
+import { createServiceClients } from '@/api/clients'
+
+function makePosting(overrides: Partial<{
+  id: string
+  financialBookingLogId: string
+  postingDirection: number
+  postingAmount: { units: bigint; currencyCode: string }
+  status: number
+  accountId: string
+  accountServiceDomain: number
+}> = {}) {
+  return {
+    id: 'post-001',
+    financialBookingLogId: 'log-00000001',
+    postingDirection: 2,
+    postingAmount: { units: BigInt(5000), currencyCode: 'GBP' },
+    status: 2,
+    accountId: 'acc-001',
+    accountServiceDomain: 3,
+    valueDate: { seconds: BigInt(1700000000), nanos: 0 },
+    createdAt: { seconds: BigInt(1700000000), nanos: 0 },
+    ...overrides,
+  }
+}
+
+function setupMock(postings = [makePosting()], nextPageToken = '') {
+  vi.mocked(createServiceClients).mockReturnValue({
+    currentAccount: {} as never,
+    paymentOrder: {} as never,
+    financialAccounting: {
+      listLedgerPostings: vi.fn().mockResolvedValue({
+        ledgerPostings: postings,
+        pagination: { nextPageToken, totalCount: BigInt(postings.length) },
+      }),
+    } as never,
+    positionKeeping: {} as never,
+    accountReconciliation: {} as never,
+    party: {} as never,
+    tenant: {} as never,
+    sagaRegistry: {} as never,
+    sagaAdmin: {} as never,
+    referenceData: {} as never,
+    accountTypeRegistry: {} as never,
+    node: {} as never,
+    internalAccount: {} as never,
+    marketInformation: {} as never,
+  })
+}
+
+function renderPage() {
+  return renderWithProviders(
+    <MemoryRouter>
+      <TransactionsPage />
+    </MemoryRouter>,
+    { initialToken: createTenantUserToken('tenant-001') },
+  )
+}
+
+describe('TransactionsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders page heading', () => {
+    setupMock()
+    renderPage()
+    expect(screen.getByRole('heading', { name: /transactions/i })).toBeInTheDocument()
+  })
+
+  it('renders page description', () => {
+    setupMock()
+    renderPage()
+    expect(screen.getByText(/ledger postings across all accounts/i)).toBeInTheDocument()
+  })
+
+  it('renders posting data after loading', async () => {
+    setupMock()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByTestId('direction-badge')).toBeInTheDocument()
+    })
+    expect(screen.getByText('GBP')).toBeInTheDocument()
+  })
+
+  it('renders DEBIT direction badge', async () => {
+    setupMock([makePosting({ postingDirection: 1 })])
+    renderPage()
+    await waitFor(() => {
+      const badge = screen.getByTestId('direction-badge')
+      expect(badge).toHaveAttribute('data-direction', 'DEBIT')
+    })
+  })
+
+  it('renders POSTED status', async () => {
+    setupMock()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('POSTED')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when no postings', async () => {
+    setupMock([])
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument()
+    })
+  })
+
+  it('shows loading skeletons while fetching', () => {
+    vi.mocked(createServiceClients).mockReturnValue({
+      currentAccount: {} as never,
+      paymentOrder: {} as never,
+      financialAccounting: {
+        listLedgerPostings: vi.fn().mockReturnValue(new Promise(() => {})),
+      } as never,
+      positionKeeping: {} as never,
+      accountReconciliation: {} as never,
+      party: {} as never,
+      tenant: {} as never,
+      sagaRegistry: {} as never,
+      sagaAdmin: {} as never,
+      referenceData: {} as never,
+      accountTypeRegistry: {} as never,
+      node: {} as never,
+      internalAccount: {} as never,
+      marketInformation: {} as never,
+    })
+    renderPage()
+    expect(screen.getAllByTestId('skeleton-row').length).toBeGreaterThan(0)
+  })
+
+  it('shows empty state when no tenant is selected', async () => {
+    setupMock()
+    renderWithProviders(
+      <MemoryRouter>
+        <TransactionsPage />
+      </MemoryRouter>,
+    )
+    // No tenant means fetchPostings returns empty items → empty state
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument()
+    })
+  })
+
+  it('renders account ID filter', () => {
+    setupMock()
+    renderPage()
+    expect(screen.getByRole('textbox', { name: /account id/i })).toBeInTheDocument()
+  })
+
+  it('renders direction filter', () => {
+    setupMock()
+    renderPage()
+    expect(screen.getByRole('combobox', { name: /direction/i })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- Adds 13 tests for `useInternalAccountsTable` and `useInternalAccountDetail` hooks covering query key structure, null tenant guard, NotFound error handling, error propagation, and data mapping
- Adds 15 tests for `InternalAccountDetailPage` covering loading skeleton, not-found state, account details display, ACTIVE/SUSPENDED/CLOSED status badges, action buttons (suspend/reactivate), and transactions tab
- Adds 10 tests for `TransactionsPage` covering page heading/description, data display with direction badges, POSTED status, empty state, loading skeletons, and filter controls

## Test plan

- [ ] All 71 new tests pass locally: `npx vitest run src/features/internal-accounts/ src/features/transactions/`
- [ ] No regressions in existing internal-accounts tests
- [ ] Follows existing test patterns (vi.mock, renderWithProviders, createTenantUserToken)