### PR TITLE
test: Add API gateway and internal account unit tests

### DIFF
--- a/services/api-gateway/auth/composite_validator_test.go
+++ b/services/api-gateway/auth/composite_validator_test.go
@@ -1,0 +1,114 @@
+package auth
+
+import (
+	"errors"
+	"testing"
+
+	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCompositeJWTValidator(t *testing.T) {
+	v1 := &mockValidator{claims: &platformauth.Claims{UserID: "user-1"}}
+	v2 := &mockValidator{claims: &platformauth.Claims{UserID: "user-2"}}
+
+	composite := NewCompositeJWTValidator(v1, v2)
+
+	assert.NotNil(t, composite)
+	assert.Len(t, composite.validators, 2)
+}
+
+func TestCompositeJWTValidator_EmptyValidators_ReturnsError(t *testing.T) {
+	composite := NewCompositeJWTValidator()
+
+	claims, err := composite.ValidateToken("any-token")
+
+	assert.Nil(t, claims)
+	assert.ErrorIs(t, err, platformauth.ErrInvalidToken)
+}
+
+func TestCompositeJWTValidator_FirstValidatorSucceeds(t *testing.T) {
+	expectedClaims := &platformauth.Claims{
+		UserID:   "user-1",
+		TenantID: "acme_corp",
+	}
+	v1 := &mockValidator{claims: expectedClaims}
+	v2 := &mockValidator{claims: &platformauth.Claims{UserID: "user-2"}}
+
+	composite := NewCompositeJWTValidator(v1, v2)
+
+	claims, err := composite.ValidateToken("some-token")
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedClaims, claims)
+}
+
+func TestCompositeJWTValidator_FirstFailsSecondSucceeds(t *testing.T) {
+	expectedClaims := &platformauth.Claims{
+		UserID:   "user-2",
+		TenantID: "beta_corp",
+	}
+	v1 := &mockValidator{err: platformauth.ErrInvalidToken}
+	v2 := &mockValidator{claims: expectedClaims}
+
+	composite := NewCompositeJWTValidator(v1, v2)
+
+	claims, err := composite.ValidateToken("some-token")
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedClaims, claims)
+}
+
+func TestCompositeJWTValidator_AllFail_ReturnsLastError(t *testing.T) {
+	firstErr := errors.New("first validator error")
+	lastErr := errors.New("last validator error")
+	v1 := &mockValidator{err: firstErr}
+	v2 := &mockValidator{err: lastErr}
+
+	composite := NewCompositeJWTValidator(v1, v2)
+
+	claims, err := composite.ValidateToken("invalid-token")
+
+	assert.Nil(t, claims)
+	assert.ErrorIs(t, err, lastErr)
+}
+
+func TestCompositeJWTValidator_SingleValidator_Succeeds(t *testing.T) {
+	expectedClaims := &platformauth.Claims{UserID: "solo-user"}
+	v := &mockValidator{claims: expectedClaims}
+
+	composite := NewCompositeJWTValidator(v)
+
+	claims, err := composite.ValidateToken("token")
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedClaims, claims)
+}
+
+func TestCompositeJWTValidator_SingleValidator_Fails(t *testing.T) {
+	v := &mockValidator{err: platformauth.ErrInvalidToken}
+
+	composite := NewCompositeJWTValidator(v)
+
+	claims, err := composite.ValidateToken("expired-token")
+
+	assert.Nil(t, claims)
+	assert.ErrorIs(t, err, platformauth.ErrInvalidToken)
+}
+
+func TestCompositeJWTValidator_ThreeValidators_ThirdSucceeds(t *testing.T) {
+	expectedClaims := &platformauth.Claims{UserID: "third-user"}
+	errFirst := errors.New("first fails")
+	errSecond := errors.New("second fails")
+	v1 := &mockValidator{err: errFirst}
+	v2 := &mockValidator{err: errSecond}
+	v3 := &mockValidator{claims: expectedClaims}
+
+	composite := NewCompositeJWTValidator(v1, v2, v3)
+
+	claims, err := composite.ValidateToken("token")
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedClaims, claims)
+}

