### PR TITLE
test: add targeted unit tests for backend flame graph hotspots

### DIFF
--- a/services/control-plane/internal/manifest/export_coverage_test.go
+++ b/services/control-plane/internal/manifest/export_coverage_test.go
@@ -1,292 +1,292 @@
 package manifest
 
 import (
-    "context"
-    "errors"
-    "testing"
+	"context"
+	"errors"
+	"testing"
 
-    controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/require"
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestNewExportService_ValidInputs verifies the happy path constructor.
 func TestNewExportService_ValidInputs(t *testing.T) {
-    repo := &Repository{}
-    history, err := NewHistoryService(repo)
-    require.NoError(t, err)
+	repo := &Repository{}
+	history, err := NewHistoryService(repo)
+	require.NoError(t, err)
 
-    svc, err := NewExportService(history, &ExportCollectors{})
-    require.NoError(t, err)
-    require.NotNil(t, svc)
+	svc, err := NewExportService(history, &ExportCollectors{})
+	require.NoError(t, err)
+	require.NotNil(t, svc)
 }
 
 // TestNewExportService_NilCollectors_DefaultsToEmpty verifies that passing nil
 // collectors is treated as an empty collectors set (no panic, no error).
 func TestNewExportService_NilCollectors_DefaultsToEmpty(t *testing.T) {
-    repo := &Repository{}
-    history, err := NewHistoryService(repo)
-    require.NoError(t, err)
+	repo := &Repository{}
+	history, err := NewHistoryService(repo)
+	require.NoError(t, err)
 
-    svc, err := NewExportService(history, nil)
-    require.NoError(t, err)
-    require.NotNil(t, svc)
+	svc, err := NewExportService(history, nil)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
 
-    // Verify that a collect call with nil collectors and nil fallback is a no-op.
-    result := &ExportResult{
-        Manifest:       &controlplanev1.Manifest{Version: "1.0"},
-        SectionSources: make(map[string]string),
-    }
-    svc.collectInstruments(context.Background(), result, nil, "")
-    assert.Nil(t, result.Manifest.Instruments)
-    assert.Empty(t, result.SectionSources)
+	// Verify that a collect call with nil collectors and nil fallback is a no-op.
+	result := &ExportResult{
+		Manifest:       &controlplanev1.Manifest{Version: "1.0"},
+		SectionSources: make(map[string]string),
+	}
+	svc.collectInstruments(context.Background(), result, nil, "")
+	assert.Nil(t, result.Manifest.Instruments)
+	assert.Empty(t, result.SectionSources)
 }
 
 // TestIsNotFound_WrappedError verifies that isNotFound detects wrapped ErrVersionNotFound.
 func TestIsNotFound_WrappedError(t *testing.T) {
-    wrapped := errors.New("context: " + ErrVersionNotFound.Error())
-    // Direct wrapping via %w.
-    wrapErr := errors.Join(ErrVersionNotFound, errors.New("extra context"))
-    assert.True(t, isNotFound(ErrVersionNotFound))
-    assert.False(t, isNotFound(wrapped))
-    assert.True(t, isNotFound(wrapErr))
+	wrapped := errors.New("context: " + ErrVersionNotFound.Error())
+	// Direct wrapping via %w.
+	wrapErr := errors.Join(ErrVersionNotFound, errors.New("extra context"))
+	assert.True(t, isNotFound(ErrVersionNotFound))
+	assert.False(t, isNotFound(wrapped))
+	assert.True(t, isNotFound(wrapErr))
 }
 
 // TestExportService_CollectFallbackOnlySections_WithNilFallback verifies that
 // all fallback-only collect functions are no-ops when fallback is nil.
 func TestExportService_CollectFallbackOnlySections_WithNilFallback(t *testing.T) {
-    svc := &ExportService{collectors: &ExportCollectors{}}
+	svc := &ExportService{collectors: &ExportCollectors{}}
 
-    result := &ExportResult{
-        Manifest:       &controlplanev1.Manifest{},
-        SectionSources: make(map[string]string),
-    }
+	result := &ExportResult{
+		Manifest:       &controlplanev1.Manifest{},
+		SectionSources: make(map[string]string),
+	}
 
-    svc.collectValuationRules(result, nil, "")
-    assert.Nil(t, result.Manifest.ValuationRules)
-    assert.Empty(t, result.SectionSources["valuation_rules"])
+	svc.collectValuationRules(result, nil, "")
+	assert.Nil(t, result.Manifest.ValuationRules)
+	assert.Empty(t, result.SectionSources["valuation_rules"])
 
-    svc.collectMappings(result, nil, "")
-    assert.Nil(t, result.Manifest.Mappings)
-    assert.Empty(t, result.SectionSources["mappings"])
+	svc.collectMappings(result, nil, "")
+	assert.Nil(t, result.Manifest.Mappings)
+	assert.Empty(t, result.SectionSources["mappings"])
 
-    svc.collectPartyTypes(result, nil, "")
-    assert.Nil(t, result.Manifest.PartyTypes)
-    assert.Empty(t, result.SectionSources["party_types"])
+	svc.collectPartyTypes(result, nil, "")
+	assert.Nil(t, result.Manifest.PartyTypes)
+	assert.Empty(t, result.SectionSources["party_types"])
 
-    svc.collectPaymentRails(result, nil, "")
-    assert.Nil(t, result.Manifest.PaymentRails)
-    assert.Empty(t, result.SectionSources["payment_rails"])
+	svc.collectPaymentRails(result, nil, "")
+	assert.Nil(t, result.Manifest.PaymentRails)
+	assert.Empty(t, result.SectionSources["payment_rails"])
 }
 
 // TestExportService_CollectOrganizations_WithNilFallback verifies no panic when
 // the organizations collector errors and there is no fallback.
 func TestExportService_CollectOrganizations_WithNilFallback(t *testing.T) {
-    svc := &ExportService{
-        collectors: &ExportCollectors{
-            Organizations: &mockOrganizationCollector{err: errors.New("timeout")},
-        },
-    }
-    result := &ExportResult{
-        Manifest:       &controlplanev1.Manifest{},
-        SectionSources: make(map[string]string),
-    }
+	svc := &ExportService{
+		collectors: &ExportCollectors{
+			Organizations: &mockOrganizationCollector{err: errors.New("timeout")},
+		},
+	}
+	result := &ExportResult{
+		Manifest:       &controlplanev1.Manifest{},
+		SectionSources: make(map[string]string),
+	}
 
-    svc.collectOrganizations(context.Background(), result, nil, "")
-    assert.Nil(t, result.Manifest.Organizations)
-    require.Len(t, result.Warnings, 1)
-    assert.Contains(t, result.Warnings[0], "timeout")
+	svc.collectOrganizations(context.Background(), result, nil, "")
+	assert.Nil(t, result.Manifest.Organizations)
+	require.Len(t, result.Warnings, 1)
+	assert.Contains(t, result.Warnings[0], "timeout")
 }
 
 // TestExportService_CollectInternalAccounts_WithNilFallback verifies no panic
 // when internal accounts collector errors without fallback.
 func TestExportService_CollectInternalAccounts_WithNilFallback(t *testing.T) {
-    svc := &ExportService{
-        collectors: &ExportCollectors{
-            InternalAccounts: &mockInternalAccountCollector{err: errors.New("unreachable")},
-        },
-    }
-    result := &ExportResult{
-        Manifest:       &controlplanev1.Manifest{},
-        SectionSources: make(map[string]string),
-    }
+	svc := &ExportService{
+		collectors: &ExportCollectors{
+			InternalAccounts: &mockInternalAccountCollector{err: errors.New("unreachable")},
+		},
+	}
+	result := &ExportResult{
+		Manifest:       &controlplanev1.Manifest{},
+		SectionSources: make(map[string]string),
+	}
 
-    svc.collectInternalAccounts(context.Background(), result, nil, "")
-    assert.Nil(t, result.Manifest.InternalAccounts)
-    require.Len(t, result.Warnings, 1)
-    assert.Contains(t, result.Warnings[0], "unreachable")
+	svc.collectInternalAccounts(context.Background(), result, nil, "")
+	assert.Nil(t, result.Manifest.InternalAccounts)
+	require.Len(t, result.Warnings, 1)
+	assert.Contains(t, result.Warnings[0], "unreachable")
 }
 
 // TestExportService_CollectOperationalGateway_WithNilFallback verifies no panic
 // when gateway collector errors without fallback.
 func TestExportService_CollectOperationalGateway_WithNilFallback(t *testing.T) {
-    svc := &ExportService{
-        collectors: &ExportCollectors{
-            OperationalGateway: &mockOperationalGatewayCollector{
-                connErr:  errors.New("gateway down"),
-                routeErr: errors.New("route fail"),
-            },
-        },
-    }
-    result := &ExportResult{
-        Manifest:       &controlplanev1.Manifest{},
-        SectionSources: make(map[string]string),
-    }
+	svc := &ExportService{
+		collectors: &ExportCollectors{
+			OperationalGateway: &mockOperationalGatewayCollector{
+				connErr:  errors.New("gateway down"),
+				routeErr: errors.New("route fail"),
+			},
+		},
+	}
+	result := &ExportResult{
+		Manifest:       &controlplanev1.Manifest{},
+		SectionSources: make(map[string]string),
+	}
 
-    svc.collectOperationalGateway(context.Background(), result, nil, "")
-    assert.Nil(t, result.Manifest.OperationalGateway)
-    require.Len(t, result.Warnings, 1)
-    assert.Contains(t, result.Warnings[0], "gateway down")
-    assert.Contains(t, result.Warnings[0], "route fail")
+	svc.collectOperationalGateway(context.Background(), result, nil, "")
+	assert.Nil(t, result.Manifest.OperationalGateway)
+	require.Len(t, result.Warnings, 1)
+	assert.Contains(t, result.Warnings[0], "gateway down")
+	assert.Contains(t, result.Warnings[0], "route fail")
 }
 
 // TestExportService_CollectMarketData_WithNilFallback verifies no panic when
 // market data collector errors without fallback.
 func TestExportService_CollectMarketData_WithNilFallback(t *testing.T) {
-    svc := &ExportService{
-        collectors: &ExportCollectors{
-            MarketData: &mockMarketDataCollector{srcErr: errors.New("market error")},
-        },
-    }
-    result := &ExportResult{
-        Manifest:       &controlplanev1.Manifest{},
-        SectionSources: make(map[string]string),
-    }
+	svc := &ExportService{
+		collectors: &ExportCollectors{
+			MarketData: &mockMarketDataCollector{srcErr: errors.New("market error")},
+		},
+	}
+	result := &ExportResult{
+		Manifest:       &controlplanev1.Manifest{},
+		SectionSources: make(map[string]string),
+	}
 
-    svc.collectMarketData(context.Background(), result, nil, "")
-    assert.Nil(t, result.Manifest.MarketData)
-    require.Len(t, result.Warnings, 1)
-    assert.Contains(t, result.Warnings[0], "market error")
+	svc.collectMarketData(context.Background(), result, nil, "")
+	assert.Nil(t, result.Manifest.MarketData)
+	require.Len(t, result.Warnings, 1)
+	assert.Contains(t, result.Warnings[0], "market error")
 }
 
 // TestExportService_ManifestChecksumEmpty verifies checksum of empty manifest.
 func TestExportService_ManifestChecksumEmpty(t *testing.T) {
-    sum, err := manifestChecksum(&controlplanev1.Manifest{})
-    require.NoError(t, err)
-    assert.Len(t, sum, 64)
-    assert.NotEmpty(t, sum)
+	sum, err := manifestChecksum(&controlplanev1.Manifest{})
+	require.NoError(t, err)
+	assert.Len(t, sum, 64)
+	assert.NotEmpty(t, sum)
 }
 
 // TestExportResult_ToProtoResponse_EmptyWarnings verifies nil warnings are
 // preserved correctly in the proto response.
 func TestExportResult_ToProtoResponse_EmptyWarnings(t *testing.T) {
-    result := &ExportResult{
-        Manifest:       &controlplanev1.Manifest{Version: "2.0"},
-        Checksum:       "deadbeef",
-        SectionSources: map[string]string{},
-        Warnings:       nil,
-    }
-    resp := result.ToProtoResponse()
-    assert.Equal(t, "2.0", resp.Manifest.Version)
-    assert.Nil(t, resp.Warnings)
+	result := &ExportResult{
+		Manifest:       &controlplanev1.Manifest{Version: "2.0"},
+		Checksum:       "deadbeef",
+		SectionSources: map[string]string{},
+		Warnings:       nil,
+	}
+	resp := result.ToProtoResponse()
+	assert.Equal(t, "2.0", resp.Manifest.Version)
+	assert.Nil(t, resp.Warnings)
 }
 
 // TestExportService_CollectOrganizations_NilCollector_WithFallback verifies that
 // when Organizations collector is nil, data is sourced from the fallback manifest.
 func TestExportService_CollectOrganizations_NilCollector_WithFallback(t *testing.T) {
-    svc := &ExportService{collectors: &ExportCollectors{}} // nil Organizations collector
+	svc := &ExportService{collectors: &ExportCollectors{}} // nil Organizations collector
 
-    fb := testFallbackManifest()
-    fb.Organizations = []*controlplanev1.OrganizationDefinition{
-        {Code: "PLATFORM", Name: "Platform Org", PartyType: "ORGANIZATION"},
-    }
+	fb := testFallbackManifest()
+	fb.Organizations = []*controlplanev1.OrganizationDefinition{
+		{Code: "PLATFORM", Name: "Platform Org", PartyType: "ORGANIZATION"},
+	}
 
-    result := &ExportResult{
-        Manifest:       &controlplanev1.Manifest{},
-        SectionSources: make(map[string]string),
-    }
+	result := &ExportResult{
+		Manifest:       &controlplanev1.Manifest{},
+		SectionSources: make(map[string]string),
+	}
 
-    svc.collectOrganizations(context.Background(), result, fb, "1.5")
-    assert.Equal(t, fb.Organizations, result.Manifest.Organizations)
-    assert.Equal(t, "fallback:manifest-v1.5", result.SectionSources["organizations"])
+	svc.collectOrganizations(context.Background(), result, fb, "1.5")
+	assert.Equal(t, fb.Organizations, result.Manifest.Organizations)
+	assert.Equal(t, "fallback:manifest-v1.5", result.SectionSources["organizations"])
 }
 
 // TestExportService_CollectInternalAccounts_NilCollector_WithFallback verifies that
 // when InternalAccounts collector is nil, data is sourced from the fallback manifest.
 func TestExportService_CollectInternalAccounts_NilCollector_WithFallback(t *testing.T) {
-    svc := &ExportService{collectors: &ExportCollectors{}} // nil InternalAccounts collector
+	svc := &ExportService{collectors: &ExportCollectors{}} // nil InternalAccounts collector
 
-    fb := testFallbackManifest()
-    fb.InternalAccounts = []*controlplanev1.InternalAccountDefinition{
-        {Code: "NOSTRO_GBP", AccountType: "NOSTRO", Instrument: "GBP"},
-    }
+	fb := testFallbackManifest()
+	fb.InternalAccounts = []*controlplanev1.InternalAccountDefinition{
+		{Code: "NOSTRO_GBP", AccountType: "NOSTRO", Instrument: "GBP"},
+	}
 
-    result := &ExportResult{
-        Manifest:       &controlplanev1.Manifest{},
-        SectionSources: make(map[string]string),
-    }
+	result := &ExportResult{
+		Manifest:       &controlplanev1.Manifest{},
+		SectionSources: make(map[string]string),
+	}
 
-    svc.collectInternalAccounts(context.Background(), result, fb, "1.5")
-    assert.Equal(t, fb.InternalAccounts, result.Manifest.InternalAccounts)
-    assert.Equal(t, "fallback:manifest-v1.5", result.SectionSources["internal_accounts"])
+	svc.collectInternalAccounts(context.Background(), result, fb, "1.5")
+	assert.Equal(t, fb.InternalAccounts, result.Manifest.InternalAccounts)
+	assert.Equal(t, "fallback:manifest-v1.5", result.SectionSources["internal_accounts"])
 }
 
 // TestExportService_CollectMarketData_NilCollector_WithFallback verifies that
 // when MarketData collector is nil, data is sourced from the fallback manifest.
 func TestExportService_CollectMarketData_NilCollector_WithFallback(t *testing.T) {
-    svc := &ExportService{collectors: &ExportCollectors{}} // nil MarketData collector
+	svc := &ExportService{collectors: &ExportCollectors{}} // nil MarketData collector
 
-    fb := testFallbackManifest()
-    fb.MarketData = &controlplanev1.MarketDataConfig{
-        Sources: []*controlplanev1.MarketDataSourceDefinition{
-            {Code: "ECB", Name: "European Central Bank"},
-        },
-    }
+	fb := testFallbackManifest()
+	fb.MarketData = &controlplanev1.MarketDataConfig{
+		Sources: []*controlplanev1.MarketDataSourceDefinition{
+			{Code: "ECB", Name: "European Central Bank"},
+		},
+	}
 
-    result := &ExportResult{
-        Manifest:       &controlplanev1.Manifest{},
-        SectionSources: make(map[string]string),
-    }
+	result := &ExportResult{
+		Manifest:       &controlplanev1.Manifest{},
+		SectionSources: make(map[string]string),
+	}
 
-    svc.collectMarketData(context.Background(), result, fb, "1.5")
-    assert.Equal(t, fb.MarketData, result.Manifest.MarketData)
-    assert.Equal(t, "fallback:manifest-v1.5", result.SectionSources["market_data"])
+	svc.collectMarketData(context.Background(), result, fb, "1.5")
+	assert.Equal(t, fb.MarketData, result.Manifest.MarketData)
+	assert.Equal(t, "fallback:manifest-v1.5", result.SectionSources["market_data"])
 }
 
 // TestExportService_CollectOperationalGateway_NilCollector_WithFallback verifies
 // that when OperationalGateway collector is nil, data comes from the fallback.
 func TestExportService_CollectOperationalGateway_NilCollector_WithFallback(t *testing.T) {
-    svc := &ExportService{collectors: &ExportCollectors{}} // nil OperationalGateway collector
+	svc := &ExportService{collectors: &ExportCollectors{}} // nil OperationalGateway collector
 
-    fb := testFallbackManifest()
-    fb.OperationalGateway = &controlplanev1.OperationalGatewayConfig{
-        ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
-            {ConnectionId: "stripe", ProviderName: "Stripe"},
-        },
-    }
+	fb := testFallbackManifest()
+	fb.OperationalGateway = &controlplanev1.OperationalGatewayConfig{
+		ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+			{ConnectionId: "stripe", ProviderName: "Stripe"},
+		},
+	}
 
