### PR TITLE
fix: Wire RegistrationHandler into unified binary

### DIFF
--- a/cmd/meridian/gateway.go
+++ b/cmd/meridian/gateway.go
@@ -207,6 +207,9 @@ func (a *loopbackTenantCreator) CreateTenant(ctx context.Context, tenantID, slug
 	if err != nil {
 		return "", err
 	}
+	if resp.Tenant == nil {
+		return "", fmt.Errorf("InitiateTenant returned nil tenant")
+	}
 	return resp.Tenant.TenantId, nil
 }
 

--- a/cmd/meridian/gateway.go
+++ b/cmd/meridian/gateway.go
@@ -6,15 +6,18 @@ import (
 	"log/slog"
 	"time"
 
+	tenantv1 "github.com/meridianhub/meridian/api/proto/meridian/tenant/v1"
 	gateway "github.com/meridianhub/meridian/services/api-gateway"
 	"github.com/meridianhub/meridian/services/api-gateway/eventstream"
 	"github.com/meridianhub/meridian/services/api-gateway/eventstream/adapters"
+	identitypersistence "github.com/meridianhub/meridian/services/identity/adapters/persistence"
 	tenantpersistence "github.com/meridianhub/meridian/services/tenant/adapters/persistence"
 
 	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/env"
 	platformgateway "github.com/meridianhub/meridian/shared/platform/gateway"
 
+	"google.golang.org/grpc"
 	"gorm.io/gorm"
 )
 
@@ -182,4 +185,58 @@ func buildUnifiedEventStreamComponents(db *gorm.DB, logger *slog.Logger) (*event
 	handler := eventstream.NewHandler(router, logger)
 
 	return router, handler
+}
+
+// ─── Registration Wiring ────────────────────────────────────────────────────
+
+// loopbackTenantCreator adapts the tenant gRPC service client to the
+// gateway.TenantCreator interface used by RegistrationHandler.
+type loopbackTenantCreator struct {
+	client tenantv1.TenantServiceClient
+	logger *slog.Logger
+}
+
+func (a *loopbackTenantCreator) CreateTenant(ctx context.Context, tenantID, slug, displayName string) (string, error) {
+	resp, err := a.client.InitiateTenant(ctx, &tenantv1.InitiateTenantRequest{
+		TenantId:        tenantID,
+		DisplayName:     displayName,
+		Slug:            slug,
+		Subdomain:       slug,
+		SettlementAsset: "USD",
+	})
+	if err != nil {
+		return "", err
+	}
+	return resp.Tenant.TenantId, nil
+}
+
+func (a *loopbackTenantCreator) DeleteTenant(ctx context.Context, tenantID string) error {
+	_, err := a.client.UpdateTenantStatus(ctx, &tenantv1.UpdateTenantStatusRequest{
+		TenantId: tenantID,
+		Status:   tenantv1.TenantStatus_TENANT_STATUS_DEPROVISIONED,
+	})
+	return err
+}
+
+// wireRegistration creates the self-service registration handler and returns
+// a ServerOption to install it. Returns nil on error (graceful degradation).
+func wireRegistration(identityDB *gorm.DB, rawConn *grpc.ClientConn, baseDomain string, logger *slog.Logger) gateway.ServerOption {
+	identityRepo := identitypersistence.NewRepository(identityDB)
+	tenantClient := tenantv1.NewTenantServiceClient(rawConn)
+
+	creator := &loopbackTenantCreator{client: tenantClient, logger: logger}
+
+	handler, err := gateway.NewRegistrationHandler(gateway.RegistrationHandlerConfig{
+		TenantCreator: creator,
+		IdentityRepo:  identityRepo,
+		BaseDomain:    baseDomain,
+		Logger:        logger,
+	})
+	if err != nil {
+		logger.Warn("self-service registration disabled", "error", err)
+		return nil
+	}
+
+	logger.Info("self-service registration handler initialized", "base_domain", baseDomain)
+	return gateway.WithRegistrationHandler(handler)
 }

