### PR TITLE
test: Add position keeping persistence and domain unit tests

### DIFF
--- a/services/position-keeping/adapters/persistence/position_log_batch_test.go
+++ b/services/position-keeping/adapters/persistence/position_log_batch_test.go
@@ -1,0 +1,173 @@
+package persistence_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPositionLogBatch_EmptyBatch_IsNoOp(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	err := tc.repo.CreateBatch(context.Background(), nil)
+	assert.NoError(t, err)
+
+	err = tc.repo.CreateBatch(context.Background(), []*domain.FinancialPositionLog{})
+	assert.NoError(t, err)
+}
+
+func TestPositionLogBatch_SingleLog(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+	log := buildBatchTestLog(t, "ACC-BATCH-SINGLE")
+
+	err := tc.repo.CreateBatch(ctx, []*domain.FinancialPositionLog{log})
+	require.NoError(t, err)
+
+	retrieved, err := tc.repo.FindByID(ctx, log.LogID)
+	require.NoError(t, err)
+	assert.Equal(t, log.LogID, retrieved.LogID)
+}
+
+func TestPositionLogBatch_MultipleLogs_AllPersisted(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+	const count = 10
+	const accountID = "ACC-BATCH-MULTI"
+
+	logs := make([]*domain.FinancialPositionLog, count)
+	for i := 0; i < count; i++ {
+		logs[i] = buildBatchTestLog(t, accountID)
+	}
+
+	require.NoError(t, tc.repo.CreateBatch(ctx, logs))
+
+	retrieved, err := tc.repo.FindByAccountID(ctx, accountID)
+	require.NoError(t, err)
+	assert.Len(t, retrieved, count)
+}
+
+func TestPositionLogBatch_DuplicateInBatch_RollsBackAll(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+	log := buildBatchTestLog(t, "ACC-BATCH-DUP")
+
+	// Include the same log twice to trigger unique_violation during COPY
+	err := tc.repo.CreateBatch(ctx, []*domain.FinancialPositionLog{log, log})
+	assert.ErrorIs(t, err, domain.ErrConflict)
+
+	// Nothing should have been persisted (transaction rolled back)
+	_, findErr := tc.repo.FindByID(ctx, log.LogID)
+	assert.ErrorIs(t, findErr, domain.ErrNotFound)
+}
+
+func TestPositionLogBatch_WithComplexAggregates(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+	const accountID = "ACC-BATCH-COMPLEX"
+
+	// Build logs with entries + lineage + audit trail
+	var logs []*domain.FinancialPositionLog
+	for i := 0; i < 3; i++ {
+		amount, err := domain.NewMoney(decimal.NewFromFloat(float64(100*(i+1))), domain.CurrencyGBP)
+		require.NoError(t, err)
+
+		entry, err := domain.NewTransactionLogEntry(
+			uuid.New(),
+			accountID,
+			amount,
+			domain.PostingDirectionDebit,
+			time.Now().UTC(),
+			"batch complex test",
+			"REF-BATCH-COMPLEX",
+			domain.TransactionSourceManual,
+		)
+		require.NoError(t, err)
+
+		parentID := uuid.New()
+		lineage, err := domain.NewTransactionLineage(
+			uuid.New(), "payment", &parentID,
+			[]uuid.UUID{uuid.New()},
+			[]uuid.UUID{},
+		)
+		require.NoError(t, err)
+
+		log, err := domain.NewFinancialPositionLog(accountID, entry, lineage)
+		require.NoError(t, err)
+
+		auditEntry, err := domain.NewAuditTrailEntry("batch-user", "create", "batch created", "10.0.0.1", nil)
+		require.NoError(t, err)
+		require.NoError(t, log.AddAuditEntry(auditEntry))
+
+		logs = append(logs, log)
+	}
+
+	require.NoError(t, tc.repo.CreateBatch(ctx, logs))
+
+	// Verify all were persisted with their related entities
+	retrieved, err := tc.repo.FindByAccountID(ctx, accountID)
+	require.NoError(t, err)
+	assert.Len(t, retrieved, 3)
+
+	for _, r := range retrieved {
+		assert.Len(t, r.TransactionLogEntries, 1)
+		require.NotNil(t, r.TransactionLineage)
+		assert.NotNil(t, r.TransactionLineage.ParentTransactionID())
+		assert.Len(t, r.AuditTrail, 1)
+	}
+}
+
+func TestPositionLogBatch_AlreadyExistingLog_Conflict(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+	log := buildBatchTestLog(t, "ACC-BATCH-EXIST")
+
+	// Persist individually first
+	require.NoError(t, tc.repo.Create(ctx, log))
+
+	// Batch with the same log must conflict
+	err := tc.repo.CreateBatch(ctx, []*domain.FinancialPositionLog{log})
+	assert.ErrorIs(t, err, domain.ErrConflict)
+}
+
+// buildBatchTestLog creates a FinancialPositionLog for batch tests.
+func buildBatchTestLog(t *testing.T, accountID string) *domain.FinancialPositionLog {
+	t.Helper()
+
+	amount, err := domain.NewMoney(decimal.NewFromFloat(75.00), domain.CurrencyEUR)
+	require.NoError(t, err)
+
+	entry, err := domain.NewTransactionLogEntry(
+		uuid.New(),
+		accountID,
+		amount,
+		domain.PostingDirectionCredit,
+		time.Now().UTC(),
+		"batch test",
+		"REF-BATCH",
+		domain.TransactionSourceAutomated,
+	)
+	require.NoError(t, err)
+
+	log, err := domain.NewFinancialPositionLog(accountID, entry, nil)
+	require.NoError(t, err)
+
+	return log
+}

