### PR TITLE
test: Add operational gateway unit tests

### DIFF
--- a/services/operational-gateway/adapters/persistence/route_repository_test.go
+++ b/services/operational-gateway/adapters/persistence/route_repository_test.go
@@ -1,0 +1,271 @@
+package persistence
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+	"github.com/meridianhub/meridian/services/operational-gateway/ports"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeRoute constructs a minimal domain.Route for testing.
+func makeRoute(t *testing.T, tenantID, instructionType, connectionID string) *domain.Route {
+	t.Helper()
+	route, err := domain.NewRoute(tenantID, instructionType, connectionID)
+	require.NoError(t, err)
+	return route
+}
+
+// insertRouteConnection creates a provider connection row to satisfy instruction_routes FK constraints.
+func insertRouteConnection(t *testing.T, connRepo *ConnectionRepository, tenantID, connectionID string) {
+	t.Helper()
+	conn, err := domain.NewProviderConnection(
+		tenantID,
+		"test-provider",
+		"test-type",
+		domain.ProtocolHTTPS,
+		"https://api.example.com",
+		&domain.APIKeyAuth{HeaderName: "X-Key", SecretRef: "ref"},
+		domain.RetryPolicy{MaxAttempts: 3, InitialBackoff: 100 * time.Millisecond, BackoffMultiplier: 2.0},
+		domain.RateLimitConfig{},
+	)
+	require.NoError(t, err)
+	conn.ConnectionID = connectionID
+	require.NoError(t, connRepo.Upsert(context.Background(), conn))
+}
+
+// TestRouteRepository_Upsert_Create verifies a new route can be inserted.
+func TestRouteRepository_Upsert_Create(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	connRepo := NewConnectionRepository(db)
+	routeRepo := NewRouteRepository(db)
+
+	tenantID := uuid.New().String()
+	connID := uuid.New().String()
+	insertRouteConnection(t, connRepo, tenantID, connID)
+
+	route := makeRoute(t, tenantID, "kyc.verify", connID)
+	require.NoError(t, routeRepo.Upsert(ctx, route))
+
+	found, err := routeRepo.FindByInstructionType(ctx, tenantID, "kyc.verify")
+	require.NoError(t, err)
+	assert.Equal(t, tenantID, found.TenantID)
+	assert.Equal(t, "kyc.verify", found.InstructionType)
+	assert.Equal(t, connID, found.ConnectionID)
+}
+
+// TestRouteRepository_Upsert_Update verifies upsert replaces an existing route.
+func TestRouteRepository_Upsert_Update(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	connRepo := NewConnectionRepository(db)
+	routeRepo := NewRouteRepository(db)
+
+	tenantID := uuid.New().String()
+	connID1 := uuid.New().String()
+	connID2 := uuid.New().String()
+	insertRouteConnection(t, connRepo, tenantID, connID1)
+	insertRouteConnection(t, connRepo, tenantID, connID2)
+
+	// Initial upsert.
+	route := makeRoute(t, tenantID, "device.command", connID1)
+	route.HTTPMethod = "POST"
+	route.PathTemplate = "/v1/commands"
+	require.NoError(t, routeRepo.Upsert(ctx, route))
+
+	// Update with new connection and fields.
+	updated := makeRoute(t, tenantID, "device.command", connID2)
+	updated.HTTPMethod = "PUT"
+	updated.PathTemplate = "/v2/commands"
+	updated.OutboundMapping = "device-outbound"
+	updated.InboundMapping = "device-inbound"
+	require.NoError(t, routeRepo.Upsert(ctx, updated))
+
+	found, err := routeRepo.FindByInstructionType(ctx, tenantID, "device.command")
+	require.NoError(t, err)
+	assert.Equal(t, connID2, found.ConnectionID)
+	assert.Equal(t, "PUT", found.HTTPMethod)
+	assert.Equal(t, "/v2/commands", found.PathTemplate)
+	assert.Equal(t, "device-outbound", found.OutboundMapping)
+	assert.Equal(t, "device-inbound", found.InboundMapping)
+}
+
+// TestRouteRepository_Upsert_WithFallback verifies fallback connection is persisted.
+func TestRouteRepository_Upsert_WithFallback(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	connRepo := NewConnectionRepository(db)
+	routeRepo := NewRouteRepository(db)
+
+	tenantID := uuid.New().String()
+	connID := uuid.New().String()
+	fallbackID := uuid.New().String()
+	insertRouteConnection(t, connRepo, tenantID, connID)
+	insertRouteConnection(t, connRepo, tenantID, fallbackID)
+
+	route := makeRoute(t, tenantID, "notification.send", connID)
+	route.FallbackConnectionID = fallbackID
+	require.NoError(t, routeRepo.Upsert(ctx, route))
+
+	found, err := routeRepo.FindByInstructionType(ctx, tenantID, "notification.send")
+	require.NoError(t, err)
+	assert.Equal(t, fallbackID, found.FallbackConnectionID)
+}
+
+// TestRouteRepository_FindByInstructionType_NotFound verifies ErrRouteNotFound is returned.
+func TestRouteRepository_FindByInstructionType_NotFound(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	routeRepo := NewRouteRepository(db)
+
+	_, err := routeRepo.FindByInstructionType(ctx, uuid.New().String(), "nonexistent.type")
+	require.ErrorIs(t, err, ports.ErrRouteNotFound)
+}
+
+// TestRouteRepository_FindByInstructionType_InvalidTenantUUID verifies non-UUID tenant returns ErrRouteNotFound.
+func TestRouteRepository_FindByInstructionType_InvalidTenantUUID(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	routeRepo := NewRouteRepository(db)
+
+	_, err := routeRepo.FindByInstructionType(ctx, "not-a-uuid", "kyc.verify")
+	require.ErrorIs(t, err, ports.ErrRouteNotFound)
+}
+
+// TestRouteRepository_ListByTenant_Empty verifies empty slice when no routes exist.
+func TestRouteRepository_ListByTenant_Empty(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	routeRepo := NewRouteRepository(db)
+
+	routes, err := routeRepo.ListByTenant(ctx, uuid.New().String())
+	require.NoError(t, err)
+	assert.Empty(t, routes)
+}
+
+// TestRouteRepository_ListByTenant_InvalidUUID verifies non-UUID tenant returns empty slice (not an error).
+func TestRouteRepository_ListByTenant_InvalidUUID(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	routeRepo := NewRouteRepository(db)
+
+	routes, err := routeRepo.ListByTenant(ctx, "not-a-uuid")
+	require.NoError(t, err)
+	assert.Empty(t, routes)
+}
+
+// TestRouteRepository_ListByTenant_OrderedByInstructionType verifies routes are ordered alphabetically.
+func TestRouteRepository_ListByTenant_OrderedByInstructionType(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	connRepo := NewConnectionRepository(db)
+	routeRepo := NewRouteRepository(db)
+
+	tenantID := uuid.New().String()
+	connID := uuid.New().String()
+	insertRouteConnection(t, connRepo, tenantID, connID)
+
+	// Insert in reverse alphabetical order.
+	for _, itype := range []string{"notification.send", "kyc.verify", "device.command"} {
+		route := makeRoute(t, tenantID, itype, connID)
+		require.NoError(t, routeRepo.Upsert(ctx, route))
+	}
+
+	routes, err := routeRepo.ListByTenant(ctx, tenantID)
+	require.NoError(t, err)
+	require.Len(t, routes, 3)
+
+	// Results must be ordered by instruction_type ASC.
+	assert.Equal(t, "device.command", routes[0].InstructionType)
+	assert.Equal(t, "kyc.verify", routes[1].InstructionType)
+	assert.Equal(t, "notification.send", routes[2].InstructionType)
+}
+
+// TestRouteRepository_ListByTenant_TenantIsolation verifies routes from other tenants are not returned.
+func TestRouteRepository_ListByTenant_TenantIsolation(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	connRepo := NewConnectionRepository(db)
+	routeRepo := NewRouteRepository(db)
+
+	tenant1 := uuid.New().String()
+	tenant2 := uuid.New().String()
+	connID1 := uuid.New().String()
+	connID2 := uuid.New().String()
+	insertRouteConnection(t, connRepo, tenant1, connID1)
+	insertRouteConnection(t, connRepo, tenant2, connID2)
+
+	route1 := makeRoute(t, tenant1, "kyc.verify", connID1)
+	require.NoError(t, routeRepo.Upsert(ctx, route1))
+	route2 := makeRoute(t, tenant2, "kyc.verify", connID2)
+	require.NoError(t, routeRepo.Upsert(ctx, route2))
+
+	routes1, err := routeRepo.ListByTenant(ctx, tenant1)
+	require.NoError(t, err)
+	require.Len(t, routes1, 1)
+	assert.Equal(t, tenant1, routes1[0].TenantID)
+
+	routes2, err := routeRepo.ListByTenant(ctx, tenant2)
+	require.NoError(t, err)
+	require.Len(t, routes2, 1)
+	assert.Equal(t, tenant2, routes2[0].TenantID)
+}
+
+// TestRouteRepository_Upsert_AllFields verifies all optional fields round-trip correctly.
+func TestRouteRepository_Upsert_AllFields(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	connRepo := NewConnectionRepository(db)
+	routeRepo := NewRouteRepository(db)
+
+	tenantID := uuid.New().String()
+	connID := uuid.New().String()
+	fallbackID := uuid.New().String()
+	insertRouteConnection(t, connRepo, tenantID, connID)
+	insertRouteConnection(t, connRepo, tenantID, fallbackID)
+
+	route := makeRoute(t, tenantID, "payment.initiate", connID)
+	route.FallbackConnectionID = fallbackID
+	route.OutboundMapping = "payment-outbound"
+	route.InboundMapping = "payment-inbound"
+	route.HTTPMethod = "POST"
+	route.PathTemplate = "/v1/payments"
+	require.NoError(t, routeRepo.Upsert(ctx, route))
+
+	found, err := routeRepo.FindByInstructionType(ctx, tenantID, "payment.initiate")
+	require.NoError(t, err)
+	assert.Equal(t, tenantID, found.TenantID)
+	assert.Equal(t, "payment.initiate", found.InstructionType)
+	assert.Equal(t, connID, found.ConnectionID)
+	assert.Equal(t, fallbackID, found.FallbackConnectionID)
+	assert.Equal(t, "payment-outbound", found.OutboundMapping)
+	assert.Equal(t, "payment-inbound", found.InboundMapping)
+	assert.Equal(t, "POST", found.HTTPMethod)
+	assert.Equal(t, "/v1/payments", found.PathTemplate)
+	assert.False(t, found.CreatedAt.IsZero())
+	assert.False(t, found.UpdatedAt.IsZero())
+}
+
+// TestRouteRepository_Upsert_ClearsOptionalFields verifies removing fallback on update works.
+func TestRouteRepository_Upsert_ClearsOptionalFields(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	connRepo := NewConnectionRepository(db)
+	routeRepo := NewRouteRepository(db)
+
+	tenantID := uuid.New().String()
+	connID := uuid.New().String()
+	fallbackID := uuid.New().String()
+	insertRouteConnection(t, connRepo, tenantID, connID)
+	insertRouteConnection(t, connRepo, tenantID, fallbackID)
+
+	// Insert with fallback.
+	route := makeRoute(t, tenantID, "kyc.check", connID)
+	route.FallbackConnectionID = fallbackID
+	route.OutboundMapping = "outbound-v1"
+	require.NoError(t, routeRepo.Upsert(ctx, route))
+
+	// Update without fallback (should clear it).
+	updated := makeRoute(t, tenantID, "kyc.check", connID)
+	updated.OutboundMapping = "outbound-v2"
+	require.NoError(t, routeRepo.Upsert(ctx, updated))
+
+	found, err := routeRepo.FindByInstructionType(ctx, tenantID, "kyc.check")
+	require.NoError(t, err)
+	assert.Empty(t, found.FallbackConnectionID)
+	assert.Equal(t, "outbound-v2", found.OutboundMapping)
+}