--- a/cmd/meridian/gateway.go
+++ b/cmd/meridian/gateway.go
@@ -189,6 +189,9 @@ func buildUnifiedEventStreamComponents(db *gorm.DB, logger *slog.Logger) (*event
 
 // ─── Registration Wiring ────────────────────────────────────────────────────
 
+// errNilTenantResponse is returned when InitiateTenant succeeds but returns a nil tenant.
+var errNilTenantResponse = fmt.Errorf("InitiateTenant returned nil tenant")
+
 // loopbackTenantCreator adapts the tenant gRPC service client to the
 // gateway.TenantCreator interface used by RegistrationHandler.
 type loopbackTenantCreator struct {
@@ -208,7 +211,7 @@ func (a *loopbackTenantCreator) CreateTenant(ctx context.Context, tenantID, slug
 		return "", err
 	}
 	if resp.Tenant == nil {
-		return "", fmt.Errorf("InitiateTenant returned nil tenant")
+		return "", errNilTenantResponse
 	}
 	return resp.Tenant.TenantId, nil
 }

--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -259,6 +259,12 @@ func run(logger *slog.Logger, grpcPort, httpPort int) error {
 	bffSigner, bffAuthOpts := wireBFFAuth(conns.gormDB("identity"), logger)
 	extraGWOpts = append(extraGWOpts, bffAuthOpts...)
 
+	// Wire self-service registration handler (public endpoint, no auth required).
+	baseDomain := env.GetEnvOrDefault("BASE_DOMAIN", "localhost")
+	if regOpt := wireRegistration(conns.gormDB("identity"), loopback.rawConn, baseDomain, logger); regOpt != nil {
+		extraGWOpts = append(extraGWOpts, regOpt)
+	}
+
 	gwServer, err := wireGateway(grpcPort, httpPort, platformDSN, conns.gormDB("tenant"), bffSigner, logger, extraGWOpts...)
 	if err != nil {
 		return fmt.Errorf("gateway init: %w", err)

--- a/cmd/meridian/registration_wiring_test.go
+++ b/cmd/meridian/registration_wiring_test.go
@@ -77,6 +77,20 @@ func TestLoopbackTenantCreator_CreateTenant(t *testing.T) {
 	assert.NotEmpty(t, stub.initiateReq.SettlementAsset, "settlement_asset must be set (proto requires it)")
 }
 
+func TestLoopbackTenantCreator_CreateTenant_NilTenantInResponse(t *testing.T) {
+	stub := &stubTenantServiceClient{
+		initiateResp: &tenantv1.InitiateTenantResponse{Tenant: nil},
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	creator := &loopbackTenantCreator{client: stub, logger: logger}
+
+	_, err := creator.CreateTenant(context.Background(), "acme_corp", "acme-corp", "Acme Corp")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil tenant")
+}
+
 func TestLoopbackTenantCreator_DeleteTenant(t *testing.T) {
 	stub := &stubTenantServiceClient{
 		updateStatusResp: &tenantv1.UpdateTenantStatusResponse{},

--- a/cmd/meridian/registration_wiring_test.go
+++ b/cmd/meridian/registration_wiring_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	tenantv1 "github.com/meridianhub/meridian/api/proto/meridian/tenant/v1"
+	gateway "github.com/meridianhub/meridian/services/api-gateway"
+	identitydomain "github.com/meridianhub/meridian/services/identity/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// stubTenantServiceClient is a minimal stub implementing TenantServiceClient
+// for testing the loopbackTenantCreator adapter.
+type stubTenantServiceClient struct {
+	tenantv1.TenantServiceClient
+	initiateCalled bool
+	initiateReq    *tenantv1.InitiateTenantRequest
+	initiateResp   *tenantv1.InitiateTenantResponse
+	initiateErr    error
+
+	updateStatusCalled bool
+	updateStatusReq    *tenantv1.UpdateTenantStatusRequest
+	updateStatusResp   *tenantv1.UpdateTenantStatusResponse
+	updateStatusErr    error
+}
+
+func (s *stubTenantServiceClient) InitiateTenant(_ context.Context, req *tenantv1.InitiateTenantRequest, _ ...grpc.CallOption) (*tenantv1.InitiateTenantResponse, error) {
+	s.initiateCalled = true
+	s.initiateReq = req
+	if s.initiateErr != nil {
+		return nil, s.initiateErr
+	}
+	return s.initiateResp, nil
+}
+
+func (s *stubTenantServiceClient) UpdateTenantStatus(_ context.Context, req *tenantv1.UpdateTenantStatusRequest, _ ...grpc.CallOption) (*tenantv1.UpdateTenantStatusResponse, error) {
+	s.updateStatusCalled = true
+	s.updateStatusReq = req
+	if s.updateStatusErr != nil {
+		return nil, s.updateStatusErr
+	}
+	return s.updateStatusResp, nil
+}
+
+func TestLoopbackTenantCreator_CreateTenant(t *testing.T) {
+	stub := &stubTenantServiceClient{
+		initiateResp: &tenantv1.InitiateTenantResponse{
+			Tenant: &tenantv1.Tenant{TenantId: "acme_corp"},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	creator := &loopbackTenantCreator{client: stub, logger: logger}
+
+	tenantID, err := creator.CreateTenant(context.Background(), "acme_corp", "acme-corp", "Acme Corp")
+
+	require.NoError(t, err)
+	assert.Equal(t, "acme_corp", tenantID)
+	assert.True(t, stub.initiateCalled)
+	assert.Equal(t, "acme_corp", stub.initiateReq.TenantId)
+	assert.Equal(t, "Acme Corp", stub.initiateReq.DisplayName)
+	assert.Equal(t, "acme-corp", stub.initiateReq.Slug)
+	assert.Equal(t, "acme-corp", stub.initiateReq.Subdomain)
+	assert.NotEmpty(t, stub.initiateReq.SettlementAsset, "settlement_asset must be set (proto requires it)")
+}
+
+func TestLoopbackTenantCreator_DeleteTenant(t *testing.T) {
+	stub := &stubTenantServiceClient{
+		updateStatusResp: &tenantv1.UpdateTenantStatusResponse{},
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	creator := &loopbackTenantCreator{client: stub, logger: logger}
+
+	err := creator.DeleteTenant(context.Background(), "acme_corp")
+
+	require.NoError(t, err)
+	assert.True(t, stub.updateStatusCalled)
+	assert.Equal(t, "acme_corp", stub.updateStatusReq.TenantId)
+	assert.Equal(t, tenantv1.TenantStatus_TENANT_STATUS_DEPROVISIONED, stub.updateStatusReq.Status)
+}
+
+// TestRegistrationEndpoint_Reachable verifies that when the RegistrationHandler
+// is wired into the gateway server, POST /api/v1/register returns a non-401
+// response (proving the route is registered and not falling through to the
+// auth-protected catch-all).
+func TestRegistrationEndpoint_Reachable(t *testing.T) {
+	t.Setenv("AUTH_ENABLED", "false")
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	httpPort := allocateFreePort(t)
+
+	// Build a stub TenantCreator that returns a canned tenant ID.
+	stubCreator := &loopbackTenantCreator{
+		client: &stubTenantServiceClient{
+			initiateResp: &tenantv1.InitiateTenantResponse{
+				Tenant: &tenantv1.Tenant{TenantId: "test_org"},
+			},
+		},
+		logger: logger,
+	}
+
+	// Create a registration handler with a nil identity repo.
+	// The request will fail at identity provisioning (expected), but crucially
+	// it should NOT return 401 - proving the route is registered.
+	handler, err := gateway.NewRegistrationHandler(gateway.RegistrationHandlerConfig{
+		TenantCreator: stubCreator,
+		IdentityRepo:  &noopIdentityRepo{},
+		BaseDomain:    "test.local",
+		Logger:        logger,
+	})
+	require.NoError(t, err)
+
+	config := &gateway.Config{Port: httpPort}
+	srv := gateway.NewServer(config, logger, nil,
+		gateway.WithRegistrationHandler(handler),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() { _ = srv.Start(ctx) }()
+
+	// Wait for server to bind.
+	addr := fmt.Sprintf("localhost:%d", httpPort)
+	for range 40 {
+		conn, dialErr := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+		if dialErr == nil {
+			conn.Close()
+			break
+		}
+		time.Sleep(50 * time.Millisecond) //nolint:forbidigo
+	}
+
+	body, _ := json.Marshal(map[string]string{
+		"slug":     "test-org",
+		"email":    "admin@test.org",
+		"password": "StrongPass123!",
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		fmt.Sprintf("http://localhost:%d/api/v1/register", httpPort),
+		bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := (&http.Client{Timeout: 5 * time.Second}).Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// The key assertion: NOT 401 (route is reachable, not blocked by auth).
+	// We accept any status that isn't 401 - the actual business logic may
+	// return 500 (identity repo is a noop) or 201 (if the stub works end-to-end).
+	assert.NotEqual(t, http.StatusUnauthorized, resp.StatusCode,
+		"registration endpoint should not require authentication")
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer shutdownCancel()
+	_ = srv.Shutdown(shutdownCtx)
+}
+
+// noopIdentityRepo satisfies identitydomain.Repository for the integration test.
+// SaveIdentityWithRoles succeeds; all other methods return errors.
+type noopIdentityRepo struct{}
+
+func (n *noopIdentityRepo) Save(_ context.Context, _ *identitydomain.Identity) error {
+	return fmt.Errorf("not implemented")
+}
+func (n *noopIdentityRepo) FindByID(_ context.Context, _ uuid.UUID) (*identitydomain.Identity, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (n *noopIdentityRepo) FindByEmail(_ context.Context, _ string) (*identitydomain.Identity, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (n *noopIdentityRepo) ListByTenant(_ context.Context) ([]*identitydomain.Identity, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (n *noopIdentityRepo) SaveRoleAssignment(_ context.Context, _ *identitydomain.RoleAssignment) error {
+	return fmt.Errorf("not implemented")
+}
+func (n *noopIdentityRepo) FindRoleAssignments(_ context.Context, _ uuid.UUID) ([]*identitydomain.RoleAssignment, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (n *noopIdentityRepo) SaveIdentityWithInvitation(_ context.Context, _ *identitydomain.Identity, _ *identitydomain.Invitation) error {
+	return fmt.Errorf("not implemented")
+}
+func (n *noopIdentityRepo) SaveIdentityWithRoles(_ context.Context, _ *identitydomain.Identity, _ []*identitydomain.RoleAssignment) error {
+	return nil // success - allows registration to complete
+}
+func (n *noopIdentityRepo) SaveRoleAssignments(_ context.Context, _ []*identitydomain.RoleAssignment) error {
+	return fmt.Errorf("not implemented")
+}
+func (n *noopIdentityRepo) SaveInvitation(_ context.Context, _ *identitydomain.Invitation) error {
+	return fmt.Errorf("not implemented")
+}
+func (n *noopIdentityRepo) FindInvitationByTokenHash(_ context.Context, _ string) (*identitydomain.Invitation, error) {
+	return nil, fmt.Errorf("not implemented")
+}

--- a/cmd/meridian/registration_wiring_test.go
+++ b/cmd/meridian/registration_wiring_test.go
@@ -16,6 +16,7 @@ import (
 	tenantv1 "github.com/meridianhub/meridian/api/proto/meridian/tenant/v1"
 	gateway "github.com/meridianhub/meridian/services/api-gateway"
 	identitydomain "github.com/meridianhub/meridian/services/identity/domain"
+	"github.com/meridianhub/meridian/shared/platform/await"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -135,14 +136,15 @@ func TestRegistrationEndpoint_Reachable(t *testing.T) {
 
 	// Wait for server to bind.
 	addr := fmt.Sprintf("localhost:%d", httpPort)
-	for range 40 {
+	err = await.UntilNoError(func() error {
 		conn, dialErr := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
-		if dialErr == nil {
-			conn.Close()
-			break
+		if dialErr != nil {
+			return dialErr
 		}
-		time.Sleep(50 * time.Millisecond) //nolint:forbidigo
-	}
+		conn.Close()
+		return nil
+	})
+	require.NoError(t, err, "gateway server did not start")
 
 	body, _ := json.Marshal(map[string]string{
 		"slug":     "test-org",

--- a/cmd/meridian/registration_wiring_test.go
+++ b/cmd/meridian/registration_wiring_test.go
@@ -193,33 +193,43 @@ type noopIdentityRepo struct{}
 func (n *noopIdentityRepo) Save(_ context.Context, _ *identitydomain.Identity) error {
 	return fmt.Errorf("not implemented")
 }
+
 func (n *noopIdentityRepo) FindByID(_ context.Context, _ uuid.UUID) (*identitydomain.Identity, error) {
 	return nil, fmt.Errorf("not implemented")
 }
+
 func (n *noopIdentityRepo) FindByEmail(_ context.Context, _ string) (*identitydomain.Identity, error) {
 	return nil, fmt.Errorf("not implemented")
 }
+
 func (n *noopIdentityRepo) ListByTenant(_ context.Context) ([]*identitydomain.Identity, error) {
 	return nil, fmt.Errorf("not implemented")
 }
+
 func (n *noopIdentityRepo) SaveRoleAssignment(_ context.Context, _ *identitydomain.RoleAssignment) error {
 	return fmt.Errorf("not implemented")
 }
+
 func (n *noopIdentityRepo) FindRoleAssignments(_ context.Context, _ uuid.UUID) ([]*identitydomain.RoleAssignment, error) {
 	return nil, fmt.Errorf("not implemented")
 }
+
 func (n *noopIdentityRepo) SaveIdentityWithInvitation(_ context.Context, _ *identitydomain.Identity, _ *identitydomain.Invitation) error {
 	return fmt.Errorf("not implemented")
 }
+
 func (n *noopIdentityRepo) SaveIdentityWithRoles(_ context.Context, _ *identitydomain.Identity, _ []*identitydomain.RoleAssignment) error {
 	return nil // success - allows registration to complete
 }
+
 func (n *noopIdentityRepo) SaveRoleAssignments(_ context.Context, _ []*identitydomain.RoleAssignment) error {
 	return fmt.Errorf("not implemented")
 }
+
 func (n *noopIdentityRepo) SaveInvitation(_ context.Context, _ *identitydomain.Invitation) error {
 	return fmt.Errorf("not implemented")
 }
+
 func (n *noopIdentityRepo) FindInvitationByTokenHash(_ context.Context, _ string) (*identitydomain.Invitation, error) {
 	return nil, fmt.Errorf("not implemented")
 }


### PR DESCRIPTION
## Summary

- The self-service registration endpoint (`POST /api/v1/register`) returned 401 "missing authentication credentials" on demo because the `RegistrationHandler` was implemented but never wired into the unified binary's server construction
- Added `loopbackTenantCreator` adapter bridging `gateway.TenantCreator` to the tenant gRPC service via loopback connection
- Wired `RegistrationHandler` into `wireGateway` options in `main.go`

## Root Cause

`WithRegistrationHandler` was defined (`registration_handler.go:280`) but never called. The route at `server.go:210` is guarded by `if s.registrationHandler != nil` - since no handler was set, requests fell through to the catch-all `/` route with full auth middleware.

## Changes

| File | Change |
|------|--------|
| `cmd/meridian/gateway.go` | Added `loopbackTenantCreator` adapter + `wireRegistration` function |
| `cmd/meridian/main.go` | Called `wireRegistration` after `wireBFFAuth`, before `wireGateway` |
| `cmd/meridian/registration_wiring_test.go` | Unit tests for adapter + integration test proving route is reachable (not 401) |

## Test plan

- [x] `TestLoopbackTenantCreator_CreateTenant` - verifies field mapping to `InitiateTenantRequest`
- [x] `TestLoopbackTenantCreator_DeleteTenant` - verifies compensation uses `DEPROVISIONED` status
- [x] `TestRegistrationEndpoint_Reachable` - proves `/api/v1/register` returns non-401 when handler is wired
- [x] All existing `cmd/meridian/` tests pass (15/15)
- [x] All existing `services/api-gateway/` tests pass
- [ ] Deploy to demo and verify `POST /api/v1/register` returns 201