### PR TITLE
test: Add market information and tenant service unit tests

### DIFF
--- a/services/market-information/adapters/persistence/base_repository_test.go
+++ b/services/market-information/adapters/persistence/base_repository_test.go
@@ -1,0 +1,179 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	pgcontainer "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// baseRepoTestPool is the shared connection pool for base_repository integration tests.
+// Initialized once in TestMain and closed on exit.
+var baseRepoTestPool *pgxpool.Pool
+
+// TestMain sets up a shared PostgreSQL testcontainer for all base_repository tests.
+// Using a shared container avoids the overhead of creating a new container per test.
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+
+	pgc, err := pgcontainer.Run(ctx,
+		"postgres:16-alpine",
+		pgcontainer.WithDatabase("test_base_repo"),
+		pgcontainer.WithUsername("test"),
+		pgcontainer.WithPassword("test"),
+		testcontainers.WithWaitStrategy(
+			wait.ForAll(
+				wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
+				wait.ForListeningPort("5432/tcp"),
+			).WithDeadline(60*time.Second)),
+	)
+	if err != nil {
+		os.Exit(1)
+	}
+
+	connStr, err := pgc.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		_ = pgc.Terminate(ctx)
+		os.Exit(1)
+	}
+
+	poolCfg, err := pgxpool.ParseConfig(connStr)
+	if err != nil {
+		_ = pgc.Terminate(ctx)
+		os.Exit(1)
+	}
+
+	baseRepoTestPool, err = pgxpool.NewWithConfig(ctx, poolCfg)
+	if err != nil {
+		_ = pgc.Terminate(ctx)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	baseRepoTestPool.Close()
+	_ = pgc.Terminate(ctx)
+	os.Exit(code)
+}
+
+func TestNewBaseRepository_StoresPool(t *testing.T) {
+	repo := newBaseRepository(baseRepoTestPool)
+	assert.NotNil(t, repo.pool)
+	assert.Equal(t, baseRepoTestPool, repo.pool)
+}
+
+func TestBaseRepository_SetSearchPath_NoTenant(t *testing.T) {
+	repo := newBaseRepository(baseRepoTestPool)
+	ctx := context.Background() // no tenant in context
+
+	tx, err := baseRepoTestPool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Without tenant in context, setSearchPath is a no-op
+	err = repo.setSearchPath(ctx, tx)
+	assert.NoError(t, err)
+}
+
+func TestBaseRepository_SetSearchPath_WithTenant(t *testing.T) {
+	repo := newBaseRepository(baseRepoTestPool)
+	ctx := context.Background()
+	tenantID := tenant.MustNewTenantID("test_corp")
+
+	// Create schema for tenant
+	_, err := baseRepoTestPool.Exec(ctx, `CREATE SCHEMA IF NOT EXISTS "org_test_corp"`)
+	require.NoError(t, err)
+
+	tenantCtx := tenant.WithTenant(ctx, tenantID)
+	tx, err := baseRepoTestPool.Begin(tenantCtx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(tenantCtx) }()
+
+	err = repo.setSearchPath(tenantCtx, tx)
+	assert.NoError(t, err)
+}
+
+func TestBaseRepository_WithReadTransaction_ExecutesFunction(t *testing.T) {
+	repo := newBaseRepository(baseRepoTestPool)
+	ctx := context.Background()
+
+	executed := false
+	err := repo.withReadTransaction(ctx, func(_ pgx.Tx) error {
+		executed = true
+		return nil
+	})
+
+	assert.NoError(t, err)
+	assert.True(t, executed)
+}
+
+func TestBaseRepository_WithReadTransaction_ReturnsError(t *testing.T) {
+	repo := newBaseRepository(baseRepoTestPool)
+	ctx := context.Background()
+
+	sentinel := errors.New("read error")
+	err := repo.withReadTransaction(ctx, func(_ pgx.Tx) error {
+		return sentinel
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel)
+}
+
+func TestBaseRepository_WithWriteTransaction_ExecutesFunction(t *testing.T) {
+	repo := newBaseRepository(baseRepoTestPool)
+	ctx := context.Background()
+
+	executed := false
+	err := repo.withWriteTransaction(ctx, func(_ pgx.Tx) error {
+		executed = true
+		return nil
+	})
+
+	assert.NoError(t, err)
+	assert.True(t, executed)
+}
+
+func TestBaseRepository_WithWriteTransaction_ReturnsError(t *testing.T) {
+	repo := newBaseRepository(baseRepoTestPool)
+	ctx := context.Background()
+
+	sentinel := errors.New("write error")
+	err := repo.withWriteTransaction(ctx, func(_ pgx.Tx) error {
+		return sentinel
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel)
+}
+
+func TestBaseRepository_WithReadTransaction_WithTenantScope(t *testing.T) {
+	ctx := context.Background()
+	tenantID := tenant.MustNewTenantID("scoped_corp")
+
+	// Create schema for tenant
+	_, err := baseRepoTestPool.Exec(ctx, `CREATE SCHEMA IF NOT EXISTS "org_scoped_corp"`)
+	require.NoError(t, err)
+
+	repo := newBaseRepository(baseRepoTestPool)
+	tenantCtx := tenant.WithTenant(ctx, tenantID)
+
+	executed := false
+	err = repo.withReadTransaction(tenantCtx, func(_ pgx.Tx) error {
+		executed = true
+		return nil
+	})
+
+	assert.NoError(t, err)
+	assert.True(t, executed)
+}

--- a/services/market-information/adapters/persistence/repositories_test.go
+++ b/services/market-information/adapters/persistence/repositories_test.go
@@ -1,0 +1,34 @@
+package persistence_test
+
+import (
+	"testing"
+
+	"github.com/meridianhub/meridian/services/market-information/adapters/persistence"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRepositories_PanicsOnEmptyMasterTenantID(t *testing.T) {
+	assert.Panics(t, func() {
+		// nil pool is fine here - panics before using it
+		persistence.NewRepositories(nil, "")
+	})
+}
+
+func TestNewRepositories_ReturnsNonNilRepositories(t *testing.T) {
+	// NewRepositories stores the pool but does not connect during construction.
+	// Passing nil is sufficient for verifying the returned struct is populated.
+	repos := persistence.NewRepositories(nil, "master_tenant")
+	require.NotNil(t, repos)
+	assert.NotNil(t, repos.DataSet)
+	assert.NotNil(t, repos.Observation)
+	assert.NotNil(t, repos.Source)
+}
+
+func TestNewRepositories_AllFieldsPopulated(t *testing.T) {
+	repos := persistence.NewRepositories(nil, "any_master_id")
+
+	require.NotNil(t, repos.DataSet, "DataSet repository should not be nil")
+	require.NotNil(t, repos.Observation, "Observation repository should not be nil")
+	require.NotNil(t, repos.Source, "Source repository should not be nil")
+}

--- a/services/market-information/domain/data_category_test.go
+++ b/services/market-information/domain/data_category_test.go
@@ -1,0 +1,75 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDataCategoryUtilization_IsValid verifies the UTILIZATION constant is valid.
+// The dataset_test.go covers PRICING and CONTEXTUAL but not UTILIZATION.
+func TestDataCategoryUtilization_IsValid(t *testing.T) {
+	assert.True(t, DataCategoryUtilization.IsValid())
+}
+
+func TestDataCategoryUtilization_String(t *testing.T) {
+	assert.Equal(t, "UTILIZATION", DataCategoryUtilization.String())
+}
+
+// TestDataCategory_AllThreeConstantsValid verifies all three category constants are valid.
+func TestDataCategory_AllThreeConstantsValid(t *testing.T) {
+	categories := []DataCategory{
+		DataCategoryPricing,
+		DataCategoryContextual,
+		DataCategoryUtilization,
+	}
+
+	for _, c := range categories {
+		assert.True(t, c.IsValid(), "expected %q to be valid", c)
+	}
+}
+
+// TestDataCategory_UnknownValuesInvalid verifies several invalid inputs.
+func TestDataCategory_UnknownValuesInvalid(t *testing.T) {
+	invalid := []DataCategory{
+		DataCategory("UNKNOWN"),
+		DataCategory(""),
+		DataCategory("pricing"),    // lowercase
+		DataCategory("PRICE"),      // partial match
+		DataCategory("contextual"), // lowercase
+	}
+
+	for _, c := range invalid {
+		assert.False(t, c.IsValid(), "expected %q to be invalid", c)
+	}
+}
+
+// TestDataCategory_StringPreservesArbitraryValue verifies String() returns
+// the underlying string even for non-constant values.
+func TestDataCategory_StringPreservesArbitraryValue(t *testing.T) {
+	custom := DataCategory("MY_CUSTOM_CATEGORY")
+	assert.Equal(t, "MY_CUSTOM_CATEGORY", custom.String())
+}
+
+// TestDataCategory_UsedAsMapKey verifies DataCategory can be used as a map key.
+func TestDataCategory_UsedAsMapKey(t *testing.T) {
+	labels := map[DataCategory]string{
+		DataCategoryPricing:     "market pricing",
+		DataCategoryContextual:  "reference data",
+		DataCategoryUtilization: "resource usage",
+	}
+
+	assert.Equal(t, "market pricing", labels[DataCategoryPricing])
+	assert.Equal(t, "reference data", labels[DataCategoryContextual])
+	assert.Equal(t, "resource usage", labels[DataCategoryUtilization])
+
+	_, exists := labels[DataCategory("NONEXISTENT")]
+	assert.False(t, exists)
+}
+
+// TestDataCategory_ConstantStringValues verifies underlying string values of constants.
+func TestDataCategory_ConstantStringValues(t *testing.T) {
+	assert.Equal(t, DataCategory("PRICING"), DataCategoryPricing)
+	assert.Equal(t, DataCategory("CONTEXTUAL"), DataCategoryContextual)
+	assert.Equal(t, DataCategory("UTILIZATION"), DataCategoryUtilization)
+}

--- a/services/market-information/domain/dataset_status_test.go
+++ b/services/market-information/domain/dataset_status_test.go
@@ -1,0 +1,94 @@
+package domain
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestErrInvalidStatusTransition_IsSentinelError verifies the sentinel error
+// can be detected via errors.Is after wrapping.
+func TestErrInvalidStatusTransition_IsSentinelError(t *testing.T) {
+	wrapped := errors.New("outer: " + ErrInvalidStatusTransition.Error())
+	// Direct match
+	assert.ErrorIs(t, ErrInvalidStatusTransition, ErrInvalidStatusTransition)
+	// Ensure it is actually the sentinel and not nil
+	assert.NotNil(t, ErrInvalidStatusTransition)
+	assert.NotNil(t, wrapped)
+}
+
+// TestDataSetStatus_CanTransitionTo_UnknownSource verifies unknown source status
+// cannot transition to any valid status.
+func TestDataSetStatus_CanTransitionTo_UnknownSource(t *testing.T) {
+	unknown := DataSetStatus("UNKNOWN_SOURCE")
+
+	assert.False(t, unknown.CanTransitionTo(DataSetStatusDraft))
+	assert.False(t, unknown.CanTransitionTo(DataSetStatusActive))
+	assert.False(t, unknown.CanTransitionTo(DataSetStatusDeprecated))
+}
+
+// TestDataSetStatus_CanTransitionTo_UnknownTarget verifies known source statuses
+// cannot transition to unknown target statuses.
+func TestDataSetStatus_CanTransitionTo_UnknownTarget(t *testing.T) {
+	unknown := DataSetStatus("UNKNOWN_TARGET")
+
+	assert.False(t, DataSetStatusDraft.CanTransitionTo(unknown))
+	assert.False(t, DataSetStatusActive.CanTransitionTo(unknown))
+	assert.False(t, DataSetStatusDeprecated.CanTransitionTo(unknown))
+}
+
+// TestValidateStatusTransition_WrapsErrInvalidStatusTransition verifies that errors
+// returned by ValidateStatusTransition wrap ErrInvalidStatusTransition with errors.Is.
+func TestValidateStatusTransition_WrapsErrInvalidStatusTransition(t *testing.T) {
+	tests := []struct {
+		name string
+		from DataSetStatus
+		to   DataSetStatus
+	}{
+		{"same status", DataSetStatusDraft, DataSetStatusDraft},
+		{"backward", DataSetStatusActive, DataSetStatusDraft},
+		{"from terminal", DataSetStatusDeprecated, DataSetStatusActive},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateStatusTransition(tt.from, tt.to)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, ErrInvalidStatusTransition),
+				"expected errors.Is match for ErrInvalidStatusTransition, got: %v", err)
+		})
+	}
+}
+
+// TestDataSetStatus_IsValid_AllKnownValues exhaustively tests all known status values.
+func TestDataSetStatus_IsValid_AllKnownValues(t *testing.T) {
+	valid := []DataSetStatus{DataSetStatusDraft, DataSetStatusActive, DataSetStatusDeprecated}
+	for _, s := range valid {
+		assert.True(t, s.IsValid(), "%q should be valid", s)
+	}
+
+	invalid := []DataSetStatus{
+		DataSetStatus(""),
+		DataSetStatus("draft"),
+		DataSetStatus("active"),
+		DataSetStatus("deprecated"),
+		DataSetStatus("UNKNOWN"),
+		DataSetStatus("PENDING"),
+	}
+	for _, s := range invalid {
+		assert.False(t, s.IsValid(), "%q should be invalid", s)
+	}
+}
+
+// TestDataSetStatus_ActiveTransitions verifies ACTIVE state transitions specifically.
+// ACTIVE can only go to DEPRECATED, not back to DRAFT.
+func TestDataSetStatus_ActiveTransitions(t *testing.T) {
+	assert.False(t, DataSetStatusActive.CanTransitionTo(DataSetStatusDraft),
+		"ACTIVE should not go back to DRAFT")
+	assert.True(t, DataSetStatusActive.CanTransitionTo(DataSetStatusDeprecated),
+		"ACTIVE should be deprecatable")
+	assert.False(t, DataSetStatusActive.CanTransitionTo(DataSetStatusActive),
+		"ACTIVE should not self-transition")
+}

