### PR TITLE
Tighten BSL license to threshold-based production use

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -8,9 +8,10 @@ Licensor:             Meridian Hub Ltd
 Licensed Work:        Meridian
                       The Licensed Work is (c) 2025-2026 Meridian Hub Ltd.
 Additional Use Grant: You may make production use of the Licensed Work, provided
-                      Your use does not include offering the Licensed Work to third
-                      parties as a commercial billing, ledger, treasury, or financial
-                      accounting service that competes with Meridian Hub products.
+                      that the total number of active accounts (accounts not in a
+                      closed or archived state) across all tenants does not exceed
+                      5,000. Production use exceeding this limit requires a commercial
+                      license from the Licensor.
 Change Date:          February 12, 2030
 Change License:       Apache License, Version 2.0
 

--- a/README.md
+++ b/README.md
@@ -183,13 +183,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development setup, Kubernete
 
 Business Source License 1.1 - See [LICENSE](LICENSE).
 
-You can use, modify, and deploy Meridian in production to run your own
-business - a bank running its own ledger, an energy company managing its own
-settlement, a startup billing its own customers. The only restriction: you
-cannot offer Meridian itself to third parties as a competing commercial
-billing, ledger, treasury, or financial accounting service.
+Free for development, testing, and evaluation. Production use is free for up
+to 5,000 active accounts across all tenants. Beyond that, a commercial license
+is required.
 
-Converts to Apache 2.0 on February 12, 2030.
-
-For alternative licensing arrangements, contact
-[ben@meridianhub.org](mailto:ben@meridianhub.org).
+Converts to Apache 2.0 on February 12, 2030. For commercial licensing,
+contact [ben@meridianhub.org](mailto:ben@meridianhub.org).


### PR DESCRIPTION
## Summary

- Change the Additional Use Grant from anti-competitive-service model to
  threshold-based: free production use up to 5,000 active accounts across
  all tenants
- Above that threshold, a commercial license is required
- Development, testing, and evaluation remain unrestricted at any scale
- Update README license section to reflect the new terms

This follows the MariaDB pattern for BSL licensing - free tier for startups
and small deployments, commercial license when there's clear commercial value.

## Test plan

- [ ] Review LICENSE wording for legal clarity
- [ ] Verify README accurately summarizes the license terms