### PR TITLE
test: Add identity and party service unit tests

### DIFF
--- a/services/identity/service/mappers_test.go
+++ b/services/identity/service/mappers_test.go
@@ -1,0 +1,127 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/identity/v1"
+	"github.com/meridianhub/meridian/services/identity/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- identityToProto: cases not covered by grpc_service_test.go ---
+
+func TestIdentityToProto_WithoutExternalIDP(t *testing.T) {
+	// Verifies that when ExternalIDP is empty, the external_idp/external_idp_sub fields
+	// are not populated (the mapper guard: if identity.ExternalIDP() != "")
+	identity, err := domain.NewIdentity("local@example.com")
+	require.NoError(t, err)
+
+	proto := identityToProto(identity)
+
+	require.NotNil(t, proto)
+	assert.Empty(t, proto.ExternalIdp)
+	assert.Empty(t, proto.ExternalIdpSub)
+}
+
+func TestIdentityToProto_PendingInviteStatus(t *testing.T) {
+	identity, err := domain.NewIdentity("new@example.com")
+	require.NoError(t, err)
+
+	proto := identityToProto(identity)
+
+	require.NotNil(t, proto)
+	assert.Equal(t, pb.IdentityStatus_IDENTITY_STATUS_PENDING_INVITE, proto.Status)
+}
+
+func TestIdentityToProto_TimestampsPopulated(t *testing.T) {
+	before := time.Now().Truncate(time.Second)
+	identity, err := domain.NewIdentity("ts@example.com")
+	require.NoError(t, err)
+
+	proto := identityToProto(identity)
+
+	require.NotNil(t, proto)
+	require.NotNil(t, proto.CreatedAt)
+	require.NotNil(t, proto.UpdatedAt)
+	assert.False(t, proto.CreatedAt.AsTime().Before(before))
+	assert.False(t, proto.UpdatedAt.AsTime().Before(before))
+}
+
+// --- roleAssignmentToProto: GrantedAt is populated ---
+
+func TestRoleAssignmentToProto_GrantedAtPopulated(t *testing.T) {
+	identityID := uuid.New()
+	granterID := uuid.New()
+
+	ra, err := domain.NewRoleAssignment(identityID, granterID, string(domain.RolePlatform), string(domain.RoleAdmin))
+	require.NoError(t, err)
+
+	proto := roleAssignmentToProto(ra)
+
+	require.NotNil(t, proto)
+	require.NotNil(t, proto.GrantedAt)
+}
+
+// --- roleAssignmentToProto: revocation without revokedBy ---
+
+func TestRoleAssignmentToProto_RevocationWithoutRevokedBy(t *testing.T) {
+	revokedAt := time.Now()
+	ra := domain.ReconstructRoleAssignment(
+		uuid.New(), uuid.New(), uuid.New(),
+		domain.RoleAdmin, nil, &revokedAt, nil, // revokedBy is nil
+		time.Now(), time.Now(),
+	)
+
+	proto := roleAssignmentToProto(ra)
+
+	require.NotNil(t, proto)
+	assert.True(t, proto.Revoked)
+	assert.NotNil(t, proto.RevokedAt)
+	assert.Empty(t, proto.RevokedBy)
+}
+
+// --- protoRoleToDomain: unknown proto value ---
+
+func TestProtoRoleToDomain_UnrecognizedValue(t *testing.T) {
+	result := protoRoleToDomain(pb.Role(9999))
+	assert.Equal(t, "", result)
+}
+
+// --- Round-trip: domain role -> proto -> domain ---
+
+func TestRoleRoundTrip(t *testing.T) {
+	// Confirm roles that survive domain -> proto -> domain without loss
+	cases := []struct {
+		role  domain.Role
+		proto pb.Role
+	}{
+		{domain.RoleOperator, pb.Role_ROLE_OPERATOR},
+		{domain.RoleAdmin, pb.Role_ROLE_ADMIN},
+		{domain.RoleTenantOwner, pb.Role_ROLE_TENANT_OWNER},
+		{domain.RolePlatform, pb.Role_ROLE_PLATFORM_ADMIN},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.role), func(t *testing.T) {
+			got := domainRoleToProto(tc.role)
+			assert.Equal(t, tc.proto, got)
+			assert.Equal(t, string(tc.role), protoRoleToDomain(got))
+		})
+	}
+}
+
+// --- SUPER_ADMIN alias mapping ---
+
+func TestProtoRoleToDomain_SuperAdminAlias(t *testing.T) {
+	// SUPER_ADMIN is an API alias for PLATFORM_ADMIN; both map to domain.RolePlatform.
+	// On roundtrip, SUPER_ADMIN is stored as PLATFORM and returned as PLATFORM_ADMIN.
+	result := protoRoleToDomain(pb.Role_ROLE_SUPER_ADMIN)
+	assert.Equal(t, string(domain.RolePlatform), result)
+
+	// And PLATFORM_ADMIN also maps back to PLATFORM
+	resultPA := protoRoleToDomain(pb.Role_ROLE_PLATFORM_ADMIN)
+	assert.Equal(t, result, resultPA)
+}