-    result := &ExportResult{
-        Manifest:       &controlplanev1.Manifest{},
-        SectionSources: make(map[string]string),
-    }
+	result := &ExportResult{
+		Manifest:       &controlplanev1.Manifest{},
+		SectionSources: make(map[string]string),
+	}
 
-    svc.collectOperationalGateway(context.Background(), result, fb, "1.5")
-    assert.Equal(t, fb.OperationalGateway, result.Manifest.OperationalGateway)
-    assert.Equal(t, "fallback:manifest-v1.5", result.SectionSources["operational_gateway"])
+	svc.collectOperationalGateway(context.Background(), result, fb, "1.5")
+	assert.Equal(t, fb.OperationalGateway, result.Manifest.OperationalGateway)
+	assert.Equal(t, "fallback:manifest-v1.5", result.SectionSources["operational_gateway"])
 }
 
 // TestExportService_CollectAllFallbackSections_SourceLabels verifies that
 // fallback-only sections use the correct version label in SectionSources.
 func TestExportService_CollectAllFallbackSections_SourceLabels(t *testing.T) {
-    svc := &ExportService{collectors: &ExportCollectors{}}
+	svc := &ExportService{collectors: &ExportCollectors{}}
 
-    // Use testFallbackManifest which has non-nil ValuationRules.
-    fb := testFallbackManifest()
+	// Use testFallbackManifest which has non-nil ValuationRules.
+	fb := testFallbackManifest()
 
-    result := &ExportResult{
-        Manifest:       &controlplanev1.Manifest{},
-        SectionSources: make(map[string]string),
-    }
+	result := &ExportResult{
+		Manifest:       &controlplanev1.Manifest{},
+		SectionSources: make(map[string]string),
+	}
 
-    svc.collectValuationRules(result, fb, "3.0")
-    assert.Equal(t, "fallback:manifest-v3.0", result.SectionSources["valuation_rules"])
+	svc.collectValuationRules(result, fb, "3.0")
+	assert.Equal(t, "fallback:manifest-v3.0", result.SectionSources["valuation_rules"])
 
-    svc.collectMappings(result, fb, "3.0")
-    assert.Equal(t, "fallback:manifest-v3.0", result.SectionSources["mappings"])
+	svc.collectMappings(result, fb, "3.0")
+	assert.Equal(t, "fallback:manifest-v3.0", result.SectionSources["mappings"])
 
-    svc.collectPartyTypes(result, fb, "3.0")
-    assert.Equal(t, "fallback:manifest-v3.0", result.SectionSources["party_types"])
+	svc.collectPartyTypes(result, fb, "3.0")
+	assert.Equal(t, "fallback:manifest-v3.0", result.SectionSources["party_types"])
 
-    svc.collectPaymentRails(result, fb, "3.0")
-    assert.Equal(t, "fallback:manifest-v3.0", result.SectionSources["payment_rails"])
+	svc.collectPaymentRails(result, fb, "3.0")
+	assert.Equal(t, "fallback:manifest-v3.0", result.SectionSources["payment_rails"])
 }

--- a/services/control-plane/internal/manifest/export_coverage_test.go
+++ b/services/control-plane/internal/manifest/export_coverage_test.go
@@ -1,0 +1,292 @@
+package manifest
+
+import (
+    "context"
+    "errors"
+    "testing"
+
+    controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// TestNewExportService_ValidInputs verifies the happy path constructor.
+func TestNewExportService_ValidInputs(t *testing.T) {
+    repo := &Repository{}
+    history, err := NewHistoryService(repo)
+    require.NoError(t, err)
+
+    svc, err := NewExportService(history, &ExportCollectors{})
+    require.NoError(t, err)
+    require.NotNil(t, svc)
+}
+
+// TestNewExportService_NilCollectors_DefaultsToEmpty verifies that passing nil
+// collectors is treated as an empty collectors set (no panic, no error).
+func TestNewExportService_NilCollectors_DefaultsToEmpty(t *testing.T) {
+    repo := &Repository{}
+    history, err := NewHistoryService(repo)
+    require.NoError(t, err)
+
+    svc, err := NewExportService(history, nil)
+    require.NoError(t, err)
+    require.NotNil(t, svc)
+
+    // Verify that a collect call with nil collectors and nil fallback is a no-op.
+    result := &ExportResult{
+        Manifest:       &controlplanev1.Manifest{Version: "1.0"},
+        SectionSources: make(map[string]string),
+    }
+    svc.collectInstruments(context.Background(), result, nil, "")
+    assert.Nil(t, result.Manifest.Instruments)
+    assert.Empty(t, result.SectionSources)
+}
+
+// TestIsNotFound_WrappedError verifies that isNotFound detects wrapped ErrVersionNotFound.
+func TestIsNotFound_WrappedError(t *testing.T) {
+    wrapped := errors.New("context: " + ErrVersionNotFound.Error())
+    // Direct wrapping via %w.
+    wrapErr := errors.Join(ErrVersionNotFound, errors.New("extra context"))
+    assert.True(t, isNotFound(ErrVersionNotFound))
+    assert.False(t, isNotFound(wrapped))
+    assert.True(t, isNotFound(wrapErr))
+}
+
+// TestExportService_CollectFallbackOnlySections_WithNilFallback verifies that
+// all fallback-only collect functions are no-ops when fallback is nil.
+func TestExportService_CollectFallbackOnlySections_WithNilFallback(t *testing.T) {
+    svc := &ExportService{collectors: &ExportCollectors{}}
+
+    result := &ExportResult{
+        Manifest:       &controlplanev1.Manifest{},
+        SectionSources: make(map[string]string),
+    }
+
+    svc.collectValuationRules(result, nil, "")
+    assert.Nil(t, result.Manifest.ValuationRules)
+    assert.Empty(t, result.SectionSources["valuation_rules"])
+
+    svc.collectMappings(result, nil, "")
+    assert.Nil(t, result.Manifest.Mappings)
+    assert.Empty(t, result.SectionSources["mappings"])
+
+    svc.collectPartyTypes(result, nil, "")
+    assert.Nil(t, result.Manifest.PartyTypes)
+    assert.Empty(t, result.SectionSources["party_types"])
+
+    svc.collectPaymentRails(result, nil, "")
+    assert.Nil(t, result.Manifest.PaymentRails)
+    assert.Empty(t, result.SectionSources["payment_rails"])
+}
+
+// TestExportService_CollectOrganizations_WithNilFallback verifies no panic when
+// the organizations collector errors and there is no fallback.
+func TestExportService_CollectOrganizations_WithNilFallback(t *testing.T) {
+    svc := &ExportService{
+        collectors: &ExportCollectors{
+            Organizations: &mockOrganizationCollector{err: errors.New("timeout")},
+        },
+    }
+    result := &ExportResult{
+        Manifest:       &controlplanev1.Manifest{},
+        SectionSources: make(map[string]string),
+    }
+
+    svc.collectOrganizations(context.Background(), result, nil, "")
+    assert.Nil(t, result.Manifest.Organizations)
+    require.Len(t, result.Warnings, 1)
+    assert.Contains(t, result.Warnings[0], "timeout")
+}
+
+// TestExportService_CollectInternalAccounts_WithNilFallback verifies no panic
+// when internal accounts collector errors without fallback.
+func TestExportService_CollectInternalAccounts_WithNilFallback(t *testing.T) {
+    svc := &ExportService{
+        collectors: &ExportCollectors{
+            InternalAccounts: &mockInternalAccountCollector{err: errors.New("unreachable")},
+        },
+    }
+    result := &ExportResult{
+        Manifest:       &controlplanev1.Manifest{},
+        SectionSources: make(map[string]string),
+    }
+
+    svc.collectInternalAccounts(context.Background(), result, nil, "")
+    assert.Nil(t, result.Manifest.InternalAccounts)
+    require.Len(t, result.Warnings, 1)
+    assert.Contains(t, result.Warnings[0], "unreachable")
+}
+
+// TestExportService_CollectOperationalGateway_WithNilFallback verifies no panic
+// when gateway collector errors without fallback.
+func TestExportService_CollectOperationalGateway_WithNilFallback(t *testing.T) {
+    svc := &ExportService{
+        collectors: &ExportCollectors{
+            OperationalGateway: &mockOperationalGatewayCollector{
+                connErr:  errors.New("gateway down"),
+                routeErr: errors.New("route fail"),
+            },
+        },
+    }
+    result := &ExportResult{
+        Manifest:       &controlplanev1.Manifest{},
+        SectionSources: make(map[string]string),
+    }
+
+    svc.collectOperationalGateway(context.Background(), result, nil, "")
+    assert.Nil(t, result.Manifest.OperationalGateway)
+    require.Len(t, result.Warnings, 1)
+    assert.Contains(t, result.Warnings[0], "gateway down")
+    assert.Contains(t, result.Warnings[0], "route fail")
+}
+
+// TestExportService_CollectMarketData_WithNilFallback verifies no panic when
+// market data collector errors without fallback.
+func TestExportService_CollectMarketData_WithNilFallback(t *testing.T) {
+    svc := &ExportService{
+        collectors: &ExportCollectors{
+            MarketData: &mockMarketDataCollector{srcErr: errors.New("market error")},
+        },
+    }
+    result := &ExportResult{
+        Manifest:       &controlplanev1.Manifest{},
+        SectionSources: make(map[string]string),
+    }
+
+    svc.collectMarketData(context.Background(), result, nil, "")
+    assert.Nil(t, result.Manifest.MarketData)
+    require.Len(t, result.Warnings, 1)
+    assert.Contains(t, result.Warnings[0], "market error")
+}
+
+// TestExportService_ManifestChecksumEmpty verifies checksum of empty manifest.
+func TestExportService_ManifestChecksumEmpty(t *testing.T) {
+    sum, err := manifestChecksum(&controlplanev1.Manifest{})
+    require.NoError(t, err)
+    assert.Len(t, sum, 64)
+    assert.NotEmpty(t, sum)
+}
+
+// TestExportResult_ToProtoResponse_EmptyWarnings verifies nil warnings are
+// preserved correctly in the proto response.
+func TestExportResult_ToProtoResponse_EmptyWarnings(t *testing.T) {
+    result := &ExportResult{
+        Manifest:       &controlplanev1.Manifest{Version: "2.0"},
+        Checksum:       "deadbeef",
+        SectionSources: map[string]string{},
+        Warnings:       nil,
+    }
+    resp := result.ToProtoResponse()
+    assert.Equal(t, "2.0", resp.Manifest.Version)
+    assert.Nil(t, resp.Warnings)
+}
+
+// TestExportService_CollectOrganizations_NilCollector_WithFallback verifies that
+// when Organizations collector is nil, data is sourced from the fallback manifest.
+func TestExportService_CollectOrganizations_NilCollector_WithFallback(t *testing.T) {
+    svc := &ExportService{collectors: &ExportCollectors{}} // nil Organizations collector
+
+    fb := testFallbackManifest()
+    fb.Organizations = []*controlplanev1.OrganizationDefinition{
+        {Code: "PLATFORM", Name: "Platform Org", PartyType: "ORGANIZATION"},
+    }
+
+    result := &ExportResult{
+        Manifest:       &controlplanev1.Manifest{},
+        SectionSources: make(map[string]string),
+    }
+
+    svc.collectOrganizations(context.Background(), result, fb, "1.5")
+    assert.Equal(t, fb.Organizations, result.Manifest.Organizations)
+    assert.Equal(t, "fallback:manifest-v1.5", result.SectionSources["organizations"])
+}
+
+// TestExportService_CollectInternalAccounts_NilCollector_WithFallback verifies that
+// when InternalAccounts collector is nil, data is sourced from the fallback manifest.
+func TestExportService_CollectInternalAccounts_NilCollector_WithFallback(t *testing.T) {
+    svc := &ExportService{collectors: &ExportCollectors{}} // nil InternalAccounts collector
+
+    fb := testFallbackManifest()
+    fb.InternalAccounts = []*controlplanev1.InternalAccountDefinition{
+        {Code: "NOSTRO_GBP", AccountType: "NOSTRO", Instrument: "GBP"},
+    }
+
+    result := &ExportResult{
+        Manifest:       &controlplanev1.Manifest{},
+        SectionSources: make(map[string]string),
+    }
+
+    svc.collectInternalAccounts(context.Background(), result, fb, "1.5")
+    assert.Equal(t, fb.InternalAccounts, result.Manifest.InternalAccounts)
+    assert.Equal(t, "fallback:manifest-v1.5", result.SectionSources["internal_accounts"])
+}
+
+// TestExportService_CollectMarketData_NilCollector_WithFallback verifies that
+// when MarketData collector is nil, data is sourced from the fallback manifest.
+func TestExportService_CollectMarketData_NilCollector_WithFallback(t *testing.T) {
+    svc := &ExportService{collectors: &ExportCollectors{}} // nil MarketData collector
+
+    fb := testFallbackManifest()
+    fb.MarketData = &controlplanev1.MarketDataConfig{
+        Sources: []*controlplanev1.MarketDataSourceDefinition{
+            {Code: "ECB", Name: "European Central Bank"},
+        },
+    }
+
+    result := &ExportResult{
+        Manifest:       &controlplanev1.Manifest{},
+        SectionSources: make(map[string]string),
+    }
+
+    svc.collectMarketData(context.Background(), result, fb, "1.5")
+    assert.Equal(t, fb.MarketData, result.Manifest.MarketData)
+    assert.Equal(t, "fallback:manifest-v1.5", result.SectionSources["market_data"])
+}
+
+// TestExportService_CollectOperationalGateway_NilCollector_WithFallback verifies
+// that when OperationalGateway collector is nil, data comes from the fallback.
+func TestExportService_CollectOperationalGateway_NilCollector_WithFallback(t *testing.T) {
+    svc := &ExportService{collectors: &ExportCollectors{}} // nil OperationalGateway collector
+
+    fb := testFallbackManifest()
+    fb.OperationalGateway = &controlplanev1.OperationalGatewayConfig{
+        ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+            {ConnectionId: "stripe", ProviderName: "Stripe"},
+        },
+    }
+
+    result := &ExportResult{
+        Manifest:       &controlplanev1.Manifest{},
+        SectionSources: make(map[string]string),
+    }
+
+    svc.collectOperationalGateway(context.Background(), result, fb, "1.5")
+    assert.Equal(t, fb.OperationalGateway, result.Manifest.OperationalGateway)
+    assert.Equal(t, "fallback:manifest-v1.5", result.SectionSources["operational_gateway"])
+}
+
+// TestExportService_CollectAllFallbackSections_SourceLabels verifies that
+// fallback-only sections use the correct version label in SectionSources.
+func TestExportService_CollectAllFallbackSections_SourceLabels(t *testing.T) {
+    svc := &ExportService{collectors: &ExportCollectors{}}
+
+    // Use testFallbackManifest which has non-nil ValuationRules.
+    fb := testFallbackManifest()
+
+    result := &ExportResult{
+        Manifest:       &controlplanev1.Manifest{},
+        SectionSources: make(map[string]string),
+    }
+
+    svc.collectValuationRules(result, fb, "3.0")
+    assert.Equal(t, "fallback:manifest-v3.0", result.SectionSources["valuation_rules"])
+
+    svc.collectMappings(result, fb, "3.0")
+    assert.Equal(t, "fallback:manifest-v3.0", result.SectionSources["mappings"])
+
+    svc.collectPartyTypes(result, fb, "3.0")
+    assert.Equal(t, "fallback:manifest-v3.0", result.SectionSources["party_types"])
+
+    svc.collectPaymentRails(result, fb, "3.0")
+    assert.Equal(t, "fallback:manifest-v3.0", result.SectionSources["payment_rails"])
+}

