### PR TITLE
test: Add control plane service and economy generator unit tests

### DIFF
--- a/services/control-plane/service/economy_generator_test.go
+++ b/services/control-plane/service/economy_generator_test.go
@@ -1,0 +1,168 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"testing/fstest"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/services/control-plane/internal/generator"
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// ---------------------------------------------------------------------------
+// EconomyGeneratorConfig field tests
+// ---------------------------------------------------------------------------
+
+func TestEconomyGeneratorConfig_Defaults(t *testing.T) {
+	cfg := EconomyGeneratorConfig{}
+	assert.Nil(t, cfg.SchemaRegistry)
+	assert.Nil(t, cfg.ManifestHistory)
+	assert.Nil(t, cfg.CookbookFS)
+	assert.Nil(t, cfg.LLMClient)
+	assert.Nil(t, cfg.Validator)
+	assert.Nil(t, cfg.Logger)
+}
+
+func TestEconomyGeneratorConfig_FieldAssignment(t *testing.T) {
+	reg := schema.NewRegistry()
+	llm := &stubLLMClient{}
+	val := &stubManifestValidator{}
+	historian := &stubManifestHistorian{}
+	cookbookFS := fstest.MapFS{}
+
+	cfg := EconomyGeneratorConfig{
+		SchemaRegistry:  reg,
+		LLMClient:       llm,
+		Validator:       val,
+		ManifestHistory: historian,
+		CookbookFS:      cookbookFS,
+	}
+
+	assert.Equal(t, reg, cfg.SchemaRegistry)
+	assert.Equal(t, llm, cfg.LLMClient)
+	assert.Equal(t, val, cfg.Validator)
+	assert.Equal(t, historian, cfg.ManifestHistory)
+	assert.Equal(t, cookbookFS, cfg.CookbookFS)
+}
+
+// ---------------------------------------------------------------------------
+// RegisterEconomyGeneratorService - configuration combinations
+// ---------------------------------------------------------------------------
+
+func TestRegisterEconomyGeneratorService_NilRegistryError(t *testing.T) {
+	server := grpc.NewServer()
+	defer server.Stop()
+
+	err := RegisterEconomyGeneratorService(server, EconomyGeneratorConfig{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "schema registry is required")
+}
+
+func TestRegisterEconomyGeneratorService_OnlyRegistry(t *testing.T) {
+	// All optional fields nil - should succeed with a valid registry.
+	server := grpc.NewServer()
+	defer server.Stop()
+
+	err := RegisterEconomyGeneratorService(server, EconomyGeneratorConfig{
+		SchemaRegistry: schema.NewRegistry(),
+	})
+	require.NoError(t, err)
+}
+
+func TestRegisterEconomyGeneratorService_WithManifestHistory(t *testing.T) {
+	server := grpc.NewServer()
+	defer server.Stop()
+
+	err := RegisterEconomyGeneratorService(server, EconomyGeneratorConfig{
+		SchemaRegistry:  schema.NewRegistry(),
+		ManifestHistory: &stubManifestHistorian{},
+	})
+	require.NoError(t, err)
+}
+
+func TestRegisterEconomyGeneratorService_WithCookbookFS(t *testing.T) {
+	server := grpc.NewServer()
+	defer server.Stop()
+
+	cookbookFS := fstest.MapFS{
+		"patterns/simple.yaml": &fstest.MapFile{Data: []byte("name: simple\n")},
+	}
+
+	err := RegisterEconomyGeneratorService(server, EconomyGeneratorConfig{
+		SchemaRegistry: schema.NewRegistry(),
+		CookbookFS:     cookbookFS,
+	})
+	require.NoError(t, err)
+}
+
+func TestRegisterEconomyGeneratorService_LLMClientWithoutValidator(t *testing.T) {
+	// LLMClient provided but Validator is nil - valid at registration time;
+	// GenerateManifest will fail at call time but registration succeeds.
+	server := grpc.NewServer()
+	defer server.Stop()
+
+	err := RegisterEconomyGeneratorService(server, EconomyGeneratorConfig{
+		SchemaRegistry: schema.NewRegistry(),
+		LLMClient:      &stubLLMClient{},
+	})
+	require.NoError(t, err)
+}
+
+func TestRegisterEconomyGeneratorService_ValidatorWithoutLLMClient(t *testing.T) {
+	// Validator provided but LLMClient is nil - also valid at registration.
+	server := grpc.NewServer()
+	defer server.Stop()
+
+	err := RegisterEconomyGeneratorService(server, EconomyGeneratorConfig{
+		SchemaRegistry: schema.NewRegistry(),
+		Validator:      &stubManifestValidator{},
+	})
+	require.NoError(t, err)
+}
+
+func TestRegisterEconomyGeneratorService_AllFields(t *testing.T) {
+	server := grpc.NewServer()
+	defer server.Stop()
+
+	err := RegisterEconomyGeneratorService(server, EconomyGeneratorConfig{
+		SchemaRegistry:  schema.NewRegistry(),
+		ManifestHistory: &stubManifestHistorian{},
+		CookbookFS:      fstest.MapFS{},
+		LLMClient:       &stubLLMClient{},
+		Validator:       &stubManifestValidator{},
+	})
+	require.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// Stub types (local to economy_generator_test.go)
+// ---------------------------------------------------------------------------
+
+// stubLLMClient satisfies generator.LLMClient.
+type stubLLMClient struct{}
+
+func (s *stubLLMClient) Generate(_ context.Context, _ string) (string, error) { return "", nil }
+func (s *stubLLMClient) Fix(_ context.Context, _ string, _ []generator.ValidationError) (string, error) {
+	return "", nil
+}
+
+// stubManifestValidator satisfies generator.ManifestValidator.
+type stubManifestValidator struct{}
+
+func (s *stubManifestValidator) ValidateDryRun(_ context.Context, _ string) (*generator.ValidationResult, error) {
+	return &generator.ValidationResult{Valid: true}, nil
+}
+
+// stubManifestHistorian satisfies generator.ManifestHistorian.
+type stubManifestHistorian struct {
+	manifest *controlplanev1.Manifest
+	err      error
+}
+
+func (s *stubManifestHistorian) GetCurrentManifest(_ context.Context) (*controlplanev1.Manifest, error) {
+	return s.manifest, s.err
+}

--- a/services/control-plane/service/manifest_history_test.go
+++ b/services/control-plane/service/manifest_history_test.go
@@ -1,0 +1,148 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/services/control-plane/internal/manifest"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// ---------------------------------------------------------------------------
+// ManifestHistoryServiceConfig field tests
+// ---------------------------------------------------------------------------
+
+func TestManifestHistoryServiceConfig_Defaults(t *testing.T) {
+	cfg := ManifestHistoryServiceConfig{}
+	assert.Nil(t, cfg.DB)
+	assert.Nil(t, cfg.Logger)
+	assert.Nil(t, cfg.ExportCollectors)
+	assert.Nil(t, cfg.Applier)
+}
+
+func TestErrDBRequired_Message(t *testing.T) {
+	assert.EqualError(t, ErrDBRequired, "manifest history service: database connection is required")
+}
+
+// ---------------------------------------------------------------------------
+// RegisterManifestHistoryService - configuration combinations
+// ---------------------------------------------------------------------------
+
+func TestRegisterManifestHistoryService_NilDBError(t *testing.T) {
+	server := grpc.NewServer()
+	defer server.Stop()
+
+	err := RegisterManifestHistoryService(server, ManifestHistoryServiceConfig{})
+	require.ErrorIs(t, err, ErrDBRequired)
+}
+
+func TestRegisterManifestHistoryService_WithApplier(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires testcontainer")
+	}
+
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+	defer cleanup()
+
+	server := grpc.NewServer()
+	defer server.Stop()
+
+	err := RegisterManifestHistoryService(server, ManifestHistoryServiceConfig{
+		DB:      db,
+		Applier: &stubApplier{},
+	})
+	require.NoError(t, err)
+}
+
+func TestRegisterManifestHistoryService_WithExportCollectorsAndApplier(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires testcontainer")
+	}
+
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+	defer cleanup()
+
+	server := grpc.NewServer()
+	defer server.Stop()
+
+	err := RegisterManifestHistoryService(server, ManifestHistoryServiceConfig{
+		DB:               db,
+		ExportCollectors: &manifest.ExportCollectors{},
+		Applier:          &stubApplier{},
+	})
+	require.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// SeedManifestVersion - additional edge cases
+// ---------------------------------------------------------------------------
+
+func TestSeedManifestVersion_NilManifest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires testcontainer")
+	}
+
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+	defer cleanup()
+
+	tc := testdb.SetupTenantSchema(t, db, "test_seed_nil")
+	defer tc.Cleanup()
+	testdb.CreateTable(t, tc.DB, tc.Tenant, manifestVersionsDDL)
+
+	// nil manifest - should return an error wrapping the nil-manifest sentinel.
+	_, err := SeedManifestVersion(tc.Ctx, tc.DB, nil, "system:bootstrap")
+	require.Error(t, err)
+}
+
+func TestSeedManifestVersion_NilDBWithManifest(t *testing.T) {
+	mf := &controlplanev1.Manifest{
+		Version:  "1.0",
+		Metadata: &controlplanev1.ManifestMetadata{Name: "Test", Industry: "platform"},
+	}
+	_, err := SeedManifestVersion(context.Background(), nil, mf, "system:bootstrap")
+	require.ErrorIs(t, err, ErrDBRequired)
+}
+
+func TestSeedManifestVersion_SecondSeedReturnsFalse(t *testing.T) {
+	// Equivalent to the idempotency test already in bootstrap_test.go but expressed
+	// as an explicit second-seed assertion for clarity.
+	if testing.Short() {
+		t.Skip("requires testcontainer")
+	}
+
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+	defer cleanup()
+
+	tc := testdb.SetupTenantSchema(t, db, "test_seed_idem")
+	defer tc.Cleanup()
+	testdb.CreateTable(t, tc.DB, tc.Tenant, manifestVersionsDDL)
+
+	mf := &controlplanev1.Manifest{
+		Version:  "1.0",
+		Metadata: &controlplanev1.ManifestMetadata{Name: "Test", Industry: "platform"},
+	}
+
+	seeded, err := SeedManifestVersion(tc.Ctx, tc.DB, mf, "system:bootstrap")
+	require.NoError(t, err)
+	require.True(t, seeded)
+
+	// Third call should also return false (idempotent).
+	seeded, err = SeedManifestVersion(tc.Ctx, tc.DB, mf, "system:bootstrap")
+	require.NoError(t, err)
+	assert.False(t, seeded, "repeated seed calls should be no-ops")
+}
+
+// ---------------------------------------------------------------------------
+// Stub types (local to manifest_history_test.go)
+// ---------------------------------------------------------------------------
+
+// stubApplier satisfies manifest.Applier.
+type stubApplier struct{}
+
+func (s *stubApplier) ApplyManifest(_ context.Context, _ *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+	return &controlplanev1.ApplyManifestResponse{}, nil
+}


### PR DESCRIPTION
## Summary

- Add `service/economy_generator_test.go` covering `EconomyGeneratorConfig` defaults, all optional field combinations (LLMClient, Validator, ManifestHistory, CookbookFS), and registration error paths
- Add `service/manifest_history_test.go` covering `ManifestHistoryServiceConfig` defaults, `ErrDBRequired` error message, Applier wiring, and `SeedManifestVersion` nil-manifest and idempotency edge cases

## Test plan

- `go test -short ./services/control-plane/service/...` passes (unit tests, no testcontainers)
- Integration tests (testcontainer-backed) skipped with `-short`, run in CI

## Task Master

test-coverage.16 - Control Plane Service & Economy Generator Unit Tests