--- a/services/identity/service/server_test.go
+++ b/services/identity/service/server_test.go
@@ -1,0 +1,47 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+)
+
+// --- Health Check ---
+
+func TestCheck_ReturnsServing(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+
+	resp, err := svc.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
+}
+
+func TestCheck_WithServiceName_ReturnsServing(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+
+	resp, err := svc.Check(ctx, &grpc_health_v1.HealthCheckRequest{
+		Service: "identity",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
+}
+
+func TestWatch_ReturnsUnimplemented(t *testing.T) {
+	svc, _ := newTestService(t)
+
+	err := svc.Watch(&grpc_health_v1.HealthCheckRequest{}, nil)
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Unimplemented, status.Code(err))
+}

--- a/services/party/service/outbox_event_publisher_test.go
+++ b/services/party/service/outbox_event_publisher_test.go
@@ -1,0 +1,78 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// --- NewOutboxVerificationEventPublisher ---
+
+func TestNewOutboxVerificationEventPublisher_CreatesPublisher(t *testing.T) {
+	publisher := events.NewOutboxPublisher("party")
+	db := &gorm.DB{}
+
+	p := NewOutboxVerificationEventPublisher(publisher, db)
+
+	require.NotNil(t, p)
+	assert.Equal(t, publisher, p.publisher)
+	assert.Equal(t, db, p.db)
+}
+
+func TestNewOutboxVerificationEventPublisher_WithNilDB(t *testing.T) {
+	publisher := events.NewOutboxPublisher("party")
+
+	// Constructor does not enforce non-nil db - callers are responsible
+	p := NewOutboxVerificationEventPublisher(publisher, nil)
+
+	require.NotNil(t, p)
+	assert.Nil(t, p.db)
+}
+
+// --- VerificationCompletedEvent field population ---
+
+func TestVerificationCompletedEvent_AllFields(t *testing.T) {
+	riskScore := 0.42
+	reason := "address verified"
+
+	e := VerificationCompletedEvent{
+		EventID:        "evt-123",
+		PartyID:        "party-456",
+		VerificationID: "verif-789",
+		Provider:       "jumio",
+		Status:         "APPROVED",
+		RiskScore:      &riskScore,
+		Reason:         &reason,
+		CompletedAt:    time.Now(),
+		Metadata:       map[string]string{"key": "value"},
+	}
+
+	assert.Equal(t, "evt-123", e.EventID)
+	assert.Equal(t, "party-456", e.PartyID)
+	assert.Equal(t, "verif-789", e.VerificationID)
+	assert.Equal(t, "jumio", e.Provider)
+	assert.Equal(t, "APPROVED", e.Status)
+	assert.Equal(t, &riskScore, e.RiskScore)
+	assert.Equal(t, &reason, e.Reason)
+	assert.Equal(t, map[string]string{"key": "value"}, e.Metadata)
+}
+
+func TestVerificationCompletedEvent_OptionalFieldsNil(t *testing.T) {
+	e := VerificationCompletedEvent{
+		EventID:        "evt-001",
+		PartyID:        "party-001",
+		VerificationID: "verif-001",
+		Provider:       "provider",
+		Status:         "REJECTED",
+		RiskScore:      nil,
+		Reason:         nil,
+		CompletedAt:    time.Now(),
+	}
+
+	assert.Nil(t, e.RiskScore)
+	assert.Nil(t, e.Reason)
+}

--- a/services/party/service/party_handlers_test.go
+++ b/services/party/service/party_handlers_test.go
@@ -1,0 +1,166 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// RegisterParty with initial attributes is not covered by existing grpc_service_test.go tests.
+
+func TestRegisterParty_WithInitialAttributes(t *testing.T) {
+	ctx := context.Background()
+	mock := newMockRepository()
+	svc := newTestService(mock)
+
+	resp, err := svc.RegisterParty(ctx, &pb.RegisterPartyRequest{
+		PartyType: pb.PartyType_PARTY_TYPE_ORGANIZATION,
+		LegalName: "Tech Corp Ltd",
+		Attributes: []*quantityv1.AttributeEntry{
+			{Key: "industry", Value: "technology"},
+			{Key: "country", Value: "GB"},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Party)
+
+	assert.Equal(t, 2, len(resp.Party.Attributes))
+	// Attributes are stored and returned (exact order not guaranteed by map iteration)
+	keyValues := make(map[string]string)
+	for _, a := range resp.Party.Attributes {
+		keyValues[a.Key] = a.Value
+	}
+	assert.Equal(t, "technology", keyValues["industry"])
+	assert.Equal(t, "GB", keyValues["country"])
+}
+
+func TestRegisterParty_WithDisplayNameAndAttributes(t *testing.T) {
+	ctx := context.Background()
+	mock := newMockRepository()
+	svc := newTestService(mock)
+
+	resp, err := svc.RegisterParty(ctx, &pb.RegisterPartyRequest{
+		PartyType:   pb.PartyType_PARTY_TYPE_ORGANIZATION,
+		LegalName:   "Meridian Financial Services Ltd",
+		DisplayName: "Meridian FS",
+		Attributes: []*quantityv1.AttributeEntry{
+			{Key: "sector", Value: "finance"},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "Meridian FS", resp.Party.DisplayName)
+	assert.Equal(t, 1, len(resp.Party.Attributes))
+	assert.Equal(t, "sector", resp.Party.Attributes[0].Key)
+	assert.Equal(t, "finance", resp.Party.Attributes[0].Value)
+}
+
+// RegisterParty with no attributes should return empty attributes, not nil
+
+func TestRegisterParty_NoAttributes_ReturnsEmptyList(t *testing.T) {
+	ctx := context.Background()
+	mock := newMockRepository()
+	svc := newTestService(mock)
+
+	resp, err := svc.RegisterParty(ctx, &pb.RegisterPartyRequest{
+		PartyType: pb.PartyType_PARTY_TYPE_PERSON,
+		LegalName: "John Doe",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	// No attributes provided - should not include any in response
+	assert.Empty(t, resp.Party.Attributes)
+}
+
+// UpdateParty with attributes field mask - verify attribute replacement
+
+func TestUpdateParty_AttributesReplace(t *testing.T) {
+	ctx := context.Background()
+	mock := newMockRepository()
+	svc := newTestService(mock)
+
+	// Register a party with initial attributes via domain
+	resp1, err := svc.RegisterParty(ctx, &pb.RegisterPartyRequest{
+		PartyType: pb.PartyType_PARTY_TYPE_ORGANIZATION,
+		LegalName: "Replace Org",
+		Attributes: []*quantityv1.AttributeEntry{
+			{Key: "old_key", Value: "old_value"},
+		},
+	})
+	require.NoError(t, err)
+
+	// Update with new attributes - should replace, not merge
+	resp2, err := svc.UpdateParty(ctx, &pb.UpdatePartyRequest{
+		PartyId: resp1.Party.PartyId,
+		Attributes: []*quantityv1.AttributeEntry{
+			{Key: "new_key", Value: "new_value"},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp2)
+	assert.Equal(t, 1, len(resp2.Party.Attributes))
+	assert.Equal(t, "new_key", resp2.Party.Attributes[0].Key)
+	assert.Equal(t, "new_value", resp2.Party.Attributes[0].Value)
+}
+
+// Verify that UpdateParty with version 0 (unset) skips the version check
+
+func TestUpdateParty_ZeroVersionSkipsCheck(t *testing.T) {
+	ctx := context.Background()
+	mock := newMockRepository()
+	svc := newTestService(mock)
+
+	resp1, err := svc.RegisterParty(ctx, &pb.RegisterPartyRequest{
+		PartyType: pb.PartyType_PARTY_TYPE_PERSON,
+		LegalName: "Version Test",
+	})
+	require.NoError(t, err)
+
+	// Version 0 means "don't check" - should succeed regardless of actual version
+	resp2, err := svc.UpdateParty(ctx, &pb.UpdatePartyRequest{
+		PartyId:     resp1.Party.PartyId,
+		DisplayName: "Updated Name",
+		Version:     0, // Zero version skips check
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "Updated Name", resp2.Party.DisplayName)
+}
+
+// ControlParty returns InvalidArgument for invalid party type action combinations
+
+func TestControlParty_ReturnsInternalOnSaveError_Suspend(t *testing.T) {
+	ctx := context.Background()
+	mock := newMockRepository()
+	svc := newTestService(mock)
+
+	// Register party, then inject save error for control action
+	resp1, err := svc.RegisterParty(ctx, &pb.RegisterPartyRequest{
+		PartyType: pb.PartyType_PARTY_TYPE_PERSON,
+		LegalName: "Control Test",
+	})
+	require.NoError(t, err)
+
+	// Now inject a save error
+	mock.saveErr = errDatabaseTimeout
+
+	_, err = svc.ControlParty(ctx, &pb.ControlPartyRequest{
+		PartyId:       resp1.Party.PartyId,
+		ControlAction: pb.ControlAction_CONTROL_ACTION_SUSPEND,
+		Reason:        "testing",
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+}

--- a/services/party/service/server_test.go
+++ b/services/party/service/server_test.go
@@ -1,0 +1,111 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/party/domain"
+	"github.com/meridianhub/meridian/services/party/verification"
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// TestNewService_WithBuilders_SetsFields verifies that With* option methods
+// actually populate the service fields with the provided non-nil values.
+// (TestWithBuilders in update_control_test.go only verifies chaining with nil args.)
+
+func TestNewService_WithBuilders_SetsFields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WithPaymentMethodRepository sets pmRepo field", func(t *testing.T) {
+		mock := newMockRepository()
+		svc, err := NewService(mock, nil)
+		require.NoError(t, err)
+
+		pmMock := newMockPMRepo()
+		_ = svc.WithPaymentMethodRepository(pmMock)
+
+		assert.Equal(t, pmMock, svc.pmRepo)
+	})
+
+	t.Run("WithVerificationProvider sets verificationProvider field", func(t *testing.T) {
+		mock := newMockRepository()
+		svc, err := NewService(mock, nil)
+		require.NoError(t, err)
+
+		provider := verification.NewMockProvider().WithAlwaysApprove(true)
+		_ = svc.WithVerificationProvider(provider)
+
+		assert.Equal(t, provider, svc.verificationProvider)
+	})
+
+	t.Run("WithAttributeValidator sets attributeValidator field", func(t *testing.T) {
+		mock := newMockRepository()
+		svc, err := NewService(mock, nil)
+		require.NoError(t, err)
+
+		validator := &AttributeValidator{}
+		_ = svc.WithAttributeValidator(validator)
+
+		assert.Equal(t, validator, svc.attributeValidator)
+	})
+
+	t.Run("WithOutboxPublisher sets both outboxPublisher and db fields", func(t *testing.T) {
+		mock := newMockRepository()
+		svc, err := NewService(mock, nil)
+		require.NoError(t, err)
+
+		publisher := events.NewOutboxPublisher("party-test")
+		db := &gorm.DB{}
+		_ = svc.WithOutboxPublisher(publisher, db)
+
+		assert.Equal(t, publisher, svc.outboxPublisher)
+		assert.Equal(t, db, svc.db)
+	})
+}
+
+// TestSavePartyWithEvent_NoOutbox_PublishFnNotCalled verifies that when no outbox publisher
+// is configured, the publishFn callback is never invoked - only Save is called.
+
+func TestSavePartyWithEvent_NoOutbox_PublishFnNotCalled(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	mock := newMockRepository()
+	svc := newTestService(mock)
+
+	party, err := domain.NewParty(domain.PartyTypePerson, "Callback Test")
+	require.NoError(t, err)
+
+	publishCalled := false
+	err = svc.savePartyWithEvent(ctx, party, func(_ *gorm.DB) error {
+		publishCalled = true
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.False(t, publishCalled, "publishFn should not be called when outbox is not configured")
+	assert.Contains(t, mock.parties, party.ID())
+}
+
+// TestSavePartyWithEvent_NoOutbox_PropagatesSaveError verifies error propagation
+// when the fallback Save fails.
+
+func TestSavePartyWithEvent_NoOutbox_PropagatesSaveError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	mock := newMockRepository()
+	mock.saveErr = errDatabaseFailed
+	svc := newTestService(mock)
+
+	party, err := domain.NewParty(domain.PartyTypePerson, "Error Test")
+	require.NoError(t, err)
+
+	err = svc.savePartyWithEvent(ctx, party, nil)
+
+	require.Error(t, err)
+	assert.Equal(t, errDatabaseFailed, err)
+}


### PR DESCRIPTION
## Summary

- Add `mappers_test.go` for identity service: tests for `identityToProto` nil/timestamp/no-IDP paths, role round-trip, revocation without revokedBy, SUPER_ADMIN alias, unrecognized proto values
- Add `server_test.go` for identity service: health `Check` returns SERVING, `Watch` returns Unimplemented
- Add `party_handlers_test.go`: `RegisterParty` with initial attributes and display name, `UpdateParty` attribute replacement and zero-version behavior, `ControlParty` save error path
- Add `outbox_event_publisher_test.go`: constructor verification and `VerificationCompletedEvent` field population
- Add `server_test.go` for party service: With* option methods verify field assignment, `savePartyWithEvent` publishFn not called without outbox, error propagation

## Test plan

- [ ] `go test ./services/identity/service/...` passes (all new tests)
- [ ] `go test ./services/party/service/...` passes (all new tests)
- [ ] CI green