### PR TITLE
feat: bare domain registration with slug availability checking

### DIFF
--- a/cmd/meridian/gateway.go
+++ b/cmd/meridian/gateway.go
@@ -224,16 +224,28 @@ func (a *loopbackTenantCreator) DeleteTenant(ctx context.Context, tenantID strin
 	return err
 }
 
+// loopbackSlugChecker adapts the tenant persistence repository to the
+// gateway.SlugChecker interface used by RegistrationHandler.
+type loopbackSlugChecker struct {
+	repo *tenantpersistence.Repository
+}
+
+func (c *loopbackSlugChecker) IsSlugAvailable(ctx context.Context, slug string) (bool, error) {
+	return c.repo.IsSlugAvailable(ctx, slug)
+}
+
 // wireRegistration creates the self-service registration handler and returns
 // a ServerOption to install it. Returns nil on error (graceful degradation).
-func wireRegistration(identityDB *gorm.DB, rawConn *grpc.ClientConn, baseDomain string, logger *slog.Logger) gateway.ServerOption {
+func wireRegistration(identityDB, tenantDB *gorm.DB, rawConn *grpc.ClientConn, baseDomain string, logger *slog.Logger) gateway.ServerOption {
 	identityRepo := identitypersistence.NewRepository(identityDB)
 	tenantClient := tenantv1.NewTenantServiceClient(rawConn)
 
 	creator := &loopbackTenantCreator{client: tenantClient, logger: logger}
+	slugChecker := &loopbackSlugChecker{repo: tenantpersistence.NewRepository(tenantDB)}
 
 	handler, err := gateway.NewRegistrationHandler(gateway.RegistrationHandlerConfig{
 		TenantCreator: creator,
+		SlugChecker:   slugChecker,
 		IdentityRepo:  identityRepo,
 		BaseDomain:    baseDomain,
 		Logger:        logger,

--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -261,7 +261,7 @@ func run(logger *slog.Logger, grpcPort, httpPort int) error {
 
 	// Wire self-service registration handler (public endpoint, no auth required).
 	baseDomain := env.GetEnvOrDefault("BASE_DOMAIN", "localhost")
-	if regOpt := wireRegistration(conns.gormDB("identity"), loopback.rawConn, baseDomain, logger); regOpt != nil {
+	if regOpt := wireRegistration(conns.gormDB("identity"), conns.gormDB("tenant"), loopback.rawConn, baseDomain, logger); regOpt != nil {
 		extraGWOpts = append(extraGWOpts, regOpt)
 	}
 

--- a/frontend/src/features/registration/pages/register-page.test.tsx
+++ b/frontend/src/features/registration/pages/register-page.test.tsx
@@ -5,6 +5,33 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { renderWithProviders } from '@/test/test-utils'
 import { RegisterPage } from './register-page'
 
+/** Mock fetch to handle both registration and slug availability endpoints. */
+function mockFetchForRegistration(overrides?: {
+  registerStatus?: number
+  registerBody?: object
+  slugAvailable?: boolean
+}) {
+  const {
+    registerStatus = 201,
+    registerBody = { tenant_id: 'my-org', login_url: '/login?tenant=my-org' },
+    slugAvailable = true,
+  } = overrides ?? {}
+
+  return vi.spyOn(global, 'fetch').mockImplementation(async (input) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url
+    if (url.includes('/api/v1/slugs/')) {
+      return new Response(JSON.stringify({ available: slugAvailable }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    return new Response(JSON.stringify(registerBody), {
+      status: registerStatus,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  })
+}
+
 function setup() {
   const user = userEvent.setup({ delay: null })
   renderWithProviders(
@@ -20,12 +47,7 @@ function setup() {
 
 describe('RegisterPage', () => {
   beforeEach(() => {
-    vi.spyOn(global, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ tenant_id: 'my-org', login_url: '/login?tenant=my-org' }), {
-        status: 201,
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    )
+    mockFetchForRegistration()
   })
 
   afterEach(() => {
@@ -62,18 +84,27 @@ describe('RegisterPage', () => {
   it('shows slug validation error for too-short slug after debounce', async () => {
     const { user } = setup()
     await user.type(screen.getByLabelText(/organization slug/i), 'ab')
-    await new Promise((resolve) => setTimeout(resolve, 400))
     await waitFor(() => {
       expect(screen.getByText(/at least 3 characters/i)).toBeInTheDocument()
     })
   }, 8000)
 
-  it('shows slug format ok message for valid slug after debounce', async () => {
+  it('shows slug available message after checking backend', async () => {
     const { user } = setup()
     await user.type(screen.getByLabelText(/organization slug/i), 'my-org')
-    await new Promise((resolve) => setTimeout(resolve, 400))
     await waitFor(() => {
-      expect(screen.getByText(/slug format looks good/i)).toBeInTheDocument()
+      expect(screen.getByText(/slug is available/i)).toBeInTheDocument()
+    })
+  }, 8000)
+
+  it('shows slug taken message when backend reports unavailable', async () => {
+    vi.restoreAllMocks()
+    mockFetchForRegistration({ slugAvailable: false })
+
+    const { user } = setup()
+    await user.type(screen.getByLabelText(/organization slug/i), 'taken-org')
+    await waitFor(() => {
+      expect(screen.getByText(/slug is already taken/i)).toBeInTheDocument()
     })
   }, 8000)
 
@@ -102,12 +133,11 @@ describe('RegisterPage', () => {
   })
 
   it('shows error on 409 slug conflict', async () => {
-    vi.spyOn(global, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ error: 'slug is already taken' }), {
-        status: 409,
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    )
+    vi.restoreAllMocks()
+    mockFetchForRegistration({
+      registerStatus: 409,
+      registerBody: { error: 'slug is already taken' },
+    })
 
     const { user } = setup()
     await user.type(screen.getByLabelText(/organization slug/i), 'taken-slug')
@@ -121,12 +151,8 @@ describe('RegisterPage', () => {
   })
 
   it('shows error on 429 rate limit', async () => {
-    vi.spyOn(global, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ error: 'too many requests' }), {
-        status: 429,
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    )
+    vi.restoreAllMocks()
+    mockFetchForRegistration({ registerStatus: 429, registerBody: { error: 'too many requests' } })
 
     const { user } = setup()
     await user.type(screen.getByLabelText(/organization slug/i), 'my-org')
@@ -152,7 +178,17 @@ describe('RegisterPage', () => {
   })
 
   it('shows error on network failure', async () => {
-    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('Network error'))
+    vi.restoreAllMocks()
+    vi.spyOn(global, 'fetch').mockImplementation(async (input) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url
+      if (url.includes('/api/v1/slugs/')) {
+        return new Response(JSON.stringify({ available: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      throw new Error('Network error')
+    })
 
     const { user } = setup()
     await user.type(screen.getByLabelText(/organization slug/i), 'my-org')
@@ -166,10 +202,18 @@ describe('RegisterPage', () => {
   })
 
   it('shows loading state while submitting', async () => {
+    vi.restoreAllMocks()
     let resolveFetch!: (value: Response) => void
-    vi.spyOn(global, 'fetch').mockImplementation(
-      () => new Promise<Response>((resolve) => { resolveFetch = resolve }),
-    )
+    vi.spyOn(global, 'fetch').mockImplementation(async (input) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url
+      if (url.includes('/api/v1/slugs/')) {
+        return new Response(JSON.stringify({ available: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      return new Promise<Response>((resolve) => { resolveFetch = resolve })
+    })
 
     const { user } = setup()
     await user.type(screen.getByLabelText(/organization slug/i), 'my-org')
@@ -202,4 +246,18 @@ describe('RegisterPage', () => {
     await user.tab()
     expect(document.activeElement).toBe(screen.getByLabelText(/password/i))
   })
+
+  it('disables submit button when slug is taken', async () => {
+    vi.restoreAllMocks()
+    mockFetchForRegistration({ slugAvailable: false })
+
+    const { user } = setup()
+    await user.type(screen.getByLabelText(/organization slug/i), 'taken-org')
+
+    await waitFor(() => {
+      expect(screen.getByText(/slug is already taken/i)).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('button', { name: /create account/i })).toBeDisabled()
+  }, 8000)
 })

--- a/frontend/src/features/registration/pages/register-page.tsx
+++ b/frontend/src/features/registration/pages/register-page.tsx
@@ -1,78 +1,11 @@
 import { useState, useCallback, useEffect, useRef, type FormEvent } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
-
-/** Validates a tenant slug: lowercase alphanumeric + hyphens, 3-63 chars. */
-function validateSlug(slug: string): string | null {
-  if (slug.length < 3) return 'Slug must be at least 3 characters'
-  if (slug.length > 63) return 'Slug must be at most 63 characters'
-  if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(slug))
-    return 'Slug may only contain lowercase letters, numbers, and hyphens, and must start and end with a letter or number'
-  return null
-}
-
-/** Returns 0-4 strength score for a password. */
-function passwordStrength(password: string): number {
-  if (password.length === 0) return 0
-  let score = 0
-  if (password.length >= 8) score++
-  if (password.length >= 12) score++
-  if (/[A-Z]/.test(password) && /[a-z]/.test(password)) score++
-  if (/[0-9]/.test(password)) score++
-  if (/[^A-Za-z0-9]/.test(password)) score++
-  return Math.min(score, 4)
-}
-
-const STRENGTH_LABEL = ['', 'Weak', 'Fair', 'Good', 'Strong']
-const STRENGTH_COLOR = ['', 'bg-destructive', 'bg-yellow-500', 'bg-blue-500', 'bg-green-500']
-
-interface PasswordStrengthBarProps {
-  password: string
-}
-
-function PasswordStrengthBar({ password }: PasswordStrengthBarProps) {
-  const score = passwordStrength(password)
-  if (!password) return null
-  return (
-    <div className="mt-1 space-y-1">
-      <div className="flex gap-1">
-        {[1, 2, 3, 4].map((i) => (
-          <div
-            key={i}
-            className={`h-1 flex-1 rounded-full transition-colors ${i <= score ? STRENGTH_COLOR[score] : 'bg-muted'}`}
-          />
-        ))}
-      </div>
-      <p className="text-xs text-muted-foreground">{STRENGTH_LABEL[score]}</p>
-    </div>
-  )
-}
-
-type SlugAvailability = 'idle' | 'checking' | 'available' | 'taken' | 'error'
-
-interface SlugStatusProps {
-  slug: string
-  error: string | null
-  availability: SlugAvailability
-}
-
-function SlugStatus({ slug, error, availability }: SlugStatusProps) {
-  if (!slug) return null
-  if (error) {
-    return <p className="mt-1 text-xs text-destructive">{error}</p>
-  }
-  switch (availability) {
-    case 'checking':
-      return <p className="mt-1 text-xs text-muted-foreground">Checking availability...</p>
-    case 'available':
-      return <p className="mt-1 text-xs text-green-600">Slug is available</p>
-    case 'taken':
-      return <p className="mt-1 text-xs text-destructive">Slug is already taken</p>
-    case 'error':
-      return <p className="mt-1 text-xs text-muted-foreground">Could not check availability</p>
-    default:
-      return <p className="mt-1 text-xs text-green-600">Slug format looks good</p>
-  }
-}
+import {
+  validateSlug,
+  PasswordStrengthBar,
+  SlugStatus,
+  type SlugAvailability,
+} from './registration-helpers'
 
 export function RegisterPage() {
   const navigate = useNavigate()
@@ -134,7 +67,6 @@ export function RegisterPage() {
   }, [slug])
 
   const handleSlugChange = useCallback((value: string) => {
-    // Normalize to lowercase as user types
     setSlug(value.toLowerCase().replace(/[^a-z0-9-]/g, ''))
   }, [])
 

--- a/frontend/src/features/registration/pages/register-page.tsx
+++ b/frontend/src/features/registration/pages/register-page.tsx
@@ -42,7 +42,10 @@ export function RegisterPage() {
       fetch(`/api/v1/slugs/${encodeURIComponent(slug)}/available`, {
         signal: controller.signal,
       })
-        .then((res) => res.json() as Promise<{ available: boolean; reason?: string }>)
+        .then((res) => {
+          if (!res.ok) throw new Error(`status ${res.status}`)
+          return res.json() as Promise<{ available: boolean; reason?: string }>
+        })
         .then((data) => {
           if (!controller.signal.aborted) {
             setSlugAvailability(data.available ? 'available' : 'taken')

--- a/frontend/src/features/registration/pages/register-page.tsx
+++ b/frontend/src/features/registration/pages/register-page.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, type FormEvent } from 'react'
+import { useState, useCallback, useEffect, useRef, type FormEvent } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 
 /** Validates a tenant slug: lowercase alphanumeric + hyphens, 3-63 chars. */
@@ -47,17 +47,31 @@ function PasswordStrengthBar({ password }: PasswordStrengthBarProps) {
   )
 }
 
+type SlugAvailability = 'idle' | 'checking' | 'available' | 'taken' | 'error'
+
 interface SlugStatusProps {
   slug: string
   error: string | null
+  availability: SlugAvailability
 }
 
-function SlugStatus({ slug, error }: SlugStatusProps) {
+function SlugStatus({ slug, error, availability }: SlugStatusProps) {
   if (!slug) return null
   if (error) {
     return <p className="mt-1 text-xs text-destructive">{error}</p>
   }
-  return <p className="mt-1 text-xs text-green-600">Slug format looks good</p>
+  switch (availability) {
+    case 'checking':
+      return <p className="mt-1 text-xs text-muted-foreground">Checking availability...</p>
+    case 'available':
+      return <p className="mt-1 text-xs text-green-600">Slug is available</p>
+    case 'taken':
+      return <p className="mt-1 text-xs text-destructive">Slug is already taken</p>
+    case 'error':
+      return <p className="mt-1 text-xs text-muted-foreground">Could not check availability</p>
+    default:
+      return <p className="mt-1 text-xs text-green-600">Slug format looks good</p>
+  }
 }
 
 export function RegisterPage() {
@@ -67,19 +81,56 @@ export function RegisterPage() {
   const [password, setPassword] = useState('')
   const [displayName, setDisplayName] = useState('')
   const [slugError, setSlugError] = useState<string | null>(null)
+  const [slugAvailability, setSlugAvailability] = useState<SlugAvailability>('idle')
   const [formError, setFormError] = useState('')
   const [loading, setLoading] = useState(false)
+  const slugCheckController = useRef<AbortController | null>(null)
 
-  // Debounced slug validation
+  // Debounced slug validation + availability check
   useEffect(() => {
     if (!slug) {
       setSlugError(null)
+      setSlugAvailability('idle')
       return
     }
+
+    const formatError = validateSlug(slug)
+    if (formatError) {
+      setSlugError(formatError)
+      setSlugAvailability('idle')
+      return
+    }
+
+    setSlugError(null)
+    setSlugAvailability('checking')
+
     const timer = setTimeout(() => {
-      setSlugError(validateSlug(slug))
-    }, 300)
-    return () => clearTimeout(timer)
+      // Abort any in-flight request
+      slugCheckController.current?.abort()
+      const controller = new AbortController()
+      slugCheckController.current = controller
+
+      fetch(`/api/v1/slugs/${encodeURIComponent(slug)}/available`, {
+        signal: controller.signal,
+      })
+        .then((res) => res.json() as Promise<{ available: boolean; reason?: string }>)
+        .then((data) => {
+          if (!controller.signal.aborted) {
+            setSlugAvailability(data.available ? 'available' : 'taken')
+          }
+        })
+        .catch((err: unknown) => {
+          if (err instanceof DOMException && err.name === 'AbortError') return
+          if (!controller.signal.aborted) {
+            setSlugAvailability('error')
+          }
+        })
+    }, 400)
+
+    return () => {
+      clearTimeout(timer)
+      slugCheckController.current?.abort()
+    }
   }, [slug])
 
   const handleSlugChange = useCallback((value: string) => {
@@ -95,6 +146,11 @@ export function RegisterPage() {
       const slugValidation = validateSlug(slug)
       if (slugValidation) {
         setSlugError(slugValidation)
+        return
+      }
+
+      if (slugAvailability === 'taken') {
+        setFormError('That slug is already taken. Please choose a different one.')
         return
       }
 
@@ -154,7 +210,7 @@ export function RegisterPage() {
         setLoading(false)
       }
     },
-    [slug, email, password, displayName, navigate],
+    [slug, slugAvailability, email, password, displayName, navigate],
   )
 
   const inputClass =
@@ -192,7 +248,7 @@ export function RegisterPage() {
               Lowercase letters, numbers, and hyphens. 3-63 characters.
             </p>
             <div id="slug-status" aria-live="polite">
-              <SlugStatus slug={slug} error={slugError} />
+              <SlugStatus slug={slug} error={slugError} availability={slugAvailability} />
             </div>
           </div>
 
@@ -256,7 +312,7 @@ export function RegisterPage() {
 
           <button
             type="submit"
-            disabled={loading || !!slugError}
+            disabled={loading || !!slugError || slugAvailability === 'taken'}
             className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {loading ? 'Creating account...' : 'Create account'}

--- a/frontend/src/features/registration/pages/register-page.tsx
+++ b/frontend/src/features/registration/pages/register-page.tsx
@@ -1,11 +1,7 @@
 import { useState, useCallback, useEffect, useRef, type FormEvent } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
-import {
-  validateSlug,
-  PasswordStrengthBar,
-  SlugStatus,
-  type SlugAvailability,
-} from './registration-helpers'
+import { validateSlug, type SlugAvailability } from './registration-utils'
+import { PasswordStrengthBar, SlugStatus } from './registration-helpers'
 
 export function RegisterPage() {
   const navigate = useNavigate()

--- a/frontend/src/features/registration/pages/registration-helpers.tsx
+++ b/frontend/src/features/registration/pages/registration-helpers.tsx
@@ -1,23 +1,4 @@
-/** Validates a tenant slug: lowercase alphanumeric + hyphens, 3-63 chars. */
-export function validateSlug(slug: string): string | null {
-  if (slug.length < 3) return 'Slug must be at least 3 characters'
-  if (slug.length > 63) return 'Slug must be at most 63 characters'
-  if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(slug))
-    return 'Slug may only contain lowercase letters, numbers, and hyphens, and must start and end with a letter or number'
-  return null
-}
-
-/** Returns 0-4 strength score for a password. */
-export function passwordStrength(password: string): number {
-  if (password.length === 0) return 0
-  let score = 0
-  if (password.length >= 8) score++
-  if (password.length >= 12) score++
-  if (/[A-Z]/.test(password) && /[a-z]/.test(password)) score++
-  if (/[0-9]/.test(password)) score++
-  if (/[^A-Za-z0-9]/.test(password)) score++
-  return Math.min(score, 4)
-}
+import { passwordStrength, type SlugAvailability } from './registration-utils'
 
 const STRENGTH_LABEL = ['', 'Weak', 'Fair', 'Good', 'Strong']
 const STRENGTH_COLOR = ['', 'bg-destructive', 'bg-yellow-500', 'bg-blue-500', 'bg-green-500']
@@ -39,8 +20,6 @@ export function PasswordStrengthBar({ password }: { password: string }) {
     </div>
   )
 }
-
-export type SlugAvailability = 'idle' | 'checking' | 'available' | 'taken' | 'error'
 
 interface SlugStatusProps {
   slug: string

--- a/frontend/src/features/registration/pages/registration-helpers.tsx
+++ b/frontend/src/features/registration/pages/registration-helpers.tsx
@@ -1,0 +1,68 @@
+/** Validates a tenant slug: lowercase alphanumeric + hyphens, 3-63 chars. */
+export function validateSlug(slug: string): string | null {
+  if (slug.length < 3) return 'Slug must be at least 3 characters'
+  if (slug.length > 63) return 'Slug must be at most 63 characters'
+  if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(slug))
+    return 'Slug may only contain lowercase letters, numbers, and hyphens, and must start and end with a letter or number'
+  return null
+}
+
+/** Returns 0-4 strength score for a password. */
+export function passwordStrength(password: string): number {
+  if (password.length === 0) return 0
+  let score = 0
+  if (password.length >= 8) score++
+  if (password.length >= 12) score++
+  if (/[A-Z]/.test(password) && /[a-z]/.test(password)) score++
+  if (/[0-9]/.test(password)) score++
+  if (/[^A-Za-z0-9]/.test(password)) score++
+  return Math.min(score, 4)
+}
+
+const STRENGTH_LABEL = ['', 'Weak', 'Fair', 'Good', 'Strong']
+const STRENGTH_COLOR = ['', 'bg-destructive', 'bg-yellow-500', 'bg-blue-500', 'bg-green-500']
+
+export function PasswordStrengthBar({ password }: { password: string }) {
+  const score = passwordStrength(password)
+  if (!password) return null
+  return (
+    <div className="mt-1 space-y-1">
+      <div className="flex gap-1">
+        {[1, 2, 3, 4].map((i) => (
+          <div
+            key={i}
+            className={`h-1 flex-1 rounded-full transition-colors ${i <= score ? STRENGTH_COLOR[score] : 'bg-muted'}`}
+          />
+        ))}
+      </div>
+      <p className="text-xs text-muted-foreground">{STRENGTH_LABEL[score]}</p>
+    </div>
+  )
+}
+
+export type SlugAvailability = 'idle' | 'checking' | 'available' | 'taken' | 'error'
+
+interface SlugStatusProps {
+  slug: string
+  error: string | null
+  availability: SlugAvailability
+}
+
+export function SlugStatus({ slug, error, availability }: SlugStatusProps) {
+  if (!slug) return null
+  if (error) {
+    return <p className="mt-1 text-xs text-destructive">{error}</p>
+  }
+  switch (availability) {
+    case 'checking':
+      return <p className="mt-1 text-xs text-muted-foreground">Checking availability...</p>
+    case 'available':
+      return <p className="mt-1 text-xs text-green-600">Slug is available</p>
+    case 'taken':
+      return <p className="mt-1 text-xs text-destructive">Slug is already taken</p>
+    case 'error':
+      return <p className="mt-1 text-xs text-muted-foreground">Could not check availability</p>
+    default:
+      return <p className="mt-1 text-xs text-green-600">Slug format looks good</p>
+  }
+}

--- a/frontend/src/features/registration/pages/registration-utils.ts
+++ b/frontend/src/features/registration/pages/registration-utils.ts
@@ -1,0 +1,22 @@
+/** Validates a tenant slug: lowercase alphanumeric + hyphens, 3-63 chars. */
+export function validateSlug(slug: string): string | null {
+  if (slug.length < 3) return 'Slug must be at least 3 characters'
+  if (slug.length > 63) return 'Slug must be at most 63 characters'
+  if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(slug))
+    return 'Slug may only contain lowercase letters, numbers, and hyphens, and must start and end with a letter or number'
+  return null
+}
+
+/** Returns 0-4 strength score for a password. */
+export function passwordStrength(password: string): number {
+  if (password.length === 0) return 0
+  let score = 0
+  if (password.length >= 8) score++
+  if (password.length >= 12) score++
+  if (/[A-Z]/.test(password) && /[a-z]/.test(password)) score++
+  if (/[0-9]/.test(password)) score++
+  if (/[^A-Za-z0-9]/.test(password)) score++
+  return Math.min(score, 4)
+}
+
+export type SlugAvailability = 'idle' | 'checking' | 'available' | 'taken' | 'error'

--- a/services/api-gateway/registration_handler.go
+++ b/services/api-gateway/registration_handler.go
@@ -288,10 +288,19 @@ func (h *RegistrationHandler) provisionAdminIdentity(ctx context.Context, tenant
 
 // HandleSlugAvailable handles GET /api/v1/slugs/{slug}/available.
 // Returns {"available": true/false} with optional validation errors.
+// Rate limited per IP to prevent slug enumeration.
 func (h *RegistrationHandler) HandleSlugAvailable(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		w.Header().Set("Allow", "GET")
 		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	clientIP := getClientIP(r)
+	if !h.rateLimiter.Allow(clientIP) {
+		writeJSON(w, http.StatusTooManyRequests, map[string]string{
+			"error": "too many requests, please try again later",
+		})
 		return
 	}
 

--- a/services/api-gateway/registration_handler.go
+++ b/services/api-gateway/registration_handler.go
@@ -46,10 +46,18 @@ type TenantCreator interface {
 	DeleteTenant(ctx context.Context, tenantID string) error
 }
 
+// SlugChecker abstracts slug availability checks for the registration handler.
+type SlugChecker interface {
+	// IsSlugAvailable returns true if the slug is not in use.
+	IsSlugAvailable(ctx context.Context, slug string) (bool, error)
+}
+
 // RegistrationHandler handles self-service tenant registration.
 // POST /api/v1/register - creates a tenant and an initial admin identity.
+// GET /api/v1/slugs/{slug}/available - checks slug availability.
 type RegistrationHandler struct {
 	tenantCreator TenantCreator
+	slugChecker   SlugChecker
 	identityRepo  identitydomain.Repository
 	rateLimiter   *RegistrationRateLimiter
 	baseDomain    string
@@ -59,6 +67,7 @@ type RegistrationHandler struct {
 // RegistrationHandlerConfig holds dependencies for creating a RegistrationHandler.
 type RegistrationHandlerConfig struct {
 	TenantCreator TenantCreator
+	SlugChecker   SlugChecker
 	IdentityRepo  identitydomain.Repository
 	RateLimiter   *RegistrationRateLimiter
 	BaseDomain    string
@@ -82,6 +91,7 @@ func NewRegistrationHandler(cfg RegistrationHandlerConfig) (*RegistrationHandler
 	}
 	return &RegistrationHandler{
 		tenantCreator: cfg.TenantCreator,
+		slugChecker:   cfg.SlugChecker,
 		identityRepo:  cfg.IdentityRepo,
 		rateLimiter:   rl,
 		baseDomain:    cfg.BaseDomain,
@@ -274,6 +284,53 @@ func (h *RegistrationHandler) provisionAdminIdentity(ctx context.Context, tenant
 	}
 
 	return nil
+}
+
+// HandleSlugAvailable handles GET /api/v1/slugs/{slug}/available.
+// Returns {"available": true/false} with optional validation errors.
+func (h *RegistrationHandler) HandleSlugAvailable(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	slug := r.PathValue("slug")
+	if slug == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "slug is required"})
+		return
+	}
+
+	if err := tenantdomain.ValidateSlug(slug); err != nil {
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"available": false,
+			"reason":    fmt.Sprintf("invalid slug: %v", err),
+		})
+		return
+	}
+
+	if h.slugChecker == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error": "slug availability check not configured",
+		})
+		return
+	}
+
+	available, err := h.slugChecker.IsSlugAvailable(r.Context(), slug)
+	if err != nil {
+		h.logger.ErrorContext(r.Context(), "slug availability check failed",
+			"slug", slug, "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error": "failed to check slug availability",
+		})
+		return
+	}
+
+	resp := map[string]interface{}{"available": available}
+	if !available {
+		resp["reason"] = "slug is already taken"
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // WithRegistrationHandler sets the self-service registration handler for the server.

--- a/services/api-gateway/registration_handler_test.go
+++ b/services/api-gateway/registration_handler_test.go
@@ -89,6 +89,14 @@ func (s *stubIdentityRepo) FindInvitationByTokenHash(_ context.Context, _ string
 	return nil, identitydomain.ErrInvitationNotFound
 }
 
+type stubSlugChecker struct {
+	isAvailableFn func(ctx context.Context, slug string) (bool, error)
+}
+
+func (s *stubSlugChecker) IsSlugAvailable(ctx context.Context, slug string) (bool, error) {
+	return s.isAvailableFn(ctx, slug)
+}
+
 // --- Helper ---
 
 func defaultStubs() (*stubTenantCreator, *stubIdentityRepo) {
@@ -107,6 +115,20 @@ func newRegistrationHandler(t *testing.T, tc gateway.TenantCreator, ir identityd
 		TenantCreator: tc,
 		IdentityRepo:  ir,
 		RateLimiter:   gateway.NewRegistrationRateLimiter(100), // high limit for tests
+		BaseDomain:    "meridian.app",
+		Logger:        slog.Default(),
+	})
+	require.NoError(t, err)
+	return h
+}
+
+func newRegistrationHandlerWithSlugChecker(t *testing.T, tc gateway.TenantCreator, ir identitydomain.Repository, sc gateway.SlugChecker) *gateway.RegistrationHandler {
+	t.Helper()
+	h, err := gateway.NewRegistrationHandler(gateway.RegistrationHandlerConfig{
+		TenantCreator: tc,
+		IdentityRepo:  ir,
+		SlugChecker:   sc,
+		RateLimiter:   gateway.NewRegistrationRateLimiter(100),
 		BaseDomain:    "meridian.app",
 		Logger:        slog.Default(),
 	})
@@ -434,4 +456,121 @@ func TestNewRegistrationHandler_Validation(t *testing.T) {
 		IdentityRepo:  ir,
 	})
 	assert.ErrorIs(t, err, gateway.ErrRegistrationLoggerRequired)
+}
+
+// --- Slug Availability Tests ---
+
+func slugAvailableRequest(handler *gateway.RegistrationHandler, slug string) *httptest.ResponseRecorder {
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/slugs/"+slug+"/available", nil)
+	r.SetPathValue("slug", slug)
+	w := httptest.NewRecorder()
+	handler.HandleSlugAvailable(w, r)
+	return w
+}
+
+func TestSlugAvailable_Available(t *testing.T) {
+	tc, ir := defaultStubs()
+	sc := &stubSlugChecker{
+		isAvailableFn: func(_ context.Context, _ string) (bool, error) {
+			return true, nil
+		},
+	}
+	h := newRegistrationHandlerWithSlugChecker(t, tc, ir, sc)
+	w := slugAvailableRequest(h, "my-org")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	resp := parseResponse(t, w)
+	assert.Equal(t, true, resp["available"])
+	assert.Nil(t, resp["reason"])
+}
+
+func TestSlugAvailable_Taken(t *testing.T) {
+	tc, ir := defaultStubs()
+	sc := &stubSlugChecker{
+		isAvailableFn: func(_ context.Context, _ string) (bool, error) {
+			return false, nil
+		},
+	}
+	h := newRegistrationHandlerWithSlugChecker(t, tc, ir, sc)
+	w := slugAvailableRequest(h, "taken-org")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	resp := parseResponse(t, w)
+	assert.Equal(t, false, resp["available"])
+	assert.Equal(t, "slug is already taken", resp["reason"])
+}
+
+func TestSlugAvailable_InvalidSlug(t *testing.T) {
+	tc, ir := defaultStubs()
+	sc := &stubSlugChecker{
+		isAvailableFn: func(_ context.Context, _ string) (bool, error) {
+			return true, nil
+		},
+	}
+	h := newRegistrationHandlerWithSlugChecker(t, tc, ir, sc)
+
+	tests := []struct {
+		name string
+		slug string
+	}{
+		{"too short", "ab"},
+		{"uppercase", "Acme"},
+		{"leading hyphen", "-org"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := slugAvailableRequest(h, tt.slug)
+			assert.Equal(t, http.StatusOK, w.Code)
+			resp := parseResponse(t, w)
+			assert.Equal(t, false, resp["available"])
+			assert.Contains(t, resp["reason"], "invalid slug")
+		})
+	}
+}
+
+func TestSlugAvailable_EmptySlug(t *testing.T) {
+	tc, ir := defaultStubs()
+	h := newRegistrationHandler(t, tc, ir)
+	w := slugAvailableRequest(h, "")
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSlugAvailable_NoSlugChecker(t *testing.T) {
+	tc, ir := defaultStubs()
+	h := newRegistrationHandler(t, tc, ir) // no slug checker configured
+	w := slugAvailableRequest(h, "my-org")
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestSlugAvailable_CheckerError(t *testing.T) {
+	tc, ir := defaultStubs()
+	sc := &stubSlugChecker{
+		isAvailableFn: func(_ context.Context, _ string) (bool, error) {
+			return false, errors.New("database connection lost")
+		},
+	}
+	h := newRegistrationHandlerWithSlugChecker(t, tc, ir, sc)
+	w := slugAvailableRequest(h, "my-org")
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestSlugAvailable_MethodNotAllowed(t *testing.T) {
+	tc, ir := defaultStubs()
+	sc := &stubSlugChecker{
+		isAvailableFn: func(_ context.Context, _ string) (bool, error) {
+			return true, nil
+		},
+	}
+	h := newRegistrationHandlerWithSlugChecker(t, tc, ir, sc)
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/slugs/my-org/available", nil)
+	r.SetPathValue("slug", "my-org")
+	w := httptest.NewRecorder()
+	h.HandleSlugAvailable(w, r)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
 }

--- a/services/api-gateway/server.go
+++ b/services/api-gateway/server.go
@@ -205,9 +205,10 @@ func (s *Server) registerRoutes() {
 		s.mux.Handle("GET /api/auth/callback", http.HandlerFunc(s.ssoHandler.HandleCallback))
 	}
 
-	// Self-service registration endpoint - NO middleware (public, unauthenticated).
+	// Self-service registration endpoints - NO middleware (public, unauthenticated).
 	if s.registrationHandler != nil {
 		s.mux.Handle("POST /api/v1/register", http.HandlerFunc(s.registrationHandler.HandleRegister))
+		s.mux.Handle("GET /api/v1/slugs/{slug}/available", http.HandlerFunc(s.registrationHandler.HandleSlugAvailable))
 	}
 
 	// API routes - with auth and tenant middleware chain.


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/slugs/{slug}/available` public endpoint that checks whether a tenant slug is taken, returning `{available: bool, reason?: string}`
- Wires slug availability checking through the tenant persistence repository via a new `SlugChecker` interface on the `RegistrationHandler`
- Updates the registration form to call the slug availability endpoint with a 400ms debounce as the user types, showing real-time feedback (available/taken/checking)
- Disables the submit button when the slug is known to be taken, preventing wasted registration attempts
- Backend `POST /api/v1/register` was already registered without auth middleware and works from the bare domain

## Test plan

- [x] Backend: 7 new unit tests for slug availability endpoint (available, taken, invalid, empty, no checker, error, method not allowed)
- [x] Backend: Existing 11 registration handler tests still pass
- [x] Backend: Wiring tests pass (loopback creator, registration endpoint reachable)
- [x] Frontend: 3 new tests (slug available, slug taken, submit disabled when taken)
- [x] Frontend: All 16 registration page tests pass
- [ ] CI passes