### PR TITLE
fix: allow operator and auditor roles to access admin routes

### DIFF
--- a/frontend/src/components/routing.tsx
+++ b/frontend/src/components/routing.tsx
@@ -41,7 +41,7 @@ interface AdminOnlyRouteProps {
   children: ReactNode
 }
 
-const ADMIN_ROLES = ['admin', 'tenant-admin', 'super-admin', 'platform-admin', 'tenant-owner']
+const ADMIN_ROLES = ['admin', 'tenant-admin', 'super-admin', 'platform-admin', 'tenant-owner', 'operator', 'auditor']
 
 /**
  * Redirects users without admin-level roles to /.

--- a/frontend/src/features/identity/components/admin-only-route.test.tsx
+++ b/frontend/src/features/identity/components/admin-only-route.test.tsx
@@ -50,4 +50,22 @@ describe('AdminOnlyRoute', () => {
     renderWithRoute(superAdminToken)
     expect(screen.getByTestId('admin-content')).toBeInTheDocument()
   })
+
+  it('renders children for operator', () => {
+    const operatorToken = createTestToken({
+      roles: ['operator'],
+      tenantId: 'test-tenant',
+    })
+    renderWithRoute(operatorToken)
+    expect(screen.getByTestId('admin-content')).toBeInTheDocument()
+  })
+
+  it('renders children for auditor', () => {
+    const auditorToken = createTestToken({
+      roles: ['auditor'],
+      tenantId: 'test-tenant',
+    })
+    renderWithRoute(auditorToken)
+    expect(screen.getByTestId('admin-content')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary

- The `AdminOnlyRoute` frontend guard blocked `operator` and `auditor` roles from accessing `/users`, silently redirecting them to the dashboard
- The backend RBAC (`ListIdentities`) correctly allows these roles - the frontend guard was more restrictive than intended
- This caused the demo environment's `operator@volterra.energy` user to be unable to view the Users page

## Changes Made

- Added `operator` and `auditor` to `ADMIN_ROLES` in `routing.tsx` to align with backend RBAC permissions
- Added test cases for both roles in `admin-only-route.test.tsx`

## Test plan

- [x] Added failing tests for operator and auditor roles (TDD red)
- [x] Fixed `ADMIN_ROLES` to include both roles (TDD green)
- [x] All 2525 frontend tests pass
- [ ] Verify on demo: operator user can access `/users` page