### PR TITLE
fix: make instrument registration idempotent and automate demo deploy

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -210,6 +210,32 @@ jobs:
             docker compose exec -T caddy caddy reload --config /etc/caddy/Caddyfile
             docker image prune -f
 
+      - name: Run migrations
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            docker exec meridian-meridian-1 /meridian --migrate
+
+      - name: Seed demo data
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            docker exec meridian-meridian-1 /seed-dev \
+              --gateway-url=http://localhost:8090 \
+              --grpc-addr=localhost:50051 \
+              --tenant-id=volterra_energy \
+              --tenant-slug=volterra \
+              --display-name='Volterra Energy' \
+              --subdomain=volterra.demo.meridianhub.cloud \
+              --manifest=/app/examples/manifests/energy.json \
+              --with-fixtures
+
       - name: Verify deployment health
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:

--- a/services/reference-data/registry/postgres_registry.go
+++ b/services/reference-data/registry/postgres_registry.go
@@ -14,7 +14,6 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/lib/pq"
 	refcel "github.com/meridianhub/meridian/services/reference-data/cel"
@@ -273,6 +272,7 @@ func (r *PostgresRegistry) ListByStatus(ctx context.Context, status Status) ([]*
 }
 
 // CreateDraft creates a new instrument definition in DRAFT status.
