### PR TITLE
test: Add forecasting service unit tests

### DIFF
--- a/services/forecasting/adapters/mds/refdata_adapter_test.go
+++ b/services/forecasting/adapters/mds/refdata_adapter_test.go
@@ -1,0 +1,66 @@
+package mds
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoOpRefDataClient_AlwaysReturnsConfiguredError(t *testing.T) {
+	client := &NoOpRefDataClient{}
+
+	result, err := client.GetNodeByResolutionKey(context.Background(), "tenant-1", "some-key")
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, ErrRefDataNotConfigured)
+}
+
+func TestNoOpRefDataClient_ErrorMessageContainsResolutionKey(t *testing.T) {
+	client := &NoOpRefDataClient{}
+	resolutionKey := "GB/SOUTH/GRID"
+
+	_, err := client.GetNodeByResolutionKey(context.Background(), "tenant-42", resolutionKey)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), resolutionKey)
+}
+
+func TestNoOpRefDataClient_DifferentTenantsAndKeys(t *testing.T) {
+	client := &NoOpRefDataClient{}
+
+	tests := []struct {
+		tenantID      string
+		resolutionKey string
+	}{
+		{"tenant-1", "region:us-east-1"},
+		{"tenant-2", "node:grid-point-42"},
+		{"tenant-3", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.tenantID+"/"+tc.resolutionKey, func(t *testing.T) {
+			result, err := client.GetNodeByResolutionKey(context.Background(), tc.tenantID, tc.resolutionKey)
+
+			require.Error(t, err)
+			assert.Nil(t, result)
+			assert.True(t, errors.Is(err, ErrRefDataNotConfigured))
+		})
+	}
+}
+
+func TestNoOpRefDataClient_CancelledContextStillReturnsError(t *testing.T) {
+	client := &NoOpRefDataClient{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	result, err := client.GetNodeByResolutionKey(ctx, "tenant-1", "some-key")
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	// NoOpRefDataClient always returns ErrRefDataNotConfigured regardless of context
+	assert.ErrorIs(t, err, ErrRefDataNotConfigured)
+}

--- a/services/forecasting/adapters/persistence/mappers_test.go
+++ b/services/forecasting/adapters/persistence/mappers_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/meridianhub/meridian/services/forecasting/domain"
 )
 
