### PR TITLE
feat: redirect to tenant subdomain after registration

### DIFF
--- a/frontend/src/features/registration/pages/register-page.test.tsx
+++ b/frontend/src/features/registration/pages/register-page.test.tsx
@@ -134,10 +134,11 @@ describe('RegisterPage', () => {
 
   it('shows redirect message on success with absolute login_url', async () => {
     vi.restoreAllMocks()
+    // jsdom hostname is "localhost", so use a subdomain of localhost
     mockFetchForRegistration({
       registerBody: {
         tenant_id: 'my-org',
-        login_url: 'https://my-org.demo.meridianhub.cloud/login',
+        login_url: 'https://my-org.localhost/login',
       },
     })
 
@@ -151,6 +152,50 @@ describe('RegisterPage', () => {
     await waitFor(() => {
       expect(screen.getByText(/account created/i)).toBeInTheDocument()
       expect(screen.getByText(/redirecting to your organization/i)).toBeInTheDocument()
+    })
+  })
+
+  it('falls back to client navigation when login_url is http (not https)', async () => {
+    vi.restoreAllMocks()
+    mockFetchForRegistration({
+      registerBody: {
+        tenant_id: 'my-org',
+        login_url: 'http://my-org.localhost/login',
+      },
+    })
+
+    const { user } = setup()
+
+    await user.type(screen.getByLabelText(/organization slug/i), 'my-org')
+    await user.type(screen.getByLabelText(/email/i), 'admin@example.com')
+    await user.type(screen.getByLabelText(/password/i), 'SecurePass123!')
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    // Should NOT show redirect message - falls back to navigate()
+    await waitFor(() => {
+      expect(screen.queryByText(/account created/i)).not.toBeInTheDocument()
+    })
+  })
+
+  it('falls back to client navigation when login_url domain is untrusted', async () => {
+    vi.restoreAllMocks()
+    mockFetchForRegistration({
+      registerBody: {
+        tenant_id: 'my-org',
+        login_url: 'https://evil.example.com/login',
+      },
+    })
+
+    const { user } = setup()
+
+    await user.type(screen.getByLabelText(/organization slug/i), 'my-org')
+    await user.type(screen.getByLabelText(/email/i), 'admin@example.com')
+    await user.type(screen.getByLabelText(/password/i), 'SecurePass123!')
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    // Should NOT show redirect message - untrusted domain
+    await waitFor(() => {
+      expect(screen.queryByText(/account created/i)).not.toBeInTheDocument()
     })
   })
 

--- a/frontend/src/features/registration/pages/register-page.test.tsx
+++ b/frontend/src/features/registration/pages/register-page.test.tsx
@@ -114,7 +114,7 @@ describe('RegisterPage', () => {
     expect(screen.getByText(/weak|fair|good|strong/i)).toBeInTheDocument()
   })
 
-  it('submits the form and redirects to login on success', async () => {
+  it('submits the form and navigates to login on success with relative login_url', async () => {
     const { user } = setup()
 
     await user.type(screen.getByLabelText(/organization slug/i), 'my-org')
@@ -130,6 +130,28 @@ describe('RegisterPage', () => {
       '/api/v1/register',
       expect.objectContaining({ method: 'POST' }),
     )
+  })
+
+  it('shows redirect message on success with absolute login_url', async () => {
+    vi.restoreAllMocks()
+    mockFetchForRegistration({
+      registerBody: {
+        tenant_id: 'my-org',
+        login_url: 'https://my-org.demo.meridianhub.cloud/login',
+      },
+    })
+
+    const { user } = setup()
+
+    await user.type(screen.getByLabelText(/organization slug/i), 'my-org')
+    await user.type(screen.getByLabelText(/email/i), 'admin@example.com')
+    await user.type(screen.getByLabelText(/password/i), 'SecurePass123!')
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/account created/i)).toBeInTheDocument()
+      expect(screen.getByText(/redirecting to your organization/i)).toBeInTheDocument()
+    })
   })
 
   it('shows error on 409 slug conflict', async () => {

--- a/frontend/src/features/registration/pages/register-page.tsx
+++ b/frontend/src/features/registration/pages/register-page.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useRef, type FormEvent } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
-import { validateSlug, type SlugAvailability } from './registration-utils'
-import { PasswordStrengthBar, SlugStatus } from './registration-helpers'
+import { validateSlug, isSafeRedirectUrl, type SlugAvailability } from './registration-utils'
+import { PasswordStrengthBar, SlugStatus, RedirectSuccess } from './registration-helpers'
 
 export function RegisterPage() {
   const navigate = useNavigate()
@@ -147,20 +147,7 @@ export function RegisterPage() {
         } | null
         const loginUrl = typeof data?.login_url === 'string' ? data.login_url : undefined
 
-        // Validate absolute URLs: must be HTTPS and share the current domain suffix
-        // (e.g., my-org.demo.meridianhub.cloud when on demo.meridianhub.cloud)
-        const isSafeAbsoluteUrl = (url: string): boolean => {
-          try {
-            const parsed = new URL(url)
-            if (parsed.protocol !== 'https:') return false
-            const currentHost = window.location.hostname
-            return parsed.hostname.endsWith(`.${currentHost}`) || parsed.hostname === currentHost
-          } catch {
-            return false
-          }
-        }
-
-        if (loginUrl && isSafeAbsoluteUrl(loginUrl)) {
+        if (loginUrl && isSafeRedirectUrl(loginUrl)) {
           // Safe tenant subdomain URL - show success then redirect
           setRedirecting(true)
           redirectTimerRef.current = window.setTimeout(() => {
@@ -188,16 +175,7 @@ export function RegisterPage() {
     'w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
 
   if (redirecting) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <div className="w-full max-w-sm space-y-4 px-4 text-center">
-          <h1 className="text-2xl font-semibold">Account created!</h1>
-          <p className="text-muted-foreground">
-            Redirecting to your organization...
-          </p>
-        </div>
-      </div>
-    )
+    return <RedirectSuccess />
   }
 
   return (

--- a/frontend/src/features/registration/pages/register-page.tsx
+++ b/frontend/src/features/registration/pages/register-page.tsx
@@ -13,6 +13,7 @@ export function RegisterPage() {
   const [slugAvailability, setSlugAvailability] = useState<SlugAvailability>('idle')
   const [formError, setFormError] = useState('')
   const [loading, setLoading] = useState(false)
+  const [redirecting, setRedirecting] = useState(false)
   const slugCheckController = useRef<AbortController | null>(null)
 
   // Debounced slug validation + availability check
@@ -129,7 +130,22 @@ export function RegisterPage() {
           return
         }
 
-        void navigate('/login?registered=1')
+        const data = (await response.json().catch(() => null)) as {
+          tenant_id?: string
+          login_url?: string
+        } | null
+        const loginUrl = data?.login_url
+
+        if (loginUrl && (loginUrl.startsWith('https://') || loginUrl.startsWith('http://'))) {
+          // Absolute URL - redirect to tenant subdomain
+          setRedirecting(true)
+          window.setTimeout(() => {
+            window.location.href = loginUrl
+          }, 1500)
+        } else {
+          // Relative path or missing - use client-side navigation
+          void navigate(loginUrl ?? '/login?registered=1')
+        }
       } catch (error) {
         if (error instanceof DOMException && error.name === 'AbortError') {
           setFormError('Registration timed out. Please try again.')
@@ -146,6 +162,19 @@ export function RegisterPage() {
 
   const inputClass =
     'w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+
+  if (redirecting) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="w-full max-w-sm space-y-4 px-4 text-center">
+          <h1 className="text-2xl font-semibold">Account created!</h1>
+          <p className="text-muted-foreground">
+            Redirecting to your organization...
+          </p>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="flex min-h-screen items-center justify-center">

--- a/frontend/src/features/registration/pages/register-page.tsx
+++ b/frontend/src/features/registration/pages/register-page.tsx
@@ -15,6 +15,17 @@ export function RegisterPage() {
   const [loading, setLoading] = useState(false)
   const [redirecting, setRedirecting] = useState(false)
   const slugCheckController = useRef<AbortController | null>(null)
+  const redirectTimerRef = useRef<number | null>(null)
+
+  // Clean up redirect timer on unmount
+  useEffect(() => {
+    return () => {
+      if (redirectTimerRef.current !== null) {
+        window.clearTimeout(redirectTimerRef.current)
+        redirectTimerRef.current = null
+      }
+    }
+  }, [])
 
   // Debounced slug validation + availability check
   useEffect(() => {
@@ -134,16 +145,29 @@ export function RegisterPage() {
           tenant_id?: string
           login_url?: string
         } | null
-        const loginUrl = data?.login_url
+        const loginUrl = typeof data?.login_url === 'string' ? data.login_url : undefined
 
-        if (loginUrl && (loginUrl.startsWith('https://') || loginUrl.startsWith('http://'))) {
-          // Absolute URL - redirect to tenant subdomain
+        // Validate absolute URLs: must be HTTPS and share the current domain suffix
+        // (e.g., my-org.demo.meridianhub.cloud when on demo.meridianhub.cloud)
+        const isSafeAbsoluteUrl = (url: string): boolean => {
+          try {
+            const parsed = new URL(url)
+            if (parsed.protocol !== 'https:') return false
+            const currentHost = window.location.hostname
+            return parsed.hostname.endsWith(`.${currentHost}`) || parsed.hostname === currentHost
+          } catch {
+            return false
+          }
+        }
+
+        if (loginUrl && isSafeAbsoluteUrl(loginUrl)) {
+          // Safe tenant subdomain URL - show success then redirect
           setRedirecting(true)
-          window.setTimeout(() => {
+          redirectTimerRef.current = window.setTimeout(() => {
             window.location.href = loginUrl
           }, 1500)
         } else {
-          // Relative path or missing - use client-side navigation
+          // Relative path, missing, or untrusted URL - use client-side navigation
           void navigate(loginUrl ?? '/login?registered=1')
         }
       } catch (error) {

--- a/frontend/src/features/registration/pages/register-page.tsx
+++ b/frontend/src/features/registration/pages/register-page.tsx
@@ -155,7 +155,9 @@ export function RegisterPage() {
           }, 1500)
         } else {
           // Relative path, missing, or untrusted URL - use client-side navigation
-          void navigate(loginUrl ?? '/login?registered=1')
+          // Reject absolute URLs that failed validation to avoid broken SPA routes
+          const fallbackPath = (loginUrl && !loginUrl.startsWith('http')) ? loginUrl : '/login?registered=1'
+          void navigate(fallbackPath)
         }
       } catch (error) {
         if (error instanceof DOMException && error.name === 'AbortError') {

--- a/frontend/src/features/registration/pages/registration-helpers.tsx
+++ b/frontend/src/features/registration/pages/registration-helpers.tsx
@@ -27,6 +27,19 @@ interface SlugStatusProps {
   availability: SlugAvailability
 }
 
+export function RedirectSuccess() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="w-full max-w-sm space-y-4 px-4 text-center">
+        <h1 className="text-2xl font-semibold">Account created!</h1>
+        <p className="text-muted-foreground">
+          Redirecting to your organization...
+        </p>
+      </div>
+    </div>
+  )
+}
+
 export function SlugStatus({ slug, error, availability }: SlugStatusProps) {
   if (!slug) return null
   if (error) {

--- a/frontend/src/features/registration/pages/registration-helpers.tsx
+++ b/frontend/src/features/registration/pages/registration-helpers.tsx
@@ -30,7 +30,12 @@ interface SlugStatusProps {
 export function RedirectSuccess() {
   return (
     <div className="flex min-h-screen items-center justify-center">
-      <div className="w-full max-w-sm space-y-4 px-4 text-center">
+      <div
+        className="w-full max-w-sm space-y-4 px-4 text-center"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
         <h1 className="text-2xl font-semibold">Account created!</h1>
         <p className="text-muted-foreground">
           Redirecting to your organization...

--- a/frontend/src/features/registration/pages/registration-utils.ts
+++ b/frontend/src/features/registration/pages/registration-utils.ts
@@ -20,3 +20,15 @@ export function passwordStrength(password: string): number {
 }
 
 export type SlugAvailability = 'idle' | 'checking' | 'available' | 'taken' | 'error'
+
+/** Returns true if the URL is HTTPS and shares the current hostname suffix. */
+export function isSafeRedirectUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'https:') return false
+    const currentHost = window.location.hostname
+    return parsed.hostname.endsWith(`.${currentHost}`) || parsed.hostname === currentHost
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

- After successful registration at `demo.meridianhub.cloud/register`, the user is now redirected to their tenant's login page at `{slug}.demo.meridianhub.cloud/login`
- Uses the `login_url` field already returned by the registration API response
- Shows a brief "Account created! Redirecting to your organization..." message before redirect (1.5s delay)
- Falls back to client-side navigation for relative URLs (when `baseDomain` is not configured)

## Changes

- `register-page.tsx`: Parse `login_url` from registration response; absolute URLs trigger a full-page redirect with success message, relative URLs use react-router navigation
- `register-page.test.tsx`: Added test for absolute URL redirect path showing success message; renamed existing test for clarity

## Test plan

- [x] All 17 existing registration tests pass
- [x] New test verifies absolute URL redirect shows success message
- [x] No TypeScript errors in changed files
- [ ] Manual: Register on demo.meridianhub.cloud and verify redirect to tenant subdomain