### PR TITLE
test: Add payment order service unit tests

### DIFF
--- a/services/payment-order/adapters/gateway/payment_gateway_test.go
+++ b/services/payment-order/adapters/gateway/payment_gateway_test.go
@@ -1,0 +1,95 @@
+package gateway_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/payment-order/adapters/gateway"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStatus_Constants verifies all gateway status constants are distinct and non-empty.
+func TestStatus_Constants(t *testing.T) {
+	t.Parallel()
+
+	statuses := []gateway.Status{
+		gateway.StatusAccepted,
+		gateway.StatusRejected,
+		gateway.StatusPending,
+	}
+
+	seen := make(map[gateway.Status]bool)
+	for _, s := range statuses {
+		assert.False(t, seen[s], "duplicate status constant: %s", s)
+		seen[s] = true
+		assert.NotEmpty(t, string(s))
+	}
+}
+
+// TestPaymentRequest_Construction verifies that a PaymentRequest can be fully populated.
+func TestPaymentRequest_Construction(t *testing.T) {
+	t.Parallel()
+
+	amount, err := domain.NewMoney("GBP", 10000)
+	require.NoError(t, err)
+
+	req := gateway.PaymentRequest{
+		PaymentOrderID:    uuid.New(),
+		DebtorAccountID:   "acc-123",
+		CreditorReference: "GB82WEST12345698765432",
+		Amount:            amount,
+		IdempotencyKey:    "idem-key-1",
+	}
+
+	assert.NotEqual(t, uuid.UUID{}, req.PaymentOrderID)
+	assert.Equal(t, "acc-123", req.DebtorAccountID)
+	assert.Equal(t, "GB82WEST12345698765432", req.CreditorReference)
+	assert.Equal(t, "idem-key-1", req.IdempotencyKey)
+}
+
+// TestPaymentResponse_Construction verifies PaymentResponse fields.
+func TestPaymentResponse_Construction(t *testing.T) {
+	t.Parallel()
+
+	resp := gateway.PaymentResponse{
+		GatewayReferenceID: "GW-" + uuid.New().String(),
+		Status:             gateway.StatusAccepted,
+		Message:            "payment accepted",
+		PlatformFeeAmount:  250,
+	}
+
+	assert.NotEmpty(t, resp.GatewayReferenceID)
+	assert.Equal(t, gateway.StatusAccepted, resp.Status)
+	assert.Equal(t, "payment accepted", resp.Message)
+	assert.Equal(t, int64(250), resp.PlatformFeeAmount)
+}
+
+// TestPaymentResponse_ZeroFee verifies that a zero platform fee is valid.
+func TestPaymentResponse_ZeroFee(t *testing.T) {
+	t.Parallel()
+
+	resp := gateway.PaymentResponse{
+		GatewayReferenceID: "GW-ref",
+		Status:             gateway.StatusAccepted,
+		PlatformFeeAmount:  0,
+	}
+
+	assert.Equal(t, int64(0), resp.PlatformFeeAmount)
+}
+
+// TestPaymentGateway_Interface verifies that MockGateway satisfies the PaymentGateway interface.
+// This is a compile-time check.
+func TestPaymentGateway_Interface(_ *testing.T) {
+	var _ gateway.PaymentGateway = (*gateway.MockGateway)(nil)
+}
+
+// TestStatus_Accepted_IsNot_Rejected verifies semantic distinctness.
+func TestStatus_Accepted_IsNot_Rejected(t *testing.T) {
+	t.Parallel()
+
+	assert.NotEqual(t, gateway.StatusAccepted, gateway.StatusRejected)
+	assert.NotEqual(t, gateway.StatusAccepted, gateway.StatusPending)
+	assert.NotEqual(t, gateway.StatusRejected, gateway.StatusPending)
+}