-func makeTestStrategy(t *testing.T, opts ...func(*domain.ForecastingStrategy)) domain.ForecastingStrategy {
+func makeTestStrategy(t *testing.T) domain.ForecastingStrategy {
 	t.Helper()
 	s, err := domain.NewForecastingStrategy(
 		"tenant-1",

--- a/services/forecasting/adapters/persistence/mappers_test.go
+++ b/services/forecasting/adapters/persistence/mappers_test.go
@@ -1,0 +1,264 @@
+package persistence
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/forecasting/domain"
+)
+
+func makeTestStrategy(t *testing.T, opts ...func(*domain.ForecastingStrategy)) domain.ForecastingStrategy {
+	t.Helper()
+	s, err := domain.NewForecastingStrategy(
+		"tenant-1",
+		"Day-Ahead Price Forecast",
+		"Generates 24-hour forward curve for electricity prices",
+		`result = [42.0] * 24`,
+		24,
+		1,
+		"0 16 * * *",
+		[]string{"SPOT_PRICE", "WEATHER_FORECAST"},
+		"FORWARD_CURVE_ELEC",
+		"GB/SOUTH",
+	)
+	require.NoError(t, err)
+	return s
+}
+
+func makeTestStrategyNoOptionals(t *testing.T) domain.ForecastingStrategy {
+	t.Helper()
+	s, err := domain.NewForecastingStrategy(
+		"tenant-2",
+		"Minimal Strategy",
+		"", // no description
+		`result = [1.0]`,
+		1,
+		1,
+		"0 0 * * *",
+		[]string{"INPUT"},
+		"OUTPUT",
+		"", // no resolution key
+	)
+	require.NoError(t, err)
+	return s
+}
+
+// --- StrategyToEntity tests ---
+
+func TestStrategyToEntity_FullStrategy(t *testing.T) {
+	s := makeTestStrategy(t)
+
+	entity := StrategyToEntity(s)
+
+	assert.Equal(t, s.ID(), entity.ID)
+	assert.Equal(t, "tenant-1", entity.TenantID)
+	assert.Equal(t, "Day-Ahead Price Forecast", entity.Name)
+	assert.Equal(t, `result = [42.0] * 24`, entity.StarlarkCode)
+	assert.Equal(t, 24, entity.HorizonHours)
+	assert.Equal(t, 1, entity.GranularityHours)
+	assert.Equal(t, "0 16 * * *", entity.Schedule)
+	assert.Equal(t, []string{"SPOT_PRICE", "WEATHER_FORECAST"}, entity.InputDatasetCodes)
+	assert.Equal(t, "FORWARD_CURVE_ELEC", entity.OutputDatasetCode)
+	assert.Equal(t, "DRAFT", entity.Status)
+	assert.Equal(t, int64(1), entity.Version)
+
+	// Optional fields present
+	assert.True(t, entity.Description.Valid)
+	assert.Equal(t, "Generates 24-hour forward curve for electricity prices", entity.Description.String)
+	assert.True(t, entity.ReferenceDataResolutionKey.Valid)
+	assert.Equal(t, "GB/SOUTH", entity.ReferenceDataResolutionKey.String)
+}
+
+func TestStrategyToEntity_EmptyOptionals(t *testing.T) {
+	s := makeTestStrategyNoOptionals(t)
+
+	entity := StrategyToEntity(s)
+
+	assert.Equal(t, "tenant-2", entity.TenantID)
+	assert.Equal(t, "Minimal Strategy", entity.Name)
+
+	// Optional fields absent
+	assert.False(t, entity.Description.Valid)
+	assert.False(t, entity.ReferenceDataResolutionKey.Valid)
+}
+
+func TestStrategyToEntity_ActiveStatus(t *testing.T) {
+	s := makeTestStrategy(t)
+	activated, err := s.Activate()
+	require.NoError(t, err)
+
+	entity := StrategyToEntity(activated)
+
+	assert.Equal(t, "ACTIVE", entity.Status)
+}
+
+func TestStrategyToEntity_DeprecatedStatus(t *testing.T) {
+	s := makeTestStrategy(t)
+	activated, err := s.Activate()
+	require.NoError(t, err)
+	deprecated, err := activated.Deprecate()
+	require.NoError(t, err)
+
+	entity := StrategyToEntity(deprecated)
+
+	assert.Equal(t, "DEPRECATED", entity.Status)
+}
+
+func TestStrategyToEntity_TimestampsPreserved(t *testing.T) {
+	s := makeTestStrategy(t)
+	entity := StrategyToEntity(s)
+
+	assert.Equal(t, s.CreatedAt().UTC(), entity.CreatedAt.UTC())
+	assert.Equal(t, s.UpdatedAt().UTC(), entity.UpdatedAt.UTC())
+}
+
+// --- EntityToStrategy tests ---
+
+func TestEntityToStrategy_FullEntity(t *testing.T) {
+	id := uuid.New()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	entity := ForecastingStrategyEntity{
+		ID:                         id,
+		TenantID:                   "tenant-3",
+		Name:                       "Energy Forecast",
+		Description:                sql.NullString{String: "Detailed energy forecast", Valid: true},
+		StarlarkCode:               `result = [10.0] * 24`,
+		HorizonHours:               24,
+		GranularityHours:           1,
+		Schedule:                   "0 8 * * *",
+		InputDatasetCodes:          []string{"ENERGY_PRICES"},
+		OutputDatasetCode:          "FORECAST_ENERGY",
+		ReferenceDataResolutionKey: sql.NullString{String: "US/EAST", Valid: true},
+		Status:                     "ACTIVE",
+		Version:                    5,
+		CreatedAt:                  now,
+		UpdatedAt:                  now,
+	}
+
+	strategy := EntityToStrategy(entity)
+
+	assert.Equal(t, id, strategy.ID())
+	assert.Equal(t, "tenant-3", strategy.TenantID())
+	assert.Equal(t, "Energy Forecast", strategy.Name())
+	assert.Equal(t, "Detailed energy forecast", strategy.Description())
+	assert.Equal(t, `result = [10.0] * 24`, strategy.StarlarkCode())
+	assert.Equal(t, 24, strategy.HorizonHours())
+	assert.Equal(t, 1, strategy.GranularityHours())
+	assert.Equal(t, "0 8 * * *", strategy.Schedule())
+	assert.Equal(t, []string{"ENERGY_PRICES"}, strategy.InputDatasetCodes())
+	assert.Equal(t, "FORECAST_ENERGY", strategy.OutputDatasetCode())
+	assert.Equal(t, "US/EAST", strategy.ReferenceDataResolutionKey())
+	assert.Equal(t, domain.StrategyStatusActive, strategy.Status())
+	assert.Equal(t, int64(5), strategy.Version())
+	assert.Equal(t, now, strategy.CreatedAt())
+	assert.Equal(t, now, strategy.UpdatedAt())
+}
+
+func TestEntityToStrategy_EmptyOptionals(t *testing.T) {
+	entity := ForecastingStrategyEntity{
+		ID:                uuid.New(),
+		TenantID:          "tenant-4",
+		Name:              "Minimal",
+		StarlarkCode:      `result = []`,
+		HorizonHours:      1,
+		GranularityHours:  1,
+		Schedule:          "0 0 * * *",
+		InputDatasetCodes: []string{"IN"},
+		OutputDatasetCode: "OUT",
+		Status:            "DRAFT",
+		Version:           1,
+		CreatedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+		// Description and ReferenceDataResolutionKey are zero values (Invalid=false)
+	}
+
+	strategy := EntityToStrategy(entity)
+
+	assert.Equal(t, "", strategy.Description())
+	assert.Equal(t, "", strategy.ReferenceDataResolutionKey())
+	assert.Equal(t, domain.StrategyStatusDraft, strategy.Status())
+}
+
+func TestEntityToStrategy_DeprecatedStatus(t *testing.T) {
+	entity := ForecastingStrategyEntity{
+		ID:                uuid.New(),
+		TenantID:          "tenant-1",
+		Name:              "Old Strategy",
+		StarlarkCode:      `result = []`,
+		HorizonHours:      1,
+		GranularityHours:  1,
+		Schedule:          "0 0 * * *",
+		InputDatasetCodes: []string{"IN"},
+		OutputDatasetCode: "OUT",
+		Status:            "DEPRECATED",
+		Version:           2,
+		CreatedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+	}
+
+	strategy := EntityToStrategy(entity)
+
+	assert.Equal(t, domain.StrategyStatusDeprecated, strategy.Status())
+}
+
+func TestEntityToStrategy_UnknownStatusDefaultsToDraft(t *testing.T) {
+	entity := ForecastingStrategyEntity{
+		ID:                uuid.New(),
+		TenantID:          "tenant-1",
+		Name:              "Strategy",
+		StarlarkCode:      `result = []`,
+		HorizonHours:      1,
+		GranularityHours:  1,
+		Schedule:          "0 0 * * *",
+		InputDatasetCodes: []string{"IN"},
+		OutputDatasetCode: "OUT",
+		Status:            "UNKNOWN_STATUS",
+		Version:           1,
+		CreatedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+	}
+
+	strategy := EntityToStrategy(entity)
+
+	assert.Equal(t, domain.StrategyStatusDraft, strategy.Status())
+}
+
+// --- Domain/Entity roundtrip tests ---
+
+func TestStrategyToEntity_EntityToStrategy_Roundtrip(t *testing.T) {
+	original := makeTestStrategy(t)
+
+	entity := StrategyToEntity(original)
+	reconstructed := EntityToStrategy(entity)
+
+	assert.Equal(t, original.ID(), reconstructed.ID())
+	assert.Equal(t, original.TenantID(), reconstructed.TenantID())
+	assert.Equal(t, original.Name(), reconstructed.Name())
+	assert.Equal(t, original.Description(), reconstructed.Description())
+	assert.Equal(t, original.StarlarkCode(), reconstructed.StarlarkCode())
+	assert.Equal(t, original.HorizonHours(), reconstructed.HorizonHours())
+	assert.Equal(t, original.GranularityHours(), reconstructed.GranularityHours())
+	assert.Equal(t, original.Schedule(), reconstructed.Schedule())
+	assert.Equal(t, original.InputDatasetCodes(), reconstructed.InputDatasetCodes())
+	assert.Equal(t, original.OutputDatasetCode(), reconstructed.OutputDatasetCode())
+	assert.Equal(t, original.ReferenceDataResolutionKey(), reconstructed.ReferenceDataResolutionKey())
+	assert.Equal(t, original.Status(), reconstructed.Status())
+	assert.Equal(t, original.Version(), reconstructed.Version())
+}
+
+func TestStrategyToEntity_EntityToStrategy_Roundtrip_NoOptionals(t *testing.T) {
+	original := makeTestStrategyNoOptionals(t)
+
+	entity := StrategyToEntity(original)
+	reconstructed := EntityToStrategy(entity)
+
+	assert.Equal(t, original.ID(), reconstructed.ID())
+	assert.Equal(t, "", reconstructed.Description())
+	assert.Equal(t, "", reconstructed.ReferenceDataResolutionKey())
+}

--- a/services/forecasting/scheduler/metrics_test.go
+++ b/services/forecasting/scheduler/metrics_test.go
@@ -238,4 +238,3 @@ func TestMetrics_RecordError_MultipleTypes(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, 3, len(f.GetMetric()))
 }
-

--- a/services/forecasting/scheduler/metrics_test.go
+++ b/services/forecasting/scheduler/metrics_test.go
@@ -32,7 +32,7 @@ func gatherMetrics(t *testing.T, reg *prometheus.Registry) map[string]*dto.Metri
 func counterValue(t *testing.T, f *dto.MetricFamily) float64 {
 	t.Helper()
 	require.NotNil(t, f)
-	require.NotEmpty(t, f.GetMetric())
+	require.Len(t, f.GetMetric(), 1, "expected exactly one label set")
 	return f.GetMetric()[0].GetCounter().GetValue()
 }
 
@@ -72,11 +72,16 @@ func TestMetrics_RecordExecution_MultipleStatuses(t *testing.T) {
 	require.True(t, ok)
 
 	// Should have two distinct label sets: status=success (2) and status=error (1)
-	var total float64
+	counts := map[string]float64{}
 	for _, metric := range f.GetMetric() {
-		total += metric.GetCounter().GetValue()
+		for _, label := range metric.GetLabel() {
+			if label.GetName() == "status" {
+				counts[label.GetValue()] = metric.GetCounter().GetValue()
+			}
+		}
 	}
-	assert.Equal(t, float64(3), total)
+	assert.Equal(t, float64(2), counts["success"], "success count")
+	assert.Equal(t, float64(1), counts["error"], "error count")
 }
 
 func TestMetrics_RecordExecution_MultipleStrategies(t *testing.T) {

--- a/services/forecasting/scheduler/metrics_test.go
+++ b/services/forecasting/scheduler/metrics_test.go
@@ -1,0 +1,241 @@
+package scheduler_test
+
+import (
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/forecasting/scheduler"
+)
+
+func newTestMetrics(t *testing.T) (*scheduler.Metrics, *prometheus.Registry) {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	return scheduler.NewMetricsWithRegistry(reg), reg
+}
+
+func gatherMetrics(t *testing.T, reg *prometheus.Registry) map[string]*dto.MetricFamily {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	index := make(map[string]*dto.MetricFamily, len(families))
+	for _, f := range families {
+		index[f.GetName()] = f
+	}
+	return index
+}
+
+func counterValue(t *testing.T, f *dto.MetricFamily) float64 {
+	t.Helper()
+	require.NotNil(t, f)
+	require.NotEmpty(t, f.GetMetric())
+	return f.GetMetric()[0].GetCounter().GetValue()
+}
+
+// --- RecordExecution ---
+
+func TestMetrics_RecordExecution_Success(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	m.RecordExecution("tenant-1", "strategy-abc", "success")
+
+	families := gatherMetrics(t, reg)
+	f, ok := families["meridian_forecasting_scheduled_executions_total"]
+	require.True(t, ok)
+	assert.Equal(t, float64(1), counterValue(t, f))
+}
+
+func TestMetrics_RecordExecution_Error(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	m.RecordExecution("tenant-1", "strategy-abc", "error")
+
+	families := gatherMetrics(t, reg)
+	f, ok := families["meridian_forecasting_scheduled_executions_total"]
+	require.True(t, ok)
+	assert.Equal(t, float64(1), counterValue(t, f))
+}
+
+func TestMetrics_RecordExecution_MultipleStatuses(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	m.RecordExecution("tenant-1", "strategy-1", "success")
+	m.RecordExecution("tenant-1", "strategy-1", "success")
+	m.RecordExecution("tenant-1", "strategy-1", "error")
+
+	families := gatherMetrics(t, reg)
+	f, ok := families["meridian_forecasting_scheduled_executions_total"]
+	require.True(t, ok)
+
+	// Should have two distinct label sets: status=success (2) and status=error (1)
+	var total float64
+	for _, metric := range f.GetMetric() {
+		total += metric.GetCounter().GetValue()
+	}
+	assert.Equal(t, float64(3), total)
+}
+
+func TestMetrics_RecordExecution_MultipleStrategies(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	m.RecordExecution("tenant-1", "strategy-a", "success")
+	m.RecordExecution("tenant-1", "strategy-b", "success")
+	m.RecordExecution("tenant-2", "strategy-c", "success")
+
+	families := gatherMetrics(t, reg)
+	f, ok := families["meridian_forecasting_scheduled_executions_total"]
+	require.True(t, ok)
+	assert.Equal(t, 3, len(f.GetMetric()))
+}
+
+// --- ObserveExecutionDuration ---
+
+func TestMetrics_ObserveExecutionDuration_RecordsHistogram(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	m.ObserveExecutionDuration("tenant-1", "strategy-1", 2.5)
+
+	families := gatherMetrics(t, reg)
+	f, ok := families["meridian_forecasting_execution_duration_seconds"]
+	require.True(t, ok)
+	require.NotEmpty(t, f.GetMetric())
+	assert.Equal(t, uint64(1), f.GetMetric()[0].GetHistogram().GetSampleCount())
+	assert.Equal(t, 2.5, f.GetMetric()[0].GetHistogram().GetSampleSum())
+}
+
+func TestMetrics_ObserveExecutionDuration_MultipleObservations(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	m.ObserveExecutionDuration("tenant-1", "strategy-1", 0.1)
+	m.ObserveExecutionDuration("tenant-1", "strategy-1", 5.0)
+	m.ObserveExecutionDuration("tenant-1", "strategy-1", 30.0)
+
+	families := gatherMetrics(t, reg)
+	f, ok := families["meridian_forecasting_execution_duration_seconds"]
+	require.True(t, ok)
+	hist := f.GetMetric()[0].GetHistogram()
+	assert.Equal(t, uint64(3), hist.GetSampleCount())
+	assert.InDelta(t, 35.1, hist.GetSampleSum(), 0.001)
+}
+
+// --- RecordLeaseFailure ---
+
+func TestMetrics_RecordLeaseFailure_Contention(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	m.RecordLeaseFailure("contention")
+	m.RecordLeaseFailure("contention")
+
+	families := gatherMetrics(t, reg)
+	f, ok := families["meridian_forecasting_lease_acquisition_failures_total"]
+	require.True(t, ok)
+	assert.Equal(t, float64(2), counterValue(t, f))
+}
+
+func TestMetrics_RecordLeaseFailure_MultipleReasons(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	m.RecordLeaseFailure("contention")
+	m.RecordLeaseFailure("timeout")
+	m.RecordLeaseFailure("db_error")
+
+	families := gatherMetrics(t, reg)
+	f, ok := families["meridian_forecasting_lease_acquisition_failures_total"]
+	require.True(t, ok)
+	assert.Equal(t, 3, len(f.GetMetric()))
+}
+
+// --- SetActiveStrategies ---
+
+func TestMetrics_SetActiveStrategies(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	m.SetActiveStrategies(5)
+
+	families := gatherMetrics(t, reg)
+	f, ok := families["meridian_forecasting_active_strategies"]
+	require.True(t, ok)
+	require.NotEmpty(t, f.GetMetric())
+	assert.Equal(t, float64(5), f.GetMetric()[0].GetGauge().GetValue())
+}
+
+func TestMetrics_SetActiveStrategies_UpdatesGauge(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	m.SetActiveStrategies(10)
+	m.SetActiveStrategies(3) // overwrite with lower value
+
+	families := gatherMetrics(t, reg)
+	f, ok := families["meridian_forecasting_active_strategies"]
+	require.True(t, ok)
+	assert.Equal(t, float64(3), f.GetMetric()[0].GetGauge().GetValue())
+}
+
+func TestMetrics_SetActiveStrategies_Zero(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	m.SetActiveStrategies(0)
+
+	families := gatherMetrics(t, reg)
+	f, ok := families["meridian_forecasting_active_strategies"]
+	require.True(t, ok)
+	assert.Equal(t, float64(0), f.GetMetric()[0].GetGauge().GetValue())
+}
+
+// --- RecordReload ---
+
+func TestMetrics_RecordReload_Success(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	m.RecordReload("success")
+	m.RecordReload("success")
+	m.RecordReload("success")
+
+	families := gatherMetrics(t, reg)
+	f, ok := families["meridian_forecasting_scheduler_reloads_total"]
+	require.True(t, ok)
+	assert.Equal(t, float64(3), counterValue(t, f))
+}
+
+func TestMetrics_RecordReload_MultipleOutcomes(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	m.RecordReload("success")
+	m.RecordReload("error")
+
+	families := gatherMetrics(t, reg)
+	f, ok := families["meridian_forecasting_scheduler_reloads_total"]
+	require.True(t, ok)
+	assert.Equal(t, 2, len(f.GetMetric()))
+}
+
+// --- RecordError ---
+
+func TestMetrics_RecordError_SingleType(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	m.RecordError("context_cancelled")
+
+	families := gatherMetrics(t, reg)
+	f, ok := families["meridian_forecasting_scheduler_errors_total"]
+	require.True(t, ok)
+	assert.Equal(t, float64(1), counterValue(t, f))
+}
+
+func TestMetrics_RecordError_MultipleTypes(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	m.RecordError("context_cancelled")
+	m.RecordError("db_error")
+	m.RecordError("starlark_panic")
+
+	families := gatherMetrics(t, reg)
+	f, ok := families["meridian_forecasting_scheduler_errors_total"]
+	require.True(t, ok)
+	assert.Equal(t, 3, len(f.GetMetric()))
+}
+

--- a/services/forecasting/starlark/builtins_test.go
+++ b/services/forecasting/starlark/builtins_test.go
@@ -117,6 +117,7 @@ func TestPercentileBuiltin_P25(t *testing.T) {
 	thread := &starlarklib.Thread{Name: "test"}
 	b := starlarklib.NewBuiltin("percentile", percentileBuiltin)
 
+	// Sorted: [10, 20, 30, 40]. rank = 0.25 * 3 = 0.75. result = 10 + 0.75 * 10 = 17.5
 	list := starlarklib.NewList([]starlarklib.Value{
 		starlarklib.Float(10.0),
 		starlarklib.Float(20.0),
@@ -125,8 +126,9 @@ func TestPercentileBuiltin_P25(t *testing.T) {
 	})
 	val, err := starlarklib.Call(thread, b, starlarklib.Tuple{list, starlarklib.MakeInt(25)}, nil)
 	require.NoError(t, err)
-	_, ok := val.(*saga.DecimalValue)
+	result, ok := val.(*saga.DecimalValue)
 	require.True(t, ok)
+	assert.Equal(t, "17.5", result.GetDecimal().String())
 }
 
 // --- filterByHourBuiltin edge cases ---
@@ -145,7 +147,15 @@ func TestFilterByHourBuiltin_MidnightHour(t *testing.T) {
 	require.NoError(t, err)
 	result, ok := val.(*starlarklib.List)
 	require.True(t, ok)
-	assert.Equal(t, 1, result.Len(), "expected only midnight observation")
+	require.Equal(t, 1, result.Len(), "expected only midnight observation")
+
+	// Verify it's the midnight item (d1), not the 01:00 item (d2)
+	kept, ok := result.Index(0).(*starlarklib.Dict)
+	require.True(t, ok)
+	tsVal, found, err := kept.Get(starlarklib.String("timestamp"))
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, starlarklib.String("2026-01-15T00:00:00Z"), tsVal)
 }
 
 func TestFilterByHourBuiltin_Hour23(t *testing.T) {
@@ -162,7 +172,15 @@ func TestFilterByHourBuiltin_Hour23(t *testing.T) {
 	require.NoError(t, err)
 	result, ok := val.(*starlarklib.List)
 	require.True(t, ok)
-	assert.Equal(t, 1, result.Len())
+	require.Equal(t, 1, result.Len())
+
+	// Verify it's the 23:00 item (d1), not the 22:59 item (d2)
+	kept, ok := result.Index(0).(*starlarklib.Dict)
+	require.True(t, ok)
+	tsVal, found, err := kept.Get(starlarklib.String("timestamp"))
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, starlarklib.String("2026-01-15T23:00:00Z"), tsVal)
 }
 
 // --- groupByHourBuiltin edge cases ---

--- a/services/forecasting/starlark/builtins_test.go
+++ b/services/forecasting/starlark/builtins_test.go
@@ -1,0 +1,277 @@
+package starlark
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	starlarklib "go.starlark.net/starlark"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+)
+
+// --- avgBuiltin with DecimalValue inputs ---
+
+func TestAvgBuiltin_WithDecimalValues(t *testing.T) {
+	thread := &starlarklib.Thread{Name: "test"}
+	b := starlarklib.NewBuiltin("avg", avgBuiltin)
+
+	dv1, err := saga.NewDecimalValue("10.0")
+	require.NoError(t, err)
+	dv2, err := saga.NewDecimalValue("20.0")
+	require.NoError(t, err)
+	dv3, err := saga.NewDecimalValue("30.0")
+	require.NoError(t, err)
+
+	list := starlarklib.NewList([]starlarklib.Value{dv1, dv2, dv3})
+	val, err := starlarklib.Call(thread, b, starlarklib.Tuple{list}, nil)
+	require.NoError(t, err)
+	result, ok := val.(*saga.DecimalValue)
+	require.True(t, ok)
+	assert.Equal(t, "20", result.GetDecimal().String())
+}
+
+func TestAvgBuiltin_SingleElement(t *testing.T) {
+	thread := &starlarklib.Thread{Name: "test"}
+	b := starlarklib.NewBuiltin("avg", avgBuiltin)
+
+	list := starlarklib.NewList([]starlarklib.Value{starlarklib.MakeInt(42)})
+	val, err := starlarklib.Call(thread, b, starlarklib.Tuple{list}, nil)
+	require.NoError(t, err)
+	result, ok := val.(*saga.DecimalValue)
+	require.True(t, ok)
+	assert.Equal(t, "42", result.GetDecimal().String())
+}
+
+func TestAvgBuiltin_WithStringDecimals(t *testing.T) {
+	thread := &starlarklib.Thread{Name: "test"}
+	b := starlarklib.NewBuiltin("avg", avgBuiltin)
+
+	list := starlarklib.NewList([]starlarklib.Value{
+		starlarklib.String("1.5"),
+		starlarklib.String("2.5"),
+	})
+	val, err := starlarklib.Call(thread, b, starlarklib.Tuple{list}, nil)
+	require.NoError(t, err)
+	result, ok := val.(*saga.DecimalValue)
+	require.True(t, ok)
+	assert.Equal(t, "2", result.GetDecimal().String())
+}
+
+// --- sumBuiltin with mixed types ---
+
+func TestSumBuiltin_MixedIntAndDecimalValues(t *testing.T) {
+	thread := &starlarklib.Thread{Name: "test"}
+	b := starlarklib.NewBuiltin("sum", sumBuiltin)
+
+	dv, err := saga.NewDecimalValue("5.5")
+	require.NoError(t, err)
+
+	list := starlarklib.NewList([]starlarklib.Value{
+		starlarklib.MakeInt(10),
+		dv,
+		starlarklib.Float(4.5),
+	})
+	val, err := starlarklib.Call(thread, b, starlarklib.Tuple{list}, nil)
+	require.NoError(t, err)
+	result, ok := val.(*saga.DecimalValue)
+	require.True(t, ok)
+	assert.Equal(t, "20", result.GetDecimal().String())
+}
+
+func TestSumBuiltin_WithTuple(t *testing.T) {
+	thread := &starlarklib.Thread{Name: "test"}
+	b := starlarklib.NewBuiltin("sum", sumBuiltin)
+
+	tuple := starlarklib.Tuple{starlarklib.MakeInt(3), starlarklib.MakeInt(7)}
+	val, err := starlarklib.Call(thread, b, starlarklib.Tuple{tuple}, nil)
+	require.NoError(t, err)
+	result, ok := val.(*saga.DecimalValue)
+	require.True(t, ok)
+	assert.Equal(t, "10", result.GetDecimal().String())
+}
+
+// --- percentileBuiltin additional cases ---
+
+func TestPercentileBuiltin_P50_OddCount(t *testing.T) {
+	thread := &starlarklib.Thread{Name: "test"}
+	b := starlarklib.NewBuiltin("percentile", percentileBuiltin)
+
+	// 5-element list: P50 should be the median (3rd element after sort)
+	list := starlarklib.NewList([]starlarklib.Value{
+		starlarklib.MakeInt(5),
+		starlarklib.MakeInt(1),
+		starlarklib.MakeInt(3),
+		starlarklib.MakeInt(7),
+		starlarklib.MakeInt(9),
+	})
+	val, err := starlarklib.Call(thread, b, starlarklib.Tuple{list, starlarklib.MakeInt(50)}, nil)
+	require.NoError(t, err)
+	result, ok := val.(*saga.DecimalValue)
+	require.True(t, ok)
+	// Sorted: [1, 3, 5, 7, 9], P50 at index 2 = 5
+	assert.Equal(t, "5", result.GetDecimal().String())
+}
+
+func TestPercentileBuiltin_P25(t *testing.T) {
+	thread := &starlarklib.Thread{Name: "test"}
+	b := starlarklib.NewBuiltin("percentile", percentileBuiltin)
+
+	list := starlarklib.NewList([]starlarklib.Value{
+		starlarklib.Float(10.0),
+		starlarklib.Float(20.0),
+		starlarklib.Float(30.0),
+		starlarklib.Float(40.0),
+	})
+	val, err := starlarklib.Call(thread, b, starlarklib.Tuple{list, starlarklib.MakeInt(25)}, nil)
+	require.NoError(t, err)
+	_, ok := val.(*saga.DecimalValue)
+	require.True(t, ok)
+}
+
+// --- filterByHourBuiltin edge cases ---
+
+func TestFilterByHourBuiltin_MidnightHour(t *testing.T) {
+	thread := &starlarklib.Thread{Name: "test"}
+	b := starlarklib.NewBuiltin("filter_by_hour", filterByHourBuiltin)
+
+	d1 := starlarklib.NewDict(1)
+	_ = d1.SetKey(starlarklib.String("timestamp"), starlarklib.String("2026-01-15T00:00:00Z"))
+	d2 := starlarklib.NewDict(1)
+	_ = d2.SetKey(starlarklib.String("timestamp"), starlarklib.String("2026-01-15T01:00:00Z"))
+
+	list := starlarklib.NewList([]starlarklib.Value{d1, d2})
+	val, err := starlarklib.Call(thread, b, starlarklib.Tuple{list, starlarklib.MakeInt(0)}, nil)
+	require.NoError(t, err)
+	result, ok := val.(*starlarklib.List)
+	require.True(t, ok)
+	assert.Equal(t, 1, result.Len(), "expected only midnight observation")
+}
+
+func TestFilterByHourBuiltin_Hour23(t *testing.T) {
+	thread := &starlarklib.Thread{Name: "test"}
+	b := starlarklib.NewBuiltin("filter_by_hour", filterByHourBuiltin)
+
+	d1 := starlarklib.NewDict(1)
+	_ = d1.SetKey(starlarklib.String("timestamp"), starlarklib.String("2026-01-15T23:00:00Z"))
+	d2 := starlarklib.NewDict(1)
+	_ = d2.SetKey(starlarklib.String("timestamp"), starlarklib.String("2026-01-15T22:59:00Z"))
+
+	list := starlarklib.NewList([]starlarklib.Value{d1, d2})
+	val, err := starlarklib.Call(thread, b, starlarklib.Tuple{list, starlarklib.MakeInt(23)}, nil)
+	require.NoError(t, err)
+	result, ok := val.(*starlarklib.List)
+	require.True(t, ok)
+	assert.Equal(t, 1, result.Len())
+}
+
+// --- groupByHourBuiltin edge cases ---
+
+func TestGroupByHourBuiltin_EmptyList(t *testing.T) {
+	thread := &starlarklib.Thread{Name: "test"}
+	b := starlarklib.NewBuiltin("group_by_hour", groupByHourBuiltin)
+
+	list := starlarklib.NewList(nil)
+	val, err := starlarklib.Call(thread, b, starlarklib.Tuple{list}, nil)
+	require.NoError(t, err)
+	dict, ok := val.(*starlarklib.Dict)
+	require.True(t, ok)
+	assert.Equal(t, 0, dict.Len())
+}
+
+func TestGroupByHourBuiltin_AllSameHour(t *testing.T) {
+	thread := &starlarklib.Thread{Name: "test"}
+	b := starlarklib.NewBuiltin("group_by_hour", groupByHourBuiltin)
+
+	makeObs := func(ts string) *starlarklib.Dict {
+		d := starlarklib.NewDict(1)
+		_ = d.SetKey(starlarklib.String("timestamp"), starlarklib.String(ts))
+		return d
+	}
+
+	list := starlarklib.NewList([]starlarklib.Value{
+		makeObs("2026-03-01T08:00:00Z"),
+		makeObs("2026-03-02T08:00:00Z"),
+		makeObs("2026-03-03T08:00:00Z"),
+	})
+	val, err := starlarklib.Call(thread, b, starlarklib.Tuple{list}, nil)
+	require.NoError(t, err)
+	dict, ok := val.(*starlarklib.Dict)
+	require.True(t, ok)
+	assert.Equal(t, 1, dict.Len(), "all observations should be in hour 8 group")
+
+	hour8Val, found, err := dict.Get(starlarklib.MakeInt(8))
+	require.NoError(t, err)
+	require.True(t, found)
+	hour8List, ok := hour8Val.(*starlarklib.List)
+	require.True(t, ok)
+	assert.Equal(t, 3, hour8List.Len())
+}
+
+// --- durationBuiltin edge cases ---
+
+func TestDurationBuiltin_ZeroValues(t *testing.T) {
+	thread := &starlarklib.Thread{Name: "test"}
+	b := starlarklib.NewBuiltin("duration", durationBuiltin)
+
+	val, err := starlarklib.Call(thread, b, starlarklib.Tuple{}, []starlarklib.Tuple{
+		{starlarklib.String("hours"), starlarklib.MakeInt(0)},
+	})
+	require.NoError(t, err)
+	result, ok := val.(starlarklib.Int)
+	require.True(t, ok)
+	n, _ := result.Int64()
+	assert.Equal(t, int64(0), n)
+}
+
+func TestDurationBuiltin_LargeHours(t *testing.T) {
+	thread := &starlarklib.Thread{Name: "test"}
+	b := starlarklib.NewBuiltin("duration", durationBuiltin)
+
+	val, err := starlarklib.Call(thread, b, starlarklib.Tuple{}, []starlarklib.Tuple{
+		{starlarklib.String("hours"), starlarklib.MakeInt(168)}, // 1 week
+	})
+	require.NoError(t, err)
+	result, ok := val.(starlarklib.Int)
+	require.True(t, ok)
+	n, _ := result.Int64()
+	assert.Equal(t, int64(168*3600), n)
+}
+
+// --- addSecondsBuiltin additional cases ---
+
+func TestAddSecondsBuiltin_ZeroSeconds(t *testing.T) {
+	thread := &starlarklib.Thread{Name: "test"}
+	b := starlarklib.NewBuiltin("add_seconds", addSecondsBuiltin)
+
+	val, err := starlarklib.Call(thread, b, starlarklib.Tuple{
+		starlarklib.String("2026-01-01T00:00:00Z"),
+		starlarklib.MakeInt(0),
+	}, nil)
+	require.NoError(t, err)
+	result, ok := val.(starlarklib.String)
+	require.True(t, ok)
+	assert.Equal(t, "2026-01-01T00:00:00Z", string(result))
+}
+
+// --- toDecimalSlice with mixed valid types ---
+
+func TestToDecimalSlice_MixedValidTypes(t *testing.T) {
+	dv, err := saga.NewDecimalValue("5.5")
+	require.NoError(t, err)
+
+	list := starlarklib.NewList([]starlarklib.Value{
+		starlarklib.MakeInt(1),
+		starlarklib.Float(2.5),
+		starlarklib.String("3.0"),
+		dv,
+	})
+
+	result, err := toDecimalSlice(list)
+	require.NoError(t, err)
+	require.Len(t, result, 4)
+	assert.Equal(t, "1", result[0].String())
+	assert.Equal(t, "2.5", result[1].String())
+	assert.Equal(t, "3", result[2].String())
+	assert.Equal(t, "5.5", result[3].String())
+}

--- a/services/reference-data/saga/reference_extractor_test.go
+++ b/services/reference-data/saga/reference_extractor_test.go
@@ -139,8 +139,8 @@ func TestReferenceExtractor_AttributeAccess(t *testing.T) {
 			instrRefs = append(instrRefs, r)
 		case ReferenceTypeAttribute:
 			attrRefs = append(attrRefs, r)
-		default:
-			// other reference types not relevant to this test
+		case ReferenceTypeStepHandler, ReferenceTypeAccount, ReferenceTypeSaga:
+			// not relevant to this test
 		}
 	}
 	require.Len(t, instrRefs, 1)

