### PR TITLE
feat: add Transactions tab to party detail page

### DIFF
--- a/frontend/src/features/parties/pages/[partyId].test.tsx
+++ b/frontend/src/features/parties/pages/[partyId].test.tsx
@@ -4,42 +4,37 @@ import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 
+const mockClients = {
+  party: {
+    retrieveParty: vi.fn().mockResolvedValue({
+      party: {
+        partyId: 'test-party-1',
+        legalName: 'Test Party',
+        partyType: 'PARTY_TYPE_ORGANIZATION',
+        status: 'PARTY_STATUS_ACTIVE',
+      },
+    }),
+    listPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: [] }),
+    retrieveReference: vi.fn().mockResolvedValue({}),
+    retrieveAssociations: vi.fn().mockResolvedValue({}),
+    retrieveBankRelations: vi.fn().mockResolvedValue({}),
+    retrieveDemographics: vi.fn().mockResolvedValue(null),
+  },
+  currentAccount: {
+    listCurrentAccounts: vi.fn().mockResolvedValue({ accounts: [], nextPageToken: '' }),
+  },
+  financialAccounting: {
+    listLedgerPostings: vi.fn().mockResolvedValue({ ledgerPostings: [] }),
+  },
+  internalAccount: {
+    listInternalAccounts: vi.fn().mockResolvedValue({ facilities: [], pagination: {} }),
+  },
+}
+
 // Mock the API context to avoid loading ungenerated proto files
 vi.mock('@/api/context', () => ({
-  useClients: vi.fn(() => ({
-    party: {
-      retrieveParty: vi.fn().mockResolvedValue({
-        party: {
-          partyId: 'test-party-1',
-          legalName: 'Test Party',
-          partyType: 'PARTY_TYPE_ORGANIZATION',
-          status: 'PARTY_STATUS_ACTIVE',
-        },
-      }),
-      listPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: [] }),
-      retrieveReference: vi.fn().mockResolvedValue({}),
-      retrieveAssociations: vi.fn().mockResolvedValue({}),
-      retrieveBankRelations: vi.fn().mockResolvedValue({}),
-      retrieveDemographics: vi.fn().mockResolvedValue(null),
-    },
-  })),
-  useApiClients: vi.fn(() => ({
-    party: {
-      retrieveParty: vi.fn().mockResolvedValue({
-        party: {
-          partyId: 'test-party-1',
-          legalName: 'Test Party',
-          partyType: 'PARTY_TYPE_ORGANIZATION',
-          status: 'PARTY_STATUS_ACTIVE',
-        },
-      }),
-      listPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: [] }),
-      retrieveReference: vi.fn().mockResolvedValue({}),
-      retrieveAssociations: vi.fn().mockResolvedValue({}),
-      retrieveBankRelations: vi.fn().mockResolvedValue({}),
-      retrieveDemographics: vi.fn().mockResolvedValue(null),
-    },
-  })),
+  useClients: vi.fn(() => mockClients),
+  useApiClients: vi.fn(() => mockClients),
 }))
 
 // Mock useAuth to avoid requiring AuthProvider in tests
@@ -101,7 +96,7 @@ describe('PartyDetailPage', () => {
     })
   })
 
-  it('renders all seven tabs', async () => {
+  it('renders all eight tabs', async () => {
     const { container } = renderAtRoute(<PartyDetailPage />, '/parties/test-party-1')
 
     // Check that tabs container is rendered (wait for data to load)
@@ -145,6 +140,29 @@ describe('PartyDetailPage', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('tab', { name: 'Payment Methods' })).toHaveAttribute('data-state', 'active')
+    })
+  })
+
+  it('renders Transactions tab trigger', async () => {
+    renderAtRoute(<PartyDetailPage />, '/parties/test-party-1')
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Transactions' })).toBeInTheDocument()
+    })
+  })
+
+  it('switches to transactions tab on click', async () => {
+    const user = userEvent.setup()
+    renderAtRoute(<PartyDetailPage />, '/parties/test-party-1')
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Transactions' })).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('tab', { name: 'Transactions' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Transactions' })).toHaveAttribute('data-state', 'active')
     })
   })
 

--- a/frontend/src/features/parties/pages/[partyId].test.tsx
+++ b/frontend/src/features/parties/pages/[partyId].test.tsx
@@ -96,12 +96,15 @@ describe('PartyDetailPage', () => {
     })
   })
 
