### PR TITLE
test: add control plane validator and differ unit tests

### DIFF
--- a/services/control-plane/internal/differ/drift_test.go
+++ b/services/control-plane/internal/differ/drift_test.go
@@ -1,0 +1,62 @@
+package differ
+
+import (
+	"context"
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoOpDriftDetector_ReturnsEmpty(t *testing.T) {
+	d := &NoOpDriftDetector{}
+	warnings, err := d.DetectDrift(context.Background(), &controlplanev1.Manifest{})
+	assert.NoError(t, err)
+	assert.Nil(t, warnings)
+}
+
+func TestNoOpDriftDetector_NilManifest(t *testing.T) {
+	d := &NoOpDriftDetector{}
+	warnings, err := d.DetectDrift(context.Background(), nil)
+	assert.NoError(t, err)
+	assert.Nil(t, warnings)
+}
+
+func TestDriftWarning_Fields(t *testing.T) {
+	w := DriftWarning{
+		ResourceType: ResourceInstrument,
+		ResourceCode: "GBP",
+		Description:  "Instrument GBP was modified outside of manifest apply",
+	}
+	assert.Equal(t, ResourceInstrument, w.ResourceType)
+	assert.Equal(t, "GBP", w.ResourceCode)
+	assert.Contains(t, w.Description, "GBP")
+}
+
+func TestManifestDiffer_WithNoOpDriftDetector(t *testing.T) {
+	drift := &NoOpDriftDetector{}
+	d := New(nil, drift)
+	require.NotNil(t, d)
+
+	plan, err := d.Diff(context.Background(), nil, &controlplanev1.Manifest{})
+	require.NoError(t, err)
+	assert.Empty(t, plan.DriftWarnings)
+}
+
+func TestValRuleKey_Direct(t *testing.T) {
+	tests := []struct {
+		from string
+		to   string
+		want string
+	}{
+		{"KWH", "GBP", "KWH->GBP"},
+		{"kwh", "gbp", "KWH->GBP"},
+		{"EUR", "USD", "EUR->USD"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.from+"->"+tc.to, func(t *testing.T) {
+			assert.Equal(t, tc.want, valRuleKey(tc.from, tc.to))
+		})
+	}
+}

--- a/services/control-plane/internal/differ/manifest_differ_helpers_test.go
+++ b/services/control-plane/internal/differ/manifest_differ_helpers_test.go
@@ -1,0 +1,264 @@
+package differ
+
+import (
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── nil manifest helpers ────────────────────────────────────────────────────
+
+func TestGetInstruments_NilManifest(t *testing.T) {
+	assert.Nil(t, getInstruments(nil))
+}
+
+func TestGetAccountTypes_NilManifest(t *testing.T) {
+	assert.Nil(t, getAccountTypes(nil))
+}
+
+func TestGetValuationRules_NilManifest(t *testing.T) {
+	assert.Nil(t, getValuationRules(nil))
+}
+
+func TestGetSagas_NilManifest(t *testing.T) {
+	assert.Nil(t, getSagas(nil))
+}
+
+func TestGetPartyTypes_NilManifest(t *testing.T) {
+	assert.Nil(t, getPartyTypes(nil))
+}
+
+func TestGetMappings_NilManifest(t *testing.T) {
+	assert.Nil(t, getMappings(nil))
+}
+
+func TestGetProviderConnections_NilManifest(t *testing.T) {
+	assert.Nil(t, getProviderConnections(nil))
+}
+
+func TestGetInstructionRoutes_NilManifest(t *testing.T) {
+	assert.Nil(t, getInstructionRoutes(nil))
+}
+
+func TestGetMarketDataSources_NilManifest(t *testing.T) {
+	assert.Nil(t, getMarketDataSources(nil))
+}
+
+func TestGetMarketDataSets_NilManifest(t *testing.T) {
+	assert.Nil(t, getMarketDataSets(nil))
+}
+
+func TestGetOrganizations_NilManifest(t *testing.T) {
+	assert.Nil(t, getOrganizations(nil))
+}
+
+func TestGetInternalAccounts_NilManifest(t *testing.T) {
+	assert.Nil(t, getInternalAccounts(nil))
+}
+
+// ─── Map building helpers ────────────────────────────────────────────────────
+
+func TestInstrumentMap(t *testing.T) {
+	instruments := []*controlplanev1.InstrumentDefinition{
+		{Code: "GBP", Name: "British Pound"},
+		{Code: "USD", Name: "US Dollar"},
+	}
+	m := instrumentMap(instruments)
+	require.Len(t, m, 2)
+	assert.Equal(t, "British Pound", m["GBP"].GetName())
+	assert.Equal(t, "US Dollar", m["USD"].GetName())
+}
+
+func TestInstrumentMap_Empty(t *testing.T) {
+	assert.Empty(t, instrumentMap(nil))
+}
+
+func TestAccountTypeMap(t *testing.T) {
+	types := []*controlplanev1.AccountTypeDefinition{
+		{Code: "SETTLEMENT", Name: "Settlement"},
+		{Code: "CLEARING", Name: "Clearing"},
+	}
+	m := accountTypeMap(types)
+	require.Len(t, m, 2)
+	assert.Equal(t, "Settlement", m["SETTLEMENT"].GetName())
+}
+
+func TestValuationRuleMap(t *testing.T) {
+	rules := []*controlplanev1.ValuationRule{
+		{FromInstrument: "KWH", ToInstrument: "GBP"},
+	}
+	m := valuationRuleMap(rules)
+	require.Len(t, m, 1)
+	_, ok := m["KWH->GBP"]
+	assert.True(t, ok)
+}
+
+func TestSagaMap(t *testing.T) {
+	sagas := []*controlplanev1.SagaDefinition{
+		{Name: "process_order"},
+		{Name: "cancel_order"},
+	}
+	m := sagaMap(sagas)
+	require.Len(t, m, 2)
+	assert.NotNil(t, m["process_order"])
+	assert.NotNil(t, m["cancel_order"])
+}
+
+func TestPartyTypeKey(t *testing.T) {
+	k := partyTypeKey("tenant-1", "CUSTOMER")
+	assert.Equal(t, "tenant-1", k.TenantID)
+	assert.Equal(t, "CUSTOMER", k.PartyType)
+	assert.Equal(t, "tenant-1:CUSTOMER", k.String())
+}
+
+func TestPartyTypeMap(t *testing.T) {
+	defs := []*partyv1.PartyTypeDefinition{
+		{TenantId: "t1", PartyType: "CUSTOMER"},
+		{TenantId: "t2", PartyType: "CUSTOMER"},
+	}
+	m := partyTypeMap(defs)
+	require.Len(t, m, 2)
+	assert.NotNil(t, m[partyTypeKey("t1", "CUSTOMER")])
+	assert.NotNil(t, m[partyTypeKey("t2", "CUSTOMER")])
+}
+
+func TestMappingKey_Helper(t *testing.T) {
+	assert.Equal(t, "order_mapping:1", mappingKey("order_mapping", 1))
+	assert.Equal(t, "my_map:42", mappingKey("my_map", 42))
+}
+
+func TestMappingMap(t *testing.T) {
+	mappings := []*mappingv1.MappingDefinition{
+		{Name: "order_mapping", Version: 1},
+		{Name: "order_mapping", Version: 2},
+	}
+	m := mappingMap(mappings)
+	require.Len(t, m, 2)
+	assert.NotNil(t, m["order_mapping:1"])
+	assert.NotNil(t, m["order_mapping:2"])
+}
+
+func TestProviderConnectionMap(t *testing.T) {
+	conns := []*controlplanev1.ProviderConnectionConfig{
+		{ConnectionId: "stripe_connect"},
+		{ConnectionId: "adyen"},
+	}
+	m := providerConnectionMap(conns)
+	require.Len(t, m, 2)
+	assert.NotNil(t, m["stripe_connect"])
+}
+
+func TestInstructionRouteMap(t *testing.T) {
+	routes := []*controlplanev1.InstructionRouteConfig{
+		{InstructionType: "CHARGE"},
+		{InstructionType: "REFUND"},
+	}
+	m := instructionRouteMap(routes)
+	require.Len(t, m, 2)
+	assert.NotNil(t, m["CHARGE"])
+}
+
+func TestOrganizationMap(t *testing.T) {
+	orgs := []*controlplanev1.OrganizationDefinition{
+		{Code: "ORG_A", Name: "Organization A"},
+	}
+	m := organizationMap(orgs)
+	assert.NotNil(t, m["ORG_A"])
+}
+
+func TestInternalAccountMap(t *testing.T) {
+	accounts := []*controlplanev1.InternalAccountDefinition{
+		{Code: "PLATFORM_REVENUE"},
+	}
+	m := internalAccountMap(accounts)
+	assert.NotNil(t, m["PLATFORM_REVENUE"])
+}
+
+// ─── Change description helpers ──────────────────────────────────────────────
+
+func TestDescribeInstrumentChanges_NameChange(t *testing.T) {
+	prev := &controlplanev1.InstrumentDefinition{Code: "GBP", Name: "Pound"}
+	updated := &controlplanev1.InstrumentDefinition{Code: "GBP", Name: "British Pound"}
+	desc := describeInstrumentChanges("GBP", prev, updated)
+	assert.Contains(t, desc, "GBP")
+	assert.Contains(t, desc, "Pound")
+	assert.Contains(t, desc, "British Pound")
+}
+
+func TestDescribeInstrumentChanges_NoChange(t *testing.T) {
+	inst := &controlplanev1.InstrumentDefinition{Code: "GBP", Name: "British Pound"}
+	desc := describeInstrumentChanges("GBP", inst, inst)
+	assert.Equal(t, "Update instrument GBP", desc)
+}
+
+func TestDescribeAccountTypeChanges_NormalBalanceChange(t *testing.T) {
+	prev := &controlplanev1.AccountTypeDefinition{
+		Code:          "SETTLEMENT",
+		Name:          "Settlement",
+		NormalBalance: controlplanev1.NormalBalance_NORMAL_BALANCE_DEBIT,
+	}
+	updated := &controlplanev1.AccountTypeDefinition{
+		Code:          "SETTLEMENT",
+		Name:          "Settlement",
+		NormalBalance: controlplanev1.NormalBalance_NORMAL_BALANCE_CREDIT,
+	}
+	desc := describeAccountTypeChanges("SETTLEMENT", prev, updated)
+	assert.Contains(t, desc, "SETTLEMENT")
+	assert.Contains(t, desc, "normal_balance")
+}
+
+func TestDescribeSagaChanges_ScriptChange(t *testing.T) {
+	prev := &controlplanev1.SagaDefinition{Name: "s1", Script: "old script"}
+	updated := &controlplanev1.SagaDefinition{Name: "s1", Script: "new script"}
+	desc := describeSagaChanges("s1", prev, updated)
+	assert.Contains(t, desc, "s1")
+	assert.Contains(t, desc, "script changed")
+}
+
+func TestDescribeSagaChanges_NoChange(t *testing.T) {
+	saga := &controlplanev1.SagaDefinition{Name: "s1", Script: "same", Trigger: "api:/v1"}
+	desc := describeSagaChanges("s1", saga, saga)
+	assert.Equal(t, "Update saga s1", desc)
+}
+
+func TestDescribePartyTypeChanges_AttributeSchemaChange(t *testing.T) {
+	prev := &partyv1.PartyTypeDefinition{AttributeSchema: `{"old": "schema"}`}
+	updated := &partyv1.PartyTypeDefinition{AttributeSchema: `{"new": "schema"}`}
+	desc := describePartyTypeChanges("t1:CUSTOMER", prev, updated)
+	assert.Contains(t, desc, "attribute_schema")
+}
+
+func TestDescribeMappingChanges_TargetServiceChange(t *testing.T) {
+	prev := &mappingv1.MappingDefinition{TargetService: "order_service"}
+	updated := &mappingv1.MappingDefinition{TargetService: "payment_service"}
+	desc := describeMappingChanges("my_map:1", prev, updated)
+	assert.Contains(t, desc, "target_service")
+}
+
+func TestAttributesEqual_Equal(t *testing.T) {
+	a := map[string]string{"key": "value", "foo": "bar"}
+	b := map[string]string{"foo": "bar", "key": "value"}
+	assert.True(t, attributesEqual(a, b))
+}
+
+func TestAttributesEqual_DifferentValues(t *testing.T) {
+	a := map[string]string{"key": "value1"}
+	b := map[string]string{"key": "value2"}
+	assert.False(t, attributesEqual(a, b))
+}
+
+func TestAttributesEqual_DifferentLengths(t *testing.T) {
+	a := map[string]string{"key": "value", "extra": "field"}
+	b := map[string]string{"key": "value"}
+	assert.False(t, attributesEqual(a, b))
+}
+
+func TestAttributesEqual_NilMaps(t *testing.T) {
+	assert.True(t, attributesEqual(nil, nil))
+	assert.True(t, attributesEqual(nil, map[string]string{}))
+	assert.True(t, attributesEqual(map[string]string{}, nil))
+}

--- a/services/control-plane/internal/differ/manifest_differ_resources_test.go
+++ b/services/control-plane/internal/differ/manifest_differ_resources_test.go
@@ -341,6 +341,7 @@ func TestDiffPlan_BreakingChangesFlaggedOnDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	deletes := filterActionsByResource(plan.Actions, ActionDelete, ResourceInstrument)
-	assert.Len(t, deletes, 1)
+	require.Len(t, deletes, 1)
+	assert.True(t, deletes[0].Breaking)
 	assert.True(t, plan.HasBreakingChanges)
 }

--- a/services/control-plane/internal/differ/manifest_differ_resources_test.go
+++ b/services/control-plane/internal/differ/manifest_differ_resources_test.go
@@ -1,0 +1,342 @@
+package differ
+
+import (
+	"context"
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── diffInstruments ─────────────────────────────────────────────────────────
+
+func TestDiffInstruments_Create(t *testing.T) {
+	d := New(nil, nil)
+	manifest := &controlplanev1.Manifest{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "British Pound", Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT},
+		},
+	}
+
+	plan, err := d.Diff(context.Background(), nil, manifest)
+	require.NoError(t, err)
+
+	creates := filterActionsByResource(plan.Actions, ActionCreate, ResourceInstrument)
+	require.Len(t, creates, 1)
+	assert.Equal(t, "GBP", creates[0].ResourceCode)
+}
+
+func TestDiffInstruments_Delete(t *testing.T) {
+	d := New(nil, nil)
+	last := &controlplanev1.Manifest{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "British Pound"},
+			{Code: "USD", Name: "US Dollar"},
+		},
+	}
+	next := &controlplanev1.Manifest{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "British Pound"},
+		},
+	}
+
+	plan, err := d.Diff(context.Background(), last, next)
+	require.NoError(t, err)
+
+	deletes := filterActionsByResource(plan.Actions, ActionDelete, ResourceInstrument)
+	require.Len(t, deletes, 1)
+	assert.Equal(t, "USD", deletes[0].ResourceCode)
+}
+
+func TestDiffInstruments_Update(t *testing.T) {
+	d := New(nil, nil)
+	last := &controlplanev1.Manifest{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "Pound"},
+		},
+	}
+	next := &controlplanev1.Manifest{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "British Pound"},
+		},
+	}
+
+	plan, err := d.Diff(context.Background(), last, next)
+	require.NoError(t, err)
+
+	updates := filterActionsByResource(plan.Actions, ActionUpdate, ResourceInstrument)
+	require.Len(t, updates, 1)
+	assert.Contains(t, updates[0].Description, "GBP")
+}
+
+func TestDiffInstruments_NoChange(t *testing.T) {
+	d := New(nil, nil)
+	manifest := &controlplanev1.Manifest{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "British Pound"},
+		},
+	}
+
+	plan, err := d.Diff(context.Background(), manifest, manifest)
+	require.NoError(t, err)
+
+	noChanges := filterActionsByResource(plan.Actions, ActionNoChange, ResourceInstrument)
+	assert.Len(t, noChanges, 1)
+}
+
+// ─── diffAccountTypes ────────────────────────────────────────────────────────
+
+func TestDiffAccountTypes_Create(t *testing.T) {
+	d := New(nil, nil)
+	manifest := &controlplanev1.Manifest{
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{Code: "SETTLEMENT", Name: "Settlement"},
+		},
+	}
+
+	plan, err := d.Diff(context.Background(), nil, manifest)
+	require.NoError(t, err)
+
+	creates := filterActionsByResource(plan.Actions, ActionCreate, ResourceAccountType)
+	require.Len(t, creates, 1)
+	assert.Equal(t, "SETTLEMENT", creates[0].ResourceCode)
+}
+
+func TestDiffAccountTypes_Delete(t *testing.T) {
+	d := New(nil, nil)
+	last := &controlplanev1.Manifest{
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{Code: "SETTLEMENT", Name: "Settlement"},
+			{Code: "CLEARING", Name: "Clearing"},
+		},
+	}
+	next := &controlplanev1.Manifest{
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{Code: "SETTLEMENT", Name: "Settlement"},
+		},
+	}
+
+	plan, err := d.Diff(context.Background(), last, next)
+	require.NoError(t, err)
+
+	deletes := filterActionsByResource(plan.Actions, ActionDelete, ResourceAccountType)
+	require.Len(t, deletes, 1)
+	assert.Equal(t, "CLEARING", deletes[0].ResourceCode)
+}
+
+// ─── diffValuationRules ──────────────────────────────────────────────────────
+
+func TestDiffValuationRules_Create(t *testing.T) {
+	d := New(nil, nil)
+	manifest := &controlplanev1.Manifest{
+		ValuationRules: []*controlplanev1.ValuationRule{
+			{
+				FromInstrument: "KWH",
+				ToInstrument:   "GBP",
+				Method:         controlplanev1.ValuationMethod_VALUATION_METHOD_SPOT_RATE,
+			},
+		},
+	}
+
+	plan, err := d.Diff(context.Background(), nil, manifest)
+	require.NoError(t, err)
+
+	creates := filterActionsByResource(plan.Actions, ActionCreate, ResourceValuationRule)
+	require.Len(t, creates, 1)
+	assert.Equal(t, "KWH->GBP", creates[0].ResourceCode)
+}
+
+func TestDiffValuationRules_Delete(t *testing.T) {
+	d := New(nil, nil)
+	last := &controlplanev1.Manifest{
+		ValuationRules: []*controlplanev1.ValuationRule{
+			{FromInstrument: "KWH", ToInstrument: "GBP"},
+			{FromInstrument: "EUR", ToInstrument: "GBP"},
+		},
+	}
+	next := &controlplanev1.Manifest{
+		ValuationRules: []*controlplanev1.ValuationRule{
+			{FromInstrument: "KWH", ToInstrument: "GBP"},
+		},
+	}
+
+	plan, err := d.Diff(context.Background(), last, next)
+	require.NoError(t, err)
+
+	deletes := filterActionsByResource(plan.Actions, ActionDelete, ResourceValuationRule)
+	require.Len(t, deletes, 1)
+	assert.Equal(t, "EUR->GBP", deletes[0].ResourceCode)
+}
+
+// ─── diffSagas ───────────────────────────────────────────────────────────────
+
+func TestDiffSagas_Create(t *testing.T) {
+	d := New(nil, nil)
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "process_order", Trigger: "api:/v1/orders", Script: "def execute(ctx): pass"},
+		},
+	}
+
+	plan, err := d.Diff(context.Background(), nil, manifest)
+	require.NoError(t, err)
+
+	creates := filterActionsByResource(plan.Actions, ActionCreate, ResourceSaga)
+	require.Len(t, creates, 1)
+	assert.Equal(t, "process_order", creates[0].ResourceCode)
+}
+
+func TestDiffSagas_Update_ScriptChange(t *testing.T) {
+	d := New(nil, nil)
+	last := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "process_order", Trigger: "api:/v1/orders", Script: "old script"},
+		},
+	}
+	next := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "process_order", Trigger: "api:/v1/orders", Script: "new script"},
+		},
+	}
+
+	plan, err := d.Diff(context.Background(), last, next)
+	require.NoError(t, err)
+
+	updates := filterActionsByResource(plan.Actions, ActionUpdate, ResourceSaga)
+	require.Len(t, updates, 1)
+	assert.Contains(t, updates[0].Description, "script changed")
+}
+
+// ─── diffPartyTypes ──────────────────────────────────────────────────────────
+
+func TestDiffPartyTypes_Create(t *testing.T) {
+	d := New(nil, nil)
+	manifest := &controlplanev1.Manifest{
+		PartyTypes: []*partyv1.PartyTypeDefinition{
+			{TenantId: "t1", PartyType: "CUSTOMER"},
+		},
+	}
+
+	plan, err := d.Diff(context.Background(), nil, manifest)
+	require.NoError(t, err)
+
+	creates := filterActionsByResource(plan.Actions, ActionCreate, ResourcePartyType)
+	require.Len(t, creates, 1)
+	assert.Equal(t, "t1:CUSTOMER", creates[0].ResourceCode)
+}
+
+// ─── diffOrganizations ───────────────────────────────────────────────────────
+
+func TestDiffOrganizations_Create(t *testing.T) {
+	d := New(nil, nil)
+	manifest := &controlplanev1.Manifest{
+		Organizations: []*controlplanev1.OrganizationDefinition{
+			{Code: "PLATFORM", Name: "Platform", PartyType: "OPERATOR"},
+		},
+	}
+
+	plan, err := d.Diff(context.Background(), nil, manifest)
+	require.NoError(t, err)
+
+	creates := filterActionsByResource(plan.Actions, ActionCreate, ResourceOrganization)
+	require.Len(t, creates, 1)
+	assert.Equal(t, "PLATFORM", creates[0].ResourceCode)
+}
+
+func TestDiffOrganizations_Update_AttributeChange(t *testing.T) {
+	d := New(nil, nil)
+	last := &controlplanev1.Manifest{
+		Organizations: []*controlplanev1.OrganizationDefinition{
+			{Code: "PLATFORM", Name: "Platform", Attributes: map[string]string{"region": "EU"}},
+		},
+	}
+	next := &controlplanev1.Manifest{
+		Organizations: []*controlplanev1.OrganizationDefinition{
+			{Code: "PLATFORM", Name: "Platform", Attributes: map[string]string{"region": "US"}},
+		},
+	}
+
+	plan, err := d.Diff(context.Background(), last, next)
+	require.NoError(t, err)
+
+	updates := filterActionsByResource(plan.Actions, ActionUpdate, ResourceOrganization)
+	require.Len(t, updates, 1)
+}
+
+// ─── diffMarketDataSources ───────────────────────────────────────────────────
+
+func TestDiffMarketDataSources_Create(t *testing.T) {
+	d := New(nil, nil)
+	manifest := &controlplanev1.Manifest{
+		MarketData: &controlplanev1.MarketDataConfig{
+			Sources: []*controlplanev1.MarketDataSourceDefinition{
+				{
+					Code:       "nordpool_spot",
+					Name:       "Nord Pool Spot",
+					TrustLevel: 90,
+				},
+			},
+		},
+	}
+
+	plan, err := d.Diff(context.Background(), nil, manifest)
+	require.NoError(t, err)
+
+	creates := filterActionsByResource(plan.Actions, ActionCreate, ResourceMarketDataSource)
+	require.Len(t, creates, 1)
+	assert.Equal(t, "nordpool_spot", creates[0].ResourceCode)
+}
+
+// ─── diffInternalAccounts ────────────────────────────────────────────────────
+
+func TestDiffInternalAccounts_Create(t *testing.T) {
+	d := New(nil, nil)
+	manifest := &controlplanev1.Manifest{
+		InternalAccounts: []*controlplanev1.InternalAccountDefinition{
+			{Code: "PLATFORM_REVENUE", AccountType: "REVENUE", Instrument: "GBP"},
+		},
+	}
+
+	plan, err := d.Diff(context.Background(), nil, manifest)
+	require.NoError(t, err)
+
+	creates := filterActionsByResource(plan.Actions, ActionCreate, ResourceInternalAccount)
+	require.Len(t, creates, 1)
+	assert.Equal(t, "PLATFORM_REVENUE", creates[0].ResourceCode)
+}
+
+// ─── WithSkipSafetyChecks ────────────────────────────────────────────────────
+
+func TestDiffWithSkipSafetyChecks_AllowsDeletion(t *testing.T) {
+	d := New(nil, nil)
+	last := &controlplanev1.Manifest{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "OLD"},
+		},
+	}
+	next := &controlplanev1.Manifest{}
+
+	plan, err := d.Diff(context.Background(), last, next, WithSkipSafetyChecks())
+	require.NoError(t, err)
+	assert.Empty(t, plan.BlockedDeletions)
+}
+
+// ─── DiffPlan.HasBreakingChanges ─────────────────────────────────────────────
+
+func TestDiffPlan_BreakingChangesFlaggedOnDelete(t *testing.T) {
+	d := New(nil, nil)
+	last := &controlplanev1.Manifest{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "British Pound"},
+		},
+	}
+	next := &controlplanev1.Manifest{}
+
+	plan, err := d.Diff(context.Background(), last, next)
+	require.NoError(t, err)
+
+	deletes := filterActionsByResource(plan.Actions, ActionDelete, ResourceInstrument)
+	assert.Len(t, deletes, 1)
+}