--- a/services/operational-gateway/adapters/persistence/setup_test.go
+++ b/services/operational-gateway/adapters/persistence/setup_test.go
@@ -143,6 +143,19 @@ func createSchema(db *gorm.DB) error {
             PRIMARY KEY (id)
         )`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_instruction_attempts_instruction ON instruction_attempts (instruction_id, attempt_number)`,
+		`CREATE TABLE IF NOT EXISTS instruction_routes (
+            tenant_id UUID NOT NULL,
+            instruction_type VARCHAR(255) NOT NULL,
+            connection_id UUID NOT NULL,
+            fallback_connection_id UUID NULL,
+            outbound_mapping VARCHAR(255) NOT NULL DEFAULT '',
+            inbound_mapping VARCHAR(255) NOT NULL DEFAULT '',
+            http_method VARCHAR(10) NOT NULL DEFAULT '',
+            path_template VARCHAR(1024) NOT NULL DEFAULT '',
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            PRIMARY KEY (tenant_id, instruction_type)
+        )`,
 	}
 
 	for _, stmt := range ddl {
@@ -168,7 +181,7 @@ func getSharedDB(t *testing.T) *gorm.DB {
 // cleanTables truncates all data between tests (FK order: children first).
 func cleanTables(t *testing.T, db *gorm.DB) {
 	t.Helper()
-	tables := []string{"instruction_attempts", "instructions", "provider_connections"}
+	tables := []string{"instruction_attempts", "instructions", "instruction_routes", "provider_connections"}
 	for _, tbl := range tables {
 		if err := db.Exec("DELETE FROM " + tbl).Error; err != nil {
 			t.Fatalf("failed to clean table %s: %v", tbl, err)

--- a/services/operational-gateway/adapters/persistence/setup_test.go
+++ b/services/operational-gateway/adapters/persistence/setup_test.go
@@ -154,8 +154,11 @@ func createSchema(db *gorm.DB) error {
             path_template VARCHAR(1024) NOT NULL DEFAULT '',
             created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
             updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-            PRIMARY KEY (tenant_id, instruction_type)
+            PRIMARY KEY (tenant_id, instruction_type),
+            FOREIGN KEY (tenant_id, connection_id) REFERENCES provider_connections (tenant_id, connection_id) ON DELETE RESTRICT,
+            FOREIGN KEY (tenant_id, fallback_connection_id) REFERENCES provider_connections (tenant_id, connection_id) ON DELETE RESTRICT
         )`,
+		`CREATE INDEX IF NOT EXISTS idx_instruction_routes_connection_id ON instruction_routes (tenant_id, connection_id)`,
 	}
 
 	for _, stmt := range ddl {

--- a/services/operational-gateway/config/config_test.go
+++ b/services/operational-gateway/config/config_test.go
@@ -1,0 +1,133 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLoadConfig_Defaults verifies all default values are applied when no env vars are set.
+func TestLoadConfig_Defaults(t *testing.T) {
+	clearEnv(t)
+
+	cfg := LoadConfig()
+
+	assert.NotEmpty(t, cfg.GRPCPort, "GRPCPort should have a default")
+	assert.Empty(t, cfg.DatabaseURL, "DatabaseURL default should be empty")
+	assert.Equal(t, "info", cfg.LogLevel)
+	assert.Equal(t, 50, cfg.DispatchWorker.BatchSize)
+	assert.Equal(t, 1*time.Second, cfg.DispatchWorker.PollInterval)
+	assert.Equal(t, 30*time.Second, cfg.ExpiryWorker.ScanInterval)
+	assert.Equal(t, 100, cfg.ExpiryWorker.BatchSize)
+}
+
+// TestLoadConfig_GRPCPort verifies GRPC_PORT env var is read.
+func TestLoadConfig_GRPCPort(t *testing.T) {
+	t.Setenv("GRPC_PORT", "9090")
+
+	cfg := LoadConfig()
+
+	assert.Equal(t, "9090", cfg.GRPCPort)
+}
+
+// TestLoadConfig_DatabaseURL verifies DATABASE_URL env var is read.
+func TestLoadConfig_DatabaseURL(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://user:pass@localhost/mydb")
+
+	cfg := LoadConfig()
+
+	assert.Equal(t, "postgres://user:pass@localhost/mydb", cfg.DatabaseURL)
+}
+
+// TestLoadConfig_LogLevel verifies LOG_LEVEL env var is read.
+func TestLoadConfig_LogLevel(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "debug")
+
+	cfg := LoadConfig()
+
+	assert.Equal(t, "debug", cfg.LogLevel)
+}
+
+// TestLoadConfig_DispatchWorkerBatchSize verifies DISPATCH_WORKER_BATCH_SIZE env var is read.
+func TestLoadConfig_DispatchWorkerBatchSize(t *testing.T) {
+	t.Setenv("DISPATCH_WORKER_BATCH_SIZE", "25")
+
+	cfg := LoadConfig()
+
+	assert.Equal(t, 25, cfg.DispatchWorker.BatchSize)
+}
+
+// TestLoadConfig_DispatchWorkerBatchSize_InvalidFallsBackToDefault verifies invalid int uses default.
+func TestLoadConfig_DispatchWorkerBatchSize_InvalidFallsBackToDefault(t *testing.T) {
+	t.Setenv("DISPATCH_WORKER_BATCH_SIZE", "not-a-number")
+
+	cfg := LoadConfig()
+
+	assert.Equal(t, 50, cfg.DispatchWorker.BatchSize)
+}
+
+// TestLoadConfig_DispatchWorkerPollInterval verifies DISPATCH_WORKER_POLL_INTERVAL env var is read.
+func TestLoadConfig_DispatchWorkerPollInterval(t *testing.T) {
+	t.Setenv("DISPATCH_WORKER_POLL_INTERVAL", "500ms")
+
+	cfg := LoadConfig()
+
+	assert.Equal(t, 500*time.Millisecond, cfg.DispatchWorker.PollInterval)
+}
+
+// TestLoadConfig_ExpiryWorkerScanInterval verifies EXPIRY_WORKER_SCAN_INTERVAL env var is read.
+func TestLoadConfig_ExpiryWorkerScanInterval(t *testing.T) {
+	t.Setenv("EXPIRY_WORKER_SCAN_INTERVAL", "1m")
+
+	cfg := LoadConfig()
+
+	assert.Equal(t, 1*time.Minute, cfg.ExpiryWorker.ScanInterval)
+}
+
+// TestLoadConfig_ExpiryWorkerBatchSize verifies EXPIRY_WORKER_BATCH_SIZE env var is read.
+func TestLoadConfig_ExpiryWorkerBatchSize(t *testing.T) {
+	t.Setenv("EXPIRY_WORKER_BATCH_SIZE", "200")
+
+	cfg := LoadConfig()
+
+	assert.Equal(t, 200, cfg.ExpiryWorker.BatchSize)
+}
+
+// TestLoadConfig_AllEnvVarsSet verifies all env vars can be set together.
+func TestLoadConfig_AllEnvVarsSet(t *testing.T) {
+	t.Setenv("GRPC_PORT", "8080")
+	t.Setenv("DATABASE_URL", "postgres://host/db")
+	t.Setenv("LOG_LEVEL", "warn")
+	t.Setenv("DISPATCH_WORKER_BATCH_SIZE", "10")
+	t.Setenv("DISPATCH_WORKER_POLL_INTERVAL", "2s")
+	t.Setenv("EXPIRY_WORKER_SCAN_INTERVAL", "5m")
+	t.Setenv("EXPIRY_WORKER_BATCH_SIZE", "50")
+
+	cfg := LoadConfig()
+
+	assert.Equal(t, "8080", cfg.GRPCPort)
+	assert.Equal(t, "postgres://host/db", cfg.DatabaseURL)
+	assert.Equal(t, "warn", cfg.LogLevel)
+	assert.Equal(t, 10, cfg.DispatchWorker.BatchSize)
+	assert.Equal(t, 2*time.Second, cfg.DispatchWorker.PollInterval)
+	assert.Equal(t, 5*time.Minute, cfg.ExpiryWorker.ScanInterval)
+	assert.Equal(t, 50, cfg.ExpiryWorker.BatchSize)
+}
+
+// clearEnv unsets all config-related environment variables for a test.
+func clearEnv(t *testing.T) {
+	t.Helper()
+	vars := []string{
+		"GRPC_PORT",
+		"DATABASE_URL",
+		"LOG_LEVEL",
+		"DISPATCH_WORKER_BATCH_SIZE",
+		"DISPATCH_WORKER_POLL_INTERVAL",
+		"EXPIRY_WORKER_SCAN_INTERVAL",
+		"EXPIRY_WORKER_BATCH_SIZE",
+	}
+	for _, v := range vars {
+		t.Setenv(v, "")
+	}
+}

--- a/services/operational-gateway/domain/instruction_route_test.go
+++ b/services/operational-gateway/domain/instruction_route_test.go
@@ -1,0 +1,117 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewRoute_Success verifies a route is created with all required fields.
+func TestNewRoute_Success(t *testing.T) {
+	tenantID := "tenant-uuid-001"
+	instructionType := "kyc.verify"
+	connectionID := "conn-uuid-001"
+
+	route, err := NewRoute(tenantID, instructionType, connectionID)
+
+	require.NoError(t, err)
+	require.NotNil(t, route)
+	assert.Equal(t, tenantID, route.TenantID)
+	assert.Equal(t, instructionType, route.InstructionType)
+	assert.Equal(t, connectionID, route.ConnectionID)
+	assert.Empty(t, route.FallbackConnectionID)
+	assert.Empty(t, route.OutboundMapping)
+	assert.Empty(t, route.InboundMapping)
+	assert.Empty(t, route.HTTPMethod)
+	assert.Empty(t, route.PathTemplate)
+}
+
+// TestNewRoute_SetsTimestamps verifies CreatedAt and UpdatedAt are set on construction.
+func TestNewRoute_SetsTimestamps(t *testing.T) {
+	before := time.Now().UTC().Add(-time.Second)
+	route, err := NewRoute("tenant-1", "device.command", "conn-1")
+	after := time.Now().UTC().Add(time.Second)
+
+	require.NoError(t, err)
+	assert.True(t, route.CreatedAt.After(before), "CreatedAt should be after test start")
+	assert.True(t, route.CreatedAt.Before(after), "CreatedAt should be before test end")
+	assert.True(t, route.UpdatedAt.After(before), "UpdatedAt should be after test start")
+	assert.True(t, route.UpdatedAt.Before(after), "UpdatedAt should be before test end")
+}
+
+// TestNewRoute_MissingTenantID verifies ErrTenantIDRequired is returned.
+func TestNewRoute_MissingTenantID(t *testing.T) {
+	_, err := NewRoute("", "kyc.verify", "conn-1")
+	require.ErrorIs(t, err, ErrTenantIDRequired)
+}
+
+// TestNewRoute_MissingInstructionType verifies ErrInstructionTypeRequired is returned.
+func TestNewRoute_MissingInstructionType(t *testing.T) {
+	_, err := NewRoute("tenant-1", "", "conn-1")
+	require.ErrorIs(t, err, ErrInstructionTypeRequired)
+}
+
+// TestNewRoute_MissingConnectionID verifies ErrConnectionIDRequired is returned.
+func TestNewRoute_MissingConnectionID(t *testing.T) {
+	_, err := NewRoute("tenant-1", "kyc.verify", "")
+	require.ErrorIs(t, err, ErrConnectionIDRequired)
+}
+
+// TestRoute_OptionalFieldsCanBeSet verifies optional fields can be set after construction.
+func TestRoute_OptionalFieldsCanBeSet(t *testing.T) {
+	route, err := NewRoute("tenant-1", "payment.collect", "conn-primary")
+	require.NoError(t, err)
+
+	route.FallbackConnectionID = "conn-fallback"
+	route.OutboundMapping = "payment-outbound"
+	route.InboundMapping = "payment-inbound"
+	route.HTTPMethod = "POST"
+	route.PathTemplate = "/v1/payments"
+
+	assert.Equal(t, "conn-fallback", route.FallbackConnectionID)
+	assert.Equal(t, "payment-outbound", route.OutboundMapping)
+	assert.Equal(t, "payment-inbound", route.InboundMapping)
+	assert.Equal(t, "POST", route.HTTPMethod)
+	assert.Equal(t, "/v1/payments", route.PathTemplate)
+}
+
+// TestNewRoute_InstructionTypeVariants verifies dotted instruction types are accepted.
+func TestNewRoute_InstructionTypeVariants(t *testing.T) {
+	cases := []struct {
+		name            string
+		instructionType string
+	}{
+		{"simple", "kyc"},
+		{"dotted", "kyc.verify"},
+		{"deep", "payment.collect.retry"},
+		{"with-dash", "notification.send-sms"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			route, err := NewRoute("tenant-1", tc.instructionType, "conn-1")
+			require.NoError(t, err)
+			assert.Equal(t, tc.instructionType, route.InstructionType)
+		})
+	}
+}
+
+// TestRoute_HasFallback verifies fallback detection via non-empty FallbackConnectionID.
+func TestRoute_HasFallback(t *testing.T) {
+	route, err := NewRoute("tenant-1", "kyc.verify", "conn-primary")
+	require.NoError(t, err)
+	assert.Empty(t, route.FallbackConnectionID, "no fallback set initially")
+
+	route.FallbackConnectionID = "conn-fallback"
+	assert.NotEmpty(t, route.FallbackConnectionID, "fallback should be set")
+}
+
+// TestRoute_Errors_AreDistinct verifies route error sentinels are unique values.
+func TestRoute_Errors_AreDistinct(t *testing.T) {
+	assert.NotEqual(t, ErrInstructionTypeRequired, ErrConnectionIDRequired)
+	assert.NotEqual(t, ErrInstructionTypeRequired, ErrTenantIDRequired)
+	assert.NotEqual(t, ErrConnectionIDRequired, ErrTenantIDRequired)
+	assert.NotEqual(t, ErrInstructionRouteNotFound, ErrInstructionTypeRequired)
+}

--- a/services/operational-gateway/service/grpc_connection_service_test.go
+++ b/services/operational-gateway/service/grpc_connection_service_test.go
@@ -1,0 +1,109 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ========== TestConnection ==========
+
+// TestTestConnection_ExistingConnection_ReturnsUnimplemented verifies that when a connection exists,
+// TestConnection returns Unimplemented with a Phase 2 message (placeholder for live health check).
+func TestTestConnection_ExistingConnection_ReturnsUnimplemented(t *testing.T) {
+	svc, connRepo := newTestConnService(t)
+	ctx := tenantContext("test-tenant")
+	tid := tenantIDToUUID(tenant.TenantID("test-tenant"))
+	connID := uuid.New().String()
+
+	conn := &domain.ProviderConnection{
+		TenantID:     tid,
+		ConnectionID: connID,
+		ProviderName: "TestProvider",
+		Protocol:     domain.ProtocolHTTPS,
+		BaseURL:      "https://api.example.com",
+	}
+	connRepo.connections[tid+":"+connID] = conn
+
+	_, err := svc.TestConnection(ctx, &opgatewayv1.TestConnectionRequest{
+		ConnectionId: connID,
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unimplemented, st.Code())
+	assert.Contains(t, st.Message(), "Phase 2")
+}
+
+// ========== UpsertConnection credential type coverage ==========
+
+// TestUpsertConnection_BasicAuth verifies basic auth credentials are accepted.
+func TestUpsertConnection_BasicAuth(t *testing.T) {
+	svc, _ := newTestConnService(t)
+	ctx := tenantContext("test-tenant")
+
+	resp, err := svc.UpsertConnection(ctx, &opgatewayv1.UpsertConnectionRequest{
+		ProviderName: "ModulrFinance",
+		ProviderType: "payment_gateway",
+		Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
+		BaseUrl:      "https://api.modulrfinance.com",
+		AuthConfig: &opgatewayv1.UpsertConnectionRequest_Basic{
+			Basic: &opgatewayv1.BasicAuth{
+				Username:          "api-user",
+				PasswordSecretRef: "modulr-password",
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp.Connection)
+	assert.Equal(t, "ModulrFinance", resp.Connection.ProviderName)
+	assert.Equal(t, opgatewayv1.Protocol_PROTOCOL_HTTPS, resp.Connection.Protocol)
+}
+
+// TestUpsertConnection_OAuth2 verifies OAuth2 client credentials are accepted.
+func TestUpsertConnection_OAuth2(t *testing.T) {
+	svc, _ := newTestConnService(t)
+	ctx := tenantContext("test-tenant")
+
+	resp, err := svc.UpsertConnection(ctx, &opgatewayv1.UpsertConnectionRequest{
+		ProviderName: "OAuth2Provider",
+		ProviderType: "data_provider",
+		Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
+		BaseUrl:      "https://api.oauth2provider.com",
+		AuthConfig: &opgatewayv1.UpsertConnectionRequest_Oauth2{
+			Oauth2: &opgatewayv1.OAuth2Auth{
+				TokenUrl:        "https://auth.example.com/token",
+				ClientId:        "client-id",
+				ClientSecretRef: "client-secret-ref",
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp.Connection)
+	assert.Equal(t, "OAuth2Provider", resp.Connection.ProviderName)
+}
+
+// ========== ListConnections error path ==========
+
+// TestListConnections_RepoListError verifies Internal is returned when the repo list fails.
+func TestListConnections_RepoListError(t *testing.T) {
+	svc, connRepo := newTestConnService(t)
+	connRepo.listErr = assert.AnError
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.ListConnections(ctx, &opgatewayv1.ListConnectionsRequest{})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}

--- a/services/operational-gateway/service/grpc_service_test.go
+++ b/services/operational-gateway/service/grpc_service_test.go
@@ -124,6 +124,7 @@ type mockConnectionRepo struct {
 	connections map[string]*domain.ProviderConnection
 	upsertErr   error
 	findErr     error
+	listErr     error
 }
 
 func newMockConnectionRepo() *mockConnectionRepo {
@@ -160,6 +161,9 @@ func (m *mockConnectionRepo) FindByID(_ context.Context, tenantID string, connec
 func (m *mockConnectionRepo) ListByTenant(_ context.Context, tenantID string) ([]*domain.ProviderConnection, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
 	var result []*domain.ProviderConnection
 	for _, conn := range m.connections {
 		if conn.TenantID == tenantID {

--- a/services/operational-gateway/service/route_server_test.go
+++ b/services/operational-gateway/service/route_server_test.go
@@ -1,0 +1,166 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ========== NewInstructionRouteService logger default ==========
+
+func TestNewInstructionRouteService_NilLogger_UsesDefault(t *testing.T) {
+	svc, err := NewInstructionRouteService(newMockRouteRepo(), newMockConnectionRepo(), nil)
+	require.NoError(t, err)
+	assert.NotNil(t, svc)
+	assert.NotNil(t, svc.logger)
+}
+
+// ========== UpsertRoute additional edge cases ==========
+
+func TestUpsertRoute_WithAllOptionalFields(t *testing.T) {
+	svc, _, connRepo := newTestRouteService(t)
+	ctx := tenantContext("test-tenant")
+	tid := testTenantID()
+	connID := uuid.New().String()
+	fallbackID := uuid.New().String()
+	seedConnection(connRepo, tid, connID)
+	seedConnection(connRepo, tid, fallbackID)
+
+	resp, err := svc.UpsertRoute(ctx, &opgatewayv1.UpsertRouteRequest{
+		InstructionType:      "kyc.verify",
+		ConnectionId:         connID,
+		FallbackConnectionId: fallbackID,
+		OutboundMapping:      "kyc-outbound-v2",
+		InboundMapping:       "kyc-inbound-v2",
+		HttpMethod:           "PATCH",
+		PathTemplate:         "/v2/verifications",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "kyc.verify", resp.Route.InstructionType)
+	assert.Equal(t, connID, resp.Route.ConnectionId)
+	assert.Equal(t, fallbackID, resp.Route.FallbackConnectionId)
+	assert.Equal(t, "kyc-outbound-v2", resp.Route.OutboundMapping)
+	assert.Equal(t, "kyc-inbound-v2", resp.Route.InboundMapping)
+	assert.Equal(t, "PATCH", resp.Route.HttpMethod)
+	assert.Equal(t, "/v2/verifications", resp.Route.PathTemplate)
+}
+
+func TestUpsertRoute_IdempotentUpsert(t *testing.T) {
+	svc, routeRepo, connRepo := newTestRouteService(t)
+	ctx := tenantContext("test-tenant")
+	tid := testTenantID()
+	connID1 := uuid.New().String()
+	connID2 := uuid.New().String()
+	seedConnection(connRepo, tid, connID1)
+	seedConnection(connRepo, tid, connID2)
+
+	// First upsert.
+	_, err := svc.UpsertRoute(ctx, &opgatewayv1.UpsertRouteRequest{
+		InstructionType: "device.command",
+		ConnectionId:    connID1,
+		PathTemplate:    "/v1/commands",
+	})
+	require.NoError(t, err)
+
+	// Second upsert with different connection (update semantics).
+	resp, err := svc.UpsertRoute(ctx, &opgatewayv1.UpsertRouteRequest{
+		InstructionType: "device.command",
+		ConnectionId:    connID2,
+		PathTemplate:    "/v2/commands",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, connID2, resp.Route.ConnectionId)
+	assert.Equal(t, "/v2/commands", resp.Route.PathTemplate)
+
+	// Only one route should exist for this tenant+type.
+	routes, err := routeRepo.ListByTenant(ctx, tid)
+	require.NoError(t, err)
+	assert.Len(t, routes, 1)
+}
+
+// ========== GetRoute edge cases ==========
+
+func TestGetRoute_DifferentTenants_Isolated(t *testing.T) {
+	svc, routeRepo, _ := newTestRouteService(t)
+
+	tid1 := testTenantID()
+
+	route := &domain.Route{
+		TenantID:        tid1,
+		InstructionType: "kyc.verify",
+		ConnectionID:    uuid.New().String(),
+	}
+	routeRepo.routes[tid1+":kyc.verify"] = route
+
+	// tenant1 can find it.
+	ctx1 := tenantContext("test-tenant")
+	resp, err := svc.GetRoute(ctx1, &opgatewayv1.GetRouteRequest{InstructionType: "kyc.verify"})
+	require.NoError(t, err)
+	assert.Equal(t, "kyc.verify", resp.Route.InstructionType)
+
+	// tenant2 gets not found.
+	ctx2 := tenantContext("other-tenant")
+	_, err = svc.GetRoute(ctx2, &opgatewayv1.GetRouteRequest{InstructionType: "kyc.verify"})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+// ========== ListRoutes with multiple tenants ==========
+
+func TestListRoutes_MultiTenantIsolation(t *testing.T) {
+	svc, routeRepo, _ := newTestRouteService(t)
+
+	tid1 := testTenantID()
+	tid2 := tenantIDToUUID(tenant.TenantID("other-tenant"))
+
+	for _, itype := range []string{"kyc.verify", "device.command"} {
+		routeRepo.routes[tid1+":"+itype] = &domain.Route{TenantID: tid1, InstructionType: itype, ConnectionID: uuid.New().String()}
+	}
+	routeRepo.routes[tid2+":notification.send"] = &domain.Route{TenantID: tid2, InstructionType: "notification.send", ConnectionID: uuid.New().String()}
+
+	// tenant1 sees only their 2 routes.
+	ctx1 := tenantContext("test-tenant")
+	resp1, err := svc.ListRoutes(ctx1, &opgatewayv1.ListRoutesRequest{})
+	require.NoError(t, err)
+	assert.Len(t, resp1.Routes, 2)
+	for _, r := range resp1.Routes {
+		assert.NotEqual(t, "notification.send", r.InstructionType)
+	}
+
+	// tenant2 sees only their 1 route.
+	ctx2 := tenantContext("other-tenant")
+	resp2, err := svc.ListRoutes(ctx2, &opgatewayv1.ListRoutesRequest{})
+	require.NoError(t, err)
+	assert.Len(t, resp2.Routes, 1)
+	assert.Equal(t, "notification.send", resp2.Routes[0].InstructionType)
+}
+
+// ========== routeToProto field mapping ==========
+
+func TestRouteToProto_EmptyOptionalFields(t *testing.T) {
+	route := &domain.Route{
+		TenantID:        testTenantID(),
+		InstructionType: "kyc.verify",
+		ConnectionID:    "conn-1",
+		// All optional fields left empty.
+	}
+
+	p := routeToProto(route)
+	assert.Equal(t, "kyc.verify", p.InstructionType)
+	assert.Equal(t, "conn-1", p.ConnectionId)
+	assert.Empty(t, p.FallbackConnectionId)
+	assert.Empty(t, p.OutboundMapping)
+	assert.Empty(t, p.InboundMapping)
+	assert.Empty(t, p.HttpMethod)
+	assert.Empty(t, p.PathTemplate)
+}

--- a/services/operational-gateway/service/server_test.go
+++ b/services/operational-gateway/service/server_test.go
@@ -5,16 +5,15 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
 	"github.com/meridianhub/meridian/services/operational-gateway/domain"
-"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 	"gorm.io/gorm"
-
-	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 )
 
 // ========== Constructor nil-logger fallback tests ==========
@@ -48,21 +47,27 @@ type mockEventPublisher struct{}
 func (m *mockEventPublisher) PublishCreated(_ context.Context, _ *gorm.DB, _ *domain.Instruction) error {
 	return nil
 }
+
 func (m *mockEventPublisher) PublishDispatched(_ context.Context, _ *gorm.DB, _ *domain.Instruction) error {
 	return nil
 }
+
 func (m *mockEventPublisher) PublishDelivered(_ context.Context, _ *gorm.DB, _ *domain.Instruction) error {
 	return nil
 }
+
 func (m *mockEventPublisher) PublishAcknowledged(_ context.Context, _ *gorm.DB, _ *domain.Instruction) error {
 	return nil
 }
+
 func (m *mockEventPublisher) PublishFailed(_ context.Context, _ *gorm.DB, _ *domain.Instruction) error {
 	return nil
 }
+
 func (m *mockEventPublisher) PublishExpired(_ context.Context, _ *gorm.DB, _ *domain.Instruction) error {
 	return nil
 }
+
 func (m *mockEventPublisher) PublishCancelled(_ context.Context, _ *gorm.DB, _ *domain.Instruction) error {
 	return nil
 }
@@ -128,4 +133,3 @@ func TestDispatchInstruction_WithMetadata(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, resp.Instruction.Id)
 }
-

--- a/services/operational-gateway/service/server_test.go
+++ b/services/operational-gateway/service/server_test.go
@@ -1,0 +1,131 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+	"gorm.io/gorm"
+
+	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+)
+
+// ========== Constructor nil-logger fallback tests ==========
+
+func TestNewOperationalGatewayService_NilLogger_UsesDefault(t *testing.T) {
+	svc, err := NewOperationalGatewayService(newMockInstructionRepo(), newMockConnectionRepo(), nil)
+	require.NoError(t, err)
+	assert.NotNil(t, svc)
+	assert.NotNil(t, svc.logger)
+}
+
+func TestNewProviderConnectionService_NilLogger_UsesDefault(t *testing.T) {
+	svc, err := NewProviderConnectionService(newMockConnectionRepo(), newMockInstructionRepo(), nil)
+	require.NoError(t, err)
+	assert.NotNil(t, svc)
+	assert.NotNil(t, svc.logger)
+}
+
+// TestNewProviderConnectionService_NilInstructionRepo verifies ErrInstructionRepoNil when instruction
+// repo is nil (distinct from the existing nil-connection-repo test in grpc_service_test.go).
+func TestNewProviderConnectionService_NilInstructionRepo(t *testing.T) {
+	_, err := NewProviderConnectionService(newMockConnectionRepo(), nil, nil)
+	assert.ErrorIs(t, err, ErrInstructionRepoNil)
+}
+
+// ========== saveInstructionWithEvent: partial config via event publisher only ==========
+
+// mockEventPublisher satisfies ports.InstructionEventPublisher for partial config tests.
+type mockEventPublisher struct{}
+
+func (m *mockEventPublisher) PublishCreated(_ context.Context, _ *gorm.DB, _ *domain.Instruction) error {
+	return nil
+}
+func (m *mockEventPublisher) PublishDispatched(_ context.Context, _ *gorm.DB, _ *domain.Instruction) error {
+	return nil
+}
+func (m *mockEventPublisher) PublishDelivered(_ context.Context, _ *gorm.DB, _ *domain.Instruction) error {
+	return nil
+}
+func (m *mockEventPublisher) PublishAcknowledged(_ context.Context, _ *gorm.DB, _ *domain.Instruction) error {
+	return nil
+}
+func (m *mockEventPublisher) PublishFailed(_ context.Context, _ *gorm.DB, _ *domain.Instruction) error {
+	return nil
+}
+func (m *mockEventPublisher) PublishExpired(_ context.Context, _ *gorm.DB, _ *domain.Instruction) error {
+	return nil
+}
+func (m *mockEventPublisher) PublishCancelled(_ context.Context, _ *gorm.DB, _ *domain.Instruction) error {
+	return nil
+}
+
+// TestSaveInstructionWithEvent_PartialConfig_PublisherOnly verifies partial config (eventPublisher
+// set, db/impl absent) returns ErrEventPublishingPartialConfig. This complements
+// TestSaveInstructionWithEvent_PartialConfig (which sets db only).
+func TestSaveInstructionWithEvent_PartialConfig_PublisherOnly(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+
+	// Set only eventPublisher — partial config (db and instructionRepoImpl are nil).
+	svc.eventPublisher = &mockEventPublisher{}
+
+	tid := uuid.MustParse(testTenantID())
+	inst, err := domain.NewInstruction(tid, "device.command", uuid.Nil.String(), map[string]any{"x": 1})
+	require.NoError(t, err)
+
+	err = svc.saveInstructionWithEvent(context.Background(), inst, "key-partial", nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEventPublishingPartialConfig)
+}
+
+// ========== DispatchInstruction financial type coverage ==========
+
+// TestDispatchInstruction_AdditionalFinancialTypes verifies payment.refund, payment.initiate,
+// and payment.transfer are all rejected (supplements the payment.collect case in grpc_service_test.go).
+func TestDispatchInstruction_AdditionalFinancialTypes(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+	payload, _ := structpb.NewStruct(map[string]any{"amount": 100.0})
+
+	for _, itype := range []string{"payment.refund", "payment.initiate", "payment.transfer"} {
+		t.Run(itype, func(t *testing.T) {
+			_, err := svc.DispatchInstruction(ctx, &opgatewayv1.DispatchInstructionRequest{
+				InstructionType: itype,
+				Payload:         payload,
+				IdempotencyKey:  &commonpb.IdempotencyKey{Key: "key-" + itype},
+			})
+			require.Error(t, err)
+			st, ok := status.FromError(err)
+			require.True(t, ok)
+			assert.Equal(t, codes.InvalidArgument, st.Code())
+			assert.Contains(t, st.Message(), "financial-gateway")
+		})
+	}
+}
+
+// ========== DispatchInstruction optional fields ==========
+
+// TestDispatchInstruction_WithMetadata verifies metadata map is accepted on dispatch.
+func TestDispatchInstruction_WithMetadata(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+	payload, _ := structpb.NewStruct(map[string]any{"device_id": "dev-001"})
+
+	resp, err := svc.DispatchInstruction(ctx, &opgatewayv1.DispatchInstructionRequest{
+		InstructionType: "device.command",
+		Payload:         payload,
+		IdempotencyKey:  &commonpb.IdempotencyKey{Key: "meta-key"},
+		Metadata:        map[string]string{"env": "staging", "region": "eu-west"},
+	})
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.Instruction.Id)
+}
+

--- a/services/reference-data/saga/reference_extractor_test.go
+++ b/services/reference-data/saga/reference_extractor_test.go
@@ -139,6 +139,8 @@ func TestReferenceExtractor_AttributeAccess(t *testing.T) {
 			instrRefs = append(instrRefs, r)
 		case ReferenceTypeAttribute:
 			attrRefs = append(attrRefs, r)
+		case ReferenceTypeStepHandler, ReferenceTypeAccount, ReferenceTypeSaga:
+			// not expected in this test
 		}
 	}
 	require.Len(t, instrRefs, 1)


### PR DESCRIPTION
## Summary

- Adds unit tests for operational gateway config loading, domain route validation, gRPC service edge cases, and route repository persistence
- Supplements existing test coverage with tests for previously untested code paths
- Updates `setup_test.go` to include `instruction_routes` table DDL for persistence integration tests

## Changes Made

| File | Description |
|------|-------------|
| `config/config_test.go` | LoadConfig defaults and all env var overrides |
| `domain/instruction_route_test.go` | NewRoute validation, timestamp setting, error sentinels |
| `service/grpc_connection_service_test.go` | TestConnection (unimplemented), BasicAuth, OAuth2, list repo error |
| `service/route_server_test.go` | Upsert idempotency, all optional fields, tenant isolation, proto mapping |
| `service/server_test.go` | Nil-logger defaults, partial event publishing config, financial type rejection |
| `adapters/persistence/route_repository_test.go` | RouteRepository CRUD, upsert idempotency, ordering, tenant isolation, all fields round-trip |
| `adapters/persistence/setup_test.go` | Add `instruction_routes` DDL and table cleanup |
| `service/grpc_service_test.go` | Add `listErr` field to `mockConnectionRepo` for error path testing |

## Test plan

- [x] `go test ./services/operational-gateway/config/...` - all pass
- [x] `go test ./services/operational-gateway/domain/...` - all pass
- [x] `go test ./services/operational-gateway/service/...` - all pass
- [x] `go test ./services/operational-gateway/adapters/persistence/... -run TestRouteRepository` - all pass with CockroachDB testcontainer