--- a/services/api-gateway/auth_builder_test.go
+++ b/services/api-gateway/auth_builder_test.go
@@ -1,0 +1,109 @@
+package gateway
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildAuthMiddleware_WithJWKSURL(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	config := AuthConfig{
+		JWKSURL: "https://example.com/.well-known/jwks.json",
+	}
+
+	// NewJWKSProvider defers initial fetch, so any non-empty URL succeeds at creation.
+	middleware, err := BuildAuthMiddleware(config, logger)
+
+	require.NoError(t, err)
+	assert.NotNil(t, middleware)
+	middleware.Close()
+}
+
+func TestBuildAuthMiddleware_EmptyJWKSURL(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	config := AuthConfig{
+		JWKSURL: "", // empty URL should fail
+	}
+
+	_, err := BuildAuthMiddleware(config, logger)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create JWKS provider")
+}
+
+func TestBuildAuthMiddleware_WithLocalSigner(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	signer, err := platformauth.NewJWTSigner(platformauth.JWTSignerConfig{})
+	require.NoError(t, err)
+
+	config := AuthConfig{
+		JWKSURL: "https://example.com/.well-known/jwks.json",
+	}
+
+	middleware, err := BuildAuthMiddleware(config, logger, signer)
+
+	require.NoError(t, err)
+	assert.NotNil(t, middleware)
+	middleware.Close()
+}
+
+func TestBuildAuthMiddleware_WithAPIKeys(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	config := AuthConfig{
+		JWKSURL: "https://example.com/.well-known/jwks.json",
+		APIKeys: map[string]string{
+			"api-key-1": "service-a",
+			"api-key-2": "service-b",
+		},
+		RateLimitPerSecond: 100,
+		RateLimitBurst:     200,
+	}
+
+	middleware, err := BuildAuthMiddleware(config, logger)
+
+	require.NoError(t, err)
+	assert.NotNil(t, middleware)
+	middleware.Close()
+}
+
+func TestBuildAuthMiddleware_CloseIsIdempotent(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	config := AuthConfig{
+		JWKSURL: "https://example.com/.well-known/jwks.json",
+		APIKeys: map[string]string{"key": "identity"},
+	}
+
+	middleware, err := BuildAuthMiddleware(config, logger)
+	require.NoError(t, err)
+
+	// Close should be safe to call multiple times.
+	assert.NotPanics(t, func() {
+		middleware.Close()
+		middleware.Close()
+	})
+}
+
+func TestBuildAuthMiddleware_WithLocalSigner_NilSignerIgnored(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	config := AuthConfig{
+		JWKSURL: "https://example.com/.well-known/jwks.json",
+	}
+
+	// Passing a nil signer should fall back to dex-only path.
+	middleware, err := BuildAuthMiddleware(config, logger, nil)
+
+	require.NoError(t, err)
+	assert.NotNil(t, middleware)
+	middleware.Close()
+}

--- a/services/api-gateway/internal/middleware/response_recorder_test.go
+++ b/services/api-gateway/internal/middleware/response_recorder_test.go
@@ -85,15 +85,15 @@ func TestReleaseBuffer_ReturnedBufferIsReset(t *testing.T) {
 	assert.Equal(t, 0, b2.Len())
 }
 
