### PR TITLE
fix: handle AlreadyExists for idempotent organization registration on manifest re-apply

### DIFF
--- a/services/control-plane/internal/applier/party_client.go
+++ b/services/control-plane/internal/applier/party_client.go
@@ -75,17 +75,17 @@ func (c *PartyClient) RegisterOrganization(ctx *saga.StarlarkContext, params map
 // downstream saga steps receive the party_id. Falls back to a best-effort
 // result without party_id if the lookup fails.
 func (c *PartyClient) handleAlreadyExists(ctx context.Context, req *partyv1.RegisterPartyRequest) (any, error) {
-	existing, lookupErr := c.findPartyByExternalRef(ctx, req.GetExternalReference(), req.GetExternalReferenceType())
-	if lookupErr != nil {
+	existing, _ := c.findPartyByExternalRef(ctx, req.GetExternalReference(), req.GetExternalReferenceType())
+	if existing != nil {
 		return map[string]any{
-			"legal_name": req.GetLegalName(),
-			"status":     partyv1.PartyStatus_PARTY_STATUS_ACTIVE.String(),
+			"party_id":   existing.GetPartyId(),
+			"legal_name": existing.GetLegalName(),
+			"status":     existing.GetStatus().String(),
 		}, nil
 	}
 	return map[string]any{
-		"party_id":   existing.GetPartyId(),
-		"legal_name": existing.GetLegalName(),
-		"status":     existing.GetStatus().String(),
+		"legal_name": req.GetLegalName(),
+		"status":     partyv1.PartyStatus_PARTY_STATUS_ACTIVE.String(),
 	}, nil
 }
 

--- a/services/control-plane/internal/applier/party_client.go
+++ b/services/control-plane/internal/applier/party_client.go
@@ -7,6 +7,8 @@ import (
 	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // ErrUnknownExternalReferenceType is returned when an unrecognized external_reference_type is provided.
@@ -49,6 +51,14 @@ func (c *PartyClient) RegisterOrganization(ctx *saga.StarlarkContext, params map
 	callCtx := prepareCallContext(ctx)
 	resp, err := c.client.RegisterParty(callCtx, req)
 	if err != nil {
+		// Idempotency: treat AlreadyExists as success for manifest re-apply scenarios
+		// where the underlying party was already created by a previous apply.
+		if status.Code(err) == codes.AlreadyExists {
+			return map[string]any{
+				"legal_name": req.GetLegalName(),
+				"status":     partyv1.PartyStatus_PARTY_STATUS_ACTIVE.String(),
+			}, nil
+		}
 		return nil, fmt.Errorf("register organization: %w", err)
 	}
 

--- a/services/control-plane/internal/applier/party_client.go
+++ b/services/control-plane/internal/applier/party_client.go
@@ -15,6 +15,9 @@ import (
 // ErrUnknownExternalReferenceType is returned when an unrecognized external_reference_type is provided.
 var ErrUnknownExternalReferenceType = errors.New("unknown external_reference_type")
 
+// errPartyNotFound is returned when a party lookup finds no matching party.
+var errPartyNotFound = errors.New("party not found")
+
 // PartyClient wraps the party gRPC client to implement PartyService for use as a
 // saga handler dependency.
 //
@@ -55,18 +58,7 @@ func (c *PartyClient) RegisterOrganization(ctx *saga.StarlarkContext, params map
 		// Idempotency: treat AlreadyExists as success for manifest re-apply scenarios
 		// where the underlying party was already created by a previous apply.
 		if status.Code(err) == codes.AlreadyExists {
-			existing, lookupErr := c.findPartyByExternalRef(callCtx, req.GetExternalReference(), req.GetExternalReferenceType())
-			if lookupErr != nil || existing == nil {
-				return map[string]any{
-					"legal_name": req.GetLegalName(),
-					"status":     partyv1.PartyStatus_PARTY_STATUS_ACTIVE.String(),
-				}, nil
-			}
-			return map[string]any{
-				"party_id":   existing.GetPartyId(),
-				"legal_name": existing.GetLegalName(),
-				"status":     existing.GetStatus().String(),
-			}, nil
+			return c.handleAlreadyExists(callCtx, req)
 		}
 		return nil, fmt.Errorf("register organization: %w", err)
 	}
@@ -76,6 +68,24 @@ func (c *PartyClient) RegisterOrganization(ctx *saga.StarlarkContext, params map
 		"party_id":   party.GetPartyId(),
 		"legal_name": party.GetLegalName(),
 		"status":     party.GetStatus().String(),
+	}, nil
+}
+
+// handleAlreadyExists resolves the existing party on AlreadyExists so that
+// downstream saga steps receive the party_id. Falls back to a best-effort
+// result without party_id if the lookup fails.
+func (c *PartyClient) handleAlreadyExists(ctx context.Context, req *partyv1.RegisterPartyRequest) (any, error) {
+	existing, lookupErr := c.findPartyByExternalRef(ctx, req.GetExternalReference(), req.GetExternalReferenceType())
+	if lookupErr != nil {
+		return map[string]any{
+			"legal_name": req.GetLegalName(),
+			"status":     partyv1.PartyStatus_PARTY_STATUS_ACTIVE.String(),
+		}, nil
+	}
+	return map[string]any{
+		"party_id":   existing.GetPartyId(),
+		"legal_name": existing.GetLegalName(),
+		"status":     existing.GetStatus().String(),
 	}, nil
 }
 
@@ -99,7 +109,7 @@ func (c *PartyClient) findPartyByExternalRef(ctx context.Context, extRef string,
 		}
 		pageToken = resp.GetNextPageToken()
 		if pageToken == "" {
-			return nil, nil
+			return nil, errPartyNotFound
 		}
 	}
 }

--- a/services/control-plane/internal/applier/party_client.go
+++ b/services/control-plane/internal/applier/party_client.go
@@ -1,6 +1,7 @@
 package applier
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -54,9 +55,17 @@ func (c *PartyClient) RegisterOrganization(ctx *saga.StarlarkContext, params map
 		// Idempotency: treat AlreadyExists as success for manifest re-apply scenarios
 		// where the underlying party was already created by a previous apply.
 		if status.Code(err) == codes.AlreadyExists {
+			existing, lookupErr := c.findPartyByExternalRef(callCtx, req.GetExternalReference(), req.GetExternalReferenceType())
+			if lookupErr != nil || existing == nil {
+				return map[string]any{
+					"legal_name": req.GetLegalName(),
+					"status":     partyv1.PartyStatus_PARTY_STATUS_ACTIVE.String(),
+				}, nil
+			}
 			return map[string]any{
-				"legal_name": req.GetLegalName(),
-				"status":     partyv1.PartyStatus_PARTY_STATUS_ACTIVE.String(),
+				"party_id":   existing.GetPartyId(),
+				"legal_name": existing.GetLegalName(),
+				"status":     existing.GetStatus().String(),
 			}, nil
 		}
 		return nil, fmt.Errorf("register organization: %w", err)
@@ -68,6 +77,31 @@ func (c *PartyClient) RegisterOrganization(ctx *saga.StarlarkContext, params map
 		"legal_name": party.GetLegalName(),
 		"status":     party.GetStatus().String(),
 	}, nil
+}
+
+// findPartyByExternalRef pages through ListParties to locate an existing party
+// that matches the given external reference and type. Returns nil if not found.
+func (c *PartyClient) findPartyByExternalRef(ctx context.Context, extRef string, extRefType partyv1.ExternalReferenceType) (*partyv1.Party, error) {
+	pageToken := ""
+	for {
+		resp, err := c.client.ListParties(ctx, &partyv1.ListPartiesRequest{
+			PartyType: partyv1.PartyType_PARTY_TYPE_ORGANIZATION,
+			PageSize:  100,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list parties for lookup: %w", err)
+		}
+		for _, p := range resp.GetParties() {
+			if p.GetExternalReference() == extRef && p.GetExternalReferenceType() == extRefType {
+				return p, nil
+			}
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			return nil, nil
+		}
+	}
 }
 
 // parseExternalReferenceType converts a string to the proto ExternalReferenceType enum.

--- a/services/control-plane/internal/applier/party_client_test.go
+++ b/services/control-plane/internal/applier/party_client_test.go
@@ -1,11 +1,19 @@
 package applier
 
 import (
+	"context"
+	"net"
 	"testing"
 
 	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
 )
 
 func TestParseExternalReferenceType_Empty(t *testing.T) {
@@ -35,4 +43,102 @@ func TestParseExternalReferenceType_Stripped(t *testing.T) {
 func TestNewPartyClient(t *testing.T) {
 	c := NewPartyClient(nil)
 	assert.NotNil(t, c)
+}
+
+// ─── Fake gRPC servers ───────────────────────────────────────────────────────
+
+type fakePartyServer struct {
+	partyv1.UnimplementedPartyServiceServer
+	registerFn func(context.Context, *partyv1.RegisterPartyRequest) (*partyv1.RegisterPartyResponse, error)
+}
+
+func (f *fakePartyServer) RegisterParty(ctx context.Context, req *partyv1.RegisterPartyRequest) (*partyv1.RegisterPartyResponse, error) {
+	if f.registerFn != nil {
+		return f.registerFn(ctx, req)
+	}
+	return &partyv1.RegisterPartyResponse{
+		Party: &partyv1.Party{
+			PartyId:   "party-uuid-1",
+			LegalName: req.LegalName,
+			Status:    partyv1.PartyStatus_PARTY_STATUS_ACTIVE,
+		},
+	}, nil
+}
+
+func newPartyTestServer(t *testing.T, srv *fakePartyServer) *grpc.ClientConn {
+	t.Helper()
+
+	lis := bufconn.Listen(1024 * 1024)
+	s := grpc.NewServer()
+	partyv1.RegisterPartyServiceServer(s, srv)
+
+	go func() { _ = s.Serve(lis) }()
+	t.Cleanup(s.GracefulStop)
+
+	conn, err := grpc.NewClient("passthrough:///bufconn",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return conn
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+func TestRegisterOrganization_Success(t *testing.T) {
+	conn := newPartyTestServer(t, &fakePartyServer{})
+	client := NewPartyClient(conn)
+
+	ctx := &saga.StarlarkContext{Context: context.Background()}
+	result, err := client.RegisterOrganization(ctx, map[string]any{
+		"legal_name":   "Acme Corp",
+		"display_name": "Acme",
+	})
+
+	require.NoError(t, err)
+	m := result.(map[string]any)
+	assert.Equal(t, "party-uuid-1", m["party_id"])
+	assert.Equal(t, "Acme Corp", m["legal_name"])
+}
+
+func TestRegisterOrganization_AlreadyExists_TreatedAsSuccess(t *testing.T) {
+	srv := &fakePartyServer{
+		registerFn: func(_ context.Context, _ *partyv1.RegisterPartyRequest) (*partyv1.RegisterPartyResponse, error) {
+			return nil, status.Error(codes.AlreadyExists, "party with external reference of type LEI already exists")
+		},
+	}
+	conn := newPartyTestServer(t, srv)
+	client := NewPartyClient(conn)
+
+	ctx := &saga.StarlarkContext{Context: context.Background()}
+	result, err := client.RegisterOrganization(ctx, map[string]any{
+		"legal_name":             "Acme Corp",
+		"external_reference":     "123456",
+		"external_reference_type": "LEI",
+	})
+
+	require.NoError(t, err, "AlreadyExists should be treated as idempotent success")
+	m := result.(map[string]any)
+	assert.Equal(t, "Acme Corp", m["legal_name"])
+	assert.Equal(t, "PARTY_STATUS_ACTIVE", m["status"])
+}
+
+func TestRegisterOrganization_OtherError_Propagated(t *testing.T) {
+	srv := &fakePartyServer{
+		registerFn: func(_ context.Context, _ *partyv1.RegisterPartyRequest) (*partyv1.RegisterPartyResponse, error) {
+			return nil, status.Error(codes.Internal, "database unavailable")
+		},
+	}
+	conn := newPartyTestServer(t, srv)
+	client := NewPartyClient(conn)
+
+	ctx := &saga.StarlarkContext{Context: context.Background()}
+	_, err := client.RegisterOrganization(ctx, map[string]any{
+		"legal_name": "Acme Corp",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database unavailable")
 }

--- a/services/control-plane/internal/applier/party_client_test.go
+++ b/services/control-plane/internal/applier/party_client_test.go
@@ -114,8 +114,8 @@ func TestRegisterOrganization_AlreadyExists_TreatedAsSuccess(t *testing.T) {
 
 	ctx := &saga.StarlarkContext{Context: context.Background()}
 	result, err := client.RegisterOrganization(ctx, map[string]any{
-		"legal_name":             "Acme Corp",
-		"external_reference":     "123456",
+		"legal_name":              "Acme Corp",
+		"external_reference":      "123456",
 		"external_reference_type": "LEI",
 	})
 

--- a/services/control-plane/internal/applier/party_client_test.go
+++ b/services/control-plane/internal/applier/party_client_test.go
@@ -50,6 +50,7 @@ func TestNewPartyClient(t *testing.T) {
 type fakePartyServer struct {
 	partyv1.UnimplementedPartyServiceServer
 	registerFn func(context.Context, *partyv1.RegisterPartyRequest) (*partyv1.RegisterPartyResponse, error)
+	listFn     func(context.Context, *partyv1.ListPartiesRequest) (*partyv1.ListPartiesResponse, error)
 }
 
 func (f *fakePartyServer) RegisterParty(ctx context.Context, req *partyv1.RegisterPartyRequest) (*partyv1.RegisterPartyResponse, error) {
@@ -63,6 +64,13 @@ func (f *fakePartyServer) RegisterParty(ctx context.Context, req *partyv1.Regist
 			Status:    partyv1.PartyStatus_PARTY_STATUS_ACTIVE,
 		},
 	}, nil
+}
+
+func (f *fakePartyServer) ListParties(ctx context.Context, req *partyv1.ListPartiesRequest) (*partyv1.ListPartiesResponse, error) {
+	if f.listFn != nil {
+		return f.listFn(ctx, req)
+	}
+	return &partyv1.ListPartiesResponse{}, nil
 }
 
 func newPartyTestServer(t *testing.T, srv *fakePartyServer) *grpc.ClientConn {
@@ -108,6 +116,19 @@ func TestRegisterOrganization_AlreadyExists_TreatedAsSuccess(t *testing.T) {
 		registerFn: func(_ context.Context, _ *partyv1.RegisterPartyRequest) (*partyv1.RegisterPartyResponse, error) {
 			return nil, status.Error(codes.AlreadyExists, "party with external reference of type LEI already exists")
 		},
+		listFn: func(_ context.Context, _ *partyv1.ListPartiesRequest) (*partyv1.ListPartiesResponse, error) {
+			return &partyv1.ListPartiesResponse{
+				Parties: []*partyv1.Party{
+					{
+						PartyId:               "existing-party-uuid",
+						LegalName:             "Acme Corp",
+						Status:                partyv1.PartyStatus_PARTY_STATUS_ACTIVE,
+						ExternalReference:     "123456",
+						ExternalReferenceType: partyv1.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_LEI,
+					},
+				},
+			}, nil
+		},
 	}
 	conn := newPartyTestServer(t, srv)
 	client := NewPartyClient(conn)
@@ -121,6 +142,7 @@ func TestRegisterOrganization_AlreadyExists_TreatedAsSuccess(t *testing.T) {
 
 	require.NoError(t, err, "AlreadyExists should be treated as idempotent success")
 	m := result.(map[string]any)
+	assert.Equal(t, "existing-party-uuid", m["party_id"])
 	assert.Equal(t, "Acme Corp", m["legal_name"])
 	assert.Equal(t, "PARTY_STATUS_ACTIVE", m["status"])
 }


### PR DESCRIPTION
## Summary

- Add idempotency handling in `PartyClient.RegisterOrganization` for `codes.AlreadyExists` gRPC errors
- When re-applying a manifest to a tenant with existing organizations, the underlying `RegisterParty` call returns `AlreadyExists` because the party was already created by a prior apply
- The fix treats `AlreadyExists` as success, returning a stub result so the manifest apply saga continues

## Technical Details

The root cause: `party_client.go` `RegisterOrganization` calls the Party service's `RegisterParty` gRPC method without handling the `AlreadyExists` status code. On re-apply, the Party service detects the duplicate external reference and returns `AlreadyExists`, which propagates as a saga failure.

The planner correctly maps both `ActionCreate` and `ActionUpdate` to `MethodRegisterOrganization`, so both paths hit this code. The fix makes the client idempotent regardless of which action triggered the call.

## Test plan

- [x] New test: `TestRegisterOrganization_AlreadyExists_TreatedAsSuccess` - verifies idempotent success
- [x] New test: `TestRegisterOrganization_Success` - verifies normal registration path
- [x] New test: `TestRegisterOrganization_OtherError_Propagated` - verifies non-AlreadyExists errors still fail
- [x] All existing applier, differ, and planner tests pass