### PR TITLE
test: Add reconciliation service unit tests

### DIFF
--- a/services/reconciliation/domain/balance_imbalance_event_test.go
+++ b/services/reconciliation/domain/balance_imbalance_event_test.go
@@ -1,0 +1,155 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBalanceImbalanceDetectedEvent_UniqueEventIDs(t *testing.T) {
+	assertionID := uuid.New()
+	debits := decimal.NewFromFloat(1000.00)
+	credits := decimal.NewFromFloat(900.00)
+	imbalance := decimal.NewFromFloat(100.00)
+
+	event1 := NewBalanceImbalanceDetectedEvent(assertionID, "GBP", debits, credits, imbalance, AssertionScopePositionLedger, false, 1)
+	event2 := NewBalanceImbalanceDetectedEvent(assertionID, "GBP", debits, credits, imbalance, AssertionScopePositionLedger, false, 1)
+
+	assert.NotEqual(t, event1.EventID, event2.EventID, "each event must have a unique EventID")
+}
+
+func TestBalanceImbalanceDetectedEvent_AlwaysP1Critical(t *testing.T) {
+	event := NewBalanceImbalanceDetectedEvent(
+		uuid.New(), "GBP",
+		decimal.NewFromFloat(1000), decimal.NewFromFloat(900), decimal.NewFromFloat(100),
+		AssertionScopePositionLedger, false, 1,
+	)
+
+	assert.Equal(t, "P1_CRITICAL", event.Severity, "all imbalance events must be P1_CRITICAL")
+}
+
+func TestBalanceImbalanceDetectedEvent_DetectedAtIsUTC(t *testing.T) {
+	before := time.Now().UTC().Add(-time.Second)
+
+	event := NewBalanceImbalanceDetectedEvent(
+		uuid.New(), "GBP",
+		decimal.NewFromFloat(1000), decimal.NewFromFloat(900), decimal.NewFromFloat(100),
+		AssertionScopePositionLedger, false, 1,
+	)
+
+	after := time.Now().UTC().Add(time.Second)
+
+	assert.True(t, event.DetectedAt.After(before), "DetectedAt should be after test start")
+	assert.True(t, event.DetectedAt.Before(after), "DetectedAt should be before test end")
+	assert.Equal(t, time.UTC, event.DetectedAt.Location(), "DetectedAt must be UTC")
+}
+
+func TestBalanceImbalanceDetectedEvent_PersistenceFields(t *testing.T) {
+	t.Run("not persistent", func(t *testing.T) {
+		event := NewBalanceImbalanceDetectedEvent(
+			uuid.New(), "GBP",
+			decimal.NewFromFloat(1000), decimal.NewFromFloat(900), decimal.NewFromFloat(100),
+			AssertionScopePositionLedger, false, 2,
+		)
+
+		assert.False(t, event.IsPersistent)
+		assert.Equal(t, 2, event.ConsecutiveDays)
+	})
+
+	t.Run("persistent", func(t *testing.T) {
+		event := NewBalanceImbalanceDetectedEvent(
+			uuid.New(), "GBP",
+			decimal.NewFromFloat(1000), decimal.NewFromFloat(900), decimal.NewFromFloat(100),
+			AssertionScopePositionLedger, true, 5,
+		)
+
+		assert.True(t, event.IsPersistent)
+		assert.Equal(t, 5, event.ConsecutiveDays)
+	})
+}
+
+func TestBalanceImbalanceDetectedEvent_AmountFields(t *testing.T) {
+	debits := decimal.RequireFromString("123456.789")
+	credits := decimal.RequireFromString("123000.000")
+	imbalance := decimal.RequireFromString("456.789")
+
+	event := NewBalanceImbalanceDetectedEvent(
+		uuid.New(), "GBP",
+		debits, credits, imbalance,
+		AssertionScopePositionLedger, false, 1,
+	)
+
+	assert.True(t, debits.Equal(event.TotalDebits))
+	assert.True(t, credits.Equal(event.TotalCredits))
+	assert.True(t, imbalance.Equal(event.ImbalanceAmount))
+}
+
+func TestBalanceImbalanceDetectedEvent_ScopePreserved(t *testing.T) {
+	scopes := []AssertionScope{
+		AssertionScopePositionLedger,
+		AssertionScopeCrossAccount,
+	}
+
+	for _, scope := range scopes {
+		t.Run(scope.String(), func(t *testing.T) {
+			event := NewBalanceImbalanceDetectedEvent(
+				uuid.New(), "GBP",
+				decimal.NewFromFloat(1000), decimal.NewFromFloat(900), decimal.NewFromFloat(100),
+				scope, false, 1,
+			)
+
+			assert.Equal(t, scope, event.Scope)
+		})
+	}
+}
+
+func TestBalanceImbalanceDetectedEvent_NonCurrencyInstruments(t *testing.T) {
+	instruments := []string{"KWH", "TONNE_CO2E", "GPU_HOUR"}
+
+	for _, code := range instruments {
+		t.Run(code, func(t *testing.T) {
+			event := NewBalanceImbalanceDetectedEvent(
+				uuid.New(), code,
+				decimal.NewFromFloat(500), decimal.NewFromFloat(400), decimal.NewFromFloat(100),
+				AssertionScopePositionLedger, false, 1,
+			)
+
+			require.NotNil(t, event)
+			assert.Equal(t, code, event.InstrumentCode)
+			assert.Equal(t, "P1_CRITICAL", event.Severity)
+		})
+	}
+}
+
+func TestBalanceImbalanceDetectedEvent_AssertionIDLinked(t *testing.T) {
+	assertionID := uuid.New()
+
+	event := NewBalanceImbalanceDetectedEvent(
+		assertionID, "GBP",
+		decimal.NewFromFloat(1000), decimal.NewFromFloat(900), decimal.NewFromFloat(100),
+		AssertionScopePositionLedger, false, 1,
+	)
+
+	assert.Equal(t, assertionID, event.AssertionID, "event must reference the triggering assertion")
+	assert.NotEqual(t, assertionID, event.EventID, "EventID must be different from AssertionID")
+}
+
+func TestBalanceImbalanceDetectedEvent_SmallImbalance(t *testing.T) {
+	// Even a tiny imbalance produces a P1_CRITICAL event
+	debits := decimal.RequireFromString("100000.000000000001")
+	credits := decimal.RequireFromString("100000.000000000000")
+	imbalance := decimal.RequireFromString("0.000000000001")
+
+	event := NewBalanceImbalanceDetectedEvent(
+		uuid.New(), "GBP",
+		debits, credits, imbalance,
+		AssertionScopePositionLedger, false, 1,
+	)
+
+	assert.Equal(t, "P1_CRITICAL", event.Severity)
+	assert.True(t, imbalance.Equal(event.ImbalanceAmount))
+}

