### PR TITLE
feat: add MCP connection card to dashboard

### DIFF
--- a/frontend/src/features/dashboard/pages/index.tsx
+++ b/frontend/src/features/dashboard/pages/index.tsx
@@ -10,6 +10,7 @@ import { usePageTitle } from '@/hooks/use-page-title'
 import { StatCard } from './stat-card'
 import { ActivityFeed, type ActivityItem } from './activity-feed'
 import { QuickActions, type QuickAction } from './quick-actions'
+import { McpConnectionCard } from './mcp-connection-card'
 
 // Cache dashboard stats for 60s to reduce unnecessary refetches on navigation
 const DASHBOARD_STALE_TIME = 60_000
@@ -226,15 +227,18 @@ export function DashboardPage() {
           </CardContent>
         </Card>
 
-        {/* Quick Actions - takes 1/3 width */}
-        <Card>
-          <CardHeader>
-            <CardTitle>Quick Actions</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <QuickActions actions={quickActions} />
-          </CardContent>
-        </Card>
+        {/* Right column: Quick Actions + MCP Connection */}
+        <div className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Quick Actions</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <QuickActions actions={quickActions} />
+            </CardContent>
+          </Card>
+          <McpConnectionCard />
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/features/dashboard/pages/mcp-connection-card.test.tsx
+++ b/frontend/src/features/dashboard/pages/mcp-connection-card.test.tsx
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { McpConnectionCard } from './mcp-connection-card'
+
+vi.mock('@/contexts/tenant-context', () => ({
+  useTenantContext: vi.fn(() => ({
+    tenantSlug: 'test-tenant',
+    currentTenant: { id: 'tid', slug: 'test-tenant', name: 'Test Tenant' },
+    isPlatformAdmin: false,
+    switchTenant: vi.fn(),
+    clearTenant: vi.fn(),
+  })),
+}))
+
+vi.mock('@/contexts/auth-context', () => ({
+  useAuth: vi.fn(() => ({
+    isAuthenticated: true,
+    accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature',
+    claims: null,
+    lens: 'tenant',
+    login: vi.fn(),
+    logout: vi.fn(),
+    refreshToken: vi.fn(),
+  })),
+}))
+
+import { useTenantContext } from '@/contexts/tenant-context'
+import { useAuth } from '@/contexts/auth-context'
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>
+}
+
+const defaultTenantContext = {
+  tenantSlug: 'test-tenant',
+  currentTenant: { id: 'tid', slug: 'test-tenant', name: 'Test Tenant' },
+  isPlatformAdmin: false,
+  switchTenant: vi.fn(),
+  clearTenant: vi.fn(),
+}
+
+const defaultAuthContext = {
+  isAuthenticated: true,
+  accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature',
+  claims: null,
+  lens: 'tenant' as const,
+  login: vi.fn(),
+  logout: vi.fn(),
+  refreshToken: vi.fn(),
+}
+
+describe('McpConnectionCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useTenantContext).mockReturnValue(defaultTenantContext)
+    vi.mocked(useAuth).mockReturnValue(defaultAuthContext)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('rendering', () => {
+    it('renders card title', () => {
+      render(<McpConnectionCard />, { wrapper: Wrapper })
+
+      expect(screen.getByText('AI Connection')).toBeInTheDocument()
+      expect(screen.getByText('MCP')).toBeInTheDocument()
+    })
+
+    it('renders MCP server URL', () => {
+      render(<McpConnectionCard />, { wrapper: Wrapper })
+
+      const urlEl = screen.getByTestId('mcp-card-url')
+      expect(urlEl).toHaveTextContent('/mcp')
+    })
+
+    it('renders Claude Code config with streamable-http type', () => {
+      render(<McpConnectionCard />, { wrapper: Wrapper })
+
+      const configEl = screen.getByTestId('mcp-card-claude-config')
+      expect(configEl).toHaveTextContent('streamable-http')
+      expect(configEl).toHaveTextContent('mcpServers')
+      expect(configEl).toHaveTextContent('/mcp')
+    })
+
+    it('renders truncated auth token preview', () => {
+      render(<McpConnectionCard />, { wrapper: Wrapper })
+
+      const tokenEl = screen.getByTestId('mcp-card-token-preview')
+      expect(tokenEl).toHaveTextContent('...')
+      // Should show first 12 chars
+      expect(tokenEl).toHaveTextContent('eyJhbGciOiJI')
+    })
+
+    it('renders connection instructions', () => {
+      render(<McpConnectionCard />, { wrapper: Wrapper })
+
+      expect(screen.getByText(/Add the config above/i)).toBeInTheDocument()
+      expect(screen.getAllByText(/.mcp.json/i).length).toBeGreaterThan(0)
+    })
+
+    it('does not render when no tenant selected', () => {
+      vi.mocked(useTenantContext).mockReturnValue({
+        tenantSlug: null,
+        currentTenant: null,
+        isPlatformAdmin: true,
+        switchTenant: vi.fn(),
+        clearTenant: vi.fn(),
+      })
+
+      const { container } = render(<McpConnectionCard />, { wrapper: Wrapper })
+
+      expect(container).toBeEmptyDOMElement()
+    })
+
+    it('does not render token preview when no access token', () => {
+      vi.mocked(useAuth).mockReturnValue({
+        ...defaultAuthContext,
+        accessToken: null,
+      })
+
+      render(<McpConnectionCard />, { wrapper: Wrapper })
+
+      expect(screen.queryByTestId('mcp-card-token-preview')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('copy to clipboard', () => {
+    it('copies MCP URL when clicking copy server URL button', async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined)
+      vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
+
+      render(<McpConnectionCard />, { wrapper: Wrapper })
+
+      const copyButton = screen.getByRole('button', { name: /Copy MCP server URL/i })
+      await act(async () => {
+        copyButton.click()
+      })
+
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining('/mcp'))
+    })
+
+    it('copies Claude Code config when clicking copy config button', async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined)
+      vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
+
+      render(<McpConnectionCard />, { wrapper: Wrapper })
+
+      const copyButton = screen.getByRole('button', { name: /Copy Claude Code config/i })
+      await act(async () => {
+        copyButton.click()
+      })
+
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining('mcpServers'))
+    })
+
+    it('shows Copied! feedback after clicking copy', async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined)
+      vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
+
+      render(<McpConnectionCard />, { wrapper: Wrapper })
+
+      const copyButton = screen.getByRole('button', { name: /Copy MCP server URL/i })
+      await act(async () => {
+        copyButton.click()
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText('Copied!')).toBeInTheDocument()
+      })
+    })
+
+    it('copies auth token when clicking copy token button', async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined)
+      vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
+
+      render(<McpConnectionCard />, { wrapper: Wrapper })
+
+      const copyButton = screen.getByRole('button', { name: /Copy auth token/i })
+      await act(async () => {
+        copyButton.click()
+      })
+
+      expect(writeText).toHaveBeenCalledWith(defaultAuthContext.accessToken)
+    })
+  })
+})