+// Idempotent: if the instrument (code, version) already exists, this is a no-op.
 func (r *PostgresRegistry) CreateDraft(ctx context.Context, def *InstrumentDefinition) error {
 	// Reject system instrument creation
 	if def.IsSystem {
@@ -296,7 +296,8 @@ func (r *PostgresRegistry) CreateDraft(ctx context.Context, def *InstrumentDefin
 				$8, $9, $10,
 				$11, $12, $13,
 				$14, $15
-			)`
+			)
+			ON CONFLICT (code, version) DO NOTHING`
 
 		// Generate ID if not set
 		if def.ID == uuid.Nil {
@@ -321,10 +322,6 @@ func (r *PostgresRegistry) CreateDraft(ctx context.Context, def *InstrumentDefin
 			def.CreatedAt, def.UpdatedAt,
 		)
 		if err != nil {
-			var pgErr *pgconn.PgError
-			if errors.As(err, &pgErr) && pgErr.Code == "23505" { // unique_violation
-				return ErrAlreadyExists
-			}
 			return fmt.Errorf("failed to insert instrument definition: %w", err)
 		}
 
@@ -425,6 +422,11 @@ func (r *PostgresRegistry) ActivateInstrument(ctx context.Context, code string, 
 
 		if isSystem {
 			return ErrSystemInstrumentReadOnly
+		}
+
+		// Idempotent: already active is a no-op.
+		if Status(currentStatus) == StatusActive {
+			return nil
 		}
 
 		if err := ValidateStatusTransition(Status(currentStatus), StatusActive); err != nil {

--- a/services/reference-data/registry/postgres_registry_test.go
+++ b/services/reference-data/registry/postgres_registry_test.go
@@ -111,7 +111,7 @@ func TestPostgresRegistry_CreateDraft(t *testing.T) {
 		require.ErrorIs(t, err, registry.ErrInvalidCEL)
 	})
 
-	t.Run("rejects duplicate code+version", func(t *testing.T) {
+	t.Run("duplicate code+version is idempotent no-op", func(t *testing.T) {
 		def := &registry.InstrumentDefinition{
 			Code:      "DUPE",
 			Version:   1,
@@ -122,7 +122,7 @@ func TestPostgresRegistry_CreateDraft(t *testing.T) {
 		err := reg.CreateDraft(ctx, def)
 		require.NoError(t, err)
 
-		// Try to create again
+		// Create again - should be idempotent (ON CONFLICT DO NOTHING)
 		def2 := &registry.InstrumentDefinition{
 			Code:      "DUPE",
 			Version:   1,
@@ -131,7 +131,7 @@ func TestPostgresRegistry_CreateDraft(t *testing.T) {
 		}
 
 		err = reg.CreateDraft(ctx, def2)
-		require.ErrorIs(t, err, registry.ErrAlreadyExists)
+		require.NoError(t, err, "duplicate CreateDraft should be idempotent")
 	})
 }
 
@@ -435,7 +435,7 @@ func TestPostgresRegistry_LifecycleTransitions(t *testing.T) {
 		assert.NotNil(t, result.DeprecatedAt)
 	})
 
-	t.Run("ACTIVE to ACTIVE fails", func(t *testing.T) {
+	t.Run("ACTIVE to ACTIVE is idempotent no-op", func(t *testing.T) {
 		def := &registry.InstrumentDefinition{
 			Code:      "LIFECYCLE3",
 			Version:   1,
@@ -446,7 +446,7 @@ func TestPostgresRegistry_LifecycleTransitions(t *testing.T) {
 		require.NoError(t, reg.ActivateInstrument(ctx, "LIFECYCLE3", 1))
 
 		err := reg.ActivateInstrument(ctx, "LIFECYCLE3", 1)
-		require.ErrorIs(t, err, registry.ErrNotDraft)
+		require.NoError(t, err, "activating already-active instrument should be idempotent")
 	})
 
 	t.Run("DRAFT to DEPRECATED fails", func(t *testing.T) {

--- a/services/reference-data/registry/registry.go
+++ b/services/reference-data/registry/registry.go
@@ -58,7 +58,9 @@ var (
 	// Valid transitions: DRAFT→ACTIVE, ACTIVE→DEPRECATED.
 	ErrInvalidStateTransition = errors.New("invalid state transition")
 
-	// ErrNotDraft is returned when attempting to modify an instrument that is not in DRAFT status.
+	// ErrNotDraft is returned when attempting to modify or activate an instrument
+	// that is not in DRAFT status (e.g., DEPRECATED). Note: ACTIVE->ACTIVE is
+	// idempotent and does NOT return this error.
 	ErrNotDraft = errors.New("instrument must be in DRAFT status")
 
 	// ErrNotActive is returned when attempting operations that require ACTIVE status.
@@ -196,7 +198,9 @@ type InstrumentRegistry interface {
 	ListByStatus(ctx context.Context, status Status) ([]*InstrumentDefinition, error)
 
 	// CreateDraft creates a new instrument definition in DRAFT status.
-	// Idempotent: returns nil if an instrument with the same code+version exists.
+	// Idempotent: returns nil if an instrument with the same code+version already
+	// exists (uses ON CONFLICT DO NOTHING). The existing definition is preserved
+	// unchanged - callers needing to update should use UpdateDefinition separately.
 	// Returns ErrSystemInstrumentReadOnly if is_system=true is attempted.
 	// Returns ErrInvalidCEL if any CEL expression fails compilation.
 	// CEL expressions are compiled at creation time (fail-fast validation).

--- a/services/reference-data/registry/registry.go
+++ b/services/reference-data/registry/registry.go
@@ -196,9 +196,9 @@ type InstrumentRegistry interface {
 	ListByStatus(ctx context.Context, status Status) ([]*InstrumentDefinition, error)
 
 	// CreateDraft creates a new instrument definition in DRAFT status.
+	// Idempotent: returns nil if an instrument with the same code+version exists.
 	// Returns ErrSystemInstrumentReadOnly if is_system=true is attempted.
 	// Returns ErrInvalidCEL if any CEL expression fails compilation.
-	// Returns ErrAlreadyExists if an instrument with the same code+version exists.
 	// CEL expressions are compiled at creation time (fail-fast validation).
 	CreateDraft(ctx context.Context, def *InstrumentDefinition) error
 
@@ -210,8 +210,9 @@ type InstrumentRegistry interface {
 	UpdateDefinition(ctx context.Context, code string, version int, updates *InstrumentDefinition) error
 
 	// ActivateInstrument transitions an instrument from DRAFT to ACTIVE.
+	// Idempotent: returns nil if already ACTIVE.
 	// Returns ErrSystemInstrumentReadOnly if the instrument has is_system=true.
-	// Returns ErrNotDraft if not currently in DRAFT status.
+	// Returns ErrNotDraft if in DEPRECATED status.
 	// Once activated, validation rules become immutable.
 	ActivateInstrument(ctx context.Context, code string, version int) error
 


### PR DESCRIPTION
## Summary

Enables fully automated demo deployment by fixing the instrument registration idempotency bug that blocked re-applying manifests.

## Changes

### Instrument registration idempotency (reference-data service)
- **CreateDraft**: Added `ON CONFLICT (code, version) DO NOTHING` to the INSERT query. Previously, re-applying a manifest failed with `AlreadyExists` because the saga tried to register instruments that already existed. Now matches the idempotent pattern used by account types.
- **ActivateInstrument**: Returns early if the instrument is already ACTIVE instead of failing with `ErrNotDraft`. This makes the activate step in the ApplyManifest saga idempotent.
- Removed dead `pgconn` import (unique_violation handling was the only usage).

### Deploy automation (deploy-demo.yml)
- Added **Run migrations** step after container recreate
- Added **Seed demo data** step that runs `seed-dev` with manifest + fixtures
- Now that ApplyManifest is idempotent, the full pipeline works end-to-end without `--skip-manifest`

## Test plan

- [x] `TestPostgresRegistry_CreateDraft/duplicate_code+version_is_idempotent_no-op` - verifies CreateDraft is idempotent
- [x] `TestPostgresRegistry_LifecycleTransitions/ACTIVE_to_ACTIVE_is_idempotent_no-op` - verifies ActivateInstrument is idempotent
- [x] All existing registry tests pass
- [ ] CI: full test suite
- [ ] Manual: `seed-dev --manifest` on demo with existing instruments succeeds