--- a/services/control-plane/internal/differ/manifest_differ_resources_test.go
+++ b/services/control-plane/internal/differ/manifest_differ_resources_test.go
@@ -321,6 +321,9 @@ func TestDiffWithSkipSafetyChecks_AllowsDeletion(t *testing.T) {
 	plan, err := d.Diff(context.Background(), last, next, WithSkipSafetyChecks())
 	require.NoError(t, err)
 	assert.Empty(t, plan.BlockedDeletions)
+	deletes := filterActionsByResource(plan.Actions, ActionDelete, ResourceInstrument)
+	require.Len(t, deletes, 1)
+	assert.Equal(t, "OLD", deletes[0].ResourceCode)
 }
 
 // ─── DiffPlan.HasBreakingChanges ─────────────────────────────────────────────
@@ -339,4 +342,5 @@ func TestDiffPlan_BreakingChangesFlaggedOnDelete(t *testing.T) {
 
 	deletes := filterActionsByResource(plan.Actions, ActionDelete, ResourceInstrument)
 	assert.Len(t, deletes, 1)
+	assert.True(t, plan.HasBreakingChanges)
 }

--- a/services/control-plane/internal/differ/store_test.go
+++ b/services/control-plane/internal/differ/store_test.go
@@ -1,0 +1,81 @@
+package differ
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestManifestVersion_Fields(t *testing.T) {
+	now := time.Now()
+	mv := ManifestVersion{
+		ID:        "v-123",
+		Version:   3,
+		Manifest:  &controlplanev1.Manifest{Version: "1.0"},
+		AppliedAt: now,
+		AppliedBy: "user@example.com",
+	}
+
+	assert.Equal(t, "v-123", mv.ID)
+	assert.Equal(t, 3, mv.Version)
+	assert.Equal(t, "1.0", mv.Manifest.GetVersion())
+	assert.Equal(t, now, mv.AppliedAt)
+	assert.Equal(t, "user@example.com", mv.AppliedBy)
+}
+
+func TestManifestVersion_ZeroValue(t *testing.T) {
+	var mv ManifestVersion
+	assert.Equal(t, "", mv.ID)
+	assert.Equal(t, 0, mv.Version)
+	assert.Nil(t, mv.Manifest)
+	assert.True(t, mv.AppliedAt.IsZero())
+	assert.Equal(t, "", mv.AppliedBy)
+}
+
+// TestManifestVersionStore_InterfaceCompliance verifies compile-time interface satisfaction.
+func TestManifestVersionStore_InterfaceCompliance(t *testing.T) {
+	var _ ManifestVersionStore = (*inMemoryManifestVersionStore)(nil)
+}
+
+// inMemoryManifestVersionStore implements ManifestVersionStore for testing.
+type inMemoryManifestVersionStore struct {
+	latest *ManifestVersion
+}
+
+func (s *inMemoryManifestVersionStore) GetLatestApplied(_ context.Context) (*ManifestVersion, error) {
+	return s.latest, nil
+}
+
+func (s *inMemoryManifestVersionStore) Save(_ context.Context, manifest *controlplanev1.Manifest, appliedBy string) error {
+	s.latest = &ManifestVersion{
+		Manifest:  manifest,
+		AppliedBy: appliedBy,
+		AppliedAt: time.Now(),
+		Version:   1,
+	}
+	return nil
+}
+
+func TestInMemoryManifestVersionStore_GetLatestApplied_NilInitially(t *testing.T) {
+	store := &inMemoryManifestVersionStore{}
+	mv, err := store.GetLatestApplied(context.Background())
+	assert.NoError(t, err)
+	assert.Nil(t, mv)
+}
+
+func TestInMemoryManifestVersionStore_SaveAndGet(t *testing.T) {
+	store := &inMemoryManifestVersionStore{}
+	manifest := &controlplanev1.Manifest{Version: "1.0"}
+
+	err := store.Save(context.Background(), manifest, "user@example.com")
+	assert.NoError(t, err)
+
+	mv, err := store.GetLatestApplied(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, mv)
+	assert.Equal(t, "user@example.com", mv.AppliedBy)
+	assert.Equal(t, "1.0", mv.Manifest.GetVersion())
+}