--- a/services/payment-order/domain/saga_test.go
+++ b/services/payment-order/domain/saga_test.go
@@ -1,0 +1,149 @@
+package domain_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockSagaExecutionLogger implements domain.SagaExecutionLogger for testing.
+type mockSagaExecutionLogger struct {
+	calls     []*domain.SagaExecution
+	returnErr error
+}
+
+func (m *mockSagaExecutionLogger) PersistExecution(_ context.Context, execution *domain.SagaExecution) error {
+	m.calls = append(m.calls, execution)
+	return m.returnErr
+}
+
+// TestSagaExecutionStatus_Constants verifies all status constants are distinct.
+func TestSagaExecutionStatus_Constants(t *testing.T) {
+	t.Parallel()
+
+	statuses := []domain.SagaExecutionStatus{
+		domain.SagaExecutionStatusRunning,
+		domain.SagaExecutionStatusCompleted,
+		domain.SagaExecutionStatusFailed,
+		domain.SagaExecutionStatusCompensated,
+	}
+
+	seen := make(map[domain.SagaExecutionStatus]bool)
+	for _, s := range statuses {
+		assert.False(t, seen[s], "duplicate status: %s", s)
+		seen[s] = true
+		assert.NotEmpty(t, string(s))
+	}
+}
+
+// TestSagaExecution_ZeroValue verifies the zero value is usable.
+func TestSagaExecution_ZeroValue(t *testing.T) {
+	t.Parallel()
+
+	var exec domain.SagaExecution
+	assert.Equal(t, uuid.UUID{}, exec.ID)
+	assert.Equal(t, uuid.UUID{}, exec.PaymentOrderID)
+	assert.Empty(t, exec.SagaName)
+	assert.Equal(t, 0, exec.SagaVersion)
+	assert.Equal(t, domain.SagaExecutionStatus(""), exec.Status)
+	assert.Nil(t, exec.CompletedAt)
+}
+
+// TestSagaExecution_FullConstruction verifies all fields can be set and retrieved.
+func TestSagaExecution_FullConstruction(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.New()
+	poID := uuid.New()
+	now := time.Now()
+	completedAt := now.Add(5 * time.Second)
+
+	exec := domain.SagaExecution{
+		ID:             id,
+		PaymentOrderID: poID,
+		SagaName:       "payment_execution",
+		SagaVersion:    3,
+		Status:         domain.SagaExecutionStatusCompleted,
+		CorrelationID:  uuid.New().String(),
+		Input:          map[string]any{"amount_cents": int64(1000), "currency": "GBP"},
+		Output:         map[string]any{"lien_id": "lien-123", "gateway_reference_id": "GW-456"},
+		ErrorMessage:   "",
+		StepCount:      4,
+		DurationMs:     250,
+		StartedAt:      now,
+		CompletedAt:    &completedAt,
+	}
+
+	assert.Equal(t, id, exec.ID)
+	assert.Equal(t, poID, exec.PaymentOrderID)
+	assert.Equal(t, "payment_execution", exec.SagaName)
+	assert.Equal(t, 3, exec.SagaVersion)
+	assert.Equal(t, domain.SagaExecutionStatusCompleted, exec.Status)
+	assert.NotEmpty(t, exec.CorrelationID)
+	assert.Equal(t, int64(1000), exec.Input["amount_cents"])
+	assert.Equal(t, "lien-123", exec.Output["lien_id"])
+	assert.Equal(t, 4, exec.StepCount)
+	assert.Equal(t, int64(250), exec.DurationMs)
+	assert.Equal(t, &completedAt, exec.CompletedAt)
+}
+
+// TestSagaExecution_FailedStatusWithError verifies failed execution fields.
+func TestSagaExecution_FailedStatusWithError(t *testing.T) {
+	t.Parallel()
+
+	exec := domain.SagaExecution{
+		ID:           uuid.New(),
+		Status:       domain.SagaExecutionStatusFailed,
+		ErrorMessage: "gateway timeout: context deadline exceeded",
+		StepCount:    2,
+	}
+
+	assert.Equal(t, domain.SagaExecutionStatusFailed, exec.Status)
+	assert.NotEmpty(t, exec.ErrorMessage)
+	assert.Nil(t, exec.CompletedAt)
+}
+
+// TestSagaExecution_CompensatedStatus verifies compensated status is a distinct state.
+func TestSagaExecution_CompensatedStatus(t *testing.T) {
+	t.Parallel()
+
+	exec := domain.SagaExecution{
+		Status: domain.SagaExecutionStatusCompensated,
+	}
+
+	assert.Equal(t, domain.SagaExecutionStatusCompensated, exec.Status)
+	assert.NotEqual(t, domain.SagaExecutionStatusFailed, exec.Status)
+}
+
+// TestSagaExecutionLogger_PersistExecution verifies the mock logger records calls.
+func TestSagaExecutionLogger_PersistExecution(t *testing.T) {
+	t.Parallel()
+
+	logger := &mockSagaExecutionLogger{}
+	exec := &domain.SagaExecution{
+		ID:       uuid.New(),
+		SagaName: "payment_execution",
+		Status:   domain.SagaExecutionStatusRunning,
+	}
+
+	err := logger.PersistExecution(context.Background(), exec)
+	require.NoError(t, err)
+	assert.Len(t, logger.calls, 1)
+	assert.Equal(t, exec.ID, logger.calls[0].ID)
+}
+
+// TestSagaExecutionLogger_ErrorPropagation verifies that logger errors are returned to callers.
+func TestSagaExecutionLogger_ErrorPropagation(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := assert.AnError
+	logger := &mockSagaExecutionLogger{returnErr: expectedErr}
+
+	err := logger.PersistExecution(context.Background(), &domain.SagaExecution{})
+	assert.ErrorIs(t, err, expectedErr)
+}

