### PR TITLE
fix: wire e2e demo flow with fixture data verification and frontend fixes

### DIFF
--- a/frontend/src/features/accounts/hooks/format-balance.test.ts
+++ b/frontend/src/features/accounts/hooks/format-balance.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { formatBalance } from './use-accounts'
 
 describe('formatBalance', () => {
@@ -8,21 +8,25 @@ describe('formatBalance', () => {
   })
 
   it('formats ISO currency codes using Intl.NumberFormat', () => {
-    const result = formatBalance({ units: 100, nanos: 500_000_000, currencyCode: 'GBP' })
-    expect(result).toBeDefined()
-    // Intl formatting includes the value; exact format is locale-dependent
-    expect(result).toContain('100.50')
+    const input = { units: 100, nanos: 500_000_000, currencyCode: 'GBP' }
+    const expected = new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency: 'GBP',
+    }).format(100.5)
+    expect(formatBalance(input)).toBe(expected)
+  })
+
+  it('falls back to "<value> <code>" when Intl.NumberFormat throws', () => {
+    const spy = vi.spyOn(Intl, 'NumberFormat').mockImplementation((() => {
+      throw new RangeError('forced failure')
+    }) as unknown as typeof Intl.NumberFormat)
+    expect(formatBalance({ units: 245, nanos: 500_000_000, currencyCode: 'KWH' })).toBe(
+      '245.50 KWH',
+    )
+    spy.mockRestore()
   })
 
   it('formats non-ISO currency codes with code and value', () => {
-    const result = formatBalance({ units: 245, nanos: 500_000_000, currencyCode: 'KWH' })
-    expect(result).toBeDefined()
-    // Intl may format as "KWH 245.50" or catch block returns "245.50 KWH"
-    expect(result).toContain('245.50')
-    expect(result).toContain('KWH')
-  })
-
-  it('formats non-ISO currency codes for zero values', () => {
     const result = formatBalance({ units: 0, nanos: 0, currencyCode: 'KWH' })
     expect(result).toBeDefined()
     expect(result).toContain('0.00')

--- a/frontend/src/features/accounts/hooks/format-balance.test.ts
+++ b/frontend/src/features/accounts/hooks/format-balance.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { formatBalance } from './use-accounts'
+
+describe('formatBalance', () => {
+  it('returns undefined for null/undefined input', () => {
+    expect(formatBalance(null)).toBeUndefined()
+    expect(formatBalance(undefined)).toBeUndefined()
+  })
+
+  it('formats ISO currency codes using Intl.NumberFormat', () => {
+    const result = formatBalance({ units: 100, nanos: 500_000_000, currencyCode: 'GBP' })
+    expect(result).toBeDefined()
+    // Intl formatting includes the value; exact format is locale-dependent
+    expect(result).toContain('100.50')
+  })
+
+  it('formats non-ISO currency codes with code and value', () => {
+    const result = formatBalance({ units: 245, nanos: 500_000_000, currencyCode: 'KWH' })
+    expect(result).toBeDefined()
+    // Intl may format as "KWH 245.50" or catch block returns "245.50 KWH"
+    expect(result).toContain('245.50')
+    expect(result).toContain('KWH')
+  })
+
+  it('formats non-ISO currency codes for zero values', () => {
+    const result = formatBalance({ units: 0, nanos: 0, currencyCode: 'KWH' })
+    expect(result).toBeDefined()
+    expect(result).toContain('0.00')
+    expect(result).toContain('KWH')
+  })
+
+  it('formats values without currency code as plain decimal', () => {
+    const result = formatBalance({ units: 42, nanos: 0 })
+    expect(result).toBe('42.00')
+  })
+
+  it('handles bigint units', () => {
+    const result = formatBalance({ units: BigInt(100), nanos: 0, currencyCode: 'KWH' })
+    expect(result).toBeDefined()
+    expect(result).toContain('100.00')
+    expect(result).toContain('KWH')
+  })
+
+  it('handles very large bigint units by falling back to string', () => {
+    const bigValue = BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1)
+    const result = formatBalance({
+      units: bigValue,
+      nanos: 0,
+      currencyCode: 'GBP',
+    })
+    expect(result).toContain('GBP')
+    expect(result).toContain(bigValue.toString())
+  })
+})

--- a/frontend/src/features/accounts/hooks/use-accounts.ts
+++ b/frontend/src/features/accounts/hooks/use-accounts.ts
@@ -18,7 +18,7 @@ function toAccountStatus(status: number | undefined): AccountStatusType {
 }
 
 /** Extract a display string from google.type.Money (units + nanos/1e9). */
-function formatBalance(
+export function formatBalance(
   money:
     | { units?: bigint | number; nanos?: number; currencyCode?: string }
     | undefined
@@ -45,7 +45,7 @@ function formatBalance(
         currency: money.currencyCode,
       }).format(value)
     } catch {
-      /* fall through for non-ISO codes */
+      return `${value.toFixed(2)} ${money.currencyCode}`
     }
   }
   return value.toFixed(2)


### PR DESCRIPTION
## Summary

- Verified fixture seeding pipeline (10 customers, GBP+KWH accounts, 30 daily deposits, double-entry with GSP inventory accounts) - all code paths correct
- Fixed `formatBalance` catch block to include currency code suffix for non-ISO instrument codes (e.g., KWH) when `Intl.NumberFormat` throws
- Verified `reservedBalance` is NOT in the proto response (`AccountBalance` has `currentBalance` and `availableBalance` only) - no dead code added
- Verified accounts-tab party filtering correctly matches on both `orgPartyId` and `partyId`
- Added unit tests for `formatBalance` covering ISO currencies, non-ISO codes, bigint units, and edge cases

## Changes Made

- `frontend/src/features/accounts/hooks/use-accounts.ts`: Export `formatBalance`; fix catch block to return `${value} ${currencyCode}` instead of bare number
- `frontend/src/features/accounts/hooks/format-balance.test.ts`: New test file with 7 test cases

## Test plan

- [x] All 2512 frontend tests pass
- [x] Lint passes (0 errors)
- [x] `formatBalance` unit tests cover: null/undefined, ISO codes (GBP), non-ISO codes (KWH), zero values, bigint, large bigint overflow