### PR TITLE
test: Add audit worker and financial gateway unit tests

### DIFF
--- a/services/audit-worker/app/db_wrapper_test.go
+++ b/services/audit-worker/app/db_wrapper_test.go
@@ -1,0 +1,64 @@
+package app
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDbWrapper_Ping_Success(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectPing()
+
+	w := &dbWrapper{db: db}
+	err = w.Ping(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDbWrapper_Ping_Error(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectPing().WillReturnError(errors.New("connection refused"))
+
+	w := &dbWrapper{db: db}
+	err = w.Ping(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection refused")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDbWrapper_Stats_ReturnsDBStats(t *testing.T) {
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	w := &dbWrapper{db: db}
+	stats := w.Stats()
+
+	// A freshly opened mock DB has zero stats - just verify the type and no panic
+	assert.IsType(t, sql.DBStats{}, stats)
+}
+
+func TestDbWrapper_Stats_MaxOpenConns(t *testing.T) {
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	db.SetMaxOpenConns(10)
+
+	w := &dbWrapper{db: db}
+	stats := w.Stats()
+
+	assert.Equal(t, 10, stats.MaxOpenConnections)
+}

--- a/services/audit-worker/domain/audit_operation_test.go
+++ b/services/audit-worker/domain/audit_operation_test.go
@@ -1,0 +1,54 @@
+package domain
+
+import (
+	"testing"
+
+	auditv1 "github.com/meridianhub/meridian/api/proto/meridian/audit/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProtoToOperation(t *testing.T) {
+	tests := []struct {
+		name     string
+		op       auditv1.AuditOperation
+		expected string
+	}{
+		{
+			name:     "insert maps to INSERT",
+			op:       auditv1.AuditOperation_AUDIT_OPERATION_INSERT,
+			expected: "INSERT",
+		},
+		{
+			name:     "update maps to UPDATE",
+			op:       auditv1.AuditOperation_AUDIT_OPERATION_UPDATE,
+			expected: "UPDATE",
+		},
+		{
+			name:     "delete maps to DELETE",
+			op:       auditv1.AuditOperation_AUDIT_OPERATION_DELETE,
+			expected: "DELETE",
+		},
+		{
+			name:     "initial import maps to INITIAL_IMPORT",
+			op:       auditv1.AuditOperation_AUDIT_OPERATION_INITIAL_IMPORT,
+			expected: "INITIAL_IMPORT",
+		},
+		{
+			name:     "unspecified maps to empty string",
+			op:       auditv1.AuditOperation_AUDIT_OPERATION_UNSPECIFIED,
+			expected: "",
+		},
+		{
+			name:     "unknown value maps to empty string",
+			op:       auditv1.AuditOperation(9999),
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ProtoToOperation(tt.op)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/services/audit-worker/service/server_test.go
+++ b/services/audit-worker/service/server_test.go
@@ -1,0 +1,167 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	auditv1 "github.com/meridianhub/meridian/api/proto/meridian/audit/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRowToProto_NilOptionalFields verifies that nil optional fields are handled correctly.
+func TestRowToProto_NilOptionalFields(t *testing.T) {
+	row := auditLogRow{
+		ID:        "entry-1",
+		TableName: "accounts",
+		Operation: "INSERT",
+		RecordID:  "rec-1",
+		CreatedAt: time.Now(),
+		// ChangedBy, OldValues, NewValues all nil
+	}
+
+	entry, err := rowToProto(row)
+	require.NoError(t, err)
+
+	assert.Equal(t, "entry-1", entry.EntryId)
+	assert.Equal(t, "accounts", entry.TableName)
+	assert.Equal(t, auditv1.AuditOperation_AUDIT_OPERATION_INSERT, entry.Operation)
+	assert.Equal(t, "rec-1", entry.RecordId)
+	assert.Empty(t, entry.ChangedBy)
+	assert.Nil(t, entry.OldValues)
+	assert.Nil(t, entry.NewValues)
+}
+
+// TestRowToProto_WithAllFields verifies that all optional fields are correctly mapped.
+func TestRowToProto_WithAllFields(t *testing.T) {
+	changedBy := "alice"
+	oldVals := `{"balance": "100.00"}`
+	newVals := `{"balance": "200.00"}`
+
+	row := auditLogRow{
+		ID:        "entry-2",
+		TableName: "accounts",
+		Operation: "UPDATE",
+		RecordID:  "rec-2",
+		CreatedAt: time.Now(),
+		ChangedBy: &changedBy,
+		OldValues: &oldVals,
+		NewValues: &newVals,
+	}
+
+	entry, err := rowToProto(row)
+	require.NoError(t, err)
+
+	assert.Equal(t, "alice", entry.ChangedBy)
+	require.NotNil(t, entry.OldValues)
+	assert.Equal(t, "100.00", entry.OldValues.Fields["balance"].GetStringValue())
+	require.NotNil(t, entry.NewValues)
+	assert.Equal(t, "200.00", entry.NewValues.Fields["balance"].GetStringValue())
+}
+
+// TestRowToProto_EmptyStringValues verifies that empty string values (not nil) are skipped.
+func TestRowToProto_EmptyStringValues(t *testing.T) {
+	empty := ""
+	row := auditLogRow{
+		ID:        "entry-3",
+		TableName: "parties",
+		Operation: "DELETE",
+		RecordID:  "rec-3",
+		CreatedAt: time.Now(),
+		OldValues: &empty, // Non-nil but empty - should not produce OldValues
+		NewValues: nil,
+	}
+
+	entry, err := rowToProto(row)
+	require.NoError(t, err)
+
+	assert.Nil(t, entry.OldValues)
+	assert.Nil(t, entry.NewValues)
+}
+
+// TestRowToProto_InvalidOldValuesJSON verifies that malformed JSON returns an error.
+func TestRowToProto_InvalidOldValuesJSON(t *testing.T) {
+	badJSON := "not valid json"
+	row := auditLogRow{
+		ID:        "entry-4",
+		TableName: "accounts",
+		Operation: "UPDATE",
+		RecordID:  "rec-4",
+		CreatedAt: time.Now(),
+		OldValues: &badJSON,
+	}
+
+	_, err := rowToProto(row)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "old_values")
+}
+
+// TestRowToProto_InvalidNewValuesJSON verifies that malformed new_values JSON returns an error.
+func TestRowToProto_InvalidNewValuesJSON(t *testing.T) {
+	valid := `{"key": "val"}`
+	invalid := "not json"
+	row := auditLogRow{
+		ID:        "entry-5",
+		TableName: "accounts",
+		Operation: "UPDATE",
+		RecordID:  "rec-5",
+		CreatedAt: time.Now(),
+		OldValues: &valid,
+		NewValues: &invalid,
+	}
+
+	_, err := rowToProto(row)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "new_values")
+}
+
+// TestRowToProto_AllOperations verifies each operation string maps to the correct proto enum.
+func TestRowToProto_AllOperations(t *testing.T) {
+	tests := []struct {
+		operation string
+		expected  auditv1.AuditOperation
+	}{
+		{"INSERT", auditv1.AuditOperation_AUDIT_OPERATION_INSERT},
+		{"UPDATE", auditv1.AuditOperation_AUDIT_OPERATION_UPDATE},
+		{"DELETE", auditv1.AuditOperation_AUDIT_OPERATION_DELETE},
+		{"INITIAL_IMPORT", auditv1.AuditOperation_AUDIT_OPERATION_INITIAL_IMPORT},
+		{"UNKNOWN", auditv1.AuditOperation_AUDIT_OPERATION_UNSPECIFIED},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.operation, func(t *testing.T) {
+			row := auditLogRow{
+				ID:        "entry-op",
+				TableName: "t",
+				Operation: tt.operation,
+				RecordID:  "r",
+				CreatedAt: time.Now(),
+			}
+			entry, err := rowToProto(row)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, entry.Operation)
+		})
+	}
+}
+
+// TestJsonToStruct_ValidJSON verifies correct JSON-to-proto-struct conversion.
+func TestJsonToStruct_ValidJSON(t *testing.T) {
+	s, err := jsonToStruct(`{"name": "test", "amount": 42}`)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	assert.Equal(t, "test", s.Fields["name"].GetStringValue())
+}
+
+// TestJsonToStruct_InvalidJSON verifies that malformed JSON returns an error.
+func TestJsonToStruct_InvalidJSON(t *testing.T) {
+	_, err := jsonToStruct("not json {")
+	require.Error(t, err)
+}
+
+// TestJsonToStruct_EmptyObject verifies that an empty JSON object succeeds.
+func TestJsonToStruct_EmptyObject(t *testing.T) {
+	s, err := jsonToStruct("{}")
+	require.NoError(t, err)
+	assert.NotNil(t, s)
+	assert.Empty(t, s.Fields)
+}

--- a/services/financial-gateway/adapters/stripe/tenant_config_test.go
+++ b/services/financial-gateway/adapters/stripe/tenant_config_test.go
@@ -1,0 +1,95 @@
+package stripe
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTenantConfig_Validate_ValidConfig(t *testing.T) {
+	tc := TenantConfig{
+		ConnectedAccountID:    "acct_1234567890",
+		WebhookEndpointSecret: "whsec_abc123",
+	}
+	err := tc.Validate()
+	require.NoError(t, err)
+}
+
+func TestTenantConfig_Validate_MissingAccountID(t *testing.T) {
+	tc := TenantConfig{
+		WebhookEndpointSecret: "whsec_abc123",
+	}
+	err := tc.Validate()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMissingAccountID)
+}
+
+func TestTenantConfig_Validate_EmptyConfig(t *testing.T) {
+	tc := TenantConfig{}
+	err := tc.Validate()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMissingAccountID)
+}
+
+func TestTenantConfig_Validate_AccountIDOnly(t *testing.T) {
+	// Validate only requires AccountID; WebhookEndpointSecret is optional
+	tc := TenantConfig{
+		ConnectedAccountID: "acct_minimally_valid",
+	}
+	err := tc.Validate()
+	require.NoError(t, err)
+}
+
+func TestErrMissingAccountID_IsSentinel(t *testing.T) {
+	// Verify ErrMissingAccountID is a distinct sentinel error
+	assert.NotNil(t, ErrMissingAccountID)
+	assert.NotEqual(t, ErrMissingAccountID, ErrTenantConfigNotFound)
+}
+
+func TestErrTenantConfigNotFound_IsSentinel(t *testing.T) {
+	// Verify ErrTenantConfigNotFound is a distinct sentinel error
+	assert.NotNil(t, ErrTenantConfigNotFound)
+	assert.True(t, errors.Is(ErrTenantConfigNotFound, ErrTenantConfigNotFound))
+	assert.False(t, errors.Is(ErrTenantConfigNotFound, ErrMissingAccountID))
+}
+
+// mockTenantConfigProvider is a test-local implementation of TenantConfigProvider.
+type mockTenantConfigProvider struct {
+	configs map[string]TenantConfig
+}
+
+func (m *mockTenantConfigProvider) GetTenantConfig(tenantID string) (TenantConfig, error) {
+	cfg, ok := m.configs[tenantID]
+	if !ok {
+		return TenantConfig{}, ErrTenantConfigNotFound
+	}
+	return cfg, nil
+}
+
+func TestTenantConfigProvider_Found(t *testing.T) {
+	provider := &mockTenantConfigProvider{
+		configs: map[string]TenantConfig{
+			"tenant-1": {
+				ConnectedAccountID:    "acct_tenant1",
+				WebhookEndpointSecret: "whsec_tenant1",
+			},
+		},
+	}
+
+	cfg, err := provider.GetTenantConfig("tenant-1")
+	require.NoError(t, err)
+	assert.Equal(t, "acct_tenant1", cfg.ConnectedAccountID)
+	assert.Equal(t, "whsec_tenant1", cfg.WebhookEndpointSecret)
+}
+
+func TestTenantConfigProvider_NotFound(t *testing.T) {
+	provider := &mockTenantConfigProvider{
+		configs: map[string]TenantConfig{},
+	}
+
+	_, err := provider.GetTenantConfig("unknown-tenant")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTenantConfigNotFound)
+}