--- a/services/payment-order/service/payment_orchestrator_test.go
+++ b/services/payment-order/service/payment_orchestrator_test.go
@@ -1,0 +1,104 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewPaymentOrchestrator_NilLogger verifies that a nil logger returns ErrOrchestratorLoggerNil.
+func TestNewPaymentOrchestrator_NilLogger(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+		Logger: nil,
+		Repo:   NewMockRepository(),
+	})
+
+	assert.ErrorIs(t, err, ErrOrchestratorLoggerNil)
+}
+
+// TestNewPaymentOrchestrator_NilRepo verifies that a nil repo returns ErrOrchestratorRepoNil.
+func TestNewPaymentOrchestrator_NilRepo(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+		Logger: testLogger(),
+		Repo:   nil,
+	})
+
+	assert.ErrorIs(t, err, ErrOrchestratorRepoNil)
+}
+
+// TestNewPaymentOrchestrator_MinimalConfig verifies that an orchestrator can be created
+// with only the required logger and repo dependencies.
+func TestNewPaymentOrchestrator_MinimalConfig(t *testing.T) {
+	t.Parallel()
+
+	o, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+		Logger: testLogger(),
+		Repo:   NewMockRepository(),
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, o)
+	assert.NotNil(t, o.logger)
+	assert.NotNil(t, o.repo)
+	assert.NotNil(t, o.starlarkRunner)
+	assert.NotNil(t, o.handlerRegistry)
+	assert.NotNil(t, o.bucketEvaluator)
+}
+
+// TestNewPaymentOrchestrator_FullConfig verifies that an orchestrator is created with all optional deps.
+func TestNewPaymentOrchestrator_FullConfig(t *testing.T) {
+	t.Parallel()
+
+	o, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+		Logger:                    testLogger(),
+		Repo:                      NewMockRepository(),
+		CurrentAccountClient:      &MockCurrentAccountClient{},
+		PaymentGateway:            &MockPaymentGateway{},
+		FinancialAccountingClient: &MockFinancialAccountingClient{},
+		GatewayAccountConfig:      testGatewayAccountConfig(),
+		SagaOrchestrationEnabled:  true,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, o)
+	assert.NotNil(t, o.currentAccountClient)
+	assert.NotNil(t, o.paymentGateway)
+	assert.NotNil(t, o.financialAccountingClient)
+	assert.NotNil(t, o.gatewayAccountConfig)
+	assert.True(t, o.sagaOrchestrationEnabled)
+}
+
+// TestNewPaymentOrchestrator_AutoCreatesAccountResolver verifies that when InternalAccountClient
+// is provided without an AccountResolver, one is created automatically.
+func TestNewPaymentOrchestrator_AutoCreatesAccountResolver(t *testing.T) {
+	t.Parallel()
+
+	o, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+		Logger:                testLogger(),
+		Repo:                  NewMockRepository(),
+		InternalAccountClient: &mockInternalAccountClient{},
+		// AccountResolver intentionally omitted to trigger auto-creation
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, o.accountResolver)
+}
+
+// TestNewPaymentOrchestrator_InternalClearingDisabledByDefault verifies feature flag defaults.
+func TestNewPaymentOrchestrator_InternalClearingDisabledByDefault(t *testing.T) {
+	t.Parallel()
+
+	o, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+		Logger: testLogger(),
+		Repo:   NewMockRepository(),
+	})
+
+	require.NoError(t, err)
+	assert.False(t, o.internalClearingEnabled)
+	assert.False(t, o.sagaOrchestrationEnabled)
+}