--- a/services/reconciliation/domain/imbalance_trend_test.go
+++ b/services/reconciliation/domain/imbalance_trend_test.go
@@ -261,8 +261,8 @@ func TestImbalanceTrend_SameUTCDay(t *testing.T) {
 		assert.False(t, sameUTCDay(a, b))
 	})
 
-	t.Run("same UTC day despite different local timezone", func(t *testing.T) {
-		// 2024-01-15 23:00 UTC and 2024-01-15 00:01 UTC are same UTC day
+	t.Run("same UTC day early and late hours", func(t *testing.T) {
+		// 2024-01-15 23:00 UTC and 2024-01-15 00:01 UTC are same UTC calendar day
 		a := time.Date(2024, 1, 15, 23, 0, 0, 0, time.UTC)
 		b := time.Date(2024, 1, 15, 0, 1, 0, 0, time.UTC)
 		assert.True(t, sameUTCDay(a, b))

--- a/services/reconciliation/domain/imbalance_trend_test.go
+++ b/services/reconciliation/domain/imbalance_trend_test.go
@@ -1,0 +1,276 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPersistentImbalanceThreshold(t *testing.T) {
+	assert.Equal(t, 3, PersistentImbalanceThreshold, "threshold must be 3 consecutive days")
+}
+
+func TestImbalanceTrend_NewTrend_InitialState(t *testing.T) {
+	trend := &ImbalanceTrend{
+		TrendID:        uuid.New(),
+		InstrumentCode: "GBP",
+	}
+
+	assert.Equal(t, 0, trend.ConsecutiveDays)
+	assert.True(t, trend.LastImbalanceAmount.IsZero())
+	assert.Equal(t, uuid.Nil, trend.LastAssertionID)
+	assert.True(t, trend.FirstDetectedAt.IsZero())
+	assert.True(t, trend.LastDetectedAt.IsZero())
+	assert.Nil(t, trend.ResolvedAt)
+}
+
+func TestImbalanceTrend_RecordImbalance_FirstRecord(t *testing.T) {
+	trend := &ImbalanceTrend{
+		TrendID:        uuid.New(),
+		InstrumentCode: "GBP",
+	}
+
+	assertionID := uuid.New()
+	amount := decimal.NewFromFloat(500.00)
+
+	trend.RecordImbalance(amount, assertionID)
+
+	assert.Equal(t, 1, trend.ConsecutiveDays)
+	assert.True(t, amount.Equal(trend.LastImbalanceAmount))
+	assert.Equal(t, assertionID, trend.LastAssertionID)
+	assert.False(t, trend.LastDetectedAt.IsZero())
+	assert.Nil(t, trend.ResolvedAt)
+}
+
+func TestImbalanceTrend_RecordImbalance_SameDayNoIncrement(t *testing.T) {
+	trend := &ImbalanceTrend{
+		TrendID:        uuid.New(),
+		InstrumentCode: "GBP",
+	}
+
+	assertionID1 := uuid.New()
+	assertionID2 := uuid.New()
+	amount := decimal.NewFromFloat(500.00)
+
+	trend.RecordImbalance(amount, assertionID1)
+	assert.Equal(t, 1, trend.ConsecutiveDays)
+
+	// Same day call should not increment consecutive days
+	trend.RecordImbalance(amount, assertionID2)
+	assert.Equal(t, 1, trend.ConsecutiveDays, "same-day detection must not increment consecutive days")
+	assert.Equal(t, assertionID2, trend.LastAssertionID, "last assertion ID should be updated")
+}
+
+func TestImbalanceTrend_RecordImbalance_MultipleSameDayCalls(t *testing.T) {
+	trend := &ImbalanceTrend{
+		TrendID:        uuid.New(),
+		InstrumentCode: "GBP",
+	}
+
+	amount := decimal.NewFromFloat(100.00)
+
+	for i := 0; i < 10; i++ {
+		trend.RecordImbalance(amount, uuid.New())
+	}
+
+	assert.Equal(t, 1, trend.ConsecutiveDays, "10 same-day calls should still count as 1 day")
+}
+
+func TestImbalanceTrend_RecordImbalance_NextDayIncrement(t *testing.T) {
+	trend := &ImbalanceTrend{
+		TrendID:         uuid.New(),
+		InstrumentCode:  "GBP",
+		ConsecutiveDays: 1,
+		LastDetectedAt:  time.Now().UTC().Add(-25 * time.Hour), // yesterday
+	}
+
+	assertionID := uuid.New()
+	amount := decimal.NewFromFloat(300.00)
+
+	trend.RecordImbalance(amount, assertionID)
+
+	assert.Equal(t, 2, trend.ConsecutiveDays, "different-day detection should increment consecutive days")
+}
+
+func TestImbalanceTrend_RecordImbalance_ThresholdBreach(t *testing.T) {
+	trend := &ImbalanceTrend{
+		TrendID:        uuid.New(),
+		InstrumentCode: "GBP",
+	}
+
+	amount := decimal.NewFromFloat(250.00)
+
+	// Simulate 3 consecutive days
+	trend.RecordImbalance(amount, uuid.New())
+	assert.False(t, trend.IsPersistent())
+
+	trend.LastDetectedAt = trend.LastDetectedAt.Add(-25 * time.Hour)
+	trend.RecordImbalance(amount, uuid.New())
+	assert.False(t, trend.IsPersistent())
+
+	trend.LastDetectedAt = trend.LastDetectedAt.Add(-25 * time.Hour)
+	trend.RecordImbalance(amount, uuid.New())
+	assert.True(t, trend.IsPersistent(), "3 consecutive days must trigger persistent imbalance")
+}
+
+func TestImbalanceTrend_RecordImbalance_AmountUpdated(t *testing.T) {
+	trend := &ImbalanceTrend{
+		TrendID:        uuid.New(),
+		InstrumentCode: "GBP",
+	}
+
+	amount1 := decimal.NewFromFloat(100.00)
+	amount2 := decimal.NewFromFloat(200.00)
+
+	trend.RecordImbalance(amount1, uuid.New())
+	assert.True(t, amount1.Equal(trend.LastImbalanceAmount))
+
+	// Different day, different amount
+	trend.LastDetectedAt = trend.LastDetectedAt.Add(-25 * time.Hour)
+	trend.RecordImbalance(amount2, uuid.New())
+	assert.True(t, amount2.Equal(trend.LastImbalanceAmount), "imbalance amount should update on each recording")
+}
+
+func TestImbalanceTrend_RecordImbalance_ClearsResolvedAt(t *testing.T) {
+	now := time.Now().UTC()
+	trend := &ImbalanceTrend{
+		TrendID:        uuid.New(),
+		InstrumentCode: "GBP",
+		ResolvedAt:     &now,
+	}
+
+	trend.RecordImbalance(decimal.NewFromFloat(100.00), uuid.New())
+
+	assert.Nil(t, trend.ResolvedAt, "recording an imbalance must clear the resolved state")
+}
+
+func TestImbalanceTrend_IsPersistent_BelowThreshold(t *testing.T) {
+	trend := &ImbalanceTrend{ConsecutiveDays: 0}
+	assert.False(t, trend.IsPersistent())
+
+	trend.ConsecutiveDays = 1
+	assert.False(t, trend.IsPersistent())
+
+	trend.ConsecutiveDays = 2
+	assert.False(t, trend.IsPersistent())
+}
+
+func TestImbalanceTrend_IsPersistent_AtThreshold(t *testing.T) {
+	trend := &ImbalanceTrend{ConsecutiveDays: PersistentImbalanceThreshold}
+	assert.True(t, trend.IsPersistent(), "exactly at threshold should be persistent")
+}
+
+func TestImbalanceTrend_IsPersistent_AboveThreshold(t *testing.T) {
+	trend := &ImbalanceTrend{ConsecutiveDays: 10}
+	assert.True(t, trend.IsPersistent())
+}
+
+func TestImbalanceTrend_Resolve_ResetsDays(t *testing.T) {
+	trend := &ImbalanceTrend{
+		TrendID:         uuid.New(),
+		InstrumentCode:  "GBP",
+		ConsecutiveDays: 7,
+	}
+
+	before := time.Now().UTC().Add(-time.Second)
+	trend.Resolve()
+	after := time.Now().UTC().Add(time.Second)
+
+	assert.Equal(t, 0, trend.ConsecutiveDays)
+	require.NotNil(t, trend.ResolvedAt)
+	assert.True(t, trend.ResolvedAt.After(before))
+	assert.True(t, trend.ResolvedAt.Before(after))
+}
+
+func TestImbalanceTrend_Resolve_SetsPersistentToFalse(t *testing.T) {
+	trend := &ImbalanceTrend{
+		TrendID:         uuid.New(),
+		ConsecutiveDays: 5,
+	}
+	require.True(t, trend.IsPersistent())
+
+	trend.Resolve()
+
+	assert.False(t, trend.IsPersistent(), "resolved trend must not be persistent")
+	assert.Equal(t, 0, trend.ConsecutiveDays)
+}
+
+func TestImbalanceTrend_RecordAfterResolve_ResetsToZeroSameDay(t *testing.T) {
+	trend := &ImbalanceTrend{
+		TrendID:        uuid.New(),
+		InstrumentCode: "GBP",
+	}
+
+	// Simulate 3 days of imbalance then resolution
+	amount := decimal.NewFromFloat(100.00)
+	trend.RecordImbalance(amount, uuid.New())
+	trend.LastDetectedAt = trend.LastDetectedAt.Add(-25 * time.Hour)
+	trend.RecordImbalance(amount, uuid.New())
+	trend.LastDetectedAt = trend.LastDetectedAt.Add(-25 * time.Hour)
+	trend.RecordImbalance(amount, uuid.New())
+	assert.True(t, trend.IsPersistent())
+
+	trend.Resolve()
+	assert.Equal(t, 0, trend.ConsecutiveDays)
+
+	// New imbalance detected on the same day as Resolve - same day means no increment
+	trend.RecordImbalance(amount, uuid.New())
+	assert.Equal(t, 0, trend.ConsecutiveDays, "same-day detection after resolve does not increment")
+	assert.Nil(t, trend.ResolvedAt, "recording imbalance must clear ResolvedAt")
+}
+
+func TestImbalanceTrend_RecordAfterResolve_NextDayStartsFromOne(t *testing.T) {
+	trend := &ImbalanceTrend{
+		TrendID:        uuid.New(),
+		InstrumentCode: "GBP",
+	}
+
+	// Simulate 3 days of imbalance then resolution yesterday
+	amount := decimal.NewFromFloat(100.00)
+	trend.RecordImbalance(amount, uuid.New())
+	trend.LastDetectedAt = trend.LastDetectedAt.Add(-25 * time.Hour)
+	trend.RecordImbalance(amount, uuid.New())
+	trend.LastDetectedAt = trend.LastDetectedAt.Add(-25 * time.Hour)
+	trend.RecordImbalance(amount, uuid.New())
+	assert.True(t, trend.IsPersistent())
+
+	trend.Resolve()
+	assert.Equal(t, 0, trend.ConsecutiveDays)
+
+	// Simulate yesterday's LastDetectedAt so next recording counts as a new day
+	trend.LastDetectedAt = trend.LastDetectedAt.Add(-25 * time.Hour)
+	trend.RecordImbalance(amount, uuid.New())
+	assert.Equal(t, 1, trend.ConsecutiveDays, "next-day detection after resolve should start counter at 1")
+	assert.Nil(t, trend.ResolvedAt)
+}
+
+func TestImbalanceTrend_SameUTCDay(t *testing.T) {
+	t.Run("same day same timezone", func(t *testing.T) {
+		a := time.Date(2024, 1, 15, 8, 0, 0, 0, time.UTC)
+		b := time.Date(2024, 1, 15, 23, 59, 59, 0, time.UTC)
+		assert.True(t, sameUTCDay(a, b))
+	})
+
+	t.Run("different day", func(t *testing.T) {
+		a := time.Date(2024, 1, 15, 23, 59, 59, 0, time.UTC)
+		b := time.Date(2024, 1, 16, 0, 0, 0, 0, time.UTC)
+		assert.False(t, sameUTCDay(a, b))
+	})
+
+	t.Run("same UTC day despite different local timezone", func(t *testing.T) {
+		// 2024-01-15 23:00 UTC and 2024-01-15 00:01 UTC are same UTC day
+		a := time.Date(2024, 1, 15, 23, 0, 0, 0, time.UTC)
+		b := time.Date(2024, 1, 15, 0, 1, 0, 0, time.UTC)
+		assert.True(t, sameUTCDay(a, b))
+	})
+
+	t.Run("different years", func(t *testing.T) {
+		a := time.Date(2023, 12, 31, 12, 0, 0, 0, time.UTC)
+		b := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		assert.False(t, sameUTCDay(a, b))
+	})
+}

--- a/services/reconciliation/domain/imbalance_trend_test.go
+++ b/services/reconciliation/domain/imbalance_trend_test.go
@@ -261,10 +261,14 @@ func TestImbalanceTrend_SameUTCDay(t *testing.T) {
 		assert.False(t, sameUTCDay(a, b))
 	})
 
-	t.Run("same UTC day early and late hours", func(t *testing.T) {
-		// 2024-01-15 23:00 UTC and 2024-01-15 00:01 UTC are same UTC calendar day
-		a := time.Date(2024, 1, 15, 23, 0, 0, 0, time.UTC)
-		b := time.Date(2024, 1, 15, 0, 1, 0, 0, time.UTC)
+	t.Run("same UTC day despite different local timezones", func(t *testing.T) {
+		// 2024-01-15 23:00 UTC = 2024-01-16 07:00 in UTC+8 (next local day)
+		// 2024-01-15 01:00 UTC = 2024-01-14 17:00 in UTC-8 (previous local day)
+		// Both are 2024-01-15 UTC, so sameUTCDay must return true.
+		eastZone := time.FixedZone("UTC+8", 8*60*60)
+		westZone := time.FixedZone("UTC-8", -8*60*60)
+		a := time.Date(2024, 1, 15, 23, 0, 0, 0, time.UTC).In(eastZone)
+		b := time.Date(2024, 1, 15, 1, 0, 0, 0, time.UTC).In(westZone)
 		assert.True(t, sameUTCDay(a, b))
 	})
 

--- a/services/reconciliation/service/fa_client_test.go
+++ b/services/reconciliation/service/fa_client_test.go
@@ -15,7 +15,10 @@ type stubFAClient struct {
 	err    error
 }
 
-func (s *stubFAClient) GetDiagnosticDetail(_ context.Context, _, _ string) (*DiagnosticDetail, error) {
+func (s *stubFAClient) GetDiagnosticDetail(ctx context.Context, _, _ string) (*DiagnosticDetail, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 	if s.err != nil {
 		return nil, s.err
 	}
@@ -113,10 +116,7 @@ func TestFinancialAccountingClient_ContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
 
-	// The stub propagates the context error when the context is canceled.
-	var client FinancialAccountingClient = &stubFAClient{
-		err: ctx.Err(),
-	}
+	var client FinancialAccountingClient = &stubFAClient{}
 
 	result, err := client.GetDiagnosticDetail(ctx, "ACC-001", "GBP")
 

--- a/services/reconciliation/service/fa_client_test.go
+++ b/services/reconciliation/service/fa_client_test.go
@@ -110,11 +110,15 @@ func TestFinancialAccountingClient_MultipleInstruments(t *testing.T) {
 }
 
 func TestFinancialAccountingClient_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	// The stub propagates the context error when the context is canceled.
 	var client FinancialAccountingClient = &stubFAClient{
-		err: context.Canceled,
+		err: ctx.Err(),
 	}
 
-	result, err := client.GetDiagnosticDetail(context.Background(), "ACC-001", "GBP")
+	result, err := client.GetDiagnosticDetail(ctx, "ACC-001", "GBP")
 
 	require.Error(t, err)
 	assert.Nil(t, result)

--- a/services/reconciliation/service/fa_client_test.go
+++ b/services/reconciliation/service/fa_client_test.go
@@ -1,0 +1,122 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubFAClient is a configurable test implementation of FinancialAccountingClient.
+type stubFAClient struct {
+	detail *DiagnosticDetail
+	err    error
+}
+
+func (s *stubFAClient) GetDiagnosticDetail(_ context.Context, _, _ string) (*DiagnosticDetail, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.detail, nil
+}
+
+func TestDiagnosticDetail_Fields(t *testing.T) {
+	detail := &DiagnosticDetail{
+		AccountID:       "ACC-001",
+		InstrumentCode:  "GBP",
+		JournalEntryIDs: []string{"JE-001", "JE-002", "JE-003"},
+		Message:         "Missing contra-entry for JE-001",
+	}
+
+	assert.Equal(t, "ACC-001", detail.AccountID)
+	assert.Equal(t, "GBP", detail.InstrumentCode)
+	assert.Equal(t, []string{"JE-001", "JE-002", "JE-003"}, detail.JournalEntryIDs)
+	assert.Equal(t, "Missing contra-entry for JE-001", detail.Message)
+}
+
+func TestDiagnosticDetail_EmptyJournalEntries(t *testing.T) {
+	detail := &DiagnosticDetail{
+		AccountID:      "ACC-002",
+		InstrumentCode: "EUR",
+		Message:        "No journal entries found",
+	}
+
+	assert.Nil(t, detail.JournalEntryIDs)
+	assert.Equal(t, "No journal entries found", detail.Message)
+}
+
+func TestFinancialAccountingClient_Success(t *testing.T) {
+	expected := &DiagnosticDetail{
+		AccountID:       "ACC-001",
+		InstrumentCode:  "GBP",
+		JournalEntryIDs: []string{"JE-100"},
+		Message:         "Imbalance detected in journal entry JE-100",
+	}
+
+	var client FinancialAccountingClient = &stubFAClient{detail: expected}
+
+	result, err := client.GetDiagnosticDetail(context.Background(), "ACC-001", "GBP")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, expected.AccountID, result.AccountID)
+	assert.Equal(t, expected.InstrumentCode, result.InstrumentCode)
+	assert.Equal(t, expected.JournalEntryIDs, result.JournalEntryIDs)
+	assert.Equal(t, expected.Message, result.Message)
+}
+
+func TestFinancialAccountingClient_Error(t *testing.T) {
+	var client FinancialAccountingClient = &stubFAClient{
+		err: errors.New("FA service unavailable"),
+	}
+
+	result, err := client.GetDiagnosticDetail(context.Background(), "ACC-001", "GBP")
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "FA service unavailable")
+}
+
+func TestFinancialAccountingClient_NilDetail(t *testing.T) {
+	var client FinancialAccountingClient = &stubFAClient{detail: nil}
+
+	result, err := client.GetDiagnosticDetail(context.Background(), "ACC-001", "KWH")
+
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestFinancialAccountingClient_MultipleInstruments(t *testing.T) {
+	instruments := []string{"GBP", "EUR", "KWH", "TONNE_CO2E"}
+
+	for _, code := range instruments {
+		t.Run(code, func(t *testing.T) {
+			detail := &DiagnosticDetail{
+				AccountID:      "ACC-001",
+				InstrumentCode: code,
+				Message:        "Imbalance for " + code,
+			}
+			var client FinancialAccountingClient = &stubFAClient{detail: detail}
+
+			result, err := client.GetDiagnosticDetail(context.Background(), "ACC-001", code)
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, code, result.InstrumentCode)
+		})
+	}
+}
+
+func TestFinancialAccountingClient_ContextCanceled(t *testing.T) {
+	var client FinancialAccountingClient = &stubFAClient{
+		err: context.Canceled,
+	}
+
+	result, err := client.GetDiagnosticDetail(context.Background(), "ACC-001", "GBP")
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/services/reconciliation/service/pk_client_test.go
+++ b/services/reconciliation/service/pk_client_test.go
@@ -1,0 +1,177 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubPositionKeepingClient is a configurable test implementation of PositionKeepingClient.
+type stubPositionKeepingClient struct {
+	summary *PositionSummary
+	err     error
+}
+
+func (s *stubPositionKeepingClient) GetPositionSummary(_ context.Context, _, _ string) (*PositionSummary, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.summary, nil
+}
+
+func TestPositionSummary_Fields(t *testing.T) {
+	summary := &PositionSummary{
+		InstrumentCode: "GBP",
+		TotalDebits:    decimal.NewFromFloat(50000.00),
+		TotalCredits:   decimal.NewFromFloat(50000.00),
+	}
+
+	assert.Equal(t, "GBP", summary.InstrumentCode)
+	assert.True(t, decimal.NewFromFloat(50000.00).Equal(summary.TotalDebits))
+	assert.True(t, decimal.NewFromFloat(50000.00).Equal(summary.TotalCredits))
+}
+
+func TestPositionSummary_Balanced(t *testing.T) {
+	summary := &PositionSummary{
+		InstrumentCode: "EUR",
+		TotalDebits:    decimal.NewFromFloat(1234.56),
+		TotalCredits:   decimal.NewFromFloat(1234.56),
+	}
+
+	imbalance := summary.TotalDebits.Sub(summary.TotalCredits)
+	assert.True(t, imbalance.IsZero(), "balanced summary should have zero imbalance")
+}
+
+func TestPositionSummary_Imbalanced(t *testing.T) {
+	summary := &PositionSummary{
+		InstrumentCode: "GBP",
+		TotalDebits:    decimal.NewFromFloat(1000.00),
+		TotalCredits:   decimal.NewFromFloat(900.00),
+	}
+
+	imbalance := summary.TotalDebits.Sub(summary.TotalCredits)
+	assert.True(t, decimal.NewFromFloat(100.00).Equal(imbalance))
+	assert.False(t, imbalance.IsZero())
+}
+
+func TestPositionKeepingClient_Success(t *testing.T) {
+	expected := &PositionSummary{
+		InstrumentCode: "GBP",
+		TotalDebits:    decimal.NewFromFloat(50000.00),
+		TotalCredits:   decimal.NewFromFloat(50000.00),
+	}
+
+	var client PositionKeepingClient = &stubPositionKeepingClient{summary: expected}
+
+	result, err := client.GetPositionSummary(context.Background(), "ACC-001", "GBP")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "GBP", result.InstrumentCode)
+	assert.True(t, expected.TotalDebits.Equal(result.TotalDebits))
+	assert.True(t, expected.TotalCredits.Equal(result.TotalCredits))
+}
+
+func TestPositionKeepingClient_Error(t *testing.T) {
+	var client PositionKeepingClient = &stubPositionKeepingClient{
+		err: errors.New("connection refused"),
+	}
+
+	result, err := client.GetPositionSummary(context.Background(), "ACC-001", "GBP")
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "connection refused")
+}
+
+func TestPositionKeepingClient_ZeroBalances(t *testing.T) {
+	expected := &PositionSummary{
+		InstrumentCode: "GBP",
+		TotalDebits:    decimal.Zero,
+		TotalCredits:   decimal.Zero,
+	}
+
+	var client PositionKeepingClient = &stubPositionKeepingClient{summary: expected}
+
+	result, err := client.GetPositionSummary(context.Background(), "ACC-001", "GBP")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.TotalDebits.IsZero())
+	assert.True(t, result.TotalCredits.IsZero())
+}
+
+func TestPositionKeepingClient_CrossAccountQuery(t *testing.T) {
+	// Empty accountID for cross-account queries
+	expected := &PositionSummary{
+		InstrumentCode: "GBP",
+		TotalDebits:    decimal.NewFromFloat(200000.00),
+		TotalCredits:   decimal.NewFromFloat(200000.00),
+	}
+
+	var client PositionKeepingClient = &stubPositionKeepingClient{summary: expected}
+
+	result, err := client.GetPositionSummary(context.Background(), "", "GBP")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, expected.TotalDebits.Equal(result.TotalDebits))
+}
+
+func TestPositionKeepingClient_NonCurrencyInstruments(t *testing.T) {
+	instruments := []struct {
+		code    string
+		debits  string
+		credits string
+	}{
+		{"KWH", "1000000.000", "1000000.000"},
+		{"TONNE_CO2E", "500.50", "500.50"},
+		{"GPU_HOUR", "48.75", "48.75"},
+	}
+
+	for _, tc := range instruments {
+		t.Run(tc.code, func(t *testing.T) {
+			debits := decimal.RequireFromString(tc.debits)
+			credits := decimal.RequireFromString(tc.credits)
+
+			var client PositionKeepingClient = &stubPositionKeepingClient{
+				summary: &PositionSummary{
+					InstrumentCode: tc.code,
+					TotalDebits:    debits,
+					TotalCredits:   credits,
+				},
+			}
+
+			result, err := client.GetPositionSummary(context.Background(), "ACC-001", tc.code)
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tc.code, result.InstrumentCode)
+			assert.True(t, debits.Equal(result.TotalDebits))
+			assert.True(t, credits.Equal(result.TotalCredits))
+		})
+	}
+}
+
+func TestPositionKeepingClient_HighPrecisionAmounts(t *testing.T) {
+	debits := decimal.RequireFromString("123456789.123456789")
+	credits := decimal.RequireFromString("123456789.123456789")
+
+	var client PositionKeepingClient = &stubPositionKeepingClient{
+		summary: &PositionSummary{
+			InstrumentCode: "GBP",
+			TotalDebits:    debits,
+			TotalCredits:   credits,
+		},
+	}
+
+	result, err := client.GetPositionSummary(context.Background(), "ACC-001", "GBP")
+
+	require.NoError(t, err)
+	assert.True(t, debits.Equal(result.TotalDebits), "high-precision amounts must be preserved")
+	assert.True(t, credits.Equal(result.TotalCredits))
+}

--- a/services/reconciliation/service/position_provider_test.go
+++ b/services/reconciliation/service/position_provider_test.go
@@ -1,0 +1,213 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubPositionDataProvider is a configurable test implementation of PositionDataProvider.
+type stubPositionDataProvider struct {
+	pages []PositionPage
+	idx   int
+	err   error
+}
+
+func (s *stubPositionDataProvider) FetchPositions(_ context.Context, _ string, _ int32, _ string) (*PositionPage, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.idx >= len(s.pages) {
+		return &PositionPage{}, nil
+	}
+	page := s.pages[s.idx]
+	s.idx++
+	return &page, nil
+}
+
+func TestPositionRecord_Fields(t *testing.T) {
+	rec := PositionRecord{
+		AccountID:      "ACC-001",
+		InstrumentCode: "GBP",
+		Balance:        decimal.NewFromFloat(1500.75),
+		SourceSystem:   "position-keeping",
+		Attributes:     map[string]string{"log_id": "log-123"},
+	}
+
+	assert.Equal(t, "ACC-001", rec.AccountID)
+	assert.Equal(t, "GBP", rec.InstrumentCode)
+	assert.True(t, decimal.NewFromFloat(1500.75).Equal(rec.Balance))
+	assert.Equal(t, "position-keeping", rec.SourceSystem)
+	assert.Equal(t, "log-123", rec.Attributes["log_id"])
+}
+
+func TestPositionRecord_NilAttributes(t *testing.T) {
+	rec := PositionRecord{
+		AccountID:      "ACC-001",
+		InstrumentCode: "EUR",
+		Balance:        decimal.Zero,
+		SourceSystem:   "ledger",
+	}
+
+	assert.Nil(t, rec.Attributes)
+	assert.True(t, rec.Balance.IsZero())
+}
+
+func TestPositionPage_Fields(t *testing.T) {
+	records := []PositionRecord{
+		{AccountID: "ACC-001", InstrumentCode: "GBP", Balance: decimal.NewFromFloat(100)},
+		{AccountID: "ACC-002", InstrumentCode: "EUR", Balance: decimal.NewFromFloat(200)},
+	}
+	page := PositionPage{
+		Records:       records,
+		NextPageToken: "cursor-token-abc",
+	}
+
+	assert.Len(t, page.Records, 2)
+	assert.Equal(t, "cursor-token-abc", page.NextPageToken)
+}
+
+func TestPositionPage_EmptyRecords(t *testing.T) {
+	page := PositionPage{
+		Records:       nil,
+		NextPageToken: "",
+	}
+
+	assert.Empty(t, page.Records)
+	assert.Empty(t, page.NextPageToken)
+}
+
+func TestPositionDataProvider_SinglePage(t *testing.T) {
+	provider := &stubPositionDataProvider{
+		pages: []PositionPage{
+			{
+				Records: []PositionRecord{
+					{AccountID: "ACC-001", InstrumentCode: "GBP", Balance: decimal.NewFromFloat(500), SourceSystem: "pk"},
+				},
+				NextPageToken: "",
+			},
+		},
+	}
+
+	var dp PositionDataProvider = provider
+	page, err := dp.FetchPositions(context.Background(), "ACC-001", 10, "")
+
+	require.NoError(t, err)
+	require.Len(t, page.Records, 1)
+	assert.Equal(t, "ACC-001", page.Records[0].AccountID)
+	assert.Equal(t, "GBP", page.Records[0].InstrumentCode)
+	assert.Empty(t, page.NextPageToken, "single page should have no next token")
+}
+
+func TestPositionDataProvider_MultiPageAggregation(t *testing.T) {
+	provider := &stubPositionDataProvider{
+		pages: []PositionPage{
+			{
+				Records: []PositionRecord{
+					{AccountID: "ACC-001", InstrumentCode: "GBP", Balance: decimal.NewFromFloat(100)},
+				},
+				NextPageToken: "page2",
+			},
+			{
+				Records: []PositionRecord{
+					{AccountID: "ACC-001", InstrumentCode: "EUR", Balance: decimal.NewFromFloat(200)},
+				},
+				NextPageToken: "",
+			},
+		},
+	}
+
+	var dp PositionDataProvider = provider
+
+	// Fetch first page
+	page1, err := dp.FetchPositions(context.Background(), "ACC-001", 10, "")
+	require.NoError(t, err)
+	require.Len(t, page1.Records, 1)
+	assert.Equal(t, "GBP", page1.Records[0].InstrumentCode)
+	assert.Equal(t, "page2", page1.NextPageToken)
+
+	// Fetch second page
+	page2, err := dp.FetchPositions(context.Background(), "ACC-001", 10, page1.NextPageToken)
+	require.NoError(t, err)
+	require.Len(t, page2.Records, 1)
+	assert.Equal(t, "EUR", page2.Records[0].InstrumentCode)
+	assert.Empty(t, page2.NextPageToken)
+}
+
+func TestPositionDataProvider_Error(t *testing.T) {
+	provider := &stubPositionDataProvider{
+		err: errors.New("position keeping unavailable"),
+	}
+
+	var dp PositionDataProvider = provider
+	page, err := dp.FetchPositions(context.Background(), "ACC-001", 10, "")
+
+	require.Error(t, err)
+	assert.Nil(t, page)
+	assert.Contains(t, err.Error(), "position keeping unavailable")
+}
+
+func TestPositionDataProvider_EmptyPage(t *testing.T) {
+	provider := &stubPositionDataProvider{
+		pages: []PositionPage{
+			{Records: nil, NextPageToken: ""},
+		},
+	}
+
+	var dp PositionDataProvider = provider
+	page, err := dp.FetchPositions(context.Background(), "ACC-001", 10, "")
+
+	require.NoError(t, err)
+	assert.Empty(t, page.Records)
+	assert.Empty(t, page.NextPageToken)
+}
+
+func TestPositionDataProvider_NegativeBalance(t *testing.T) {
+	// Negative balances are valid (debit-heavy accounts)
+	provider := &stubPositionDataProvider{
+		pages: []PositionPage{
+			{
+				Records: []PositionRecord{
+					{AccountID: "ACC-001", InstrumentCode: "GBP", Balance: decimal.NewFromFloat(-250.50)},
+				},
+			},
+		},
+	}
+
+	var dp PositionDataProvider = provider
+	page, err := dp.FetchPositions(context.Background(), "ACC-001", 10, "")
+
+	require.NoError(t, err)
+	require.Len(t, page.Records, 1)
+	assert.True(t, decimal.NewFromFloat(-250.50).Equal(page.Records[0].Balance))
+}
+
+func TestPositionDataProvider_MultipleSourceSystems(t *testing.T) {
+	provider := &stubPositionDataProvider{
+		pages: []PositionPage{
+			{
+				Records: []PositionRecord{
+					{AccountID: "ACC-001", InstrumentCode: "GBP", Balance: decimal.NewFromFloat(100), SourceSystem: "position-keeping"},
+					{AccountID: "ACC-001", InstrumentCode: "GBP", Balance: decimal.NewFromFloat(50), SourceSystem: "ledger"},
+				},
+			},
+		},
+	}
+
+	var dp PositionDataProvider = provider
+	page, err := dp.FetchPositions(context.Background(), "ACC-001", 10, "")
+
+	require.NoError(t, err)
+	require.Len(t, page.Records, 2)
+
+	sources := map[string]bool{}
+	for _, rec := range page.Records {
+		sources[rec.SourceSystem] = true
+	}
+	assert.True(t, sources["position-keeping"])
+	assert.True(t, sources["ledger"])
+}

--- a/services/reconciliation/service/position_provider_test.go
+++ b/services/reconciliation/service/position_provider_test.go
@@ -136,6 +136,12 @@ func TestPositionDataProvider_MultiPageAggregation(t *testing.T) {
 	require.Len(t, page2.Records, 1)
 	assert.Equal(t, "EUR", page2.Records[0].InstrumentCode)
 	assert.Empty(t, page2.NextPageToken)
+
+	// Aggregated result across all pages
+	aggregated := append(page1.Records, page2.Records...)
+	require.Len(t, aggregated, 2)
+	assert.Equal(t, "GBP", aggregated[0].InstrumentCode)
+	assert.Equal(t, "EUR", aggregated[1].InstrumentCode)
 }
 
 func TestPositionDataProvider_Error(t *testing.T) {

--- a/services/reconciliation/service/server_test.go
+++ b/services/reconciliation/service/server_test.go
@@ -1,0 +1,99 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/pkg/valuation"
+	"github.com/stretchr/testify/assert"
+)
+
+// Minimal stubs for valuation interfaces.
+
+type stubPolicyRuntime struct{}
+
+func (stubPolicyRuntime) CompilePolicy(_ string) (valuation.CompiledPolicy, error) { return nil, nil }
+func (stubPolicyRuntime) EvaluatePolicy(_ context.Context, _ valuation.CompiledPolicy, _ map[string]interface{}) (interface{}, uint64, error) {
+	return nil, 0, nil
+}
+
+type stubStarlarkRuntime struct{}
+
+func (stubStarlarkRuntime) Execute(_ context.Context, _ string, _ *valuation.Request) (*valuation.Response, error) {
+	return nil, nil
+}
+
+type stubValuationCache struct{}
+
+func (stubValuationCache) GetMethod(_ string, _ *int) (*valuation.Method, error)         { return nil, nil }
+func (stubValuationCache) SetMethod(_ *valuation.Method) error                           { return nil }
+func (stubValuationCache) GetPolicy(_ string, _ *int) (valuation.CompiledPolicy, error)  { return nil, nil }
+func (stubValuationCache) SetPolicy(_ string, _ int, _ valuation.CompiledPolicy) error   { return nil }
+func (stubValuationCache) Clear()                                                        {}
+
+func TestWithPolicyRuntime(t *testing.T) {
+	rt := stubPolicyRuntime{}
+	svc := NewAccountReconciliationService(WithPolicyRuntime(rt))
+	assert.Equal(t, rt, svc.policyRuntime)
+}
+
+func TestWithStarlarkRuntime(t *testing.T) {
+	rt := stubStarlarkRuntime{}
+	svc := NewAccountReconciliationService(WithStarlarkRuntime(rt))
+	assert.Equal(t, rt, svc.starlarkRuntime)
+}
+
+func TestWithValuationCache(t *testing.T) {
+	c := stubValuationCache{}
+	svc := NewAccountReconciliationService(WithValuationCache(c))
+	assert.Equal(t, c, svc.valuationCache)
+}
+
+func TestNewAccountReconciliationService_DefaultLogger(t *testing.T) {
+	// Without WithLogger, a default logger should be set.
+	svc := NewAccountReconciliationService()
+	assert.NotNil(t, svc.logger, "default logger must be initialized when not provided")
+}
+
+func TestNewAccountReconciliationService_PauseSignalsInitialized(t *testing.T) {
+	svc := NewAccountReconciliationService()
+	assert.NotNil(t, svc.pauseSignals, "pauseSignals map must be initialized")
+}
+
+func TestNewAccountReconciliationService_AllValuationOptions(t *testing.T) {
+	policyRuntime := stubPolicyRuntime{}
+	starlarkRuntime := stubStarlarkRuntime{}
+	cache := stubValuationCache{}
+
+	svc := NewAccountReconciliationService(
+		WithPolicyRuntime(policyRuntime),
+		WithStarlarkRuntime(starlarkRuntime),
+		WithValuationCache(cache),
+	)
+
+	assert.Equal(t, policyRuntime, svc.policyRuntime)
+	assert.Equal(t, starlarkRuntime, svc.starlarkRuntime)
+	assert.Equal(t, cache, svc.valuationCache)
+}
+
+func TestWithLogger_OverridesDefault(t *testing.T) {
+	// Providing a custom logger should override the default.
+	customLogger := testLogger()
+	svc := NewAccountReconciliationService(WithLogger(customLogger))
+	assert.Equal(t, customLogger, svc.logger)
+}
+
+func TestNewAccountReconciliationService_NilFieldsByDefault(t *testing.T) {
+	svc := NewAccountReconciliationService()
+
+	// Optional dependencies should be nil when not configured.
+	assert.Nil(t, svc.runRepo)
+	assert.Nil(t, svc.disputeRepo)
+	assert.Nil(t, svc.assertor)
+	assert.Nil(t, svc.snapshotCapturer)
+	assert.Nil(t, svc.varianceDetector)
+	assert.Nil(t, svc.varianceValuator)
+	assert.Nil(t, svc.policyRuntime)
+	assert.Nil(t, svc.starlarkRuntime)
+	assert.Nil(t, svc.valuationCache)
+}

--- a/services/reconciliation/service/server_test.go
+++ b/services/reconciliation/service/server_test.go
@@ -25,11 +25,13 @@ func (stubStarlarkRuntime) Execute(_ context.Context, _ string, _ *valuation.Req
 
 type stubValuationCache struct{}
 
-func (stubValuationCache) GetMethod(_ string, _ *int) (*valuation.Method, error)         { return nil, nil }
-func (stubValuationCache) SetMethod(_ *valuation.Method) error                           { return nil }
-func (stubValuationCache) GetPolicy(_ string, _ *int) (valuation.CompiledPolicy, error)  { return nil, nil }
-func (stubValuationCache) SetPolicy(_ string, _ int, _ valuation.CompiledPolicy) error   { return nil }
-func (stubValuationCache) Clear()                                                        {}
+func (stubValuationCache) GetMethod(_ string, _ *int) (*valuation.Method, error) { return nil, nil }
+func (stubValuationCache) SetMethod(_ *valuation.Method) error                   { return nil }
+func (stubValuationCache) GetPolicy(_ string, _ *int) (valuation.CompiledPolicy, error) {
+	return nil, nil
+}
+func (stubValuationCache) SetPolicy(_ string, _ int, _ valuation.CompiledPolicy) error { return nil }
+func (stubValuationCache) Clear()                                                      {}
 
 func TestWithPolicyRuntime(t *testing.T) {
 	rt := stubPolicyRuntime{}

--- a/services/reference-data/saga/reference_extractor_test.go
+++ b/services/reference-data/saga/reference_extractor_test.go
@@ -139,6 +139,8 @@ func TestReferenceExtractor_AttributeAccess(t *testing.T) {
 			instrRefs = append(instrRefs, r)
 		case ReferenceTypeAttribute:
 			attrRefs = append(attrRefs, r)
+		case ReferenceTypeStepHandler, ReferenceTypeAccount, ReferenceTypeSaga:
+			// not expected in this test; ignore
 		}
 	}
 	require.Len(t, instrRefs, 1)


### PR DESCRIPTION
## Summary

- Add unit tests for `domain/balance_imbalance_event.go`: event creation, P1_CRITICAL severity enforcement, unique EventID generation, precision handling, scope propagation
- Add unit tests for `domain/imbalance_trend.go`: threshold breach at 3 consecutive days, same-day no-increment, next-day increment, resolve/restart behavior, `sameUTCDay` helper
- Add unit tests for `service/fa_client.go`: `FinancialAccountingClient` interface contract, `DiagnosticDetail` struct, multi-instrument coverage, context cancellation
- Add unit tests for `service/pk_client.go`: `PositionKeepingClient` interface, `PositionSummary` struct, cross-account queries, high-precision decimals, non-currency instruments
- Add unit tests for `service/position_provider.go`: `PositionDataProvider` interface, `PositionRecord`/`PositionPage` types, multi-page aggregation, negative balances, multiple source systems
- Add unit tests for `service/server.go`: `WithPolicyRuntime`, `WithStarlarkRuntime`, `WithValuationCache` options, default logger initialization, nil-field defaults

## Test plan

- [ ] `go test ./services/reconciliation/domain/...` passes
- [ ] `go test ./services/reconciliation/service/...` passes
- [ ] All 6 new test files compile with no warnings