--- a/services/control-plane/internal/manifest/export_coverage_test.go
+++ b/services/control-plane/internal/manifest/export_coverage_test.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
@@ -45,10 +46,11 @@ func TestNewExportService_NilCollectors_DefaultsToEmpty(t *testing.T) {
 // TestIsNotFound_WrappedError verifies that isNotFound detects wrapped ErrVersionNotFound.
 func TestIsNotFound_WrappedError(t *testing.T) {
 	wrapped := errors.New("context: " + ErrVersionNotFound.Error())
-	// Direct wrapping via %w.
+	wrappedWithW := fmt.Errorf("wrapped: %w", ErrVersionNotFound)
 	wrapErr := errors.Join(ErrVersionNotFound, errors.New("extra context"))
 	assert.True(t, isNotFound(ErrVersionNotFound))
 	assert.False(t, isNotFound(wrapped))
+	assert.True(t, isNotFound(wrappedWithW))
 	assert.True(t, isNotFound(wrapErr))
 }
 

--- a/services/control-plane/internal/stripe/webhook_coverage_test.go
+++ b/services/control-plane/internal/stripe/webhook_coverage_test.go
@@ -1,314 +1,314 @@
 package stripe
 
 import (
-    "bytes"
-    "context"
-    "encoding/json"
-    "net/http"
-    "net/http/httptest"
-    "testing"
-    "time"
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
 
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // --- Payment intent succeeded: missing charge ID ---
 
 func TestHandleWebhook_PaymentIntentSucceeded_MissingChargeID(t *testing.T) {
-    pub := &mockPublisher{}
-    handler, err := NewWebhookHandler(WebhookHandlerConfig{
-        Publisher:     pub,
-        WebhookSecret: testWebhookSecret,
-    })
-    require.NoError(t, err)
+	pub := &mockPublisher{}
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		Publisher:     pub,
+		WebhookSecret: testWebhookSecret,
+	})
+	require.NoError(t, err)
 
-    // Build payload WITHOUT latest_charge field.
-    payload, err := json.Marshal(map[string]any{
-        "id":      "evt_test_no_charge",
-        "type":    "payment_intent.succeeded",
-        "created": time.Now().Unix(),
-        "data": map[string]any{
-            "object": map[string]any{
-                "id":       "pi_no_charge",
-                "object":   "payment_intent",
-                "amount":   5000,
-                "currency": "gbp",
-                "metadata": map[string]string{
-                    "tenant_id": "meridian-ops",
-                    "party_id":  "party-123",
-                },
-                "status": "succeeded",
-                // no latest_charge
-            },
-        },
-    })
-    require.NoError(t, err)
+	// Build payload WITHOUT latest_charge field.
+	payload, err := json.Marshal(map[string]any{
+		"id":      "evt_test_no_charge",
+		"type":    "payment_intent.succeeded",
+		"created": time.Now().Unix(),
+		"data": map[string]any{
+			"object": map[string]any{
+				"id":       "pi_no_charge",
+				"object":   "payment_intent",
+				"amount":   5000,
+				"currency": "gbp",
+				"metadata": map[string]string{
+					"tenant_id": "meridian-ops",
+					"party_id":  "party-123",
+				},
+				"status": "succeeded",
+				// no latest_charge
+			},
+		},
+	})
+	require.NoError(t, err)
 
-    sig := signPayload(t, payload, testWebhookSecret)
-    req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
-    req.Header.Set(StripeSignatureHeader, sig)
+	sig := signPayload(t, payload, testWebhookSecret)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+	req.Header.Set(StripeSignatureHeader, sig)
 
-    rr := httptest.NewRecorder()
-    handler.HandleWebhook(rr, req)
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
 
-    // Returns 500 to trigger Stripe retry (charge may populate on re-delivery).
-    assert.Equal(t, http.StatusInternalServerError, rr.Code)
-    assert.Empty(t, pub.events)
+	// Returns 500 to trigger Stripe retry (charge may populate on re-delivery).
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Empty(t, pub.events)
 }
 
 // --- Payment intent failed: valid event with minimal data object ---
 
 func TestHandleWebhook_PaymentIntentFailed_MinimalPayload(t *testing.T) {
-    pub := &mockPublisher{}
-    handler, err := NewWebhookHandler(WebhookHandlerConfig{
-        Publisher:     pub,
-        WebhookSecret: testWebhookSecret,
-    })
-    require.NoError(t, err)
+	pub := &mockPublisher{}
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		Publisher:     pub,
+		WebhookSecret: testWebhookSecret,
+	})
+	require.NoError(t, err)
 
-    // Minimal valid payment_intent object - just enough for the Stripe SDK to parse.
-    payload, err := json.Marshal(map[string]any{
-        "id":      "evt_fail_minimal",
-        "type":    "payment_intent.payment_failed",
-        "created": time.Now().Unix(),
-        "data": map[string]any{
-            "object": map[string]any{
-                "id":     "pi_minimal",
-                "object": "payment_intent",
-                // no last_payment_error, no metadata
-            },
-        },
-    })
-    require.NoError(t, err)
+	// Minimal valid payment_intent object - just enough for the Stripe SDK to parse.
+	payload, err := json.Marshal(map[string]any{
+		"id":      "evt_fail_minimal",
+		"type":    "payment_intent.payment_failed",
+		"created": time.Now().Unix(),
+		"data": map[string]any{
+			"object": map[string]any{
+				"id":     "pi_minimal",
+				"object": "payment_intent",
+				// no last_payment_error, no metadata
+			},
+		},
+	})
+	require.NoError(t, err)
 
-    sig := signPayload(t, payload, testWebhookSecret)
-    req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
-    req.Header.Set(StripeSignatureHeader, sig)
+	sig := signPayload(t, payload, testWebhookSecret)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+	req.Header.Set(StripeSignatureHeader, sig)
 
-    rr := httptest.NewRecorder()
-    handler.HandleWebhook(rr, req)
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
 
-    // Failure logged, 200 returned (failure is just logged, not retried).
-    assert.Equal(t, http.StatusOK, rr.Code)
-    assert.Empty(t, pub.events)
+	// Failure logged, 200 returned (failure is just logged, not retried).
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, pub.events)
 }
 
 // --- Payment intent failed: nil LastPaymentError (no error code) ---
 
 func TestHandleWebhook_PaymentIntentFailed_NoErrorMessage(t *testing.T) {
-    pub := &mockPublisher{}
-    handler, err := NewWebhookHandler(WebhookHandlerConfig{
-        Publisher:     pub,
-        WebhookSecret: testWebhookSecret,
-    })
-    require.NoError(t, err)
+	pub := &mockPublisher{}
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		Publisher:     pub,
+		WebhookSecret: testWebhookSecret,
+	})
+	require.NoError(t, err)
 
-    // Payload WITHOUT last_payment_error.
-    payload, err := json.Marshal(map[string]any{
-        "id":      "evt_fail_no_error",
-        "type":    "payment_intent.payment_failed",
-        "created": time.Now().Unix(),
-        "data": map[string]any{
-            "object": map[string]any{
-                "id":       "pi_fail_no_err",
-                "object":   "payment_intent",
-                "amount":   3000,
-                "currency": "gbp",
-                "metadata": map[string]string{
-                    "tenant_id": "meridian-ops",
-                    "party_id":  "party-456",
-                },
-                "status": "requires_payment_method",
-                // no last_payment_error
-            },
-        },
-    })
-    require.NoError(t, err)
+	// Payload WITHOUT last_payment_error.
+	payload, err := json.Marshal(map[string]any{
+		"id":      "evt_fail_no_error",
+		"type":    "payment_intent.payment_failed",
+		"created": time.Now().Unix(),
+		"data": map[string]any{
+			"object": map[string]any{
+				"id":       "pi_fail_no_err",
+				"object":   "payment_intent",
+				"amount":   3000,
+				"currency": "gbp",
+				"metadata": map[string]string{
+					"tenant_id": "meridian-ops",
+					"party_id":  "party-456",
+				},
+				"status": "requires_payment_method",
+				// no last_payment_error
+			},
+		},
+	})
+	require.NoError(t, err)
 
-    sig := signPayload(t, payload, testWebhookSecret)
-    req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
-    req.Header.Set(StripeSignatureHeader, sig)
+	sig := signPayload(t, payload, testWebhookSecret)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+	req.Header.Set(StripeSignatureHeader, sig)
 
-    rr := httptest.NewRecorder()
-    handler.HandleWebhook(rr, req)
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
 
-    // Should still return 200 - failure is logged, no event published.
-    assert.Equal(t, http.StatusOK, rr.Code)
-    assert.Empty(t, pub.events)
+	// Should still return 200 - failure is logged, no event published.
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, pub.events)
 }
 
 // --- Charge refunded: missing tenant_id in all metadata ---
 
 func TestHandleWebhook_ChargeRefunded_MissingTenantID(t *testing.T) {
-    pub := &mockPublisher{}
-    handler, err := NewWebhookHandler(WebhookHandlerConfig{
-        Publisher:     pub,
-        WebhookSecret: testWebhookSecret,
-    })
-    require.NoError(t, err)
+	pub := &mockPublisher{}
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		Publisher:     pub,
+		WebhookSecret: testWebhookSecret,
+	})
+	require.NoError(t, err)
 