--- a/services/financial-gateway/service/server_test.go
+++ b/services/financial-gateway/service/server_test.go
@@ -1,0 +1,103 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	stripego "github.com/stripe/stripe-go/v82"
+
+	financialgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_gateway/v1"
+	stripeadapter "github.com/meridianhub/meridian/services/financial-gateway/adapters/stripe"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// TestNewFinancialGatewayService_WithPartialConfig verifies that a service can be created
+// with adapter set but no ClientFactory (partial config is allowed at construction time).
+func TestNewFinancialGatewayService_WithPartialConfig(t *testing.T) {
+	creator := &mockCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, nil
+		},
+	}
+
+	adapter, err := stripeadapter.NewPaymentIntentAdapter(creator, stripeadapter.PaymentIntentAdapterConfig{}, slog.Default())
+	require.NoError(t, err)
+
+	// ClientFactory is nil - service construction should still succeed
+	svc, err := NewFinancialGatewayService(Config{
+		StripeAdapter: adapter,
+		Logger:        slog.Default(),
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, svc)
+}
+
+// TestDispatchPayment_ResponseContainsPlatformFee verifies that platform fee is included in the response
+// when the Stripe adapter returns a non-zero fee.
+func TestDispatchPayment_ResponseContainsPlatformFee(t *testing.T) {
+	creator := &mockCreator{
+		createFn: func(_ context.Context, params *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return &stripego.PaymentIntent{
+				ID:     "pi_with_fee",
+				Status: stripego.PaymentIntentStatusSucceeded,
+			}, nil
+		},
+	}
+	svc := newServiceWithStripeMocks(t, creator, nil, nil)
+
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("test-tenant"))
+	resp, err := svc.DispatchPayment(ctx, testStripeRequest())
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.DispatchId)
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", resp.PaymentOrderId)
+	assert.NotNil(t, resp.CreatedAt)
+}
+
+// TestGetProviderHealth_UnspecifiedRail verifies that an unspecified rail returns Unimplemented.
+func TestGetProviderHealth_UnspecifiedRail(t *testing.T) {
+	svc, err := NewFinancialGatewayService(Config{Logger: slog.Default()})
+	require.NoError(t, err)
+
+	_, err = svc.GetProviderHealth(context.Background(), &financialgatewayv1.GetProviderHealthRequest{
+		Rail: financialgatewayv1.PaymentRail_PAYMENT_RAIL_UNSPECIFIED,
+	})
+	require.Error(t, err)
+}
+
+// TestCancelPayment_ContextDeadlineExceeded_Factory verifies DeadlineExceeded from client factory.
+func TestCancelPayment_ContextDeadlineExceeded_Factory(t *testing.T) {
+	svc, err := NewFinancialGatewayService(Config{Logger: slog.Default()})
+	require.NoError(t, err)
+
+	// No stripe adapter configured - returns Unavailable
+	_, err = svc.CancelPayment(context.Background(), &financialgatewayv1.CancelPaymentRequest{
+		PaymentOrderId: "po-1",
+		Reason:         "timeout test",
+	})
+	require.Error(t, err)
+}
+
+// TestDispatchPayment_StripeSuccess_ResponseFields verifies all response fields for a successful dispatch.
+func TestDispatchPayment_StripeSuccess_ResponseFields(t *testing.T) {
+	creator := &mockCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return &stripego.PaymentIntent{
+				ID:     "pi_field_check",
+				Status: stripego.PaymentIntentStatusSucceeded,
+			}, nil
+		},
+	}
+	svc := newServiceWithStripeMocks(t, creator, nil, nil)
+
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("test-tenant"))
+	resp, err := svc.DispatchPayment(ctx, testStripeRequest())
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, resp.DispatchId, "dispatch ID must be a non-empty UUID")
+	assert.Equal(t, financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE, resp.Rail)
+	assert.Equal(t, "pi_field_check", resp.ProviderReference)
+	assert.NotNil(t, resp.CreatedAt)
+}

