### PR TITLE
test: add coverage for frontend hooks

### DIFF
--- a/frontend/src/hooks/use-event-stream.test.tsx
+++ b/frontend/src/hooks/use-event-stream.test.tsx
@@ -22,7 +22,10 @@ class MockWebSocket {
   onmessage: ((ev: MessageEvent) => void) | null = null
   onerror: ((ev: Event) => void) | null = null
   send = vi.fn()
-  close = vi.fn()
+  close = vi.fn(() => {
+    // Mimic real WebSocket: closing fires onclose
+    this.onclose?.(new CloseEvent('close'))
+  })
 
   constructor(url: string) {
     this.url = url
@@ -381,18 +384,32 @@ describe('useEventStream', () => {
     }
   })
 
-  it('closes WebSocket on error then triggers reconnect via onclose', () => {
-    renderHook(() => useEventStream(), { wrapper: createWrapper() })
+  it('closes WebSocket on error then triggers reconnect via onclose', async () => {
+    vi.useFakeTimers()
 
-    act(() => {
-      mockWsInstances[0].simulateOpen()
-    })
+    try {
+      renderHook(() => useEventStream(), { wrapper: createWrapper() })
 
-    act(() => {
-      mockWsInstances[0].simulateError()
-    })
+      act(() => {
+        mockWsInstances[0].simulateOpen()
+      })
+      expect(mockWsInstances).toHaveLength(1)
 
-    expect(mockWsInstances[0].close).toHaveBeenCalled()
+      act(() => {
+        mockWsInstances[0].simulateError()
+      })
+
+      expect(mockWsInstances[0].close).toHaveBeenCalled()
+
+      // close fires onclose, which triggers reconnect with backoff
+      await act(async () => {
+        vi.advanceTimersByTime(3000)
+      })
+
+      expect(mockWsInstances.length).toBeGreaterThanOrEqual(2)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('constructs correct WebSocket URL based on protocol', () => {

--- a/frontend/src/hooks/use-event-stream.test.tsx
+++ b/frontend/src/hooks/use-event-stream.test.tsx
@@ -1,108 +1,402 @@
-import { describe, it, expect, vi } from 'vitest'
-import { renderHook } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
-import { useEventStream, EVENT_QUERY_MAP, type DomainEvent } from './use-event-stream'
-import { TenantProvider } from '@/contexts/tenant-context'
-import { AuthProvider } from '@/contexts/auth-context'
+import { EVENT_QUERY_MAP, type DomainEvent, type UseEventStreamOptions } from './use-event-stream'
 
-const createTestQueryClient = () =>
-  new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-      mutations: { retry: false },
-    },
-  })
+// --- Mocks ---
 
-const createWrapper = () => {
-  const testQueryClient = createTestQueryClient()
+// Mock useTenantSlug to control tenant context without the full provider tree
+const mockTenantSlug = vi.fn<() => string | null>(() => 'acme')
+vi.mock('./use-tenant-context', () => ({
+  useTenantSlug: () => mockTenantSlug(),
+}))
 
+// Track WebSocket instances created by the hook
+let mockWsInstances: MockWebSocket[] = []
+
+class MockWebSocket {
+  url: string
+  onopen: ((ev: Event) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor(url: string) {
+    this.url = url
+    mockWsInstances.push(this)
+  }
+
+  simulateOpen() {
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: unknown) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+
+  simulateClose() {
+    this.onclose?.(new CloseEvent('close'))
+  }
+
+  simulateError() {
+    this.onerror?.(new Event('error'))
+  }
+}
+
+// --- Helpers ---
+
+function createWrapper(queryClient?: QueryClient) {
+  const client =
+    queryClient ??
+    new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    })
   return ({ children }: { children: ReactNode }) => (
-    <QueryClientProvider client={testQueryClient}>
-      <AuthProvider>
-        <TenantProvider>{children}</TenantProvider>
-      </AuthProvider>
-    </QueryClientProvider>
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
   )
 }
 
-describe('useEventStream', () => {
-  it('should return stable interface with connected and lastEvent', () => {
-    const { result } = renderHook(() => useEventStream(), {
-      wrapper: createWrapper(),
-    })
+function makeServerEvent(overrides: Partial<DomainEvent> = {}) {
+  const event: DomainEvent = {
+    eventType: 'AccountStatusChanged',
+    tenantSlug: 'acme',
+    payload: { accountId: 'acc-1' },
+    timestamp: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  }
+  return {
+    type: 'event' as const,
+    event: {
+      event_id: 'evt-1',
+      event_type: event.eventType,
+      tenant_id: event.tenantSlug,
+      timestamp: event.timestamp.toISOString(),
+      payload: event.payload,
+    },
+  }
+}
 
-    expect(result.current).toHaveProperty('connected')
-    expect(result.current).toHaveProperty('lastEvent')
-    expect(result.current).not.toHaveProperty('error')
+// Lazy-import the hook after mocks are set up
+let useEventStream: (
+  options?: UseEventStreamOptions,
+) => { connected: boolean; lastEvent: DomainEvent | null }
+
+beforeEach(async () => {
+  mockWsInstances = []
+  mockTenantSlug.mockReturnValue('acme')
+
+  vi.stubGlobal('WebSocket', MockWebSocket)
+  vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid' })
+
+  const mod = await import('./use-event-stream')
+  useEventStream = mod.useEventStream
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+// --- Tests ---
+
+describe('EVENT_QUERY_MAP', () => {
+  it('maps AccountStatusChanged to account query keys', () => {
+    const event: DomainEvent = {
+      eventType: 'AccountStatusChanged',
+      tenantSlug: 'acme',
+      payload: { accountId: 'acc-1' },
+      timestamp: new Date(),
+    }
+    const keys = EVENT_QUERY_MAP.AccountStatusChanged(event)
+    expect(keys).toEqual([
+      ['tenants', 'acme', 'accounts'],
+      ['tenants', 'acme', 'accounts', 'acc-1'],
+    ])
   })
 
-  it('should initialize with connected=false', () => {
-    const { result } = renderHook(() => useEventStream(), {
+  it('maps TransactionCompleted to account and position-log keys', () => {
+    const event: DomainEvent = {
+      eventType: 'TransactionCompleted',
+      tenantSlug: 'beta',
+      payload: { accountId: 'acc-2' },
+      timestamp: new Date(),
+    }
+    const keys = EVENT_QUERY_MAP.TransactionCompleted(event)
+    expect(keys).toEqual([
+      ['tenants', 'beta', 'accounts', 'acc-2'],
+      ['tenants', 'beta', 'position-logs'],
+    ])
+  })
+
+  it('maps PaymentOrderCompleted to payment-order keys', () => {
+    const event: DomainEvent = {
+      eventType: 'PaymentOrderCompleted',
+      tenantSlug: 'acme',
+      payload: { paymentOrderId: 'po-1' },
+      timestamp: new Date(),
+    }
+    const keys = EVENT_QUERY_MAP.PaymentOrderCompleted(event)
+    expect(keys).toEqual([
+      ['tenants', 'acme', 'payment-orders'],
+      ['tenants', 'acme', 'payment-orders', 'po-1'],
+    ])
+  })
+})
+
+describe('useEventStream', () => {
+  it('connects to WebSocket on mount and sets connected state', () => {
+    const { result } = renderHook(() => useEventStream(), { wrapper: createWrapper() })
+
+    expect(result.current.connected).toBe(false)
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+    })
+
+    expect(result.current.connected).toBe(true)
+  })
+
+  it('sends subscribe message on open', () => {
+    renderHook(() => useEventStream(), { wrapper: createWrapper() })
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+    })
+
+    expect(mockWsInstances[0].send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'subscribe', id: 'test-uuid', channels: ['*'] }),
+    )
+  })
+
+  it('does not connect when tenantSlug is null', () => {
+    mockTenantSlug.mockReturnValue(null)
+
+    renderHook(() => useEventStream(), { wrapper: createWrapper() })
+
+    expect(mockWsInstances).toHaveLength(0)
+  })
+
+  it('delivers events via lastEvent state', () => {
+    const { result } = renderHook(() => useEventStream(), { wrapper: createWrapper() })
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+      mockWsInstances[0].simulateMessage(makeServerEvent())
+    })
+
+    expect(result.current.lastEvent).toEqual({
+      eventType: 'AccountStatusChanged',
+      tenantSlug: 'acme',
+      payload: { accountId: 'acc-1' },
+      timestamp: new Date('2026-01-01T00:00:00Z'),
+    })
+  })
+
+  it('calls onEvent callback when event matches', () => {
+    const onEvent = vi.fn()
+
+    renderHook(() => useEventStream({ onEvent }), { wrapper: createWrapper() })
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+      mockWsInstances[0].simulateMessage(makeServerEvent())
+    })
+
+    expect(onEvent).toHaveBeenCalledTimes(1)
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: 'AccountStatusChanged' }),
+    )
+  })
+
+  it('filters events by eventTypes when specified', () => {
+    const onEvent = vi.fn()
+
+    renderHook(() => useEventStream({ eventTypes: ['TransactionCompleted'], onEvent }), {
       wrapper: createWrapper(),
     })
 
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+      mockWsInstances[0].simulateMessage(makeServerEvent({ eventType: 'AccountStatusChanged' }))
+    })
+
+    expect(onEvent).not.toHaveBeenCalled()
+
+    act(() => {
+      mockWsInstances[0].simulateMessage(
+        makeServerEvent({ eventType: 'TransactionCompleted', payload: { accountId: 'acc-1' } }),
+      )
+    })
+
+    expect(onEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('enforces tenant isolation - ignores events from other tenants', () => {
+    const onEvent = vi.fn()
+
+    renderHook(() => useEventStream({ onEvent }), { wrapper: createWrapper() })
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+      mockWsInstances[0].simulateMessage(makeServerEvent({ tenantSlug: 'other-tenant' }))
+    })
+
+    expect(onEvent).not.toHaveBeenCalled()
+  })
+
+  it('invalidates React Query cache when autoInvalidate is true (default)', () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    })
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    renderHook(() => useEventStream(), { wrapper: createWrapper(queryClient) })
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+      mockWsInstances[0].simulateMessage(makeServerEvent())
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledTimes(2)
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['tenants', 'acme', 'accounts'],
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['tenants', 'acme', 'accounts', 'acc-1'],
+    })
+  })
+
+  it('does not invalidate queries when autoInvalidate is false', () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    })
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    renderHook(() => useEventStream({ autoInvalidate: false }), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+      mockWsInstances[0].simulateMessage(makeServerEvent())
+    })
+
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not invalidate queries for unknown event types', () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    })
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    renderHook(() => useEventStream(), { wrapper: createWrapper(queryClient) })
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+      mockWsInstances[0].simulateMessage(makeServerEvent({ eventType: 'UnknownEvent' }))
+    })
+
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+
+  it('silently ignores malformed messages', () => {
+    const onEvent = vi.fn()
+
+    renderHook(() => useEventStream({ onEvent }), { wrapper: createWrapper() })
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+      mockWsInstances[0].onmessage?.(new MessageEvent('message', { data: 'not-json' }))
+    })
+
+    expect(onEvent).not.toHaveBeenCalled()
+  })
+
+  it('ignores non-event message types', () => {
+    const onEvent = vi.fn()
+
+    renderHook(() => useEventStream({ onEvent }), { wrapper: createWrapper() })
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+      mockWsInstances[0].simulateMessage({ type: 'subscribed', subscription_id: 'sub-1' })
+    })
+
+    expect(onEvent).not.toHaveBeenCalled()
+  })
+
+  it('closes WebSocket on unmount', () => {
+    const { unmount } = renderHook(() => useEventStream(), { wrapper: createWrapper() })
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+    })
+
+    unmount()
+
+    expect(mockWsInstances[0].close).toHaveBeenCalled()
+  })
+
+  it('sets connected to false on WebSocket close', () => {
+    const { result } = renderHook(() => useEventStream(), { wrapper: createWrapper() })
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+    })
+    expect(result.current.connected).toBe(true)
+
+    act(() => {
+      mockWsInstances[0].simulateClose()
+    })
     expect(result.current.connected).toBe(false)
   })
 