--- a/frontend/src/features/dashboard/pages/mcp-connection-card.tsx
+++ b/frontend/src/features/dashboard/pages/mcp-connection-card.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useRef, useState } from 'react'
+import { Bot, Check, Copy } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useAuth } from '@/contexts/auth-context'
+import { useTenantContext } from '@/contexts/tenant-context'
+import { buildMcpTenantUrl } from '@/api/config'
+
+const MCP_BASE_URL =
+  import.meta.env.VITE_MCP_SERVER_URL ??
+  import.meta.env.VITE_API_BASE_URL ??
+  'http://localhost:8091'
+
+function buildClaudeCodeConfig(serverUrl: string): string {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        meridian: {
+          type: 'streamable-http',
+          url: `${serverUrl}/mcp`,
+        },
+      },
+    },
+    null,
+    2,
+  )
+}
+
+function CopyButton({ text, label }: { text: string; label: string }) {
+  const [copied, setCopied] = useState(false)
+  const timerRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current)
+    }
+  }, [])
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current)
+      timerRef.current = window.setTimeout(() => setCopied(false), 2000)
+    } catch {
+      setCopied(false)
+    }
+  }
+
+  return (
+    <Button variant="outline" size="sm" onClick={handleCopy} aria-label={label}>
+      {copied ? (
+        <>
+          <Check className="mr-1.5 size-3.5" />
+          Copied!
+        </>
+      ) : (
+        <>
+          <Copy className="mr-1.5 size-3.5" />
+          Copy
+        </>
+      )}
+    </Button>
+  )
+}
+
+export function McpConnectionCard() {
+  const { tenantSlug } = useTenantContext()
+  const { accessToken } = useAuth()
+
+  if (!tenantSlug) return null
+
+  const serverUrl = buildMcpTenantUrl(MCP_BASE_URL, tenantSlug)
+  const mcpUrl = `${serverUrl}/mcp`
+  const claudeCodeConfig = buildClaudeCodeConfig(serverUrl)
+
+  const tokenPreview = accessToken
+    ? `${accessToken.slice(0, 12)}...${accessToken.slice(-6)}`
+    : null
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Bot className="h-4 w-4" />
+          AI Connection
+          <Badge variant="secondary" className="ml-auto text-xs font-normal">
+            MCP
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* MCP URL */}
+        <div className="space-y-1.5">
+          <p className="text-xs font-medium text-muted-foreground">Server URL</p>
+          <div className="flex items-center gap-2">
+            <code
+              data-testid="mcp-card-url"
+              className="flex-1 truncate rounded-md bg-muted px-2.5 py-1.5 font-mono text-xs"
+            >
+              {mcpUrl}
+            </code>
+            <CopyButton text={mcpUrl} label="Copy MCP server URL" />
+          </div>
+        </div>
+
+        {/* Auth token preview */}
+        {tokenPreview && (
+          <div className="space-y-1.5">
+            <p className="text-xs font-medium text-muted-foreground">Auth Token</p>
+            <div className="flex items-center gap-2">
+              <code
+                data-testid="mcp-card-token-preview"
+                className="flex-1 rounded-md bg-muted px-2.5 py-1.5 font-mono text-xs"
+              >
+                {tokenPreview}
+              </code>
+              <CopyButton text={accessToken!} label="Copy auth token" />
+            </div>
+          </div>
+        )}
+
+        {/* Claude Code / .mcp.json config */}
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-medium text-muted-foreground">
+              Claude Code <span className="font-normal opacity-70">(.mcp.json)</span>
+            </p>
+            <CopyButton text={claudeCodeConfig} label="Copy Claude Code config" />
+          </div>
+          <pre
+            data-testid="mcp-card-claude-config"
+            className="overflow-x-auto rounded-md bg-muted p-3 font-mono text-xs leading-relaxed"
+          >
+            {claudeCodeConfig}
+          </pre>
+        </div>
+
+        {/* Brief instructions */}
+        <p className="text-xs text-muted-foreground">
+          Add the config above to your{' '}
+          <code className="rounded bg-muted px-1 py-0.5 font-mono">.mcp.json</code> or Claude
+          Desktop config to connect AI assistants to this tenant.
+        </p>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/features/dashboard/pages/mcp-connection-card.tsx
+++ b/frontend/src/features/dashboard/pages/mcp-connection-card.tsx
@@ -76,7 +76,9 @@ export function McpConnectionCard() {
   const claudeCodeConfig = buildClaudeCodeConfig(serverUrl)
 
   const tokenPreview = accessToken
-    ? `${accessToken.slice(0, 12)}...${accessToken.slice(-6)}`
+    ? accessToken.length > 18
+      ? `${accessToken.slice(0, 12)}...${accessToken.slice(-6)}`
+      : `${accessToken.slice(0, 4)}...`
     : null
 
   return (


### PR DESCRIPTION
## Summary

- Adds `McpConnectionCard` component to the dashboard right column
- Displays MCP server URL, truncated auth token preview, and Claude Code `.mcp.json` config snippet with copy-to-clipboard for each
- Card is hidden when no tenant is selected (returns null)
- Uses `useTenantContext()` for tenant slug, `useAuth()` for access token, and `buildMcpTenantUrl()` from `@/api/config`

## Changes Made

- `frontend/src/features/dashboard/pages/mcp-connection-card.tsx` - new component
- `frontend/src/features/dashboard/pages/mcp-connection-card.test.tsx` - 11 tests covering rendering, no-tenant guard, no-token guard, and copy-to-clipboard behaviour
- `frontend/src/features/dashboard/pages/index.tsx` - wraps Quick Actions + McpConnectionCard in a right column `div`

## Test plan

- [ ] All 42 dashboard tests pass (`npx vitest --run src/features/dashboard/`)
- [ ] Card renders with MCP URL, token preview, and config snippet when tenant is selected
- [ ] Card does not render when no tenant is selected
- [ ] Token preview section is hidden when no access token
- [ ] Copy buttons show "Copied!" feedback after click