--- a/services/financial-gateway/service/server_test.go
+++ b/services/financial-gateway/service/server_test.go
@@ -5,14 +5,57 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	stripego "github.com/stripe/stripe-go/v82"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	financialgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_gateway/v1"
 	stripeadapter "github.com/meridianhub/meridian/services/financial-gateway/adapters/stripe"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
+
+// newServiceWithFee creates a service with a flat platform fee configured.
+func newServiceWithFee(t *testing.T, creator stripeadapter.PaymentIntentCreator, feeMinorUnits int64) *FinancialGatewayService {
+	t.Helper()
+
+	fee := &stripeadapter.PlatformFeeConfig{
+		Type:  stripeadapter.PlatformFeeTypeFlat,
+		Value: decimal.NewFromInt(feeMinorUnits),
+	}
+
+	adapter, err := stripeadapter.NewPaymentIntentAdapter(creator, stripeadapter.PaymentIntentAdapterConfig{
+		PlatformFee: fee,
+	}, slog.Default())
+	require.NoError(t, err)
+
+	provider := &mockConfigProvider{
+		configs: map[string]stripeadapter.TenantConfig{
+			"test-tenant": {
+				ConnectedAccountID:    "acct_test_123",
+				WebhookEndpointSecret: "whsec_test",
+			},
+		},
+	}
+
+	factory, err := stripeadapter.NewClientFactory(stripeadapter.Config{
+		APIKey:             "sk_test_key",
+		TenantCacheSize:    10,
+		TenantCacheTTL:     60000000000,
+		CircuitBreakerName: "test-cb",
+	}, provider, slog.Default())
+	require.NoError(t, err)
+
+	svc, err := NewFinancialGatewayService(Config{
+		StripeAdapter: adapter,
+		ClientFactory: factory,
+		Logger:        slog.Default(),
+	})
+	require.NoError(t, err)
+	return svc
+}
 
 // TestNewFinancialGatewayService_WithPartialConfig verifies that a service can be created
 // with adapter set but no ClientFactory (partial config is allowed at construction time).