--- a/services/payment-order/worker/billing_scheduler_adapters_test.go
+++ b/services/payment-order/worker/billing_scheduler_adapters_test.go
@@ -1,0 +1,142 @@
+package worker
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/scheduler"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// BillingScheduleProvider
+// =============================================================================
+
+// TestBillingScheduleProvider_ListSchedules_ReturnsCorrectFormat verifies the schedule
+// ID format and that cron expression is passed through correctly.
+func TestBillingScheduleProvider_ListSchedules_ReturnsCorrectFormat(t *testing.T) {
+	t.Parallel()
+
+	provider := NewBillingScheduleProvider("tenant-xyz", "0 2 1 * *")
+	schedules, err := provider.ListSchedules(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, schedules, 1)
+
+	s := schedules[0]
+	assert.Equal(t, "billing:tenant-xyz", s.ID)
+	assert.Equal(t, "0 2 1 * *", s.CronExpr)
+	assert.Equal(t, "tenant-xyz", s.TenantID)
+}
+
+// TestBillingScheduleProvider_ListSchedules_AlwaysReturnsSingleSchedule verifies that
+// exactly one schedule is returned regardless of context.
+func TestBillingScheduleProvider_ListSchedules_AlwaysReturnsSingleSchedule(t *testing.T) {
+	t.Parallel()
+
+	provider := NewBillingScheduleProvider("t1", "*/5 * * * *")
+
+	for i := 0; i < 3; i++ {
+		schedules, err := provider.ListSchedules(context.Background())
+		require.NoError(t, err)
+		assert.Len(t, schedules, 1, "should always return exactly one schedule")
+	}
+}
+
+// TestBillingScheduleProvider_ListSchedules_ImplementsInterface verifies compile-time
+// interface satisfaction.
+func TestBillingScheduleProvider_ListSchedules_ImplementsInterface(t *testing.T) {
+	t.Parallel()
+
+	var _ scheduler.ScheduleProvider = NewBillingScheduleProvider("t", "0 * * * *")
+}
+
+// =============================================================================
+// BillingExecutor - constructor and configuration
+// =============================================================================
+
+// TestNewBillingExecutor_DefaultConfig verifies a minimal executor can be created.
+func TestNewBillingExecutor_DefaultConfig(t *testing.T) {
+	t.Parallel()
+
+	repo := newMockBillingRepo()
+	redisClient := setupMiniredis(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	metrics := NewBillingMetricsWithRegistry(prometheus.NewRegistry())
+
+	executor := NewBillingExecutor(repo, redisClient, metrics, BillingExecutorConfig{}, logger)
+
+	assert.NotNil(t, executor)
+	assert.Nil(t, executor.invoiceGenerator, "invoiceGenerator should start nil")
+	assert.Nil(t, executor.paymentInitiator, "paymentInitiator should start nil")
+	assert.False(t, executor.config.ShadowMode)
+}
+
+// TestNewBillingExecutor_ShadowMode verifies shadow mode is stored on executor.
+func TestNewBillingExecutor_ShadowMode(t *testing.T) {
+	t.Parallel()
+
+	repo := newMockBillingRepo()
+	redisClient := setupMiniredis(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	metrics := NewBillingMetricsWithRegistry(prometheus.NewRegistry())
+
+	executor := NewBillingExecutor(repo, redisClient, metrics, BillingExecutorConfig{ShadowMode: true}, logger)
+	assert.True(t, executor.config.ShadowMode)
+}
+
+// =============================================================================
+// BillingExecutor - idempotency via Redis
+// =============================================================================
+
+// TestBillingExecutor_Execute_SkipsIfDuplicateInRedis verifies that a billing run is
+// skipped when the idempotency key already exists in Redis (from a previous execution).
+func TestBillingExecutor_Execute_SkipsIfDuplicateInRedis(t *testing.T) {
+	t.Parallel()
+
+	repo := newMockBillingRepo()
+	redisClient := setupMiniredis(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	metrics := NewBillingMetricsWithRegistry(prometheus.NewRegistry())
+
+	origNow := NowFunc
+	NowFunc = func() time.Time {
+		return time.Date(2026, 7, 1, 2, 0, 0, 0, time.UTC)
+	}
+	defer func() { NowFunc = origNow }()
+
+	executor := NewBillingExecutor(repo, redisClient, metrics, BillingExecutorConfig{}, logger)
+	schedule := scheduler.Schedule{
+		ID:       "billing:tenant-redis-skip",
+		CronExpr: "0 2 1 * *",
+		TenantID: "tenant-redis-skip",
+	}
+
+	// First execution should succeed and mark Redis key
+	err := executor.Execute(context.Background(), schedule)
+	require.NoError(t, err)
+
+	// Second execution should detect the Redis key and skip
+	err = executor.Execute(context.Background(), schedule)
+	require.NoError(t, err)
+
+	// Verify only one billing run was created in the repo
+	assert.Len(t, repo.runs, 1)
+}
+
+// TestBillingExecutor_Execute_ImplementsInterface verifies compile-time interface check.
+func TestBillingExecutor_Execute_ImplementsInterface(t *testing.T) {
+	t.Parallel()
+
+	repo := newMockBillingRepo()
+	redisClient := setupMiniredis(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	metrics := NewBillingMetricsWithRegistry(prometheus.NewRegistry())
+
+	var _ scheduler.Executor = NewBillingExecutor(repo, redisClient, metrics, BillingExecutorConfig{}, logger)
+}

--- a/services/payment-order/worker/billing_scheduler_adapters_test.go
+++ b/services/payment-order/worker/billing_scheduler_adapters_test.go
@@ -96,9 +96,8 @@ func TestNewBillingExecutor_ShadowMode(t *testing.T) {
 
 // TestBillingExecutor_Execute_SkipsIfDuplicateInRedis verifies that a billing run is
 // skipped when the idempotency key already exists in Redis (from a previous execution).
+// Not parallel: mutates the package-level NowFunc global.
 func TestBillingExecutor_Execute_SkipsIfDuplicateInRedis(t *testing.T) {
-	t.Parallel()
-
 	repo := newMockBillingRepo()
 	redisClient := setupMiniredis(t)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))


### PR DESCRIPTION
## Summary

- Adds unit tests for previously uncovered areas of the payment-order service
- Focuses on `NewPaymentOrchestrator` constructor validation, saga domain model, gateway interface, and billing adapter compliance

## Changes Made

| File | What is tested |
|------|----------------|
| `service/payment_orchestrator_test.go` | `NewPaymentOrchestrator` constructor: nil logger, nil repo, minimal config, auto account resolver creation, feature flag defaults |
| `domain/saga_test.go` | `SagaExecution` domain model fields, `SagaExecutionStatus` constants, `SagaExecutionLogger` interface error propagation |
| `adapters/gateway/payment_gateway_test.go` | `PaymentGateway` interface compliance, `Status` constants distinctness, `PaymentRequest`/`PaymentResponse` construction |
| `worker/billing_scheduler_adapters_test.go` | `BillingScheduleProvider` schedule ID format, `BillingExecutor` constructor defaults, Redis idempotency deduplication |

## Test plan

- [x] All new tests pass: `go test ./services/payment-order/...`
- [x] No regressions in existing tests
- [x] Tests are parallel-safe