--- a/services/control-plane/internal/differ/store_test.go
+++ b/services/control-plane/internal/differ/store_test.go
@@ -36,7 +36,7 @@ func TestManifestVersion_ZeroValue(t *testing.T) {
 }
 
 // TestManifestVersionStore_InterfaceCompliance verifies compile-time interface satisfaction.
-func TestManifestVersionStore_InterfaceCompliance(t *testing.T) {
+func TestManifestVersionStore_InterfaceCompliance(_ *testing.T) {
 	var _ ManifestVersionStore = (*inMemoryManifestVersionStore)(nil)
 }
 

--- a/services/control-plane/internal/validator/cel_validator_test.go
+++ b/services/control-plane/internal/validator/cel_validator_test.go
@@ -10,9 +10,9 @@ import (
 
 func TestExtractRef(t *testing.T) {
 	tests := []struct {
-		name  string
-		ref   string
-		want  string
+		name string
+		ref  string
+		want string
 	}{
 		{"empty", "", ""},
 		{"simple", "#/components/schemas/Foo", "Foo"},

--- a/services/control-plane/internal/validator/cel_validator_test.go
+++ b/services/control-plane/internal/validator/cel_validator_test.go
@@ -1,0 +1,190 @@
+package validator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractRef(t *testing.T) {
+	tests := []struct {
+		name  string
+		ref   string
+		want  string
+	}{
+		{"empty", "", ""},
+		{"simple", "#/components/schemas/Foo", "Foo"},
+		{"message ref", "#/components/messages/BarMessage", "BarMessage"},
+		{"no slash", "Foo", "Foo"},
+		{"single slash", "/Foo", "Foo"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractRef(tc.ref)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestParseAsyncAPIFile_ValidDocument(t *testing.T) {
+	yaml := `
+asyncapi: "3.0.0"
+channels:
+  market_data_received:
+    messages:
+      PriceUpdate:
+        $ref: "#/components/messages/PriceUpdateMessage"
+components:
+  messages:
+    PriceUpdateMessage:
+      payload:
+        $ref: "#/components/schemas/PriceUpdatePayload"
+  schemas:
+    PriceUpdatePayload:
+      properties:
+        amount: {}
+        currency: {}
+        timestamp: {}
+`
+	schemas := make(map[string]map[string]bool)
+	parseAsyncAPIFile([]byte(yaml), schemas)
+
+	channelFields, ok := schemas["market_data_received"]
+	require.True(t, ok, "expected channel to be parsed")
+	assert.True(t, channelFields["amount"])
+	assert.True(t, channelFields["currency"])
+	assert.True(t, channelFields["timestamp"])
+}
+
+func TestParseAsyncAPIFile_InvalidYAML(t *testing.T) {
+	schemas := make(map[string]map[string]bool)
+	parseAsyncAPIFile([]byte("not: valid: yaml: {{{"), schemas)
+	assert.Empty(t, schemas)
+}
+
+func TestParseAsyncAPIFile_EmptyDocument(t *testing.T) {
+	schemas := make(map[string]map[string]bool)
+	parseAsyncAPIFile([]byte("{}"), schemas)
+	assert.Empty(t, schemas)
+}
+
+func TestParseAsyncAPIFile_MissingMessageRef(t *testing.T) {
+	yaml := `
+channels:
+  my_channel:
+    messages:
+      MyMsg:
+        $ref: "#/components/messages/DoesNotExist"
+components:
+  messages: {}
+  schemas: {}
+`
+	schemas := make(map[string]map[string]bool)
+	parseAsyncAPIFile([]byte(yaml), schemas)
+	assert.Empty(t, schemas)
+}
+
+func TestValidateMappingCELExpression_Valid(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	result := &ValidationResult{Valid: true}
+	v.validateMappingCELExpression("payload.amount > 0", "mappings[0].inbound_validation_cel", result)
+	assert.Empty(t, result.Errors)
+}
+
+func TestValidateMappingCELExpression_UndeclaredReference(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	result := &ValidationResult{Valid: true}
+	v.validateMappingCELExpression("paylod.amount > 0", "mappings[0].inbound_validation_cel", result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "CEL_UNDECLARED_REFERENCE", result.Errors[0].Code)
+	assert.Contains(t, result.Errors[0].Suggestion, "payload")
+}
+
+func TestValidateMappingCELExpression_TooLong(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	result := &ValidationResult{Valid: true}
+	longExpr := strings.Repeat("a", 2049)
+	v.validateMappingCELExpression(longExpr, "mappings[0].inbound_validation_cel", result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "CEL_EXPRESSION_TOO_LONG", result.Errors[0].Code)
+}
+
+func TestValidateMappingCELExpression_SyntaxError(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	result := &ValidationResult{Valid: true}
+	v.validateMappingCELExpression("payload.amount >>>", "mappings[0].inbound_validation_cel", result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "CEL_COMPILATION_ERROR", result.Errors[0].Code)
+}
+
+func TestExtractCELFieldRefs_BasicSelect(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	fields := extractCELFieldRefs("event.amount > 0 && event.currency == 'GBP'", v.eventFilterEnv)
+	assert.Contains(t, fields, "amount")
+	assert.Contains(t, fields, "currency")
+}
+
+func TestExtractCELFieldRefs_IndexAccess(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	// event["amount"] style access
+	fields := extractCELFieldRefs(`event["amount"] > 0`, v.eventFilterEnv)
+	assert.Contains(t, fields, "amount")
+}
+
+func TestExtractCELFieldRefs_InvalidExpression(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	fields := extractCELFieldRefs("not valid >>> cel", v.eventFilterEnv)
+	assert.Nil(t, fields)
+}
+
+func TestValidateEventFilterCEL_Valid(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	result := &ValidationResult{Valid: true}
+	v.validateEventFilterCEL("event.amount > 0", "sagas[0].filter", result)
+	assert.Empty(t, result.Errors)
+}
+
+func TestValidateEventFilterCEL_TooLong(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	result := &ValidationResult{Valid: true}
+	longExpr := strings.Repeat("a", 4097)
+	v.validateEventFilterCEL(longExpr, "sagas[0].filter", result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "CEL_EXPRESSION_TOO_LONG", result.Errors[0].Code)
+}
+
+func TestValidateEventFilterCEL_UndeclaredReference(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	result := &ValidationResult{Valid: true}
+	v.validateEventFilterCEL("evnt.amount > 0", "sagas[0].filter", result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "CEL_UNDECLARED_REFERENCE", result.Errors[0].Code)
+	assert.Contains(t, result.Errors[0].Suggestion, "event")
+}

--- a/services/control-plane/internal/validator/crossref_validator_test.go
+++ b/services/control-plane/internal/validator/crossref_validator_test.go
@@ -1,0 +1,265 @@
+package validator
+
+import (
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── Duplicate detection ────────────────────────────────────────────────────
+
+func TestValidateDuplicates_EmptyManifest(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	result := &ValidationResult{Valid: true}
+	v.validateDuplicates(&controlplanev1.Manifest{}, result)
+	assert.Empty(t, result.Errors)
+}
+
+func TestValidateDuplicates_NoDuplicates(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	result := &ValidationResult{Valid: true}
+	v.validateDuplicates(manifest, result)
+	assert.Empty(t, result.Errors)
+}
+
+func TestValidateDuplicates_DuplicateInstrumentCodes(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "British Pound", Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT},
+			{Code: "GBP", Name: "Duplicate", Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateDuplicates(manifest, result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "DUPLICATE_CODE", result.Errors[0].Code)
+	assert.Equal(t, "instruments[1].code", result.Errors[0].Path)
+}
+
+func TestValidateDuplicates_DuplicateAccountTypeCodes(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{Code: "SETTLEMENT", Name: "Settlement"},
+			{Code: "SETTLEMENT", Name: "Duplicate Settlement"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateDuplicates(manifest, result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "DUPLICATE_CODE", result.Errors[0].Code)
+	assert.Equal(t, "account_types[1].code", result.Errors[0].Path)
+}
+
+func TestValidateDuplicates_DuplicateSagaNames(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "process_settlement", Trigger: "api:/v1/settle"},
+			{Name: "process_settlement", Trigger: "api:/v1/settle2"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateDuplicates(manifest, result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "DUPLICATE_NAME", result.Errors[0].Code)
+}
+
+func TestValidateDuplicates_EventTriggerWithoutFilterWarning(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "my_saga", Trigger: "event:market_data_received"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateDuplicates(manifest, result)
+
+	require.Len(t, result.Warnings, 1)
+	assert.Equal(t, "MISSING_EVENT_FILTER", result.Warnings[0].Code)
+}
+
+// ─── Webhook trigger validation ─────────────────────────────────────────────
+
+func TestValidateWebhookTriggers_ValidConnection(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "on_payment", Trigger: "webhook:stripe_connect"},
+		},
+		OperationalGateway: &controlplanev1.OperationalGatewayConfig{
+			ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+				{ConnectionId: "stripe_connect"},
+			},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateWebhookTriggers(manifest, result)
+	assert.Empty(t, result.Errors)
+}
+
+func TestValidateWebhookTriggers_UnknownConnection(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "on_payment", Trigger: "webhook:unknown_provider"},
+		},
+		OperationalGateway: &controlplanev1.OperationalGatewayConfig{
+			ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+				{ConnectionId: "stripe_connect"},
+			},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateWebhookTriggers(manifest, result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "UNKNOWN_WEBHOOK_SOURCE", result.Errors[0].Code)
+}
+
+func TestValidateWebhookTriggers_NoWebhookTriggers(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "process", Trigger: "api:/v1/process"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateWebhookTriggers(manifest, result)
+	assert.Empty(t, result.Errors)
+}
+
+// ─── Scheduled trigger validation ───────────────────────────────────────────
+
+func TestValidateScheduledTriggers_Unique(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "daily_billing", Trigger: "scheduled:daily_billing"},
+			{Name: "monthly_report", Trigger: "scheduled:monthly_report"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateScheduledTriggers(manifest, result)
+	assert.Empty(t, result.Errors)
+}
+
+func TestValidateScheduledTriggers_Duplicate(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "billing_a", Trigger: "scheduled:daily_billing"},
+			{Name: "billing_b", Trigger: "scheduled:daily_billing"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateScheduledTriggers(manifest, result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "DUPLICATE_SCHEDULED_TRIGGER", result.Errors[0].Code)
+}
+
+// ─── API trigger validation ──────────────────────────────────────────────────
+
+func TestValidateAPITriggers_ValidPath_Direct(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "create_order", Trigger: "api:/v1/orders"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateAPITriggers(manifest, result)
+	assert.Empty(t, result.Errors)
+}
+
+func TestValidateAPITriggers_InvalidPathFormat_Direct(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "bad_path", Trigger: "api:no-leading-slash"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateAPITriggers(manifest, result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "INVALID_API_PATH_FORMAT", result.Errors[0].Code)
+}
+
+func TestValidateAPITriggers_DuplicatePath_Direct(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "saga_a", Trigger: "api:/v1/orders"},
+			{Name: "saga_b", Trigger: "api:/v1/orders"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateAPITriggers(manifest, result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "DUPLICATE_API_TRIGGER", result.Errors[0].Code)
+}
+
+func TestValidateAPITriggers_NonAPITriggerSkipped(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "event_saga", Trigger: "event:some_channel"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateAPITriggers(manifest, result)
+	assert.Empty(t, result.Errors)
+}

--- a/services/control-plane/internal/validator/crossref_validator_test.go
+++ b/services/control-plane/internal/validator/crossref_validator_test.go
@@ -200,8 +200,11 @@ func TestValidateScheduledTriggers_Duplicate(t *testing.T) {
 // ─── API trigger validation ──────────────────────────────────────────────────
 
 func TestValidateAPITriggers_ValidPath_Direct(t *testing.T) {
+	// Use a validator without an apiPathRegistry so path existence is not checked.
+	// This tests only the format validation logic.
 	v, err := New()
 	require.NoError(t, err)
+	v.apiPathRegistry = nil // disable spec-based path checking
 
 	manifest := &controlplanev1.Manifest{
 		Sagas: []*controlplanev1.SagaDefinition{
@@ -227,13 +230,15 @@ func TestValidateAPITriggers_InvalidPathFormat_Direct(t *testing.T) {
 	result := &ValidationResult{Valid: true}
 	v.validateAPITriggers(manifest, result)
 
-	require.Len(t, result.Errors, 1)
-	assert.Equal(t, "INVALID_API_PATH_FORMAT", result.Errors[0].Code)
+	formatErrors := filterValidationErrors(result.Errors, "INVALID_API_PATH_FORMAT")
+	require.Len(t, formatErrors, 1)
+	assert.Equal(t, "sagas[0].trigger", formatErrors[0].Path)
 }
 
 func TestValidateAPITriggers_DuplicatePath_Direct(t *testing.T) {
 	v, err := New()
 	require.NoError(t, err)
+	v.apiPathRegistry = nil // disable spec-based path checking
 
 	manifest := &controlplanev1.Manifest{
 		Sagas: []*controlplanev1.SagaDefinition{
@@ -245,8 +250,9 @@ func TestValidateAPITriggers_DuplicatePath_Direct(t *testing.T) {
 	result := &ValidationResult{Valid: true}
 	v.validateAPITriggers(manifest, result)
 
-	require.Len(t, result.Errors, 1)
-	assert.Equal(t, "DUPLICATE_API_TRIGGER", result.Errors[0].Code)
+	dupeErrors := filterValidationErrors(result.Errors, "DUPLICATE_API_TRIGGER")
+	require.Len(t, dupeErrors, 1)
+	assert.Equal(t, "sagas[1].trigger", dupeErrors[0].Path)
 }
 
 func TestValidateAPITriggers_NonAPITriggerSkipped(t *testing.T) {

--- a/services/control-plane/internal/validator/domain_validator_test.go
+++ b/services/control-plane/internal/validator/domain_validator_test.go
@@ -1,0 +1,401 @@
+package validator
+
+import (
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── Payment Rails ───────────────────────────────────────────────────────────
+
+func TestValidatePaymentRails_ValidRail(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		PaymentRails: []*controlplanev1.PaymentRails{
+			{
+				Provider:         "stripe_connect",
+				AccountId:        "acct_1234567890123456",
+				SupportedMethods: []string{"card"},
+			},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validatePaymentRails(manifest, result)
+	assert.Empty(t, result.Errors)
+	assert.Empty(t, result.Warnings)
+}
+
+func TestValidatePaymentRails_InvalidProvider_Direct(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		PaymentRails: []*controlplanev1.PaymentRails{
+			{Provider: "paypal"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validatePaymentRails(manifest, result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "INVALID_PAYMENT_PROVIDER", result.Errors[0].Code)
+	assert.Equal(t, "payment_rails[0].provider", result.Errors[0].Path)
+}
+
+func TestValidatePaymentRails_InvalidAccountIDFormat_Direct(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		PaymentRails: []*controlplanev1.PaymentRails{
+			{
+				Provider:  "stripe_connect",
+				AccountId: "not_a_stripe_account_id",
+			},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validatePaymentRails(manifest, result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "INVALID_ACCOUNT_ID_FORMAT", result.Errors[0].Code)
+}
+
+func TestValidatePaymentRails_ValidAccountIDFormat(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		PaymentRails: []*controlplanev1.PaymentRails{
+			{
+				Provider:  "stripe_connect",
+				AccountId: "acct_AbCdEf1234567890",
+			},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validatePaymentRails(manifest, result)
+	assert.Empty(t, result.Errors)
+}
+
+func TestValidatePaymentRails_UnknownPaymentMethod_Direct(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		PaymentRails: []*controlplanev1.PaymentRails{
+			{
+				Provider:         "stripe_connect",
+				SupportedMethods: []string{"crypto"},
+			},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validatePaymentRails(manifest, result)
+	assert.Empty(t, result.Errors) // unknown method is a warning only
+	require.Len(t, result.Warnings, 1)
+	assert.Equal(t, "UNKNOWN_PAYMENT_METHOD", result.Warnings[0].Code)
+}
+
+func TestValidatePaymentRails_EmptyProvider(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	// Empty provider is not validated (skip check)
+	manifest := &controlplanev1.Manifest{
+		PaymentRails: []*controlplanev1.PaymentRails{
+			{Provider: ""},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validatePaymentRails(manifest, result)
+	assert.Empty(t, result.Errors)
+}
+
+// ─── Platform Fee ────────────────────────────────────────────────────────────
+
+func TestValidatePlatformFee_ValidDecimal(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	fee := &controlplanev1.PlatformFee{Value: "0.025"}
+	result := &ValidationResult{Valid: true}
+	v.validatePlatformFee(fee, "payment_rails[0].platform_fee", result)
+	assert.Empty(t, result.Errors)
+}
+
+func TestValidatePlatformFee_Zero(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	fee := &controlplanev1.PlatformFee{Value: "0"}
+	result := &ValidationResult{Valid: true}
+	v.validatePlatformFee(fee, "payment_rails[0].platform_fee", result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "INVALID_PLATFORM_FEE_VALUE", result.Errors[0].Code)
+	assert.Contains(t, result.Errors[0].Message, "greater than 0")
+}
+
+func TestValidatePlatformFee_Negative(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	fee := &controlplanev1.PlatformFee{Value: "-0.01"}
+	result := &ValidationResult{Valid: true}
+	v.validatePlatformFee(fee, "payment_rails[0].platform_fee", result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "INVALID_PLATFORM_FEE_VALUE", result.Errors[0].Code)
+}
+
+func TestValidatePlatformFee_InvalidDecimal(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	fee := &controlplanev1.PlatformFee{Value: "not-a-number"}
+	result := &ValidationResult{Valid: true}
+	v.validatePlatformFee(fee, "payment_rails[0].platform_fee", result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "INVALID_PLATFORM_FEE_VALUE", result.Errors[0].Code)
+}
+
+func TestValidatePlatformFee_EmptyValue(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	fee := &controlplanev1.PlatformFee{Value: ""}
+	result := &ValidationResult{Valid: true}
+	v.validatePlatformFee(fee, "payment_rails[0].platform_fee", result)
+	assert.Empty(t, result.Errors)
+}
+
+// ─── Party Types ──────────────────────────────────────────────────────────────
+
+func TestValidatePartyTypes_ValidDefinition_Direct(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		PartyTypes: []*partyv1.PartyTypeDefinition{
+			{
+				TenantId:        "tenant-1",
+				PartyType:       "CUSTOMER",
+				AttributeSchema: `{"name": "string"}`,
+			},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validatePartyTypes(manifest, result)
+	assert.Empty(t, result.Errors)
+}
+
+func TestValidatePartyTypes_InvalidJSON(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		PartyTypes: []*partyv1.PartyTypeDefinition{
+			{
+				TenantId:        "tenant-1",
+				PartyType:       "CUSTOMER",
+				AttributeSchema: `{not valid json`,
+			},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validatePartyTypes(manifest, result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "INVALID_JSON_SCHEMA", result.Errors[0].Code)
+}
+
+func TestValidatePartyTypes_DuplicateType(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		PartyTypes: []*partyv1.PartyTypeDefinition{
+			{TenantId: "tenant-1", PartyType: "CUSTOMER"},
+			{TenantId: "tenant-1", PartyType: "CUSTOMER"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validatePartyTypes(manifest, result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "DUPLICATE_PARTY_TYPE", result.Errors[0].Code)
+}
+
+func TestValidatePartyTypes_DifferentTenantsSameType(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		PartyTypes: []*partyv1.PartyTypeDefinition{
+			{TenantId: "tenant-1", PartyType: "CUSTOMER"},
+			{TenantId: "tenant-2", PartyType: "CUSTOMER"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validatePartyTypes(manifest, result)
+	assert.Empty(t, result.Errors)
+}
+
+func TestValidatePartyTypes_InvalidValidationCEL_Direct(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		PartyTypes: []*partyv1.PartyTypeDefinition{
+			{
+				TenantId:      "tenant-1",
+				PartyType:     "CUSTOMER",
+				ValidationCel: "undeclared_var > 0",
+			},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validatePartyTypes(manifest, result)
+	assert.NotEmpty(t, result.Errors)
+}
+
+// ─── Mapping validation ──────────────────────────────────────────────────────
+
+func TestValidateMappingBatch_RequiresBatchTargetPath(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	mp := &mappingv1.MappingDefinition{
+		IsBatch:         true,
+		BatchTargetPath: "",
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateMappingBatch(mp, "mappings[0]", result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "MAPPING_BATCH_TARGET_REQUIRED", result.Errors[0].Code)
+}
+
+func TestValidateMappingBatch_WithBatchTargetPath(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	mp := &mappingv1.MappingDefinition{
+		IsBatch:         true,
+		BatchTargetPath: "items",
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateMappingBatch(mp, "mappings[0]", result)
+	assert.Empty(t, result.Errors)
+}
+
+func TestValidateMappingStatus_Unspecified(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	mp := &mappingv1.MappingDefinition{
+		Status: mappingv1.MappingStatus_MAPPING_STATUS_UNSPECIFIED,
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateMappingStatus(mp, "mappings[0]", result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "INVALID_MAPPING_STATUS", result.Errors[0].Code)
+}
+
+func TestValidateMappingStatus_Active(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	mp := &mappingv1.MappingDefinition{
+		Status: mappingv1.MappingStatus_MAPPING_STATUS_ACTIVE,
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateMappingStatus(mp, "mappings[0]", result)
+	assert.Empty(t, result.Errors)
+}
+
+func TestValidateMappingIdempotency_NilConfig(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	mp := &mappingv1.MappingDefinition{}
+	result := &ValidationResult{Valid: true}
+	v.validateMappingIdempotency(mp, "mappings[0]", result)
+	assert.Empty(t, result.Errors)
+}
+
+func TestValidateMappingIdempotency_MissingSourceSelector(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	mp := &mappingv1.MappingDefinition{
+		Idempotency: &mappingv1.IdempotencyConfig{
+			UseContentHash: false,
+			SourceSelector: "",
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateMappingIdempotency(mp, "mappings[0]", result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "IDEMPOTENCY_SOURCE_REQUIRED", result.Errors[0].Code)
+}
+
+func TestValidateMappingIdempotency_MissingContentHashFields(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	mp := &mappingv1.MappingDefinition{
+		Idempotency: &mappingv1.IdempotencyConfig{
+			UseContentHash:    true,
+			ContentHashFields: nil,
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateMappingIdempotency(mp, "mappings[0]", result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "IDEMPOTENCY_HASH_FIELDS_REQUIRED", result.Errors[0].Code)
+}
+
+func TestValidateMappingIdempotency_ValidContentHash(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	mp := &mappingv1.MappingDefinition{
+		Idempotency: &mappingv1.IdempotencyConfig{
+			UseContentHash:    true,
+			ContentHashFields: []string{"amount", "currency"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateMappingIdempotency(mp, "mappings[0]", result)
+	assert.Empty(t, result.Errors)
+}

--- a/services/control-plane/internal/validator/lifecycle_validator_test.go
+++ b/services/control-plane/internal/validator/lifecycle_validator_test.go
@@ -1,0 +1,298 @@
+package validator
+
+import (
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── Orphan detection ────────────────────────────────────────────────────────
+
+func TestValidateOperationalGatewayOrphans_NilGateway(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{}
+	result := &ValidationResult{Valid: true}
+	v.validateOperationalGatewayOrphans(manifest, result)
+	assert.Empty(t, result.Warnings)
+}
+
+func TestDetectOrphanProviderConnections_ReferencedByRoute(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		OperationalGateway: &controlplanev1.OperationalGatewayConfig{
+			ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+				{ConnectionId: "stripe_connect"},
+			},
+			InstructionRoutes: []*controlplanev1.InstructionRouteConfig{
+				{InstructionType: "CHARGE", ConnectionId: "stripe_connect"},
+			},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateOperationalGatewayOrphans(manifest, result)
+	// Provider connection is referenced by the instruction route, so no ORPHAN_PROVIDER_CONNECTION warning.
+	orphanConns := filterValidationErrors(result.Warnings, "ORPHAN_PROVIDER_CONNECTION")
+	assert.Empty(t, orphanConns)
+}
+
+func TestDetectOrphanProviderConnections_ReferencedByWebhook(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "on_payment", Trigger: "webhook:stripe_connect"},
+		},
+		OperationalGateway: &controlplanev1.OperationalGatewayConfig{
+			ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+				{ConnectionId: "stripe_connect"},
+			},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateOperationalGatewayOrphans(manifest, result)
+	assert.Empty(t, result.Warnings)
+}
+
+func TestDetectOrphanProviderConnections_Orphan(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		OperationalGateway: &controlplanev1.OperationalGatewayConfig{
+			ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+				{ConnectionId: "unused_provider"},
+			},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateOperationalGatewayOrphans(manifest, result)
+
+	require.Len(t, result.Warnings, 1)
+	assert.Equal(t, "ORPHAN_PROVIDER_CONNECTION", result.Warnings[0].Code)
+	assert.Contains(t, result.Warnings[0].Message, "unused_provider")
+}
+
+func TestDetectOrphanProviderConnections_FallbackConnection(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		OperationalGateway: &controlplanev1.OperationalGatewayConfig{
+			ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+				{ConnectionId: "primary"},
+				{ConnectionId: "fallback"},
+			},
+			InstructionRoutes: []*controlplanev1.InstructionRouteConfig{
+				{InstructionType: "CHARGE", ConnectionId: "primary", FallbackConnectionId: "fallback"},
+			},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateOperationalGatewayOrphans(manifest, result)
+	// Both provider connections are referenced (primary + fallback), so no ORPHAN_PROVIDER_CONNECTION warnings.
+	orphanConns := filterValidationErrors(result.Warnings, "ORPHAN_PROVIDER_CONNECTION")
+	assert.Empty(t, orphanConns)
+}
+
+func TestDetectOrphanInstructionRoutes_UsedInSaga(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{
+				Name:    "charge_customer",
+				Trigger: "api:/v1/charge",
+				Script:  `def execute(ctx):\n    dispatch_instruction("CHARGE", {})\n`,
+			},
+		},
+		OperationalGateway: &controlplanev1.OperationalGatewayConfig{
+			ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+				{ConnectionId: "stripe_connect"},
+			},
+			InstructionRoutes: []*controlplanev1.InstructionRouteConfig{
+				{InstructionType: "CHARGE", ConnectionId: "stripe_connect"},
+			},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateOperationalGatewayOrphans(manifest, result)
+	assert.Empty(t, result.Warnings)
+}
+
+func TestDetectOrphanInstructionRoutes_NotUsed(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{
+				Name:    "process_order",
+				Trigger: "api:/v1/orders",
+				Script:  "def execute(ctx):\n    return {}\n",
+			},
+		},
+		OperationalGateway: &controlplanev1.OperationalGatewayConfig{
+			ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+				{ConnectionId: "stripe_connect"},
+			},
+			InstructionRoutes: []*controlplanev1.InstructionRouteConfig{
+				{InstructionType: "REFUND", ConnectionId: "stripe_connect"},
+			},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateOperationalGatewayOrphans(manifest, result)
+
+	// Expect one warning: unused provider connection + one warning: unused instruction route
+	// The provider connection is referenced by the instruction route, so only instruction route is orphan
+	orphanRoutes := filterValidationErrors(result.Warnings, "ORPHAN_INSTRUCTION_ROUTE")
+	require.Len(t, orphanRoutes, 1)
+	assert.Contains(t, orphanRoutes[0].Message, "REFUND")
+}
+
+// ─── Immutability checks ─────────────────────────────────────────────────────
+
+func TestValidateImmutability_NoChange(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "British Pound"},
+		},
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{Code: "SETTLEMENT", Name: "Settlement"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateImmutability(manifest, manifest, result)
+	assert.Empty(t, result.Errors)
+}
+
+func TestValidateImmutability_InstrumentCodeChanged_Direct(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	previous := &controlplanev1.Manifest{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "British Pound"},
+		},
+	}
+	current := &controlplanev1.Manifest{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "USD", Name: "US Dollar"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateImmutability(current, previous, result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "IMMUTABLE_FIELD_CHANGED", result.Errors[0].Code)
+	assert.Contains(t, result.Errors[0].Message, "GBP")
+	assert.Contains(t, result.Errors[0].Message, "USD")
+}
+
+func TestValidateImmutability_AccountTypeCodeChanged_Direct(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	previous := &controlplanev1.Manifest{
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{Code: "SETTLEMENT", Name: "Settlement"},
+		},
+	}
+	current := &controlplanev1.Manifest{
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{Code: "CLEARING", Name: "Clearing"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateImmutability(current, previous, result)
+
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "IMMUTABLE_FIELD_CHANGED", result.Errors[0].Code)
+}
+
+func TestValidateImmutability_AddingNewInstrument(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	previous := &controlplanev1.Manifest{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "British Pound"},
+		},
+	}
+	current := &controlplanev1.Manifest{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "British Pound"},
+			{Code: "USD", Name: "US Dollar"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateImmutability(current, previous, result)
+	assert.Empty(t, result.Errors)
+}
+
+// ─── dispatchInstructionRegex ────────────────────────────────────────────────
+
+func TestDispatchInstructionRegex_PositionalArg(t *testing.T) {
+	script := `dispatch_instruction("CHARGE", {})`
+	matches := dispatchInstructionRegex.FindAllStringSubmatch(script, -1)
+	require.Len(t, matches, 1)
+	assert.Equal(t, "CHARGE", matches[0][1])
+}
+
+func TestDispatchInstructionRegex_KeywordArg(t *testing.T) {
+	script := `dispatch_instruction(instruction_type="REFUND", payload={})`
+	matches := dispatchInstructionRegex.FindAllStringSubmatch(script, -1)
+	require.Len(t, matches, 1)
+	assert.Equal(t, "REFUND", matches[0][1])
+}
+
+func TestDispatchInstructionRegex_MultipleInstructions(t *testing.T) {
+	script := `
+def execute(ctx):
+    dispatch_instruction('CHARGE', {})
+    dispatch_instruction('NOTIFY', {})
+`
+	matches := dispatchInstructionRegex.FindAllStringSubmatch(script, -1)
+	require.Len(t, matches, 2)
+	types := []string{matches[0][1], matches[1][1]}
+	assert.Contains(t, types, "CHARGE")
+	assert.Contains(t, types, "NOTIFY")
+}
+
+func TestDispatchInstructionRegex_NoMatch(t *testing.T) {
+	script := `def execute(ctx):\n    return {}\n`
+	matches := dispatchInstructionRegex.FindAllStringSubmatch(script, -1)
+	assert.Empty(t, matches)
+}
+
+// filterValidationErrors filters warnings by error code.
+func filterValidationErrors(errs []ValidationError, code string) []ValidationError {
+	var out []ValidationError
+	for _, e := range errs {
+		if e.Code == code {
+			out = append(out, e)
+		}
+	}
+	return out
+}

--- a/services/control-plane/internal/validator/starlark_validator_test.go
+++ b/services/control-plane/internal/validator/starlark_validator_test.go
@@ -1,0 +1,210 @@
+package validator
+
+import (
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.starlark.net/starlark"
+)
+
+func TestPermissiveServiceStub_Interface(t *testing.T) {
+	stub := newPermissiveServiceStub("position_keeping")
+
+	assert.Equal(t, "<service position_keeping>", stub.String())
+	assert.Equal(t, "service", stub.Type())
+	assert.True(t, bool(stub.Truth()))
+	assert.Nil(t, stub.AttrNames())
+
+	_, hashErr := stub.Hash()
+	assert.ErrorIs(t, hashErr, ErrUnhashable)
+
+	// Attr returns a callable
+	val, err := stub.Attr("initiate_log")
+	assert.NoError(t, err)
+	assert.NotNil(t, val)
+}
+
+func TestPermissiveServiceStub_AttrCallable(t *testing.T) {
+	stub := newPermissiveServiceStub("position_keeping")
+
+	attr, err := stub.Attr("some_handler")
+	require.NoError(t, err)
+
+	builtin, ok := attr.(*starlark.Builtin)
+	require.True(t, ok)
+
+	// Should be callable and return a permissive result
+	thread := &starlark.Thread{Name: "test"}
+	result, callErr := starlark.Call(thread, builtin, nil, nil)
+	assert.NoError(t, callErr)
+	assert.NotNil(t, result)
+}
+
+func TestPermissiveResult_Interface(t *testing.T) {
+	r := &permissiveResult{}
+
+	assert.Equal(t, "<result>", r.String())
+	assert.Equal(t, "result", r.Type())
+	assert.True(t, bool(r.Truth()))
+	assert.Nil(t, r.AttrNames())
+
+	_, hashErr := r.Hash()
+	assert.ErrorIs(t, hashErr, ErrUnhashable)
+
+	// Attr always returns another permissive result
+	val, err := r.Attr("anything")
+	assert.NoError(t, err)
+	assert.NotNil(t, val)
+	_, ok := val.(*permissiveResult)
+	assert.True(t, ok)
+}
+
+func TestErrUnhashable(t *testing.T) {
+	assert.EqualError(t, ErrUnhashable, "unhashable: module")
+}
+
+func TestValidateStarlarkScripts_ValidScript(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{
+				Name:    "process_order",
+				Trigger: "api:/v1/orders",
+				Script:  "def execute(ctx):\n    return {\"status\": \"ok\"}\n",
+			},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateStarlarkScripts(manifest, result)
+	assert.Empty(t, result.Errors)
+}
+
+func TestValidateStarlarkScripts_SyntaxError(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{
+				Name:    "bad_saga",
+				Trigger: "api:/v1/bad",
+				Script:  "def execute(ctx):\n    return {{{invalid",
+			},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateStarlarkScripts(manifest, result)
+	require.NotEmpty(t, result.Errors)
+	assert.Equal(t, CodeStarlarkSyntaxError, result.Errors[0].Code)
+}
+
+func TestValidateStarlarkScripts_WhileLoopRejected(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	// Starlark forbids while loops - they don't compile
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{
+				Name:    "infinite_saga",
+				Trigger: "api:/v1/infinite",
+				Script:  "def execute(ctx):\n    while True:\n        pass\n",
+			},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateStarlarkScripts(manifest, result)
+	assert.NotEmpty(t, result.Errors)
+}
+
+func TestValidateStarlarkScripts_ValidForLoop(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{
+				Name:    "loop_saga",
+				Trigger: "api:/v1/loop",
+				Script: `def execute(ctx):
+    items = [1, 2, 3]
+    total = 0
+    for item in items:
+        total = total + item
+    return {"total": total}
+`,
+			},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateStarlarkScripts(manifest, result)
+	assert.Empty(t, result.Errors)
+}
+
+func TestValidateStarlarkScripts_ScriptTooLarge(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	// Build a script that exceeds the size limit (65536 bytes)
+	const maxSize = 65536
+	bigScript := make([]byte, maxSize+1)
+	for i := range bigScript {
+		bigScript[i] = '#' // comment character
+	}
+
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{
+				Name:    "huge_saga",
+				Trigger: "api:/v1/huge",
+				Script:  string(bigScript),
+			},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateStarlarkScripts(manifest, result)
+	require.NotEmpty(t, result.Errors)
+	assert.Contains(t, result.Errors[0].Code, "STARLARK")
+}
+
+func TestValidateStarlarkScripts_KnownServiceBinding(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	// Use a known service binding (position_keeping)
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{
+				Name:    "log_position",
+				Trigger: "api:/v1/log",
+				Script: `def execute(ctx):
+    result = ctx.position_keeping.initiate_log(
+        position_id="test",
+        amount=Decimal("100"),
+        direction="CREDIT",
+    )
+    return {"done": True}
+`,
+			},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateStarlarkScripts(manifest, result)
+	// Without a schema registry, permissive stubs allow any call
+	assert.Empty(t, result.Errors)
+}
+
+func TestCodeConstants(t *testing.T) {
+	assert.Equal(t, "STARLARK_SYNTAX_ERROR", CodeStarlarkSyntaxError)
+	assert.Equal(t, "STARLARK_COMPILATION_ERROR", CodeStarlarkCompilationError)
+}

--- a/services/control-plane/internal/validator/starlark_validator_test.go
+++ b/services/control-plane/internal/validator/starlark_validator_test.go
@@ -122,7 +122,7 @@ func TestValidateStarlarkScripts_WhileLoopRejected(t *testing.T) {
 	result := &ValidationResult{Valid: true}
 	v.validateStarlarkScripts(manifest, result)
 	require.NotEmpty(t, result.Errors)
-	assert.Equal(t, CodeStarlarkSyntaxError, result.Errors[0].Code)
+	assert.Equal(t, CodeStarlarkCompilationError, result.Errors[0].Code)
 }
 
 func TestValidateStarlarkScripts_ValidForLoop(t *testing.T) {

--- a/services/control-plane/internal/validator/starlark_validator_test.go
+++ b/services/control-plane/internal/validator/starlark_validator_test.go
@@ -121,7 +121,8 @@ func TestValidateStarlarkScripts_WhileLoopRejected(t *testing.T) {
 
 	result := &ValidationResult{Valid: true}
 	v.validateStarlarkScripts(manifest, result)
-	assert.NotEmpty(t, result.Errors)
+	require.NotEmpty(t, result.Errors)
+	assert.Equal(t, CodeStarlarkSyntaxError, result.Errors[0].Code)
 }
 
 func TestValidateStarlarkScripts_ValidForLoop(t *testing.T) {

--- a/services/control-plane/service/apply_manifest_test.go
+++ b/services/control-plane/service/apply_manifest_test.go
@@ -1,0 +1,30 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestRegisterApplyManifestService_NilPool_Direct(t *testing.T) {
+	server := grpc.NewServer()
+	err := RegisterApplyManifestService(server, ApplyManifestServiceConfig{
+		Pool: nil,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPoolRequired)
+}
+
+func TestErrPoolRequired_Message(t *testing.T) {
+	assert.EqualError(t, ErrPoolRequired, "apply manifest service: pool is required")
+}
+
+func TestApplyManifestServiceConfig_Defaults(t *testing.T) {
+	// Default config has nil Pool - should fail with ErrPoolRequired
+	cfg := ApplyManifestServiceConfig{}
+	assert.Nil(t, cfg.Pool)
+	assert.Nil(t, cfg.Logger)
+	assert.Nil(t, cfg.HandlerDeps)
+}


### PR DESCRIPTION
## Summary

- Adds unit tests for control plane CEL, crossref, domain, lifecycle, and Starlark validators
- Adds unit tests for differ helpers, resource diffing, drift detection, and store interface
- Adds service-layer tests for apply manifest registration error handling

## Changes Made

### Validator package (`services/control-plane/internal/validator/`)
- `cel_validator_test.go` - Tests for CEL expression helpers: `extractRef`, `parseAsyncAPIFile`, `validateMappingCELExpression`, `extractCELFieldRefs`, `validateEventFilterCEL`
- `crossref_validator_test.go` - Tests for duplicate detection and trigger validation (webhooks, scheduled, API triggers)
- `domain_validator_test.go` - Tests for payment rail validation, platform fee decimal checks, party type validation, mapping batch/status/idempotency constraints
- `lifecycle_validator_test.go` - Tests for operational gateway orphan detection, immutability enforcement, `dispatchInstructionRegex`
- `starlark_validator_test.go` - Tests for Starlark script validation, permissive service stubs, while loop rejection, error code constants

### Differ package (`services/control-plane/internal/differ/`)
- `drift_test.go` - Tests for `NoOpDriftDetector`, `DriftWarning` struct, `valRuleKey`
- `manifest_differ_helpers_test.go` - Tests for nil-safe manifest accessors, map-building helpers, change description functions, `attributesEqual`
- `manifest_differ_resources_test.go` - Tests for resource-specific diff operations (create/update/delete/no-change for instruments, account types, sagas, parties, organizations, internal accounts, market data, valuation rules)
- `store_test.go` - Tests for `ManifestVersion` struct fields and `ManifestVersionStore` interface contract via in-memory implementation

### Service package (`services/control-plane/service/`)
- `apply_manifest_test.go` - Tests for `RegisterApplyManifestService` nil-pool error handling and `ErrPoolRequired`

## Test plan

- [x] `go test ./services/control-plane/internal/validator/...` - passes (12s)
- [x] `go test ./services/control-plane/internal/differ/` - passes (all non-persistence tests)
- [x] New service tests pass when run in isolation

Note: `./services/control-plane/internal/differ/persistence/...` and `./services/control-plane/service/...` have pre-existing integration tests requiring Docker (CockroachDB/Postgres testcontainers) that are unrelated to these changes.