-    // Charge payload with no tenant_id in either charge or PI metadata.
-    payload, err := json.Marshal(map[string]any{
-        "id":      "evt_refund_no_tenant",
-        "type":    "charge.refunded",
-        "created": time.Now().Unix(),
-        "data": map[string]any{
-            "object": map[string]any{
-                "id":              "ch_no_tenant",
-                "object":          "charge",
-                "amount_refunded": 2000,
-                "currency":        "gbp",
-                "metadata": map[string]string{
-                    // no tenant_id
-                    "party_id": "party-789",
-                },
-                "payment_intent": map[string]any{
-                    "id":     "pi_no_tenant",
-                    "object": "payment_intent",
-                    "metadata": map[string]string{
-                        // no tenant_id
-                    },
-                },
-            },
-        },
-    })
-    require.NoError(t, err)
+	// Charge payload with no tenant_id in either charge or PI metadata.
+	payload, err := json.Marshal(map[string]any{
+		"id":      "evt_refund_no_tenant",
+		"type":    "charge.refunded",
+		"created": time.Now().Unix(),
+		"data": map[string]any{
+			"object": map[string]any{
+				"id":              "ch_no_tenant",
+				"object":          "charge",
+				"amount_refunded": 2000,
+				"currency":        "gbp",
+				"metadata": map[string]string{
+					// no tenant_id
+					"party_id": "party-789",
+				},
+				"payment_intent": map[string]any{
+					"id":       "pi_no_tenant",
+					"object":   "payment_intent",
+					"metadata": map[string]string{
+						// no tenant_id
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
 
-    sig := signPayload(t, payload, testWebhookSecret)
-    req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
-    req.Header.Set(StripeSignatureHeader, sig)
+	sig := signPayload(t, payload, testWebhookSecret)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+	req.Header.Set(StripeSignatureHeader, sig)
 
-    rr := httptest.NewRecorder()
-    handler.HandleWebhook(rr, req)
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
 
-    // Acknowledged without processing.
-    assert.Equal(t, http.StatusOK, rr.Code)
-    assert.Empty(t, pub.events)
+	// Acknowledged without processing.
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, pub.events)
 
-    var resp WebhookResponse
-    require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
-    assert.True(t, resp.Received)
-    assert.Contains(t, resp.Message, "without tenant context")
+	var resp WebhookResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.True(t, resp.Received)
+	assert.Contains(t, resp.Message, "without tenant context")
 }
 
 // --- Charge refunded: has tenant_id but missing party_id ---
 
 func TestHandleWebhook_ChargeRefunded_MissingPartyID(t *testing.T) {
-    pub := &mockPublisher{}
-    handler, err := NewWebhookHandler(WebhookHandlerConfig{
-        Publisher:     pub,
-        WebhookSecret: testWebhookSecret,
-    })
-    require.NoError(t, err)
+	pub := &mockPublisher{}
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		Publisher:     pub,
+		WebhookSecret: testWebhookSecret,
+	})
+	require.NoError(t, err)
 
-    payload, err := json.Marshal(map[string]any{
-        "id":      "evt_refund_no_party",
-        "type":    "charge.refunded",
-        "created": time.Now().Unix(),
-        "data": map[string]any{
-            "object": map[string]any{
-                "id":              "ch_no_party",
-                "object":          "charge",
-                "amount_refunded": 1500,
-                "currency":        "gbp",
-                "metadata": map[string]string{
-                    "tenant_id": "meridian-ops",
-                    // no party_id
-                },
-            },
-        },
-    })
-    require.NoError(t, err)
+	payload, err := json.Marshal(map[string]any{
+		"id":      "evt_refund_no_party",
+		"type":    "charge.refunded",
+		"created": time.Now().Unix(),
+		"data": map[string]any{
+			"object": map[string]any{
+				"id":              "ch_no_party",
+				"object":          "charge",
+				"amount_refunded": 1500,
+				"currency":        "gbp",
+				"metadata": map[string]string{
+					"tenant_id": "meridian-ops",
+					// no party_id
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
 
-    sig := signPayload(t, payload, testWebhookSecret)
-    req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
-    req.Header.Set(StripeSignatureHeader, sig)
+	sig := signPayload(t, payload, testWebhookSecret)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+	req.Header.Set(StripeSignatureHeader, sig)
 
-    rr := httptest.NewRecorder()
-    handler.HandleWebhook(rr, req)
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
 
-    // Acknowledged without processing.
-    assert.Equal(t, http.StatusOK, rr.Code)
-    assert.Empty(t, pub.events)
+	// Acknowledged without processing.
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, pub.events)
 
-    var resp WebhookResponse
-    require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
-    assert.True(t, resp.Received)
-    assert.Contains(t, resp.Message, "without party context")
+	var resp WebhookResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.True(t, resp.Received)
+	assert.Contains(t, resp.Message, "without party context")
 }
 
 // --- Charge refunded: publish failure ---
 
 func TestHandleWebhook_ChargeRefunded_PublishFailure(t *testing.T) {
-    pub := &mockPublisher{
-        publishFunc: func(_ context.Context, _ *PaymentEvent) error {
-            return ErrPublishFailed
-        },
-    }
-    handler, err := NewWebhookHandler(WebhookHandlerConfig{
-        Publisher:     pub,
-        WebhookSecret: testWebhookSecret,
-    })
-    require.NoError(t, err)
+	pub := &mockPublisher{
+		publishFunc: func(_ context.Context, _ *PaymentEvent) error {
+			return ErrPublishFailed
+		},
+	}
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		Publisher:     pub,
+		WebhookSecret: testWebhookSecret,
+	})
+	require.NoError(t, err)
 
-    payload := buildChargeRefundedPayload(t, "ch_pub_fail", 3000)
-    sig := signPayload(t, payload, testWebhookSecret)
+	payload := buildChargeRefundedPayload(t, "ch_pub_fail", 3000)
+	sig := signPayload(t, payload, testWebhookSecret)
 
-    req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
-    req.Header.Set(StripeSignatureHeader, sig)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+	req.Header.Set(StripeSignatureHeader, sig)
 
-    rr := httptest.NewRecorder()
-    handler.HandleWebhook(rr, req)
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
 
-    // Returns 500 to trigger Stripe retry.
-    assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	// Returns 500 to trigger Stripe retry.
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
 }
 
 // --- Charge refunded: no PaymentIntent in charge (uses charge.Metadata only) ---
 
 func TestHandleWebhook_ChargeRefunded_NilPaymentIntent(t *testing.T) {
-    pub := &mockPublisher{}
-    handler, err := NewWebhookHandler(WebhookHandlerConfig{
-        Publisher:     pub,
-        WebhookSecret: testWebhookSecret,
-    })
-    require.NoError(t, err)
+	pub := &mockPublisher{}
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		Publisher:     pub,
+		WebhookSecret: testWebhookSecret,
+	})
+	require.NoError(t, err)
 
-    // Charge without a payment_intent, metadata on the charge directly.
-    payload, err := json.Marshal(map[string]any{
-        "id":      "evt_refund_no_pi",
-        "type":    "charge.refunded",
-        "created": time.Now().Unix(),
-        "data": map[string]any{
-            "object": map[string]any{
-                "id":              "ch_no_pi",
-                "object":          "charge",
-                "amount_refunded": 800,
-                "currency":        "eur",
-                "metadata": map[string]string{
-                    "tenant_id": "meridian-ops",
-                    "party_id":  "party-no-pi",
-                },
-                // no payment_intent field
-            },
-        },
-    })
-    require.NoError(t, err)
+	// Charge without a payment_intent, metadata on the charge directly.
+	payload, err := json.Marshal(map[string]any{
+		"id":      "evt_refund_no_pi",
+		"type":    "charge.refunded",
+		"created": time.Now().Unix(),
+		"data": map[string]any{
+			"object": map[string]any{
+				"id":              "ch_no_pi",
+				"object":          "charge",
+				"amount_refunded": 800,
+				"currency":        "eur",
+				"metadata": map[string]string{
+					"tenant_id": "meridian-ops",
+					"party_id":  "party-no-pi",
+				},
+				// no payment_intent field
+			},
+		},
+	})
+	require.NoError(t, err)
 
-    sig := signPayload(t, payload, testWebhookSecret)
-    req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
-    req.Header.Set(StripeSignatureHeader, sig)
+	sig := signPayload(t, payload, testWebhookSecret)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+	req.Header.Set(StripeSignatureHeader, sig)
 
-    rr := httptest.NewRecorder()
-    handler.HandleWebhook(rr, req)
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
 
-    assert.Equal(t, http.StatusOK, rr.Code)
-    require.Len(t, pub.events, 1)
-    evt := pub.events[0]
-    assert.Equal(t, "charge.refunded", evt.EventType)
-    assert.Equal(t, "ch_no_pi", evt.ChargeID)
-    assert.Equal(t, "EUR", evt.Currency)
-    assert.Equal(t, int64(800), evt.AmountCents)
-    assert.Empty(t, evt.PaymentIntentID) // no PI
+	assert.Equal(t, http.StatusOK, rr.Code)
+	require.Len(t, pub.events, 1)
+	evt := pub.events[0]
+	assert.Equal(t, "charge.refunded", evt.EventType)
+	assert.Equal(t, "ch_no_pi", evt.ChargeID)
+	assert.Equal(t, "EUR", evt.Currency)
+	assert.Equal(t, int64(800), evt.AmountCents)
+	assert.Empty(t, evt.PaymentIntentID) // no PI
 }

--- a/services/control-plane/internal/stripe/webhook_coverage_test.go
+++ b/services/control-plane/internal/stripe/webhook_coverage_test.go
@@ -1,0 +1,314 @@
+package stripe
+
+import (
+    "bytes"
+    "context"
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+    "time"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// --- Payment intent succeeded: missing charge ID ---
+
+func TestHandleWebhook_PaymentIntentSucceeded_MissingChargeID(t *testing.T) {
+    pub := &mockPublisher{}
+    handler, err := NewWebhookHandler(WebhookHandlerConfig{
+        Publisher:     pub,
+        WebhookSecret: testWebhookSecret,
+    })
+    require.NoError(t, err)
+
+    // Build payload WITHOUT latest_charge field.
+    payload, err := json.Marshal(map[string]any{
+        "id":      "evt_test_no_charge",
+        "type":    "payment_intent.succeeded",
+        "created": time.Now().Unix(),
+        "data": map[string]any{
+            "object": map[string]any{
+                "id":       "pi_no_charge",
+                "object":   "payment_intent",
+                "amount":   5000,
+                "currency": "gbp",
+                "metadata": map[string]string{
+                    "tenant_id": "meridian-ops",
+                    "party_id":  "party-123",
+                },
+                "status": "succeeded",
+                // no latest_charge
+            },
+        },
+    })
+    require.NoError(t, err)
+
+    sig := signPayload(t, payload, testWebhookSecret)
+    req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+    req.Header.Set(StripeSignatureHeader, sig)
+
+    rr := httptest.NewRecorder()
+    handler.HandleWebhook(rr, req)
+
+    // Returns 500 to trigger Stripe retry (charge may populate on re-delivery).
+    assert.Equal(t, http.StatusInternalServerError, rr.Code)
+    assert.Empty(t, pub.events)
+}
+
+// --- Payment intent failed: valid event with minimal data object ---
+
+func TestHandleWebhook_PaymentIntentFailed_MinimalPayload(t *testing.T) {
+    pub := &mockPublisher{}
+    handler, err := NewWebhookHandler(WebhookHandlerConfig{
+        Publisher:     pub,
+        WebhookSecret: testWebhookSecret,
+    })
+    require.NoError(t, err)
+
+    // Minimal valid payment_intent object - just enough for the Stripe SDK to parse.
+    payload, err := json.Marshal(map[string]any{
+        "id":      "evt_fail_minimal",
+        "type":    "payment_intent.payment_failed",
+        "created": time.Now().Unix(),
+        "data": map[string]any{
+            "object": map[string]any{
+                "id":     "pi_minimal",
+                "object": "payment_intent",
+                // no last_payment_error, no metadata
+            },
+        },
+    })
+    require.NoError(t, err)
+
+    sig := signPayload(t, payload, testWebhookSecret)
+    req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+    req.Header.Set(StripeSignatureHeader, sig)
+
+    rr := httptest.NewRecorder()
+    handler.HandleWebhook(rr, req)
+
+    // Failure logged, 200 returned (failure is just logged, not retried).
+    assert.Equal(t, http.StatusOK, rr.Code)
+    assert.Empty(t, pub.events)
+}
+
+// --- Payment intent failed: nil LastPaymentError (no error code) ---
+
+func TestHandleWebhook_PaymentIntentFailed_NoErrorMessage(t *testing.T) {
+    pub := &mockPublisher{}
+    handler, err := NewWebhookHandler(WebhookHandlerConfig{
+        Publisher:     pub,
+        WebhookSecret: testWebhookSecret,
+    })
+    require.NoError(t, err)
+
+    // Payload WITHOUT last_payment_error.
+    payload, err := json.Marshal(map[string]any{
+        "id":      "evt_fail_no_error",
+        "type":    "payment_intent.payment_failed",
+        "created": time.Now().Unix(),
+        "data": map[string]any{
+            "object": map[string]any{
+                "id":       "pi_fail_no_err",
+                "object":   "payment_intent",
+                "amount":   3000,
+                "currency": "gbp",
+                "metadata": map[string]string{
+                    "tenant_id": "meridian-ops",
+                    "party_id":  "party-456",
+                },
+                "status": "requires_payment_method",
+                // no last_payment_error
+            },
+        },
+    })
+    require.NoError(t, err)
+
+    sig := signPayload(t, payload, testWebhookSecret)
+    req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+    req.Header.Set(StripeSignatureHeader, sig)
+
+    rr := httptest.NewRecorder()
+    handler.HandleWebhook(rr, req)
+
+    // Should still return 200 - failure is logged, no event published.
+    assert.Equal(t, http.StatusOK, rr.Code)
+    assert.Empty(t, pub.events)
+}
+
+// --- Charge refunded: missing tenant_id in all metadata ---
+
+func TestHandleWebhook_ChargeRefunded_MissingTenantID(t *testing.T) {
+    pub := &mockPublisher{}
+    handler, err := NewWebhookHandler(WebhookHandlerConfig{
+        Publisher:     pub,
+        WebhookSecret: testWebhookSecret,
+    })
+    require.NoError(t, err)
+
+    // Charge payload with no tenant_id in either charge or PI metadata.
+    payload, err := json.Marshal(map[string]any{
+        "id":      "evt_refund_no_tenant",
+        "type":    "charge.refunded",
+        "created": time.Now().Unix(),
+        "data": map[string]any{
+            "object": map[string]any{
+                "id":              "ch_no_tenant",
+                "object":          "charge",
+                "amount_refunded": 2000,
+                "currency":        "gbp",
+                "metadata": map[string]string{
+                    // no tenant_id
+                    "party_id": "party-789",
+                },
+                "payment_intent": map[string]any{
+                    "id":     "pi_no_tenant",
+                    "object": "payment_intent",
+                    "metadata": map[string]string{
+                        // no tenant_id
+                    },
+                },
+            },
+        },
+    })
+    require.NoError(t, err)
+
+    sig := signPayload(t, payload, testWebhookSecret)
+    req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+    req.Header.Set(StripeSignatureHeader, sig)
+
+    rr := httptest.NewRecorder()
+    handler.HandleWebhook(rr, req)
+
+    // Acknowledged without processing.
+    assert.Equal(t, http.StatusOK, rr.Code)
+    assert.Empty(t, pub.events)
+
+    var resp WebhookResponse
+    require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+    assert.True(t, resp.Received)
+    assert.Contains(t, resp.Message, "without tenant context")
+}
+
+// --- Charge refunded: has tenant_id but missing party_id ---
+
+func TestHandleWebhook_ChargeRefunded_MissingPartyID(t *testing.T) {
+    pub := &mockPublisher{}
+    handler, err := NewWebhookHandler(WebhookHandlerConfig{
+        Publisher:     pub,
+        WebhookSecret: testWebhookSecret,
+    })
+    require.NoError(t, err)
+
+    payload, err := json.Marshal(map[string]any{
+        "id":      "evt_refund_no_party",
+        "type":    "charge.refunded",
+        "created": time.Now().Unix(),
+        "data": map[string]any{
+            "object": map[string]any{
+                "id":              "ch_no_party",
+                "object":          "charge",
+                "amount_refunded": 1500,
+                "currency":        "gbp",
+                "metadata": map[string]string{
+                    "tenant_id": "meridian-ops",
+                    // no party_id
+                },
+            },
+        },
+    })
+    require.NoError(t, err)
+
+    sig := signPayload(t, payload, testWebhookSecret)
+    req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+    req.Header.Set(StripeSignatureHeader, sig)
+
+    rr := httptest.NewRecorder()
+    handler.HandleWebhook(rr, req)
+
+    // Acknowledged without processing.
+    assert.Equal(t, http.StatusOK, rr.Code)
+    assert.Empty(t, pub.events)
+
+    var resp WebhookResponse
+    require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+    assert.True(t, resp.Received)
+    assert.Contains(t, resp.Message, "without party context")
+}
+
+// --- Charge refunded: publish failure ---
+
+func TestHandleWebhook_ChargeRefunded_PublishFailure(t *testing.T) {
+    pub := &mockPublisher{
+        publishFunc: func(_ context.Context, _ *PaymentEvent) error {
+            return ErrPublishFailed
+        },
+    }
+    handler, err := NewWebhookHandler(WebhookHandlerConfig{
+        Publisher:     pub,
+        WebhookSecret: testWebhookSecret,
+    })
+    require.NoError(t, err)
+
+    payload := buildChargeRefundedPayload(t, "ch_pub_fail", 3000)
+    sig := signPayload(t, payload, testWebhookSecret)
+
+    req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+    req.Header.Set(StripeSignatureHeader, sig)
+
+    rr := httptest.NewRecorder()
+    handler.HandleWebhook(rr, req)
+
+    // Returns 500 to trigger Stripe retry.
+    assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+// --- Charge refunded: no PaymentIntent in charge (uses charge.Metadata only) ---
+
+func TestHandleWebhook_ChargeRefunded_NilPaymentIntent(t *testing.T) {
+    pub := &mockPublisher{}
+    handler, err := NewWebhookHandler(WebhookHandlerConfig{
+        Publisher:     pub,
+        WebhookSecret: testWebhookSecret,
+    })
+    require.NoError(t, err)
+
+    // Charge without a payment_intent, metadata on the charge directly.
+    payload, err := json.Marshal(map[string]any{
+        "id":      "evt_refund_no_pi",
+        "type":    "charge.refunded",
+        "created": time.Now().Unix(),
+        "data": map[string]any{
+            "object": map[string]any{
+                "id":              "ch_no_pi",
+                "object":          "charge",
+                "amount_refunded": 800,
+                "currency":        "eur",
+                "metadata": map[string]string{
+                    "tenant_id": "meridian-ops",
+                    "party_id":  "party-no-pi",
+                },
+                // no payment_intent field
+            },
+        },
+    })
+    require.NoError(t, err)
+
+    sig := signPayload(t, payload, testWebhookSecret)
+    req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+    req.Header.Set(StripeSignatureHeader, sig)
+
+    rr := httptest.NewRecorder()
+    handler.HandleWebhook(rr, req)
+
+    assert.Equal(t, http.StatusOK, rr.Code)
+    require.Len(t, pub.events, 1)
+    evt := pub.events[0]
+    assert.Equal(t, "charge.refunded", evt.EventType)
+    assert.Equal(t, "ch_no_pi", evt.ChargeID)
+    assert.Equal(t, "EUR", evt.Currency)
+    assert.Equal(t, int64(800), evt.AmountCents)
+    assert.Empty(t, evt.PaymentIntentID) // no PI
+}

--- a/services/mcp-server/internal/tools/gateway_coverage_test.go
+++ b/services/mcp-server/internal/tools/gateway_coverage_test.go
@@ -1,0 +1,467 @@
+// Package tools provides the tool registry for the MCP server.
+package tools_test
+
+import (
+    "context"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "google.golang.org/protobuf/types/known/timestamppb"
+
+    commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+    opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+    "github.com/meridianhub/meridian/services/mcp-server/internal/tools"
+)
+
+// --- Auth method coverage ---
+
+func TestGatewayConnectionHealth_AuthMethods(t *testing.T) {
+    tests := []struct {
+        name      string
+        makeConn  func() *opgatewayv1.ProviderConnection
+        wantAuth  string
+    }{
+        {
+            name: "oauth2",
+            makeConn: func() *opgatewayv1.ProviderConnection {
+                return &opgatewayv1.ProviderConnection{
+                    ConnectionId: "650e8400-e29b-41d4-a716-446655440002",
+                    ProviderName: "Provider",
+                    Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
+                    HealthStatus: opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY,
+                    AuthConfig: &opgatewayv1.ProviderConnection_Oauth2{
+                        Oauth2: &opgatewayv1.OAuth2Auth{
+                            TokenUrl:        "https://auth.example.com/token",
+                            ClientSecretRef: "oauth-secret",
+                        },
+                    },
+                }
+            },
+            wantAuth: "oauth2",
+        },
+        {
+            name: "hmac",
+            makeConn: func() *opgatewayv1.ProviderConnection {
+                return &opgatewayv1.ProviderConnection{
+                    ConnectionId: "650e8400-e29b-41d4-a716-446655440003",
+                    ProviderName: "Provider",
+                    Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
+                    HealthStatus: opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY,
+                    AuthConfig: &opgatewayv1.ProviderConnection_Hmac{
+                        Hmac: &opgatewayv1.HMACAuth{
+                            Algorithm: "SHA256",
+                            SecretRef: "hmac-key",
+                        },
+                    },
+                }
+            },
+            wantAuth: "hmac",
+        },
+        {
+            name: "mtls",
+            makeConn: func() *opgatewayv1.ProviderConnection {
+                return &opgatewayv1.ProviderConnection{
+                    ConnectionId: "650e8400-e29b-41d4-a716-446655440004",
+                    ProviderName: "Provider",
+                    Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
+                    HealthStatus: opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY,
+                    AuthConfig: &opgatewayv1.ProviderConnection_Mtls{
+                        Mtls: &opgatewayv1.MTLSAuth{
+                            ClientCertSecretRef: "client-cert",
+                            ClientKeySecretRef:  "client-key",
+                        },
+                    },
+                }
+            },
+            wantAuth: "mtls",
+        },
+        {
+            name: "unknown (nil auth config)",
+            makeConn: func() *opgatewayv1.ProviderConnection {
+                return &opgatewayv1.ProviderConnection{
+                    ConnectionId: "650e8400-e29b-41d4-a716-446655440005",
+                    ProviderName: "Provider",
+                    Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
+                    HealthStatus: opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY,
+                    // AuthConfig intentionally unset
+                }
+            },
+            wantAuth: "unknown",
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            conn := tt.makeConn()
+            mock := &mockGatewayConnectionQuerier{
+                getConnectionFn: func(_ context.Context, _ *opgatewayv1.GetConnectionRequest) (*opgatewayv1.GetConnectionResponse, error) {
+                    return &opgatewayv1.GetConnectionResponse{Connection: conn}, nil
+                },
+            }
+
+            result := callGatewayTool(t, tools.GatewayClients{ConnectionQuerier: mock},
+                "meridian_gateway_connection_health",
+                map[string]interface{}{"connection_id": conn.ConnectionId})
+
+            connResult := result["connection"].(map[string]interface{})
+            assert.Equal(t, tt.wantAuth, connResult["auth_method"])
+        })
+    }
+}
+
+// --- Protocol string coverage ---
+
+func TestGatewayConnectionHealth_Protocols(t *testing.T) {
+    tests := []struct {
+        name         string
+        protocol     opgatewayv1.Protocol
+        wantProtocol string
+    }{
+        {name: "GRPC", protocol: opgatewayv1.Protocol_PROTOCOL_GRPC, wantProtocol: "GRPC"},
+        {name: "WEBHOOK", protocol: opgatewayv1.Protocol_PROTOCOL_WEBHOOK, wantProtocol: "WEBHOOK"},
+        {name: "MQTT", protocol: opgatewayv1.Protocol_PROTOCOL_MQTT, wantProtocol: "MQTT"},
+        {name: "AMQP", protocol: opgatewayv1.Protocol_PROTOCOL_AMQP, wantProtocol: "AMQP"},
+        {name: "UNSPECIFIED", protocol: opgatewayv1.Protocol_PROTOCOL_UNSPECIFIED, wantProtocol: "UNSPECIFIED"},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            mock := &mockGatewayConnectionQuerier{
+                listConnectionsFn: func(_ context.Context, _ *opgatewayv1.ListConnectionsRequest) (*opgatewayv1.ListConnectionsResponse, error) {
+                    return &opgatewayv1.ListConnectionsResponse{
+                        Connections: []*opgatewayv1.ProviderConnection{
+                            {
+                                ConnectionId: "conn-123",
+                                ProviderName: "Provider",
+                                Protocol:     tt.protocol,
+                                HealthStatus: opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY,
+                            },
+                        },
+                    }, nil
+                },
+            }
+
+            result := callGatewayTool(t, tools.GatewayClients{ConnectionQuerier: mock},
+                "meridian_gateway_connection_health", map[string]interface{}{})
+
+            connections := result["connections"].([]interface{})
+            require.Len(t, connections, 1)
+            conn := connections[0].(map[string]interface{})
+            assert.Equal(t, tt.wantProtocol, conn["protocol"])
+        })
+    }
+}
+
+// --- InstructionStatus string coverage ---
+
+func TestGatewayDispatchStatus_InstructionStatusStrings(t *testing.T) {
+    tests := []struct {
+        protoStatus opgatewayv1.InstructionStatus
+        wantString  string
+    }{
+        {opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_DISPATCHING, "DISPATCHING"},
+        {opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_DELIVERED, "DELIVERED"},
+        {opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_ACKNOWLEDGED, "ACKNOWLEDGED"},
+        {opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_RETRYING, "RETRYING"},
+        {opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_EXPIRED, "EXPIRED"},
+        {opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_UNSPECIFIED, "UNSPECIFIED"},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.wantString, func(t *testing.T) {
+            mock := &mockGatewayInstructionQuerier{
+                listInstructionsFn: func(_ context.Context, _ *opgatewayv1.ListInstructionsRequest) (*opgatewayv1.ListInstructionsResponse, error) {
+                    return &opgatewayv1.ListInstructionsResponse{
+                        Instructions: []*opgatewayv1.Instruction{
+                            {
+                                Id:     "instr-001",
+                                Status: tt.protoStatus,
+                            },
+                        },
+                    }, nil
+                },
+            }
+
+            result := callGatewayTool(t, tools.GatewayClients{InstructionQuerier: mock},
+                "meridian_gateway_dispatch_status", map[string]interface{}{})
+
+            instructions := result["instructions"].([]interface{})
+            require.Len(t, instructions, 1)
+            instr := instructions[0].(map[string]interface{})
+            assert.Equal(t, tt.wantString, instr["status"])
+        })
+    }
+}
+
+// --- Priority string coverage ---
+
+func TestGatewayDispatchStatus_PriorityStrings(t *testing.T) {
+    tests := []struct {
+        priority   opgatewayv1.Priority
+        wantString string
+    }{
+        {opgatewayv1.Priority_PRIORITY_LOW, "LOW"},
+        {opgatewayv1.Priority_PRIORITY_CRITICAL, "CRITICAL"},
+        {opgatewayv1.Priority_PRIORITY_UNSPECIFIED, "UNSPECIFIED"},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.wantString, func(t *testing.T) {
+            mock := &mockGatewayInstructionQuerier{
+                listInstructionsFn: func(_ context.Context, _ *opgatewayv1.ListInstructionsRequest) (*opgatewayv1.ListInstructionsResponse, error) {
+                    return &opgatewayv1.ListInstructionsResponse{
+                        Instructions: []*opgatewayv1.Instruction{
+                            {
+                                Id:       "instr-001",
+                                Priority: tt.priority,
+                            },
+                        },
+                    }, nil
+                },
+            }
+
+            result := callGatewayTool(t, tools.GatewayClients{InstructionQuerier: mock},
+                "meridian_gateway_dispatch_status", map[string]interface{}{})
+
+            instructions := result["instructions"].([]interface{})
+            require.Len(t, instructions, 1)
+            instr := instructions[0].(map[string]interface{})
+            assert.Equal(t, tt.wantString, instr["priority"])
+        })
+    }
+}
+
+// --- Pagination token coverage ---
+
+func TestGatewayDispatchStatus_PaginationToken_IncludedInResponse(t *testing.T) {
+    mock := &mockGatewayInstructionQuerier{
+        listInstructionsFn: func(_ context.Context, _ *opgatewayv1.ListInstructionsRequest) (*opgatewayv1.ListInstructionsResponse, error) {
+            return &opgatewayv1.ListInstructionsResponse{
+                Instructions: []*opgatewayv1.Instruction{
+                    {Id: "instr-001", Status: opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_PENDING},
+                },
+                Pagination: &commonv1.PaginationResponse{
+                    NextPageToken: "next-page-cursor-abc",
+                },
+            }, nil
+        },
+    }
+
+    result := callGatewayTool(t, tools.GatewayClients{InstructionQuerier: mock},
+        "meridian_gateway_dispatch_status", map[string]interface{}{})
+
+    assert.Equal(t, "next-page-cursor-abc", result["next_page_token"])
+    assert.EqualValues(t, 1, result["count"])
+}
+
+// --- GetConnection nil response coverage ---
+
+func TestGatewayConnectionHealth_GetConnection_NilResponse(t *testing.T) {
+    connectionID := "650e8400-e29b-41d4-a716-446655440009"
+    mock := &mockGatewayConnectionQuerier{
+        getConnectionFn: func(_ context.Context, req *opgatewayv1.GetConnectionRequest) (*opgatewayv1.GetConnectionResponse, error) {
+            assert.Equal(t, connectionID, req.ConnectionId)
+            return &opgatewayv1.GetConnectionResponse{Connection: nil}, nil
+        },
+    }
+
+    result := callGatewayTool(t, tools.GatewayClients{ConnectionQuerier: mock},
+        "meridian_gateway_connection_health",
+        map[string]interface{}{"connection_id": connectionID})
+
+    assert.Contains(t, result["message"], connectionID)
+    assert.Nil(t, result["connection"])
+}
+
+// --- CancelInstruction nil response coverage ---
+
+func TestGatewayCancelInstruction_NilInstructionResponse(t *testing.T) {
+    instructionID := "550e8400-e29b-41d4-a716-446655440099"
+    mock := &mockGatewayInstructionWriter{
+        cancelInstructionFn: func(_ context.Context, req *opgatewayv1.CancelInstructionRequest) (*opgatewayv1.CancelInstructionResponse, error) {
+            assert.Equal(t, instructionID, req.InstructionId)
+            return &opgatewayv1.CancelInstructionResponse{Instruction: nil}, nil
+        },
+    }
+
+    result := callGatewayTool(t, tools.GatewayClients{InstructionWriter: mock},
+        "meridian_gateway_cancel_instruction",
+        map[string]interface{}{"instruction_id": instructionID})
+
+    assert.Contains(t, result["message"], instructionID)
+    assert.Nil(t, result["instruction"])
+}
+
+// --- InstructionDetail nil instruction response coverage ---
+
+func TestGatewayInstructionDetail_NilInstructionResponse(t *testing.T) {
+    instructionID := "550e8400-e29b-41d4-a716-446655440098"
+    mock := &mockGatewayInstructionQuerier{
+        getInstructionFn: func(_ context.Context, req *opgatewayv1.GetInstructionRequest) (*opgatewayv1.GetInstructionResponse, error) {
+            assert.Equal(t, instructionID, req.InstructionId)
+            return &opgatewayv1.GetInstructionResponse{Instruction: nil}, nil
+        },
+    }
+
+    result := callGatewayTool(t, tools.GatewayClients{InstructionQuerier: mock},
+        "meridian_gateway_instruction_detail",
+        map[string]interface{}{"instruction_id": instructionID})
+
+    assert.Contains(t, result["message"], instructionID)
+    assert.Nil(t, result["instruction"])
+}
+
+// --- Valid from_time/to_time are forwarded to gRPC request ---
+
+func TestGatewayDispatchStatus_ValidTimeRange_AppliedToRequest(t *testing.T) {
+    var capturedReq *opgatewayv1.ListInstructionsRequest
+    mock := &mockGatewayInstructionQuerier{
+        listInstructionsFn: func(_ context.Context, req *opgatewayv1.ListInstructionsRequest) (*opgatewayv1.ListInstructionsResponse, error) {
+            capturedReq = req
+            return &opgatewayv1.ListInstructionsResponse{}, nil
+        },
+    }
+
+    result := callGatewayTool(t, tools.GatewayClients{InstructionQuerier: mock},
+        "meridian_gateway_dispatch_status", map[string]interface{}{
+            "from_time": "2026-01-01T00:00:00Z",
+            "to_time":   "2026-01-10T00:00:00Z",
+        })
+
+    assert.Equal(t, "no instructions found matching the query", result["message"])
+    require.NotNil(t, capturedReq)
+    require.NotNil(t, capturedReq.DateRange)
+    assert.Equal(t, "2026-01-01T00:00:00Z", capturedReq.DateRange.StartDate)
+    assert.Equal(t, "2026-01-10T00:00:00Z", capturedReq.DateRange.EndDate)
+}
+
+// --- Connection health list with pagination token ---
+
+func TestGatewayConnectionHealth_ListWithPaginationToken(t *testing.T) {
+    mock := &mockGatewayConnectionQuerier{
+        listConnectionsFn: func(_ context.Context, _ *opgatewayv1.ListConnectionsRequest) (*opgatewayv1.ListConnectionsResponse, error) {
+            return &opgatewayv1.ListConnectionsResponse{
+                Connections: []*opgatewayv1.ProviderConnection{
+                    {
+                        ConnectionId: "conn-001",
+                        ProviderName: "Provider",
+                        Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
+                        HealthStatus: opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY,
+                    },
+                },
+                Pagination: &commonv1.PaginationResponse{
+                    NextPageToken: "conn-next-page",
+                },
+            }, nil
+        },
+    }
+
+    result := callGatewayTool(t, tools.GatewayClients{ConnectionQuerier: mock},
+        "meridian_gateway_connection_health", map[string]interface{}{})
+
+    assert.Equal(t, "conn-next-page", result["next_page_token"])
+    assert.EqualValues(t, 1, result["count"])
+}
+
+// --- Connection health with retry policy and rate limit coverage ---
+
+func TestGatewayConnectionHealth_RetryPolicyAndRateLimit(t *testing.T) {
+    mock := &mockGatewayConnectionQuerier{
+        listConnectionsFn: func(_ context.Context, _ *opgatewayv1.ListConnectionsRequest) (*opgatewayv1.ListConnectionsResponse, error) {
+            return &opgatewayv1.ListConnectionsResponse{
+                Connections: []*opgatewayv1.ProviderConnection{
+                    {
+                        ConnectionId: "conn-retry",
+                        ProviderName: "Provider",
+                        Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
+                        HealthStatus: opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY,
+                        RetryPolicy: &opgatewayv1.RetryPolicy{
+                            MaxAttempts:            3,
+                            InitialBackoffSeconds:  1,
+                            MaxBackoffSeconds:      30,
+                            BackoffMultiplier:      2.0,
+                        },
+                        RateLimit: &opgatewayv1.RateLimit{
+                            RequestsPerSecond: 100,
+                            BurstSize:         200,
+                        },
+                        LastHealthCheckAt: timestamppb.Now(),
+                    },
+                },
+            }, nil
+        },
+    }
+
+    result := callGatewayTool(t, tools.GatewayClients{ConnectionQuerier: mock},
+        "meridian_gateway_connection_health", map[string]interface{}{})
+
+    connections := result["connections"].([]interface{})
+    require.Len(t, connections, 1)
+    conn := connections[0].(map[string]interface{})
+
+    retryPolicy := conn["retry_policy"].(map[string]interface{})
+    assert.EqualValues(t, 3, retryPolicy["max_attempts"])
+    assert.EqualValues(t, 1, retryPolicy["initial_backoff_seconds"])
+    assert.EqualValues(t, 30, retryPolicy["max_backoff_seconds"])
+
+    rateLimit := conn["rate_limit"].(map[string]interface{})
+    assert.EqualValues(t, 100, rateLimit["requests_per_second"])
+    assert.EqualValues(t, 200, rateLimit["burst_size"])
+
+    assert.NotEmpty(t, conn["last_health_check_at"])
+}
+
+// --- Instruction detail with metadata and optional fields coverage ---
+
+func TestGatewayInstructionDetail_WithMetadataAndScheduling(t *testing.T) {
+    instructionID := "550e8400-e29b-41d4-a716-446655440088"
+    now := timestamppb.Now()
+    mock := &mockGatewayInstructionQuerier{
+        getInstructionFn: func(_ context.Context, _ *opgatewayv1.GetInstructionRequest) (*opgatewayv1.GetInstructionResponse, error) {
+            return &opgatewayv1.GetInstructionResponse{
+                Instruction: &opgatewayv1.Instruction{
+                    Id:              instructionID,
+                    InstructionType: "payment.initiate",
+                    Status:          opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_PENDING,
+                    CorrelationId:   "corr-abc",
+                    CausationId:     "cause-xyz",
+                    ScheduledAt:     now,
+                    ExpiresAt:       now,
+                    UpdatedAt:       now,
+                    Metadata: map[string]string{
+                        "reference": "REF-001",
+                    },
+                    Attempts: []*opgatewayv1.InstructionAttempt{
+                        {
+                            AttemptNumber:       1,
+                            DispatchedAt:        now,
+                            ResponseStatusCode:  200,
+                            DurationMs:          150,
+                            ResponseBodyPreview: `{"status":"ok"}`,
+                        },
+                    },
+                },
+            }, nil
+        },
+    }
+
+    result := callGatewayTool(t, tools.GatewayClients{InstructionQuerier: mock},
+        "meridian_gateway_instruction_detail",
+        map[string]interface{}{"instruction_id": instructionID})
+
+    instr := result["instruction"].(map[string]interface{})
+    assert.Equal(t, "corr-abc", instr["correlation_id"])
+    assert.Equal(t, "cause-xyz", instr["causation_id"])
+    assert.NotEmpty(t, instr["scheduled_at"])
+    assert.NotEmpty(t, instr["expires_at"])
+    assert.NotEmpty(t, instr["updated_at"])
+
+    metadata := instr["metadata"].(map[string]interface{})
+    assert.Equal(t, "REF-001", metadata["reference"])
+
+    attempts := instr["attempts"].([]interface{})
+    require.Len(t, attempts, 1)
+    attempt := attempts[0].(map[string]interface{})
+    assert.Equal(t, `{"status":"ok"}`, attempt["response_body_preview"])
+}

