### PR TITLE
feat: add nightly demo reset GitHub Action

### DIFF
--- a/.github/workflows/demo-reset.yml
+++ b/.github/workflows/demo-reset.yml
@@ -1,0 +1,48 @@
+name: Demo Reset
+
+# Nightly reset of the demo environment to a clean state with fresh seed data.
+# Pulls the latest demo image, wipes per-service databases, runs migrations,
+# and re-seeds the volterra_energy demo tenant with fixture data.
+#
+# Required secrets:
+#   DEMO_SSH_PRIVATE_KEY  - Private SSH key for the deploy user on the Droplet
+#   DROPLET_IP            - IP address of the DigitalOcean Droplet
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: demo-reset
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  reset:
+    name: Reset Demo Environment
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: demo
+      url: https://demo.meridianhub.cloud
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.DEMO_SSH_PRIVATE_KEY }}
+
+      - name: Add droplet to known hosts
+        run: ssh-keyscan -H "${{ secrets.DROPLET_IP }}" >> ~/.ssh/known_hosts
+
+      - name: Reset demo environment
+        env:
+          DEMO_HOST: deploy@${{ secrets.DROPLET_IP }}
+          NO_CONFIRM: "1"
+        run: ./scripts/reset-demo.sh

--- a/.github/workflows/demo-reset.yml
+++ b/.github/workflows/demo-reset.yml
@@ -5,8 +5,11 @@ name: Demo Reset
 # and re-seeds the volterra_energy demo tenant with fixture data.
 #
 # Required secrets:
-#   DEMO_SSH_PRIVATE_KEY  - Private SSH key for the deploy user on the Droplet
-#   DROPLET_IP            - IP address of the DigitalOcean Droplet
+#   DEMO_SSH_PRIVATE_KEY      - Private SSH key for the deploy user on the Droplet
+#   DROPLET_IP                - IP address of the DigitalOcean Droplet
+#   DROPLET_SSH_HOST_KEY      - Pinned SSH host key entry for the Droplet
+#                               Obtain via: ssh-keyscan -H <droplet-ip>
+#                               Store the full output line as the secret value
 
 on:
   schedule:
@@ -39,7 +42,11 @@ jobs:
           ssh-private-key: ${{ secrets.DEMO_SSH_PRIVATE_KEY }}
 
       - name: Add droplet to known hosts
-        run: ssh-keyscan -H "${{ secrets.DROPLET_IP }}" >> ~/.ssh/known_hosts
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "${{ secrets.DROPLET_SSH_HOST_KEY }}" >> ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
 
       - name: Reset demo environment
         env:

--- a/scripts/reset-demo.sh
+++ b/scripts/reset-demo.sh
@@ -2,22 +2,25 @@
 # reset-demo.sh — Destroy and recreate the demo environment from scratch.
 #
 # This script:
-#   1. Stops the meridian containers (keeps postgres running)
-#   2. Drops and recreates all meridian per-service databases
-#   3. Runs pre-migration scripts for PostgreSQL compatibility
-#   4. Starts meridian and runs migrations
-#   5. Seeds the demo tenant with fixture data via gRPC
+#   1. Pulls the latest demo Docker image
+#   2. Stops the meridian containers (keeps postgres running)
+#   3. Drops and recreates all meridian per-service databases
+#   4. Runs pre-migration scripts for PostgreSQL compatibility
+#   5. Starts meridian and runs migrations
+#   6. Seeds the demo tenant with fixture data via gRPC
+#   7. Verifies the environment is healthy
 #
 # Usage:
 #   ./scripts/reset-demo.sh
 #   DEMO_HOST=user@custom-host ./scripts/reset-demo.sh
+#   NO_CONFIRM=1 ./scripts/reset-demo.sh          # skip confirmation (for CI)
 #
 # Prerequisites:
 #   - SSH config entry for the demo host (default alias: "meridian-demo")
 #     Add to ~/.ssh/config:
 #       Host meridian-demo
 #           HostName <droplet-ip>
-#           User root
+#           User deploy
 #   - The demo stack must already be deployed (docker-compose.yml in /opt/meridian)
 #
 # Container names assume the docker-compose project name is "meridian"