--- a/services/position-keeping/adapters/persistence/position_log_read_test.go
+++ b/services/position-keeping/adapters/persistence/position_log_read_test.go
@@ -1,0 +1,245 @@
+package persistence_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/position-keeping/adapters/persistence"
+	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPositionLogRead_FindByID_NotFound(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	_, err := tc.repo.FindByID(context.Background(), uuid.New())
+	assert.ErrorIs(t, err, domain.ErrNotFound)
+}
+
+func TestPositionLogRead_FindByAccountID_NoResults(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	logs, err := tc.repo.FindByAccountID(context.Background(), "ACC-NONEXISTENT")
+	require.NoError(t, err)
+	assert.Empty(t, logs)
+}
+
+func TestPositionLogRead_FindByAccountID_MultipleResults(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+	const accountID = "ACC-READ-MULTI"
+
+	for i := 0; i < 3; i++ {
+		log := buildReadTestLog(t, accountID)
+		require.NoError(t, tc.repo.Create(ctx, log))
+	}
+	// Add one for a different account — must not appear in results
+	require.NoError(t, tc.repo.Create(ctx, buildReadTestLog(t, "ACC-READ-OTHER")))
+
+	logs, err := tc.repo.FindByAccountID(ctx, accountID)
+	require.NoError(t, err)
+	assert.Len(t, logs, 3)
+	for _, l := range logs {
+		assert.Equal(t, accountID, l.AccountID)
+	}
+}
+
+func TestPositionLogRead_List_InvalidLimit(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	_, err := tc.repo.List(context.Background(), domain.PositionLogFilter{Limit: 0})
+	assert.ErrorIs(t, err, persistence.ErrInvalidLimit)
+}
+
+func TestPositionLogRead_List_Pagination(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+	const accountID = "ACC-READ-PAGE"
+
+	for i := 0; i < 5; i++ {
+		require.NoError(t, tc.repo.Create(ctx, buildReadTestLog(t, accountID)))
+	}
+
+	accID := accountID
+
+	// First page: limit 2
+	page1, err := tc.repo.List(ctx, domain.PositionLogFilter{AccountID: &accID, Limit: 2, Offset: 0})
+	require.NoError(t, err)
+	assert.Len(t, page1, 2)
+
+	// Second page: offset 2
+	page2, err := tc.repo.List(ctx, domain.PositionLogFilter{AccountID: &accID, Limit: 2, Offset: 2})
+	require.NoError(t, err)
+	assert.Len(t, page2, 2)
+
+	// Third page: offset 4 — only 1 remaining
+	page3, err := tc.repo.List(ctx, domain.PositionLogFilter{AccountID: &accID, Limit: 2, Offset: 4})
+	require.NoError(t, err)
+	assert.Len(t, page3, 1)
+
+	// Verify no duplicates across pages
+	seen := make(map[uuid.UUID]bool)
+	for _, page := range [][]*domain.FinancialPositionLog{page1, page2, page3} {
+		for _, l := range page {
+			assert.False(t, seen[l.LogID], "LogID %s appeared on multiple pages", l.LogID)
+			seen[l.LogID] = true
+		}
+	}
+}
+
+func TestPositionLogRead_List_AccountIDsFilter(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+
+	const acc1 = "ACC-READ-IDS-1"
+	const acc2 = "ACC-READ-IDS-2"
+	const acc3 = "ACC-READ-IDS-3"
+
+	require.NoError(t, tc.repo.Create(ctx, buildReadTestLog(t, acc1)))
+	require.NoError(t, tc.repo.Create(ctx, buildReadTestLog(t, acc2)))
+	require.NoError(t, tc.repo.Create(ctx, buildReadTestLog(t, acc3)))
+
+	// AccountIDs filter: should return acc1 and acc2 but not acc3
+	logs, err := tc.repo.List(ctx, domain.PositionLogFilter{
+		AccountIDs: []string{acc1, acc2},
+		Limit:      10,
+	})
+	require.NoError(t, err)
+	assert.Len(t, logs, 2)
+
+	accountsFound := make(map[string]bool)
+	for _, l := range logs {
+		accountsFound[l.AccountID] = true
+	}
+	assert.True(t, accountsFound[acc1])
+	assert.True(t, accountsFound[acc2])
+	assert.False(t, accountsFound[acc3])
+}
+
+func TestPositionLogRead_FindPendingForReconciliation_NoLimit(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+	const accountID = "ACC-READ-PENDING"
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, tc.repo.Create(ctx, buildReadTestLog(t, accountID)))
+	}
+
+	// limit=0 should return all pending records
+	logs, err := tc.repo.FindPendingForReconciliation(ctx, 0)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(logs), 3)
+	for _, l := range logs {
+		assert.Equal(t, domain.TransactionStatusPending, l.StatusTracking.CurrentStatus)
+		assert.Equal(t, domain.ReconciliationStatusUnreconciled, l.StatusTracking.ReconciliationStatus)
+	}
+}
+
+func TestPositionLogRead_FindPendingForReconciliation_WithLimit(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+	const accountID = "ACC-READ-PENDING-LIM"
+
+	for i := 0; i < 4; i++ {
+		require.NoError(t, tc.repo.Create(ctx, buildReadTestLog(t, accountID)))
+	}
+
+	logs, err := tc.repo.FindPendingForReconciliation(ctx, 2)
+	require.NoError(t, err)
+	assert.Len(t, logs, 2)
+}
+
+func TestPositionLogRead_FindByID_LoadsRelatedEntities(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+
+	amount, err := domain.NewMoney(decimal.NewFromFloat(100), domain.CurrencyGBP)
+	require.NoError(t, err)
+
+	entry, err := domain.NewTransactionLogEntry(
+		uuid.New(),
+		"ACC-READ-RELATED",
+		amount,
+		domain.PostingDirectionDebit,
+		time.Now().UTC(),
+		"related test",
+		"REF-RELATED",
+		domain.TransactionSourceManual,
+	)
+	require.NoError(t, err)
+
+	parentID := uuid.New()
+	lineage, err := domain.NewTransactionLineage(
+		uuid.New(), "payment", &parentID,
+		[]uuid.UUID{uuid.New()},
+		[]uuid.UUID{uuid.New()},
+	)
+	require.NoError(t, err)
+
+	log, err := domain.NewFinancialPositionLog("ACC-READ-RELATED", entry, lineage)
+	require.NoError(t, err)
+
+	auditEntry, err := domain.NewAuditTrailEntry("user", "create", "created", "127.0.0.1", map[string]string{"k": "v"})
+	require.NoError(t, err)
+	require.NoError(t, log.AddAuditEntry(auditEntry))
+
+	require.NoError(t, tc.repo.Create(ctx, log))
+
+	retrieved, err := tc.repo.FindByID(ctx, log.LogID)
+	require.NoError(t, err)
+
+	// Transaction log entries loaded
+	assert.Len(t, retrieved.TransactionLogEntries, 1)
+
+	// Transaction lineage loaded with parent
+	require.NotNil(t, retrieved.TransactionLineage)
+	require.NotNil(t, retrieved.TransactionLineage.ParentTransactionID())
+	assert.Equal(t, parentID, *retrieved.TransactionLineage.ParentTransactionID())
+
+	// Audit trail loaded
+	assert.Len(t, retrieved.AuditTrail, 1)
+}
+
+// buildReadTestLog creates a minimal FinancialPositionLog for read tests.
+func buildReadTestLog(t *testing.T, accountID string) *domain.FinancialPositionLog {
+	t.Helper()
+
+	amount, err := domain.NewMoney(decimal.NewFromFloat(25.00), domain.CurrencyUSD)
+	require.NoError(t, err)
+
+	entry, err := domain.NewTransactionLogEntry(
+		uuid.New(),
+		accountID,
+		amount,
+		domain.PostingDirectionDebit,
+		time.Now().UTC(),
+		"read test",
+		"REF-READ",
+		domain.TransactionSourceAutomated,
+	)
+	require.NoError(t, err)
+
+	log, err := domain.NewFinancialPositionLog(accountID, entry, nil)
+	require.NoError(t, err)
+
+	return log
+}

