### PR TITLE
test: Add event router domain unit tests

### DIFF
--- a/services/event-router/adapters/messaging/platform_metering_handler_test.go
+++ b/services/event-router/adapters/messaging/platform_metering_handler_test.go
@@ -1,0 +1,208 @@
+package messaging
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	auditv1 "github.com/meridianhub/meridian/api/proto/meridian/audit/v1"
+	auditdomain "github.com/meridianhub/meridian/services/audit-worker/domain"
+	"github.com/meridianhub/meridian/services/event-router/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// newValidAuditEvent returns an AuditEvent that passes protovalidate checks.
+func newValidAuditEvent() *auditv1.AuditEvent {
+	return &auditv1.AuditEvent{
+		EventId:       "550e8400-e29b-41d4-a716-446655440001",
+		SchemaName:    "current_account",
+		TableName:     "current_account",
+		Operation:     auditv1.AuditOperation_AUDIT_OPERATION_INSERT,
+		RecordId:      "rec-123",
+		ChangedBy:     "test-user",
+		CorrelationId: "corr-456",
+		Timestamp:     timestamppb.Now(),
+		Metadata: map[string]string{
+			"tenant_id": "00000000-0000-0000-0000-000000000000",
+		},
+	}
+}
+
+// TestNewPlatformMeteringHandler_Valid verifies successful handler creation without options.
+func TestNewPlatformMeteringHandler_Valid(t *testing.T) {
+	transformer := newTestTransformer()
+	mockPK := newMockPositionKeepingClient()
+
+	h, err := NewPlatformMeteringHandler(transformer, mockPK)
+	require.NoError(t, err)
+	require.NotNil(t, h)
+	assert.False(t, h.HasMDSPublisher())
+}
+
+// TestNewPlatformMeteringHandler_WithMDSPublisher_SetsFlag verifies the option sets the publisher flag.
+func TestNewPlatformMeteringHandler_WithMDSPublisher_SetsFlag(t *testing.T) {
+	transformer := newTestTransformer()
+	mockPK := newMockPositionKeepingClient()
+	mockMDS := newMockUtilizationPublisher()
+
+	h, err := NewPlatformMeteringHandler(transformer, mockPK, WithMeteringMDSPublisher(mockMDS))
+	require.NoError(t, err)
+	assert.True(t, h.HasMDSPublisher())
+}
+
+// TestPlatformMeteringHandler_Handle_InvalidEvent verifies proto validation rejects events
+// with missing required fields (e.g., no event_id, no schema_name).
+func TestPlatformMeteringHandler_Handle_InvalidEvent(t *testing.T) {
+	transformer := newTestTransformer()
+	mockPK := newMockPositionKeepingClient()
+
+	h, err := NewPlatformMeteringHandler(transformer, mockPK)
+	require.NoError(t, err)
+
+	// AuditEvent with no required fields set — protovalidate should reject it
+	emptyEvent := &auditv1.AuditEvent{}
+
+	handleErr := h.Handle(context.Background(), "audit.events", emptyEvent, nil)
+
+	require.Error(t, handleErr)
+	assert.ErrorIs(t, handleErr, ErrInvalidAuditEvent)
+	assert.Empty(t, mockPK.getMeasurements())
+}
+
+// TestPlatformMeteringHandler_Handle_Success verifies a valid event produces the correct measurement.
+func TestPlatformMeteringHandler_Handle_Success(t *testing.T) {
+	transformer := newTestTransformer()
+	mockPK := newMockPositionKeepingClient()
+
+	h, err := NewPlatformMeteringHandler(transformer, mockPK)
+	require.NoError(t, err)
+
+	event := newValidAuditEvent()
+	handleErr := h.Handle(context.Background(), "audit.events", event, nil)
+
+	require.NoError(t, handleErr)
+	measurements := mockPK.getMeasurements()
+	require.Len(t, measurements, 1)
+	assert.Equal(t, "MERIDIAN-CURRENT-ACCOUNT-OPS", measurements[0].AssetCode)
+	assert.Equal(t, "AUDIT_STREAM", measurements[0].Source)
+	assert.Equal(t, "current_account", measurements[0].Attributes["service"])
+	assert.Equal(t, "INSERT", measurements[0].Attributes["operation"])
+}
+
+// TestPlatformMeteringHandler_Handle_PKError verifies error propagation when the PK client fails.
+func TestPlatformMeteringHandler_Handle_PKError(t *testing.T) {
+	transformer := newTestTransformer()
+	mockPK := newMockPositionKeepingClient()
+	mockPK.recordMeasurementFunc = func(_ context.Context, _ *auditdomain.Measurement) error {
+		return errors.New("position keeping service unavailable")
+	}
+
+	h, err := NewPlatformMeteringHandler(transformer, mockPK)
+	require.NoError(t, err)
+
+	event := newValidAuditEvent()
+	handleErr := h.Handle(context.Background(), "audit.events", event, nil)
+
+	require.Error(t, handleErr)
+	assert.Contains(t, handleErr.Error(), "failed to record measurement")
+}
+
+// TestPlatformMeteringHandler_Handle_WithMDS_ServiceAndOperation verifies dual-output fan-out
+// preserves ServiceName and OperationType in the MDS measurement.
+func TestPlatformMeteringHandler_Handle_WithMDS_ServiceAndOperation(t *testing.T) {
+	transformer := newTestTransformer()
+	mockPK := newMockPositionKeepingClient()
+	mockMDS := newMockUtilizationPublisher()
+
+	h, err := NewPlatformMeteringHandler(transformer, mockPK, WithMeteringMDSPublisher(mockMDS))
+	require.NoError(t, err)
+
+	event := newValidAuditEvent()
+	handleErr := h.Handle(context.Background(), "audit.events", event, nil)
+
+	require.NoError(t, handleErr)
+	assert.Len(t, mockPK.getMeasurements(), 1)
+	// MDS measurement carries ServiceName and OperationType from the AuditEvent
+	require.Len(t, mockMDS.getMeasurements(), 1)
+	mds := mockMDS.getMeasurements()[0]
+	assert.Equal(t, "current_account", mds.ServiceName)
+	assert.Equal(t, "INSERT", mds.OperationType)
+}
+
+// TestPlatformMeteringHandler_Handle_PKError_DoesNotPublishToMDS verifies that when PK fails,
+// MDS does not receive the measurement (PK path is the primary gate).
+func TestPlatformMeteringHandler_Handle_PKError_DoesNotPublishToMDS(t *testing.T) {
+	transformer := newTestTransformer()
+	mockPK := newMockPositionKeepingClient()
+	mockPK.recordMeasurementFunc = func(_ context.Context, _ *auditdomain.Measurement) error {
+		return errors.New("pk failure")
+	}
+	mockMDS := newMockUtilizationPublisher()
+
+	h, err := NewPlatformMeteringHandler(transformer, mockPK, WithMeteringMDSPublisher(mockMDS))
+	require.NoError(t, err)
+
+	event := newValidAuditEvent()
+	handleErr := h.Handle(context.Background(), "audit.events", event, nil)
+
+	require.Error(t, handleErr)
+	// MDS must not receive a measurement when PK failed
+	assert.Empty(t, mockMDS.getMeasurements())
+}
+
+// TestPlatformMeteringHandler_Handle_MDSPublish_PanicRecovery verifies that a panic inside
+// the MDS publish path is recovered and does not propagate to the caller.
+func TestPlatformMeteringHandler_Handle_MDSPublish_PanicRecovery(t *testing.T) {
+	transformer := newTestTransformer()
+	mockPK := newMockPositionKeepingClient()
+	panicPublisher := &mockUtilizationPublisher{
+		publishFunc: func(_ *domain.UtilizationMeasurement) {
+			panic("mds publish panic")
+		},
+	}
+
+	h, err := NewPlatformMeteringHandler(transformer, mockPK, WithMeteringMDSPublisher(panicPublisher))
+	require.NoError(t, err)
+
+	event := newValidAuditEvent()
+	// A panic inside publishToMDS must not escape the handler
+	handleErr := h.Handle(context.Background(), "audit.events", event, nil)
+
+	require.NoError(t, handleErr)
+	// PK measurement was recorded despite MDS panic
+	assert.Len(t, mockPK.getMeasurements(), 1)
+}
+
+// TestPlatformMeteringHandler_Handle_MultipleEvents verifies sequential processing of events.
+func TestPlatformMeteringHandler_Handle_MultipleEvents(t *testing.T) {
+	transformer := newTestTransformer()
+	mockPK := newMockPositionKeepingClient()
+
+	h, err := NewPlatformMeteringHandler(transformer, mockPK)
+	require.NoError(t, err)
+
+	events := []*auditv1.AuditEvent{
+		newValidAuditEvent(),
+		{
+			EventId:       "550e8400-e29b-41d4-a716-446655440002",
+			SchemaName:    "payment_order",
+			TableName:     "payment_order",
+			Operation:     auditv1.AuditOperation_AUDIT_OPERATION_UPDATE,
+			RecordId:      "rec-456",
+			ChangedBy:     "test-user",
+			CorrelationId: "corr-789",
+			Timestamp:     timestamppb.Now(),
+			Metadata: map[string]string{
+				"tenant_id": "11111111-1111-1111-1111-111111111111",
+			},
+		},
+	}
+
+	for _, event := range events {
+		require.NoError(t, h.Handle(context.Background(), "audit.events", event, nil))
+	}
+
+	assert.Len(t, mockPK.getMeasurements(), 2)
+}