-func TestReleaseBuffer_LargeBuffer_NotReturnedToPool(t *testing.T) {
+func TestReleaseBuffer_LargeBuffer_DoesNotPanic(t *testing.T) {
 	// Create a buffer larger than 64KB threshold.
+	// releaseBuffer drops oversized buffers instead of returning them to the pool.
 	large := make([]byte, 65*1024)
 	b := &bytes.Buffer{}
 	_, err := b.Write(large)
 	require.NoError(t, err)
 	assert.Greater(t, b.Cap(), 64*1024)
 
-	// Should not panic, even though it won't be returned to the pool.
 	assert.NotPanics(t, func() {
 		releaseBuffer(b)
 	})

--- a/services/api-gateway/internal/middleware/response_recorder_test.go
+++ b/services/api-gateway/internal/middleware/response_recorder_test.go
@@ -1,0 +1,100 @@
+package middleware
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewResponseRecorder_Defaults(t *testing.T) {
+	rec := newResponseRecorder()
+	defer rec.release()
+
+	assert.Equal(t, http.StatusOK, rec.code)
+	assert.NotNil(t, rec.headers)
+	assert.NotNil(t, rec.buf)
+	assert.False(t, rec.wroteHeader)
+}
+
+func TestResponseRecorder_WriteHeader_Idempotent(t *testing.T) {
+	rec := newResponseRecorder()
+	defer rec.release()
+
+	rec.WriteHeader(http.StatusCreated)
+	rec.WriteHeader(http.StatusBadRequest) // second call is a no-op
+
+	assert.Equal(t, http.StatusCreated, rec.code)
+	assert.True(t, rec.wroteHeader)
+}
+
+func TestResponseRecorder_Write_SetsWroteHeader(t *testing.T) {
+	rec := newResponseRecorder()
+	defer rec.release()
+
+	assert.False(t, rec.wroteHeader)
+
+	_, err := rec.Write([]byte("hello"))
+	require.NoError(t, err)
+
+	assert.True(t, rec.wroteHeader)
+	assert.Equal(t, http.StatusOK, rec.code)
+}
+
+func TestResponseRecorder_Write_AccumulatesBody(t *testing.T) {
+	rec := newResponseRecorder()
+	defer rec.release()
+
+	_, err := rec.Write([]byte("foo"))
+	require.NoError(t, err)
+	_, err = rec.Write([]byte("bar"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "foobar", rec.buf.String())
+}
+
+func TestResponseRecorder_Header_ReturnsHeaders(t *testing.T) {
+	rec := newResponseRecorder()
+	defer rec.release()
+
+	rec.Header().Set("X-Custom", "value")
+
+	assert.Equal(t, "value", rec.headers.Get("X-Custom"))
+	assert.Equal(t, rec.headers, rec.Header())
+}
+
+func TestAcquireBuffer_ReturnsEmptyBuffer(t *testing.T) {
+	b := acquireBuffer()
+	defer releaseBuffer(b)
+
+	assert.Equal(t, 0, b.Len())
+}
+
+func TestReleaseBuffer_ReturnedBufferIsReset(t *testing.T) {
+	b := acquireBuffer()
+	_, err := b.WriteString("some data")
+	require.NoError(t, err)
+
+	releaseBuffer(b)
+
+	// Acquire again - should get a reset buffer (may or may not be the same object).
+	b2 := acquireBuffer()
+	defer releaseBuffer(b2)
+	assert.Equal(t, 0, b2.Len())
+}
+
+func TestReleaseBuffer_LargeBuffer_NotReturnedToPool(t *testing.T) {
+	// Create a buffer larger than 64KB threshold.
+	large := make([]byte, 65*1024)
+	b := &bytes.Buffer{}
+	_, err := b.Write(large)
+	require.NoError(t, err)
+	assert.Greater(t, b.Cap(), 64*1024)
+
+	// Should not panic, even though it won't be returned to the pool.
+	assert.NotPanics(t, func() {
+		releaseBuffer(b)
+	})
+}

--- a/services/internal-account/adapters/persistence/valuation_feature_repository_test.go
+++ b/services/internal-account/adapters/persistence/valuation_feature_repository_test.go
@@ -1,7 +1,6 @@
 package persistence
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/uuid"
@@ -80,7 +79,7 @@ func TestNewValuationFeatureRepository_FindByID_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, ErrValuationFeatureNotFound)
 }
 
-func TestNewValuationFeatureRepository_WithNilContext(t *testing.T) {
+func TestNewValuationFeatureRepository_WithTx_ReturnsNewRepo(t *testing.T) {
 	gormDB, _, cleanup := testdb.SetupTestDB(t,
 		testdb.WithModels(&vf.Entity{}),
 		testdb.WithTenant(testTenantID),
@@ -90,10 +89,10 @@ func TestNewValuationFeatureRepository_WithNilContext(t *testing.T) {
 	repo := NewValuationFeatureRepository(gormDB)
 	assert.NotNil(t, repo)
 
-	// WithTx should return a new repository instance.
+	// WithTx should return a new repository instance scoped to the transaction.
 	tx := gormDB.Begin()
 	defer tx.Rollback()
 	txRepo := repo.WithTx(tx)
 	assert.NotNil(t, txRepo)
-	_ = context.Background()
+	assert.NotSame(t, repo, txRepo)
 }

--- a/services/internal-account/adapters/persistence/valuation_feature_repository_test.go
+++ b/services/internal-account/adapters/persistence/valuation_feature_repository_test.go
@@ -39,8 +39,8 @@ func TestNewValuationFeatureRepository_IsSharedRepository(t *testing.T) {
 	repo := NewValuationFeatureRepository(gormDB)
 
 	// ValuationFeatureRepository is a type alias for vf.Repository.
-	// Verify the returned repo is a *vf.Repository by calling a shared method.
-	_ = (*vf.Repository)(repo)
+	// Verify the returned repo exposes the shared package's DB() method.
+	assert.NotNil(t, repo.DB())
 }
 
 func TestNewValuationFeatureRepository_Create_FindByID(t *testing.T) {

--- a/services/internal-account/adapters/persistence/valuation_feature_repository_test.go
+++ b/services/internal-account/adapters/persistence/valuation_feature_repository_test.go
@@ -1,0 +1,99 @@
+package persistence
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	vf "github.com/meridianhub/meridian/shared/pkg/valuationfeature"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValuationFeatureRepository_ErrorAliases(t *testing.T) {
+	assert.Equal(t, vf.ErrNotFound, ErrValuationFeatureNotFound)
+	assert.Equal(t, vf.ErrVersionConflict, ErrValuationFeatureVersionConflict)
+	assert.Equal(t, vf.ErrAlreadyExists, ErrValuationFeatureAlreadyExists)
+}
+
+func TestNewValuationFeatureRepository_ReturnsNonNil(t *testing.T) {
+	gormDB, _, cleanup := testdb.SetupTestDB(t,
+		testdb.WithModels(&vf.Entity{}),
+		testdb.WithTenant(testTenantID),
+	)
+	defer cleanup()
+
+	repo := NewValuationFeatureRepository(gormDB)
+
+	assert.NotNil(t, repo)
+}
+
+func TestNewValuationFeatureRepository_IsSharedRepository(t *testing.T) {
+	gormDB, _, cleanup := testdb.SetupTestDB(t,
+		testdb.WithModels(&vf.Entity{}),
+		testdb.WithTenant(testTenantID),
+	)
+	defer cleanup()
+
+	repo := NewValuationFeatureRepository(gormDB)
+
+	// ValuationFeatureRepository is a type alias for vf.Repository.
+	// Verify the returned repo is a *vf.Repository by calling a shared method.
+	_ = (*vf.Repository)(repo)
+}
+
+func TestNewValuationFeatureRepository_Create_FindByID(t *testing.T) {
+	gormDB, ctx, cleanup := testdb.SetupTestDB(t,
+		testdb.WithModels(&vf.Entity{}),
+		testdb.WithTenant(testTenantID),
+	)
+	defer cleanup()
+
+	repo := NewValuationFeatureRepository(gormDB)
+	accountID := uuid.New()
+	methodID := uuid.New()
+
+	feature, err := vf.NewValuationFeature(accountID, "USD", methodID, 1, nil, "test-user")
+	require.NoError(t, err)
+
+	err = repo.Create(ctx, feature)
+	require.NoError(t, err)
+
+	retrieved, err := repo.FindByID(ctx, feature.ID)
+	require.NoError(t, err)
+	assert.Equal(t, feature.ID, retrieved.ID)
+	assert.Equal(t, "USD", retrieved.InstrumentCode)
+}
+
+func TestNewValuationFeatureRepository_FindByID_NotFound(t *testing.T) {
+	gormDB, ctx, cleanup := testdb.SetupTestDB(t,
+		testdb.WithModels(&vf.Entity{}),
+		testdb.WithTenant(testTenantID),
+	)
+	defer cleanup()
+
+	repo := NewValuationFeatureRepository(gormDB)
+
+	_, err := repo.FindByID(ctx, uuid.New())
+
+	assert.ErrorIs(t, err, ErrValuationFeatureNotFound)
+}
+
+func TestNewValuationFeatureRepository_WithNilContext(t *testing.T) {
+	gormDB, _, cleanup := testdb.SetupTestDB(t,
+		testdb.WithModels(&vf.Entity{}),
+		testdb.WithTenant(testTenantID),
+	)
+	defer cleanup()
+
+	repo := NewValuationFeatureRepository(gormDB)
+	assert.NotNil(t, repo)
+
+	// WithTx should return a new repository instance.
+	tx := gormDB.Begin()
+	defer tx.Rollback()
+	txRepo := repo.WithTx(tx)
+	assert.NotNil(t, txRepo)
+	_ = context.Background()
+}

--- a/services/internal-account/domain/valuation_feature_test.go
+++ b/services/internal-account/domain/valuation_feature_test.go
@@ -1,0 +1,81 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	vf "github.com/meridianhub/meridian/shared/pkg/valuationfeature"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValuationFeature_LifecycleStatusConstants(t *testing.T) {
+	assert.Equal(t, vf.LifecycleStatusInitiated, ValuationFeatureLifecycleStatusInitiated)
+	assert.Equal(t, vf.LifecycleStatusActive, ValuationFeatureLifecycleStatusActive)
+	assert.Equal(t, vf.LifecycleStatusTerminated, ValuationFeatureLifecycleStatusTerminated)
+}
+
+func TestValuationFeature_ErrorAliases(t *testing.T) {
+	assert.Equal(t, vf.ErrInvalidLifecycleTransition, ErrInvalidValuationFeatureTransition)
+	assert.Equal(t, vf.ErrNotActive, ErrValuationFeatureNotActive)
+	assert.Equal(t, vf.ErrInvalidParameters, ErrInvalidValuationFeatureParameters)
+	assert.Equal(t, vf.ErrInstrumentCodeEmpty, ErrValuationFeatureInstrumentEmpty)
+}
+
+func TestNewValuationFeature_DelegatesToShared(t *testing.T) {
+	accountID := uuid.New()
+	methodID := uuid.New()
+	params := map[string]interface{}{"source": "ECB"}
+
+	feature, err := NewValuationFeature(accountID, "USD", methodID, 1, params, "test-user")
+
+	require.NoError(t, err)
+	assert.NotNil(t, feature)
+	assert.Equal(t, accountID, feature.AccountID)
+	assert.Equal(t, "USD", feature.InstrumentCode)
+	assert.Equal(t, methodID, feature.ValuationMethodID)
+	assert.Equal(t, 1, feature.ValuationMethodVersion)
+	assert.Equal(t, params, feature.Parameters)
+	assert.Equal(t, ValuationFeatureLifecycleStatusInitiated, feature.LifecycleStatus)
+	assert.Equal(t, "test-user", feature.CreatedBy)
+	assert.Equal(t, 1, feature.Version)
+}
+
+func TestNewValuationFeature_EmptyInstrumentCode_ReturnsError(t *testing.T) {
+	accountID := uuid.New()
+	methodID := uuid.New()
+
+	_, err := NewValuationFeature(accountID, "", methodID, 1, nil, "test-user")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrValuationFeatureInstrumentEmpty)
+}
+
+func TestValuationFeature_TypeAlias_SupportsSharedMethods(t *testing.T) {
+	accountID := uuid.New()
+	methodID := uuid.New()
+
+	feature, err := NewValuationFeature(accountID, "GBP", methodID, 2, nil, "creator")
+	require.NoError(t, err)
+
+	assert.False(t, feature.IsActive())
+	assert.False(t, feature.IsTerminal())
+
+	// Activate transitions to ACTIVE.
+	err = feature.Activate("activator")
+	require.NoError(t, err)
+	assert.True(t, feature.IsActive())
+	assert.Equal(t, ValuationFeatureLifecycleStatusActive, feature.LifecycleStatus)
+
+	// Terminate transitions to TERMINATED.
+	err = feature.Terminate("terminator")
+	require.NoError(t, err)
+	assert.True(t, feature.IsTerminal())
+	assert.Equal(t, ValuationFeatureLifecycleStatusTerminated, feature.LifecycleStatus)
+}
+
+func TestValuationFeature_LifecycleStatus_IsString(t *testing.T) {
+	assert.Equal(t, ValuationFeatureLifecycleStatus("INITIATED"), ValuationFeatureLifecycleStatusInitiated)
+	assert.Equal(t, ValuationFeatureLifecycleStatus("ACTIVE"), ValuationFeatureLifecycleStatusActive)
+	assert.Equal(t, ValuationFeatureLifecycleStatus("TERMINATED"), ValuationFeatureLifecycleStatusTerminated)
+}


### PR DESCRIPTION
## Summary

- **auth_builder_test.go**: Tests for `BuildAuthMiddleware` covering JWKS URL validation, local signer composite path, API key config, and idempotent Close
- **auth/composite_validator_test.go**: Unit tests for `CompositeJWTValidator` covering empty validators, first-wins, fallback ordering, and all-fail scenarios
- **internal/middleware/response_recorder_test.go**: Additional tests for `responseRecorder` covering defaults, WriteHeader idempotency, implicit header on Write, and buffer pool behavior
- **internal-account/domain/valuation_feature_test.go**: Verifies constant/error re-exports match shared package and `NewValuationFeature` delegates correctly
- **internal-account/adapters/persistence/valuation_feature_repository_test.go**: Tests constructor, error aliases, and CRUD operations via the shared repository implementation

## Test plan

- [x] All new tests pass locally
- [x] `go vet` passes on all affected packages
- [x] No existing tests broken