--- a/services/position-keeping/adapters/persistence/position_log_write_test.go
+++ b/services/position-keeping/adapters/persistence/position_log_write_test.go
@@ -1,0 +1,228 @@
+package persistence_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/meridianhub/meridian/services/position-keeping/adapters/persistence"
+	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPositionLogWrite_Create_NilLog(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	err := tc.repo.Create(context.Background(), nil)
+	assert.ErrorIs(t, err, persistence.ErrNilLog)
+}
+
+func TestPositionLogWrite_Create_DuplicateConflict(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+	log := buildWriteTestLog(t, "ACC-WRITE-001")
+
+	require.NoError(t, tc.repo.Create(ctx, log))
+
+	// Creating the same log again (same LogID) must return ErrConflict
+	err := tc.repo.Create(ctx, log)
+	assert.ErrorIs(t, err, domain.ErrConflict)
+}
+
+func TestPositionLogWrite_Create_Roundtrip(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+	log := buildWriteTestLog(t, "ACC-WRITE-002")
+
+	require.NoError(t, tc.repo.Create(ctx, log))
+
+	retrieved, err := tc.repo.FindByID(ctx, log.LogID)
+	require.NoError(t, err)
+	assert.Equal(t, log.LogID, retrieved.LogID)
+	assert.Equal(t, log.AccountID, retrieved.AccountID)
+	assert.Equal(t, log.Version, retrieved.Version)
+	assert.Equal(t, 1, len(retrieved.TransactionLogEntries))
+	assert.Equal(t, 1, len(retrieved.AuditTrail))
+}
+
+func TestPositionLogWrite_Update_NilLog(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	err := tc.repo.Update(context.Background(), nil)
+	assert.ErrorIs(t, err, persistence.ErrNilLog)
+}
+
+func TestPositionLogWrite_Update_NotFound(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	log := buildWriteTestLog(t, "ACC-WRITE-003")
+	// Not persisted — update must return ErrNotFound
+	err := tc.repo.Update(context.Background(), log)
+	assert.ErrorIs(t, err, domain.ErrNotFound)
+}
+
+func TestPositionLogWrite_Update_OptimisticLock(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+	log := buildWriteTestLog(t, "ACC-WRITE-004")
+	require.NoError(t, tc.repo.Create(ctx, log))
+
+	// Simulate concurrent update: bump version in DB so our update is stale
+	_, err := tc.pool.Exec(ctx,
+		`UPDATE position_keeping.financial_position_log SET version = version + 1 WHERE log_id = $1`,
+		log.LogID,
+	)
+	require.NoError(t, err)
+
+	// Domain update increments version to 2, but DB version is already 2
+	auditEntry, err := domain.NewAuditTrailEntry("user", "post", "posted", "127.0.0.1", nil)
+	require.NoError(t, err)
+	require.NoError(t, log.MarkPosted("Posted", auditEntry))
+
+	err = tc.repo.Update(ctx, log)
+	assert.ErrorIs(t, err, domain.ErrOptimisticLock)
+}
+
+func TestPositionLogWrite_Update_Success(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+	log := buildWriteTestLog(t, "ACC-WRITE-005")
+	require.NoError(t, tc.repo.Create(ctx, log))
+
+	auditEntry, err := domain.NewAuditTrailEntry("user", "post", "posted", "127.0.0.1", nil)
+	require.NoError(t, err)
+	require.NoError(t, log.MarkPosted("Posted successfully", auditEntry))
+
+	require.NoError(t, tc.repo.Update(ctx, log))
+
+	retrieved, err := tc.repo.FindByID(ctx, log.LogID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.TransactionStatusPosted, retrieved.StatusTracking.CurrentStatus)
+	assert.Equal(t, uint64(2), retrieved.Version)
+}
+
+func TestPositionLogWrite_CreateWithOutbox_Success(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+	log := buildWriteTestLog(t, "ACC-WRITE-006")
+
+	postFnCalled := false
+	postFn := func(_ pgx.Tx) error {
+		postFnCalled = true
+		return nil
+	}
+
+	require.NoError(t, tc.repo.CreateWithOutbox(ctx, log, postFn))
+	assert.True(t, postFnCalled)
+
+	// Verify the log was persisted
+	retrieved, err := tc.repo.FindByID(ctx, log.LogID)
+	require.NoError(t, err)
+	assert.Equal(t, log.LogID, retrieved.LogID)
+}
+
+func TestPositionLogWrite_CreateWithOutbox_PostFnError_RollsBack(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+	log := buildWriteTestLog(t, "ACC-WRITE-007")
+
+	postFn := func(_ pgx.Tx) error {
+		return assert.AnError
+	}
+
+	err := tc.repo.CreateWithOutbox(ctx, log, postFn)
+	require.Error(t, err)
+
+	// Log must NOT be persisted because the transaction was rolled back
+	_, findErr := tc.repo.FindByID(ctx, log.LogID)
+	assert.ErrorIs(t, findErr, domain.ErrNotFound)
+}
+
+func TestPositionLogWrite_CreateWithOutbox_NilPostFn(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+	log := buildWriteTestLog(t, "ACC-WRITE-008")
+
+	// nil postFn should be handled gracefully
+	require.NoError(t, tc.repo.CreateWithOutbox(ctx, log, nil))
+
+	retrieved, err := tc.repo.FindByID(ctx, log.LogID)
+	require.NoError(t, err)
+	assert.Equal(t, log.LogID, retrieved.LogID)
+}
+
+func TestPositionLogWrite_UpdateWithOutbox_Success(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+	log := buildWriteTestLog(t, "ACC-WRITE-009")
+	require.NoError(t, tc.repo.Create(ctx, log))
+
+	auditEntry, err := domain.NewAuditTrailEntry("user", "post", "posted", "127.0.0.1", nil)
+	require.NoError(t, err)
+	require.NoError(t, log.MarkPosted("Posted", auditEntry))
+
+	outboxCalled := false
+	postFn := func(_ pgx.Tx) error {
+		outboxCalled = true
+		return nil
+	}
+
+	require.NoError(t, tc.repo.UpdateWithOutbox(ctx, log, postFn))
+	assert.True(t, outboxCalled)
+
+	retrieved, err := tc.repo.FindByID(ctx, log.LogID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.TransactionStatusPosted, retrieved.StatusTracking.CurrentStatus)
+}
+
+// buildWriteTestLog creates a minimal FinancialPositionLog for write tests.
+func buildWriteTestLog(t *testing.T, accountID string) *domain.FinancialPositionLog {
+	t.Helper()
+
+	amount, err := domain.NewMoney(decimal.NewFromFloat(50.00), domain.CurrencyGBP)
+	require.NoError(t, err)
+
+	entry, err := domain.NewTransactionLogEntry(
+		uuid.New(),
+		accountID,
+		amount,
+		domain.PostingDirectionCredit,
+		time.Now().UTC(),
+		"write test",
+		"REF-WRITE",
+		domain.TransactionSourceManual,
+	)
+	require.NoError(t, err)
+
+	log, err := domain.NewFinancialPositionLog(accountID, entry, nil)
+	require.NoError(t, err)
+
+	auditEntry, err := domain.NewAuditTrailEntry("test-user", "create", "created", "127.0.0.1", nil)
+	require.NoError(t, err)
+	require.NoError(t, log.AddAuditEntry(auditEntry))
+
+	return log
+}