--- a/services/event-router/domain/audit_event_transformer_test.go
+++ b/services/event-router/domain/audit_event_transformer_test.go
@@ -1,0 +1,197 @@
+package domain_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	auditv1 "github.com/meridianhub/meridian/api/proto/meridian/audit/v1"
+	auditdomain "github.com/meridianhub/meridian/services/audit-worker/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// newEventRouterTransformer creates an AuditEventTransformer configured for event-router tests.
+// Uses tenant-zero as both tenant and billing account (system tenant billing).
+func newEventRouterTransformer() *auditdomain.AuditEventTransformer {
+	tenantZeroID := uuid.MustParse("00000000-0000-0000-0000-000000000000")
+	tenantTestID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	tenantAccountMap := map[uuid.UUID]uuid.UUID{
+		tenantZeroID: tenantZeroID,
+		tenantTestID: tenantTestID,
+	}
+	return auditdomain.NewAuditEventTransformer(tenantAccountMap)
+}
+
+// newAuditEventWithTenant constructs a valid AuditEvent for the given tenant ID.
+func newAuditEventWithTenant(schemaName, tenantID string, op auditv1.AuditOperation) *auditv1.AuditEvent {
+	return &auditv1.AuditEvent{
+		EventId:       uuid.New().String(),
+		SchemaName:    schemaName,
+		TableName:     schemaName,
+		Operation:     op,
+		RecordId:      "rec-" + uuid.New().String()[:8],
+		ChangedBy:     "test-user",
+		CorrelationId: uuid.New().String(),
+		Timestamp:     timestamppb.Now(),
+		Metadata: map[string]string{
+			"tenant_id": tenantID,
+		},
+	}
+}
+
+// TestAuditEventTransformer_Transform_KnownTenant verifies transformation for a registered tenant.
+func TestAuditEventTransformer_Transform_KnownTenant(t *testing.T) {
+	transformer := newEventRouterTransformer()
+
+	event := newAuditEventWithTenant(
+		"current_account",
+		"00000000-0000-0000-0000-000000000000",
+		auditv1.AuditOperation_AUDIT_OPERATION_INSERT,
+	)
+
+	measurement, err := transformer.Transform(event)
+
+	require.NoError(t, err)
+	require.NotNil(t, measurement, "expected measurement for known tenant")
+	assert.Equal(t, "MERIDIAN-CURRENT-ACCOUNT-OPS", measurement.AssetCode)
+	assert.Equal(t, "AUDIT_STREAM", measurement.Source)
+	assert.Equal(t, "current_account", measurement.Attributes["service"])
+	assert.Equal(t, "INSERT", measurement.Attributes["operation"])
+}
+
+// TestAuditEventTransformer_Transform_UnknownTenant verifies that unknown tenants
+// produce an error (not in the account mapping).
+func TestAuditEventTransformer_Transform_UnknownTenant(t *testing.T) {
+	transformer := newEventRouterTransformer()
+
+	event := newAuditEventWithTenant(
+		"current_account",
+		"ffffffff-ffff-ffff-ffff-ffffffffffff", // not in the transformer map
+		auditv1.AuditOperation_AUDIT_OPERATION_INSERT,
+	)
+
+	measurement, err := transformer.Transform(event)
+
+	// Unknown tenant returns an error — caller must handle filtering
+	require.Error(t, err)
+	assert.Nil(t, measurement)
+	assert.Contains(t, err.Error(), "tenant not found")
+}
+
+// TestAuditEventTransformer_Transform_Metadata verifies timestamp and ID fields are populated.
+func TestAuditEventTransformer_Transform_Metadata(t *testing.T) {
+	transformer := newEventRouterTransformer()
+
+	tenantID := "00000000-0000-0000-0000-000000000000"
+	event := newAuditEventWithTenant("payment_order", tenantID, auditv1.AuditOperation_AUDIT_OPERATION_UPDATE)
+
+	before := time.Now()
+	measurement, err := transformer.Transform(event)
+	after := time.Now()
+
+	require.NoError(t, err)
+	require.NotNil(t, measurement)
+
+	// Measurement ID is a UUID
+	assert.NotEqual(t, uuid.Nil, measurement.ID)
+
+	// AccountID maps to tenant billing account
+	expectedAccountID := uuid.MustParse(tenantID)
+	assert.Equal(t, expectedAccountID, measurement.AccountID)
+
+	// Period timestamps are within the test window
+	assert.True(t, !measurement.Period.Start.Before(before.Add(-time.Second)))
+	assert.True(t, !measurement.Period.Start.After(after.Add(time.Second)))
+}
+
+// TestAuditEventTransformer_Transform_EventTypes verifies INSERT, UPDATE, DELETE all produce measurements.
+func TestAuditEventTransformer_Transform_EventTypes(t *testing.T) {
+	transformer := newEventRouterTransformer()
+	tenantID := "00000000-0000-0000-0000-000000000000"
+
+	tests := []struct {
+		name      string
+		operation auditv1.AuditOperation
+		wantOp    string
+	}{
+		{"insert", auditv1.AuditOperation_AUDIT_OPERATION_INSERT, "INSERT"},
+		{"update", auditv1.AuditOperation_AUDIT_OPERATION_UPDATE, "UPDATE"},
+		{"delete", auditv1.AuditOperation_AUDIT_OPERATION_DELETE, "DELETE"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := newAuditEventWithTenant("current_account", tenantID, tt.operation)
+
+			measurement, err := transformer.Transform(event)
+
+			require.NoError(t, err)
+			require.NotNil(t, measurement)
+			assert.Equal(t, tt.wantOp, measurement.Attributes["operation"])
+		})
+	}
+}
+
+// TestAuditEventTransformer_Transform_MultipleServices verifies different schema names
+// produce correctly labelled measurements.
+func TestAuditEventTransformer_Transform_MultipleServices(t *testing.T) {
+	transformer := newEventRouterTransformer()
+	tenantID := "00000000-0000-0000-0000-000000000000"
+
+	services := []struct {
+		schemaName      string
+		wantAssetCode   string
+	}{
+		{"current_account", "MERIDIAN-CURRENT-ACCOUNT-OPS"},
+		{"payment_order", "MERIDIAN-PAYMENT-ORDER-OPS"},
+		{"financial_accounting", "MERIDIAN-FINANCIAL-ACCOUNTING-OPS"},
+	}
+
+	for _, svc := range services {
+		t.Run(svc.schemaName, func(t *testing.T) {
+			event := newAuditEventWithTenant(svc.schemaName, tenantID, auditv1.AuditOperation_AUDIT_OPERATION_INSERT)
+
+			measurement, err := transformer.Transform(event)
+
+			require.NoError(t, err)
+			require.NotNil(t, measurement)
+			assert.Equal(t, svc.wantAssetCode, measurement.AssetCode)
+			assert.Equal(t, svc.schemaName, measurement.Attributes["service"])
+		})
+	}
+}
+
+// TestAuditEventTransformer_Transform_QualityScore verifies quality score is set on measurements.
+func TestAuditEventTransformer_Transform_QualityScore(t *testing.T) {
+	transformer := newEventRouterTransformer()
+	tenantID := "00000000-0000-0000-0000-000000000000"
+
+	event := newAuditEventWithTenant("current_account", tenantID, auditv1.AuditOperation_AUDIT_OPERATION_INSERT)
+
+	measurement, err := transformer.Transform(event)
+
+	require.NoError(t, err)
+	require.NotNil(t, measurement)
+	// Quality score should be set (non-zero for actual measurements)
+	assert.Positive(t, measurement.QualityScore)
+}
+
+// TestAuditEventTransformer_Transform_SecondTenant verifies a second registered tenant
+// also produces measurements.
+func TestAuditEventTransformer_Transform_SecondTenant(t *testing.T) {
+	transformer := newEventRouterTransformer()
+
+	event := newAuditEventWithTenant(
+		"current_account",
+		"11111111-1111-1111-1111-111111111111",
+		auditv1.AuditOperation_AUDIT_OPERATION_INSERT,
+	)
+
+	measurement, err := transformer.Transform(event)
+
+	require.NoError(t, err)
+	require.NotNil(t, measurement)
+	assert.Equal(t, uuid.MustParse("11111111-1111-1111-1111-111111111111"), measurement.AccountID)
+}

