### PR TITLE
fix: allow --with-fixtures to run independently of --skip-manifest

### DIFF
--- a/cmd/seed-dev/cmd/root.go
+++ b/cmd/seed-dev/cmd/root.go
@@ -138,27 +138,25 @@ func runSeed(_ *cobra.Command, _ []string) error {
 
 	if skipManifest {
 		fmt.Println("Skipping manifest application (--skip-manifest set).")
-		fmt.Println("Seed complete.")
-		return nil
-	}
-
-	// Use separate connection for control-plane if address differs from tenant service
-	cpAddr := controlPlaneAddr
-	if cpAddr == "" {
-		cpAddr = grpcAddr
-	}
-	manifestConn := conn
-	if cpAddr != grpcAddr {
-		manifestConn, err = grpc.NewClient(cpAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
-		if err != nil {
-			return fmt.Errorf("connect to control-plane gRPC server %s: %w", cpAddr, err)
+	} else {
+		// Use separate connection for control-plane if address differs from tenant service
+		cpAddr := controlPlaneAddr
+		if cpAddr == "" {
+			cpAddr = grpcAddr
 		}
-		defer func() { _ = manifestConn.Close() }()
-	}
+		manifestConn := conn
+		if cpAddr != grpcAddr {
+			manifestConn, err = grpc.NewClient(cpAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+			if err != nil {
+				return fmt.Errorf("connect to control-plane gRPC server %s: %w", cpAddr, err)
+			}
+			defer func() { _ = manifestConn.Close() }()
+		}
 
-	fmt.Printf("Applying manifest from %s ...\n", manifestPath)
-	if err := applyManifest(ctx, manifestConn, tenantID, manifestPath); err != nil {
-		return fmt.Errorf("apply manifest: %w", err)
+		fmt.Printf("Applying manifest from %s ...\n", manifestPath)
+		if err := applyManifest(ctx, manifestConn, tenantID, manifestPath); err != nil {
+			return fmt.Errorf("apply manifest: %w", err)
+		}
 	}
 
 	if withFixtures {

--- a/cmd/seed-dev/cmd/root_test.go
+++ b/cmd/seed-dev/cmd/root_test.go
@@ -116,6 +116,11 @@ func TestSkipManifestDoesNotBlockFixtures(t *testing.T) {
 	// Verify that --skip-manifest and --with-fixtures can be set independently.
 	// The bug: runSeed() returned early when skipManifest was true,
 	// preventing withFixtures code from executing.
+	origSkip, origFixtures := skipManifest, withFixtures
+	t.Cleanup(func() {
+		skipManifest = origSkip
+		withFixtures = origFixtures
+	})
 
 	cmd := rootCmd
 
@@ -126,8 +131,4 @@ func TestSkipManifestDoesNotBlockFixtures(t *testing.T) {
 	// After parsing, both package-level vars should be set.
 	assert.True(t, skipManifest, "skipManifest flag should be true")
 	assert.True(t, withFixtures, "withFixtures flag should be true")
-
-	// Reset for other tests.
-	skipManifest = false
-	withFixtures = false
 }

--- a/cmd/seed-dev/cmd/root_test.go
+++ b/cmd/seed-dev/cmd/root_test.go
@@ -1,10 +1,116 @@
+// Package cmd implements the seed-dev CLI commands.
 package cmd
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestCheckHealth_Healthy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	assert.True(t, checkHealth(srv.URL))
+}
+
+func TestCheckHealth_Unhealthy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	assert.False(t, checkHealth(srv.URL))
+}
+
+func TestCheckHealth_ConnectionRefused(t *testing.T) {
+	assert.False(t, checkHealth("http://127.0.0.1:1"))
+}
+
+func TestGetEnvOrDefault_ReturnsDefault(t *testing.T) {
+	result := getEnvOrDefault("SEED_DEV_NONEXISTENT_VAR_99999", "my-default")
+	assert.Equal(t, "my-default", result)
+}
+
+func TestGetEnvOrDefault_ReturnsEnvValue(t *testing.T) {
+	t.Setenv("SEED_DEV_TEST_VAR", "from-env")
+	result := getEnvOrDefault("SEED_DEV_TEST_VAR", "my-default")
+	assert.Equal(t, "from-env", result)
+}
+
+func TestApplyManifest_InvalidFile(t *testing.T) {
+	err := applyManifest(t.Context(), nil, "dev_tenant", "/nonexistent/path/manifest.json")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read manifest file")
+}
+
+func TestApplyManifest_InvalidJSON(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "bad.json")
+	require.NoError(t, os.WriteFile(tmp, []byte("not valid json {{"), 0o600))
+
+	err := applyManifest(t.Context(), nil, "dev_tenant", tmp)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse manifest JSON")
+}
+
+func TestApplyManifest_ParsesEnergyManifest(t *testing.T) {
+	// Verify the example manifest parses as valid protobuf JSON without a live server.
+	// We pass nil conn, so after successful parse it will fail at the gRPC call stage.
+	manifestPath := "../../../examples/manifests/energy.json"
+	if _, err := os.Stat(manifestPath); os.IsNotExist(err) {
+		t.Skip("energy.json not found; skipping parse test")
+	}
+
+	data, err := os.ReadFile(manifestPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	// Unmarshal using the same path as production code to confirm it is valid.
+	tmp := filepath.Join(t.TempDir(), "energy.json")
+	require.NoError(t, os.WriteFile(tmp, data, 0o600))
+
+	// applyManifest with nil conn will panic on the gRPC call; only test parse path.
+	// We test parse separately via a helper to avoid a nil-conn panic.
+	err = unmarshalManifestFile(tmp)
+	assert.NoError(t, err)
+}
+
+func TestRootCmd_DefaultFlagValues(t *testing.T) {
+	// Ensure the flags registered on rootCmd have the expected defaults.
+	// These values must match what is documented and expected by docker-compose / scripts.
+	f := rootCmd.Flags()
+
+	gwURL, err := f.GetString("gateway-url")
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost:8090", gwURL)
+
+	grpc, err := f.GetString("grpc-addr")
+	require.NoError(t, err)
+	assert.Equal(t, "localhost:50051", grpc)
+
+	manifest, err := f.GetString("manifest")
+	require.NoError(t, err)
+	assert.Equal(t, "examples/manifests/energy.json", manifest)
+
+	tenantIDFlag, err := f.GetString("tenant-id")
+	require.NoError(t, err)
+	assert.Equal(t, "dev_tenant", tenantIDFlag)
+
+	tenantSlugFlag, err := f.GetString("tenant-slug")
+	require.NoError(t, err)
+	assert.Equal(t, "dev-tenant", tenantSlugFlag)
+
+	skip, err := f.GetBool("skip-manifest")
+	require.NoError(t, err)
+	assert.False(t, skip)
+}
 
 func TestSkipManifestDoesNotBlockFixtures(t *testing.T) {
 	// Verify that --skip-manifest and --with-fixtures can be set independently.

--- a/cmd/seed-dev/cmd/root_test.go
+++ b/cmd/seed-dev/cmd/root_test.go
@@ -1,113 +1,27 @@
-// Package cmd implements the seed-dev CLI commands.
 package cmd
 
 import (
-	"net/http"
-	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestCheckHealth_Healthy(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
+func TestSkipManifestDoesNotBlockFixtures(t *testing.T) {
+	// Verify that --skip-manifest and --with-fixtures can be set independently.
+	// The bug: runSeed() returned early when skipManifest was true,
+	// preventing withFixtures code from executing.
 
-	assert.True(t, checkHealth(srv.URL))
-}
+	cmd := rootCmd
 
-func TestCheckHealth_Unhealthy(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusServiceUnavailable)
-	}))
-	defer srv.Close()
-
-	assert.False(t, checkHealth(srv.URL))
-}
-
-func TestCheckHealth_ConnectionRefused(t *testing.T) {
-	assert.False(t, checkHealth("http://127.0.0.1:1"))
-}
-
-func TestGetEnvOrDefault_ReturnsDefault(t *testing.T) {
-	result := getEnvOrDefault("SEED_DEV_NONEXISTENT_VAR_99999", "my-default")
-	assert.Equal(t, "my-default", result)
-}
-
-func TestGetEnvOrDefault_ReturnsEnvValue(t *testing.T) {
-	t.Setenv("SEED_DEV_TEST_VAR", "from-env")
-	result := getEnvOrDefault("SEED_DEV_TEST_VAR", "my-default")
-	assert.Equal(t, "from-env", result)
-}
-
-func TestApplyManifest_InvalidFile(t *testing.T) {
-	err := applyManifest(t.Context(), nil, "dev_tenant", "/nonexistent/path/manifest.json")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "read manifest file")
-}
-
-func TestApplyManifest_InvalidJSON(t *testing.T) {
-	tmp := filepath.Join(t.TempDir(), "bad.json")
-	require.NoError(t, os.WriteFile(tmp, []byte("not valid json {{"), 0o600))
-
-	err := applyManifest(t.Context(), nil, "dev_tenant", tmp)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "parse manifest JSON")
-}
-
-func TestApplyManifest_ParsesEnergyManifest(t *testing.T) {
-	// Verify the example manifest parses as valid protobuf JSON without a live server.
-	// We pass nil conn, so after successful parse it will fail at the gRPC call stage.
-	manifestPath := "../../../examples/manifests/energy.json"
-	if _, err := os.Stat(manifestPath); os.IsNotExist(err) {
-		t.Skip("energy.json not found; skipping parse test")
-	}
-
-	data, err := os.ReadFile(manifestPath)
-	require.NoError(t, err)
-	require.NotEmpty(t, data)
-
-	// Unmarshal using the same path as production code to confirm it is valid.
-	tmp := filepath.Join(t.TempDir(), "energy.json")
-	require.NoError(t, os.WriteFile(tmp, data, 0o600))
-
-	// applyManifest with nil conn will panic on the gRPC call; only test parse path.
-	// We test parse separately via a helper to avoid a nil-conn panic.
-	err = unmarshalManifestFile(tmp)
+	// Parse flags without executing - verify both flags are accepted together.
+	err := cmd.ParseFlags([]string{"--skip-manifest", "--with-fixtures"})
 	assert.NoError(t, err)
-}
 
-func TestRootCmd_DefaultFlagValues(t *testing.T) {
-	// Ensure the flags registered on rootCmd have the expected defaults.
-	// These values must match what is documented and expected by docker-compose / scripts.
-	f := rootCmd.Flags()
+	// After parsing, both package-level vars should be set.
+	assert.True(t, skipManifest, "skipManifest flag should be true")
+	assert.True(t, withFixtures, "withFixtures flag should be true")
 
-	gwURL, err := f.GetString("gateway-url")
-	require.NoError(t, err)
-	assert.Equal(t, "http://localhost:8090", gwURL)
-
-	grpc, err := f.GetString("grpc-addr")
-	require.NoError(t, err)
-	assert.Equal(t, "localhost:50051", grpc)
-
-	manifest, err := f.GetString("manifest")
-	require.NoError(t, err)
-	assert.Equal(t, "examples/manifests/energy.json", manifest)
-
-	tenantIDFlag, err := f.GetString("tenant-id")
-	require.NoError(t, err)
-	assert.Equal(t, "dev_tenant", tenantIDFlag)
-
-	tenantSlugFlag, err := f.GetString("tenant-slug")
-	require.NoError(t, err)
-	assert.Equal(t, "dev-tenant", tenantSlugFlag)
-
-	skip, err := f.GetBool("skip-manifest")
-	require.NoError(t, err)
-	assert.False(t, skip)
+	// Reset for other tests.
+	skipManifest = false
+	withFixtures = false
 }


### PR DESCRIPTION
## Summary

- Fixes `seed-dev --skip-manifest --with-fixtures` silently skipping fixture seeding
- The early `return nil` at root.go:139-142 when `--skip-manifest` was set prevented the fixture block from ever executing
- Restructures `runSeed()` control flow: manifest logic wrapped in `if/else` so fixtures run regardless

## Changes Made

- `cmd/seed-dev/cmd/root.go`: Replace early return with `if !skipManifest { ... } else { ... }` block, keeping fixture code always reachable
- `cmd/seed-dev/cmd/root_test.go`: Add test verifying both flags can be set independently

## Test plan

- [ ] `go build ./cmd/seed-dev/` compiles cleanly
- [ ] `go test ./cmd/seed-dev/cmd/` passes
- [ ] CI passes
- [ ] Manual: `seed-dev --skip-manifest --with-fixtures` now seeds fixtures without applying manifest

## Task

manifest-integrity.11 - Fix seed-dev --with-fixtures to work independently of --skip-manifest