@@ -33,13 +36,13 @@ PG_CONTAINER="meridian-postgres-1"
 APP_CONTAINER="meridian-meridian-1"
 
 # Verify SSH connectivity before proceeding
-if ! ssh -o ConnectTimeout=5 "${DEMO_HOST}" "true" 2>/dev/null; then
+if ! ssh -o ConnectTimeout=5 -o BatchMode=yes "${DEMO_HOST}" "true" 2>/dev/null; then
   echo "ERROR: Cannot connect to ${DEMO_HOST}"
   echo ""
   echo "Ensure your ~/.ssh/config has an entry:"
   echo "  Host meridian-demo"
   echo "      HostName <droplet-ip>"
-  echo "      User root"
+  echo "      User deploy"
   echo ""
   echo "Or override: DEMO_HOST=user@host ./scripts/reset-demo.sh"
   exit 1
@@ -47,16 +50,23 @@ fi
 
 echo "=== Resetting Demo Environment on ${DEMO_HOST} ==="
 echo ""
-echo "WARNING: This will destroy all data in the demo database."
-echo "Press Ctrl+C within 5 seconds to abort..."
-sleep 5
+
+if [ "${NO_CONFIRM:-0}" != "1" ]; then
+  echo "WARNING: This will destroy all data in the demo database."
+  echo "Press Ctrl+C within 5 seconds to abort..."
+  sleep 5
+fi
 
 echo ""
-echo "=== Step 1: Stop meridian + mcp-server (keep postgres) ==="
+echo "=== Step 1: Pull latest demo image ==="
+ssh "${DEMO_HOST}" "cd ${DEMO_DIR} && docker compose pull meridian mcp-server"
+
+echo ""
+echo "=== Step 2: Stop meridian + mcp-server (keep postgres) ==="
 ssh "${DEMO_HOST}" "cd ${DEMO_DIR} && docker compose stop meridian mcp-server"
 
 echo ""
-echo "=== Step 2: Drop and recreate databases ==="
+echo "=== Step 3: Drop and recreate databases ==="
 
 # Terminate active connections to meridian_* databases
 ssh "${DEMO_HOST}" "docker exec ${PG_CONTAINER} psql -U ${PG_USER} -d ${PG_USER} -c \"
@@ -78,26 +88,42 @@ done"
 ssh "${DEMO_HOST}" "docker exec ${PG_CONTAINER} psql -U ${PG_USER} -d ${PG_USER} -f /docker-entrypoint-initdb.d/init-databases.sql"
 
 echo ""
-echo "=== Step 3: Run pre-migration scripts ==="
+echo "=== Step 4: Run pre-migration scripts ==="
 # PostgreSQL requires ALTER TABLE DROP CONSTRAINT for constraint-backed unique indexes.
 # CockroachDB uses DROP INDEX CASCADE instead. This pre-migration resolves the divergence.
 # See deploy/demo/pg-pre-migration.sql for details.
 ssh "${DEMO_HOST}" "docker exec ${PG_CONTAINER} psql -U ${PG_USER} -d meridian_reference_data -c \"ALTER TABLE IF EXISTS public.platform_saga_definition DROP CONSTRAINT IF EXISTS uq_platform_saga_definition_name;\""
 
 echo ""
-echo "=== Step 4: Start meridian and run migrations ==="
+echo "=== Step 5: Start meridian and run migrations ==="
 ssh "${DEMO_HOST}" "cd ${DEMO_DIR} && docker compose up -d meridian"
-sleep 3
+
+# Wait for meridian container to start before running migrations
+attempt=0
+until [ $attempt -ge 20 ]; do
+  attempt=$((attempt + 1))
+  if ssh "${DEMO_HOST}" "docker inspect --format '{{.State.Running}}' ${APP_CONTAINER} 2>/dev/null" | grep -q "true"; then
+    echo "  meridian container running after ${attempt} attempts"
+    break
+  fi
+  if [ $attempt -ge 20 ]; then
+    echo "  meridian container failed to start"
+    ssh "${DEMO_HOST}" "cd ${DEMO_DIR} && docker compose logs meridian --tail=20"
+    exit 1
+  fi
+  sleep 3
+done
+
 ssh "${DEMO_HOST}" "docker exec ${APP_CONTAINER} /meridian --migrate"
 
 echo ""
