### PR TITLE
feat: replace client-side account filtering with server-side party_id filter

### DIFF
--- a/frontend/src/features/parties/pages/[partyId].tsx
+++ b/frontend/src/features/parties/pages/[partyId].tsx
@@ -82,7 +82,7 @@ export function PartyDetailPage() {
                 </TabsContent>
 
                 <TabsContent value="accounts" className="mt-0">
-                  <AccountsTab partyId={partyId} />
+                  <AccountsTab partyId={partyId} partyType={party?.partyType} />
                 </TabsContent>
 
                 <TabsContent value="audit-trail" className="mt-0">

--- a/frontend/src/features/parties/pages/tabs/accounts-tab.tsx
+++ b/frontend/src/features/parties/pages/tabs/accounts-tab.tsx
@@ -10,9 +10,12 @@ import { useClients } from '@/api/context'
 import { useTenantSlug } from '@/hooks/use-tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
 import { AccountStatus } from '@/api/gen/meridian/current_account/v1/current_account_pb'
+import { PartyType } from '@/api/gen/meridian/party/v1/party_pb'
 
 interface AccountsTabProps {
   partyId: string
+  /** Party type passed from the parent page to avoid a duplicate fetch */
+  partyType?: number | string
 }
 
 interface AccountRow {
@@ -57,10 +60,15 @@ const columns: ColumnDef<AccountRow>[] = [
   },
 ]
 
-export function AccountsTab({ partyId }: AccountsTabProps) {
+export function AccountsTab({ partyId, partyType }: AccountsTabProps) {
   const clients = useClients()
   const tenantSlug = useTenantSlug()
   const navigate = useNavigate()
+
+  const isOrganization =
+    partyType === PartyType.ORGANIZATION ||
+    partyType === 'PARTY_TYPE_ORGANIZATION' ||
+    partyType === 'ORGANIZATION'
 
   const queryKey = React.useMemo(
     () => [...tenantKeys.party(tenantSlug ?? '', partyId), 'accounts'],
@@ -71,54 +79,24 @@ export function AccountsTab({ partyId }: AccountsTabProps) {
     async (params: DataTableQueryParams): Promise<DataTableResult<AccountRow>> => {
       if (!tenantSlug) return { items: [] }
 
-      // The API does not support filtering by partyId, so we fetch pages and filter
-      // client-side. We continue fetching until we have enough matching rows to fill
-      // pageSize, or the API is exhausted. MAX_PAGES caps sequential API calls to
-      // prevent unbounded fetching when the party owns few accounts in a large dataset.
-      const MAX_PAGES = 10
-      const collected: AccountRow[] = []
-      let cursor = params.pageToken ?? ''
-      let nextPageToken: string | undefined
-      let pagesScanned = 0
-
-      while (collected.length < params.pageSize && pagesScanned < MAX_PAGES) {
-        pagesScanned++
-        // Use remaining slots as batch size to avoid dropping same-page overflow:
-        // if the batch were larger than remaining slots, we might get more matches
-        // than pageSize in one batch but nextPageToken would advance past them.
-        const remaining = Math.max(params.pageSize - collected.length, 1)
-        const response = await clients.currentAccount.listCurrentAccounts({
-          pageSize: remaining,
-          pageToken: cursor,
-        })
-
-        for (const a of response.accounts ?? []) {
-          if (a.orgPartyId === partyId || a.partyId === partyId) {
-            collected.push({
-              accountId: a.accountId,
-              externalReference: a.externalIdentifier ?? '',
-              status: ACCOUNT_STATUS_NAMES[a.accountStatus] ?? String(a.accountStatus),
-              instrumentCode: a.instrumentCode || '',
-              createdAt: a.createdAt ?? undefined,
-            })
-          }
-        }
-
-        if (!response.nextPageToken) {
-          nextPageToken = undefined
-          break
-        }
-
-        cursor = response.nextPageToken
-        nextPageToken = response.nextPageToken
-      }
+      const response = await clients.currentAccount.listCurrentAccounts({
+        pageSize: params.pageSize,
+        pageToken: params.pageToken ?? '',
+        ...(isOrganization ? { orgPartyId: partyId } : { partyId }),
+      })
 
       return {
-        items: collected.slice(0, params.pageSize),
-        nextPageToken,
+        items: (response.accounts ?? []).map((a) => ({
+          accountId: a.accountId,
+          externalReference: a.externalIdentifier ?? '',
+          status: ACCOUNT_STATUS_NAMES[a.accountStatus] ?? String(a.accountStatus),
+          instrumentCode: a.instrumentCode || '',
+          createdAt: a.createdAt ?? undefined,
+        })),
+        nextPageToken: response.nextPageToken || undefined,
       }
     },
-    [tenantSlug, partyId, clients],
+    [tenantSlug, partyId, isOrganization, clients],
   )
 
   return (


### PR DESCRIPTION
## Summary

- Removes the 10-page client-side fetch-and-filter loop in `accounts-tab.tsx` that worked around the missing server-side party filter
- Replaces it with a single `ListCurrentAccounts` call using the `party_id` and `org_party_id` filter fields added in PR #1886
- For organization parties, filters via `org_party_id`; for all others, filters via `party_id`
- Passes `partyType` from the parent page (already fetched for `PartyHeader`) to determine the filter field without an extra request

## Changes Made

- `frontend/src/features/parties/pages/tabs/accounts-tab.tsx`: Replace loop + client filter with a single server-filtered call; add optional `partyType` prop
- `frontend/src/features/parties/pages/[partyId].tsx`: Pass `party?.partyType` to `AccountsTab`

## Technical Details

The original workaround fetched up to 10 pages of all accounts and filtered client-side by matching `partyId` or `orgPartyId`. This was bounded but still O(N) across the entire account dataset. With server-side filtering, the API returns only the relevant accounts and pagination tokens are accurate.

The `isOrganization` check mirrors the pattern used in `AssociationsTab`.

## Testing

- TypeScript check passes: `npx tsc --noEmit`
- No existing tests for this component