--- a/services/tenant/provisioner/migration_runner_test.go
+++ b/services/tenant/provisioner/migration_runner_test.go
@@ -12,7 +12,7 @@ import (
 // writeMigrationFile creates a migration SQL file in the given directory.
 func writeMigrationFile(t *testing.T, dir, filename, content string) {
 	t.Helper()
-	err := os.WriteFile(filepath.Join(dir, filename), []byte(content), 0600)
+	err := os.WriteFile(filepath.Join(dir, filename), []byte(content), 0o600)
 	require.NoError(t, err)
 }
 
@@ -121,9 +121,9 @@ func TestReadMigrationFiles_IgnoresNonSQLFiles(t *testing.T) {
 	writeMigrationFile(t, dir, "001_init.sql", "CREATE TABLE foo (id INT);")
 
 	// Non-SQL files should be ignored
-	err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Migrations"), 0600)
+	err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Migrations"), 0o600)
 	require.NoError(t, err)
-	err = os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("notes"), 0600)
+	err = os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("notes"), 0o600)
 	require.NoError(t, err)
 
 	migrations, err := p.readMigrationFiles(dir)
@@ -140,7 +140,7 @@ func TestReadMigrationFiles_IgnoresSubdirectories(t *testing.T) {
 
 	// Create a subdirectory (should be ignored)
 	subdir := filepath.Join(dir, "subdir")
-	require.NoError(t, os.Mkdir(subdir, 0700))
+	require.NoError(t, os.Mkdir(subdir, 0o700))
 	writeMigrationFile(t, subdir, "002_sub.sql", "CREATE TABLE bar (id INT);")
 
 	migrations, err := p.readMigrationFiles(dir)
@@ -427,9 +427,9 @@ func TestReadMigrationFiles_MultipleFilesContent(t *testing.T) {
 	p := newMinimalProvisioner(nil)
 
 	files := map[string]string{
-		"001_create_tables.sql":  "CREATE TABLE foo (id INT);",
-		"002_add_indexes.sql":    "CREATE INDEX idx_foo ON foo(id);",
-		"003_seed_data.sql":      "INSERT INTO foo VALUES (1);",
+		"001_create_tables.sql": "CREATE TABLE foo (id INT);",
+		"002_add_indexes.sql":   "CREATE INDEX idx_foo ON foo(id);",
+		"003_seed_data.sql":     "INSERT INTO foo VALUES (1);",
 	}
 
 	for name, content := range files {
@@ -494,4 +494,3 @@ func TestReadMigrationFiles_SortingConsistency(t *testing.T) {
 	assert.Equal(t, "20251204000001_e.sql", migrations[3].Filename)
 	assert.Equal(t, "20251205000001_b.sql", migrations[4].Filename)
 }
-

--- a/services/tenant/provisioner/migration_runner_test.go
+++ b/services/tenant/provisioner/migration_runner_test.go
@@ -3,6 +3,7 @@ package provisioner
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -416,7 +417,8 @@ func TestProcessMigrationSQL_CaseInsensitiveCreateSchema(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := p.processMigrationSQL(tt.sql, "org_tenant")
-			assert.NotContains(t, result, tt.sql)
+			assert.False(t, strings.Contains(strings.ToUpper(result), "CREATE SCHEMA"),
+				"CREATE SCHEMA should be stripped from result, got: %q", result)
 		})
 	}
 }

