### PR TITLE
test: Add reference data service unit tests

### DIFF
--- a/services/reference-data/accounttype/postgres_registry_cel_test.go
+++ b/services/reference-data/accounttype/postgres_registry_cel_test.go
@@ -1,0 +1,197 @@
+package accounttype_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/reference-data/accounttype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newCELTestDefinition creates a definition with the provided CEL fields.
+func newCELTestDefinition(code, validationCEL, eligibilityCEL string) *accounttype.Definition {
+	return &accounttype.Definition{
+		Code:            code,
+		Version:         1,
+		DisplayName:     "CEL Test " + code,
+		NormalBalance:   accounttype.NormalBalanceCredit,
+		BehaviorClass:   accounttype.BehaviorClassCustomer,
+		InstrumentCode:  "GBP",
+		AttributeSchema: json.RawMessage(`{}`),
+		Attributes:      map[string]any{},
+		ValidationCEL:   validationCEL,
+		EligibilityCEL:  eligibilityCEL,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ValidateTransaction
+// ---------------------------------------------------------------------------
+
+func TestValidateTransaction(t *testing.T) {
+	reg, pool := setupTestAccountTypeRegistry(t)
+	ctx := setupAccountTypeTenantContext(t, pool, "cel-validate-tx")
+
+	t.Run("no CEL expression always returns valid", func(t *testing.T) {
+		def := newTestDefinition("NO_CEL_VALIDATE", "GBP")
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		result, err := reg.ValidateTransaction(ctx, "NO_CEL_VALIDATE", 1, accounttype.AttributeBag{})
+		require.NoError(t, err)
+		assert.True(t, result.Valid)
+		assert.Empty(t, result.Errors)
+	})
+
+	t.Run("expression passes with positive amount", func(t *testing.T) {
+		def := newCELTestDefinition("CEL_VALID_AMOUNT", `parse_decimal(amount) > 0.0`, "")
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		result, err := reg.ValidateTransaction(ctx, "CEL_VALID_AMOUNT", 1, accounttype.AttributeBag{
+			Amount: "100.00",
+		})
+		require.NoError(t, err)
+		assert.True(t, result.Valid)
+		assert.Empty(t, result.Errors)
+	})
+
+	t.Run("expression fails with zero amount", func(t *testing.T) {
+		def := newCELTestDefinition("CEL_ZERO_AMOUNT", `parse_decimal(amount) > 0.0`, "")
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		result, err := reg.ValidateTransaction(ctx, "CEL_ZERO_AMOUNT", 1, accounttype.AttributeBag{
+			Amount: "0.00",
+		})
+		require.NoError(t, err)
+		assert.False(t, result.Valid)
+		assert.NotEmpty(t, result.Errors)
+	})
+
+	t.Run("definition not found returns ErrNotFound", func(t *testing.T) {
+		_, err := reg.ValidateTransaction(ctx, "NONEXISTENT_VALIDATE", 99, accounttype.AttributeBag{})
+		require.ErrorIs(t, err, accounttype.ErrNotFound)
+	})
+
+	t.Run("second call uses cached program", func(t *testing.T) {
+		def := newCELTestDefinition("CEL_CACHE_TEST", `parse_decimal(amount) > 0.0`, "")
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		result1, err := reg.ValidateTransaction(ctx, "CEL_CACHE_TEST", 1, accounttype.AttributeBag{Amount: "50.00"})
+		require.NoError(t, err)
+
+		result2, err := reg.ValidateTransaction(ctx, "CEL_CACHE_TEST", 1, accounttype.AttributeBag{Amount: "50.00"})
+		require.NoError(t, err)
+
+		assert.Equal(t, result1.Valid, result2.Valid)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CheckEligibility
+// ---------------------------------------------------------------------------
+
+func TestCheckEligibility(t *testing.T) {
+	reg, pool := setupTestAccountTypeRegistry(t)
+	ctx := setupAccountTypeTenantContext(t, pool, "cel-check-elig")
+
+	t.Run("no CEL expression always returns eligible", func(t *testing.T) {
+		def := newTestDefinition("NO_CEL_ELIG", "GBP")
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		result, err := reg.CheckEligibility(ctx, "NO_CEL_ELIG", 1, accounttype.AttributeBag{})
+		require.NoError(t, err)
+		assert.True(t, result.Valid)
+		assert.Empty(t, result.Errors)
+	})
+
+	t.Run("expression passes when attribute matches", func(t *testing.T) {
+		def := newCELTestDefinition("CEL_ELIG_MATCH", "", `party.status == 'ACTIVE'`)
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		result, err := reg.CheckEligibility(ctx, "CEL_ELIG_MATCH", 1, accounttype.AttributeBag{
+			Attributes: map[string]string{"status": "ACTIVE"},
+		})
+		require.NoError(t, err)
+		assert.True(t, result.Valid)
+	})
+
+	t.Run("expression fails when attribute mismatches", func(t *testing.T) {
+		def := newCELTestDefinition("CEL_ELIG_MISMATCH", "", `party.status == 'ACTIVE'`)
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		result, err := reg.CheckEligibility(ctx, "CEL_ELIG_MISMATCH", 1, accounttype.AttributeBag{
+			Attributes: map[string]string{"status": "SUSPENDED"},
+		})
+		require.NoError(t, err)
+		assert.False(t, result.Valid)
+		assert.NotEmpty(t, result.Errors)
+	})
+
+	t.Run("nil attributes defaults to empty map", func(t *testing.T) {
+		def := newCELTestDefinition("CEL_NIL_ATTRS", "", `true`)
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		result, err := reg.CheckEligibility(ctx, "CEL_NIL_ATTRS", 1, accounttype.AttributeBag{
+			Attributes: nil,
+		})
+		require.NoError(t, err)
+		assert.True(t, result.Valid)
+	})
+
+	t.Run("definition not found returns ErrNotFound", func(t *testing.T) {
+		_, err := reg.CheckEligibility(ctx, "NONEXISTENT_ELIG", 1, accounttype.AttributeBag{})
+		require.ErrorIs(t, err, accounttype.ErrNotFound)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// GetProductFeatures
+// ---------------------------------------------------------------------------
+
+func TestGetProductFeatures(t *testing.T) {
+	reg, pool := setupTestAccountTypeRegistry(t)
+	ctx := setupAccountTypeTenantContext(t, pool, "cel-product-features")
+
+	t.Run("returns stored attributes", func(t *testing.T) {
+		def := &accounttype.Definition{
+			Code:            "FEAT_TEST",
+			Version:         1,
+			DisplayName:     "Feature Test",
+			NormalBalance:   accounttype.NormalBalanceCredit,
+			BehaviorClass:   accounttype.BehaviorClassCustomer,
+			InstrumentCode:  "GBP",
+			AttributeSchema: json.RawMessage(`{}`),
+			Attributes:      map[string]any{"tier": "gold", "limit": float64(5000)},
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		features, err := reg.GetProductFeatures(ctx, "FEAT_TEST", 1)
+		require.NoError(t, err)
+		assert.Equal(t, "gold", features["tier"])
+		assert.Equal(t, float64(5000), features["limit"])
+	})
+
+	t.Run("nil attributes returns empty map", func(t *testing.T) {
+		def := &accounttype.Definition{
+			Code:            "FEAT_NIL",
+			Version:         1,
+			DisplayName:     "Feature Nil Test",
+			NormalBalance:   accounttype.NormalBalanceCredit,
+			BehaviorClass:   accounttype.BehaviorClassCustomer,
+			InstrumentCode:  "GBP",
+			AttributeSchema: json.RawMessage(`{}`),
+			Attributes:      nil,
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		features, err := reg.GetProductFeatures(ctx, "FEAT_NIL", 1)
+		require.NoError(t, err)
+		assert.NotNil(t, features)
+		assert.Empty(t, features)
+	})
+
+	t.Run("definition not found returns ErrNotFound", func(t *testing.T) {
+		_, err := reg.GetProductFeatures(ctx, "NONEXISTENT_FEAT", 1)
+		require.ErrorIs(t, err, accounttype.ErrNotFound)
+	})
+}

--- a/services/reference-data/accounttype/postgres_registry_helpers_test.go
+++ b/services/reference-data/accounttype/postgres_registry_helpers_test.go
@@ -1,0 +1,194 @@
+package accounttype
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// hasNonEmptySchema
+// ---------------------------------------------------------------------------
+
+func TestHasNonEmptySchema_NilOrEmpty(t *testing.T) {
+	assert.False(t, hasNonEmptySchema(nil))
+	assert.False(t, hasNonEmptySchema(json.RawMessage("")))
+	assert.False(t, hasNonEmptySchema(json.RawMessage("  ")))
+}
+
+func TestHasNonEmptySchema_EmptyObject(t *testing.T) {
+	assert.False(t, hasNonEmptySchema(json.RawMessage("{}")))
+	assert.False(t, hasNonEmptySchema(json.RawMessage("  {}  ")))
+}
+
+func TestHasNonEmptySchema_NullLiteral(t *testing.T) {
+	assert.False(t, hasNonEmptySchema(json.RawMessage("null")))
+}
+
+func TestHasNonEmptySchema_NonEmptySchema(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object","properties":{"amount":{"type":"number"}}}`)
+	assert.True(t, hasNonEmptySchema(schema))
+}
+
+// ---------------------------------------------------------------------------
+// nullString
+// ---------------------------------------------------------------------------
+
+func TestNullString_EmptyString(t *testing.T) {
+	ns := nullString("")
+	assert.False(t, ns.Valid)
+	assert.Equal(t, "", ns.String)
+}
+
+func TestNullString_NonEmptyString(t *testing.T) {
+	ns := nullString("hello")
+	assert.True(t, ns.Valid)
+	assert.Equal(t, "hello", ns.String)
+}
+
+func TestNullString_Whitespace(t *testing.T) {
+	// Whitespace is NOT empty - only empty string becomes NULL.
+	ns := nullString("  ")
+	assert.True(t, ns.Valid)
+	assert.Equal(t, "  ", ns.String)
+}
+
+// ---------------------------------------------------------------------------
+// marshalAttributes
+// ---------------------------------------------------------------------------
+
+func TestMarshalAttributes_Nil(t *testing.T) {
+	b, err := marshalAttributes(nil)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("{}"), b)
+}
+
+func TestMarshalAttributes_EmptyMap(t *testing.T) {
+	b, err := marshalAttributes(map[string]any{})
+	require.NoError(t, err)
+	assert.JSONEq(t, "{}", string(b))
+}
+
+func TestMarshalAttributes_NonEmpty(t *testing.T) {
+	attrs := map[string]any{"key": "value", "count": 42}
+	b, err := marshalAttributes(attrs)
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(b, &result))
+	assert.Equal(t, "value", result["key"])
+	assert.Equal(t, float64(42), result["count"])
+}
+
+// ---------------------------------------------------------------------------
+// validateJSONSchema
+// ---------------------------------------------------------------------------
+
+func TestValidateJSONSchema_ValidMinimalSchema(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object"}`)
+	err := validateJSONSchema(schema)
+	assert.NoError(t, err)
+}
+
+func TestValidateJSONSchema_ValidFullSchema(t *testing.T) {
+	schema := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"amount": {"type": "number"},
+			"currency": {"type": "string"}
+		},
+		"required": ["amount"]
+	}`)
+	err := validateJSONSchema(schema)
+	assert.NoError(t, err)
+}
+
+func TestValidateJSONSchema_InvalidJSON(t *testing.T) {
+	schema := json.RawMessage(`not valid json`)
+	err := validateJSONSchema(schema)
+	assert.Error(t, err)
+}
+
+func TestValidateJSONSchema_InvalidSchemaStructure(t *testing.T) {
+	// Valid JSON but invalid JSON Schema (unknown type).
+	schema := json.RawMessage(`{"type": "not_a_valid_type"}`)
+	err := validateJSONSchema(schema)
+	assert.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// validateSchemaIfPresent
+// ---------------------------------------------------------------------------
+
+func TestValidateSchemaIfPresent_NilSchema(t *testing.T) {
+	err := validateSchemaIfPresent(nil)
+	assert.NoError(t, err)
+}
+
+func TestValidateSchemaIfPresent_EmptyObjectSchema(t *testing.T) {
+	err := validateSchemaIfPresent(json.RawMessage("{}"))
+	assert.NoError(t, err)
+}
+
+func TestValidateSchemaIfPresent_ValidSchema(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object","properties":{"n":{"type":"number"}}}`)
+	err := validateSchemaIfPresent(schema)
+	assert.NoError(t, err)
+}
+
+func TestValidateSchemaIfPresent_InvalidSchemaWrapsError(t *testing.T) {
+	schema := json.RawMessage(`not json`)
+	err := validateSchemaIfPresent(schema)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidAttributeSchema)
+}
+
+// ---------------------------------------------------------------------------
+// validateAttributesAgainstSchema
+// ---------------------------------------------------------------------------
+
+func TestValidateAttributesAgainstSchema_ValidAttributes(t *testing.T) {
+	schema := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"tier": {"type": "string"},
+			"limit": {"type": "number"}
+		},
+		"required": ["tier"]
+	}`)
+	attrs := map[string]any{"tier": "gold", "limit": 5000.0}
+	err := validateAttributesAgainstSchema(schema, attrs)
+	assert.NoError(t, err)
+}
+
+func TestValidateAttributesAgainstSchema_MissingRequiredField(t *testing.T) {
+	schema := json.RawMessage(`{
+		"type": "object",
+		"properties": {"tier": {"type": "string"}},
+		"required": ["tier"]
+	}`)
+	attrs := map[string]any{"limit": 1000.0}
+	err := validateAttributesAgainstSchema(schema, attrs)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAttributesInvalid)
+}
+
+func TestValidateAttributesAgainstSchema_WrongType(t *testing.T) {
+	schema := json.RawMessage(`{
+		"type": "object",
+		"properties": {"limit": {"type": "number"}}
+	}`)
+	attrs := map[string]any{"limit": "not-a-number"}
+	err := validateAttributesAgainstSchema(schema, attrs)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAttributesInvalid)
+}
+
+func TestValidateAttributesAgainstSchema_EmptyAttrsEmptySchema(t *testing.T) {
+	schema := json.RawMessage(`{"type": "object"}`)
+	attrs := map[string]any{}
+	err := validateAttributesAgainstSchema(schema, attrs)
+	assert.NoError(t, err)
+}

--- a/services/reference-data/cel/compiler_test.go
+++ b/services/reference-data/cel/compiler_test.go
@@ -1,0 +1,98 @@
+package cel_test
+
+import (
+	"errors"
+	"testing"
+
+	refcel "github.com/meridianhub/meridian/services/reference-data/cel"
+	sharedcel "github.com/meridianhub/meridian/shared/pkg/cel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// NewCompiler re-export
+// ---------------------------------------------------------------------------
+
+func TestNewCompiler_ReturnsCompilerWithoutError(t *testing.T) {
+	compiler, err := refcel.NewCompiler()
+	require.NoError(t, err)
+	assert.NotNil(t, compiler)
+}
+
+func TestNewCompiler_IsAliasForSharedCompiler(t *testing.T) {
+	// Both constructors should succeed and produce working compilers.
+	refCompiler, err := refcel.NewCompiler()
+	require.NoError(t, err)
+
+	sharedCompiler, err := sharedcel.NewCompiler()
+	require.NoError(t, err)
+
+	// Both compilers should compile valid expressions without error.
+	_, err = refCompiler.CompileValidation(`parse_decimal(amount) > 0.0`)
+	assert.NoError(t, err)
+
+	_, err = sharedCompiler.CompileValidation(`parse_decimal(amount) > 0.0`)
+	assert.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// Constant re-exports
+// ---------------------------------------------------------------------------
+
+func TestConstants_AreReExported(t *testing.T) {
+	assert.Equal(t, sharedcel.CELVersion, refcel.CELVersion)
+	assert.Equal(t, sharedcel.MaxExpressionLength, refcel.MaxExpressionLength)
+	assert.Equal(t, sharedcel.MaxExpressionDepth, refcel.MaxExpressionDepth)
+	assert.Equal(t, sharedcel.CostLimit, refcel.CostLimit)
+}
+
+// ---------------------------------------------------------------------------
+// Error variable re-exports
+// ---------------------------------------------------------------------------
+
+func TestErrors_AreReExported(t *testing.T) {
+	assert.True(t, errors.Is(refcel.ErrExpressionTooLong, sharedcel.ErrExpressionTooLong))
+	assert.True(t, errors.Is(refcel.ErrExpressionTooDeep, sharedcel.ErrExpressionTooDeep))
+	assert.True(t, errors.Is(refcel.ErrEnvironmentCreation, sharedcel.ErrEnvironmentCreation))
+	assert.True(t, errors.Is(refcel.ErrCompilation, sharedcel.ErrCompilation))
+	assert.True(t, errors.Is(refcel.ErrEligibilityNotBool, sharedcel.ErrEligibilityNotBool))
+	assert.True(t, errors.Is(refcel.ErrBucketKeyNotString, sharedcel.ErrBucketKeyNotString))
+	assert.True(t, errors.Is(refcel.ErrValidationNotBool, sharedcel.ErrValidationNotBool))
+}
+
+// ---------------------------------------------------------------------------
+// CompileValidation via re-exported Compiler type
+// ---------------------------------------------------------------------------
+
+func TestCompiler_ValidatesValidExpression(t *testing.T) {
+	compiler, err := refcel.NewCompiler()
+	require.NoError(t, err)
+
+	_, err = compiler.CompileValidation(`parse_decimal(amount) > 0.0`)
+	assert.NoError(t, err)
+}
+
+func TestCompiler_RejectsInvalidExpression(t *testing.T) {
+	compiler, err := refcel.NewCompiler()
+	require.NoError(t, err)
+
+	_, err = compiler.CompileValidation(`undefined_variable_xyz > 0`)
+	assert.Error(t, err)
+}
+
+func TestCompiler_CompileEligibility_ValidExpression(t *testing.T) {
+	compiler, err := refcel.NewCompiler()
+	require.NoError(t, err)
+
+	_, err = compiler.CompileEligibility(`party.status == 'ACTIVE'`)
+	assert.NoError(t, err)
+}
+
+func TestCompiler_CompileBucketKey_ValidExpression(t *testing.T) {
+	compiler, err := refcel.NewCompiler()
+	require.NoError(t, err)
+
+	_, err = compiler.CompileBucketKey(`bucket_key([attributes["type"]])`)
+	assert.NoError(t, err)
+}

--- a/services/reference-data/mapping/errors_test.go
+++ b/services/reference-data/mapping/errors_test.go
@@ -1,0 +1,79 @@
+package mapping_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/reference-data/mapping"
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// Error sentinel existence
+// ---------------------------------------------------------------------------
+
+func TestMappingErrors_AllSentinelsNonNil(t *testing.T) {
+	sentinels := []error{
+		mapping.ErrNotFound,
+		mapping.ErrNotDraft,
+		mapping.ErrNotActive,
+		mapping.ErrAlreadyExists,
+		mapping.ErrInvalidCEL,
+		mapping.ErrInvalidJSON,
+		mapping.ErrInvalidJSONSchema,
+		mapping.ErrInvalidGjsonPath,
+		mapping.ErrDuplicateExternalPath,
+		mapping.ErrDuplicateInternalPath,
+		mapping.ErrBatchTargetPathRequired,
+		mapping.ErrIdempotencyConfig,
+		mapping.ErrOptimisticLock,
+		mapping.ErrInvalidStatusTransition,
+		mapping.ErrTransformVariantRequired,
+		mapping.ErrTransformVariantConflict,
+		mapping.ErrCELCompilerNil,
+		mapping.ErrRequiredField,
+	}
+
+	for _, e := range sentinels {
+		assert.NotNil(t, e)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Error sentinel identity (errors.Is)
+// ---------------------------------------------------------------------------
+
+func TestMappingErrors_SentinelsMatchThemselves(t *testing.T) {
+	assert.True(t, errors.Is(mapping.ErrNotFound, mapping.ErrNotFound))
+	assert.True(t, errors.Is(mapping.ErrNotDraft, mapping.ErrNotDraft))
+	assert.True(t, errors.Is(mapping.ErrNotActive, mapping.ErrNotActive))
+	assert.True(t, errors.Is(mapping.ErrAlreadyExists, mapping.ErrAlreadyExists))
+	assert.True(t, errors.Is(mapping.ErrInvalidCEL, mapping.ErrInvalidCEL))
+	assert.True(t, errors.Is(mapping.ErrInvalidJSON, mapping.ErrInvalidJSON))
+	assert.True(t, errors.Is(mapping.ErrCELCompilerNil, mapping.ErrCELCompilerNil))
+	assert.True(t, errors.Is(mapping.ErrRequiredField, mapping.ErrRequiredField))
+}
+
+// ---------------------------------------------------------------------------
+// Error sentinel distinctness
+// ---------------------------------------------------------------------------
+
+func TestMappingErrors_SentinelsAreDistinct(t *testing.T) {
+	assert.NotEqual(t, mapping.ErrNotFound, mapping.ErrNotDraft)
+	assert.NotEqual(t, mapping.ErrNotDraft, mapping.ErrNotActive)
+	assert.NotEqual(t, mapping.ErrAlreadyExists, mapping.ErrNotFound)
+	assert.NotEqual(t, mapping.ErrInvalidCEL, mapping.ErrInvalidJSON)
+	assert.NotEqual(t, mapping.ErrInvalidJSONSchema, mapping.ErrInvalidGjsonPath)
+	assert.NotEqual(t, mapping.ErrDuplicateExternalPath, mapping.ErrDuplicateInternalPath)
+	assert.NotEqual(t, mapping.ErrTransformVariantRequired, mapping.ErrTransformVariantConflict)
+	assert.NotEqual(t, mapping.ErrCELCompilerNil, mapping.ErrRequiredField)
+}
+
+// ---------------------------------------------------------------------------
+// Wrapping with errors.Is
+// ---------------------------------------------------------------------------
+
+func TestMappingErrors_IsWrappable(t *testing.T) {
+	wrapped := errors.Join(mapping.ErrNotFound, errors.New("additional context"))
+	assert.True(t, errors.Is(wrapped, mapping.ErrNotFound))
+}

--- a/services/reference-data/saga/reference_extractor_test.go
+++ b/services/reference-data/saga/reference_extractor_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.starlark.net/syntax" //nolint:depguard // required for direct AST walking in internal extractor tests
+	"go.starlark.net/syntax"
 )
 
 // parseAndExtractFull parses a full Starlark file and returns extracted references.

--- a/services/reference-data/saga/reference_extractor_test.go
+++ b/services/reference-data/saga/reference_extractor_test.go
@@ -1,0 +1,234 @@
+package saga
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.starlark.net/syntax" //nolint:depguard
+)
+
+// parseAndExtractFull parses a full Starlark file and returns extracted references.
+func parseAndExtractFull(t *testing.T, script string) ([]Reference, error) {
+	t.Helper()
+
+	opts := &syntax.FileOptions{}
+	f, err := opts.Parse("test.star", script, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	e := &referenceExtractor{}
+	for _, stmt := range f.Stmts {
+		e.walkStmt(stmt)
+	}
+	return e.references, nil
+}
+
+// ---------------------------------------------------------------------------
+// resolve_instrument
+// ---------------------------------------------------------------------------
+
+func TestReferenceExtractor_InstrumentRef(t *testing.T) {
+	refs, err := parseAndExtractFull(t, `x = resolve_instrument("GBP")`)
+	require.NoError(t, err)
+
+	require.Len(t, refs, 1)
+	assert.Equal(t, ReferenceTypeInstrument, refs[0].Type)
+	assert.Equal(t, "GBP", refs[0].Key)
+}
+
+func TestReferenceExtractor_InstrumentRef_SingleQuotes(t *testing.T) {
+	refs, err := parseAndExtractFull(t, `x = resolve_instrument('USD')`)
+	require.NoError(t, err)
+
+	require.Len(t, refs, 1)
+	assert.Equal(t, ReferenceTypeInstrument, refs[0].Type)
+	assert.Equal(t, "USD", refs[0].Key)
+}
+
+func TestReferenceExtractor_InstrumentRef_NoArgs(t *testing.T) {
+	// Should not produce a reference if no literal argument.
+	refs, err := parseAndExtractFull(t, `x = resolve_instrument()`)
+	require.NoError(t, err)
+	assert.Empty(t, refs)
+}
+
+// ---------------------------------------------------------------------------
+// resolve_account
+// ---------------------------------------------------------------------------
+
+func TestReferenceExtractor_AccountRef(t *testing.T) {
+	refs, err := parseAndExtractFull(t, `acc = resolve_account("clearing_account")`)
+	require.NoError(t, err)
+
+	require.Len(t, refs, 1)
+	assert.Equal(t, ReferenceTypeAccount, refs[0].Type)
+	assert.Equal(t, "clearing_account", refs[0].Key)
+}
+
+// ---------------------------------------------------------------------------
+// invoke_saga
+// ---------------------------------------------------------------------------
+
+func TestReferenceExtractor_InvokeSaga_PositionalArg(t *testing.T) {
+	refs, err := parseAndExtractFull(t, `invoke_saga("payment.process", params={})`)
+	require.NoError(t, err)
+
+	require.Len(t, refs, 1)
+	assert.Equal(t, ReferenceTypeSaga, refs[0].Type)
+	assert.Equal(t, "payment.process", refs[0].Key)
+}
+
+func TestReferenceExtractor_InvokeSaga_KeywordArg(t *testing.T) {
+	refs, err := parseAndExtractFull(t, `invoke_saga(saga_name="fee.calculate", params={})`)
+	require.NoError(t, err)
+
+	require.Len(t, refs, 1)
+	assert.Equal(t, ReferenceTypeSaga, refs[0].Type)
+	assert.Equal(t, "fee.calculate", refs[0].Key)
+}
+
+// ---------------------------------------------------------------------------
+// step handler
+// ---------------------------------------------------------------------------
+
+func TestReferenceExtractor_StepHandler(t *testing.T) {
+	script := `step(action="position_keeping.initiate_log", params={"amount": "100"})`
+	refs, err := parseAndExtractFull(t, script)
+	require.NoError(t, err)
+
+	require.Len(t, refs, 1)
+	assert.Equal(t, ReferenceTypeStepHandler, refs[0].Type)
+	assert.Equal(t, "position_keeping.initiate_log", refs[0].Key)
+	assert.True(t, refs[0].ParamsKnown)
+	assert.Contains(t, refs[0].Params, "amount")
+}
+
+func TestReferenceExtractor_StepHandler_NoAction(t *testing.T) {
+	// step() without action kwarg produces no reference.
+	refs, err := parseAndExtractFull(t, `step(params={"amount": "100"})`)
+	require.NoError(t, err)
+	assert.Empty(t, refs)
+}
+
+func TestReferenceExtractor_StepHandler_VariableParams(t *testing.T) {
+	script := `step(action="my.handler", params=my_dict)`
+	refs, err := parseAndExtractFull(t, script)
+	require.NoError(t, err)
+
+	require.Len(t, refs, 1)
+	assert.Equal(t, ReferenceTypeStepHandler, refs[0].Type)
+	assert.False(t, refs[0].ParamsKnown, "params from variable should mark ParamsKnown=false")
+}
+
+// ---------------------------------------------------------------------------
+// Attribute access
+// ---------------------------------------------------------------------------
+
+func TestReferenceExtractor_AttributeAccess(t *testing.T) {
+	script := `val = resolve_instrument("GBP").attributes["precision"]`
+	refs, err := parseAndExtractFull(t, script)
+	require.NoError(t, err)
+
+	// Should produce instrument ref AND attribute ref.
+	var attrRefs []Reference
+	for _, r := range refs {
+		if r.Type == ReferenceTypeAttribute {
+			attrRefs = append(attrRefs, r)
+		}
+	}
+	require.Len(t, attrRefs, 1)
+	assert.Equal(t, "precision", attrRefs[0].AttributeKey)
+	assert.Equal(t, "GBP", attrRefs[0].InstrumentCode)
+}
+
+// ---------------------------------------------------------------------------
+// Nested / compound statements
+// ---------------------------------------------------------------------------
+
+func TestReferenceExtractor_IfStatement(t *testing.T) {
+	script := `
+if True:
+    x = resolve_instrument("GBP")
+else:
+    x = resolve_instrument("USD")
+`
+	refs, err := parseAndExtractFull(t, script)
+	require.NoError(t, err)
+
+	codes := make([]string, 0, len(refs))
+	for _, r := range refs {
+		if r.Type == ReferenceTypeInstrument {
+			codes = append(codes, r.Key)
+		}
+	}
+	assert.Contains(t, codes, "GBP")
+	assert.Contains(t, codes, "USD")
+}
+
+func TestReferenceExtractor_ForStatement(t *testing.T) {
+	script := `
+for item in items:
+    x = resolve_instrument("EUR")
+`
+	refs, err := parseAndExtractFull(t, script)
+	require.NoError(t, err)
+
+	require.Len(t, refs, 1)
+	assert.Equal(t, "EUR", refs[0].Key)
+}
+
+func TestReferenceExtractor_DefStatement(t *testing.T) {
+	script := `
+def my_func():
+    return resolve_instrument("CHF")
+`
+	refs, err := parseAndExtractFull(t, script)
+	require.NoError(t, err)
+
+	require.Len(t, refs, 1)
+	assert.Equal(t, "CHF", refs[0].Key)
+}
+
+// ---------------------------------------------------------------------------
+// Multiple references in one script
+// ---------------------------------------------------------------------------
+
+func TestReferenceExtractor_MultipleTypes(t *testing.T) {
+	script := `
+instrument = resolve_instrument("GBP")
+account = resolve_account("clearing")
+step(action="position_keeping.initiate_log", params={"amount": "0"})
+invoke_saga("fee.calculate", params={})
+`
+	refs, err := parseAndExtractFull(t, script)
+	require.NoError(t, err)
+
+	typeCount := map[ReferenceType]int{}
+	for _, r := range refs {
+		typeCount[r.Type]++
+	}
+	assert.Equal(t, 1, typeCount[ReferenceTypeInstrument])
+	assert.Equal(t, 1, typeCount[ReferenceTypeAccount])
+	assert.Equal(t, 1, typeCount[ReferenceTypeStepHandler])
+	assert.Equal(t, 1, typeCount[ReferenceTypeSaga])
+}
+
+// ---------------------------------------------------------------------------
+// walkExpr edge cases
+// ---------------------------------------------------------------------------
+
+func TestReferenceExtractor_NilExpr_DoesNotPanic(t *testing.T) {
+	e := &referenceExtractor{}
+	// Should not panic.
+	assert.NotPanics(t, func() {
+		e.walkExpr(nil)
+	})
+}
+
+func TestReferenceExtractor_EmptyScript_ProducesNoRefs(t *testing.T) {
+	refs, err := parseAndExtractFull(t, ``)
+	require.NoError(t, err)
+	assert.Empty(t, refs)
+}

--- a/services/reference-data/saga/reference_extractor_test.go
+++ b/services/reference-data/saga/reference_extractor_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.starlark.net/syntax" //nolint:depguard
+	"go.starlark.net/syntax" //nolint:depguard // required for direct AST walking in internal extractor tests
 )
 
 // parseAndExtractFull parses a full Starlark file and returns extracted references.

--- a/services/reference-data/saga/reference_extractor_test.go
+++ b/services/reference-data/saga/reference_extractor_test.go
@@ -132,12 +132,17 @@ func TestReferenceExtractor_AttributeAccess(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should produce instrument ref AND attribute ref.
-	var attrRefs []Reference
+	var instrRefs, attrRefs []Reference
 	for _, r := range refs {
-		if r.Type == ReferenceTypeAttribute {
+		switch r.Type {
+		case ReferenceTypeInstrument:
+			instrRefs = append(instrRefs, r)
+		case ReferenceTypeAttribute:
 			attrRefs = append(attrRefs, r)
 		}
 	}
+	require.Len(t, instrRefs, 1)
+	assert.Equal(t, "GBP", instrRefs[0].Key)
 	require.Len(t, attrRefs, 1)
 	assert.Equal(t, "precision", attrRefs[0].AttributeKey)
 	assert.Equal(t, "GBP", attrRefs[0].InstrumentCode)

--- a/services/reference-data/saga/version_pinning_test.go
+++ b/services/reference-data/saga/version_pinning_test.go
@@ -1,0 +1,201 @@
+package saga_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reference-data/saga"
+	pkgsaga "github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// ComputeScriptHash / VerifyScriptHash (pure unit tests - no DB)
+// ---------------------------------------------------------------------------
+
+func TestComputeScriptHash(t *testing.T) {
+	t.Run("deterministic", func(t *testing.T) {
+		h1 := saga.ComputeScriptHash("def posting_rules(ctx): pass")
+		h2 := saga.ComputeScriptHash("def posting_rules(ctx): pass")
+		assert.Equal(t, h1, h2)
+	})
+
+	t.Run("different inputs produce different hashes", func(t *testing.T) {
+		h1 := saga.ComputeScriptHash("script_a")
+		h2 := saga.ComputeScriptHash("script_b")
+		assert.NotEqual(t, h1, h2)
+	})
+
+	t.Run("empty string returns 64-char hex", func(t *testing.T) {
+		h := saga.ComputeScriptHash("")
+		assert.Len(t, h, 64)
+	})
+
+	t.Run("returns lowercase hex only", func(t *testing.T) {
+		h := saga.ComputeScriptHash("some script content")
+		assert.Len(t, h, 64)
+		for _, c := range h {
+			assert.True(t, (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'),
+				"hash must be lowercase hex, got %c", c)
+		}
+	})
+}
+
+func TestVerifyScriptHash(t *testing.T) {
+	t.Run("matching hash returns nil", func(t *testing.T) {
+		script := "def posting_rules(ctx): return []"
+		hash := saga.ComputeScriptHash(script)
+		assert.NoError(t, saga.VerifyScriptHash(script, hash))
+	})
+
+	t.Run("mismatched hash returns ErrScriptHashMismatch", func(t *testing.T) {
+		script := "def posting_rules(ctx): return []"
+		wrongHash := saga.ComputeScriptHash("different script")
+		err := saga.VerifyScriptHash(script, wrongHash)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, saga.ErrScriptHashMismatch)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// VersionPinning.PinVersion (integration - requires DB)
+// ---------------------------------------------------------------------------
+
+func TestVersionPinning_PinVersion(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "vp-pin-tenant")
+
+	script := "def posting_rules(ctx):\n    return []"
+	def := &saga.Definition{
+		Name:    "payment.process",
+		Version: 1,
+		Script:  script,
+	}
+	require.NoError(t, reg.CreateDraft(ctx, def))
+	require.NoError(t, reg.ActivateSaga(ctx, def.ID))
+
+	vp := saga.NewVersionPinning(reg)
+
+	t.Run("pins tenant script and records hash", func(t *testing.T) {
+		instance := &pkgsaga.SagaInstance{ID: uuid.New()}
+		resolved, err := vp.PinVersion(ctx, instance, "payment.process")
+		require.NoError(t, err)
+		assert.NotNil(t, resolved)
+		assert.Equal(t, def.ID, instance.SagaDefinitionID)
+		assert.NotEmpty(t, instance.ScriptHashAtStart)
+		// Tenant-only saga: no platform version to pin.
+		assert.Nil(t, instance.PlatformSagaVersionID)
+	})
+
+	t.Run("hash at start matches actual script", func(t *testing.T) {
+		instance := &pkgsaga.SagaInstance{ID: uuid.New()}
+		_, err := vp.PinVersion(ctx, instance, "payment.process")
+		require.NoError(t, err)
+		assert.Equal(t, saga.ComputeScriptHash(script), instance.ScriptHashAtStart)
+	})
+
+	t.Run("unknown saga name returns error", func(t *testing.T) {
+		instance := &pkgsaga.SagaInstance{ID: uuid.New()}
+		_, err := vp.PinVersion(ctx, instance, "nonexistent.saga")
+		require.Error(t, err)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// VersionPinning.ResolveForReplay (integration - requires DB)
+// ---------------------------------------------------------------------------
+
+func TestVersionPinning_ResolveForReplay(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "vp-replay-tenant")
+
+	script := "def posting_rules(ctx):\n    return []"
+	def := &saga.Definition{
+		Name:    "deposit.process",
+		Version: 1,
+		Script:  script,
+	}
+	require.NoError(t, reg.CreateDraft(ctx, def))
+	require.NoError(t, reg.ActivateSaga(ctx, def.ID))
+
+	vp := saga.NewVersionPinning(reg)
+
+	t.Run("resolves correct script for tenant saga", func(t *testing.T) {
+		instance := &pkgsaga.SagaInstance{ID: uuid.New()}
+		_, err := vp.PinVersion(ctx, instance, "deposit.process")
+		require.NoError(t, err)
+
+		resolvedScript, err := vp.ResolveForReplay(ctx, instance)
+		require.NoError(t, err)
+		assert.Equal(t, script, resolvedScript)
+	})
+
+	t.Run("corrupted hash returns ErrScriptHashMismatch", func(t *testing.T) {
+		instance := &pkgsaga.SagaInstance{
+			ID:                    uuid.New(),
+			SagaDefinitionID:      def.ID,
+			ScriptHashAtStart:     "0000000000000000000000000000000000000000000000000000000000000000",
+			PlatformSagaVersionID: nil,
+		}
+
+		_, err := vp.ResolveForReplay(ctx, instance)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, saga.ErrScriptHashMismatch)
+	})
+}
+
+func TestVersionPinning_ResolveForReplay_PlatformVersion(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "vp-replay-platform")
+
+	platformScript := "def posting_rules(ctx):\n    pass"
+	platformID := seedPlatformSaga(t, pool, ctx, "platform.transfer", platformScript)
+
+	tenantDefID := seedTenantSagaWithPlatformRef(t, pool, ctx, "platform.transfer", 1, platformID, "ACTIVE")
+	vp := saga.NewVersionPinning(reg)
+
+	t.Run("resolves pinned platform script", func(t *testing.T) {
+		instance := &pkgsaga.SagaInstance{
+			ID:                    uuid.New(),
+			SagaDefinitionID:      tenantDefID,
+			PlatformSagaVersionID: &platformID,
+			ScriptHashAtStart:     saga.ComputeScriptHash(platformScript),
+		}
+
+		resolvedScript, err := vp.ResolveForReplay(ctx, instance)
+		require.NoError(t, err)
+		assert.Equal(t, platformScript, resolvedScript)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// VersionPinning.GetResolvedDefinition (integration - requires DB)
+// ---------------------------------------------------------------------------
+
+func TestVersionPinning_GetResolvedDefinition(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "vp-get-resolved")
+
+	def := &saga.Definition{
+		Name:    "refund.process",
+		Version: 1,
+		Script:  "def posting_rules(ctx):\n    return []",
+	}
+	require.NoError(t, reg.CreateDraft(ctx, def))
+	require.NoError(t, reg.ActivateSaga(ctx, def.ID))
+
+	vp := saga.NewVersionPinning(reg)
+
+	t.Run("returns definition with resolved script", func(t *testing.T) {
+		resolved, err := vp.GetResolvedDefinition(ctx, def.ID)
+		require.NoError(t, err)
+		assert.Equal(t, def.ID, resolved.ID)
+		assert.NotEmpty(t, resolved.ResolvedScript)
+	})
+
+	t.Run("unknown ID returns ErrNotFound", func(t *testing.T) {
+		_, err := vp.GetResolvedDefinition(ctx, uuid.New())
+		require.ErrorIs(t, err, saga.ErrNotFound)
+	})
+}

--- a/services/reference-data/valuation/domain_test.go
+++ b/services/reference-data/valuation/domain_test.go
@@ -1,0 +1,149 @@
+package valuation_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reference-data/valuation"
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// LifecycleStatus constants
+// ---------------------------------------------------------------------------
+
+func TestLifecycleStatus_Constants(t *testing.T) {
+	assert.Equal(t, valuation.LifecycleStatus("INITIATED"), valuation.StatusInitiated)
+	assert.Equal(t, valuation.LifecycleStatus("ACTIVE"), valuation.StatusActive)
+	assert.Equal(t, valuation.LifecycleStatus("DEPRECATED"), valuation.StatusDeprecated)
+}
+
+func TestLifecycleStatus_StringRepresentation(t *testing.T) {
+	assert.Equal(t, "INITIATED", string(valuation.StatusInitiated))
+	assert.Equal(t, "ACTIVE", string(valuation.StatusActive))
+	assert.Equal(t, "DEPRECATED", string(valuation.StatusDeprecated))
+}
+
+// ---------------------------------------------------------------------------
+// Domain error sentinels
+// ---------------------------------------------------------------------------
+
+func TestValuationErrors_AreSentinels(t *testing.T) {
+	errs := []error{
+		valuation.ErrNotFound,
+		valuation.ErrAlreadyExists,
+		valuation.ErrSystemReadOnly,
+		valuation.ErrNotInitiated,
+		valuation.ErrNotActive,
+		valuation.ErrInvalidCEL,
+		valuation.ErrRequiredPolicyMissing,
+	}
+	for _, e := range errs {
+		assert.NotNil(t, e, "error sentinel should not be nil")
+		assert.True(t, errors.Is(e, e), "sentinel should match itself via errors.Is")
+	}
+}
+
+func TestValuationErrors_AreDistinct(t *testing.T) {
+	assert.NotEqual(t, valuation.ErrNotFound, valuation.ErrAlreadyExists)
+	assert.NotEqual(t, valuation.ErrSystemReadOnly, valuation.ErrNotInitiated)
+	assert.NotEqual(t, valuation.ErrNotActive, valuation.ErrInvalidCEL)
+	assert.NotEqual(t, valuation.ErrRequiredPolicyMissing, valuation.ErrNotFound)
+}
+
+// ---------------------------------------------------------------------------
+// Method struct
+// ---------------------------------------------------------------------------
+
+func TestMethod_CanBeConstructedWithRequiredFields(t *testing.T) {
+	now := time.Now().UTC()
+	m := &valuation.Method{
+		ID:               uuid.New(),
+		Name:             "gbp_to_usd",
+		Version:          1,
+		InputInstrument:  "GBP",
+		OutputInstrument: "USD",
+		LogicScript:      "def convert(ctx): return ctx.amount * 1.25",
+		LifecycleStatus:  valuation.StatusInitiated,
+		CreatedAt:        now,
+		ValidFrom:        now,
+	}
+
+	assert.NotEqual(t, uuid.Nil, m.ID)
+	assert.Equal(t, "gbp_to_usd", m.Name)
+	assert.Equal(t, 1, m.Version)
+	assert.Equal(t, "GBP", m.InputInstrument)
+	assert.Equal(t, "USD", m.OutputInstrument)
+	assert.Equal(t, valuation.StatusInitiated, m.LifecycleStatus)
+	assert.False(t, m.IsSystem)
+	assert.Nil(t, m.ActivatedAt)
+	assert.Nil(t, m.DeprecatedAt)
+	assert.Nil(t, m.ValidTo)
+}
+
+func TestMethod_RequiredPoliciesDefaultNil(t *testing.T) {
+	m := &valuation.Method{}
+	assert.Nil(t, m.RequiredPolicies)
+}
+
+func TestMethod_SystemFlagDefaultsFalse(t *testing.T) {
+	m := &valuation.Method{
+		ID: uuid.New(),
+	}
+	assert.False(t, m.IsSystem)
+}
+
+// ---------------------------------------------------------------------------
+// Policy struct
+// ---------------------------------------------------------------------------
+
+func TestPolicy_CanBeConstructedWithRequiredFields(t *testing.T) {
+	now := time.Now().UTC()
+	p := &valuation.Policy{
+		ID:              uuid.New(),
+		Name:            "exchange_rate_policy",
+		Version:         1,
+		CelExpression:   `inputs.rate > 0.0`,
+		OutputType:      "double",
+		LifecycleStatus: valuation.StatusActive,
+		CreatedAt:       now,
+		ValidFrom:       now,
+	}
+
+	assert.NotEqual(t, uuid.Nil, p.ID)
+	assert.Equal(t, "exchange_rate_policy", p.Name)
+	assert.Equal(t, 1, p.Version)
+	assert.Equal(t, "double", p.OutputType)
+	assert.Equal(t, valuation.StatusActive, p.LifecycleStatus)
+	assert.Nil(t, p.ActivatedAt)
+	assert.Nil(t, p.DeprecatedAt)
+}
+
+// ---------------------------------------------------------------------------
+// DryRunResult struct
+// ---------------------------------------------------------------------------
+
+func TestDryRunResult_SuccessCase(t *testing.T) {
+	r := valuation.DryRunResult{
+		Success:       true,
+		Output:        "1.25",
+		EstimatedCost: 5,
+		Errors:        nil,
+	}
+	assert.True(t, r.Success)
+	assert.Equal(t, "1.25", r.Output)
+	assert.Equal(t, 5, r.EstimatedCost)
+	assert.Empty(t, r.Errors)
+}
+
+func TestDryRunResult_FailureCase(t *testing.T) {
+	r := valuation.DryRunResult{
+		Success: false,
+		Errors:  []string{"compilation error: undefined variable"},
+	}
+	assert.False(t, r.Success)
+	assert.Len(t, r.Errors, 1)
+	assert.Contains(t, r.Errors[0], "compilation error")
+}


### PR DESCRIPTION
## Summary

- Add CEL integration tests for `PostgresRegistry` (ValidateTransaction, CheckEligibility, GetProductFeatures)
- Add whitebox tests for internal accounttype helpers (schema validation, attribute marshalling)
- Add re-export verification tests for the `cel` package
- Add internal tests for the Starlark `referenceExtractor` AST walker
- Add integration tests for `VersionPinning` (PinVersion, ResolveForReplay, GetResolvedDefinition) and pure unit tests for ComputeScriptHash/VerifyScriptHash
- Add domain type tests for the `valuation` package (LifecycleStatus, error sentinels, struct field coverage)
- Add error sentinel completeness and distinctness tests for the `mapping` package

## Test plan

- [x] All new tests compile and pass locally (`go test ./services/reference-data/...`)
- [x] Pure unit tests (no DB): helpers, cel, mapping, valuation domain, extractor, hash functions
- [x] Integration tests (testcontainers postgres): CEL operations, version pinning