### PR TITLE
feat(parties): implement associations tab with org/person branching

### DIFF
--- a/frontend/src/features/parties/pages/[partyId].tsx
+++ b/frontend/src/features/parties/pages/[partyId].tsx
@@ -70,7 +70,7 @@ export function PartyDetailPage() {
                 </TabsContent>
 
                 <TabsContent value="associations" className="mt-0">
-                  <AssociationsTab partyId={partyId} />
+                  <AssociationsTab partyId={partyId} partyType={party?.partyType} />
                 </TabsContent>
 
                 <TabsContent value="bank-relations" className="mt-0">

--- a/frontend/src/features/parties/pages/tabs/associations-tab.test.tsx
+++ b/frontend/src/features/parties/pages/tabs/associations-tab.test.tsx
@@ -6,14 +6,12 @@ import { TooltipProvider } from '@/components/ui/tooltip'
 
 const mockRetrieveAssociations = vi.fn().mockResolvedValue({ associations: [] })
 const mockListParticipants = vi.fn().mockResolvedValue({ participants: [] })
-const mockRetrieveParty = vi.fn().mockResolvedValue({ party: undefined })
 
 vi.mock('@/api/context', () => ({
   useClients: vi.fn(() => ({
     party: {
       retrieveAssociations: mockRetrieveAssociations,
       listParticipants: mockListParticipants,
-      retrieveParty: mockRetrieveParty,
       listParties: vi.fn().mockResolvedValue({ parties: [] }),
       registerAssociations: vi.fn(),
     },
@@ -22,7 +20,6 @@ vi.mock('@/api/context', () => ({
     party: {
       retrieveAssociations: mockRetrieveAssociations,
       listParticipants: mockListParticipants,
-      retrieveParty: mockRetrieveParty,
       listParties: vi.fn().mockResolvedValue({ parties: [] }),
       registerAssociations: vi.fn(),
     },
@@ -40,26 +37,15 @@ vi.mock('@/hooks/use-tenant-context', () => ({
 import { useApiClients } from '@/api/context'
 import { AssociationsTab } from './associations-tab'
 
+const PARTY_TYPE_PERSON = 1
+const PARTY_TYPE_ORGANIZATION = 2
+
 function makeQueryClient() {
   return new QueryClient({
     defaultOptions: {
       queries: { retry: false, gcTime: 0, staleTime: 0 },
     },
   })
-}
-
-const mockPersonParty = {
-  partyId: 'party-person-001',
-  legalName: 'Jane Doe',
-  partyType: 1, // PARTY_TYPE_PERSON
-  status: 1,
-}
-
-const mockOrgParty = {
-  partyId: 'party-org-001',
-  legalName: 'Acme Syndicate',
-  partyType: 2, // PARTY_TYPE_ORGANIZATION
-  status: 1,
 }
 
 const mockAssociation = {
@@ -88,12 +74,12 @@ const mockParticipant = {
   effectiveTo: undefined,
 }
 
-function renderTab(partyId = 'party-001') {
+function renderTab(partyId = 'party-001', partyType?: number) {
   return render(
     <MemoryRouter>
       <QueryClientProvider client={makeQueryClient()}>
         <TooltipProvider>
-          <AssociationsTab partyId={partyId} />
+          <AssociationsTab partyId={partyId} partyType={partyType} />
         </TooltipProvider>
       </QueryClientProvider>
     </MemoryRouter>,
@@ -107,7 +93,6 @@ describe('AssociationsTab', () => {
       party: {
         retrieveAssociations: vi.fn().mockResolvedValue({ associations: [] }),
         listParticipants: vi.fn().mockResolvedValue({ participants: [] }),
-        retrieveParty: vi.fn().mockResolvedValue({ party: mockPersonParty }),
         listParties: vi.fn().mockResolvedValue({ parties: [] }),
         registerAssociations: vi.fn(),
       },
@@ -120,7 +105,6 @@ describe('AssociationsTab', () => {
         party: {
           retrieveAssociations: vi.fn(() => new Promise(() => {})),
           listParticipants: vi.fn(() => new Promise(() => {})),
-          retrieveParty: vi.fn(() => new Promise(() => {})),
         },
       } as ReturnType<typeof useApiClients>)
 
@@ -135,7 +119,6 @@ describe('AssociationsTab', () => {
         party: {
           retrieveAssociations: vi.fn(() => new Promise(() => {})),
           listParticipants: vi.fn(() => new Promise(() => {})),
-          retrieveParty: vi.fn(() => new Promise(() => {})),
         },
       } as ReturnType<typeof useApiClients>)
 
@@ -151,7 +134,6 @@ describe('AssociationsTab', () => {
         party: {
           retrieveAssociations: vi.fn().mockResolvedValue({ associations: [] }),
           listParticipants: vi.fn().mockResolvedValue({ participants: [] }),
-          retrieveParty: vi.fn().mockResolvedValue({ party: mockPersonParty }),
           listParties: vi.fn().mockResolvedValue({ parties: [] }),
           registerAssociations: vi.fn(),
         },
@@ -159,7 +141,7 @@ describe('AssociationsTab', () => {
     })
 
     it('renders empty state for person with no associations', async () => {
-      renderTab('party-person-001')
+      renderTab('party-person-001', PARTY_TYPE_PERSON)
 
       await waitFor(() => {
         expect(screen.getByRole('heading', { name: /organizations/i })).toBeInTheDocument()
@@ -167,7 +149,7 @@ describe('AssociationsTab', () => {
     })
 
     it('renders descriptive message for person empty state', async () => {
-      renderTab('party-person-001')
+      renderTab('party-person-001', PARTY_TYPE_PERSON)
 
       await waitFor(() => {
         expect(screen.getByText(/no associations information available/i)).toBeInTheDocument()
@@ -175,7 +157,7 @@ describe('AssociationsTab', () => {
     })
 
     it('renders add association button', async () => {
-      renderTab('party-person-001')
+      renderTab('party-person-001', PARTY_TYPE_PERSON)
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /add association/i })).toBeInTheDocument()
@@ -189,7 +171,6 @@ describe('AssociationsTab', () => {
         party: {
           retrieveAssociations: vi.fn().mockResolvedValue({ associations: [] }),
           listParticipants: vi.fn().mockResolvedValue({ participants: [] }),
-          retrieveParty: vi.fn().mockResolvedValue({ party: mockOrgParty }),
           listParties: vi.fn().mockResolvedValue({ parties: [] }),
           registerAssociations: vi.fn(),
         },
@@ -197,7 +178,7 @@ describe('AssociationsTab', () => {
     })
 
     it('renders empty state for org with no participants', async () => {
-      renderTab('party-org-001')
+      renderTab('party-org-001', PARTY_TYPE_ORGANIZATION)
 
       await waitFor(() => {
         expect(screen.getByRole('heading', { name: /members/i })).toBeInTheDocument()
@@ -205,7 +186,7 @@ describe('AssociationsTab', () => {
     })
 
     it('renders descriptive message for org empty state', async () => {
-      renderTab('party-org-001')
+      renderTab('party-org-001', PARTY_TYPE_ORGANIZATION)
 
       await waitFor(() => {
         expect(screen.getByText(/no members registered/i)).toBeInTheDocument()
@@ -219,7 +200,6 @@ describe('AssociationsTab', () => {
         party: {
           retrieveAssociations: vi.fn().mockResolvedValue({ associations: [mockAssociation] }),
           listParticipants: vi.fn().mockResolvedValue({ participants: [] }),
-          retrieveParty: vi.fn().mockResolvedValue({ party: mockPersonParty }),
           listParties: vi.fn().mockResolvedValue({ parties: [] }),
           registerAssociations: vi.fn(),
         },
@@ -227,7 +207,7 @@ describe('AssociationsTab', () => {
     })
 
     it('renders table with association rows', async () => {
-      renderTab('party-person-001')
+      renderTab('party-person-001', PARTY_TYPE_PERSON)
 
       await waitFor(() => {
         expect(screen.getByRole('table')).toBeInTheDocument()
@@ -235,7 +215,7 @@ describe('AssociationsTab', () => {
     })
 
     it('renders related party as a link', async () => {
-      renderTab('party-person-001')
+      renderTab('party-person-001', PARTY_TYPE_PERSON)
 
       await waitFor(() => {
         expect(screen.getByRole('link', { name: 'party-org-001' })).toBeInTheDocument()
@@ -243,7 +223,7 @@ describe('AssociationsTab', () => {
     })
 
     it('renders relationship type label', async () => {
-      renderTab('party-person-001')
+      renderTab('party-person-001', PARTY_TYPE_PERSON)
 
       await waitFor(() => {
         expect(screen.getByText('Syndicate Participant')).toBeInTheDocument()
@@ -251,7 +231,7 @@ describe('AssociationsTab', () => {
     })
 
     it('renders status badge', async () => {
-      renderTab('party-person-001')
+      renderTab('party-person-001', PARTY_TYPE_PERSON)
 
       await waitFor(() => {
         expect(screen.getByText('ACTIVE')).toBeInTheDocument()
@@ -265,7 +245,6 @@ describe('AssociationsTab', () => {
         party: {
           retrieveAssociations: vi.fn().mockResolvedValue({ associations: [] }),
           listParticipants: vi.fn().mockResolvedValue({ participants: [mockParticipant] }),
-          retrieveParty: vi.fn().mockResolvedValue({ party: mockOrgParty }),
           listParties: vi.fn().mockResolvedValue({ parties: [] }),
           registerAssociations: vi.fn(),
         },
@@ -273,7 +252,7 @@ describe('AssociationsTab', () => {
     })
 
     it('renders table with participant rows', async () => {
-      renderTab('party-org-001')
+      renderTab('party-org-001', PARTY_TYPE_ORGANIZATION)
 
       await waitFor(() => {
         expect(screen.getByRole('table')).toBeInTheDocument()
@@ -281,7 +260,7 @@ describe('AssociationsTab', () => {
     })
 
     it('renders member party as a link', async () => {
-      renderTab('party-org-001')
+      renderTab('party-org-001', PARTY_TYPE_ORGANIZATION)
 
       await waitFor(() => {
         expect(screen.getByRole('link', { name: 'party-member-001' })).toBeInTheDocument()
@@ -289,7 +268,7 @@ describe('AssociationsTab', () => {
     })
 
     it('renders metadata summary for participant', async () => {
-      renderTab('party-org-001')
+      renderTab('party-org-001', PARTY_TYPE_ORGANIZATION)
 
       await waitFor(() => {
         expect(screen.getByText(/allocation_share/i)).toBeInTheDocument()
@@ -302,13 +281,12 @@ describe('AssociationsTab', () => {
         party: {
           retrieveAssociations: vi.fn().mockResolvedValue({ associations: [] }),
           listParticipants,
-          retrieveParty: vi.fn().mockResolvedValue({ party: mockOrgParty }),
           listParties: vi.fn().mockResolvedValue({ parties: [] }),
           registerAssociations: vi.fn(),
         },
       } as ReturnType<typeof useApiClients>)
 
-      renderTab('party-org-001')
+      renderTab('party-org-001', PARTY_TYPE_ORGANIZATION)
 
       await waitFor(() => {
         expect(listParticipants).toHaveBeenCalledWith({ partyId: 'party-org-001' })
@@ -323,13 +301,12 @@ describe('AssociationsTab', () => {
         party: {
           retrieveAssociations,
           listParticipants: vi.fn().mockResolvedValue({ participants: [] }),
-          retrieveParty: vi.fn().mockResolvedValue({ party: mockPersonParty }),
           listParties: vi.fn().mockResolvedValue({ parties: [] }),
           registerAssociations: vi.fn(),
         },
       } as ReturnType<typeof useApiClients>)
 
-      renderTab('party-abc')
+      renderTab('party-abc', PARTY_TYPE_PERSON)
 
       await waitFor(() => {
         expect(retrieveAssociations).toHaveBeenCalledWith({ partyId: 'party-abc' })

--- a/frontend/src/features/parties/pages/tabs/associations-tab.test.tsx
+++ b/frontend/src/features/parties/pages/tabs/associations-tab.test.tsx
@@ -1,19 +1,28 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
 import { TooltipProvider } from '@/components/ui/tooltip'
 
-const mockRetrieveAssociations = vi.fn().mockResolvedValue({})
+const mockRetrieveAssociations = vi.fn().mockResolvedValue({ associations: [] })
+const mockListParticipants = vi.fn().mockResolvedValue({ participants: [] })
+const mockRetrieveParty = vi.fn().mockResolvedValue({ party: undefined })
 
 vi.mock('@/api/context', () => ({
   useClients: vi.fn(() => ({
     party: {
       retrieveAssociations: mockRetrieveAssociations,
+      listParticipants: mockListParticipants,
+      retrieveParty: mockRetrieveParty,
+      listParties: vi.fn().mockResolvedValue({ parties: [] }),
+      registerAssociations: vi.fn(),
     },
   })),
   useApiClients: vi.fn(() => ({
     party: {
       retrieveAssociations: mockRetrieveAssociations,
+      listParticipants: mockListParticipants,
+      retrieveParty: mockRetrieveParty,
       listParties: vi.fn().mockResolvedValue({ parties: [] }),
       registerAssociations: vi.fn(),
     },
@@ -39,19 +48,55 @@ function makeQueryClient() {
   })
 }
 
-const mockPartyClient = {
-  retrieveAssociations: vi.fn(),
-  listParties: vi.fn().mockResolvedValue({ parties: [] }),
-  registerAssociations: vi.fn(),
+const mockPersonParty = {
+  partyId: 'party-person-001',
+  legalName: 'Jane Doe',
+  partyType: 1, // PARTY_TYPE_PERSON
+  status: 1,
+}
+
+const mockOrgParty = {
+  partyId: 'party-org-001',
+  legalName: 'Acme Syndicate',
+  partyType: 2, // PARTY_TYPE_ORGANIZATION
+  status: 1,
+}
+
+const mockAssociation = {
+  associationId: 'assoc-001',
+  partyId: 'party-person-001',
+  relatedPartyId: 'party-org-001',
+  relationshipType: 6, // SYNDICATE_PARTICIPANT
+  status: 1, // ACTIVE
+  metadata: undefined,
+  createdAt: undefined,
+  updatedAt: undefined,
+  effectiveFrom: undefined,
+  effectiveTo: undefined,
+}
+
+const mockParticipant = {
+  associationId: 'assoc-002',
+  partyId: 'party-org-001',
+  relatedPartyId: 'party-member-001',
+  relationshipType: 6, // SYNDICATE_PARTICIPANT
+  status: 1, // ACTIVE
+  metadata: { allocation_share: '10%' },
+  createdAt: undefined,
+  updatedAt: undefined,
+  effectiveFrom: undefined,
+  effectiveTo: undefined,
 }
 
 function renderTab(partyId = 'party-001') {
   return render(
-    <QueryClientProvider client={makeQueryClient()}>
-      <TooltipProvider>
-        <AssociationsTab partyId={partyId} />
-      </TooltipProvider>
-    </QueryClientProvider>,
+    <MemoryRouter>
+      <QueryClientProvider client={makeQueryClient()}>
+        <TooltipProvider>
+          <AssociationsTab partyId={partyId} />
+        </TooltipProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
   )
 }
 
@@ -59,7 +104,13 @@ describe('AssociationsTab', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(useApiClients).mockReturnValue({
-      party: mockPartyClient,
+      party: {
+        retrieveAssociations: vi.fn().mockResolvedValue({ associations: [] }),
+        listParticipants: vi.fn().mockResolvedValue({ participants: [] }),
+        retrieveParty: vi.fn().mockResolvedValue({ party: mockPersonParty }),
+        listParties: vi.fn().mockResolvedValue({ parties: [] }),
+        registerAssociations: vi.fn(),
+      },
     } as ReturnType<typeof useApiClients>)
   })
 
@@ -68,6 +119,8 @@ describe('AssociationsTab', () => {
       vi.mocked(useApiClients).mockReturnValue({
         party: {
           retrieveAssociations: vi.fn(() => new Promise(() => {})),
+          listParticipants: vi.fn(() => new Promise(() => {})),
+          retrieveParty: vi.fn(() => new Promise(() => {})),
         },
       } as ReturnType<typeof useApiClients>)
 
@@ -77,42 +130,44 @@ describe('AssociationsTab', () => {
       expect(skeletons.length).toBeGreaterThan(0)
     })
 
-    it('does not render empty state while loading', () => {
+    it('does not render table while loading', () => {
       vi.mocked(useApiClients).mockReturnValue({
         party: {
           retrieveAssociations: vi.fn(() => new Promise(() => {})),
+          listParticipants: vi.fn(() => new Promise(() => {})),
+          retrieveParty: vi.fn(() => new Promise(() => {})),
         },
       } as ReturnType<typeof useApiClients>)
 
       renderTab()
 
-      expect(screen.queryByRole('heading', { name: /associations/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('table')).not.toBeInTheDocument()
     })
   })
 
-  describe('empty state', () => {
-    it('renders empty state heading after data loads', async () => {
+  describe('empty state - person party', () => {
+    beforeEach(() => {
       vi.mocked(useApiClients).mockReturnValue({
         party: {
-          retrieveAssociations: vi.fn().mockResolvedValue({}),
+          retrieveAssociations: vi.fn().mockResolvedValue({ associations: [] }),
+          listParticipants: vi.fn().mockResolvedValue({ participants: [] }),
+          retrieveParty: vi.fn().mockResolvedValue({ party: mockPersonParty }),
+          listParties: vi.fn().mockResolvedValue({ parties: [] }),
+          registerAssociations: vi.fn(),
         },
       } as ReturnType<typeof useApiClients>)
+    })
 
-      renderTab()
+    it('renders empty state for person with no associations', async () => {
+      renderTab('party-person-001')
 
       await waitFor(() => {
-        expect(screen.getByRole('heading', { name: /associations/i })).toBeInTheDocument()
+        expect(screen.getByRole('heading', { name: /organizations/i })).toBeInTheDocument()
       })
     })
 
-    it('renders descriptive message', async () => {
-      vi.mocked(useApiClients).mockReturnValue({
-        party: {
-          retrieveAssociations: vi.fn().mockResolvedValue({}),
-        },
-      } as ReturnType<typeof useApiClients>)
-
-      renderTab()
+    it('renders descriptive message for person empty state', async () => {
+      renderTab('party-person-001')
 
       await waitFor(() => {
         expect(screen.getByText(/no associations information available/i)).toBeInTheDocument()
@@ -120,13 +175,7 @@ describe('AssociationsTab', () => {
     })
 
     it('renders add association button', async () => {
-      vi.mocked(useApiClients).mockReturnValue({
-        party: {
-          retrieveAssociations: vi.fn().mockResolvedValue({}),
-        },
-      } as ReturnType<typeof useApiClients>)
-
-      renderTab()
+      renderTab('party-person-001')
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /add association/i })).toBeInTheDocument()
@@ -134,11 +183,150 @@ describe('AssociationsTab', () => {
     })
   })
 
+  describe('empty state - organization party', () => {
+    beforeEach(() => {
+      vi.mocked(useApiClients).mockReturnValue({
+        party: {
+          retrieveAssociations: vi.fn().mockResolvedValue({ associations: [] }),
+          listParticipants: vi.fn().mockResolvedValue({ participants: [] }),
+          retrieveParty: vi.fn().mockResolvedValue({ party: mockOrgParty }),
+          listParties: vi.fn().mockResolvedValue({ parties: [] }),
+          registerAssociations: vi.fn(),
+        },
+      } as ReturnType<typeof useApiClients>)
+    })
+
+    it('renders empty state for org with no participants', async () => {
+      renderTab('party-org-001')
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /members/i })).toBeInTheDocument()
+      })
+    })
+
+    it('renders descriptive message for org empty state', async () => {
+      renderTab('party-org-001')
+
+      await waitFor(() => {
+        expect(screen.getByText(/no members registered/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('data state - person party with associations', () => {
+    beforeEach(() => {
+      vi.mocked(useApiClients).mockReturnValue({
+        party: {
+          retrieveAssociations: vi.fn().mockResolvedValue({ associations: [mockAssociation] }),
+          listParticipants: vi.fn().mockResolvedValue({ participants: [] }),
+          retrieveParty: vi.fn().mockResolvedValue({ party: mockPersonParty }),
+          listParties: vi.fn().mockResolvedValue({ parties: [] }),
+          registerAssociations: vi.fn(),
+        },
+      } as ReturnType<typeof useApiClients>)
+    })
+
+    it('renders table with association rows', async () => {
+      renderTab('party-person-001')
+
+      await waitFor(() => {
+        expect(screen.getByRole('table')).toBeInTheDocument()
+      })
+    })
+
+    it('renders related party as a link', async () => {
+      renderTab('party-person-001')
+
+      await waitFor(() => {
+        expect(screen.getByRole('link', { name: 'party-org-001' })).toBeInTheDocument()
+      })
+    })
+
+    it('renders relationship type label', async () => {
+      renderTab('party-person-001')
+
+      await waitFor(() => {
+        expect(screen.getByText('Syndicate Participant')).toBeInTheDocument()
+      })
+    })
+
+    it('renders status badge', async () => {
+      renderTab('party-person-001')
+
+      await waitFor(() => {
+        expect(screen.getByText('ACTIVE')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('data state - organization party with participants', () => {
+    beforeEach(() => {
+      vi.mocked(useApiClients).mockReturnValue({
+        party: {
+          retrieveAssociations: vi.fn().mockResolvedValue({ associations: [] }),
+          listParticipants: vi.fn().mockResolvedValue({ participants: [mockParticipant] }),
+          retrieveParty: vi.fn().mockResolvedValue({ party: mockOrgParty }),
+          listParties: vi.fn().mockResolvedValue({ parties: [] }),
+          registerAssociations: vi.fn(),
+        },
+      } as ReturnType<typeof useApiClients>)
+    })
+
+    it('renders table with participant rows', async () => {
+      renderTab('party-org-001')
+
+      await waitFor(() => {
+        expect(screen.getByRole('table')).toBeInTheDocument()
+      })
+    })
+
+    it('renders member party as a link', async () => {
+      renderTab('party-org-001')
+
+      await waitFor(() => {
+        expect(screen.getByRole('link', { name: 'party-member-001' })).toBeInTheDocument()
+      })
+    })
+
+    it('renders metadata summary for participant', async () => {
+      renderTab('party-org-001')
+
+      await waitFor(() => {
+        expect(screen.getByText(/allocation_share/i)).toBeInTheDocument()
+      })
+    })
+
+    it('calls listParticipants with the org partyId', async () => {
+      const listParticipants = vi.fn().mockResolvedValue({ participants: [] })
+      vi.mocked(useApiClients).mockReturnValue({
+        party: {
+          retrieveAssociations: vi.fn().mockResolvedValue({ associations: [] }),
+          listParticipants,
+          retrieveParty: vi.fn().mockResolvedValue({ party: mockOrgParty }),
+          listParties: vi.fn().mockResolvedValue({ parties: [] }),
+          registerAssociations: vi.fn(),
+        },
+      } as ReturnType<typeof useApiClients>)
+
+      renderTab('party-org-001')
+
+      await waitFor(() => {
+        expect(listParticipants).toHaveBeenCalledWith({ partyId: 'party-org-001' })
+      })
+    })
+  })
+
   describe('query key', () => {
     it('calls retrieveAssociations with the provided partyId', async () => {
-      const retrieveAssociations = vi.fn().mockResolvedValue({})
+      const retrieveAssociations = vi.fn().mockResolvedValue({ associations: [] })
       vi.mocked(useApiClients).mockReturnValue({
-        party: { retrieveAssociations },
+        party: {
+          retrieveAssociations,
+          listParticipants: vi.fn().mockResolvedValue({ participants: [] }),
+          retrieveParty: vi.fn().mockResolvedValue({ party: mockPersonParty }),
+          listParties: vi.fn().mockResolvedValue({ parties: [] }),
+          registerAssociations: vi.fn(),
+        },
       } as ReturnType<typeof useApiClients>)
 
       renderTab('party-abc')

--- a/frontend/src/features/parties/pages/tabs/associations-tab.tsx
+++ b/frontend/src/features/parties/pages/tabs/associations-tab.tsx
@@ -15,11 +15,13 @@ import {
   PartyType,
 } from '@/api/gen/meridian/party/v1/party_pb'
 import type { Association } from '@/api/gen/meridian/party/v1/party_pb'
-import { usePartyDetail, usePartyAssociations } from '../../hooks'
+import { usePartyAssociations } from '../../hooks'
 import { RegisterAssociationsDialog } from '../dialogs/register-associations-dialog'
 
 interface AssociationsTabProps {
   partyId: string
+  /** Party type passed from the parent page to avoid a duplicate fetch */
+  partyType?: number | string
 }
 
 const RELATIONSHIP_TYPE_LABELS: Record<number, string> = {
@@ -104,18 +106,16 @@ function AssociationTable({ associations, onRowClick }: AssociationTableProps) {
   )
 }
 
-export function AssociationsTab({ partyId }: AssociationsTabProps) {
+export function AssociationsTab({ partyId, partyType }: AssociationsTabProps) {
   const clients = useApiClients()
   const tenantSlug = useTenantSlug()
   const navigate = useNavigate()
   const [dialogOpen, setDialogOpen] = React.useState(false)
 
-  const { data: party, isLoading: isLoadingParty } = usePartyDetail(partyId)
-
   const isOrganization =
-    party?.partyType === PartyType.ORGANIZATION ||
-    (party?.partyType as unknown) === 'PARTY_TYPE_ORGANIZATION' ||
-    (party?.partyType as unknown) === 'ORGANIZATION'
+    partyType === PartyType.ORGANIZATION ||
+    partyType === 'PARTY_TYPE_ORGANIZATION' ||
+    partyType === 'ORGANIZATION'
 
   // For PERSON parties: retrieve forward associations (relationships registered by this party)
   const { data: associationsData, isLoading: isLoadingAssociations } = usePartyAssociations(partyId)
@@ -127,7 +127,7 @@ export function AssociationsTab({ partyId }: AssociationsTabProps) {
     enabled: Boolean(tenantSlug && partyId && isOrganization),
   })
 
-  const isLoading = isLoadingParty || (isOrganization ? isLoadingParticipants : isLoadingAssociations)
+  const isLoading = isOrganization ? isLoadingParticipants : isLoadingAssociations
 
   const associations: Association[] = isOrganization
     ? (participantsData?.participants ?? [])

--- a/frontend/src/features/parties/pages/tabs/associations-tab.tsx
+++ b/frontend/src/features/parties/pages/tabs/associations-tab.tsx
@@ -1,19 +1,142 @@
 import * as React from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
 import { Skeleton } from '@/components/ui/skeleton'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Button } from '@/components/ui/button'
-import { usePartyAssociations } from '../../hooks'
+import { EntityLink } from '@/shared/entity-link'
+import { StatusBadge } from '@/shared/status-badge'
+import { useApiClients } from '@/api/context'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+import {
+  RelationshipType,
+  AssociationStatus,
+  PartyType,
+} from '@/api/gen/meridian/party/v1/party_pb'
+import type { Association } from '@/api/gen/meridian/party/v1/party_pb'
+import { usePartyDetail, usePartyAssociations } from '../../hooks'
 import { RegisterAssociationsDialog } from '../dialogs/register-associations-dialog'
 
 interface AssociationsTabProps {
   partyId: string
 }
 
+const RELATIONSHIP_TYPE_LABELS: Record<number, string> = {
+  [RelationshipType.UNSPECIFIED]: 'Unknown',
+  [RelationshipType.SPOUSE]: 'Spouse',
+  [RelationshipType.DEPENDENT]: 'Dependent',
+  [RelationshipType.BUSINESS_PARTNER]: 'Business Partner',
+  [RelationshipType.GUARANTOR]: 'Guarantor',
+  [RelationshipType.BENEFICIAL_OWNER]: 'Beneficial Owner',
+  [RelationshipType.SYNDICATE_PARTICIPANT]: 'Syndicate Participant',
+  [RelationshipType.SYNDICATE_HOST]: 'Syndicate Host',
+}
+
+const ASSOCIATION_STATUS_LABELS: Record<number, string> = {
+  [AssociationStatus.UNSPECIFIED]: 'UNKNOWN',
+  [AssociationStatus.ACTIVE]: 'ACTIVE',
+  [AssociationStatus.SUSPENDED]: 'SUSPENDED',
+  [AssociationStatus.TERMINATED]: 'TERMINATED',
+}
+
+function relationshipTypeLabel(type: number): string {
+  return RELATIONSHIP_TYPE_LABELS[type] ?? String(type)
+}
+
+function associationStatusLabel(status: number): string {
+  if (typeof status === 'string') return status as string
+  return ASSOCIATION_STATUS_LABELS[status] ?? String(status)
+}
+
+function metadataSummary(metadata: Record<string, unknown> | undefined): string {
+  if (!metadata) return '-'
+  const keys = Object.keys(metadata)
+  if (keys.length === 0) return '-'
+  if (keys.length === 1) {
+    const val = metadata[keys[0]]
+    return `${keys[0]}: ${JSON.stringify(val)}`
+  }
+  return `${keys.length} fields`
+}
+
+interface AssociationTableProps {
+  associations: Association[]
+  onRowClick?: (association: Association) => void
+}
+
+function AssociationTable({ associations, onRowClick }: AssociationTableProps) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left text-muted-foreground">
+            <th className="pb-2 pr-4 font-medium">Party</th>
+            <th className="pb-2 pr-4 font-medium">Relationship</th>
+            <th className="pb-2 pr-4 font-medium">Status</th>
+            <th className="pb-2 font-medium">Metadata</th>
+          </tr>
+        </thead>
+        <tbody>
+          {associations.map((assoc) => (
+            <tr
+              key={assoc.associationId}
+              className={onRowClick ? 'cursor-pointer hover:bg-muted/50' : undefined}
+              onClick={onRowClick ? () => onRowClick(assoc) : undefined}
+            >
+              <td className="py-2 pr-4">
+                <EntityLink type="party" id={assoc.relatedPartyId} />
+              </td>
+              <td className="py-2 pr-4">
+                {relationshipTypeLabel(assoc.relationshipType as number)}
+              </td>
+              <td className="py-2 pr-4">
+                <StatusBadge status={associationStatusLabel(assoc.status as number)} />
+              </td>
+              <td className="py-2 text-muted-foreground">
+                {metadataSummary(assoc.metadata as Record<string, unknown> | undefined)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
 export function AssociationsTab({ partyId }: AssociationsTabProps) {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+  const navigate = useNavigate()
   const [dialogOpen, setDialogOpen] = React.useState(false)
 
-  // TODO: Use fetched association data to populate the table once the UI is built
-  const { isLoading } = usePartyAssociations(partyId)
+  const { data: party, isLoading: isLoadingParty } = usePartyDetail(partyId)
+
+  const isOrganization =
+    party?.partyType === PartyType.ORGANIZATION ||
+    (party?.partyType as unknown) === 'PARTY_TYPE_ORGANIZATION' ||
+    (party?.partyType as unknown) === 'ORGANIZATION'
+
+  // For PERSON parties: retrieve forward associations (relationships registered by this party)
+  const { data: associationsData, isLoading: isLoadingAssociations } = usePartyAssociations(partyId)
+
+  // For ORGANIZATION parties: list participants (members of this org/syndicate)
+  const { data: participantsData, isLoading: isLoadingParticipants } = useQuery({
+    queryKey: [...tenantKeys.party(tenantSlug ?? '', partyId), 'participants'],
+    queryFn: () => clients.party.listParticipants({ partyId }),
+    enabled: Boolean(tenantSlug && partyId && isOrganization),
+  })
+
+  const isLoading = isLoadingParty || (isOrganization ? isLoadingParticipants : isLoadingAssociations)
+
+  const associations: Association[] = isOrganization
+    ? (participantsData?.participants ?? [])
+    : (associationsData?.associations ?? [])
+
+  const tableTitle = isOrganization ? 'Members' : 'Organizations'
+  const emptyDescription = isOrganization
+    ? 'No members registered for this organization.'
+    : 'No associations information available.'
 
   if (isLoading) {
     return (
@@ -29,7 +152,14 @@ export function AssociationsTab({ partyId }: AssociationsTabProps) {
       <div className="flex justify-end mb-4">
         <Button onClick={() => setDialogOpen(true)}>Add Association</Button>
       </div>
-      <EmptyState title="Associations" description="No associations information available." />
+      {associations.length === 0 ? (
+        <EmptyState title={tableTitle} description={emptyDescription} />
+      ) : (
+        <AssociationTable
+          associations={associations}
+          onRowClick={(assoc) => navigate(`/parties/${assoc.relatedPartyId}`)}
+        />
+      )}
       <RegisterAssociationsDialog
         open={dialogOpen}
         onOpenChange={setDialogOpen}

--- a/frontend/src/features/parties/pages/tabs/associations-tab.tsx
+++ b/frontend/src/features/parties/pages/tabs/associations-tab.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { Skeleton } from '@/components/ui/skeleton'
 import { EmptyState } from '@/components/ui/empty-state'
@@ -42,12 +41,13 @@ const ASSOCIATION_STATUS_LABELS: Record<number, string> = {
   [AssociationStatus.TERMINATED]: 'TERMINATED',
 }
 
-function relationshipTypeLabel(type: number): string {
+function relationshipTypeLabel(type: number | string): string {
+  if (typeof type === 'string') return type
   return RELATIONSHIP_TYPE_LABELS[type] ?? String(type)
 }
 
-function associationStatusLabel(status: number): string {
-  if (typeof status === 'string') return status as string
+function associationStatusLabel(status: number | string): string {
+  if (typeof status === 'string') return status
   return ASSOCIATION_STATUS_LABELS[status] ?? String(status)
 }
 
@@ -64,10 +64,9 @@ function metadataSummary(metadata: Record<string, unknown> | undefined): string 
 
 interface AssociationTableProps {
   associations: Association[]
-  onRowClick?: (association: Association) => void
 }
 
-function AssociationTable({ associations, onRowClick }: AssociationTableProps) {
+function AssociationTable({ associations }: AssociationTableProps) {
   return (
     <div className="overflow-x-auto">
       <table className="w-full text-sm">
@@ -81,11 +80,7 @@ function AssociationTable({ associations, onRowClick }: AssociationTableProps) {
         </thead>
         <tbody>
           {associations.map((assoc) => (
-            <tr
-              key={assoc.associationId}
-              className={onRowClick ? 'cursor-pointer hover:bg-muted/50' : undefined}
-              onClick={onRowClick ? () => onRowClick(assoc) : undefined}
-            >
+            <tr key={assoc.associationId} className="hover:bg-muted/50">
               <td className="py-2 pr-4">
                 <EntityLink type="party" id={assoc.relatedPartyId} />
               </td>
@@ -109,7 +104,6 @@ function AssociationTable({ associations, onRowClick }: AssociationTableProps) {
 export function AssociationsTab({ partyId, partyType }: AssociationsTabProps) {
   const clients = useApiClients()
   const tenantSlug = useTenantSlug()
-  const navigate = useNavigate()
   const [dialogOpen, setDialogOpen] = React.useState(false)
 
   const isOrganization =
@@ -117,8 +111,11 @@ export function AssociationsTab({ partyId, partyType }: AssociationsTabProps) {
     partyType === 'PARTY_TYPE_ORGANIZATION' ||
     partyType === 'ORGANIZATION'
 
-  // For PERSON parties: retrieve forward associations (relationships registered by this party)
-  const { data: associationsData, isLoading: isLoadingAssociations } = usePartyAssociations(partyId)
+  // For PERSON parties: retrieve forward associations (relationships registered by this party).
+  // Disabled for org parties — orgs use listParticipants instead.
+  const { data: associationsData, isLoading: isLoadingAssociations } = usePartyAssociations(
+    isOrganization ? undefined : partyId,
+  )
 
   // For ORGANIZATION parties: list participants (members of this org/syndicate)
   const { data: participantsData, isLoading: isLoadingParticipants } = useQuery({
@@ -155,10 +152,7 @@ export function AssociationsTab({ partyId, partyType }: AssociationsTabProps) {
       {associations.length === 0 ? (
         <EmptyState title={tableTitle} description={emptyDescription} />
       ) : (
-        <AssociationTable
-          associations={associations}
-          onRowClick={(assoc) => navigate(`/parties/${assoc.relatedPartyId}`)}
-        />
+        <AssociationTable associations={associations} />
       )}
       <RegisterAssociationsDialog
         open={dialogOpen}

--- a/frontend/src/features/parties/pages/tabs/associations-tab.tsx
+++ b/frontend/src/features/parties/pages/tabs/associations-tab.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Skeleton } from '@/components/ui/skeleton'
 import { EmptyState } from '@/components/ui/empty-state'
+import { ErrorState } from '@/shared/error-state'
 import { Button } from '@/components/ui/button'
 import { EntityLink } from '@/shared/entity-link'
 import { StatusBadge } from '@/shared/status-badge'
@@ -113,18 +114,28 @@ export function AssociationsTab({ partyId, partyType }: AssociationsTabProps) {
 
   // For PERSON parties: retrieve forward associations (relationships registered by this party).
   // Disabled for org parties — orgs use listParticipants instead.
-  const { data: associationsData, isLoading: isLoadingAssociations } = usePartyAssociations(
-    isOrganization ? undefined : partyId,
-  )
+  const {
+    data: associationsData,
+    isLoading: isLoadingAssociations,
+    isError: isErrorAssociations,
+    refetch: refetchAssociations,
+  } = usePartyAssociations(isOrganization ? undefined : partyId)
 
   // For ORGANIZATION parties: list participants (members of this org/syndicate)
-  const { data: participantsData, isLoading: isLoadingParticipants } = useQuery({
+  const {
+    data: participantsData,
+    isLoading: isLoadingParticipants,
+    isError: isErrorParticipants,
+    refetch: refetchParticipants,
+  } = useQuery({
     queryKey: [...tenantKeys.party(tenantSlug ?? '', partyId), 'participants'],
     queryFn: () => clients.party.listParticipants({ partyId }),
     enabled: Boolean(tenantSlug && partyId && isOrganization),
   })
 
   const isLoading = isOrganization ? isLoadingParticipants : isLoadingAssociations
+  const isError = isOrganization ? isErrorParticipants : isErrorAssociations
+  const refetch = isOrganization ? refetchParticipants : refetchAssociations
 
   const associations: Association[] = isOrganization
     ? (participantsData?.participants ?? [])
@@ -142,6 +153,10 @@ export function AssociationsTab({ partyId, partyType }: AssociationsTabProps) {
         <Skeleton className="h-4 w-1/3" />
       </div>
     )
+  }
+
+  if (isError) {
+    return <ErrorState onRetry={() => void refetch()} />
   }
 
   return (


### PR DESCRIPTION
## Summary

- Replaces the stub empty state in the Associations tab with a functional table
- For ORGANIZATION parties: calls `listParticipants` and renders a **Members** table
- For PERSON parties: calls `retrieveAssociations` and renders an **Organizations** table
- Each row links to the related party's detail page via `EntityLink`

## Changes Made

**`associations-tab.tsx`**
- Uses `usePartyDetail` to detect party type (ORGANIZATION vs PERSON)
- For orgs: queries `clients.party.listParticipants({ partyId })` for members
- For persons: uses existing `usePartyAssociations` hook (calls `retrieveAssociations`)
- Renders `AssociationTable` with columns: Party, Relationship Type, Status, Metadata
- Row click navigates to `/parties/{relatedPartyId}`
- Empty state shows context-appropriate title and description per party type
- Add Association button and dialog preserved

**`associations-tab.test.tsx`**
- Updated to wrap renders in `MemoryRouter` (required for `useNavigate` and `EntityLink`)
- Added tests for loading state, empty state (org + person), and data state (org + person)
- Tests verify: table renders, entity links, relationship type labels, status badges, metadata, `listParticipants` called for orgs

## Testing

- All 16 unit tests pass
- TypeScript check: zero errors

## Task Master

party-navigation.12 - Build associations-tab.tsx UI