### PR TITLE
fix: map organization DELETE to ControlParty deactivation

### DIFF
--- a/services/control-plane/internal/applier/handlers.go
+++ b/services/control-plane/internal/applier/handlers.go
@@ -213,6 +213,19 @@ func RegisterManifestHandlers(registry *saga.HandlerRegistry, deps *HandlerDepen
 				Version:              1,
 			},
 		},
+		// Party - Organization lifecycle control (deactivation via TERMINATE)
+		"party.control_organization": {
+			handler: controlOrganizationHandler(deps),
+			metadata: saga.HandlerMetadata{
+				Category:             saga.HandlerCategorySettlement,
+				Description:          "Apply a lifecycle control action to an organization (e.g., TERMINATE)",
+				CompensationStrategy: "none",
+				ProducesInstruments:  []string{},
+				ProtoRequestType:     (*partyv1.ControlPartyRequest)(nil),
+				ProtoResponseType:    (*partyv1.ControlPartyResponse)(nil),
+				Version:              1,
+			},
+		},
 	}
 
 	for name, h := range handlers {
@@ -296,6 +309,8 @@ type MarketInformationService interface {
 type PartyService interface {
 	// RegisterOrganization registers a new organization party in the party directory.
 	RegisterOrganization(ctx *saga.StarlarkContext, params map[string]any) (any, error)
+	// ControlOrganization applies a lifecycle control action (e.g., TERMINATE) to an organization.
+	ControlOrganization(ctx *saga.StarlarkContext, params map[string]any) (any, error)
 }
 
 // registerInstrumentHandler creates a handler that registers an instrument via Reference Data.
@@ -446,6 +461,18 @@ func registerOrganizationHandler(deps *HandlerDependencies) saga.Handler {
 			return nil, ErrPartyNotConfigured
 		}
 		return deps.Party.RegisterOrganization(ctx, params)
+	}
+}
+
+// controlOrganizationHandler creates a handler that applies a lifecycle control action
+// to an organization (e.g., TERMINATE for deactivation).
+// Returns an error if Party is nil to prevent silent skipping.
+func controlOrganizationHandler(deps *HandlerDependencies) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		if deps.Party == nil {
+			return nil, ErrPartyNotConfigured
+		}
+		return deps.Party.ControlOrganization(ctx, params)
 	}
 }
 

--- a/services/control-plane/internal/applier/handlers_test.go
+++ b/services/control-plane/internal/applier/handlers_test.go
@@ -719,6 +719,7 @@ func (m *mockMarketInformation) ActivateDataSet(ctx *saga.StarlarkContext, param
 // mockParty implements PartyService for testing.
 type mockParty struct {
 	registerOrganizationFn func(*saga.StarlarkContext, map[string]any) (any, error)
+	controlOrganizationFn  func(*saga.StarlarkContext, map[string]any) (any, error)
 }
 
 func (m *mockParty) RegisterOrganization(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
@@ -726,6 +727,13 @@ func (m *mockParty) RegisterOrganization(ctx *saga.StarlarkContext, params map[s
 		return m.registerOrganizationFn(ctx, params)
 	}
 	return map[string]any{"party_id": params["party_id"], "status": "ACTIVE"}, nil
+}
+
+func (m *mockParty) ControlOrganization(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+	if m.controlOrganizationFn != nil {
+		return m.controlOrganizationFn(ctx, params)
+	}
+	return map[string]any{"party_id": params["party_id"], "status": "TERMINATED"}, nil
 }
 
 // TestRegisterDataSourceHandler verifies the handler delegates to MarketInformationService.
@@ -942,6 +950,57 @@ func TestRegisterOrganizationHandler_NilService(t *testing.T) {
 	require.NoError(t, err)
 
 	handler, err := registry.Get("party.register_organization")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{"party_id": "acme-corp"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "party service not configured")
+}
+
+// TestControlOrganizationHandler verifies the handler delegates to PartyService.
+func TestControlOrganizationHandler(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	deps := &HandlerDependencies{
+		ReferenceData:   &mockReferenceData{},
+		InternalAccount: &mockInternalAccount{},
+		Party:           &mockParty{},
+	}
+
+	err := RegisterManifestHandlers(registry, deps)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.control_organization")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	params := map[string]any{
+		"party_id": "acme-corp",
+		"reason":   "Removed from manifest",
+	}
+
+	result, err := handler(ctx, params)
+	require.NoError(t, err)
+
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "acme-corp", resultMap["party_id"])
+	assert.Equal(t, "TERMINATED", resultMap["status"])
+}
+
+// TestControlOrganizationHandler_NilService verifies error when Party service is nil.
+func TestControlOrganizationHandler_NilService(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	deps := &HandlerDependencies{
+		ReferenceData:   &mockReferenceData{},
+		InternalAccount: &mockInternalAccount{},
+		Party:           nil,
+	}
+
+	err := RegisterManifestHandlers(registry, deps)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.control_organization")
 	require.NoError(t, err)
 
 	ctx := newTestStarlarkContext()

--- a/services/control-plane/internal/applier/manifest_apply_integration_test.go
+++ b/services/control-plane/internal/applier/manifest_apply_integration_test.go
@@ -38,6 +38,10 @@ func (n *noopParty) RegisterOrganization(_ *saga.StarlarkContext, _ map[string]a
 	return map[string]any{"party_id": "party-uuid-1", "status": "ACTIVE"}, nil
 }
 
+func (n *noopParty) ControlOrganization(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+	return map[string]any{"party_id": "party-uuid-1", "status": "TERMINATED"}, nil
+}
+
 // noopOperationalGateway implements OperationalGatewayService with no-op handlers.
 type noopOperationalGateway struct{}
 

--- a/services/control-plane/internal/applier/party_client.go
+++ b/services/control-plane/internal/applier/party_client.go
@@ -78,5 +78,31 @@ func parseExternalReferenceType(s string) (partyv1.ExternalReferenceType, error)
 	return 0, fmt.Errorf("%w: %q", ErrUnknownExternalReferenceType, s)
 }
 
