### PR TITLE
fix: resolve contextcheck lint errors and flaky lease renewer test

### DIFF
--- a/cmd/meridian/connections.go
+++ b/cmd/meridian/connections.go
@@ -221,20 +221,20 @@ func newLoopbackClients(ctx context.Context, grpcPort int, svcCreds *platformaut
 		return nil, fmt.Errorf("mds loopback: %w", err)
 	}
 
-	pk, pkClose, err := pkclient.New(pkclient.Config{Target: target, DialOptions: opts})
+	pk, pkClose, err := pkclient.New(ctx, pkclient.Config{Target: target, DialOptions: opts})
 	if err != nil {
 		_ = mdsClose()
 		return nil, fmt.Errorf("pk loopback: %w", err)
 	}
 
-	fa, faClose, err := faclient.New(faclient.Config{Target: target, DialOptions: opts})
+	fa, faClose, err := faclient.New(ctx, faclient.Config{Target: target, DialOptions: opts})
 	if err != nil {
 		_ = mdsClose()
 		pkClose()
 		return nil, fmt.Errorf("fa loopback: %w", err)
 	}
 
-	party, partyClose, err := partyclient.New(partyclient.Config{Target: target, DialOptions: opts})
+	party, partyClose, err := partyclient.New(ctx, partyclient.Config{Target: target, DialOptions: opts})
 	if err != nil {
 		_ = mdsClose()
 		pkClose()

--- a/services/financial-accounting/client/client.go
+++ b/services/financial-accounting/client/client.go
@@ -117,7 +117,7 @@ type Client struct {
 //	    return err
 //	}
 //	defer cleanup()
-func New(cfg Config) (*Client, func(), error) {
+func New(ctx context.Context, cfg Config) (*Client, func(), error) {
 	// Apply defaults
 	if cfg.Timeout == 0 {
 		cfg.Timeout = DefaultTimeout
@@ -147,7 +147,7 @@ func New(cfg Config) (*Client, func(), error) {
 		}
 
 		// Use platform factory for DNS-based load balancing
-		conn, err = platformgrpc.NewClient(context.Background(), platformgrpc.ClientConfig{
+		conn, err = platformgrpc.NewClient(ctx, platformgrpc.ClientConfig{
 			ServiceName: cfg.ServiceName,
 			Namespace:   cfg.Namespace,
 			Port:        cfg.Port,

--- a/services/financial-accounting/client/client_methods_test.go
+++ b/services/financial-accounting/client/client_methods_test.go
@@ -182,7 +182,7 @@ func (m *retrieveFinancialBookingLogMock) RetrieveFinancialBookingLog(ctx contex
 }
 
 func TestConn_ReturnsConnection(t *testing.T) {
-	c, cleanup, err := New(Config{Target: "localhost:50052"})
+	c, cleanup, err := New(context.Background(), Config{Target: "localhost:50052"})
 	require.NoError(t, err)
 	defer cleanup()
 

--- a/services/financial-accounting/client/client_test.go
+++ b/services/financial-accounting/client/client_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -10,7 +11,7 @@ import (
 )
 
 func TestNew_WithTarget(t *testing.T) {
-	client, cleanup, err := New(Config{
+	client, cleanup, err := New(context.Background(), Config{
 		Target:  "localhost:50052",
 		Timeout: 10 * time.Second,
 	})
@@ -26,7 +27,7 @@ func TestNew_WithTarget(t *testing.T) {
 }
 
 func TestNew_WithServiceName(t *testing.T) {
-	client, cleanup, err := New(Config{
+	client, cleanup, err := New(context.Background(), Config{
 		ServiceName: "financial-accounting",
 		Namespace:   "default",
 		Port:        50052,
@@ -43,7 +44,7 @@ func TestNew_WithServiceName(t *testing.T) {
 }
 
 func TestNew_Defaults(t *testing.T) {
-	client, cleanup, err := New(Config{
+	client, cleanup, err := New(context.Background(), Config{
 		Target: "localhost:50052",
 	})
 	require.NoError(t, err)
@@ -54,7 +55,7 @@ func TestNew_Defaults(t *testing.T) {
 }
 
 func TestNew_RequiresTargetOrServiceName(t *testing.T) {
-	_, _, err := New(Config{})
+	_, _, err := New(context.Background(), Config{})
 	assert.ErrorIs(t, err, ErrTargetRequired)
 }
 
@@ -75,7 +76,7 @@ func TestNew_DefaultsApplied(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, cleanup, err := New(tt.cfg)
+			client, cleanup, err := New(context.Background(), tt.cfg)
 			require.NoError(t, err)
 			defer cleanup()
 			require.NotNil(t, client)
@@ -84,7 +85,7 @@ func TestNew_DefaultsApplied(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
-	client, cleanup, err := New(Config{
+	client, cleanup, err := New(context.Background(), Config{
 		Target: "localhost:50052",
 	})
 	require.NoError(t, err)
@@ -109,7 +110,7 @@ func TestConstants(t *testing.T) {
 
 func TestNew_WithResilience(t *testing.T) {
 	resilienceConfig := clients.DefaultResilientClientConfig("financial-accounting-client")
-	client, cleanup, err := New(Config{
+	client, cleanup, err := New(context.Background(), Config{
 		Target:     "localhost:50052",
 		Resilience: &resilienceConfig,
 	})
@@ -122,7 +123,7 @@ func TestNew_WithResilience(t *testing.T) {
 }
 
 func TestNew_WithoutResilience(t *testing.T) {
-	client, cleanup, err := New(Config{
+	client, cleanup, err := New(context.Background(), Config{
 		Target: "localhost:50052",
 	})
 	require.NoError(t, err)

--- a/services/party/client/client.go
+++ b/services/party/client/client.go
@@ -117,7 +117,7 @@ type Client struct {
 //	    return err
 //	}
 //	defer cleanup()
-func New(cfg Config) (*Client, func(), error) {
+func New(ctx context.Context, cfg Config) (*Client, func(), error) {
 	// Apply defaults
 	if cfg.Timeout == 0 {
 		cfg.Timeout = DefaultTimeout
@@ -147,7 +147,7 @@ func New(cfg Config) (*Client, func(), error) {
 		}
 
 		// Use platform factory for DNS-based load balancing
-		conn, err = platformgrpc.NewClient(context.Background(), platformgrpc.ClientConfig{
+		conn, err = platformgrpc.NewClient(ctx, platformgrpc.ClientConfig{
 			ServiceName: cfg.ServiceName,
 			Namespace:   cfg.Namespace,
 			Port:        cfg.Port,

--- a/services/party/client/client_test.go
+++ b/services/party/client/client_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestNew_WithTarget(t *testing.T) {
-	client, cleanup, err := New(Config{
+	client, cleanup, err := New(context.Background(), Config{
 		Target:  "localhost:50055",
 		Timeout: 10 * time.Second,
 	})
@@ -35,7 +35,7 @@ func TestNew_WithTarget(t *testing.T) {
 }
 
 func TestNew_WithServiceName(t *testing.T) {
-	client, cleanup, err := New(Config{
+	client, cleanup, err := New(context.Background(), Config{
 		ServiceName: "party",
 		Namespace:   "default",
 		Port:        50055,
@@ -52,7 +52,7 @@ func TestNew_WithServiceName(t *testing.T) {
 }
 
 func TestNew_Defaults(t *testing.T) {
-	client, cleanup, err := New(Config{
+	client, cleanup, err := New(context.Background(), Config{
 		Target: "localhost:50055",
 	})
 	require.NoError(t, err)
@@ -64,7 +64,7 @@ func TestNew_Defaults(t *testing.T) {
 }
 
 func TestNew_RequiresTargetOrServiceName(t *testing.T) {
-	_, _, err := New(Config{})
+	_, _, err := New(context.Background(), Config{})
 	assert.ErrorIs(t, err, ErrTargetRequired)
 }
 
@@ -88,7 +88,7 @@ func TestNew_DefaultsApplied(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, cleanup, err := New(tt.cfg)
+			client, cleanup, err := New(context.Background(), tt.cfg)
 			require.NoError(t, err)
 			defer cleanup()
 			require.NotNil(t, client)
@@ -97,7 +97,7 @@ func TestNew_DefaultsApplied(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
-	client, cleanup, err := New(Config{
+	client, cleanup, err := New(context.Background(), Config{
 		Target: "localhost:50055",
 	})
 	require.NoError(t, err)
@@ -123,7 +123,7 @@ func TestConstants(t *testing.T) {
 
 func TestNew_WithResilience(t *testing.T) {
 	resilienceConfig := clients.DefaultResilientClientConfig("party-client")
-	client, cleanup, err := New(Config{
+	client, cleanup, err := New(context.Background(), Config{
 		Target:     "localhost:50055",
 		Resilience: &resilienceConfig,
 	})
@@ -136,7 +136,7 @@ func TestNew_WithResilience(t *testing.T) {
 }
 
 func TestNew_WithoutResilience(t *testing.T) {
-	client, cleanup, err := New(Config{
+	client, cleanup, err := New(context.Background(), Config{
 		Target: "localhost:50055",
 	})
 	require.NoError(t, err)

--- a/services/payment-order/cmd/clients.go
+++ b/services/payment-order/cmd/clients.go
@@ -78,7 +78,7 @@ func createCurrentAccountClient(namespace string, logger *slog.Logger, tracer *o
 // createFinancialAccountingClient creates the FinancialAccounting gRPC client with resilience patterns.
 // Uses the service-owned client package from services/financial-accounting/client for standardized
 // client creation with built-in tracing and resilience patterns.
-func createFinancialAccountingClient(namespace string, logger *slog.Logger, tracer *observability.Tracer) (service.FinancialAccountingClient, func(), error) {
+func createFinancialAccountingClient(ctx context.Context, namespace string, logger *slog.Logger, tracer *observability.Tracer) (service.FinancialAccountingClient, func(), error) {
 	logger.Info("connecting to financial-accounting service",
 		"service", financialaccountingclient.ServiceName,
 		"namespace", namespace,
@@ -110,7 +110,7 @@ func createFinancialAccountingClient(namespace string, logger *slog.Logger, trac
 	)
 
 	// Use the service-owned client package with DNS-based load balancing
-	client, cleanup, err := financialaccountingclient.New(financialaccountingclient.Config{
+	client, cleanup, err := financialaccountingclient.New(ctx, financialaccountingclient.Config{
 		ServiceName: financialaccountingclient.ServiceName,
 		Namespace:   namespace,
 		Port:        ports.FinancialAccounting,

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -132,7 +132,7 @@ func run(logger *slog.Logger) error {
 	}
 	defer caCleanup()
 
-	financialAccountingClient, faCleanup, err := createFinancialAccountingClient(namespace, logger, tracer)
+	financialAccountingClient, faCleanup, err := createFinancialAccountingClient(ctx, namespace, logger, tracer)
 	if err != nil {
 		return fmt.Errorf("failed to create financial accounting client: %w", err)
 	}
@@ -244,7 +244,7 @@ func run(logger *slog.Logger) error {
 	// Create position-keeping client for Starlark handlers.
 	// Note: payment-order needs position-keeping for payment execution sagas.
 	// This is optional during migration - service can start without it until Starlark is active.
-	posKeepingClient, posKeepingCleanup, err := positionkeepingclient.New(positionkeepingclient.Config{
+	posKeepingClient, posKeepingCleanup, err := positionkeepingclient.New(ctx, positionkeepingclient.Config{
 		ServiceName: positionkeepingclient.ServiceName,
 		Namespace:   namespace,
 		Port:        ports.PositionKeeping,
@@ -293,7 +293,7 @@ func run(logger *slog.Logger) error {
 	}
 
 	// Create Party client for Starlark handlers (party.get_default_payment_method).
-	partyClient, partyCleanup, err := partyclient.New(partyclient.Config{
+	partyClient, partyCleanup, err := partyclient.New(ctx, partyclient.Config{
 		ServiceName: partyclient.ServiceName,
 		Namespace:   namespace,
 		Port:        ports.Party,

--- a/services/position-keeping/client/client.go
+++ b/services/position-keeping/client/client.go
@@ -118,7 +118,7 @@ type Client struct {
 //	    return err
 //	}
 //	defer cleanup()
-func New(cfg Config) (*Client, func(), error) {
+func New(ctx context.Context, cfg Config) (*Client, func(), error) {
 	// Apply defaults
 	if cfg.Timeout == 0 {
 		cfg.Timeout = DefaultTimeout
@@ -148,7 +148,7 @@ func New(cfg Config) (*Client, func(), error) {
 		}
 
 		// Use platform factory for DNS-based load balancing
-		conn, err = platformgrpc.NewClient(context.Background(), platformgrpc.ClientConfig{
+		conn, err = platformgrpc.NewClient(ctx, platformgrpc.ClientConfig{
 			ServiceName: cfg.ServiceName,
 			Namespace:   cfg.Namespace,
 			Port:        cfg.Port,

--- a/services/position-keeping/client/client_test.go
+++ b/services/position-keeping/client/client_test.go
@@ -105,7 +105,7 @@ func TestGetAccountBalance_Success(t *testing.T) {
 	cfg, cleanup := setupTestServer(t, mock)
 	defer cleanup()
 
-	c, clientCleanup, err := client.New(cfg)
+	c, clientCleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer clientCleanup()
 
@@ -133,7 +133,7 @@ func TestGetAccountBalance_NotFound(t *testing.T) {
 	cfg, cleanup := setupTestServer(t, mock)
 	defer cleanup()
 
-	c, clientCleanup, err := client.New(cfg)
+	c, clientCleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer clientCleanup()
 
@@ -163,7 +163,7 @@ func TestGetAccountBalance_ServerError(t *testing.T) {
 	cfg, cleanup := setupTestServer(t, mock)
 	defer cleanup()
 
-	c, clientCleanup, err := client.New(cfg)
+	c, clientCleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer clientCleanup()
 
@@ -210,7 +210,7 @@ func TestGetAccountBalances_Success(t *testing.T) {
 	cfg, cleanup := setupTestServer(t, mock)
 	defer cleanup()
 
-	c, clientCleanup, err := client.New(cfg)
+	c, clientCleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer clientCleanup()
 
@@ -242,7 +242,7 @@ func TestGetAccountBalances_NotFound(t *testing.T) {
 	cfg, cleanup := setupTestServer(t, mock)
 	defer cleanup()
 
-	c, clientCleanup, err := client.New(cfg)
+	c, clientCleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer clientCleanup()
 
@@ -271,7 +271,7 @@ func TestGetAccountBalances_EmptyResponse(t *testing.T) {
 	cfg, cleanup := setupTestServer(t, mock)
 	defer cleanup()
 
-	c, clientCleanup, err := client.New(cfg)
+	c, clientCleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer clientCleanup()
 
@@ -297,7 +297,7 @@ func TestGetAccountBalance_ContextCanceled(t *testing.T) {
 	cfg, cleanup := setupTestServer(t, mock)
 	defer cleanup()
 
-	c, clientCleanup, err := client.New(cfg)
+	c, clientCleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer clientCleanup()
 
@@ -339,7 +339,7 @@ func TestGetAccountBalances_WithInstrumentFilter(t *testing.T) {
 	cfg, cleanup := setupTestServer(t, mock)
 	defer cleanup()
 
-	c, clientCleanup, err := client.New(cfg)
+	c, clientCleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer clientCleanup()
 

--- a/services/position-keeping/client/client_unhappy_test.go
+++ b/services/position-keeping/client/client_unhappy_test.go
@@ -108,7 +108,7 @@ func setupFullTestServer(t *testing.T, mock *fullMockServer) (client.Config, fun
 }
 
 func TestNew_ErrTargetRequired(t *testing.T) {
-	c, cleanup, err := client.New(client.Config{})
+	c, cleanup, err := client.New(context.Background(), client.Config{})
 	assert.ErrorIs(t, err, client.ErrTargetRequired)
 	assert.Nil(t, c)
 	assert.Nil(t, cleanup)
@@ -124,7 +124,7 @@ func TestNew_Defaults(t *testing.T) {
 	cfg.Port = 0       // Should default to 50053
 	cfg.Namespace = "" // Should default to "default"
 
-	c, cleanup, err := client.New(cfg)
+	c, cleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, c)
 	defer cleanup()
@@ -137,7 +137,7 @@ func TestInitiateFinancialPositionLog_Error(t *testing.T) {
 	cfg, serverCleanup := setupFullTestServer(t, mock)
 	defer serverCleanup()
 
-	c, cleanup, err := client.New(cfg)
+	c, cleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer cleanup()
 
@@ -162,7 +162,7 @@ func TestInitiateFinancialPositionLogBatch_Success(t *testing.T) {
 	cfg, serverCleanup := setupFullTestServer(t, mock)
 	defer serverCleanup()
 
-	c, cleanup, err := client.New(cfg)
+	c, cleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer cleanup()
 
@@ -178,7 +178,7 @@ func TestInitiateFinancialPositionLogBatch_Error(t *testing.T) {
 	cfg, serverCleanup := setupFullTestServer(t, mock)
 	defer serverCleanup()
 
-	c, cleanup, err := client.New(cfg)
+	c, cleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer cleanup()
 
@@ -195,7 +195,7 @@ func TestUpdateFinancialPositionLog_Error(t *testing.T) {
 	cfg, serverCleanup := setupFullTestServer(t, mock)
 	defer serverCleanup()
 
-	c, cleanup, err := client.New(cfg)
+	c, cleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer cleanup()
 
@@ -219,7 +219,7 @@ func TestRetrieveFinancialPositionLog_Success(t *testing.T) {
 	cfg, serverCleanup := setupFullTestServer(t, mock)
 	defer serverCleanup()
 
-	c, cleanup, err := client.New(cfg)
+	c, cleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer cleanup()
 
@@ -237,7 +237,7 @@ func TestRetrieveFinancialPositionLog_Error(t *testing.T) {
 	cfg, serverCleanup := setupFullTestServer(t, mock)
 	defer serverCleanup()
 
-	c, cleanup, err := client.New(cfg)
+	c, cleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer cleanup()
 
@@ -256,7 +256,7 @@ func TestBulkImportTransactions_Success(t *testing.T) {
 	cfg, serverCleanup := setupFullTestServer(t, mock)
 	defer serverCleanup()
 
-	c, cleanup, err := client.New(cfg)
+	c, cleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer cleanup()
 
@@ -274,7 +274,7 @@ func TestBulkImportTransactions_Error(t *testing.T) {
 	cfg, serverCleanup := setupFullTestServer(t, mock)
 	defer serverCleanup()
 
-	c, cleanup, err := client.New(cfg)
+	c, cleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer cleanup()
 
@@ -296,7 +296,7 @@ func TestListFinancialPositionLogs_Success(t *testing.T) {
 	cfg, serverCleanup := setupFullTestServer(t, mock)
 	defer serverCleanup()
 
-	c, cleanup, err := client.New(cfg)
+	c, cleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer cleanup()
 
@@ -312,7 +312,7 @@ func TestListFinancialPositionLogs_Error(t *testing.T) {
 	cfg, serverCleanup := setupFullTestServer(t, mock)
 	defer serverCleanup()
 
-	c, cleanup, err := client.New(cfg)
+	c, cleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer cleanup()
 
@@ -329,7 +329,7 @@ func TestReleaseReservation_Success(t *testing.T) {
 	cfg, serverCleanup := setupFullTestServer(t, mock)
 	defer serverCleanup()
 
-	c, cleanup, err := client.New(cfg)
+	c, cleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer cleanup()
 
@@ -347,7 +347,7 @@ func TestReleaseReservation_Error(t *testing.T) {
 	cfg, serverCleanup := setupFullTestServer(t, mock)
 	defer serverCleanup()
 
-	c, cleanup, err := client.New(cfg)
+	c, cleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer cleanup()
 
@@ -364,7 +364,7 @@ func TestClient_Close(t *testing.T) {
 	cfg, serverCleanup := setupFullTestServer(t, mock)
 	defer serverCleanup()
 
-	c, _, err := client.New(cfg)
+	c, _, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 
 	err = c.Close()
@@ -376,7 +376,7 @@ func TestClient_Conn(t *testing.T) {
 	cfg, serverCleanup := setupFullTestServer(t, mock)
 	defer serverCleanup()
 
-	c, cleanup, err := client.New(cfg)
+	c, cleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer cleanup()
 
@@ -396,7 +396,7 @@ func TestInitiateFinancialPositionLog_Success(t *testing.T) {
 	cfg, serverCleanup := setupFullTestServer(t, mock)
 	defer serverCleanup()
 
-	c, cleanup, err := client.New(cfg)
+	c, cleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer cleanup()
 
@@ -419,7 +419,7 @@ func TestUpdateFinancialPositionLog_Success(t *testing.T) {
 	cfg, serverCleanup := setupFullTestServer(t, mock)
 	defer serverCleanup()
 
-	c, cleanup, err := client.New(cfg)
+	c, cleanup, err := client.New(context.Background(), cfg)
 	require.NoError(t, err)
 	defer cleanup()
 

--- a/services/tenant/cmd/main.go
+++ b/services/tenant/cmd/main.go
@@ -171,7 +171,7 @@ func run(logger *slog.Logger) error {
 	namespace := env.GetEnvOrDefault("K8S_NAMESPACE", "default")
 	partyEnabled := env.GetEnvOrDefault("PARTY_SERVICE_ENABLED", envValueTrue) == envValueTrue
 	if partyEnabled {
-		pc, cleanup, err := createPartyClient(namespace, logger, tracer)
+		pc, cleanup, err := createPartyClient(ctx, namespace, logger, tracer)
 		if err != nil {
 			return fmt.Errorf("failed to create party client: %w", err)
 		}
@@ -395,7 +395,7 @@ func getConfigSource(key string) string {
 // Uses the service-owned client package from services/party/client for standardized
 // client creation with built-in tracing and resilience patterns.
 // Returns a PartyClient interface adapter wrapping the underlying party client.
-func createPartyClient(namespace string, logger *slog.Logger, tracer *observability.Tracer) (service.PartyClient, func(), error) {
+func createPartyClient(ctx context.Context, namespace string, logger *slog.Logger, tracer *observability.Tracer) (service.PartyClient, func(), error) {
 	logger.Info("connecting to party service",
 		"service", partyclient.ServiceName,
 		"namespace", namespace,
@@ -427,7 +427,7 @@ func createPartyClient(namespace string, logger *slog.Logger, tracer *observabil
 	)
 
 	// Use the service-owned client package with DNS-based load balancing
-	pc, cleanup, err := partyclient.New(partyclient.Config{
+	pc, cleanup, err := partyclient.New(ctx, partyclient.Config{
 		ServiceName: partyclient.ServiceName,
 		Namespace:   namespace,
 		Port:        ports.Party,

--- a/shared/pkg/saga/lease_renewer_test.go
+++ b/shared/pkg/saga/lease_renewer_test.go
@@ -232,9 +232,10 @@ func TestLeaseRenewer_StopIsIdempotent(t *testing.T) {
 	renewer := NewLeaseRenewer(sagaID, claimService, logger, WithRenewalInterval(50*time.Millisecond))
 
 	ctx := context.Background()
+	// Capture baseline before Start so the goroutine is not yet counted
+	initialGoroutinesIdempotent := runtime.NumGoroutine()
 	renewer.Start(ctx)
 
-	initialGoroutinesIdempotent := runtime.NumGoroutine()
 	awaitIdempotentErr := await.New().
 		AtMost(1 * time.Second).
 		PollInterval(10 * time.Millisecond).


### PR DESCRIPTION
## Summary
- Add `context.Context` parameter to `New()` in position-keeping, financial-accounting, and party gRPC clients to satisfy the `contextcheck` linter - replaces internal `context.Background()` with caller-provided context
- Fix `TestLeaseRenewer_StopIsIdempotent` race condition by capturing goroutine baseline before `Start()` instead of after

## Failing runs
- Code Quality: [#23486253043](https://github.com/meridianhub/meridian/actions/runs/23486253043) - 3 contextcheck errors
- Nightly: [#23483030921](https://github.com/meridianhub/meridian/actions/runs/23483030921) - `TestLeaseRenewer_StopIsIdempotent` failure

## Changes Made
- `services/position-keeping/client/client.go` - Add `ctx` param to `New()`
- `services/financial-accounting/client/client.go` - Add `ctx` param to `New()`
- `services/party/client/client.go` - Add `ctx` param to `New()`
- `cmd/meridian/connections.go` - Pass `ctx` to all three client constructors
- `services/payment-order/cmd/main.go` - Pass `ctx` to pk and party client constructors
- `services/payment-order/cmd/clients.go` - Pass `ctx` to fa client constructor
- `services/tenant/cmd/main.go` - Pass `ctx` to party client constructor
- `shared/pkg/saga/lease_renewer_test.go` - Move goroutine baseline capture before `Start()`

## Test plan
- [ ] CI Code Quality passes (contextcheck clean)
- [ ] CI Build & Test passes
- [ ] Nightly integration tests pass (lease renewer test no longer flaky)