-  it('should initialize with null lastEvent', () => {
-    const { result } = renderHook(() => useEventStream(), {
-      wrapper: createWrapper(),
+  it('attempts reconnect on unexpected close', async () => {
+    vi.useFakeTimers()
+
+    renderHook(() => useEventStream(), { wrapper: createWrapper() })
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+    })
+    expect(mockWsInstances).toHaveLength(1)
+
+    act(() => {
+      mockWsInstances[0].simulateClose()
     })
 
-    expect(result.current.lastEvent).toBeNull()
-  })
-
-
-  it('should contain expected event types in EVENT_QUERY_MAP', () => {
-    const expectedEventTypes = [
-      'AccountStatusChanged',
-      'TransactionCompleted',
-      'PaymentOrderCompleted',
-    ]
-
-    expectedEventTypes.forEach((eventType) => {
-      expect(EVENT_QUERY_MAP).toHaveProperty(eventType)
-    })
-  })
-
-  it('EVENT_QUERY_MAP should return array of query keys', () => {
-    const mockEvent: DomainEvent = {
-      eventType: 'AccountStatusChanged',
-      tenantSlug: 'test-tenant',
-      payload: { accountId: '123' },
-      timestamp: new Date(),
-    }
-
-    const queryKeys = EVENT_QUERY_MAP['AccountStatusChanged'](mockEvent)
-
-    expect(Array.isArray(queryKeys)).toBe(true)
-    expect(queryKeys.length).toBeGreaterThan(0)
-  })
-
-  it('should accept onEvent callback option', () => {
-    const onEventMock = vi.fn()
-
-    renderHook(() => useEventStream({ onEvent: onEventMock }), {
-      wrapper: createWrapper(),
+    // Advance past reconnect delay (base 1000ms + jitter, max ~2000ms)
+    await act(async () => {
+      vi.advanceTimersByTime(3000)
     })
 
-    expect(onEventMock).not.toHaveBeenCalled()
+    expect(mockWsInstances.length).toBeGreaterThanOrEqual(2)
+
+    vi.useRealTimers()
   })
 
-  it('should accept eventTypes filter option', () => {
-    renderHook(() => useEventStream({ eventTypes: ['AccountStatusChanged'] }), {
-      wrapper: createWrapper(),
+  it('closes WebSocket on error then triggers reconnect via onclose', () => {
+    renderHook(() => useEventStream(), { wrapper: createWrapper() })
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
     })
 
-    expect(true).toBe(true)
+    act(() => {
+      mockWsInstances[0].simulateError()
+    })
+
+    expect(mockWsInstances[0].close).toHaveBeenCalled()
   })
 
-  it('should accept autoInvalidate option', () => {
-    renderHook(() => useEventStream({ autoInvalidate: false }), {
-      wrapper: createWrapper(),
-    })
+  it('constructs correct WebSocket URL based on protocol', () => {
+    renderHook(() => useEventStream(), { wrapper: createWrapper() })
 
-    expect(true).toBe(true)
+    expect(mockWsInstances[0].url).toContain('ws:')
+    expect(mockWsInstances[0].url).toContain('/ws/events')
   })
 })

--- a/frontend/src/hooks/use-event-stream.test.tsx
+++ b/frontend/src/hooks/use-event-stream.test.tsx
@@ -358,25 +358,27 @@ describe('useEventStream', () => {
   it('attempts reconnect on unexpected close', async () => {
     vi.useFakeTimers()
 
-    renderHook(() => useEventStream(), { wrapper: createWrapper() })
+    try {
+      renderHook(() => useEventStream(), { wrapper: createWrapper() })
 
-    act(() => {
-      mockWsInstances[0].simulateOpen()
-    })
-    expect(mockWsInstances).toHaveLength(1)
+      act(() => {
+        mockWsInstances[0].simulateOpen()
+      })
+      expect(mockWsInstances).toHaveLength(1)
 
-    act(() => {
-      mockWsInstances[0].simulateClose()
-    })
+      act(() => {
+        mockWsInstances[0].simulateClose()
+      })
 
-    // Advance past reconnect delay (base 1000ms + jitter, max ~2000ms)
-    await act(async () => {
-      vi.advanceTimersByTime(3000)
-    })
+      // Advance past reconnect delay (base 1000ms + jitter, max ~2000ms)
+      await act(async () => {
+        vi.advanceTimersByTime(3000)
+      })
 
-    expect(mockWsInstances.length).toBeGreaterThanOrEqual(2)
-
-    vi.useRealTimers()
+      expect(mockWsInstances.length).toBeGreaterThanOrEqual(2)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('closes WebSocket on error then triggers reconnect via onclose', () => {

--- a/frontend/src/hooks/use-oauth-flow.test.tsx
+++ b/frontend/src/hooks/use-oauth-flow.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useOAuthFlow } from './use-oauth-flow'
+
+describe('useOAuthFlow', () => {
+  const originalLocation = window.location
+
+  beforeEach(() => {
+    // Replace window.location with a writable mock
+    Object.defineProperty(window, 'location', {
+      value: {
+        pathname: '/dashboard',
+        search: '?tab=overview',
+        hash: '#section',
+        href: '',
+      },
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  it('returns a startFlow function', () => {
+    const { result } = renderHook(() => useOAuthFlow())
+    expect(typeof result.current.startFlow).toBe('function')
+  })
+
+  it('redirects to BFF SSO endpoint with connector ID and return URL', () => {
+    const { result } = renderHook(() => useOAuthFlow())
+
+    act(() => {
+      result.current.startFlow('google')
+    })
+
+    expect(window.location.href).toBe(
+      '/api/auth/sso/google?return_url=%2Fdashboard%3Ftab%3Doverview%23section',
+    )
+  })
+
+  it('encodes connector ID in the URL path', () => {
+    const { result } = renderHook(() => useOAuthFlow())
+
+    act(() => {
+      result.current.startFlow('my connector/special')
+    })
+
+    expect(window.location.href).toContain('/api/auth/sso/my%20connector%2Fspecial')
+  })
+
+  it('handles empty search and hash', () => {
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/login', search: '', hash: '', href: '' },
+      writable: true,
+      configurable: true,
+    })
+
+    const { result } = renderHook(() => useOAuthFlow())
+
+    act(() => {
+      result.current.startFlow('github')
+    })
+
+    expect(window.location.href).toBe('/api/auth/sso/github?return_url=%2Flogin')
+  })
+
+  it('returns stable function reference across renders', () => {
+    const { result, rerender } = renderHook(() => useOAuthFlow())
+    const first = result.current.startFlow
+    rerender()
+    expect(result.current.startFlow).toBe(first)
+  })
+})

--- a/frontend/src/hooks/use-oauth-flow.test.tsx
+++ b/frontend/src/hooks/use-oauth-flow.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useOAuthFlow } from './use-oauth-flow'
 

--- a/frontend/src/hooks/use-tenant-context.test.tsx
+++ b/frontend/src/hooks/use-tenant-context.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+// Mock the tenant context so we can control return values without needing
+// the full provider tree (AuthProvider, QueryClient, etc.).
+const mockContextValue = {
+  currentTenant: { id: 'tenant-1', slug: 'acme', name: 'Acme Corp' },
+  tenantSlug: 'acme',
+  isPlatformAdmin: false,
+  switchTenant: vi.fn(),
+  clearTenant: vi.fn(),
+  applyTheme: vi.fn(),
+}
+
+vi.mock('@/contexts/tenant-context', () => ({
+  useTenantContext: vi.fn(() => mockContextValue),
+}))
+
+import { useTenantContext } from '@/contexts/tenant-context'
+import {
+  useCurrentTenant,
+  useTenantSlug,
+  useIsPlatformAdmin,
+  useSwitchTenant,
+  useClearTenant,
+} from './use-tenant-context'
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <>{children}</>
+}
+
+describe('use-tenant-context hooks', () => {
+  it('useCurrentTenant returns currentTenant from context', () => {
+    const { result } = renderHook(() => useCurrentTenant(), { wrapper })
+    expect(result.current).toEqual({ id: 'tenant-1', slug: 'acme', name: 'Acme Corp' })
+  })
+
+  it('useTenantSlug returns tenantSlug from context', () => {
+    const { result } = renderHook(() => useTenantSlug(), { wrapper })
+    expect(result.current).toBe('acme')
+  })
+
+  it('useIsPlatformAdmin returns isPlatformAdmin from context', () => {
+    const { result } = renderHook(() => useIsPlatformAdmin(), { wrapper })
+    expect(result.current).toBe(false)
+  })
+
+  it('useIsPlatformAdmin returns true for platform admins', () => {
+    vi.mocked(useTenantContext).mockReturnValue({
+      ...mockContextValue,
+      isPlatformAdmin: true,
+    })
+
+    const { result } = renderHook(() => useIsPlatformAdmin(), { wrapper })
+    expect(result.current).toBe(true)
+
+    // Restore default
+    vi.mocked(useTenantContext).mockReturnValue(mockContextValue)
+  })
+
+  it('useSwitchTenant returns switchTenant function from context', () => {
+    const { result } = renderHook(() => useSwitchTenant(), { wrapper })
+    expect(result.current).toBe(mockContextValue.switchTenant)
+  })
+
+  it('useClearTenant returns clearTenant function from context', () => {
+    const { result } = renderHook(() => useClearTenant(), { wrapper })
+    expect(result.current).toBe(mockContextValue.clearTenant)
+  })
+
+  it('useCurrentTenant returns null when no tenant selected', () => {
+    vi.mocked(useTenantContext).mockReturnValue({
+      ...mockContextValue,
+      currentTenant: null,
+      tenantSlug: null,
+    })
+
+    const { result } = renderHook(() => useCurrentTenant(), { wrapper })
+    expect(result.current).toBeNull()
+
+    vi.mocked(useTenantContext).mockReturnValue(mockContextValue)
+  })
+
+  it('useTenantSlug returns null when no tenant selected', () => {
+    vi.mocked(useTenantContext).mockReturnValue({
+      ...mockContextValue,
+      currentTenant: null,
+      tenantSlug: null,
+    })
+
+    const { result } = renderHook(() => useTenantSlug(), { wrapper })
+    expect(result.current).toBeNull()
+
+    vi.mocked(useTenantContext).mockReturnValue(mockContextValue)
+  })
+})

--- a/frontend/src/hooks/use-tenant-context.test.tsx
+++ b/frontend/src/hooks/use-tenant-context.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import type { ReactNode } from 'react'
 
@@ -31,6 +31,10 @@ function wrapper({ children }: { children: ReactNode }) {
 }
 
 describe('use-tenant-context hooks', () => {
+  beforeEach(() => {
+    vi.mocked(useTenantContext).mockReturnValue(mockContextValue)
+  })
+
   it('useCurrentTenant returns currentTenant from context', () => {
     const { result } = renderHook(() => useCurrentTenant(), { wrapper })
     expect(result.current).toEqual({ id: 'tenant-1', slug: 'acme', name: 'Acme Corp' })
@@ -55,8 +59,7 @@ describe('use-tenant-context hooks', () => {
     const { result } = renderHook(() => useIsPlatformAdmin(), { wrapper })
     expect(result.current).toBe(true)
 
-    // Restore default
-    vi.mocked(useTenantContext).mockReturnValue(mockContextValue)
+
   })
 
   it('useSwitchTenant returns switchTenant function from context', () => {


### PR DESCRIPTION
## Summary

- **use-event-stream**: Replace shallow existing tests with 20 thorough tests covering WebSocket lifecycle, tenant isolation, event filtering, React Query cache invalidation, reconnect with backoff, and malformed message handling
- **use-oauth-flow**: Add 5 tests covering SSO redirect URL construction, connector ID encoding, and return URL preservation
- **use-tenant-context**: Add 8 tests covering all convenience hooks (useCurrentTenant, useTenantSlug, useIsPlatformAdmin, useSwitchTenant, useClearTenant) and null state handling

Addresses coverage gaps flagged by Codecov for these three hook files.

## Test plan

- [x] All 33 tests pass locally via `vitest run`
- [ ] CI passes