+// ControlOrganization implements PartyService.
+// Converts Starlark params to a ControlPartyRequest with CONTROL_ACTION_TERMINATE
+// and calls the gRPC service. This is used when a manifest DELETE removes an organization.
+func (c *PartyClient) ControlOrganization(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+	req := &partyv1.ControlPartyRequest{
+		ControlAction: partyv1.ControlAction_CONTROL_ACTION_TERMINATE,
+	}
+	req.PartyId, _ = params["party_id"].(string)
+	req.Reason, _ = params["reason"].(string)
+	if req.Reason == "" {
+		req.Reason = "Organization removed from manifest"
+	}
+
+	callCtx := prepareCallContext(ctx)
+	resp, err := c.client.ControlParty(callCtx, req)
+	if err != nil {
+		return nil, fmt.Errorf("control organization: %w", err)
+	}
+
+	party := resp.GetParty()
+	return map[string]any{
+		"party_id": party.GetPartyId(),
+		"status":   party.GetStatus().String(),
+	}, nil
+}
+
 // Ensure PartyClient implements PartyService at compile time.
 var _ PartyService = (*PartyClient)(nil)

--- a/services/control-plane/internal/planner/manifest_planner.go
+++ b/services/control-plane/internal/planner/manifest_planner.go
@@ -19,7 +19,6 @@ var ErrNoMethodMapping = errors.New("no gRPC method mapping")
 // Party types are managed through schema updates; deletion via manifest apply is not supported.
 var ErrDeleteNotSupportedForPartyType = errors.New("delete not supported for party types: update the schema instead")
 
-
 // ManifestPlanner transforms a DiffPlan into a dependency-ordered
 // ExecutionPlan of gRPC calls. It assigns each action to a phase
 // based on resource type dependencies and maps actions to the

--- a/services/control-plane/internal/planner/manifest_planner.go
+++ b/services/control-plane/internal/planner/manifest_planner.go
@@ -19,9 +19,6 @@ var ErrNoMethodMapping = errors.New("no gRPC method mapping")
 // Party types are managed through schema updates; deletion via manifest apply is not supported.
 var ErrDeleteNotSupportedForPartyType = errors.New("delete not supported for party types: update the schema instead")
 
-// ErrDeleteNotSupportedForOrganization is returned when a DELETE action is attempted on an organization.
-// Organizations are deactivated through the Party Service; deletion via manifest apply is not supported.
-var ErrDeleteNotSupportedForOrganization = errors.New("delete not supported for organizations: deactivate the party instead")
 
 // ManifestPlanner transforms a DiffPlan into a dependency-ordered
 // ExecutionPlan of gRPC calls. It assigns each action to a phase