--- a/services/reference-data/saga/reference_extractor_test.go
+++ b/services/reference-data/saga/reference_extractor_test.go
@@ -139,6 +139,8 @@ func TestReferenceExtractor_AttributeAccess(t *testing.T) {
 			instrRefs = append(instrRefs, r)
 		case ReferenceTypeAttribute:
 			attrRefs = append(attrRefs, r)
+		default:
+			// other reference types not relevant to this test
 		}
 	}
 	require.Len(t, instrRefs, 1)


### PR DESCRIPTION
## Summary

- Add `refdata_adapter_test.go`: NoOpRefDataClient error wrapping and resolution key propagation
- Add `mappers_test.go`: StrategyToEntity/EntityToStrategy conversions, optional fields, status mapping, domain roundtrip
- Add `metrics_test.go`: Full Prometheus metrics coverage (execution counters, duration histograms, lease failures, active strategies gauge, reload outcomes, error types)
- Add `builtins_test.go`: Supplement existing coverage with DecimalValue inputs for avg/sum, percentile P50/P25, filter_by_hour edge cases (midnight, hour 23), group_by_hour (empty list, all same hour), duration zero/large values, add_seconds zero seconds

## Test plan

- [ ] `go test ./services/forecasting/adapters/mds/` passes
- [ ] `go test ./services/forecasting/adapters/persistence/ -run "^TestStrategyToEntity|^TestEntityToStrategy"` passes
- [ ] `go test ./services/forecasting/scheduler/` passes
- [ ] `go test ./services/forecasting/starlark/` passes