### PR TITLE
Refresh README to focus on value proposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,268 +9,116 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/meridianhub/meridian.svg)](https://pkg.go.dev/github.com/meridianhub/meridian)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/meridianhub/meridian)](https://go.dev/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/meridianhub/meridian)
 
-Open-source billing engine with a double-entry ledger.
-Define your pricing and settlement logic in code —
-Meridian handles the bookkeeping, audit trails, and payment collection.
+**The open-source transaction integrity engine for the real-world economy.**
 
-> **Status**: Active development. Core ledger, saga orchestration, and Stripe Connect
+Define your pricing, settlement, and multi-party revenue-sharing logic in code.
+Meridian handles the bookkeeping, audit trails, reconciliation, and payment collection.
+
+> **Status**: Active development. Core ledger, saga orchestration, multi-asset support, and Stripe Connect
 > integration are implemented. Looking for design partners.
 > [Contact](mailto:ben@meridianhub.org)
 
-## The Problem
+## Why Meridian
 
-Billing starts as a Stripe checkout and a cron job. Then you need usage metering.
-Then revenue splits. Then your auditor asks for a transaction trail.
-Then estimates need to reconcile with actuals.
-Now you're maintaining a financial system — and you're not a financial company.
+Billing starts as a Stripe checkout and a cron job. Then you need usage metering. Then revenue splits. Then your auditor asks for a transaction trail. Then estimates need to reconcile with actuals. Now you're maintaining a financial system - and you're not a financial company.
 
-## How It Works
+Existing solutions force a tradeoff:
 
-Define your economy in a declarative manifest — instruments, account types, and
-settlement rules. Meridian provisions the ledger, enforces double-entry
-bookkeeping, and handles compensation when something fails.
+| Platform | Limitation |
+|----------|------------|
+| Murex | $10M+/year, 3-year implementation, built for trading floors |
+| 10x / Thought Machine | Fiat currency only - cannot natively track kWh, carbon credits, or compute |
+| Stripe / Modern Treasury | Great APIs, but you still build the ledger logic yourself |
+| Custom internal systems | Years of maintenance, no audit trail, no multi-asset support |
 
-```bash
-# Register a customer
-curl -X POST http://localhost:8090/v1/parties \
-  -H "X-Tenant-ID: default" \
-  -d '{"partyType": "PARTY_TYPE_PERSON", "legalName": "Alice Smith"}'
+Meridian gives you bank-grade infrastructure without the enterprise price tag or the build-it-yourself burden.
 
-# Open an account
-curl -X POST http://localhost:8090/v1/current-accounts \
-  -H "X-Tenant-ID: default" \
-  -d '{"partyId": "...", "baseCurrency": "CURRENCY_GBP"}'
+## What Makes It Different
 
-# Deposit — ledger entries, position updates, and audit trail created atomically
-ACCOUNT_ID="<account-id-from-above>"
-curl -X POST "http://localhost:8090/v1/current-accounts/$ACCOUNT_ID/deposits" \
-  -H "X-Tenant-ID: default" \
-  -d '{"amount": {"amount": {"currencyCode": "GBP", "units": "100"}}}'
-```
+### Multi-asset ledger with dimensional type safety
 
-Behind the scenes, each operation runs as a **saga** — a multi-step workflow
-that either completes fully or compensates automatically. Sagas are written in
-sandboxed scripts that Meridian validates before execution.
+Track currency, energy (kWh), carbon credits (tCO2e), compute hours, vouchers, or any custom instrument - all in a single ledger. Compile-time type safety prevents mixing incompatible asset types. Whether you're moving money or megawatts, every movement of value is traceable, reconcilable, and compliant with double-entry principles.
 
-## What's Built
+### Saga orchestration with guaranteed termination
+
+Every operation runs as a distributed saga - a multi-step workflow that either completes fully or compensates automatically. No partial state, no manual intervention. Sagas are written in [Starlark](https://github.com/bazelbuild/starlark) (the language behind Bazel), which mathematically guarantees termination. No infinite loops, no runaway computation, no tenant can starve another's resources.
+
+### Declarative economy - define it, then run it
+
+Define instruments, account types, settlement rules, and pricing logic in a YAML + Starlark manifest. Meridian doesn't just provision the configuration - it continuously operates it. Scheduled billing fires monthly. Settlement triggers when market data arrives. Compensation reverses failed steps automatically. The manifest *is* the running system.
+
+A complete tote betting platform - instruments, accounts, double-entry settlement, Stripe integration, event-driven payouts - can be expressed in under 400 lines of manifest. No code deployment. No PRs to Meridian core. No migrations.
+
+### Bi-temporal data with quality tracking
+
+Every measurement carries what was known, how it was known, and when it was known. The quality ladder (Estimate -> Coefficient -> Actual -> Revised) handles late-arriving data, out-of-order meter reads, and T+2 settlement without locking the database.
+
+### AI-configurable infrastructure
+
+Schema-driven service modules auto-generate type-safe Starlark clients. AI can generate saga code that compiles on the first attempt because the schema constrains it to only call real handlers with real types. Configuration by conversation instead of 6-month implementations.
+
+## What You Get
 
 - **Double-entry ledger** with immutable, bi-temporal audit trail
-- **Saga orchestration** with automatic compensation — settlement completes or reverts
+- **Saga orchestration** with automatic compensation - settlement completes or reverts
+- **Multi-asset support** - currency, kWh, carbon credits, compute hours, vouchers, custom instruments
 - **Stripe Connect** integration for multi-tenant payment collection
-- **Multi-asset support** — currency, kWh, carbon credits, compute hours
-- **Reconciliation** — variance detection between expected and actual
-- **Usage metering** — ingest events, apply pricing rules, produce invoices
-- **Identity verification** — pluggable providers (Onfido, mock for development)
-- **Multi-tenant** — org-scoped accounts with data isolation
+- **Reconciliation** - variance detection, dispute management, imbalance tracking
+- **Usage metering** - ingest events, apply pricing rules, produce invoices
+- **Market data** - bi-temporal observations with quality ladder and wash-and-reload corrections
+- **Identity & KYC** - pluggable verification providers (Onfido, Stripe Identity)
+- **Multi-tenant** - schema-per-tenant data isolation
+- **Event routing** - CEL-filtered event routing to saga handlers
+- **Financial gateway** - Stripe payment intents, webhook handling, refund compensation
+- **Operational gateway** - non-financial outbound dispatch (IoT, regulatory, partner integrations)
+- **Observability** - OpenTelemetry tracing, Prometheus metrics, structured logging
+- **AI integration** - MCP server for AI assistant access to the platform
 
-## Quick Start
+## Use Cases
 
-**Prerequisites**: Go 1.26+, Docker, kubectl, kind, tilt
+Meridian ships with a [cookbook](cookbook/) of ready-to-use saga patterns and [example manifests](examples/manifests/):
 
-```bash
-git clone git@github.com:meridianhub/meridian.git
-cd meridian
-go mod download
-
-ctlptl create cluster kind --registry=ctlptl-registry --name=kind-meridian-local
-tilt up
-```
-
-- Tilt UI: <http://localhost:10350>
-- API: <http://localhost:8080>
-- gRPC: localhost:9090
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed setup and development workflow.
-
-## Local Development
-
-The dev stack runs Meridian as a single unified binary backed by a single-node CockroachDB instance.
-It is the fastest way to iterate locally without Kubernetes.
-
-### Prerequisites
-
-| Tool | Version | Install |
-|------|---------|---------|
-| Docker + Docker Compose v2 | 24+ / 2.20+ | [docs.docker.com](https://docs.docker.com/get-docker/) |
-| Go | 1.26+ | [go.dev/dl](https://go.dev/dl/) |
-| grpcurl | any | `brew install grpcurl` |
-| jq | any | `brew install jq` |
-
-### Start and Stop
-
-```bash
-# Build images and start the stack (CockroachDB + migrations + meridian)
-make dev-up
-
-# Stop containers, preserve data volumes
-make dev-down
-
-# Stop containers and delete all data volumes (full reset)
-make dev-clean
-```
-
-`make dev-up` runs `docker compose -f deploy/dev/docker-compose.yml up --build`. On first run this
-builds the `meridian` Docker image from source, which takes a few minutes. Subsequent runs use the
-cached image unless source files have changed.
-
-The `migrate` container applies all embedded schema migrations to CockroachDB on startup and then
-exits. The `meridian` container starts only after migrations complete successfully.
-
-### Port Mappings
-
-| Port | Service | Protocol |
-|------|---------|----------|
-| 26257 | CockroachDB SQL (postgres wire) | TCP |
-| 8080 | CockroachDB web UI | HTTP |
-| 50051 | Meridian gRPC | TCP |
-| 8090 | Meridian HTTP gateway | HTTP |
-
-CockroachDB is bound to `127.0.0.1` only. The Meridian ports are accessible from `localhost`.
-
-### Health Check
-
-```bash
-# HTTP health endpoint (returns 200 OK when the binary is running)
-curl -s http://localhost:8090/healthz
-
-# gRPC health check (requires grpcurl)
-grpcurl -plaintext localhost:50051 grpc.health.v1.Health/Check
-```
-
-### Using grpcurl
-
-The gRPC server has reflection enabled, so you can discover all available methods without a proto
-file.
-
-```bash
-# List all services
-grpcurl -plaintext localhost:50051 list
-
-# List methods for a specific service
-grpcurl -plaintext localhost:50051 list meridian.party.v1.PartyService
-
-# Describe a request message
-grpcurl -plaintext localhost:50051 describe meridian.party.v1.RegisterPartyRequest
-```
-
-### Basic Business Flow
-
-The gateway accepts REST/JSON on port 8090 and native gRPC on port 50051. The following commands
-execute a complete deposit flow via the HTTP/JSON gateway.
-
-```bash
-# 1. Register a party (customer)
-PARTY=$(curl -s -X POST http://localhost:8090/v1/parties \
-  -H "Content-Type: application/json" \
-  -H "X-Tenant-ID: default" \
-  -d '{"partyType": "PARTY_TYPE_PERSON", "legalName": "Alice Smith"}')
-echo $PARTY | jq .
-PARTY_ID=$(echo $PARTY | jq -r '.party.partyId')
-
-# 2. Open a current account (GBP)
-ACCOUNT=$(curl -s -X POST http://localhost:8090/v1/current-accounts \
-  -H "Content-Type: application/json" \
-  -H "X-Tenant-ID: default" \
-  -d "{
-    \"partyId\": \"$PARTY_ID\",
-    \"accountIdentification\": \"GB29NWBK60161331926819\",
-    \"baseCurrency\": \"CURRENCY_GBP\"
-  }")
-echo $ACCOUNT | jq .
-ACCOUNT_ID=$(echo $ACCOUNT | jq -r '.facility.accountId')
-
-# 3. Deposit 100 GBP
-curl -s -X POST "http://localhost:8090/v1/current-accounts/$ACCOUNT_ID/deposits" \
-  -H "Content-Type: application/json" \
-  -H "X-Tenant-ID: default" \
-  -d '{
-    "amount": {"amount": {"currencyCode": "GBP", "units": "100"}},
-    "description": "Initial deposit",
-    "reference": "REF-001",
-    "idempotencyKey": {"key": "dep-001"}
-  }' | jq .
-
-# 4. Check balances
-curl -s "http://localhost:8090/v1/accounts/$ACCOUNT_ID/balances" \
-  -H "X-Tenant-ID: default" | jq .
-```
-
-The same flow is available over native gRPC (bypasses the gateway):
-
-```bash
-# Register a party
-grpcurl -plaintext \
-  -H "x-tenant-id: default" \
-  -d '{"partyType": "PARTY_TYPE_PERSON", "legalName": "Alice Smith"}' \
-  localhost:50051 meridian.party.v1.PartyService/RegisterParty
-
-# Open a current account (substitute PARTY_ID from previous response)
-grpcurl -plaintext \
-  -H "x-tenant-id: default" \
-  -d '{"partyId": "PARTY_ID", "accountIdentification": "GB29NWBK60161331926819", "baseCurrency": "CURRENCY_GBP"}' \
-  localhost:50051 meridian.current_account.v1.CurrentAccountService/InitiateCurrentAccount
-
-# Deposit 100 GBP (substitute ACCOUNT_ID from previous response)
-grpcurl -plaintext \
-  -H "x-tenant-id: default" \
-  -d '{
-    "accountId": "ACCOUNT_ID",
-    "amount": {"amount": {"currencyCode": "GBP", "units": "100"}},
-    "description": "Initial deposit",
-    "reference": "REF-001"
-  }' \
-  localhost:50051 meridian.current_account.v1.CurrentAccountService/ExecuteDeposit
-```
-
-See [docs/guides/calling-meridian-apis.md](docs/guides/calling-meridian-apis.md) for a detailed
-API guide covering all supported protocols, error handling, and tenant isolation.
-
-### API Explorer
-
-A Swagger UI is embedded at `api/openapi/swagger-ui.html`. To browse the API interactively while
-the dev stack is running:
-
-```bash
-make swagger-ui
-# Open http://localhost:8091/swagger-ui.html
-```
-
-### Known Limitations vs Full Kubernetes Stack
-
-| Feature | Dev stack | Full K8s stack |
-|---------|-----------|----------------|
-| Kafka event publishing | Disabled (no-op) | Enabled |
-| Redis idempotency store | Disabled (Postgres fallback) | Enabled |
-| Authentication | Disabled (`AUTH_MODE=disabled`) | Embedded Dex OIDC |
-| Cron jobs / schedulers | Not running | Running |
-| Multi-replica | Single process | Horizontal pod autoscaling |
-| Observability (OTLP) | Disabled | Enabled |
-| TLS | None | cert-manager |
-
-The dev stack is suitable for feature development and integration testing. Use the full K8s stack
-(`make deploy-local`) when validating auth flows, event-driven behaviour, or multi-replica
-correctness.
+| Pattern | Description |
+|---------|-------------|
+| **SaaS billing** | Usage metering, tiered pricing, dunning, Stripe settlement |
+| **Energy settlement** | Half-hourly metering, estimate-to-actual reconciliation, grid balancing |
+| **Carbon offset** | Credit registry, retirement tracking, verified offset settlement |
+| **Tote betting** | Pooled stakes, event-driven settlement, proportional payout distribution |
+| **Payment gateway** | Stripe payment intents, webhook handling, refund compensation |
+| **KYC compliance** | Identity verification gates before account activation |
+| **Precious metals** | Commodity accounts with market-rate valuation |
+| **Dynamic pricing** | Time-of-use and capacity-based pricing with real-time adjustment |
 
 ## Architecture
 
-Built on [BIAN](https://bian.org/) banking service domain patterns.
+All services compile into a single binary for simplified deployment, organized into
+[BIAN](https://bian.org/)-aligned domain services with hexagonal architecture.
+
+### Domain Services
 
 | Service | Purpose |
 |---------|---------|
-| **CurrentAccount** | Customer accounts, transaction orchestration |
-| **PositionKeeping** | Pre-ledger transaction log, position tracking |
-| **FinancialAccounting** | Double-entry bookkeeping |
-| **PaymentOrder** | Settlement, Stripe Connect integration |
-| **Party** | Customer data, identity verification |
-| **MarketInformation** | Pricing data with quality ladder (estimate / actual / verified) |
-| **Reconciliation** | Variance detection, dispute management |
+| **CurrentAccount** | Customer accounts, deposits, withdrawals, lien management |
+| **PositionKeeping** | High-frequency position log, balance computation, compaction |
+| **FinancialAccounting** | Double-entry bookkeeping, ledger posting |
+| **PaymentOrder** | Payment orchestration, Stripe settlement, dunning, billing |
+| **Party** | Customer registration, KYC verification, payment methods |
+| **ReferenceData** | Instrument registry, account types, CEL validation, saga definitions |
+| **MarketInformation** | Bi-temporal market data, quality ladder, delta engine |
+| **Reconciliation** | Settlement runs, variance detection, dispute management |
 | **Forecasting** | Forward curves and forecast generation |
-| **ControlPlane** | Tenant management, manifest configuration, Stripe billing |
-| **EventRouter** | CEL-filtered event routing, saga triggering |
-| **FinancialGateway** | External payment provider dispatch and reconciliation |
-| **OperationalGateway** | Non-financial outbound dispatch (KYC, IoT, partner) |
-| **Identity** | OIDC authentication and identity provider integration |
+
+### Platform Services
+
+| Service | Purpose |
+|---------|---------|
+| **ControlPlane** | Manifest system, tenant management, Stripe billing |
+| **EventRouter** | CEL-filtered event routing, saga triggering, utilization metering |
+| **FinancialGateway** | Stripe payment intent adapter, webhook handling |
+| **OperationalGateway** | Non-financial outbound dispatch (IoT, regulatory, partner) |
+| **Identity** | Embedded Dex OIDC, SSO, JWT/API-key authentication |
 | **MCP Server** | AI assistant integration via Model Context Protocol |
 
 See [services/README.md](services/README.md) for the full architecture diagram
@@ -278,11 +126,37 @@ and [docs/adr/](docs/adr/) for architectural decisions.
 
 ## Technology
 
-Go | Protocol Buffers + gRPC | CockroachDB | Apache Kafka | Kubernetes | Stripe Connect
+| Layer | Stack |
+|-------|-------|
+| Language | Go |
+| API | Protocol Buffers, gRPC, REST (transcoded) |
+| Database | PostgreSQL / CockroachDB |
+| Messaging | Apache Kafka |
+| Orchestration | Kubernetes, Tilt (local dev) |
+| Scripting | Starlark (sagas), CEL (validation/routing) |
+| Payments | Stripe Connect |
+| Auth | Dex (OIDC), JWT, API keys |
+| Observability | OpenTelemetry, Prometheus, Grafana |
+
+## Try It
+
+**Prerequisites**: Docker and Docker Compose
+
+```bash
+git clone git@github.com:meridianhub/meridian.git
+cd meridian
+make dev-up
+```
+
+Open [localhost:5173](http://localhost:5173) to explore the web UI - register customers, open accounts, make deposits, and see the ledger in action. Every operation runs as a saga across multiple services with automatic compensation on failure.
+
+REST API is also available at `localhost:8090` and gRPC at `localhost:50051`.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development setup, Kubernetes deployment, and API reference.
 
 ## License
 
-Business Source License 1.1 — See [LICENSE](LICENSE).
+Business Source License 1.1 - See [LICENSE](LICENSE).
 
 - Use, modify, and deploy for any internal purpose
 - Cannot offer a competing Billing/Treasury-as-a-Service

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ Meridian handles the bookkeeping, audit trails, reconciliation, and payment coll
 
 ## Why Meridian
 
-Billing starts as a Stripe checkout and a cron job. Then you need usage metering. Then revenue splits. Then your auditor asks for a transaction trail. Then estimates need to reconcile with actuals. Now you're maintaining a financial system - and you're not a financial company.
+Billing starts as a Stripe checkout and a cron job. Then you need usage metering.
+Then revenue splits. Then your auditor asks for a transaction trail.
+Then estimates need to reconcile with actuals.
+Now you're maintaining a financial system - and you're not a financial company.
 
 Existing solutions force a tradeoff:
 
@@ -39,25 +42,47 @@ Meridian gives you bank-grade infrastructure without the enterprise price tag or
 
 ### Multi-asset ledger with dimensional type safety
 
-Track currency, energy (kWh), carbon credits (tCO2e), compute hours, vouchers, or any custom instrument - all in a single ledger. Compile-time type safety prevents mixing incompatible asset types. Whether you're moving money or megawatts, every movement of value is traceable, reconcilable, and compliant with double-entry principles.
+Track currency, energy (kWh), carbon credits (tCO2e), compute hours, vouchers,
+or any custom instrument - all in a single ledger. Compile-time type safety
+prevents mixing incompatible asset types. Whether you're moving money or
+megawatts, every movement of value is traceable, reconcilable, and compliant
+with double-entry principles.
 
 ### Saga orchestration with guaranteed termination
 
-Every operation runs as a distributed saga - a multi-step workflow that either completes fully or compensates automatically. No partial state, no manual intervention. Sagas are written in [Starlark](https://github.com/bazelbuild/starlark) (the language behind Bazel), which mathematically guarantees termination. No infinite loops, no runaway computation, no tenant can starve another's resources.
+Every operation runs as a distributed saga - a multi-step workflow that either
+completes fully or compensates automatically. No partial state, no manual
+intervention. Sagas are written in
+[Starlark](https://github.com/bazelbuild/starlark) (the language behind Bazel),
+which mathematically guarantees termination. No infinite loops, no runaway
+computation, no tenant can starve another's resources.
 
 ### Declarative economy - define it, then run it
 
-Define instruments, account types, settlement rules, and pricing logic in a YAML + Starlark manifest. Meridian doesn't just provision the configuration - it continuously operates it. Scheduled billing fires monthly. Settlement triggers when market data arrives. Compensation reverses failed steps automatically. The manifest *is* the running system.
+Define instruments, account types, settlement rules, and pricing logic in a
+YAML + Starlark manifest. Meridian doesn't just provision the configuration -
+it continuously operates it. Scheduled billing fires monthly. Settlement
+triggers when market data arrives. Compensation reverses failed steps
+automatically. The manifest *is* the running system.
 
-A complete tote betting platform - instruments, accounts, double-entry settlement, Stripe integration, event-driven payouts - can be expressed in under 400 lines of manifest. No code deployment. No PRs to Meridian core. No migrations.
+A complete tote betting platform - instruments, accounts, double-entry
+settlement, Stripe integration, event-driven payouts - can be expressed in
+under 400 lines of manifest. No code deployment. No PRs to Meridian core.
+No migrations.
 
 ### Bi-temporal data with quality tracking
 
-Every measurement carries what was known, how it was known, and when it was known. The quality ladder (Estimate -> Coefficient -> Actual -> Revised) handles late-arriving data, out-of-order meter reads, and T+2 settlement without locking the database.
+Every measurement carries what was known, how it was known, and when it was
+known. The quality ladder (Estimate -> Coefficient -> Actual -> Revised)
+handles late-arriving data, out-of-order meter reads, and T+2 settlement
+without locking the database.
 
 ### AI-configurable infrastructure
 
-Schema-driven service modules auto-generate type-safe Starlark clients. AI can generate saga code that compiles on the first attempt because the schema constrains it to only call real handlers with real types. Configuration by conversation instead of 6-month implementations.
+Schema-driven service modules auto-generate type-safe Starlark clients. AI can
+generate saga code that compiles on the first attempt because the schema
+constrains it to only call real handlers with real types. Configuration by
+conversation instead of 6-month implementations.
 
 ## What You Get
 
@@ -148,7 +173,10 @@ cd meridian
 make dev-up
 ```
 
-Open [localhost:5173](http://localhost:5173) to explore the web UI - register customers, open accounts, make deposits, and see the ledger in action. Every operation runs as a saga across multiple services with automatic compensation on failure.
+Open [localhost:5173](http://localhost:5173) to explore the web UI - register
+customers, open accounts, make deposits, and see the ledger in action. Every
+operation runs as a saga across multiple services with automatic compensation
+on failure.
 
 REST API is also available at `localhost:8090` and gRPC at `localhost:50051`.
 

--- a/README.md
+++ b/README.md
@@ -22,21 +22,10 @@ Meridian handles the bookkeeping, audit trails, reconciliation, and payment coll
 
 ## Why Meridian
 
-Billing starts as a Stripe checkout and a cron job. Then you need usage metering.
-Then revenue splits. Then your auditor asks for a transaction trail.
+Billing starts as a Stripe checkout and a cron job. Then you need usage
+metering. Then revenue splits. Then your auditor asks for a transaction trail.
 Then estimates need to reconcile with actuals.
 Now you're maintaining a financial system - and you're not a financial company.
-
-Existing solutions force a tradeoff:
-
-| Platform | Limitation |
-|----------|------------|
-| Murex | $10M+/year, 3-year implementation, built for trading floors |
-| 10x / Thought Machine | Fiat currency only - cannot natively track kWh, carbon credits, or compute |
-| Stripe / Modern Treasury | Great APIs, but you still build the ledger logic yourself |
-| Custom internal systems | Years of maintenance, no audit trail, no multi-asset support |
-
-Meridian gives you bank-grade infrastructure without the enterprise price tag or the build-it-yourself burden.
 
 ## What Makes It Different
 

--- a/README.md
+++ b/README.md
@@ -29,54 +29,58 @@ Now you're maintaining a financial system - and you're not a financial company.
 
 ## What Makes It Different
 
-### Multi-asset ledger with dimensional type safety
+### Every movement of value is traceable
 
-Track currency, energy (kWh), carbon credits (tCO2e), compute hours, vouchers,
-or any custom instrument - all in a single ledger. Compile-time type safety
-prevents mixing incompatible asset types. Whether you're moving money or
-megawatts, every movement of value is traceable, reconcilable, and compliant
-with double-entry principles.
+Whether you're moving money, megawatts, or carbon credits - every transaction
+is recorded in a double-entry ledger with an immutable audit trail. Meridian
+natively handles multiple asset types (currency, energy, carbon, compute hours,
+vouchers) in a single ledger, with type safety that prevents accidentally
+mixing incompatible units.
 
-### Saga orchestration with guaranteed termination
+### Multi-step operations that recover from failure
 
-Every operation runs as a distributed saga - a multi-step workflow that either
-completes fully or compensates automatically. No partial state, no manual
-intervention. Sagas are written in
-[Starlark](https://github.com/bazelbuild/starlark) (the language behind Bazel),
-which mathematically guarantees termination. No infinite loops, no runaway
-computation, no tenant can starve another's resources.
+Real-world transactions span multiple services - reserving funds, posting to
+the ledger, triggering settlement. If any step fails partway through, Meridian
+automatically reverses the completed steps to keep the system consistent. No
+partial state, no manual cleanup.
 
-### Declarative economy - define it, then run it
+Business logic is written in
+[Starlark](https://github.com/bazelbuild/starlark), a deterministic subset of
+Python used by Google's Bazel. It guarantees every workflow terminates - no
+infinite loops, no runaway computation, no tenant can starve another's
+resources.
+
+### Define your economy, then run it
 
 Define instruments, account types, settlement rules, and pricing logic in a
-YAML + Starlark manifest. Meridian doesn't just provision the configuration -
-it continuously operates it. Scheduled billing fires monthly. Settlement
-triggers when market data arrives. Compensation reverses failed steps
-automatically. The manifest *is* the running system.
+declarative manifest. Meridian doesn't just provision the configuration - it
+continuously operates it. Scheduled billing fires monthly. Settlement triggers
+when market data arrives. Failed steps reverse automatically. The manifest
+*is* the running system.
 
 A complete tote betting platform - instruments, accounts, double-entry
 settlement, Stripe integration, event-driven payouts - can be expressed in
 under 400 lines of manifest. No code deployment. No PRs to Meridian core.
 No migrations.
 
-### Bi-temporal data with quality tracking
+### Data that knows its own quality
 
-Every measurement carries what was known, how it was known, and when it was
-known. The quality ladder (Estimate -> Coefficient -> Actual -> Revised)
-handles late-arriving data, out-of-order meter reads, and T+2 settlement
-without locking the database.
+Measurements carry what was known, how it was known, and when it was known.
+The quality ladder (Estimate -> Coefficient -> Actual -> Revised) handles
+late-arriving data, out-of-order meter reads, and delayed settlement without
+locking the database.
 
-### AI-configurable infrastructure
+### AI-configurable
 
-Schema-driven service modules auto-generate type-safe Starlark clients. AI can
-generate saga code that compiles on the first attempt because the schema
-constrains it to only call real handlers with real types. Configuration by
-conversation instead of 6-month implementations.
+Schema-driven service modules auto-generate type-safe clients. AI can generate
+business logic that works on the first attempt because the schema constrains
+it to only call real handlers with real types. Configuration by conversation
+instead of 6-month implementations.
 
 ## What You Get
 
-- **Double-entry ledger** with immutable, bi-temporal audit trail
-- **Saga orchestration** with automatic compensation - settlement completes or reverts
+- **Double-entry ledger** with immutable audit trail
+- **Automatic failure recovery** - multi-step operations complete or revert cleanly
 - **Multi-asset support** - currency, kWh, carbon credits, compute hours, vouchers, custom instruments
 - **Stripe Connect** integration for multi-tenant payment collection
 - **Reconciliation** - variance detection, dispute management, imbalance tracking

--- a/README.md
+++ b/README.md
@@ -46,9 +46,12 @@ partial state, no manual cleanup.
 
 Business logic is written in
 [Starlark](https://github.com/bazelbuild/starlark), a deterministic subset of
-Python used by Google's Bazel. It guarantees every workflow terminates - no
-infinite loops, no runaway computation, no tenant can starve another's
-resources.
+Python used by Google's Bazel. It reads like simple Python, so your team
+reviews sagas the same way they review any other code - no new DSL to learn.
+Starlark is secure by construction: the language can't express dangerous
+operations, errors are caught at compile time, and every workflow is guaranteed
+to terminate. AI can generate reliable saga code because the schema constrains
+it to only call real handlers with real types.
 
 ### Define your economy, then run it
 
@@ -72,10 +75,11 @@ locking the database.
 
 ### AI-configurable
 
-Schema-driven service modules auto-generate type-safe clients. AI can generate
-business logic that works on the first attempt because the schema constrains
-it to only call real handlers with real types. Configuration by conversation
-instead of 6-month implementations.
+Because the economy is declarative and the scripting language is constrained,
+the entire economic model can be configured by conversation. AI generates
+working saga code, the schema catches mistakes at compile time, and the UI
+lets you visualize your instruments, accounts, and settlement flows before
+anything runs.
 
 ## What You Get
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ and [docs/adr/](docs/adr/) for architectural decisions.
 **Prerequisites**: Docker and Docker Compose
 
 ```bash
-git clone git@github.com:meridianhub/meridian.git
+git clone https://github.com/meridianhub/meridian.git
 cd meridian
 make dev-up
 ```

--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ automatically reverses the completed steps to keep the system consistent. No
 partial state, no manual cleanup.
 
 Business logic is written in
-[Starlark](https://github.com/bazelbuild/starlark), a deterministic subset of
-Python used by Google's Bazel. It reads like simple Python, so your team
-reviews sagas the same way they review any other code - no new DSL to learn.
-Starlark is secure by construction: the language can't express dangerous
-operations, errors are caught at compile time, and every workflow is guaranteed
-to terminate. AI can generate reliable saga code because the schema constrains
-it to only call real handlers with real types.
+[Starlark](https://github.com/bazelbuild/starlark), a subset of Python used
+by Google's Bazel. It reads like simple Python, so your team reviews sagas
+the same way they review any other code - no new DSL to learn. Meridian's
+runtime enforces execution step limits, so every workflow is guaranteed to
+terminate - no runaway scripts can exhaust compute resources. Errors are
+caught at compile time, and AI can generate reliable saga code because the
+schema constrains it to only call real handlers with real types.
 
 ### Define your economy, then run it
 
@@ -183,6 +183,13 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development setup, Kubernete
 
 Business Source License 1.1 - See [LICENSE](LICENSE).
 
-- Use, modify, and deploy for any internal purpose
-- Cannot offer a competing Billing/Treasury-as-a-Service
-- Converts to Apache 2.0 on February 12, 2030
+You can use, modify, and deploy Meridian in production to run your own
+business - a bank running its own ledger, an energy company managing its own
+settlement, a startup billing its own customers. The only restriction: you
+cannot offer Meridian itself to third parties as a competing commercial
+billing, ledger, treasury, or financial accounting service.
+
+Converts to Apache 2.0 on February 12, 2030.
+
+For alternative licensing arrangements, contact
+[ben@meridianhub.org](mailto:ben@meridianhub.org).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/meridianhub/meridian)
 
-**The open-source transaction integrity engine for the real-world economy.**
+**A source-available transaction integrity engine for the real-world economy.**
 
 Define your pricing, settlement, and multi-party revenue-sharing logic in code.
 Meridian handles the bookkeeping, audit trails, reconciliation, and payment collection.


### PR DESCRIPTION
## Summary

- Restructure README as a front-door page that communicates what Meridian is, why it exists, and what it can deliver - rather than serving as a local development manual
- Add DeepWiki badge
- Add competitive landscape table and key differentiators (multi-asset types, saga orchestration, declarative manifests, bi-temporal data, AI-configurable infrastructure)
- Surface cookbook patterns as a use cases table
- Simplify "Try It" to `make dev-up` + open the web UI
- Move detailed local dev instructions (port mappings, grpcurl, curl walkthroughs, K8s comparison) out of the README - these belong in CONTRIBUTING.md or docs/

## Test plan

- [ ] Verify all links resolve (DeepWiki badge, cookbook, examples/manifests, services/README, docs/adr, CONTRIBUTING)
- [ ] Review rendering on GitHub