@@ -35,25 +78,25 @@ func TestNewFinancialGatewayService_WithPartialConfig(t *testing.T) {
 	assert.NotNil(t, svc)
 }
 
-// TestDispatchPayment_ResponseContainsPlatformFee verifies that platform fee is included in the response
-// when the Stripe adapter returns a non-zero fee.
+// TestDispatchPayment_ResponseContainsPlatformFee verifies that PlatformFeeMinorUnits is
+// populated in the response when the adapter is configured with a flat fee.
 func TestDispatchPayment_ResponseContainsPlatformFee(t *testing.T) {
 	creator := &mockCreator{
-		createFn: func(_ context.Context, params *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
 			return &stripego.PaymentIntent{
 				ID:     "pi_with_fee",
 				Status: stripego.PaymentIntentStatusSucceeded,
 			}, nil
 		},
 	}
-	svc := newServiceWithStripeMocks(t, creator, nil, nil)
+	// testStripeRequest has AmountUnits=10000; flat fee of 500 minor units
+	svc := newServiceWithFee(t, creator, 500)
 
 	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("test-tenant"))
 	resp, err := svc.DispatchPayment(ctx, testStripeRequest())
 	require.NoError(t, err)
-	assert.NotEmpty(t, resp.DispatchId)
-	assert.Equal(t, "11111111-1111-1111-1111-111111111111", resp.PaymentOrderId)
-	assert.NotNil(t, resp.CreatedAt)
+	assert.Equal(t, int64(500), resp.PlatformFeeMinorUnits)
+	assert.Equal(t, "pi_with_fee", resp.ProviderReference)
 }
 
 // TestGetProviderHealth_UnspecifiedRail verifies that an unspecified rail returns Unimplemented.