--- a/services/tenant/provisioner/migration_runner_test.go
+++ b/services/tenant/provisioner/migration_runner_test.go
@@ -1,0 +1,497 @@
+package provisioner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeMigrationFile creates a migration SQL file in the given directory.
+func writeMigrationFile(t *testing.T, dir, filename, content string) {
+	t.Helper()
+	err := os.WriteFile(filepath.Join(dir, filename), []byte(content), 0600)
+	require.NoError(t, err)
+}
+
+func TestFilterMigrationsAfter_EmptyCurrentVersion(t *testing.T) {
+	migrations := []migration{
+		{Filename: "001_init.sql", Version: "001", Content: "CREATE TABLE foo (id INT)"},
+		{Filename: "002_add.sql", Version: "002", Content: "ALTER TABLE foo ADD COLUMN bar TEXT"},
+	}
+
+	// Empty current version should return nil as a safety guard
+	result := filterMigrationsAfter(migrations, "")
+	assert.Nil(t, result)
+}
+
+func TestFilterMigrationsAfter_NoNewMigrations(t *testing.T) {
+	migrations := []migration{
+		{Filename: "001_init.sql", Version: "001"},
+		{Filename: "002_add.sql", Version: "002"},
+	}
+
+	result := filterMigrationsAfter(migrations, "002")
+	assert.Empty(t, result)
+}
+
+func TestFilterMigrationsAfter_AllNewMigrations(t *testing.T) {
+	migrations := []migration{
+		{Filename: "002_add.sql", Version: "002"},
+		{Filename: "003_more.sql", Version: "003"},
+	}
+
+	result := filterMigrationsAfter(migrations, "001")
+	assert.Len(t, result, 2)
+	assert.Equal(t, "002", result[0].Version)
+	assert.Equal(t, "003", result[1].Version)
+}
+
+func TestFilterMigrationsAfter_SomeMigrationsNewer(t *testing.T) {
+	migrations := []migration{
+		{Filename: "001_init.sql", Version: "001"},
+		{Filename: "002_add.sql", Version: "002"},
+		{Filename: "003_more.sql", Version: "003"},
+		{Filename: "004_extra.sql", Version: "004"},
+	}
+
+	result := filterMigrationsAfter(migrations, "002")
+	require.Len(t, result, 2)
+	assert.Equal(t, "003", result[0].Version)
+	assert.Equal(t, "004", result[1].Version)
+}
+
+func TestFilterMigrationsAfter_DateBasedVersions(t *testing.T) {
+	migrations := []migration{
+		{Filename: "20251208000001_init.sql", Version: "20251208000001"},
+		{Filename: "20251209000001_add.sql", Version: "20251209000001"},
+		{Filename: "20260101000001_new.sql", Version: "20260101000001"},
+	}
+
+	result := filterMigrationsAfter(migrations, "20251208000001")
+	require.Len(t, result, 2)
+	assert.Equal(t, "20251209000001", result[0].Version)
+	assert.Equal(t, "20260101000001", result[1].Version)
+}
+
+func TestFilterMigrationsAfter_EmptyMigrationsList(t *testing.T) {
+	result := filterMigrationsAfter(nil, "001")
+	assert.Nil(t, result)
+}
+
+func TestReadMigrationFiles_EmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	p := newMinimalProvisioner(nil)
+
+	migrations, err := p.readMigrationFiles(dir)
+	require.NoError(t, err)
+	assert.Empty(t, migrations)
+}
+
+func TestReadMigrationFiles_NonExistentDirectory(t *testing.T) {
+	p := newMinimalProvisioner(nil)
+
+	migrations, err := p.readMigrationFiles("/nonexistent/path/that/does/not/exist")
+	require.NoError(t, err) // non-existent dir is valid (no migrations)
+	assert.Nil(t, migrations)
+}
+
+func TestReadMigrationFiles_ReadsSQLFiles(t *testing.T) {
+	dir := t.TempDir()
+	p := newMinimalProvisioner(nil)
+
+	writeMigrationFile(t, dir, "20251208000001_initial.sql", "CREATE TABLE foo (id INT);")
+	writeMigrationFile(t, dir, "20251209000001_add_column.sql", "ALTER TABLE foo ADD COLUMN name TEXT;")
+
+	migrations, err := p.readMigrationFiles(dir)
+	require.NoError(t, err)
+
+	require.Len(t, migrations, 2)
+	assert.Equal(t, "20251208000001_initial.sql", migrations[0].Filename)
+	assert.Equal(t, "20251208000001", migrations[0].Version)
+	assert.Equal(t, "CREATE TABLE foo (id INT);", migrations[0].Content)
+}
+
+func TestReadMigrationFiles_IgnoresNonSQLFiles(t *testing.T) {
+	dir := t.TempDir()
+	p := newMinimalProvisioner(nil)
+
+	writeMigrationFile(t, dir, "001_init.sql", "CREATE TABLE foo (id INT);")
+
+	// Non-SQL files should be ignored
+	err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Migrations"), 0600)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("notes"), 0600)
+	require.NoError(t, err)
+
+	migrations, err := p.readMigrationFiles(dir)
+	require.NoError(t, err)
+	require.Len(t, migrations, 1)
+	assert.Equal(t, "001_init.sql", migrations[0].Filename)
+}
+
+func TestReadMigrationFiles_IgnoresSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+	p := newMinimalProvisioner(nil)
+
+	writeMigrationFile(t, dir, "001_init.sql", "CREATE TABLE foo (id INT);")
+
+	// Create a subdirectory (should be ignored)
+	subdir := filepath.Join(dir, "subdir")
+	require.NoError(t, os.Mkdir(subdir, 0700))
+	writeMigrationFile(t, subdir, "002_sub.sql", "CREATE TABLE bar (id INT);")
+
+	migrations, err := p.readMigrationFiles(dir)
+	require.NoError(t, err)
+	require.Len(t, migrations, 1)
+	assert.Equal(t, "001_init.sql", migrations[0].Filename)
+}
+
+func TestReadMigrationFiles_SortedByFilename(t *testing.T) {
+	dir := t.TempDir()
+	p := newMinimalProvisioner(nil)
+
+	// Write out of alphabetical order
+	writeMigrationFile(t, dir, "003_third.sql", "-- third")
+	writeMigrationFile(t, dir, "001_first.sql", "-- first")
+	writeMigrationFile(t, dir, "002_second.sql", "-- second")
+
+	migrations, err := p.readMigrationFiles(dir)
+	require.NoError(t, err)
+
+	require.Len(t, migrations, 3)
+	assert.Equal(t, "001_first.sql", migrations[0].Filename)
+	assert.Equal(t, "002_second.sql", migrations[1].Filename)
+	assert.Equal(t, "003_third.sql", migrations[2].Filename)
+}
+
+func TestReadMigrationFiles_ExtractsVersionFromFilename(t *testing.T) {
+	dir := t.TempDir()
+	p := newMinimalProvisioner(nil)
+
+	writeMigrationFile(t, dir, "20251208211142_initial_schema.sql", "-- migration")
+
+	migrations, err := p.readMigrationFiles(dir)
+	require.NoError(t, err)
+
+	require.Len(t, migrations, 1)
+	assert.Equal(t, "20251208211142", migrations[0].Version)
+}
+
+func TestReadMigrationFiles_FileWithNoUnderscore(t *testing.T) {
+	dir := t.TempDir()
+	p := newMinimalProvisioner(nil)
+
+	// Filename with no underscore: version is the full name without .sql
+	writeMigrationFile(t, dir, "001.sql", "-- no underscore")
+
+	migrations, err := p.readMigrationFiles(dir)
+	require.NoError(t, err)
+
+	require.Len(t, migrations, 1)
+	assert.Equal(t, "001", migrations[0].Version)
+}
+
+func TestProcessMigrationSQL_RemovesCreateSchemaStatements(t *testing.T) {
+	p := newMinimalProvisioner(nil)
+	sql := `CREATE SCHEMA my_schema;
+CREATE TABLE foo (id INT);`
+
+	result := p.processMigrationSQL(sql, "org_tenant")
+
+	assert.NotContains(t, result, "CREATE SCHEMA")
+	assert.Contains(t, result, "CREATE TABLE foo")
+}
+
+func TestProcessMigrationSQL_RemovesCreateSchemaIfNotExists(t *testing.T) {
+	p := newMinimalProvisioner(nil)
+	sql := `CREATE SCHEMA IF NOT EXISTS my_schema;
+CREATE TABLE users (id INT);`
+
+	result := p.processMigrationSQL(sql, "org_tenant")
+
+	assert.NotContains(t, result, "CREATE SCHEMA")
+	assert.Contains(t, result, "CREATE TABLE users")
+}
+
+func TestProcessMigrationSQL_ReplacesSchemaReferences(t *testing.T) {
+	p := newMinimalProvisioner(nil)
+
+	tests := []struct {
+		name     string
+		input    string
+		contains string
+	}{
+		{
+			name:     "quoted current_account schema",
+			input:    `ALTER TABLE "current_account"."accounts" ADD COLUMN balance NUMERIC;`,
+			contains: `"org_tenant".`,
+		},
+		{
+			name:     "quoted party schema",
+			input:    `SELECT * FROM "party"."customers";`,
+			contains: `"org_tenant".`,
+		},
+		{
+			name:     "unquoted position_keeping schema",
+			input:    `CREATE INDEX ON position_keeping.ledger (id);`,
+			contains: `org_tenant.`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := p.processMigrationSQL(tt.input, "org_tenant")
+			assert.Contains(t, result, tt.contains)
+		})
+	}
+}
+
+func TestProcessMigrationSQL_NoTransformationsNeeded(t *testing.T) {
+	p := newMinimalProvisioner(nil)
+	sql := `CREATE TABLE products (id UUID PRIMARY KEY, name TEXT NOT NULL);`
+
+	result := p.processMigrationSQL(sql, "org_tenant")
+	assert.Equal(t, sql, result)
+}
+
+func TestSplitSQLStatements_SingleStatement(t *testing.T) {
+	sql := `CREATE TABLE foo (id INT)`
+
+	statements := splitSQLStatements(sql)
+	require.Len(t, statements, 1)
+	assert.Equal(t, "CREATE TABLE foo (id INT)", statements[0])
+}
+
+func TestSplitSQLStatements_MultipleStatements(t *testing.T) {
+	sql := `CREATE TABLE foo (id INT);
+CREATE TABLE bar (id INT);
+CREATE INDEX idx_foo ON foo (id);`
+
+	statements := splitSQLStatements(sql)
+	require.Len(t, statements, 3)
+	assert.Equal(t, "CREATE TABLE foo (id INT)", statements[0])
+	assert.Equal(t, "CREATE TABLE bar (id INT)", statements[1])
+	assert.Equal(t, "CREATE INDEX idx_foo ON foo (id)", statements[2])
+}
+
+func TestSplitSQLStatements_SkipsEmptyStatements(t *testing.T) {
+	sql := `CREATE TABLE foo (id INT);;; CREATE TABLE bar (id INT);`
+
+	statements := splitSQLStatements(sql)
+	require.Len(t, statements, 2)
+}
+
+func TestSplitSQLStatements_PreservesSemicolonInStringLiteral(t *testing.T) {
+	sql := `INSERT INTO config (key, value) VALUES ('delimiter', ';');`
+
+	statements := splitSQLStatements(sql)
+	require.Len(t, statements, 1)
+	assert.Contains(t, statements[0], "';'")
+}
+
+func TestSplitSQLStatements_HandlesLineComments(t *testing.T) {
+	sql := `-- This creates the foo table
+CREATE TABLE foo (id INT); -- inline comment
+CREATE TABLE bar (id INT);`
+
+	statements := splitSQLStatements(sql)
+	require.Len(t, statements, 2)
+	assert.Contains(t, statements[0], "CREATE TABLE foo")
+	assert.Contains(t, statements[1], "CREATE TABLE bar")
+}
+
+func TestSplitSQLStatements_HandlesBlockComments(t *testing.T) {
+	sql := `/* Create the foo table */
+CREATE TABLE foo (id INT);
+/* Another comment */
+CREATE TABLE bar (id INT);`
+
+	statements := splitSQLStatements(sql)
+	require.Len(t, statements, 2)
+}
+
+func TestSplitSQLStatements_EmptyInput(t *testing.T) {
+	statements := splitSQLStatements("")
+	assert.Empty(t, statements)
+}
+
+func TestSplitSQLStatements_WhitespaceOnly(t *testing.T) {
+	statements := splitSQLStatements("   \n\t  ")
+	assert.Empty(t, statements)
+}
+
+func TestSplitSQLStatements_EscapedQuoteInString(t *testing.T) {
+	// Single-quoted string with escaped single quote ''
+	sql := `INSERT INTO messages (text) VALUES ('it''s here');`
+
+	statements := splitSQLStatements(sql)
+	require.Len(t, statements, 1)
+	assert.Contains(t, statements[0], "it''s here")
+}
+
+func TestSplitSQLStatements_TrimsWhitespace(t *testing.T) {
+	sql := `   CREATE TABLE foo (id INT)   ;   CREATE TABLE bar (id INT)   ;`
+
+	statements := splitSQLStatements(sql)
+	require.Len(t, statements, 2)
+	assert.Equal(t, "CREATE TABLE foo (id INT)", statements[0])
+	assert.Equal(t, "CREATE TABLE bar (id INT)", statements[1])
+}
+
+// TestMigration_VersionExtraction_DateFormat verifies the migration struct
+// correctly stores filename, version, and content.
+func TestMigration_Fields(t *testing.T) {
+	m := migration{
+		Filename: "20251208211142_initial.sql",
+		Version:  "20251208211142",
+		Content:  "CREATE TABLE test (id INT);",
+	}
+
+	assert.Equal(t, "20251208211142_initial.sql", m.Filename)
+	assert.Equal(t, "20251208211142", m.Version)
+	assert.Equal(t, "CREATE TABLE test (id INT);", m.Content)
+}
+
+// TestFilterMigrationsAfter_PreservesOrder verifies filtered migrations maintain sort order.
+func TestFilterMigrationsAfter_PreservesOrder(t *testing.T) {
+	migrations := []migration{
+		{Version: "001"},
+		{Version: "002"},
+		{Version: "003"},
+		{Version: "004"},
+		{Version: "005"},
+	}
+
+	result := filterMigrationsAfter(migrations, "002")
+	require.Len(t, result, 3)
+	assert.Equal(t, "003", result[0].Version)
+	assert.Equal(t, "004", result[1].Version)
+	assert.Equal(t, "005", result[2].Version)
+}
+
+// TestReadMigrationFiles_ReadsContent verifies file content is read correctly.
+func TestReadMigrationFiles_ReadsContent(t *testing.T) {
+	dir := t.TempDir()
+	p := newMinimalProvisioner(nil)
+
+	sqlContent := "CREATE TABLE important (id UUID PRIMARY KEY DEFAULT gen_random_uuid());"
+	writeMigrationFile(t, dir, "001_important.sql", sqlContent)
+
+	migrations, err := p.readMigrationFiles(dir)
+	require.NoError(t, err)
+	require.Len(t, migrations, 1)
+	assert.Equal(t, sqlContent, migrations[0].Content)
+}
+
+// TestApplyMigrationList_EmptyList returns empty string and no error.
+func TestApplyMigrationList_EmptyList(t *testing.T) {
+	p := newMinimalProvisioner(nil)
+
+	// applyMigrationList with empty slice should return empty version and no error
+	// We test via readMigrationFiles returning empty + checking applyServiceMigrationsToDB path
+	_ = p // prevent unused variable - applyMigrationList requires a DB so we test readMigrationFiles instead
+
+	// Verify that filterMigrationsAfter with an empty migration list and a current version
+	// returns nil (no migrations to apply)
+	result := filterMigrationsAfter([]migration{}, "001")
+	assert.Nil(t, result)
+}
+
+// TestProcessMigrationSQL_CaseInsensitiveCreateSchema verifies CREATE SCHEMA detection is case-insensitive.
+func TestProcessMigrationSQL_CaseInsensitiveCreateSchema(t *testing.T) {
+	p := newMinimalProvisioner(nil)
+
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{"all caps", "CREATE SCHEMA test_schema;"},
+		{"mixed case", "Create Schema test_schema;"},
+		{"lowercase", "create schema test_schema;"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := p.processMigrationSQL(tt.sql, "org_tenant")
+			assert.NotContains(t, result, tt.sql)
+		})
+	}
+}
+
+// TestReadMigrationFiles_MultipleMigrationsWithContent ensures content is preserved for all files.
+func TestReadMigrationFiles_MultipleFilesContent(t *testing.T) {
+	dir := t.TempDir()
+	p := newMinimalProvisioner(nil)
+
+	files := map[string]string{
+		"001_create_tables.sql":  "CREATE TABLE foo (id INT);",
+		"002_add_indexes.sql":    "CREATE INDEX idx_foo ON foo(id);",
+		"003_seed_data.sql":      "INSERT INTO foo VALUES (1);",
+	}
+
+	for name, content := range files {
+		writeMigrationFile(t, dir, name, content)
+	}
+
+	migrations, err := p.readMigrationFiles(dir)
+	require.NoError(t, err)
+	require.Len(t, migrations, 3)
+
+	// Sorted by filename
+	assert.Equal(t, "001_create_tables.sql", migrations[0].Filename)
+	assert.Equal(t, "001", migrations[0].Version)
+	assert.Contains(t, migrations[0].Content, "CREATE TABLE foo")
+}
+
+// TestApplyMigrationList_ReturnsEmptyVersionForEmptyList mirrors the behavior documented in the code.
+func TestApplyMigrationList_ReturnsEmptyForNoMigrations(t *testing.T) {
+	// applyMigrationList with nil migrations should not be called, but we verify
+	// that the filter returns nil for empty lists correctly.
+	result := filterMigrationsAfter(nil, "20251208")
+	assert.Nil(t, result)
+}
+
+// TestFilterMigrationsAfter_ExactCurrentVersion verifies exact version match is NOT included.
+func TestFilterMigrationsAfter_ExactCurrentVersionNotIncluded(t *testing.T) {
+	migrations := []migration{
+		{Version: "001"},
+		{Version: "002"},
+	}
+
+	// "002" is current, nothing should be returned (not strictly greater than)
+	result := filterMigrationsAfter(migrations, "002")
+	assert.Empty(t, result)
+}
+
+// TestReadMigrationFiles_LargeNumberOfFiles verifies correct sorting for many files.
+func TestReadMigrationFiles_SortingConsistency(t *testing.T) {
+	dir := t.TempDir()
+	p := newMinimalProvisioner(nil)
+
+	filenames := []string{
+		"20251201000001_a.sql",
+		"20251205000001_b.sql",
+		"20251203000001_c.sql",
+		"20251202000001_d.sql",
+		"20251204000001_e.sql",
+	}
+
+	for _, fn := range filenames {
+		writeMigrationFile(t, dir, fn, "-- "+fn)
+	}
+
+	migrations, err := p.readMigrationFiles(dir)
+	require.NoError(t, err)
+	require.Len(t, migrations, 5)
+
+	// Verify sorted order
+	assert.Equal(t, "20251201000001_a.sql", migrations[0].Filename)
+	assert.Equal(t, "20251202000001_d.sql", migrations[1].Filename)
+	assert.Equal(t, "20251203000001_c.sql", migrations[2].Filename)
+	assert.Equal(t, "20251204000001_e.sql", migrations[3].Filename)
+	assert.Equal(t, "20251205000001_b.sql", migrations[4].Filename)
+}
+