--- a/services/event-router/domain/audit_event_transformer_test.go
+++ b/services/event-router/domain/audit_event_transformer_test.go
@@ -141,8 +141,8 @@ func TestAuditEventTransformer_Transform_MultipleServices(t *testing.T) {
 	tenantID := "00000000-0000-0000-0000-000000000000"
 
 	services := []struct {
-		schemaName      string
-		wantAssetCode   string
+		schemaName    string
+		wantAssetCode string
 	}{
 		{"current_account", "MERIDIAN-CURRENT-ACCOUNT-OPS"},
 		{"payment_order", "MERIDIAN-PAYMENT-ORDER-OPS"},

--- a/services/event-router/domain/audit_event_transformer_test.go
+++ b/services/event-router/domain/audit_event_transformer_test.go
@@ -135,7 +135,7 @@ func TestAuditEventTransformer_Transform_EventTypes(t *testing.T) {
 }
 
 // TestAuditEventTransformer_Transform_MultipleServices verifies different schema names
-// produce correctly labelled measurements.
+// produce correctly labeled measurements.
 func TestAuditEventTransformer_Transform_MultipleServices(t *testing.T) {
 	transformer := newEventRouterTransformer()
 	tenantID := "00000000-0000-0000-0000-000000000000"

--- a/services/event-router/domain/handler_test.go
+++ b/services/event-router/domain/handler_test.go
@@ -1,0 +1,101 @@
+package domain_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/event-router/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// fakeEventHandler is a test double implementing domain.EventHandler.
+type fakeEventHandler struct {
+	calls []handleCall
+	err   error
+}
+
+type handleCall struct {
+	Channel  string
+	Metadata map[string]string
+}
+
+func (f *fakeEventHandler) Handle(_ context.Context, channel string, _ proto.Message, metadata map[string]string) error {
+	f.calls = append(f.calls, handleCall{Channel: channel, Metadata: metadata})
+	return f.err
+}
+
+// Verify fakeEventHandler satisfies the domain.EventHandler interface at compile time.
+var _ domain.EventHandler = (*fakeEventHandler)(nil)
+
+// TestEventHandler_InterfaceCompliance verifies that any struct implementing Handle satisfies EventHandler.
+func TestEventHandler_InterfaceCompliance(t *testing.T) {
+	var h domain.EventHandler = &fakeEventHandler{}
+	assert.NotNil(t, h)
+}
+
+// TestEventHandler_Handle_RoutesChannelAndMetadata verifies channel and metadata are passed through.
+func TestEventHandler_Handle_RoutesChannelAndMetadata(t *testing.T) {
+	handler := &fakeEventHandler{}
+
+	event, err := structpb.NewStruct(map[string]any{"key": "value"})
+	require.NoError(t, err)
+
+	metadata := map[string]string{"x-correlation-id": "corr-123", "tenant_id": "t-1"}
+	callErr := handler.Handle(context.Background(), "accounts.created", event, metadata)
+
+	require.NoError(t, callErr)
+	require.Len(t, handler.calls, 1)
+	assert.Equal(t, "accounts.created", handler.calls[0].Channel)
+	assert.Equal(t, "corr-123", handler.calls[0].Metadata["x-correlation-id"])
+}
+
+// TestEventHandler_Handle_ErrorPropagation verifies errors returned by Handle are propagated.
+func TestEventHandler_Handle_ErrorPropagation(t *testing.T) {
+	expectedErr := errors.New("handler failed")
+	handler := &fakeEventHandler{err: expectedErr}
+
+	event, err := structpb.NewStruct(map[string]any{})
+	require.NoError(t, err)
+
+	callErr := handler.Handle(context.Background(), "test.channel", event, nil)
+
+	require.Error(t, callErr)
+	assert.ErrorIs(t, callErr, expectedErr)
+}
+
+// TestEventHandler_Handle_MultipleChannels verifies handler can be called for different channels.
+func TestEventHandler_Handle_MultipleChannels(t *testing.T) {
+	handler := &fakeEventHandler{}
+	channels := []string{"accounts.created", "payments.processed", "positions.updated"}
+
+	event, err := structpb.NewStruct(map[string]any{"id": "1"})
+	require.NoError(t, err)
+
+	for _, ch := range channels {
+		callErr := handler.Handle(context.Background(), ch, event, nil)
+		require.NoError(t, callErr)
+	}
+
+	require.Len(t, handler.calls, 3)
+	for i, ch := range channels {
+		assert.Equal(t, ch, handler.calls[i].Channel)
+	}
+}
+
+// TestEventHandler_Handle_NilMetadata verifies handler accepts nil metadata gracefully.
+func TestEventHandler_Handle_NilMetadata(t *testing.T) {
+	handler := &fakeEventHandler{}
+
+	event, err := structpb.NewStruct(map[string]any{})
+	require.NoError(t, err)
+
+	callErr := handler.Handle(context.Background(), "test.channel", event, nil)
+
+	require.NoError(t, callErr)
+	require.Len(t, handler.calls, 1)
+	assert.Nil(t, handler.calls[0].Metadata)
+}

--- a/services/event-router/domain/saga_trigger_test.go
+++ b/services/event-router/domain/saga_trigger_test.go
@@ -1,0 +1,141 @@
+package domain_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/event-router/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSagaTrigger is a test double implementing domain.SagaTrigger.
+type fakeSagaTrigger struct {
+	calls    []sagaTriggerCall
+	err      error
+	returnID string
+}
+
+type sagaTriggerCall struct {
+	SagaName       string
+	InputData      map[string]any
+	IdempotencyKey string
+}
+
+func (f *fakeSagaTrigger) TriggerSaga(_ context.Context, sagaName string, inputData map[string]any, idempotencyKey string) (string, error) {
+	f.calls = append(f.calls, sagaTriggerCall{
+		SagaName:       sagaName,
+		InputData:      inputData,
+		IdempotencyKey: idempotencyKey,
+	})
+	if f.err != nil {
+		return "", f.err
+	}
+	id := f.returnID
+	if id == "" {
+		id = "saga-instance-" + sagaName
+	}
+	return id, nil
+}
+
+func (f *fakeSagaTrigger) Close() error { return nil }
+
+// Verify fakeSagaTrigger satisfies domain.SagaTrigger at compile time.
+var _ domain.SagaTrigger = (*fakeSagaTrigger)(nil)
+
+// TestSagaTrigger_InterfaceCompliance verifies any struct implementing TriggerSaga satisfies SagaTrigger.
+func TestSagaTrigger_InterfaceCompliance(t *testing.T) {
+	var t1 domain.SagaTrigger = &fakeSagaTrigger{}
+	assert.NotNil(t, t1)
+}
+
+// TestSagaTrigger_TriggerSaga_PassesSagaName verifies saga name is passed through to trigger.
+func TestSagaTrigger_TriggerSaga_PassesSagaName(t *testing.T) {
+	trigger := &fakeSagaTrigger{}
+
+	id, err := trigger.TriggerSaga(context.Background(), "process_payment", map[string]any{"amount": 100}, "key-1")
+
+	require.NoError(t, err)
+	assert.Equal(t, "saga-instance-process_payment", id)
+	require.Len(t, trigger.calls, 1)
+	assert.Equal(t, "process_payment", trigger.calls[0].SagaName)
+}
+
+// TestSagaTrigger_TriggerSaga_PassesInputData verifies input data is forwarded to the saga.
+func TestSagaTrigger_TriggerSaga_PassesInputData(t *testing.T) {
+	trigger := &fakeSagaTrigger{}
+
+	inputData := map[string]any{
+		"account_id": "acc-123",
+		"amount":     "100.00",
+		"currency":   "GBP",
+	}
+
+	_, err := trigger.TriggerSaga(context.Background(), "transfer_funds", inputData, "key-2")
+
+	require.NoError(t, err)
+	require.Len(t, trigger.calls, 1)
+	assert.Equal(t, inputData, trigger.calls[0].InputData)
+}
+
+// TestSagaTrigger_TriggerSaga_IdempotencyKey verifies idempotency key is forwarded.
+func TestSagaTrigger_TriggerSaga_IdempotencyKey(t *testing.T) {
+	trigger := &fakeSagaTrigger{}
+
+	idempotencyKey := "correlation-uuid-abc123"
+	_, err := trigger.TriggerSaga(context.Background(), "create_account", map[string]any{}, idempotencyKey)
+
+	require.NoError(t, err)
+	require.Len(t, trigger.calls, 1)
+	assert.Equal(t, idempotencyKey, trigger.calls[0].IdempotencyKey)
+}
+
+// TestSagaTrigger_TriggerSaga_ErrorPropagation verifies trigger errors are propagated to the caller.
+func TestSagaTrigger_TriggerSaga_ErrorPropagation(t *testing.T) {
+	expectedErr := errors.New("control plane unavailable")
+	trigger := &fakeSagaTrigger{err: expectedErr}
+
+	_, err := trigger.TriggerSaga(context.Background(), "test_saga", map[string]any{}, "key-3")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, expectedErr)
+}
+
+// TestSagaTrigger_TriggerSaga_DuplicatePrevention verifies the same idempotency key
+// is passed each time to allow the underlying implementation to deduplicate.
+func TestSagaTrigger_TriggerSaga_DuplicatePrevention(t *testing.T) {
+	trigger := &fakeSagaTrigger{returnID: "existing-saga-id"}
+
+	// Simulates a Kafka redelivery — same idempotency key sent twice
+	idempotencyKey := "unique-event-id"
+	_, err1 := trigger.TriggerSaga(context.Background(), "process_order", map[string]any{}, idempotencyKey)
+	_, err2 := trigger.TriggerSaga(context.Background(), "process_order", map[string]any{}, idempotencyKey)
+
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+	// Both calls passed the same idempotency key — the implementation decides deduplication
+	assert.Equal(t, idempotencyKey, trigger.calls[0].IdempotencyKey)
+	assert.Equal(t, idempotencyKey, trigger.calls[1].IdempotencyKey)
+}
+
+// TestSagaTrigger_Close verifies Close releases resources without error.
+func TestSagaTrigger_Close(t *testing.T) {
+	trigger := &fakeSagaTrigger{}
+	err := trigger.Close()
+	assert.NoError(t, err)
+}
+
+// TestSagaTrigger_ContextExtraction verifies context is passed to the trigger.
+func TestSagaTrigger_ContextExtraction(t *testing.T) {
+	trigger := &fakeSagaTrigger{}
+
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "test-value")
+
+	_, err := trigger.TriggerSaga(ctx, "context_saga", map[string]any{"key": "val"}, "key-ctx")
+
+	require.NoError(t, err)
+	require.Len(t, trigger.calls, 1)
+	assert.Equal(t, "context_saga", trigger.calls[0].SagaName)
+}

--- a/services/event-router/domain/utilization_publisher_test.go
+++ b/services/event-router/domain/utilization_publisher_test.go
@@ -13,10 +13,10 @@ import (
 
 // fakeUtilizationPublisher is a test double implementing domain.UtilizationPublisher.
 type fakeUtilizationPublisher struct {
-	mu           sync.Mutex
-	published    []*domain.UtilizationMeasurement
-	stopped      bool
-	publishFunc  func(*domain.UtilizationMeasurement)
+	mu          sync.Mutex
+	published   []*domain.UtilizationMeasurement
+	stopped     bool
+	publishFunc func(*domain.UtilizationMeasurement)
 }
 
 func newFakeUtilizationPublisher() *fakeUtilizationPublisher {

--- a/services/event-router/domain/utilization_publisher_test.go
+++ b/services/event-router/domain/utilization_publisher_test.go
@@ -1,0 +1,197 @@
+package domain_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/services/event-router/domain"
+	"github.com/meridianhub/meridian/shared/platform/quantity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeUtilizationPublisher is a test double implementing domain.UtilizationPublisher.
+type fakeUtilizationPublisher struct {
+	mu           sync.Mutex
+	published    []*domain.UtilizationMeasurement
+	stopped      bool
+	publishFunc  func(*domain.UtilizationMeasurement)
+}
+
+func newFakeUtilizationPublisher() *fakeUtilizationPublisher {
+	return &fakeUtilizationPublisher{
+		published: make([]*domain.UtilizationMeasurement, 0),
+	}
+}
+
+func (f *fakeUtilizationPublisher) Publish(m *domain.UtilizationMeasurement) {
+	f.mu.Lock()
+	f.published = append(f.published, m)
+	f.mu.Unlock()
+	if f.publishFunc != nil {
+		f.publishFunc(m)
+	}
+}
+
+func (f *fakeUtilizationPublisher) Stop() {
+	f.mu.Lock()
+	f.stopped = true
+	f.mu.Unlock()
+}
+
+func (f *fakeUtilizationPublisher) getPublished() []*domain.UtilizationMeasurement {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	result := make([]*domain.UtilizationMeasurement, len(f.published))
+	copy(result, f.published)
+	return result
+}
+
+func (f *fakeUtilizationPublisher) isStopped() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.stopped
+}
+
+// Verify fakeUtilizationPublisher satisfies domain.UtilizationPublisher at compile time.
+var _ domain.UtilizationPublisher = (*fakeUtilizationPublisher)(nil)
+
+// TestUtilizationPublisher_InterfaceCompliance verifies the interface is satisfied.
+func TestUtilizationPublisher_InterfaceCompliance(t *testing.T) {
+	var p domain.UtilizationPublisher = newFakeUtilizationPublisher()
+	assert.NotNil(t, p)
+}
+
+// TestUtilizationPublisher_Publish_MessageFormatting verifies measurement fields are preserved.
+func TestUtilizationPublisher_Publish_MessageFormatting(t *testing.T) {
+	publisher := newFakeUtilizationPublisher()
+	now := time.Now()
+
+	m := &domain.UtilizationMeasurement{
+		TenantID:      "tenant-abc",
+		ServiceName:   "current-account",
+		OperationType: "CreateAccount",
+		Amount:        quantity.NewAssetFromInt(1, domain.InstrumentTransaction),
+		Timestamp:     now,
+		CorrelationID: "corr-xyz",
+	}
+
+	publisher.Publish(m)
+
+	published := publisher.getPublished()
+	require.Len(t, published, 1)
+	assert.Equal(t, "tenant-abc", published[0].TenantID)
+	assert.Equal(t, "current-account", published[0].ServiceName)
+	assert.Equal(t, "CreateAccount", published[0].OperationType)
+	assert.Equal(t, "TRANSACTION", published[0].Amount.GetInstrument().Code)
+	assert.Equal(t, now, published[0].Timestamp)
+	assert.Equal(t, "corr-xyz", published[0].CorrelationID)
+}
+
+// TestUtilizationPublisher_Publish_TopicRouting verifies different services are routed via ServiceName.
+func TestUtilizationPublisher_Publish_TopicRouting(t *testing.T) {
+	publisher := newFakeUtilizationPublisher()
+
+	services := []string{"current-account", "payment-order", "financial-accounting", "position-keeping"}
+	for _, svc := range services {
+		publisher.Publish(&domain.UtilizationMeasurement{
+			TenantID:    "tenant-1",
+			ServiceName: svc,
+			Amount:      quantity.NewAssetFromInt(1, domain.InstrumentOperation),
+			Timestamp:   time.Now(),
+		})
+	}
+
+	published := publisher.getPublished()
+	require.Len(t, published, len(services))
+	for i, svc := range services {
+		assert.Equal(t, svc, published[i].ServiceName)
+	}
+}
+
+// TestUtilizationPublisher_Publish_ErrorHandling verifies that a panicking publishFunc
+// is isolated by the caller (no crash propagation expectation at this layer).
+func TestUtilizationPublisher_Publish_ErrorHandling(t *testing.T) {
+	// The publisher interface has no return value, so errors are handled
+	// by the implementation. Verify the interface accepts calls without panicking.
+	publisher := newFakeUtilizationPublisher()
+
+	m := &domain.UtilizationMeasurement{
+		TenantID:  "tenant-1",
+		Amount:    quantity.NewAssetFromInt(1, domain.InstrumentOperation),
+		Timestamp: time.Now(),
+	}
+
+	// Should not panic
+	assert.NotPanics(t, func() {
+		publisher.Publish(m)
+	})
+
+	assert.Len(t, publisher.getPublished(), 1)
+}
+
+// TestUtilizationPublisher_Stop_GracefulShutdown verifies Stop is called and sets stopped state.
+func TestUtilizationPublisher_Stop_GracefulShutdown(t *testing.T) {
+	publisher := newFakeUtilizationPublisher()
+	assert.False(t, publisher.isStopped())
+
+	publisher.Stop()
+
+	assert.True(t, publisher.isStopped())
+}
+
+// TestUtilizationPublisher_Publish_MultipleInstruments verifies all instrument types can be published.
+func TestUtilizationPublisher_Publish_MultipleInstruments(t *testing.T) {
+	publisher := newFakeUtilizationPublisher()
+
+	instruments := []struct {
+		name       string
+		instrument quantity.Instrument
+	}{
+		{"transaction", domain.InstrumentTransaction},
+		{"api_call", domain.InstrumentAPICall},
+		{"operation", domain.InstrumentOperation},
+		{"storage_gb_hour", domain.InstrumentStorageGBHour},
+		{"compute_hour", domain.InstrumentComputeHour},
+	}
+
+	for _, inst := range instruments {
+		publisher.Publish(&domain.UtilizationMeasurement{
+			TenantID:    "tenant-1",
+			ServiceName: "test-service",
+			Amount:      quantity.NewAssetFromInt(1, inst.instrument),
+			Timestamp:   time.Now(),
+		})
+	}
+
+	published := publisher.getPublished()
+	require.Len(t, published, len(instruments))
+	for i, inst := range instruments {
+		assert.Equal(t, inst.instrument.Code, published[i].Amount.GetInstrument().Code,
+			"wrong instrument for %s", inst.name)
+	}
+}
+
+// TestUtilizationPublisher_ConcurrentPublish verifies thread-safe publishing.
+func TestUtilizationPublisher_ConcurrentPublish(t *testing.T) {
+	publisher := newFakeUtilizationPublisher()
+
+	const numPublishers = 10
+	var wg sync.WaitGroup
+	for i := 0; i < numPublishers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			publisher.Publish(&domain.UtilizationMeasurement{
+				TenantID:    "tenant-concurrent",
+				ServiceName: "test-service",
+				Amount:      quantity.NewAssetFromInt(1, domain.InstrumentOperation),
+				Timestamp:   time.Now(),
+			})
+		}()
+	}
+	wg.Wait()
+
+	assert.Len(t, publisher.getPublished(), numPublishers)
+}


### PR DESCRIPTION
## Summary

- Adds unit tests for event router domain layer covering interfaces and transformer integration
- Adds direct `PlatformMeteringHandler` unit tests that run without Kafka dependency
- Tests cover audit event transformation, EventHandler routing, SagaTrigger idempotency, UtilizationPublisher publishing, and metering handler dual-output fan-out

## Changes Made

| File | Coverage Added |
|------|---------------|
| `domain/audit_event_transformer_test.go` | Transformer: known/unknown tenants, metadata, timestamps, INSERT/UPDATE/DELETE, multiple services |
| `domain/handler_test.go` | EventHandler: channel routing, metadata passing, error propagation, multiple channels |
| `domain/saga_trigger_test.go` | SagaTrigger: saga name, input data, idempotency key, error propagation, duplicate prevention |
| `domain/utilization_publisher_test.go` | UtilizationPublisher: message formatting, topic routing, all instrument types, concurrent publish |
| `adapters/messaging/platform_metering_handler_test.go` | Handler: success path, PK errors, dual-output fan-out, MDS panic recovery, sequential events |

## Test plan

- [ ] `go test ./services/event-router/...` passes locally (all packages green)
- [ ] New tests run without Kafka dependency (direct handler construction)
- [ ] CI passes