--- a/services/position-keeping/adapters/persistence/position_log_write_test.go
+++ b/services/position-keeping/adapters/persistence/position_log_write_test.go
@@ -113,7 +113,7 @@ func TestPositionLogWrite_Update_Success(t *testing.T) {
 	retrieved, err := tc.repo.FindByID(ctx, log.LogID)
 	require.NoError(t, err)
 	assert.Equal(t, domain.TransactionStatusPosted, retrieved.StatusTracking.CurrentStatus)
-	assert.Equal(t, uint64(2), retrieved.Version)
+	assert.Equal(t, int64(2), retrieved.Version)
 }
 
 func TestPositionLogWrite_CreateWithOutbox_Success(t *testing.T) {

--- a/services/position-keeping/domain/quantity_test.go
+++ b/services/position-keeping/domain/quantity_test.go
@@ -10,10 +10,10 @@ import (
 
 func TestNewMoneyFromInstrumentCode_Currency(t *testing.T) {
 	tests := []struct {
-		name     string
-		amount   decimal.Decimal
-		code     string
-		wantErr  bool
+		name    string
+		amount  decimal.Decimal
+		code    string
+		wantErr bool
 	}{
 		{
 			name:   "valid GBP",
@@ -79,11 +79,11 @@ func TestMoneyCurrency(t *testing.T) {
 
 func TestMoneyToMinorUnits(t *testing.T) {
 	tests := []struct {
-		name       string
-		amount     decimal.Decimal
-		currency   Currency
-		wantMinor  int64
-		wantErr    bool
+		name      string
+		amount    decimal.Decimal
+		currency  Currency
+		wantMinor int64
+		wantErr   bool
 	}{
 		{
 			name:      "GBP 100.50",
@@ -137,11 +137,11 @@ func TestMoneyToMinorUnitsUnchecked(t *testing.T) {
 
 func TestNewMoneyFromMinorUnits(t *testing.T) {
 	tests := []struct {
-		name        string
-		code        string
-		minorUnits  int64
-		wantAmount  decimal.Decimal
-		wantErr     bool
+		name       string
+		code       string
+		minorUnits int64
+		wantAmount decimal.Decimal
+		wantErr    bool
 	}{
 		{
 			name:       "GBP 10000 minor = 100.00",

--- a/services/position-keeping/domain/quantity_test.go
+++ b/services/position-keeping/domain/quantity_test.go
@@ -1,0 +1,296 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMoneyFromInstrumentCode_Currency(t *testing.T) {
+	tests := []struct {
+		name     string
+		amount   decimal.Decimal
+		code     string
+		wantErr  bool
+	}{
+		{
+			name:   "valid GBP",
+			amount: decimal.NewFromFloat(100.50),
+			code:   "GBP",
+		},
+		{
+			name:   "valid USD",
+			amount: decimal.NewFromFloat(250.00),
+			code:   "USD",
+		},
+		{
+			name:   "valid EUR",
+			amount: decimal.NewFromFloat(75.25),
+			code:   "EUR",
+		},
+		{
+			name:   "zero amount GBP",
+			amount: decimal.Zero,
+			code:   "GBP",
+		},
+		{
+			name:   "negative amount",
+			amount: decimal.NewFromFloat(-50.00),
+			code:   "GBP",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := NewMoneyFromInstrumentCode(tt.amount, tt.code)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.amount, m.Amount)
+			assert.Equal(t, tt.code, m.Instrument.Code)
+		})
+	}
+}
+
+func TestNewMoneyFromInstrumentCode_NonCurrency(t *testing.T) {
+	amount := decimal.NewFromFloat(42.50)
+	m, err := NewMoneyFromInstrumentCode(amount, "KWH")
+	require.NoError(t, err)
+	assert.Equal(t, amount, m.Amount)
+	assert.Equal(t, "KWH", m.Instrument.Code)
+}
+
+func TestNewMoneyFromInstrumentCode_EmptyCode(t *testing.T) {
+	_, err := NewMoneyFromInstrumentCode(decimal.NewFromInt(100), "")
+	assert.ErrorIs(t, err, ErrEmptyCode)
+}
+
+func TestMoneyCurrency(t *testing.T) {
+	m, err := NewMoney(decimal.NewFromFloat(100), CurrencyGBP)
+	require.NoError(t, err)
+
+	cur := MoneyCurrency(m)
+	assert.Equal(t, CurrencyGBP, cur)
+}
+
+func TestMoneyToMinorUnits(t *testing.T) {
+	tests := []struct {
+		name       string
+		amount     decimal.Decimal
+		currency   Currency
+		wantMinor  int64
+		wantErr    bool
+	}{
+		{
+			name:      "GBP 100.50",
+			amount:    decimal.NewFromFloat(100.50),
+			currency:  CurrencyGBP,
+			wantMinor: 10050,
+		},
+		{
+			name:      "USD 0.01",
+			amount:    decimal.NewFromFloat(0.01),
+			currency:  CurrencyUSD,
+			wantMinor: 1,
+		},
+		{
+			name:      "zero amount",
+			amount:    decimal.Zero,
+			currency:  CurrencyEUR,
+			wantMinor: 0,
+		},
+		{
+			name:      "negative amount",
+			amount:    decimal.NewFromFloat(-50.25),
+			currency:  CurrencyGBP,
+			wantMinor: -5025,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := NewMoney(tt.amount, tt.currency)
+			require.NoError(t, err)
+
+			minorUnits, err := MoneyToMinorUnits(m)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMinor, minorUnits)
+		})
+	}
+}
+
+func TestMoneyToMinorUnitsUnchecked(t *testing.T) {
+	m, err := NewMoney(decimal.NewFromFloat(99.99), CurrencyGBP)
+	require.NoError(t, err)
+
+	minor := MoneyToMinorUnitsUnchecked(m)
+	assert.Equal(t, int64(9999), minor)
+}
+
+func TestNewMoneyFromMinorUnits(t *testing.T) {
+	tests := []struct {
+		name        string
+		code        string
+		minorUnits  int64
+		wantAmount  decimal.Decimal
+		wantErr     bool
+	}{
+		{
+			name:       "GBP 10000 minor = 100.00",
+			code:       "GBP",
+			minorUnits: 10000,
+			wantAmount: decimal.NewFromFloat(100.00),
+		},
+		{
+			name:       "USD 1 minor = 0.01",
+			code:       "USD",
+			minorUnits: 1,
+			wantAmount: decimal.NewFromFloat(0.01),
+		},
+		{
+			name:       "zero minor units",
+			code:       "EUR",
+			minorUnits: 0,
+			wantAmount: decimal.Zero,
+		},
+		{
+			name:    "invalid currency",
+			code:    "INVALID",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := NewMoneyFromMinorUnits(tt.code, tt.minorUnits)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.True(t, tt.wantAmount.Equal(m.Amount),
+				"expected %s, got %s", tt.wantAmount, m.Amount)
+		})
+	}
+}
+
+func TestNewInstrument(t *testing.T) {
+	t.Run("valid currency instrument", func(t *testing.T) {
+		inst, err := NewInstrument("GBP", 1, DimensionCurrency, 2)
+		require.NoError(t, err)
+		assert.Equal(t, "GBP", inst.Code)
+		assert.Equal(t, 2, inst.Precision)
+	})
+
+	t.Run("empty code returns error", func(t *testing.T) {
+		_, err := NewInstrument("", 1, DimensionCurrency, 2)
+		assert.ErrorIs(t, err, ErrEmptyCode)
+	})
+
+	t.Run("negative precision returns error", func(t *testing.T) {
+		_, err := NewInstrument("GBP", 1, DimensionCurrency, -1)
+		assert.ErrorIs(t, err, ErrNegativePrecision)
+	})
+}
+
+func TestMustNewInstrument_Panics(t *testing.T) {
+	assert.Panics(t, func() {
+		MustNewInstrument("", 1, DimensionCurrency, 2)
+	})
+}
+
+func TestMustNewInstrument_Valid(t *testing.T) {
+	assert.NotPanics(t, func() {
+		inst := MustNewInstrument("GBP", 1, DimensionCurrency, 2)
+		assert.Equal(t, "GBP", inst.Code)
+	})
+}
+
+func TestNewAsset(t *testing.T) {
+	inst := MustNewInstrument("KWH", 1, "ENERGY", 3)
+	amount := decimal.NewFromFloat(123.456)
+
+	a := NewAsset(amount, inst)
+	assert.True(t, amount.Equal(a.Amount))
+	assert.Equal(t, "KWH", a.Instrument.Code)
+}
+
+func TestNewAssetFromString(t *testing.T) {
+	inst := MustNewInstrument("KWH", 1, "ENERGY", 3)
+
+	t.Run("valid string", func(t *testing.T) {
+		a, err := NewAssetFromString("42.500", inst)
+		require.NoError(t, err)
+		assert.True(t, decimal.NewFromFloat(42.5).Equal(a.Amount))
+	})
+
+	t.Run("invalid string", func(t *testing.T) {
+		_, err := NewAssetFromString("not-a-number", inst)
+		assert.ErrorIs(t, err, ErrInvalidDecimalString)
+	})
+}
+
+func TestZeroFunctions(t *testing.T) {
+	t.Run("Zero money", func(t *testing.T) {
+		m, err := Zero(CurrencyGBP)
+		require.NoError(t, err)
+		assert.True(t, m.Amount.IsZero())
+		assert.Equal(t, "GBP", m.Instrument.Code)
+	})
+
+	t.Run("ZeroAsset", func(t *testing.T) {
+		inst := MustNewInstrument("KWH", 1, "ENERGY", 3)
+		a := ZeroAsset(inst)
+		assert.True(t, a.Amount.IsZero())
+	})
+}
+
+func TestParseCurrency(t *testing.T) {
+	t.Run("valid currency", func(t *testing.T) {
+		cur, err := ParseCurrency("GBP")
+		require.NoError(t, err)
+		assert.Equal(t, CurrencyGBP, cur)
+	})
+
+	t.Run("invalid currency", func(t *testing.T) {
+		_, err := ParseCurrency("INVALID")
+		require.Error(t, err)
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		_, err := ParseCurrency("")
+		require.Error(t, err)
+	})
+}
+
+func TestNewAmount(t *testing.T) {
+	inst := MustNewInstrument("KWH", 1, "ENERGY", 3)
+	a := NewAmount(inst, 1500)
+	assert.Equal(t, "KWH", a.InstrumentCode())
+	minorUnits, err := a.ToMinorUnits()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1500), minorUnits)
+}
+
+func TestNewAmountFromDecimal(t *testing.T) {
+	inst := MustNewInstrument("GBP", 1, DimensionCurrency, 2)
+	a := NewAmountFromDecimal(inst, decimal.NewFromFloat(10.00))
+	assert.Equal(t, "GBP", a.InstrumentCode())
+	minorUnits, err := a.ToMinorUnits()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1000), minorUnits)
+}
+
+func TestZeroAmount(t *testing.T) {
+	inst := MustNewInstrument("EUR", 1, DimensionCurrency, 2)
+	a := ZeroAmount(inst)
+	assert.True(t, a.IsZero())
+}

--- a/services/position-keeping/service/metrics_test.go
+++ b/services/position-keeping/service/metrics_test.go
@@ -1,0 +1,120 @@
+package service_test
+
+import (
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/position-keeping/service"
+)
+
+func TestRecordValidationFailure_IncrementsByCaller(t *testing.T) {
+	metrics := service.ExposeMetricsForTesting
+
+	// Gather current state
+	before, err := metrics.MeasurementValidationFailuresTotal.GetMetricWithLabelValues("TEST_INST_INC", service.ValidationFailureReasonCELRejected)
+	require.NoError(t, err)
+	beforeMetric := &dto.Metric{}
+	require.NoError(t, before.Write(beforeMetric))
+	var beforeVal float64
+	if beforeMetric.Counter != nil && beforeMetric.Counter.Value != nil {
+		beforeVal = *beforeMetric.Counter.Value
+	}
+
+	service.RecordValidationFailure("TEST_INST_INC", service.ValidationFailureReasonCELRejected)
+	service.RecordValidationFailure("TEST_INST_INC", service.ValidationFailureReasonCELRejected)
+
+	after, err := metrics.MeasurementValidationFailuresTotal.GetMetricWithLabelValues("TEST_INST_INC", service.ValidationFailureReasonCELRejected)
+	require.NoError(t, err)
+	afterMetric := &dto.Metric{}
+	require.NoError(t, after.Write(afterMetric))
+	var afterVal float64
+	if afterMetric.Counter != nil && afterMetric.Counter.Value != nil {
+		afterVal = *afterMetric.Counter.Value
+	}
+
+	assert.Equal(t, beforeVal+2, afterVal, "counter should increment by 2")
+}
+
+func TestRecordCardinalityViolation_Increments(t *testing.T) {
+	metrics := service.ExposeMetricsForTesting
+
+	before, err := metrics.BucketCardinalityViolationsTotal.GetMetricWithLabelValues("CARD_TEST_INST")
+	require.NoError(t, err)
+	beforeMetric := &dto.Metric{}
+	require.NoError(t, before.Write(beforeMetric))
+	var beforeVal float64
+	if beforeMetric.Counter != nil && beforeMetric.Counter.Value != nil {
+		beforeVal = *beforeMetric.Counter.Value
+	}
+
+	service.RecordCardinalityViolation("CARD_TEST_INST")
+
+	after, err := metrics.BucketCardinalityViolationsTotal.GetMetricWithLabelValues("CARD_TEST_INST")
+	require.NoError(t, err)
+	afterMetric := &dto.Metric{}
+	require.NoError(t, after.Write(afterMetric))
+	var afterVal float64
+	if afterMetric.Counter != nil && afterMetric.Counter.Value != nil {
+		afterVal = *afterMetric.Counter.Value
+	}
+
+	assert.Equal(t, beforeVal+1, afterVal, "cardinality counter should increment by 1")
+}
+
+func TestRecordOpeningBalanceValidationFailure_Increments(t *testing.T) {
+	metrics := service.ExposeMetricsForTesting
+
+	before, err := metrics.OpeningBalanceValidationFailuresTotal.GetMetricWithLabelValues("OB_TEST_INST", service.ValidationFailureReasonInstrumentNotFound)
+	require.NoError(t, err)
+	beforeMetric := &dto.Metric{}
+	require.NoError(t, before.Write(beforeMetric))
+	var beforeVal float64
+	if beforeMetric.Counter != nil && beforeMetric.Counter.Value != nil {
+		beforeVal = *beforeMetric.Counter.Value
+	}
+
+	service.RecordOpeningBalanceValidationFailure("OB_TEST_INST", service.ValidationFailureReasonInstrumentNotFound)
+	service.RecordOpeningBalanceValidationFailure("OB_TEST_INST", service.ValidationFailureReasonInstrumentNotFound)
+	service.RecordOpeningBalanceValidationFailure("OB_TEST_INST", service.ValidationFailureReasonInstrumentNotFound)
+
+	after, err := metrics.OpeningBalanceValidationFailuresTotal.GetMetricWithLabelValues("OB_TEST_INST", service.ValidationFailureReasonInstrumentNotFound)
+	require.NoError(t, err)
+	afterMetric := &dto.Metric{}
+	require.NoError(t, after.Write(afterMetric))
+	var afterVal float64
+	if afterMetric.Counter != nil && afterMetric.Counter.Value != nil {
+		afterVal = *afterMetric.Counter.Value
+	}
+
+	assert.Equal(t, beforeVal+3, afterVal, "opening balance counter should increment by 3")
+}
+
+func TestValidationFailure_DifferentLabelsCounted_Separately(t *testing.T) {
+	metrics := service.ExposeMetricsForTesting
+
+	// Read initial values for two distinct label pairs
+	getVal := func(inst, reason string) float64 {
+		m, err := metrics.MeasurementValidationFailuresTotal.GetMetricWithLabelValues(inst, reason)
+		require.NoError(t, err)
+		metric := &dto.Metric{}
+		require.NoError(t, m.Write(metric))
+		if metric.Counter != nil && metric.Counter.Value != nil {
+			return *metric.Counter.Value
+		}
+		return 0
+	}
+
+	beforeA := getVal("INST_A_SEPARATE", service.ValidationFailureReasonCELError)
+	beforeB := getVal("INST_B_SEPARATE", service.ValidationFailureReasonCELRejected)
+
+	service.RecordValidationFailure("INST_A_SEPARATE", service.ValidationFailureReasonCELError)
+
+	afterA := getVal("INST_A_SEPARATE", service.ValidationFailureReasonCELError)
+	afterB := getVal("INST_B_SEPARATE", service.ValidationFailureReasonCELRejected)
+
+	assert.Equal(t, beforeA+1, afterA, "INST_A counter should increment")
+	assert.Equal(t, beforeB, afterB, "INST_B counter should not change")
+}

--- a/services/reference-data/saga/reference_extractor_test.go
+++ b/services/reference-data/saga/reference_extractor_test.go
@@ -139,6 +139,8 @@ func TestReferenceExtractor_AttributeAccess(t *testing.T) {
 			instrRefs = append(instrRefs, r)
 		case ReferenceTypeAttribute:
 			attrRefs = append(attrRefs, r)
+		case ReferenceTypeStepHandler, ReferenceTypeAccount, ReferenceTypeSaga:
+			// not expected in this attribute-access test
 		}
 	}
 	require.Len(t, instrRefs, 1)


### PR DESCRIPTION
## Summary

- Add `position_log_batch_test.go`: batch operations (empty no-op, single/multi-log, duplicate rollback, complex aggregates with lineage+audit, conflict on pre-existing log)
- Add `position_log_read_test.go`: read operations (FindByID not-found, FindByAccountID empty/multi, List pagination with offset, AccountIDs slice filter, FindPendingForReconciliation with/without limit)
- Add `position_log_write_test.go`: write operations (nil log errors, duplicate conflict, optimistic lock detection, update success, CreateWithOutbox/UpdateWithOutbox with postFn and rollback on error)
- Add `domain/quantity_test.go`: domain-level quantity wrappers (NewMoneyFromInstrumentCode for currency/non-currency/empty codes, MoneyCurrency, MoneyToMinorUnits, NewInstrument validation, NewAsset, Zero functions, ParseCurrency, Amount factory functions)
- Add `service/metrics_test.go`: counter increment tracking with label isolation verification

## Test plan

- [ ] All 5 new test files compile and pass vet
- [ ] Domain and service tests pass: `go test ./services/position-keeping/domain/... ./services/position-keeping/service/...`
- [ ] Persistence tests pass (requires testcontainer): `go test ./services/position-keeping/adapters/persistence/... -run "TestPositionLog" -timeout 600s`
- [ ] CI passes