-echo "=== Step 5: Restart meridian (post-migration) ==="
+echo "=== Step 6: Restart meridian (post-migration) ==="
 ssh "${DEMO_HOST}" "cd ${DEMO_DIR} && docker compose restart meridian"
 
 echo ""
-echo "=== Step 6: Seed demo tenant with fixtures ==="
-# seed-dev has its own gateway health polling (60s timeout, 2s interval)
-# so no sleep needed between restart and seed
+echo "=== Step 7: Seed demo tenant with fixtures ==="
+# seed-dev has its own gateway health polling (2-minute timeout, 2s interval)
+# so no extra wait needed between restart and seed
 ssh "${DEMO_HOST}" "docker exec ${APP_CONTAINER} /seed-dev \
   --gateway-url=http://localhost:8090 \
   --grpc-addr=localhost:50051 \
@@ -109,8 +135,25 @@ ssh "${DEMO_HOST}" "docker exec ${APP_CONTAINER} /seed-dev \
   --with-fixtures"
 
 echo ""
-echo "=== Step 7: Start mcp-server ==="
+echo "=== Step 8: Start mcp-server ==="
 ssh "${DEMO_HOST}" "cd ${DEMO_DIR} && docker compose up -d mcp-server"
+
+echo ""
+echo "=== Step 9: Health check ==="
+attempt=0
+until [ $attempt -ge 24 ]; do
+  attempt=$((attempt + 1))
+  if ssh "${DEMO_HOST}" "curl -sf http://localhost:80/healthz -H 'Host: demo.meridianhub.cloud'" > /dev/null 2>&1; then
+    echo "  Health check passed after ${attempt} attempts"
+    break
+  fi
+  if [ $attempt -ge 24 ]; then
+    echo "  Health check failed after ${attempt} attempts"
+    ssh "${DEMO_HOST}" "cd ${DEMO_DIR} && docker compose logs --tail=30"
+    exit 1
+  fi
+  sleep 5
+done
 
 echo ""
 echo "=== Demo Reset Complete ==="


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/demo-reset.yml`: scheduled workflow (midnight UTC daily) with `workflow_dispatch` fallback, using `webfactory/ssh-agent` for SSH key management
- Updates `scripts/reset-demo.sh`: adds image pull step, `NO_CONFIRM=1` env var for CI use, container-readiness wait loop (replaces bare `sleep 3`), and health check retry loop after seeding

## Changes Made

**`.github/workflows/demo-reset.yml`**
- Cron schedule: `0 0 * * *` (midnight UTC)
- `workflow_dispatch` for manual trigger
- `concurrency` group prevents overlapping resets
- Uses `webfactory/ssh-agent@v0.9.0` for `DEMO_SSH_PRIVATE_KEY` secret
- Adds droplet to known hosts via `ssh-keyscan`
- Calls `./scripts/reset-demo.sh` with `NO_CONFIRM=1` and `DEMO_HOST=deploy@${{ secrets.DROPLET_IP }}`
- Timeout: 15 minutes, environment: `demo`

**`scripts/reset-demo.sh`** (updated)
- New step 1: `docker compose pull meridian mcp-server` before stopping services
- `NO_CONFIRM=1` env var skips the 5-second interactive abort window (set automatically by the workflow)
- Added container start wait loop before running `--migrate` (polls `docker inspect` instead of `sleep 3`)
- Added health check retry loop (24 attempts × 5s = 2 min) after seeding
- Fixed SSH connectivity check to use `-o BatchMode=yes`
- Updated default user in help text from `root` to `deploy`

## Technical Details

The reset sequence preserves postgres (keeps data volume intact) and only wipes per-service databases (`meridian_*`), which is faster and avoids postgres restart overhead. The init-databases.sql re-creates empty service databases, then migrations and seed-dev populate them fresh.

`seed-dev` has its own gateway health polling (2-minute timeout, 2s interval), so no explicit wait is needed between the meridian restart and seeding — the binary will poll until the gateway is ready.

## Testing

The workflow can be manually triggered via `workflow_dispatch` after merging. Requires `DEMO_SSH_PRIVATE_KEY` and `DROPLET_IP` secrets to be set in the `demo` environment.

For manual testing: `NO_CONFIRM=1 DEMO_HOST=deploy@<ip> ./scripts/reset-demo.sh`