--- a/services/mcp-server/internal/tools/gateway_coverage_test.go
+++ b/services/mcp-server/internal/tools/gateway_coverage_test.go
@@ -2,466 +2,466 @@
 package tools_test
 
 import (
-    "context"
-    "testing"
+	"context"
+	"testing"
 
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/require"
-    "google.golang.org/protobuf/types/known/timestamppb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
-    commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
-    opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
-    "github.com/meridianhub/meridian/services/mcp-server/internal/tools"
+	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/tools"
 )
 
 // --- Auth method coverage ---
 
 func TestGatewayConnectionHealth_AuthMethods(t *testing.T) {
-    tests := []struct {
-        name      string
-        makeConn  func() *opgatewayv1.ProviderConnection
-        wantAuth  string
-    }{
-        {
-            name: "oauth2",
-            makeConn: func() *opgatewayv1.ProviderConnection {
-                return &opgatewayv1.ProviderConnection{
-                    ConnectionId: "650e8400-e29b-41d4-a716-446655440002",
-                    ProviderName: "Provider",
-                    Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
-                    HealthStatus: opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY,
-                    AuthConfig: &opgatewayv1.ProviderConnection_Oauth2{
-                        Oauth2: &opgatewayv1.OAuth2Auth{
-                            TokenUrl:        "https://auth.example.com/token",
-                            ClientSecretRef: "oauth-secret",
-                        },
-                    },
-                }
-            },
-            wantAuth: "oauth2",
-        },
-        {
-            name: "hmac",
-            makeConn: func() *opgatewayv1.ProviderConnection {
-                return &opgatewayv1.ProviderConnection{
-                    ConnectionId: "650e8400-e29b-41d4-a716-446655440003",
-                    ProviderName: "Provider",
-                    Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
-                    HealthStatus: opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY,
-                    AuthConfig: &opgatewayv1.ProviderConnection_Hmac{
-                        Hmac: &opgatewayv1.HMACAuth{
-                            Algorithm: "SHA256",
-                            SecretRef: "hmac-key",
-                        },
-                    },
-                }
-            },
-            wantAuth: "hmac",
-        },
-        {
-            name: "mtls",
-            makeConn: func() *opgatewayv1.ProviderConnection {
-                return &opgatewayv1.ProviderConnection{
-                    ConnectionId: "650e8400-e29b-41d4-a716-446655440004",
-                    ProviderName: "Provider",
-                    Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
-                    HealthStatus: opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY,
-                    AuthConfig: &opgatewayv1.ProviderConnection_Mtls{
-                        Mtls: &opgatewayv1.MTLSAuth{
-                            ClientCertSecretRef: "client-cert",
-                            ClientKeySecretRef:  "client-key",
-                        },
-                    },
-                }
-            },
-            wantAuth: "mtls",
-        },
-        {
-            name: "unknown (nil auth config)",
-            makeConn: func() *opgatewayv1.ProviderConnection {
-                return &opgatewayv1.ProviderConnection{
-                    ConnectionId: "650e8400-e29b-41d4-a716-446655440005",
-                    ProviderName: "Provider",
-                    Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
-                    HealthStatus: opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY,
-                    // AuthConfig intentionally unset
-                }
-            },
-            wantAuth: "unknown",
-        },
-    }
+	tests := []struct {
+		name     string
+		makeConn func() *opgatewayv1.ProviderConnection
+		wantAuth string
+	}{
+		{
+			name: "oauth2",
+			makeConn: func() *opgatewayv1.ProviderConnection {
+				return &opgatewayv1.ProviderConnection{
+					ConnectionId: "650e8400-e29b-41d4-a716-446655440002",
+					ProviderName: "Provider",
+					Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
+					HealthStatus: opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY,
+					AuthConfig: &opgatewayv1.ProviderConnection_Oauth2{
+						Oauth2: &opgatewayv1.OAuth2Auth{
+							TokenUrl:        "https://auth.example.com/token",
+							ClientSecretRef: "oauth-secret",
+						},
+					},
+				}
+			},
+			wantAuth: "oauth2",
+		},
+		{
+			name: "hmac",
+			makeConn: func() *opgatewayv1.ProviderConnection {
+				return &opgatewayv1.ProviderConnection{
+					ConnectionId: "650e8400-e29b-41d4-a716-446655440003",
+					ProviderName: "Provider",
+					Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
+					HealthStatus: opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY,
+					AuthConfig: &opgatewayv1.ProviderConnection_Hmac{
+						Hmac: &opgatewayv1.HMACAuth{
+							Algorithm: "SHA256",
+							SecretRef: "hmac-key",
+						},
+					},
+				}
+			},
+			wantAuth: "hmac",
+		},
+		{
+			name: "mtls",
+			makeConn: func() *opgatewayv1.ProviderConnection {
+				return &opgatewayv1.ProviderConnection{
+					ConnectionId: "650e8400-e29b-41d4-a716-446655440004",
+					ProviderName: "Provider",
+					Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
+					HealthStatus: opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY,
+					AuthConfig: &opgatewayv1.ProviderConnection_Mtls{
+						Mtls: &opgatewayv1.MTLSAuth{
+							ClientCertSecretRef: "client-cert",
+							ClientKeySecretRef:  "client-key",
+						},
+					},
+				}
+			},
+			wantAuth: "mtls",
+		},
+		{
+			name: "unknown (nil auth config)",
+			makeConn: func() *opgatewayv1.ProviderConnection {
+				return &opgatewayv1.ProviderConnection{
+					ConnectionId: "650e8400-e29b-41d4-a716-446655440005",
+					ProviderName: "Provider",
+					Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
+					HealthStatus: opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY,
+					// AuthConfig intentionally unset
+				}
+			},
+			wantAuth: "unknown",
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            conn := tt.makeConn()
-            mock := &mockGatewayConnectionQuerier{
-                getConnectionFn: func(_ context.Context, _ *opgatewayv1.GetConnectionRequest) (*opgatewayv1.GetConnectionResponse, error) {
-                    return &opgatewayv1.GetConnectionResponse{Connection: conn}, nil
-                },
-            }
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := tt.makeConn()
+			mock := &mockGatewayConnectionQuerier{
+				getConnectionFn: func(_ context.Context, _ *opgatewayv1.GetConnectionRequest) (*opgatewayv1.GetConnectionResponse, error) {
+					return &opgatewayv1.GetConnectionResponse{Connection: conn}, nil
+				},
+			}
 
-            result := callGatewayTool(t, tools.GatewayClients{ConnectionQuerier: mock},
-                "meridian_gateway_connection_health",
-                map[string]interface{}{"connection_id": conn.ConnectionId})
+			result := callGatewayTool(t, tools.GatewayClients{ConnectionQuerier: mock},
+				"meridian_gateway_connection_health",
+				map[string]interface{}{"connection_id": conn.ConnectionId})
 
-            connResult := result["connection"].(map[string]interface{})
-            assert.Equal(t, tt.wantAuth, connResult["auth_method"])
-        })
-    }
+			connResult := result["connection"].(map[string]interface{})
+			assert.Equal(t, tt.wantAuth, connResult["auth_method"])
+		})
+	}
 }
 
 // --- Protocol string coverage ---
 
 func TestGatewayConnectionHealth_Protocols(t *testing.T) {
-    tests := []struct {
-        name         string
-        protocol     opgatewayv1.Protocol
-        wantProtocol string
-    }{
-        {name: "GRPC", protocol: opgatewayv1.Protocol_PROTOCOL_GRPC, wantProtocol: "GRPC"},
-        {name: "WEBHOOK", protocol: opgatewayv1.Protocol_PROTOCOL_WEBHOOK, wantProtocol: "WEBHOOK"},
-        {name: "MQTT", protocol: opgatewayv1.Protocol_PROTOCOL_MQTT, wantProtocol: "MQTT"},
-        {name: "AMQP", protocol: opgatewayv1.Protocol_PROTOCOL_AMQP, wantProtocol: "AMQP"},
-        {name: "UNSPECIFIED", protocol: opgatewayv1.Protocol_PROTOCOL_UNSPECIFIED, wantProtocol: "UNSPECIFIED"},
-    }
+	tests := []struct {
+		name         string
+		protocol     opgatewayv1.Protocol
+		wantProtocol string
+	}{
+		{name: "GRPC", protocol: opgatewayv1.Protocol_PROTOCOL_GRPC, wantProtocol: "GRPC"},
+		{name: "WEBHOOK", protocol: opgatewayv1.Protocol_PROTOCOL_WEBHOOK, wantProtocol: "WEBHOOK"},
+		{name: "MQTT", protocol: opgatewayv1.Protocol_PROTOCOL_MQTT, wantProtocol: "MQTT"},
+		{name: "AMQP", protocol: opgatewayv1.Protocol_PROTOCOL_AMQP, wantProtocol: "AMQP"},
+		{name: "UNSPECIFIED", protocol: opgatewayv1.Protocol_PROTOCOL_UNSPECIFIED, wantProtocol: "UNSPECIFIED"},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            mock := &mockGatewayConnectionQuerier{
-                listConnectionsFn: func(_ context.Context, _ *opgatewayv1.ListConnectionsRequest) (*opgatewayv1.ListConnectionsResponse, error) {
-                    return &opgatewayv1.ListConnectionsResponse{
-                        Connections: []*opgatewayv1.ProviderConnection{
-                            {
-                                ConnectionId: "conn-123",
-                                ProviderName: "Provider",
-                                Protocol:     tt.protocol,
-                                HealthStatus: opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY,
-                            },
-                        },
-                    }, nil
-                },
-            }
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockGatewayConnectionQuerier{
+				listConnectionsFn: func(_ context.Context, _ *opgatewayv1.ListConnectionsRequest) (*opgatewayv1.ListConnectionsResponse, error) {
+					return &opgatewayv1.ListConnectionsResponse{
+						Connections: []*opgatewayv1.ProviderConnection{
+							{
+								ConnectionId: "conn-123",
+								ProviderName: "Provider",
+								Protocol:     tt.protocol,
+								HealthStatus: opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY,
+							},
+						},
+					}, nil
+				},
+			}
 
-            result := callGatewayTool(t, tools.GatewayClients{ConnectionQuerier: mock},
-                "meridian_gateway_connection_health", map[string]interface{}{})
+			result := callGatewayTool(t, tools.GatewayClients{ConnectionQuerier: mock},
+				"meridian_gateway_connection_health", map[string]interface{}{})
 
-            connections := result["connections"].([]interface{})
-            require.Len(t, connections, 1)
-            conn := connections[0].(map[string]interface{})
-            assert.Equal(t, tt.wantProtocol, conn["protocol"])
-        })
-    }
+			connections := result["connections"].([]interface{})
+			require.Len(t, connections, 1)
+			conn := connections[0].(map[string]interface{})
+			assert.Equal(t, tt.wantProtocol, conn["protocol"])
+		})
+	}
 }
 
 // --- InstructionStatus string coverage ---
 
 func TestGatewayDispatchStatus_InstructionStatusStrings(t *testing.T) {
-    tests := []struct {
-        protoStatus opgatewayv1.InstructionStatus
-        wantString  string
-    }{
-        {opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_DISPATCHING, "DISPATCHING"},
-        {opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_DELIVERED, "DELIVERED"},
-        {opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_ACKNOWLEDGED, "ACKNOWLEDGED"},
-        {opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_RETRYING, "RETRYING"},
-        {opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_EXPIRED, "EXPIRED"},
-        {opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_UNSPECIFIED, "UNSPECIFIED"},
-    }
+	tests := []struct {
+		protoStatus opgatewayv1.InstructionStatus
+		wantString  string
+	}{
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_DISPATCHING, "DISPATCHING"},
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_DELIVERED, "DELIVERED"},
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_ACKNOWLEDGED, "ACKNOWLEDGED"},
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_RETRYING, "RETRYING"},
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_EXPIRED, "EXPIRED"},
+		{opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_UNSPECIFIED, "UNSPECIFIED"},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.wantString, func(t *testing.T) {
-            mock := &mockGatewayInstructionQuerier{
-                listInstructionsFn: func(_ context.Context, _ *opgatewayv1.ListInstructionsRequest) (*opgatewayv1.ListInstructionsResponse, error) {
-                    return &opgatewayv1.ListInstructionsResponse{
-                        Instructions: []*opgatewayv1.Instruction{
-                            {
-                                Id:     "instr-001",
-                                Status: tt.protoStatus,
-                            },
-                        },
-                    }, nil
-                },
-            }
+	for _, tt := range tests {
+		t.Run(tt.wantString, func(t *testing.T) {
+			mock := &mockGatewayInstructionQuerier{
+				listInstructionsFn: func(_ context.Context, _ *opgatewayv1.ListInstructionsRequest) (*opgatewayv1.ListInstructionsResponse, error) {
+					return &opgatewayv1.ListInstructionsResponse{
+						Instructions: []*opgatewayv1.Instruction{
+							{
+								Id:     "instr-001",
+								Status: tt.protoStatus,
+							},
+						},
+					}, nil
+				},
+			}
 
-            result := callGatewayTool(t, tools.GatewayClients{InstructionQuerier: mock},
-                "meridian_gateway_dispatch_status", map[string]interface{}{})
+			result := callGatewayTool(t, tools.GatewayClients{InstructionQuerier: mock},
+				"meridian_gateway_dispatch_status", map[string]interface{}{})
 
-            instructions := result["instructions"].([]interface{})
-            require.Len(t, instructions, 1)
-            instr := instructions[0].(map[string]interface{})
-            assert.Equal(t, tt.wantString, instr["status"])
-        })
-    }
+			instructions := result["instructions"].([]interface{})
+			require.Len(t, instructions, 1)
+			instr := instructions[0].(map[string]interface{})
+			assert.Equal(t, tt.wantString, instr["status"])
+		})
+	}
 }
 
 // --- Priority string coverage ---
 
 func TestGatewayDispatchStatus_PriorityStrings(t *testing.T) {
-    tests := []struct {
-        priority   opgatewayv1.Priority
-        wantString string
-    }{
-        {opgatewayv1.Priority_PRIORITY_LOW, "LOW"},
-        {opgatewayv1.Priority_PRIORITY_CRITICAL, "CRITICAL"},
-        {opgatewayv1.Priority_PRIORITY_UNSPECIFIED, "UNSPECIFIED"},
-    }
+	tests := []struct {
+		priority   opgatewayv1.Priority
+		wantString string
+	}{
+		{opgatewayv1.Priority_PRIORITY_LOW, "LOW"},
+		{opgatewayv1.Priority_PRIORITY_CRITICAL, "CRITICAL"},
+		{opgatewayv1.Priority_PRIORITY_UNSPECIFIED, "UNSPECIFIED"},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.wantString, func(t *testing.T) {
-            mock := &mockGatewayInstructionQuerier{
-                listInstructionsFn: func(_ context.Context, _ *opgatewayv1.ListInstructionsRequest) (*opgatewayv1.ListInstructionsResponse, error) {
-                    return &opgatewayv1.ListInstructionsResponse{
-                        Instructions: []*opgatewayv1.Instruction{
-                            {
-                                Id:       "instr-001",
-                                Priority: tt.priority,
-                            },
-                        },
-                    }, nil
-                },
-            }
+	for _, tt := range tests {
+		t.Run(tt.wantString, func(t *testing.T) {
+			mock := &mockGatewayInstructionQuerier{
+				listInstructionsFn: func(_ context.Context, _ *opgatewayv1.ListInstructionsRequest) (*opgatewayv1.ListInstructionsResponse, error) {
+					return &opgatewayv1.ListInstructionsResponse{
+						Instructions: []*opgatewayv1.Instruction{
+							{
+								Id:       "instr-001",
+								Priority: tt.priority,
+							},
+						},
+					}, nil
+				},
+			}
 
-            result := callGatewayTool(t, tools.GatewayClients{InstructionQuerier: mock},
-                "meridian_gateway_dispatch_status", map[string]interface{}{})
+			result := callGatewayTool(t, tools.GatewayClients{InstructionQuerier: mock},
+				"meridian_gateway_dispatch_status", map[string]interface{}{})
 
-            instructions := result["instructions"].([]interface{})
-            require.Len(t, instructions, 1)
-            instr := instructions[0].(map[string]interface{})
-            assert.Equal(t, tt.wantString, instr["priority"])
-        })
-    }
+			instructions := result["instructions"].([]interface{})
+			require.Len(t, instructions, 1)
+			instr := instructions[0].(map[string]interface{})
+			assert.Equal(t, tt.wantString, instr["priority"])
+		})
+	}
 }
 
 // --- Pagination token coverage ---
 
 func TestGatewayDispatchStatus_PaginationToken_IncludedInResponse(t *testing.T) {
-    mock := &mockGatewayInstructionQuerier{
-        listInstructionsFn: func(_ context.Context, _ *opgatewayv1.ListInstructionsRequest) (*opgatewayv1.ListInstructionsResponse, error) {
-            return &opgatewayv1.ListInstructionsResponse{
-                Instructions: []*opgatewayv1.Instruction{
-                    {Id: "instr-001", Status: opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_PENDING},
-                },
-                Pagination: &commonv1.PaginationResponse{
-                    NextPageToken: "next-page-cursor-abc",
-                },
-            }, nil
-        },
-    }
+	mock := &mockGatewayInstructionQuerier{
+		listInstructionsFn: func(_ context.Context, _ *opgatewayv1.ListInstructionsRequest) (*opgatewayv1.ListInstructionsResponse, error) {
+			return &opgatewayv1.ListInstructionsResponse{
+				Instructions: []*opgatewayv1.Instruction{
+					{Id: "instr-001", Status: opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_PENDING},
+				},
+				Pagination: &commonv1.PaginationResponse{
+					NextPageToken: "next-page-cursor-abc",
+				},
+			}, nil
+		},
+	}
 
-    result := callGatewayTool(t, tools.GatewayClients{InstructionQuerier: mock},
-        "meridian_gateway_dispatch_status", map[string]interface{}{})
+	result := callGatewayTool(t, tools.GatewayClients{InstructionQuerier: mock},
+		"meridian_gateway_dispatch_status", map[string]interface{}{})
 
-    assert.Equal(t, "next-page-cursor-abc", result["next_page_token"])
-    assert.EqualValues(t, 1, result["count"])
+	assert.Equal(t, "next-page-cursor-abc", result["next_page_token"])
+	assert.EqualValues(t, 1, result["count"])
 }
 
 // --- GetConnection nil response coverage ---
 
 func TestGatewayConnectionHealth_GetConnection_NilResponse(t *testing.T) {
-    connectionID := "650e8400-e29b-41d4-a716-446655440009"
-    mock := &mockGatewayConnectionQuerier{
-        getConnectionFn: func(_ context.Context, req *opgatewayv1.GetConnectionRequest) (*opgatewayv1.GetConnectionResponse, error) {
-            assert.Equal(t, connectionID, req.ConnectionId)
-            return &opgatewayv1.GetConnectionResponse{Connection: nil}, nil
-        },
-    }
+	connectionID := "650e8400-e29b-41d4-a716-446655440009"
+	mock := &mockGatewayConnectionQuerier{
+		getConnectionFn: func(_ context.Context, req *opgatewayv1.GetConnectionRequest) (*opgatewayv1.GetConnectionResponse, error) {
+			assert.Equal(t, connectionID, req.ConnectionId)
+			return &opgatewayv1.GetConnectionResponse{Connection: nil}, nil
+		},
+	}
 
-    result := callGatewayTool(t, tools.GatewayClients{ConnectionQuerier: mock},
-        "meridian_gateway_connection_health",
-        map[string]interface{}{"connection_id": connectionID})
+	result := callGatewayTool(t, tools.GatewayClients{ConnectionQuerier: mock},
+		"meridian_gateway_connection_health",
+		map[string]interface{}{"connection_id": connectionID})
 
-    assert.Contains(t, result["message"], connectionID)
-    assert.Nil(t, result["connection"])
+	assert.Contains(t, result["message"], connectionID)
+	assert.Nil(t, result["connection"])
 }
 
 // --- CancelInstruction nil response coverage ---
 
 func TestGatewayCancelInstruction_NilInstructionResponse(t *testing.T) {
-    instructionID := "550e8400-e29b-41d4-a716-446655440099"
-    mock := &mockGatewayInstructionWriter{
-        cancelInstructionFn: func(_ context.Context, req *opgatewayv1.CancelInstructionRequest) (*opgatewayv1.CancelInstructionResponse, error) {
-            assert.Equal(t, instructionID, req.InstructionId)
-            return &opgatewayv1.CancelInstructionResponse{Instruction: nil}, nil
-        },
-    }
+	instructionID := "550e8400-e29b-41d4-a716-446655440099"
+	mock := &mockGatewayInstructionWriter{
+		cancelInstructionFn: func(_ context.Context, req *opgatewayv1.CancelInstructionRequest) (*opgatewayv1.CancelInstructionResponse, error) {
+			assert.Equal(t, instructionID, req.InstructionId)
+			return &opgatewayv1.CancelInstructionResponse{Instruction: nil}, nil
+		},
+	}
 
-    result := callGatewayTool(t, tools.GatewayClients{InstructionWriter: mock},
-        "meridian_gateway_cancel_instruction",
-        map[string]interface{}{"instruction_id": instructionID})
+	result := callGatewayTool(t, tools.GatewayClients{InstructionWriter: mock},
+		"meridian_gateway_cancel_instruction",
+		map[string]interface{}{"instruction_id": instructionID})
 
-    assert.Contains(t, result["message"], instructionID)
-    assert.Nil(t, result["instruction"])
+	assert.Contains(t, result["message"], instructionID)
+	assert.Nil(t, result["instruction"])
 }
 
 // --- InstructionDetail nil instruction response coverage ---
 
 func TestGatewayInstructionDetail_NilInstructionResponse(t *testing.T) {
-    instructionID := "550e8400-e29b-41d4-a716-446655440098"
-    mock := &mockGatewayInstructionQuerier{
-        getInstructionFn: func(_ context.Context, req *opgatewayv1.GetInstructionRequest) (*opgatewayv1.GetInstructionResponse, error) {
-            assert.Equal(t, instructionID, req.InstructionId)
-            return &opgatewayv1.GetInstructionResponse{Instruction: nil}, nil
-        },
-    }
+	instructionID := "550e8400-e29b-41d4-a716-446655440098"
+	mock := &mockGatewayInstructionQuerier{
+		getInstructionFn: func(_ context.Context, req *opgatewayv1.GetInstructionRequest) (*opgatewayv1.GetInstructionResponse, error) {
+			assert.Equal(t, instructionID, req.InstructionId)
+			return &opgatewayv1.GetInstructionResponse{Instruction: nil}, nil
+		},
+	}
 
-    result := callGatewayTool(t, tools.GatewayClients{InstructionQuerier: mock},
-        "meridian_gateway_instruction_detail",
-        map[string]interface{}{"instruction_id": instructionID})
+	result := callGatewayTool(t, tools.GatewayClients{InstructionQuerier: mock},
+		"meridian_gateway_instruction_detail",
+		map[string]interface{}{"instruction_id": instructionID})
 
-    assert.Contains(t, result["message"], instructionID)
-    assert.Nil(t, result["instruction"])
+	assert.Contains(t, result["message"], instructionID)
+	assert.Nil(t, result["instruction"])
 }
 
 // --- Valid from_time/to_time are forwarded to gRPC request ---
 
 func TestGatewayDispatchStatus_ValidTimeRange_AppliedToRequest(t *testing.T) {
-    var capturedReq *opgatewayv1.ListInstructionsRequest
-    mock := &mockGatewayInstructionQuerier{
-        listInstructionsFn: func(_ context.Context, req *opgatewayv1.ListInstructionsRequest) (*opgatewayv1.ListInstructionsResponse, error) {
-            capturedReq = req
-            return &opgatewayv1.ListInstructionsResponse{}, nil
-        },
-    }
+	var capturedReq *opgatewayv1.ListInstructionsRequest
+	mock := &mockGatewayInstructionQuerier{
+		listInstructionsFn: func(_ context.Context, req *opgatewayv1.ListInstructionsRequest) (*opgatewayv1.ListInstructionsResponse, error) {
+			capturedReq = req
+			return &opgatewayv1.ListInstructionsResponse{}, nil
+		},
+	}
 
-    result := callGatewayTool(t, tools.GatewayClients{InstructionQuerier: mock},
-        "meridian_gateway_dispatch_status", map[string]interface{}{
-            "from_time": "2026-01-01T00:00:00Z",
-            "to_time":   "2026-01-10T00:00:00Z",
-        })
+	result := callGatewayTool(t, tools.GatewayClients{InstructionQuerier: mock},
+		"meridian_gateway_dispatch_status", map[string]interface{}{
+			"from_time": "2026-01-01T00:00:00Z",
+			"to_time":   "2026-01-10T00:00:00Z",
+		})
 
-    assert.Equal(t, "no instructions found matching the query", result["message"])
-    require.NotNil(t, capturedReq)
-    require.NotNil(t, capturedReq.DateRange)
-    assert.Equal(t, "2026-01-01T00:00:00Z", capturedReq.DateRange.StartDate)
-    assert.Equal(t, "2026-01-10T00:00:00Z", capturedReq.DateRange.EndDate)
+	assert.Equal(t, "no instructions found matching the query", result["message"])
+	require.NotNil(t, capturedReq)
+	require.NotNil(t, capturedReq.DateRange)
+	assert.Equal(t, "2026-01-01T00:00:00Z", capturedReq.DateRange.StartDate)
+	assert.Equal(t, "2026-01-10T00:00:00Z", capturedReq.DateRange.EndDate)
 }
 
 // --- Connection health list with pagination token ---
 
 func TestGatewayConnectionHealth_ListWithPaginationToken(t *testing.T) {
-    mock := &mockGatewayConnectionQuerier{
-        listConnectionsFn: func(_ context.Context, _ *opgatewayv1.ListConnectionsRequest) (*opgatewayv1.ListConnectionsResponse, error) {
-            return &opgatewayv1.ListConnectionsResponse{
-                Connections: []*opgatewayv1.ProviderConnection{
-                    {
-                        ConnectionId: "conn-001",
-                        ProviderName: "Provider",
-                        Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
-                        HealthStatus: opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY,
-                    },
-                },
-                Pagination: &commonv1.PaginationResponse{
-                    NextPageToken: "conn-next-page",
-                },
-            }, nil
-        },
-    }
+	mock := &mockGatewayConnectionQuerier{
+		listConnectionsFn: func(_ context.Context, _ *opgatewayv1.ListConnectionsRequest) (*opgatewayv1.ListConnectionsResponse, error) {
+			return &opgatewayv1.ListConnectionsResponse{
+				Connections: []*opgatewayv1.ProviderConnection{
+					{
+						ConnectionId: "conn-001",
+						ProviderName: "Provider",
+						Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
+						HealthStatus: opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY,
+					},
+				},
+				Pagination: &commonv1.PaginationResponse{
+					NextPageToken: "conn-next-page",
+				},
+			}, nil
+		},
+	}
 
-    result := callGatewayTool(t, tools.GatewayClients{ConnectionQuerier: mock},
-        "meridian_gateway_connection_health", map[string]interface{}{})
+	result := callGatewayTool(t, tools.GatewayClients{ConnectionQuerier: mock},
+		"meridian_gateway_connection_health", map[string]interface{}{})
 
-    assert.Equal(t, "conn-next-page", result["next_page_token"])
-    assert.EqualValues(t, 1, result["count"])
+	assert.Equal(t, "conn-next-page", result["next_page_token"])
+	assert.EqualValues(t, 1, result["count"])
 }
 
 // --- Connection health with retry policy and rate limit coverage ---
 
 func TestGatewayConnectionHealth_RetryPolicyAndRateLimit(t *testing.T) {
-    mock := &mockGatewayConnectionQuerier{
-        listConnectionsFn: func(_ context.Context, _ *opgatewayv1.ListConnectionsRequest) (*opgatewayv1.ListConnectionsResponse, error) {
-            return &opgatewayv1.ListConnectionsResponse{
-                Connections: []*opgatewayv1.ProviderConnection{
-                    {
-                        ConnectionId: "conn-retry",
-                        ProviderName: "Provider",
-                        Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
-                        HealthStatus: opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY,
-                        RetryPolicy: &opgatewayv1.RetryPolicy{
-                            MaxAttempts:            3,
-                            InitialBackoffSeconds:  1,
-                            MaxBackoffSeconds:      30,
-                            BackoffMultiplier:      2.0,
-                        },
-                        RateLimit: &opgatewayv1.RateLimit{
-                            RequestsPerSecond: 100,
-                            BurstSize:         200,
-                        },
-                        LastHealthCheckAt: timestamppb.Now(),
-                    },
-                },
-            }, nil
-        },
-    }
+	mock := &mockGatewayConnectionQuerier{
+		listConnectionsFn: func(_ context.Context, _ *opgatewayv1.ListConnectionsRequest) (*opgatewayv1.ListConnectionsResponse, error) {
+			return &opgatewayv1.ListConnectionsResponse{
+				Connections: []*opgatewayv1.ProviderConnection{
+					{
+						ConnectionId: "conn-retry",
+						ProviderName: "Provider",
+						Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
+						HealthStatus: opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY,
+						RetryPolicy: &opgatewayv1.RetryPolicy{
+							MaxAttempts:           3,
+							InitialBackoffSeconds: 1,
+							MaxBackoffSeconds:     30,
+							BackoffMultiplier:     2.0,
+						},
+						RateLimit: &opgatewayv1.RateLimit{
+							RequestsPerSecond: 100,
+							BurstSize:         200,
+						},
+						LastHealthCheckAt: timestamppb.Now(),
+					},
+				},
+			}, nil
+		},
+	}
 
-    result := callGatewayTool(t, tools.GatewayClients{ConnectionQuerier: mock},
-        "meridian_gateway_connection_health", map[string]interface{}{})
+	result := callGatewayTool(t, tools.GatewayClients{ConnectionQuerier: mock},
+		"meridian_gateway_connection_health", map[string]interface{}{})
 
-    connections := result["connections"].([]interface{})
-    require.Len(t, connections, 1)
-    conn := connections[0].(map[string]interface{})
+	connections := result["connections"].([]interface{})
+	require.Len(t, connections, 1)
+	conn := connections[0].(map[string]interface{})
 
-    retryPolicy := conn["retry_policy"].(map[string]interface{})
-    assert.EqualValues(t, 3, retryPolicy["max_attempts"])
-    assert.EqualValues(t, 1, retryPolicy["initial_backoff_seconds"])
-    assert.EqualValues(t, 30, retryPolicy["max_backoff_seconds"])
+	retryPolicy := conn["retry_policy"].(map[string]interface{})
+	assert.EqualValues(t, 3, retryPolicy["max_attempts"])
+	assert.EqualValues(t, 1, retryPolicy["initial_backoff_seconds"])
+	assert.EqualValues(t, 30, retryPolicy["max_backoff_seconds"])
 
-    rateLimit := conn["rate_limit"].(map[string]interface{})
-    assert.EqualValues(t, 100, rateLimit["requests_per_second"])
-    assert.EqualValues(t, 200, rateLimit["burst_size"])
+	rateLimit := conn["rate_limit"].(map[string]interface{})
+	assert.EqualValues(t, 100, rateLimit["requests_per_second"])
+	assert.EqualValues(t, 200, rateLimit["burst_size"])
 
-    assert.NotEmpty(t, conn["last_health_check_at"])
+	assert.NotEmpty(t, conn["last_health_check_at"])
 }
 
 // --- Instruction detail with metadata and optional fields coverage ---
 
 func TestGatewayInstructionDetail_WithMetadataAndScheduling(t *testing.T) {
-    instructionID := "550e8400-e29b-41d4-a716-446655440088"
-    now := timestamppb.Now()
-    mock := &mockGatewayInstructionQuerier{
-        getInstructionFn: func(_ context.Context, _ *opgatewayv1.GetInstructionRequest) (*opgatewayv1.GetInstructionResponse, error) {
-            return &opgatewayv1.GetInstructionResponse{
-                Instruction: &opgatewayv1.Instruction{
-                    Id:              instructionID,
-                    InstructionType: "payment.initiate",
-                    Status:          opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_PENDING,
-                    CorrelationId:   "corr-abc",
-                    CausationId:     "cause-xyz",
-                    ScheduledAt:     now,
-                    ExpiresAt:       now,
-                    UpdatedAt:       now,
-                    Metadata: map[string]string{
-                        "reference": "REF-001",
-                    },
-                    Attempts: []*opgatewayv1.InstructionAttempt{
-                        {
-                            AttemptNumber:       1,
-                            DispatchedAt:        now,
-                            ResponseStatusCode:  200,
-                            DurationMs:          150,
-                            ResponseBodyPreview: `{"status":"ok"}`,
-                        },
-                    },
-                },
-            }, nil
-        },
-    }
+	instructionID := "550e8400-e29b-41d4-a716-446655440088"
+	now := timestamppb.Now()
+	mock := &mockGatewayInstructionQuerier{
+		getInstructionFn: func(_ context.Context, _ *opgatewayv1.GetInstructionRequest) (*opgatewayv1.GetInstructionResponse, error) {
+			return &opgatewayv1.GetInstructionResponse{
+				Instruction: &opgatewayv1.Instruction{
+					Id:              instructionID,
+					InstructionType: "payment.initiate",
+					Status:          opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_PENDING,
+					CorrelationId:   "corr-abc",
+					CausationId:     "cause-xyz",
+					ScheduledAt:     now,
+					ExpiresAt:       now,
+					UpdatedAt:       now,
+					Metadata: map[string]string{
+						"reference": "REF-001",
+					},
+					Attempts: []*opgatewayv1.InstructionAttempt{
+						{
+							AttemptNumber:       1,
+							DispatchedAt:        now,
+							ResponseStatusCode:  200,
+							DurationMs:          150,
+							ResponseBodyPreview: `{"status":"ok"}`,
+						},
+					},
+				},
+			}, nil
+		},
+	}
 
-    result := callGatewayTool(t, tools.GatewayClients{InstructionQuerier: mock},
-        "meridian_gateway_instruction_detail",
-        map[string]interface{}{"instruction_id": instructionID})
+	result := callGatewayTool(t, tools.GatewayClients{InstructionQuerier: mock},
+		"meridian_gateway_instruction_detail",
+		map[string]interface{}{"instruction_id": instructionID})
 
-    instr := result["instruction"].(map[string]interface{})
-    assert.Equal(t, "corr-abc", instr["correlation_id"])
-    assert.Equal(t, "cause-xyz", instr["causation_id"])
-    assert.NotEmpty(t, instr["scheduled_at"])
-    assert.NotEmpty(t, instr["expires_at"])
-    assert.NotEmpty(t, instr["updated_at"])
+	instr := result["instruction"].(map[string]interface{})
+	assert.Equal(t, "corr-abc", instr["correlation_id"])
+	assert.Equal(t, "cause-xyz", instr["causation_id"])
+	assert.NotEmpty(t, instr["scheduled_at"])
+	assert.NotEmpty(t, instr["expires_at"])
+	assert.NotEmpty(t, instr["updated_at"])
 
-    metadata := instr["metadata"].(map[string]interface{})
-    assert.Equal(t, "REF-001", metadata["reference"])
+	metadata := instr["metadata"].(map[string]interface{})
+	assert.Equal(t, "REF-001", metadata["reference"])
 
-    attempts := instr["attempts"].([]interface{})
-    require.Len(t, attempts, 1)
-    attempt := attempts[0].(map[string]interface{})
-    assert.Equal(t, `{"status":"ok"}`, attempt["response_body_preview"])
+	attempts := instr["attempts"].([]interface{})
+	require.Len(t, attempts, 1)
+	attempt := attempts[0].(map[string]interface{})
+	assert.Equal(t, `{"status":"ok"}`, attempt["response_body_preview"])
 }


