### PR TITLE
fix: add exhaustive switch cases in reference_extractor_test

### DIFF
--- a/services/reference-data/saga/reference_extractor_test.go
+++ b/services/reference-data/saga/reference_extractor_test.go
@@ -140,7 +140,7 @@ func TestReferenceExtractor_AttributeAccess(t *testing.T) {
 		case ReferenceTypeAttribute:
 			attrRefs = append(attrRefs, r)
 		case ReferenceTypeAccount, ReferenceTypeSaga, ReferenceTypeStepHandler:
-			// not relevant to this test
+			t.Fatalf("unexpected reference type %s for key %s", r.Type, r.Key)
 		}
 	}
 	require.Len(t, instrRefs, 1)

--- a/services/reference-data/saga/reference_extractor_test.go
+++ b/services/reference-data/saga/reference_extractor_test.go
@@ -139,6 +139,8 @@ func TestReferenceExtractor_AttributeAccess(t *testing.T) {
 			instrRefs = append(instrRefs, r)
 		case ReferenceTypeAttribute:
 			attrRefs = append(attrRefs, r)
+		case ReferenceTypeAccount, ReferenceTypeSaga, ReferenceTypeStepHandler:
+			// not expected in this test
 		}
 	}
 	require.Len(t, instrRefs, 1)


### PR DESCRIPTION
## Summary

- Adds explicit `case ReferenceTypeAccount, ReferenceTypeSaga, ReferenceTypeStepHandler` to the switch statement in `TestReferenceExtractor_AttributeAccess`
- Satisfies the `exhaustive` golangci-lint requirement for complete enum coverage in switch statements

## Root Cause

The switch statement was added in PR #1906 to assert both instrument and attribute references in the attribute access test. The `exhaustive` linter was not caught before merge because CI ran on the original commits (before the CodeRabbit fix was added).

## Changes

- `services/reference-data/saga/reference_extractor_test.go`: Add missing enum cases to switch

## Test Plan

- [ ] golangci-lint passes (exhaustive linter satisfied)