--- a/services/tenant/provisioner/provisioner_persistence_test.go
+++ b/services/tenant/provisioner/provisioner_persistence_test.go
@@ -281,8 +281,10 @@ func TestPostgresProvisioner_StatusToEntity_RoundTrip(t *testing.T) {
 	assert.Equal(t, original.ErrorMessage, restored.ErrorMessage)
 	require.Len(t, restored.Services, 1)
 	assert.Equal(t, original.Services[0].ServiceName, restored.Services[0].ServiceName)
+	assert.Equal(t, original.Services[0].SchemaName, restored.Services[0].SchemaName)
 	assert.Equal(t, original.Services[0].State, restored.Services[0].State)
 	assert.Equal(t, original.Services[0].MigrationVersion, restored.Services[0].MigrationVersion)
+	assert.Equal(t, original.Services[0].ErrorMessage, restored.Services[0].ErrorMessage)
 }
 
 func TestPostgresProvisioner_CreateInitialServiceStatuses(t *testing.T) {

--- a/services/tenant/provisioner/provisioner_persistence_test.go
+++ b/services/tenant/provisioner/provisioner_persistence_test.go
@@ -1,6 +1,7 @@
 package provisioner
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -243,8 +244,13 @@ func TestPostgresProvisioner_StatusToEntity_WithServices(t *testing.T) {
 	entity, err := p.statusToEntity(status)
 	require.NoError(t, err)
 
-	assert.Contains(t, entity.ServiceSchemas, "party")
-	assert.Contains(t, entity.ServiceSchemas, "org_test_tenant")
+	var decoded []ServiceSchemaStatus
+	require.NoError(t, json.Unmarshal([]byte(entity.ServiceSchemas), &decoded))
+	require.Len(t, decoded, 1)
+	assert.Equal(t, "party", decoded[0].ServiceName)
+	assert.Equal(t, "org_test_tenant", decoded[0].SchemaName)
+	assert.Equal(t, ServiceStateMigrated, decoded[0].State)
+	assert.Equal(t, "20251208", decoded[0].MigrationVersion)
 }
 
 func TestPostgresProvisioner_StatusToEntity_RoundTrip(t *testing.T) {

--- a/services/tenant/provisioner/provisioner_persistence_test.go
+++ b/services/tenant/provisioner/provisioner_persistence_test.go
@@ -1,0 +1,348 @@
+package provisioner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newMinimalProvisioner creates a PostgresProvisioner with only config set,
+// for testing pure conversion functions that do not require a database connection.
+func newMinimalProvisioner(services []ServiceConfig) *PostgresProvisioner {
+	return &PostgresProvisioner{
+		config: &Config{
+			Services:            services,
+			ProvisioningTimeout: 30 * time.Second,
+		},
+	}
+}
+
+func TestProvisioningEntity_TableName(t *testing.T) {
+	entity := provisioningEntity{}
+	assert.Equal(t, "tenant_provisioning", entity.TableName())
+}
+
+func TestPostgresProvisioner_EntityToStatus_MinimalEntity(t *testing.T) {
+	p := newMinimalProvisioner(nil)
+	tenantID := tenant.MustNewTenantID("acme_bank")
+
+	now := time.Now().Truncate(time.Second)
+	entity := &provisioningEntity{
+		TenantID:  tenantID.String(),
+		State:     string(StateActive),
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	status, err := p.entityToStatus(tenantID, entity)
+	require.NoError(t, err)
+
+	assert.Equal(t, tenantID, status.TenantID)
+	assert.Equal(t, StateActive, status.State)
+	assert.Empty(t, status.ErrorMessage)
+	assert.Nil(t, status.DeprovisionedAt)
+	assert.Empty(t, status.Services)
+}
+
+func TestPostgresProvisioner_EntityToStatus_WithErrorMessage(t *testing.T) {
+	p := newMinimalProvisioner(nil)
+	tenantID := tenant.MustNewTenantID("failed_tenant")
+
+	errMsg := "database connection refused"
+	entity := &provisioningEntity{
+		TenantID:     tenantID.String(),
+		State:        string(StateFailed),
+		ErrorMessage: &errMsg,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	status, err := p.entityToStatus(tenantID, entity)
+	require.NoError(t, err)
+
+	assert.Equal(t, StateFailed, status.State)
+	assert.Equal(t, errMsg, status.ErrorMessage)
+}
+
+func TestPostgresProvisioner_EntityToStatus_WithDeprovisionedAt(t *testing.T) {
+	p := newMinimalProvisioner(nil)
+	tenantID := tenant.MustNewTenantID("deprovisioned_tenant")
+
+	deprovisionedAt := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
+	entity := &provisioningEntity{
+		TenantID:        tenantID.String(),
+		State:           string(StateDeprovisioned),
+		DeprovisionedAt: &deprovisionedAt,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+	}
+
+	status, err := p.entityToStatus(tenantID, entity)
+	require.NoError(t, err)
+
+	assert.Equal(t, StateDeprovisioned, status.State)
+	require.NotNil(t, status.DeprovisionedAt)
+	assert.Equal(t, deprovisionedAt, *status.DeprovisionedAt)
+}
+
+func TestPostgresProvisioner_EntityToStatus_WithServices(t *testing.T) {
+	p := newMinimalProvisioner(nil)
+	tenantID := tenant.MustNewTenantID("test_tenant")
+
+	entity := &provisioningEntity{
+		TenantID:       tenantID.String(),
+		State:          string(StateActive),
+		ServiceSchemas: `[{"ServiceName":"party","SchemaName":"org_test_tenant","State":"migrated","MigrationVersion":"20251208","ErrorMessage":""}]`,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+
+	status, err := p.entityToStatus(tenantID, entity)
+	require.NoError(t, err)
+
+	require.Len(t, status.Services, 1)
+	assert.Equal(t, "party", status.Services[0].ServiceName)
+	assert.Equal(t, "org_test_tenant", status.Services[0].SchemaName)
+	assert.Equal(t, ServiceStateMigrated, status.Services[0].State)
+	assert.Equal(t, "20251208", status.Services[0].MigrationVersion)
+}
+
+func TestPostgresProvisioner_EntityToStatus_InvalidJSON(t *testing.T) {
+	p := newMinimalProvisioner(nil)
+	tenantID := tenant.MustNewTenantID("bad_tenant")
+
+	entity := &provisioningEntity{
+		TenantID:       tenantID.String(),
+		State:          string(StateActive),
+		ServiceSchemas: `invalid json {{{`,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+
+	_, err := p.entityToStatus(tenantID, entity)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal service_schemas")
+}
+
+func TestPostgresProvisioner_EntityToStatus_EmptyServiceSchemas(t *testing.T) {
+	p := newMinimalProvisioner(nil)
+	tenantID := tenant.MustNewTenantID("empty_services")
+
+	entity := &provisioningEntity{
+		TenantID:       tenantID.String(),
+		State:          string(StatePending),
+		ServiceSchemas: "",
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+
+	status, err := p.entityToStatus(tenantID, entity)
+	require.NoError(t, err)
+	assert.Empty(t, status.Services)
+}
+
+func TestPostgresProvisioner_EntityToStatus_EmptyArrayServiceSchemas(t *testing.T) {
+	p := newMinimalProvisioner(nil)
+	tenantID := tenant.MustNewTenantID("empty_array")
+
+	entity := &provisioningEntity{
+		TenantID:       tenantID.String(),
+		State:          string(StatePending),
+		ServiceSchemas: "[]",
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+
+	status, err := p.entityToStatus(tenantID, entity)
+	require.NoError(t, err)
+	assert.Empty(t, status.Services)
+}
+
+func TestPostgresProvisioner_StatusToEntity_MinimalStatus(t *testing.T) {
+	p := newMinimalProvisioner(nil)
+	tenantID := tenant.MustNewTenantID("acme_bank")
+
+	now := time.Now().Truncate(time.Second)
+	status := &ProvisioningStatus{
+		TenantID:  tenantID,
+		State:     StateActive,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	entity, err := p.statusToEntity(status)
+	require.NoError(t, err)
+
+	assert.Equal(t, tenantID.String(), entity.TenantID)
+	assert.Equal(t, string(StateActive), entity.State)
+	assert.Nil(t, entity.ErrorMessage)
+	assert.Nil(t, entity.DeprovisionedAt)
+}
+
+func TestPostgresProvisioner_StatusToEntity_WithErrorMessage(t *testing.T) {
+	p := newMinimalProvisioner(nil)
+	tenantID := tenant.MustNewTenantID("failed_tenant")
+
+	status := &ProvisioningStatus{
+		TenantID:     tenantID,
+		State:        StateFailed,
+		ErrorMessage: "migration script failed",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	entity, err := p.statusToEntity(status)
+	require.NoError(t, err)
+
+	require.NotNil(t, entity.ErrorMessage)
+	assert.Equal(t, "migration script failed", *entity.ErrorMessage)
+}
+
+func TestPostgresProvisioner_StatusToEntity_WithDeprovisionedAt(t *testing.T) {
+	p := newMinimalProvisioner(nil)
+	tenantID := tenant.MustNewTenantID("deprovisioned_tenant")
+
+	deprovAt := time.Now().Add(-time.Hour).Truncate(time.Second)
+	status := &ProvisioningStatus{
+		TenantID:        tenantID,
+		State:           StateDeprovisioned,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+		DeprovisionedAt: &deprovAt,
+	}
+
+	entity, err := p.statusToEntity(status)
+	require.NoError(t, err)
+
+	require.NotNil(t, entity.DeprovisionedAt)
+	assert.Equal(t, deprovAt, *entity.DeprovisionedAt)
+}
+
+func TestPostgresProvisioner_StatusToEntity_WithServices(t *testing.T) {
+	p := newMinimalProvisioner(nil)
+	tenantID := tenant.MustNewTenantID("test_tenant")
+
+	status := &ProvisioningStatus{
+		TenantID: tenantID,
+		State:    StateActive,
+		Services: []ServiceSchemaStatus{
+			{
+				ServiceName:      "party",
+				SchemaName:       "org_test_tenant",
+				State:            ServiceStateMigrated,
+				MigrationVersion: "20251208",
+			},
+		},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	entity, err := p.statusToEntity(status)
+	require.NoError(t, err)
+
+	assert.Contains(t, entity.ServiceSchemas, "party")
+	assert.Contains(t, entity.ServiceSchemas, "org_test_tenant")
+}
+
+func TestPostgresProvisioner_StatusToEntity_RoundTrip(t *testing.T) {
+	p := newMinimalProvisioner(nil)
+	tenantID := tenant.MustNewTenantID("roundtrip_tenant")
+
+	now := time.Now().Truncate(time.Millisecond)
+	errMsg := "test error"
+	original := &ProvisioningStatus{
+		TenantID:     tenantID,
+		State:        StateFailed,
+		ErrorMessage: errMsg,
+		Services: []ServiceSchemaStatus{
+			{
+				ServiceName:      "party",
+				SchemaName:       "org_roundtrip_tenant",
+				State:            ServiceStateFailed,
+				MigrationVersion: "20251208",
+				ErrorMessage:     "failed",
+			},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	entity, err := p.statusToEntity(original)
+	require.NoError(t, err)
+
+	restored, err := p.entityToStatus(tenantID, entity)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.TenantID, restored.TenantID)
+	assert.Equal(t, original.State, restored.State)
+	assert.Equal(t, original.ErrorMessage, restored.ErrorMessage)
+	require.Len(t, restored.Services, 1)
+	assert.Equal(t, original.Services[0].ServiceName, restored.Services[0].ServiceName)
+	assert.Equal(t, original.Services[0].State, restored.Services[0].State)
+	assert.Equal(t, original.Services[0].MigrationVersion, restored.Services[0].MigrationVersion)
+}
+
+func TestPostgresProvisioner_CreateInitialServiceStatuses(t *testing.T) {
+	services := []ServiceConfig{
+		{Name: "party", MigrationPath: "/path/party"},
+		{Name: "current-account", MigrationPath: "/path/current-account"},
+		{Name: "position-keeping", MigrationPath: "/path/position-keeping"},
+	}
+	p := newMinimalProvisioner(services)
+	tenantID := tenant.MustNewTenantID("acme_bank")
+
+	statuses := p.createInitialServiceStatuses(tenantID)
+
+	require.Len(t, statuses, 3)
+
+	expectedSchema := tenantID.SchemaName()
+	for _, svc := range statuses {
+		assert.Equal(t, expectedSchema, svc.SchemaName)
+		assert.Equal(t, ServiceStatePending, svc.State)
+	}
+
+	assert.Equal(t, "party", statuses[0].ServiceName)
+	assert.Equal(t, "current-account", statuses[1].ServiceName)
+	assert.Equal(t, "position-keeping", statuses[2].ServiceName)
+}
+
+func TestPostgresProvisioner_CreateInitialServiceStatuses_PreservesOrder(t *testing.T) {
+	services := []ServiceConfig{
+		{Name: "svc-z", MigrationPath: "/z"},
+		{Name: "svc-a", MigrationPath: "/a"},
+		{Name: "svc-m", MigrationPath: "/m"},
+	}
+	p := newMinimalProvisioner(services)
+	tenantID := tenant.MustNewTenantID("order_tenant")
+
+	statuses := p.createInitialServiceStatuses(tenantID)
+
+	require.Len(t, statuses, 3)
+	assert.Equal(t, "svc-z", statuses[0].ServiceName)
+	assert.Equal(t, "svc-a", statuses[1].ServiceName)
+	assert.Equal(t, "svc-m", statuses[2].ServiceName)
+}
+
+func TestPostgresProvisioner_CreateInitialServiceStatuses_EmptyServices(t *testing.T) {
+	p := newMinimalProvisioner([]ServiceConfig{})
+	tenantID := tenant.MustNewTenantID("empty_tenant")
+
+	statuses := p.createInitialServiceStatuses(tenantID)
+	assert.Empty(t, statuses)
+}
+
+func TestPostgresProvisioner_CreateInitialServiceStatuses_SchemaName(t *testing.T) {
+	services := []ServiceConfig{
+		{Name: "party", MigrationPath: "/path"},
+	}
+	p := newMinimalProvisioner(services)
+	tenantID := tenant.MustNewTenantID("beta_corp")
+
+	statuses := p.createInitialServiceStatuses(tenantID)
+
+	require.Len(t, statuses, 1)
+	assert.Equal(t, "org_beta_corp", statuses[0].SchemaName)
+}


### PR DESCRIPTION
## Summary

- Adds unit tests for `base_repository` (construction, search path, transaction wrapping) using a shared PostgreSQL testcontainer via `TestMain`
- Adds unit tests for `NewRepositories` (panic on empty master tenant ID, all fields populated)
- Adds unit tests for `DataCategory` and `DataSetStatus` domain types (complementing existing coverage in `dataset_test.go`)
- Adds unit tests for `PostgresProvisioner` persistence helpers: `entityToStatus`, `statusToEntity`, `createInitialServiceStatuses`, `TableName`
- Adds unit tests for migration runner pure functions: `filterMigrationsAfter`, `readMigrationFiles`, `processMigrationSQL`, `splitSQLStatements`

## Test plan

- [ ] `go test ./services/market-information/adapters/persistence/... -run "TestBaseRepository|TestNewBase|TestNewRepositories"` - all pass
- [ ] `go test ./services/market-information/domain/... -run "TestDataCategory|TestDataSetStatus|TestValidateStatus|TestErr"` - all pass
- [ ] `go test ./services/tenant/provisioner/... -run "TestProvisioningEntity|TestPostgresProvisioner_Entity|TestPostgresProvisioner_Status|TestPostgresProvisioner_Create|TestFilter|TestReadMigration|TestProcessMigration|TestSplitSQL|TestMigration"` - all pass