-  it('renders all eight tabs', async () => {
-    const { container } = renderAtRoute(<PartyDetailPage />, '/parties/test-party-1')
+  it('renders all tabs', async () => {
+    renderAtRoute(<PartyDetailPage />, '/parties/test-party-1')
 
-    // Check that tabs container is rendered (wait for data to load)
     await waitFor(() => {
-      expect(container.querySelector('[role="tablist"]')).toBeInTheDocument()
+      const tabs = screen.getAllByRole('tab')
+      // 9 base tabs (Overview, Demographics, References, Associations,
+      // Bank Relations, Payment Methods, Accounts, Transactions, Audit Trail)
+      // Internal Accounts is org-only and requires numeric PartyType enum match
+      expect(tabs.length).toBe(9)
     })
   })
 

--- a/frontend/src/features/parties/pages/[partyId].tsx
+++ b/frontend/src/features/parties/pages/[partyId].tsx
@@ -14,6 +14,7 @@ import { PaymentMethodsTab } from './tabs/payment-methods-tab'
 import { AuditTrailTab } from './tabs/audit-trail-tab'
 import { AccountsTab } from './tabs/accounts-tab'
 import { InternalAccountsTab } from './tabs/internal-accounts-tab'
+import { TransactionsTab } from './tabs/transactions-tab'
 
 export function PartyDetailPage() {
   const { partyId } = useParams<{ partyId: string }>()
@@ -59,6 +60,7 @@ export function PartyDetailPage() {
                 {isOrganization && (
                   <TabsTrigger value="internal-accounts">Internal Accounts</TabsTrigger>
                 )}
+                <TabsTrigger value="transactions">Transactions</TabsTrigger>
                 <TabsTrigger value="audit-trail">Audit Trail</TabsTrigger>
               </TabsList>
 
@@ -96,6 +98,10 @@ export function PartyDetailPage() {
                     <InternalAccountsTab partyId={partyId} />
                   </TabsContent>
                 )}
+
+                <TabsContent value="transactions" className="mt-0">
+                  <TransactionsTab partyId={partyId} partyType={party?.partyType} />
+                </TabsContent>
 
                 <TabsContent value="audit-trail" className="mt-0">
                   <AuditTrailTab partyId={partyId} />

--- a/frontend/src/features/parties/pages/tabs/transactions-tab.test.tsx
+++ b/frontend/src/features/parties/pages/tabs/transactions-tab.test.tsx
@@ -132,6 +132,26 @@ describe('TransactionsTab', () => {
         expect(screen.getByText(/failed to load transactions/i)).toBeInTheDocument()
       })
     })
+
+    it('renders error message when postings fetch fails', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        currentAccount: {
+          listCurrentAccounts: vi.fn().mockResolvedValue({
+            accounts: [{ accountId: 'acct-001' }],
+            nextPageToken: '',
+          }),
+        },
+        financialAccounting: {
+          listLedgerPostings: vi.fn().mockRejectedValue(new Error('postings error')),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByText(/failed to load transactions/i)).toBeInTheDocument()
+      })
+    })
   })
 
   describe('data display', () => {

--- a/frontend/src/features/parties/pages/tabs/transactions-tab.test.tsx
+++ b/frontend/src/features/parties/pages/tabs/transactions-tab.test.tsx
@@ -1,0 +1,378 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { BrowserRouter } from 'react-router-dom'
+
+vi.mock('@/api/context', () => ({
+  useClients: vi.fn(),
+}))
+
+vi.mock('@/hooks/use-tenant-context', () => ({
+  useTenantSlug: () => 'test-tenant',
+}))
+
+import { useClients } from '@/api/context'
+import { TransactionsTab } from './transactions-tab'
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+    },
+  })
+}
+
+function renderTab(partyId = 'party-001', partyType?: string) {
+  return render(
+    <BrowserRouter>
+      <QueryClientProvider client={makeQueryClient()}>
+        <TransactionsTab partyId={partyId} partyType={partyType} />
+      </QueryClientProvider>
+    </BrowserRouter>,
+  )
+}
+
+const mockPostings = [
+  {
+    id: 'posting-1',
+    postingDirection: 2, // CREDIT
+    postingAmount: { units: 10000n, nanos: 0, currencyCode: 'GBP' },
+    accountId: 'acct-001',
+    status: 2, // POSTED
+    createdAt: { seconds: 1700000000, nanos: 0 },
+  },
+  {
+    id: 'posting-2',
+    postingDirection: 1, // DEBIT
+    postingAmount: { units: 5000n, nanos: 0, currencyCode: 'GBP' },
+    accountId: 'acct-002',
+    status: 1, // PENDING
+    createdAt: { seconds: 1700001000, nanos: 0 },
+  },
+]
+
+describe('TransactionsTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('loading state', () => {
+    it('renders loading skeleton while fetching accounts', () => {
+      vi.mocked(useClients).mockReturnValue({
+        currentAccount: {
+          listCurrentAccounts: vi.fn(() => new Promise(() => {})),
+        },
+        financialAccounting: {
+          listLedgerPostings: vi.fn(),
+        },
+      } as ReturnType<typeof useClients>)
+
+      const { container } = renderTab()
+      expect(container.querySelector('.animate-pulse')).toBeInTheDocument()
+    })
+  })
+
+  describe('empty state', () => {
+    it('renders empty message when party has no accounts', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        currentAccount: {
+          listCurrentAccounts: vi.fn().mockResolvedValue({
+            accounts: [],
+            nextPageToken: '',
+          }),
+        },
+        financialAccounting: {
+          listLedgerPostings: vi.fn().mockResolvedValue({ ledgerPostings: [] }),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByText(/no transactions found/i)).toBeInTheDocument()
+      })
+    })
+
+    it('renders empty message when accounts have no postings', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        currentAccount: {
+          listCurrentAccounts: vi.fn().mockResolvedValue({
+            accounts: [{ accountId: 'acct-001' }],
+            nextPageToken: '',
+          }),
+        },
+        financialAccounting: {
+          listLedgerPostings: vi.fn().mockResolvedValue({ ledgerPostings: [] }),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByText(/no transactions found/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('error state', () => {
+    it('renders error message when account fetch fails', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        currentAccount: {
+          listCurrentAccounts: vi.fn().mockRejectedValue(new Error('network error')),
+        },
+        financialAccounting: {
+          listLedgerPostings: vi.fn(),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByText(/failed to load transactions/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('data display', () => {
+    it('renders postings with direction, account, status, and date columns', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        currentAccount: {
+          listCurrentAccounts: vi.fn().mockResolvedValue({
+            accounts: [{ accountId: 'acct-001' }, { accountId: 'acct-002' }],
+            nextPageToken: '',
+          }),
+        },
+        financialAccounting: {
+          listLedgerPostings: vi.fn().mockResolvedValue({ ledgerPostings: mockPostings }),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByText('CREDIT')).toBeInTheDocument()
+        expect(screen.getByText('DEBIT')).toBeInTheDocument()
+        expect(screen.getByText('POSTED')).toBeInTheDocument()
+        expect(screen.getByText('PENDING')).toBeInTheDocument()
+      })
+    })
+
+    it('renders account links for each posting', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        currentAccount: {
+          listCurrentAccounts: vi.fn().mockResolvedValue({
+            accounts: [{ accountId: 'acct-001' }, { accountId: 'acct-002' }],
+            nextPageToken: '',
+          }),
+        },
+        financialAccounting: {
+          listLedgerPostings: vi.fn().mockResolvedValue({ ledgerPostings: mockPostings }),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        const links = screen.getAllByRole('link')
+        const hrefs = links.map((l) => l.getAttribute('href'))
+        expect(hrefs).toContain('/accounts/acct-001')
+        expect(hrefs).toContain('/accounts/acct-002')
+      })
+    })
+
+    it('renders table headers: Direction, Amount, Account, Status, Created', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        currentAccount: {
+          listCurrentAccounts: vi.fn().mockResolvedValue({
+            accounts: [{ accountId: 'acct-001' }],
+            nextPageToken: '',
+          }),
+        },
+        financialAccounting: {
+          listLedgerPostings: vi.fn().mockResolvedValue({ ledgerPostings: [mockPostings[0]] }),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByText('Direction')).toBeInTheDocument()
+        expect(screen.getByText('Amount')).toBeInTheDocument()
+        expect(screen.getByText('Account')).toBeInTheDocument()
+        expect(screen.getByText('Status')).toBeInTheDocument()
+        expect(screen.getByText('Created')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('account filter', () => {
+    it('does not show account filter when only one account', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        currentAccount: {
+          listCurrentAccounts: vi.fn().mockResolvedValue({
+            accounts: [{ accountId: 'acct-001' }],
+            nextPageToken: '',
+          }),
+        },
+        financialAccounting: {
+          listLedgerPostings: vi.fn().mockResolvedValue({ ledgerPostings: [mockPostings[0]] }),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.queryByLabelText(/filter by account/i)).not.toBeInTheDocument()
+      })
+    })
+
+    it('shows account filter when multiple accounts exist', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        currentAccount: {
+          listCurrentAccounts: vi.fn().mockResolvedValue({
+            accounts: [{ accountId: 'acct-001' }, { accountId: 'acct-002' }],
+            nextPageToken: '',
+          }),
+        },
+        financialAccounting: {
+          listLedgerPostings: vi.fn().mockResolvedValue({ ledgerPostings: mockPostings }),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/filter by account/i)).toBeInTheDocument()
+      })
+    })
+
+    it('filters postings when a specific account is selected', async () => {
+      const user = userEvent.setup()
+      vi.mocked(useClients).mockReturnValue({
+        currentAccount: {
+          listCurrentAccounts: vi.fn().mockResolvedValue({
+            accounts: [{ accountId: 'acct-001' }, { accountId: 'acct-002' }],
+            nextPageToken: '',
+          }),
+        },
+        financialAccounting: {
+          listLedgerPostings: vi.fn().mockResolvedValue({ ledgerPostings: mockPostings }),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/filter by account/i)).toBeInTheDocument()
+      })
+
+      // Select acct-001 - should show only CREDIT posting
+      await user.selectOptions(screen.getByLabelText(/filter by account/i), 'acct-001')
+
+      await waitFor(() => {
+        expect(screen.getByText('CREDIT')).toBeInTheDocument()
+        expect(screen.queryByText('DEBIT')).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('pagination', () => {
+    it('paginates through all pages of accounts', async () => {
+      const listCurrentAccounts = vi.fn()
+        .mockResolvedValueOnce({
+          accounts: [{ accountId: 'acct-001' }],
+          nextPageToken: 'page2-token',
+        })
+        .mockResolvedValueOnce({
+          accounts: [{ accountId: 'acct-002' }],
+          nextPageToken: '',
+        })
+
+      vi.mocked(useClients).mockReturnValue({
+        currentAccount: { listCurrentAccounts },
+        financialAccounting: {
+          listLedgerPostings: vi.fn().mockResolvedValue({ ledgerPostings: [] }),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(listCurrentAccounts).toHaveBeenCalledTimes(2)
+        expect(listCurrentAccounts).toHaveBeenNthCalledWith(1, expect.objectContaining({ pageToken: '' }))
+        expect(listCurrentAccounts).toHaveBeenNthCalledWith(2, expect.objectContaining({ pageToken: 'page2-token' }))
+      })
+    })
+  })
+
+  describe('organization party', () => {
+    it('uses orgPartyId filter for organization parties', async () => {
+      const listCurrentAccounts = vi.fn().mockResolvedValue({
+        accounts: [],
+        nextPageToken: '',
+      })
+
+      vi.mocked(useClients).mockReturnValue({
+        currentAccount: { listCurrentAccounts },
+        financialAccounting: {
+          listLedgerPostings: vi.fn().mockResolvedValue({ ledgerPostings: [] }),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab('org-party-001', 'PARTY_TYPE_ORGANIZATION')
+
+      await waitFor(() => {
+        expect(listCurrentAccounts).toHaveBeenCalledWith(
+          expect.objectContaining({ orgPartyId: 'org-party-001' }),
+        )
+      })
+    })
+
+    it('uses partyId filter for non-organization parties', async () => {
+      const listCurrentAccounts = vi.fn().mockResolvedValue({
+        accounts: [],
+        nextPageToken: '',
+      })
+
+      vi.mocked(useClients).mockReturnValue({
+        currentAccount: { listCurrentAccounts },
+        financialAccounting: {
+          listLedgerPostings: vi.fn().mockResolvedValue({ ledgerPostings: [] }),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab('person-party-001', 'PARTY_TYPE_PERSON')
+
+      await waitFor(() => {
+        expect(listCurrentAccounts).toHaveBeenCalledWith(
+          expect.objectContaining({ partyId: 'person-party-001' }),
+        )
+      })
+    })
+  })
+
+  describe('batch account IDs', () => {
+    it('calls listLedgerPostings with accountIds batch filter', async () => {
+      const listLedgerPostings = vi.fn().mockResolvedValue({ ledgerPostings: [] })
+
+      vi.mocked(useClients).mockReturnValue({
+        currentAccount: {
+          listCurrentAccounts: vi.fn().mockResolvedValue({
+            accounts: [{ accountId: 'acct-001' }, { accountId: 'acct-002' }],
+            nextPageToken: '',
+          }),
+        },
+        financialAccounting: { listLedgerPostings },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(listLedgerPostings).toHaveBeenCalledWith(
+          expect.objectContaining({ accountIds: ['acct-001', 'acct-002'] }),
+        )
+      })
+    })
+  })
+})

--- a/frontend/src/features/parties/pages/tabs/transactions-tab.test.tsx
+++ b/frontend/src/features/parties/pages/tabs/transactions-tab.test.tsx
@@ -354,7 +354,7 @@ describe('TransactionsTab', () => {
 
   describe('batch account IDs', () => {
     it('calls listLedgerPostings with accountIds batch filter', async () => {
-      const listLedgerPostings = vi.fn().mockResolvedValue({ ledgerPostings: [] })
+      const listLedgerPostings = vi.fn().mockResolvedValue({ ledgerPostings: [], pagination: {} })
 
       vi.mocked(useClients).mockReturnValue({
         currentAccount: {
@@ -372,6 +372,46 @@ describe('TransactionsTab', () => {
         expect(listLedgerPostings).toHaveBeenCalledWith(
           expect.objectContaining({ accountIds: ['acct-001', 'acct-002'] }),
         )
+      })
+    })
+
+    it('paginates through all pages of postings', async () => {
+      const listLedgerPostings = vi.fn()
+        .mockResolvedValueOnce({
+          ledgerPostings: [mockPostings[0]],
+          pagination: { nextPageToken: 'postings-page2' },
+        })
+        .mockResolvedValueOnce({
+          ledgerPostings: [mockPostings[1]],
+          pagination: {},
+        })
+
+      vi.mocked(useClients).mockReturnValue({
+        currentAccount: {
+          listCurrentAccounts: vi.fn().mockResolvedValue({
+            accounts: [{ accountId: 'acct-001' }],
+            nextPageToken: '',
+          }),
+        },
+        financialAccounting: { listLedgerPostings },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(listLedgerPostings).toHaveBeenCalledTimes(2)
+        expect(listLedgerPostings).toHaveBeenNthCalledWith(1,
+          expect.objectContaining({ pagination: { pageSize: 100, pageToken: '' } }),
+        )
+        expect(listLedgerPostings).toHaveBeenNthCalledWith(2,
+          expect.objectContaining({ pagination: { pageSize: 100, pageToken: 'postings-page2' } }),
+        )
+      })
+
+      // Both pages of postings should be displayed
+      await waitFor(() => {
+        expect(screen.getByText('CREDIT')).toBeInTheDocument()
+        expect(screen.getByText('DEBIT')).toBeInTheDocument()
       })
     })
   })

--- a/frontend/src/features/parties/pages/tabs/transactions-tab.tsx
+++ b/frontend/src/features/parties/pages/tabs/transactions-tab.tsx
@@ -9,6 +9,37 @@ import { useTenantSlug } from '@/hooks/use-tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
 import { PartyType } from '@/api/gen/meridian/party/v1/party_pb'
 
+// Currencies with non-standard decimal places (ISO 4217)
+const CURRENCY_PRECISION: Record<string, number> = {
+  JPY: 0, KRW: 0, VND: 0, BHD: 3, KWD: 3, OMR: 3,
+}
+
+function toMinorUnits(money: unknown, currency: string): bigint | null {
+  if (money === undefined || money === null) return null
+  try {
+    if (typeof money === 'bigint') return money
+    if (typeof money === 'string') return BigInt(money)
+    if (typeof money === 'object' && 'units' in money) {
+      const m = money as { units?: bigint | number | string; nanos?: number }
+      const units = typeof m.units === 'bigint' ? m.units : BigInt(m.units ?? 0)
+      const nanos = m.nanos ?? 0
+      const precision = CURRENCY_PRECISION[currency] ?? 2
+      const factor = BigInt(10 ** precision)
+      const nanosDivisor = BigInt(10 ** (9 - precision))
+      const nanosBig = BigInt(nanos)
+      const half = nanosDivisor / 2n
+      const roundedNanos =
+        nanosBig >= 0n
+          ? (nanosBig + half) / nanosDivisor
+          : (nanosBig - half) / nanosDivisor
+      return units * factor + roundedNanos
+    }
+  } catch {
+    // Invalid BigInt conversion
+  }
+  return null
+}
+
 interface TransactionsTabProps {
   partyId: string
   /** Party type passed from the parent page to avoid a duplicate fetch */
@@ -170,10 +201,12 @@ export function TransactionsTab({ partyId, partyType }: TransactionsTabProps) {
                     <StatusBadge status={getDirectionName(p.postingDirection)} />
                   </td>
                   <td className="py-2 pr-4 tabular-nums">
-                    <MoneyDisplay
-                      amount={p.postingAmount?.units}
-                      currency={p.postingAmount?.currencyCode ?? ''}
-                    />
+                    {(() => {
+                      const currency = p.postingAmount?.currencyCode ?? ''
+                      const minor = toMinorUnits(p.postingAmount, currency)
+                      if (minor === null) return '-'
+                      return <MoneyDisplay amount={minor} currency={currency} />
+                    })()}
                   </td>
                   <td className="py-2 pr-4">
                     <EntityLink type="account" id={p.accountId} />

--- a/frontend/src/features/parties/pages/tabs/transactions-tab.tsx
+++ b/frontend/src/features/parties/pages/tabs/transactions-tab.tsx
@@ -72,9 +72,9 @@ export function TransactionsTab({ partyId, partyType }: TransactionsTabProps) {
     enabled: Boolean(tenantSlug && partyId),
   })
 
-  // Step 2: Fetch ledger postings for all resolved account IDs (batch by 100)
+  // Step 2: Fetch ledger postings for all resolved account IDs (batch by 100, paginate each batch)
   const postingsQuery = useQuery({
-    queryKey: [...tenantKeys.party(tenantSlug ?? '', partyId), 'transactions'],
+    queryKey: [...tenantKeys.party(tenantSlug ?? '', partyId), 'transactions', accountIdsQuery.data],
     queryFn: async () => {
       const accountIds = accountIdsQuery.data ?? []
       if (accountIds.length === 0) return []
@@ -83,15 +83,19 @@ export function TransactionsTab({ partyId, partyType }: TransactionsTabProps) {
         []
       for (let i = 0; i < accountIds.length; i += 100) {
         const batch = accountIds.slice(i, i + 100)
-        const resp = await clients.financialAccounting.listLedgerPostings({
-          pagination: { pageSize: 100, pageToken: '' },
-          accountIds: batch,
-        })
-        allPostings.push(...(resp.ledgerPostings ?? []))
+        let pageToken = ''
+        do {
+          const resp = await clients.financialAccounting.listLedgerPostings({
+            pagination: { pageSize: 100, pageToken },
+            accountIds: batch,
+          })
+          allPostings.push(...(resp.ledgerPostings ?? []))
+          pageToken = resp.pagination?.nextPageToken || ''
+        } while (pageToken)
       }
       return allPostings
     },
-    enabled: Boolean(tenantSlug && accountIdsQuery.data !== undefined),
+    enabled: Boolean(tenantSlug && accountIdsQuery.data && accountIdsQuery.data.length > 0),
   })
 
   const isLoading = accountIdsQuery.isLoading || postingsQuery.isLoading

--- a/frontend/src/features/parties/pages/tabs/transactions-tab.tsx
+++ b/frontend/src/features/parties/pages/tabs/transactions-tab.tsx
@@ -1,0 +1,191 @@
+import * as React from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { StatusBadge } from '@/shared/status-badge'
+import { TimeDisplay } from '@/shared/time-display'
+import { MoneyDisplay } from '@/shared/money-display'
+import { EntityLink } from '@/shared/entity-link'
+import { useClients } from '@/api/context'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+import { PartyType } from '@/api/gen/meridian/party/v1/party_pb'
+
+interface TransactionsTabProps {
+  partyId: string
+  /** Party type passed from the parent page to avoid a duplicate fetch */
+  partyType?: number | string
+}
+
+function getDirectionName(direction: unknown): string {
+  if (typeof direction === 'string') return direction
+  if (typeof direction === 'number') {
+    const dirMap: Record<number, string> = { 0: 'UNSPECIFIED', 1: 'DEBIT', 2: 'CREDIT' }
+    return dirMap[direction] ?? String(direction)
+  }
+  return String(direction ?? '')
+}
+
+function getStatusName(status: unknown): string {
+  if (typeof status === 'string') return status
+  if (typeof status === 'number') {
+    const statusMap: Record<number, string> = {
+      0: 'UNSPECIFIED',
+      1: 'PENDING',
+      2: 'POSTED',
+      3: 'FAILED',
+      4: 'CANCELLED',
+      5: 'REVERSED',
+    }
+    return statusMap[status] ?? String(status)
+  }
+  return String(status ?? '')
+}
+
+export function TransactionsTab({ partyId, partyType }: TransactionsTabProps) {
+  const clients = useClients()
+  const tenantSlug = useTenantSlug()
+  const [selectedAccount, setSelectedAccount] = React.useState<string>('')
+
+  const isOrganization =
+    partyType === PartyType.ORGANIZATION ||
+    partyType === 'PARTY_TYPE_ORGANIZATION' ||
+    partyType === 'ORGANIZATION'
+
+  // Step 1: Resolve all account IDs for this party (paginate all pages)
+  const accountIdsQuery = useQuery({
+    queryKey: [...tenantKeys.party(tenantSlug ?? '', partyId), 'transaction-account-ids'],
+    queryFn: async (): Promise<string[]> => {
+      const ids: string[] = []
+      let pageToken = ''
+      do {
+        const resp = await clients.currentAccount.listCurrentAccounts({
+          pageSize: 100,
+          pageToken,
+          ...(isOrganization ? { orgPartyId: partyId } : { partyId }),
+        })
+        for (const acct of resp.accounts ?? []) {
+          ids.push(acct.accountId)
+        }
+        pageToken = resp.nextPageToken || ''
+      } while (pageToken)
+      return ids
+    },
+    enabled: Boolean(tenantSlug && partyId),
+  })
+
+  // Step 2: Fetch ledger postings for all resolved account IDs (batch by 100)
+  const postingsQuery = useQuery({
+    queryKey: [...tenantKeys.party(tenantSlug ?? '', partyId), 'transactions'],
+    queryFn: async () => {
+      const accountIds = accountIdsQuery.data ?? []
+      if (accountIds.length === 0) return []
+
+      const allPostings: Awaited<ReturnType<typeof clients.financialAccounting.listLedgerPostings>>['ledgerPostings'] =
+        []
+      for (let i = 0; i < accountIds.length; i += 100) {
+        const batch = accountIds.slice(i, i + 100)
+        const resp = await clients.financialAccounting.listLedgerPostings({
+          pagination: { pageSize: 100, pageToken: '' },
+          accountIds: batch,
+        })
+        allPostings.push(...(resp.ledgerPostings ?? []))
+      }
+      return allPostings
+    },
+    enabled: Boolean(tenantSlug && accountIdsQuery.data !== undefined),
+  })
+
+  const isLoading = accountIdsQuery.isLoading || postingsQuery.isLoading
+  const isError = accountIdsQuery.isError || postingsQuery.isError
+
+  const allPostings = postingsQuery.data ?? []
+
+  // Build account filter options from resolved account IDs
+  const accountIds = accountIdsQuery.data ?? []
+
+  // Filter displayed postings by selected account
+  const displayedPostings = selectedAccount
+    ? allPostings.filter((p) => p.accountId === selectedAccount)
+    : allPostings
+
+  return (
+    <div className="space-y-4">
+      {/* Account filter */}
+      {accountIds.length > 1 && (
+        <div className="flex items-center gap-2">
+          <label htmlFor="account-filter" className="text-sm font-medium text-muted-foreground">
+            Filter by account:
+          </label>
+          <select
+            id="account-filter"
+            value={selectedAccount}
+            onChange={(e) => setSelectedAccount(e.target.value)}
+            className="rounded-md border border-input bg-background px-3 py-1.5 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          >
+            <option value="">All accounts</option>
+            {accountIds.map((id) => (
+              <option key={id} value={id}>
+                {id}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {isLoading && (
+        <div className="animate-pulse space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="h-8 rounded bg-muted" />
+          ))}
+        </div>
+      )}
+
+      {isError && (
+        <p className="text-sm text-muted-foreground">Failed to load transactions.</p>
+      )}
+
+      {!isLoading && !isError && displayedPostings.length === 0 && (
+        <p className="text-sm text-muted-foreground">No transactions found for this party.</p>
+      )}
+
+      {!isLoading && !isError && displayedPostings.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-xs font-medium text-muted-foreground">
+                <th className="pb-2 pr-4">Direction</th>
+                <th className="pb-2 pr-4">Amount</th>
+                <th className="pb-2 pr-4">Account</th>
+                <th className="pb-2 pr-4">Status</th>
+                <th className="pb-2">Created</th>
+              </tr>
+            </thead>
+            <tbody>
+              {displayedPostings.map((p) => (
+                <tr key={p.id} className="border-b last:border-0">
+                  <td className="py-2 pr-4">
+                    <StatusBadge status={getDirectionName(p.postingDirection)} />
+                  </td>
+                  <td className="py-2 pr-4 tabular-nums">
+                    <MoneyDisplay
+                      amount={p.postingAmount?.units}
+                      currency={p.postingAmount?.currencyCode ?? ''}
+                    />
+                  </td>
+                  <td className="py-2 pr-4">
+                    <EntityLink type="account" id={p.accountId} />
+                  </td>
+                  <td className="py-2 pr-4">
+                    <StatusBadge status={getStatusName(p.status)} />
+                  </td>
+                  <td className="py-2">
+                    <TimeDisplay timestamp={p.createdAt} format="relative" />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/parties/pages/tabs/transactions-tab.tsx
+++ b/frontend/src/features/parties/pages/tabs/transactions-tab.tsx
@@ -52,7 +52,7 @@ export function TransactionsTab({ partyId, partyType }: TransactionsTabProps) {
 
   // Step 1: Resolve all account IDs for this party (paginate all pages)
   const accountIdsQuery = useQuery({
-    queryKey: [...tenantKeys.party(tenantSlug ?? '', partyId), 'transaction-account-ids'],
+    queryKey: [...tenantKeys.party(tenantSlug ?? '', partyId), 'transaction-account-ids', isOrganization],
     queryFn: async (): Promise<string[]> => {
       const ids: string[] = []
       let pageToken = ''

--- a/frontend/src/features/parties/pages/tabs/transactions-tab.tsx
+++ b/frontend/src/features/parties/pages/tabs/transactions-tab.tsx
@@ -94,7 +94,7 @@ export function TransactionsTab({ partyId, partyType }: TransactionsTabProps) {
           ...(isOrganization ? { orgPartyId: partyId } : { partyId }),
         })
         for (const acct of resp.accounts ?? []) {
-          ids.push(acct.accountId)
+          if (acct.accountId) ids.push(acct.accountId)
         }
         pageToken = resp.nextPageToken || ''
       } while (pageToken)
@@ -195,8 +195,8 @@ export function TransactionsTab({ partyId, partyType }: TransactionsTabProps) {
               </tr>
             </thead>
             <tbody>
-              {displayedPostings.map((p) => (
-                <tr key={p.id} className="border-b last:border-0">
+              {displayedPostings.map((p, idx) => (
+                <tr key={p.id || idx} className="border-b last:border-0">
                   <td className="py-2 pr-4">
                     <StatusBadge status={getDirectionName(p.postingDirection)} />
                   </td>


### PR DESCRIPTION
## Summary

- Adds a Transactions tab to the party detail page that shows ledger postings for all accounts owned by the party
- Resolves account IDs via ListCurrentAccounts (with party_id or org_party_id filter depending on party type), then fetches postings using the batch account_ids filter on ListLedgerPostings
- Includes account filter dropdown when multiple accounts exist, loading/error/empty states, and pagination support

## Technical Details

- **Task**: party-navigation.13
- New components: `TransactionsTab` with direction/amount/account/status/created columns
- Leverages batch `account_ids` filter added in tasks 4 and 15
- Merged with upstream Internal Accounts tab (task 10) - both tabs coexist

## Test plan

- [x] Unit tests for loading, empty, error states
- [x] Unit tests for data display (direction, amount, account links, status, timestamps)
- [x] Unit tests for account filter (show/hide, filtering behavior)
- [x] Unit tests for pagination through multiple pages of accounts
- [x] Unit tests for organization vs person party type (orgPartyId vs partyId)
- [x] Unit tests for batch accountIds filter on listLedgerPostings
- [x] Integration tests for tab rendering and switching in PartyDetailPage
- [x] All 164 party page tests passing