@@ -65,19 +108,25 @@ func TestGetProviderHealth_UnspecifiedRail(t *testing.T) {
 		Rail: financialgatewayv1.PaymentRail_PAYMENT_RAIL_UNSPECIFIED,
 	})
 	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unimplemented, st.Code())
 }
 
-// TestCancelPayment_ContextDeadlineExceeded_Factory verifies DeadlineExceeded from client factory.
-func TestCancelPayment_ContextDeadlineExceeded_Factory(t *testing.T) {
+// TestCancelPayment_AdapterNotConfigured_ReturnsUnavailable verifies that CancelPayment
+// returns Unavailable when the stripe adapter is not configured.
+func TestCancelPayment_AdapterNotConfigured_ReturnsUnavailable(t *testing.T) {
 	svc, err := NewFinancialGatewayService(Config{Logger: slog.Default()})
 	require.NoError(t, err)
 
-	// No stripe adapter configured - returns Unavailable
 	_, err = svc.CancelPayment(context.Background(), &financialgatewayv1.CancelPaymentRequest{
 		PaymentOrderId: "po-1",
-		Reason:         "timeout test",
+		Reason:         "test",
 	})
 	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unavailable, st.Code())
 }
 
 // TestDispatchPayment_StripeSuccess_ResponseFields verifies all response fields for a successful dispatch.