### PR DESCRIPTION
## Summary

Adds ~1000 lines of targeted unit tests to close coverage gaps for three backend flame graph hotspots identified in test-coverage-80.54.

**gateway.go** (`services/mcp-server/internal/tools`) - was 72.1%:
- Auth method name coverage: oauth2, hmac, mtls, unknown auth config
- Protocol string coverage: GRPC, WEBHOOK, MQTT, AMQP, UNSPECIFIED
- InstructionStatus string coverage: DISPATCHING, DELIVERED, ACKNOWLEDGED, RETRYING, EXPIRED
- Priority string coverage: LOW, CRITICAL, UNSPECIFIED
- Pagination token in list responses (instructions and connections)
- Nil response paths for GetConnection, CancelInstruction, InstructionDetail
- Valid date range filter applied to gRPC request
- Instruction detail with metadata, scheduling, and attempt preview fields
- Connection health with retry policy and rate limit fields

**export.go** (`services/control-plane/internal/manifest`) - was 69.9%:
- NewExportService happy path and nil-collectors defaulting to empty
- nil-collector + non-nil-fallback paths for Organizations, InternalAccounts, MarketData, and OperationalGateway
- isNotFound with wrapped/joined errors
- Fallback-only section source labels (mappings, party_types, payment_rails, valuation_rules)
- ToProtoResponse with nil warnings

**webhook.go** (`services/control-plane/internal/stripe`) - was 78.7%:
- PaymentIntentSucceeded with missing latest_charge returns 500 (triggers Stripe retry)
- PaymentIntentFailed with nil LastPaymentError still returns 200
- PaymentIntentFailed with minimal data object
- ChargeRefunded with missing tenant_id returns 200 with acknowledgment message
- ChargeRefunded with missing party_id returns 200 with acknowledgment message
- ChargeRefunded publish failure returns 500
- ChargeRefunded with nil PaymentIntent uses charge.Metadata only, no PI ID set

## Test plan

- [x] All new tests pass locally: `go test ./services/mcp-server/internal/tools/... ./services/control-plane/internal/manifest/... ./services/control-plane/internal/stripe/... -short`
- [x] No changes to production code - tests only
- [x] Table-driven patterns used where multiple values need testing
- [x] Follows existing mock patterns from gateway_test.go, export_test.go, webhook_test.go