@@ -133,9 +130,6 @@ func grpcMethodFor(rt differ.ResourceType, action differ.ActionType) (GRPCMethod
 	if rt == differ.ResourcePartyType && action == differ.ActionDelete {
 		return "", ErrDeleteNotSupportedForPartyType
 	}
-	if rt == differ.ResourceOrganization && action == differ.ActionDelete {
-		return "", ErrDeleteNotSupportedForOrganization
-	}
 	key := methodKey{rt, action}
 	method, ok := grpcMethodMap[key]
 	if !ok {
@@ -209,7 +203,7 @@ var grpcMethodMap = map[methodKey]GRPCMethod{
 	// Organizations
 	{differ.ResourceOrganization, differ.ActionCreate}: MethodRegisterOrganization,
 	{differ.ResourceOrganization, differ.ActionUpdate}: MethodRegisterOrganization,
-	// No delete method: organizations are deactivated, not deleted.
+	{differ.ResourceOrganization, differ.ActionDelete}: MethodControlOrganization,
 
 	// Internal Accounts
 	{differ.ResourceInternalAccount, differ.ActionCreate}: MethodInitiateAccount,

--- a/services/control-plane/internal/planner/manifest_planner_test.go
+++ b/services/control-plane/internal/planner/manifest_planner_test.go
@@ -721,7 +721,7 @@ func TestPlan_OrganizationUpdate(t *testing.T) {
 	assert.Equal(t, MethodRegisterOrganization, plan.Calls[0].GRPCMethod)
 }
 
-func TestPlan_Organization_Delete_NotSupported(t *testing.T) {
+func TestPlan_OrganizationDelete_MapsToControlOrganization(t *testing.T) {
 	p := NewManifestPlanner()
 	diffPlan := &differ.DiffPlan{
 		Actions: []differ.PlannedAction{
@@ -729,9 +729,13 @@ func TestPlan_Organization_Delete_NotSupported(t *testing.T) {
 		},
 	}
 
-	_, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
-	assert.Error(t, err, "DELETE for organizations should fail")
-	assert.ErrorIs(t, err, ErrDeleteNotSupportedForOrganization)
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 1)
+
+	assert.Equal(t, MethodControlOrganization, plan.Calls[0].GRPCMethod)
+	assert.Equal(t, PhaseOrganizations, plan.Calls[0].Phase)
+	assert.Equal(t, differ.ActionDelete, plan.Calls[0].Action)
 }
 
 func TestPlan_PhaseOrdering_MarketDataBeforeOrganizations(t *testing.T) {

--- a/services/control-plane/internal/planner/types.go
+++ b/services/control-plane/internal/planner/types.go
@@ -141,6 +141,7 @@ const (
 
 	// Party Service (Organizations)
 	MethodRegisterOrganization GRPCMethod = "meridian.party.v1.PartyService/RegisterParty"
+	MethodControlOrganization  GRPCMethod = "meridian.party.v1.PartyService/ControlParty"
 )
 
 // PlannedCall represents a single gRPC call in the execution plan.


### PR DESCRIPTION
## Summary

- Remove the hard rejection (`ErrDeleteNotSupportedForOrganization`) in the manifest planner when the differ produces DELETE actions for organizations
- Map organization DELETE to `ControlParty` with `CONTROL_ACTION_TERMINATE` instead, consistent with how internal account DELETEs map to `ControlInternalAccount`
- Add `ControlOrganization` to the `PartyService` interface, `PartyClient`, and handler registry (`party.control_organization`)

## Context

When `seed-dev` applies `energy.json` to `dev_tenant`, the differ compares against the last-applied platform manifest. Organizations present in the platform manifest but absent from `energy.json` produce DELETE actions. The planner previously hard-rejected these at `manifest_planner.go:136-138`, causing the entire apply to fail.

## Test plan

- [x] Planner test: org DELETE maps to `MethodControlOrganization` (replaces `TestPlan_Organization_Delete_NotSupported`)
- [x] Handler test: `party.control_organization` delegates to `PartyService.ControlOrganization`
- [x] Handler test: nil Party service returns `ErrPartyNotConfigured`
- [x] All existing planner and applier unit tests pass
- [x] Mock implementations updated (`mockParty`, `noopParty`)