--- a/services/payment-order/adapters/gateway/stripe/tenant_config_test.go
+++ b/services/payment-order/adapters/gateway/stripe/tenant_config_test.go
@@ -1,0 +1,94 @@
+package stripe
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTenantConfig_ValidConfigWithBothFields(t *testing.T) {
+	tc := TenantConfig{
+		ConnectedAccountID:    "acct_1234567890",
+		WebhookEndpointSecret: "whsec_abc123",
+	}
+	err := tc.Validate()
+	require.NoError(t, err)
+}
+
+func TestTenantConfig_MissingAccountID_WebhookSet(t *testing.T) {
+	// Webhook alone is not sufficient - account ID is required
+	tc := TenantConfig{
+		WebhookEndpointSecret: "whsec_abc123",
+	}
+	err := tc.Validate()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMissingAccountID)
+}
+
+func TestTenantConfig_AccountIDOnly_IsValid(t *testing.T) {
+	// WebhookEndpointSecret is optional; AccountID alone is sufficient
+	tc := TenantConfig{
+		ConnectedAccountID: "acct_minimally_valid",
+	}
+	err := tc.Validate()
+	require.NoError(t, err)
+}
+
+func TestTenantConfigErrors_AreDistinct(t *testing.T) {
+	assert.NotNil(t, ErrMissingAccountID)
+	assert.NotNil(t, ErrTenantConfigNotFound)
+	assert.NotEqual(t, ErrMissingAccountID, ErrTenantConfigNotFound)
+	assert.False(t, errors.Is(ErrTenantConfigNotFound, ErrMissingAccountID))
+	assert.False(t, errors.Is(ErrMissingAccountID, ErrTenantConfigNotFound))
+}
+
+// testTenantConfigProvider is a test-local implementation of TenantConfigProvider.
+type testTenantConfigProvider struct {
+	configs map[string]TenantConfig
+}
+
+func (m *testTenantConfigProvider) GetTenantConfig(tenantID string) (TenantConfig, error) {
+	cfg, ok := m.configs[tenantID]
+	if !ok {
+		return TenantConfig{}, ErrTenantConfigNotFound
+	}
+	return cfg, nil
+}
+
+func TestTenantConfigProvider_ReturnsConfig(t *testing.T) {
+	provider := &testTenantConfigProvider{
+		configs: map[string]TenantConfig{
+			"tenant-1": {
+				ConnectedAccountID:    "acct_tenant1",
+				WebhookEndpointSecret: "whsec_tenant1",
+			},
+		},
+	}
+
+	cfg, err := provider.GetTenantConfig("tenant-1")
+	require.NoError(t, err)
+	assert.Equal(t, "acct_tenant1", cfg.ConnectedAccountID)
+	assert.Equal(t, "whsec_tenant1", cfg.WebhookEndpointSecret)
+}
+
+func TestTenantConfigProvider_ReturnsNotFoundError(t *testing.T) {
+	provider := &testTenantConfigProvider{
+		configs: map[string]TenantConfig{},
+	}
+
+	_, err := provider.GetTenantConfig("unknown-tenant")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTenantConfigNotFound)
+}
+
+func TestTenantConfig_FieldAccess(t *testing.T) {
+	tc := TenantConfig{
+		ConnectedAccountID:    "acct_abc",
+		WebhookEndpointSecret: "whsec_xyz",
+	}
+
+	assert.Equal(t, "acct_abc", tc.ConnectedAccountID)
+	assert.Equal(t, "whsec_xyz", tc.WebhookEndpointSecret)
+}


### PR DESCRIPTION
## Summary

- Adds unit tests for previously untested audit-worker components: `domain.ProtoToOperation`, `app.dbWrapper` (Ping/Stats via sqlmock), and helper functions `rowToProto`/`jsonToStruct` in the service layer
- Adds unit tests for `TenantConfig.Validate()` and sentinel error assertions in `financial-gateway/adapters/stripe` and `payment-order/adapters/gateway/stripe`
- Adds additional edge case tests for `financial-gateway/service` server (response field verification, partial config construction)

## Test plan

- [x] `go test ./services/audit-worker/domain/...` - passes
- [x] `go test ./services/audit-worker/app/...` - passes
- [x] `go test ./services/audit-worker/service/... -run TestRowToProto|TestJsonToStruct` - passes
- [x] `go test ./services/financial-gateway/adapters/stripe/...` - passes
- [x] `go test ./services/financial-gateway/service/...` - passes
- [x] `go test ./services/payment-order/adapters/gateway/stripe/...` - passes

## Task Master

test-coverage.18