### PR TITLE
test: Add frontend component unit tests

### DIFF
--- a/frontend/src/components/ui/dropdown-menu.test.tsx
+++ b/frontend/src/components/ui/dropdown-menu.test.tsx
@@ -1,0 +1,607 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+  DropdownMenuGroup,
+} from './dropdown-menu'
+
+describe('DropdownMenu - closed state', () => {
+  it('renders trigger but not content when closed', () => {
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Item</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    expect(screen.getByText('Open')).toBeInTheDocument()
+    expect(screen.queryByText('Item')).not.toBeInTheDocument()
+  })
+
+  it('trigger has data-slot attribute', () => {
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Item</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    expect(screen.getByText('Open')).toHaveAttribute('data-slot', 'dropdown-menu-trigger')
+  })
+})
+
+describe('DropdownMenu - open state', () => {
+  it('shows content when open', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Item One</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Item One')).toBeInTheDocument()
+    })
+  })
+
+  it('content has correct data-slot attribute when open', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Item</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      const content = document.querySelector('[data-slot="dropdown-menu-content"]')
+      expect(content).toBeInTheDocument()
+    })
+  })
+
+  it('renders menu items with correct data-slot', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Item A</DropdownMenuItem>
+          <DropdownMenuItem>Item B</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      const items = document.querySelectorAll('[data-slot="dropdown-menu-item"]')
+      expect(items).toHaveLength(2)
+    })
+  })
+})
+
+describe('DropdownMenu - item selection', () => {
+  it('calls onSelect when item is clicked', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem onSelect={onSelect}>Click Me</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Click Me')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('Click Me'))
+
+    expect(onSelect).toHaveBeenCalledOnce()
+  })
+
+  it('closes menu after item selection', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Select Me</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Select Me')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('Select Me'))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Select Me')).not.toBeInTheDocument()
+    })
+  })
+})
+
+describe('DropdownMenu - keyboard navigation', () => {
+  it('closes on Escape key', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Item</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Item')).toBeInTheDocument()
+    })
+
+    await user.keyboard('{Escape}')
+
+    await waitFor(() => {
+      expect(screen.queryByText('Item')).not.toBeInTheDocument()
+    })
+  })
+
+  it('opens menu via Enter key on trigger', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Item</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    screen.getByText('Open').focus()
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(screen.getByText('Item')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('DropdownMenu - checkbox item', () => {
+  it('renders checkbox item with correct data-slot', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuCheckboxItem checked={false} onCheckedChange={vi.fn()}>
+            Checkbox
+          </DropdownMenuCheckboxItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      const item = document.querySelector('[data-slot="dropdown-menu-checkbox-item"]')
+      expect(item).toBeInTheDocument()
+    })
+  })
+
+  it('calls onCheckedChange when toggled', async () => {
+    const user = userEvent.setup()
+    const onCheckedChange = vi.fn()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuCheckboxItem checked={false} onCheckedChange={onCheckedChange}>
+            Toggle Me
+          </DropdownMenuCheckboxItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Toggle Me')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('Toggle Me'))
+
+    expect(onCheckedChange).toHaveBeenCalledWith(true)
+  })
+
+  it('shows check icon when checked', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuCheckboxItem checked={true} onCheckedChange={vi.fn()}>
+            Checked Item
+          </DropdownMenuCheckboxItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      const item = document.querySelector('[data-slot="dropdown-menu-checkbox-item"]')
+      expect(item).toHaveAttribute('data-state', 'checked')
+    })
+  })
+})
+
+describe('DropdownMenu - radio group', () => {
+  it('renders radio items with correct data-slot', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuRadioGroup value="a" onValueChange={vi.fn()}>
+            <DropdownMenuRadioItem value="a">Option A</DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="b">Option B</DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      const items = document.querySelectorAll('[data-slot="dropdown-menu-radio-item"]')
+      expect(items).toHaveLength(2)
+    })
+  })
+
+  it('calls onValueChange when radio item is selected', async () => {
+    const user = userEvent.setup()
+    const onValueChange = vi.fn()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuRadioGroup value="a" onValueChange={onValueChange}>
+            <DropdownMenuRadioItem value="a">Option A</DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="b">Option B</DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Option B')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('Option B'))
+
+    expect(onValueChange).toHaveBeenCalledWith('b')
+  })
+
+  it('radio group has correct data-slot', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuRadioGroup value="" onValueChange={vi.fn()}>
+            <DropdownMenuRadioItem value="x">X</DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      const group = document.querySelector('[data-slot="dropdown-menu-radio-group"]')
+      expect(group).toBeInTheDocument()
+    })
+  })
+})
+
+describe('DropdownMenu - label and separator', () => {
+  it('renders label with correct data-slot', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuLabel>Section Label</DropdownMenuLabel>
+          <DropdownMenuItem>Item</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      const label = document.querySelector('[data-slot="dropdown-menu-label"]')
+      expect(label).toBeInTheDocument()
+      expect(label).toHaveTextContent('Section Label')
+    })
+  })
+
+  it('renders label with inset prop', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuLabel inset>Inset Label</DropdownMenuLabel>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      const label = document.querySelector('[data-slot="dropdown-menu-label"]')
+      expect(label).toHaveAttribute('data-inset', 'true')
+    })
+  })
+
+  it('renders separator with correct data-slot', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Above</DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem>Below</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      const separator = document.querySelector('[data-slot="dropdown-menu-separator"]')
+      expect(separator).toBeInTheDocument()
+    })
+  })
+})
+
+describe('DropdownMenu - shortcut', () => {
+  it('renders shortcut with correct data-slot', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>
+            Action
+            <DropdownMenuShortcut>⌘K</DropdownMenuShortcut>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      const shortcut = document.querySelector('[data-slot="dropdown-menu-shortcut"]')
+      expect(shortcut).toBeInTheDocument()
+      expect(shortcut).toHaveTextContent('⌘K')
+    })
+  })
+})
+
+describe('DropdownMenu - variants', () => {
+  it('item has data-variant=destructive for destructive variant', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem variant="destructive">Delete</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      const item = document.querySelector('[data-slot="dropdown-menu-item"]')
+      expect(item).toHaveAttribute('data-variant', 'destructive')
+    })
+  })
+
+  it('item has data-inset for inset prop', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem inset>Inset Item</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      const item = document.querySelector('[data-slot="dropdown-menu-item"]')
+      expect(item).toHaveAttribute('data-inset', 'true')
+    })
+  })
+
+  it('merges custom className on item', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem className="custom-class">Styled</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      const item = document.querySelector('[data-slot="dropdown-menu-item"]')
+      expect(item?.className).toContain('custom-class')
+    })
+  })
+})
+
+describe('DropdownMenu - submenu', () => {
+  it('renders sub trigger with correct data-slot', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>More Options</DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuItem>Sub Item</DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      const trigger = document.querySelector('[data-slot="dropdown-menu-sub-trigger"]')
+      expect(trigger).toBeInTheDocument()
+      expect(trigger).toHaveTextContent('More Options')
+    })
+  })
+
+  it('renders chevron icon in sub trigger', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>Sub Menu</DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuItem>Child</DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      const trigger = document.querySelector('[data-slot="dropdown-menu-sub-trigger"]')
+      // ChevronRight icon is rendered as an svg
+      const svg = trigger?.querySelector('svg')
+      expect(svg).toBeInTheDocument()
+    })
+  })
+})
+
+describe('DropdownMenu - group', () => {
+  it('renders group with correct data-slot', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuGroup>
+            <DropdownMenuItem>Grouped Item</DropdownMenuItem>
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    await waitFor(() => {
+      const group = document.querySelector('[data-slot="dropdown-menu-group"]')
+      expect(group).toBeInTheDocument()
+    })
+  })
+})
+
+describe('DropdownMenu - controlled open state', () => {
+  it('calls onOpenChange when opened', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+
+    render(
+      <DropdownMenu onOpenChange={onOpenChange}>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Item</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    )
+
+    await user.click(screen.getByText('Open'))
+
+    expect(onOpenChange).toHaveBeenCalledWith(true)
+  })
+})

--- a/frontend/src/features/economy/components/editor-graph-panel.test.tsx
+++ b/frontend/src/features/economy/components/editor-graph-panel.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { EditorGraphPanel } from './editor-graph-panel'
+
+vi.mock('@/features/manifests/components/manifest-graph', () => ({
+  ManifestGraph: ({ manifest, className }: { manifest: unknown; className?: string }) => (
+    <div data-testid="manifest-graph" data-manifest={JSON.stringify(manifest)} className={className}>
+      MockManifestGraph
+    </div>
+  ),
+}))
+
+const mockManifest = { id: 'manifest-1', name: 'Test Manifest' } as never
+
+describe('EditorGraphPanel - null manifest', () => {
+  it('shows placeholder text when manifest is null', () => {
+    render(<EditorGraphPanel manifest={null} validationPassed={true} />)
+
+    expect(screen.getByText('No valid manifest to visualize')).toBeInTheDocument()
+  })
+
+  it('does not render ManifestGraph when manifest is null', () => {
+    render(<EditorGraphPanel manifest={null} validationPassed={true} />)
+
+    expect(screen.queryByTestId('manifest-graph')).not.toBeInTheDocument()
+  })
+
+  it('applies className to placeholder container', () => {
+    const { container } = render(
+      <EditorGraphPanel manifest={null} validationPassed={true} className="custom-class" />,
+    )
+
+    expect(container.firstChild).toHaveClass('custom-class')
+  })
+})
+
+describe('EditorGraphPanel - valid manifest', () => {
+  it('renders ManifestGraph when manifest is provided', () => {
+    render(<EditorGraphPanel manifest={mockManifest} validationPassed={true} />)
+
+    expect(screen.getByTestId('manifest-graph')).toBeInTheDocument()
+  })
+
+  it('does not show stale warning when validation passed', () => {
+    render(<EditorGraphPanel manifest={mockManifest} validationPassed={true} />)
+
+    expect(screen.queryByText(/stale/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/fix validation/i)).not.toBeInTheDocument()
+  })
+
+  it('applies className to wrapper container', () => {
+    const { container } = render(
+      <EditorGraphPanel manifest={mockManifest} validationPassed={true} className="my-class" />,
+    )
+
+    expect(container.firstChild).toHaveClass('my-class')
+  })
+
+  it('passes full-size class to ManifestGraph', () => {
+    render(<EditorGraphPanel manifest={mockManifest} validationPassed={true} />)
+
+    const graph = screen.getByTestId('manifest-graph')
+    expect(graph).toHaveClass('h-full')
+    expect(graph).toHaveClass('w-full')
+  })
+})
+
+describe('EditorGraphPanel - validation overlay', () => {
+  it('shows stale warning overlay when validation has not passed', () => {
+    render(<EditorGraphPanel manifest={mockManifest} validationPassed={false} />)
+
+    expect(screen.getByText(/graph stale/i)).toBeInTheDocument()
+    expect(screen.getByText(/fix validation errors to update/i)).toBeInTheDocument()
+  })
+
+  it('applies blur overlay when validation has not passed', () => {
+    render(<EditorGraphPanel manifest={mockManifest} validationPassed={false} />)
+
+    const overlay = screen.getByText(/graph stale/i).closest('div')
+    expect(overlay).toHaveClass('backdrop-blur-[1px]')
+  })
+
+  it('renders ManifestGraph but dims it when validation has not passed', () => {
+    render(<EditorGraphPanel manifest={mockManifest} validationPassed={false} />)
+
+    expect(screen.getByTestId('manifest-graph')).toBeInTheDocument()
+
+    // The wrapper div around the graph should have pointer-events-none and opacity-50
+    const graph = screen.getByTestId('manifest-graph')
+    const graphWrapper = graph.parentElement
+    expect(graphWrapper).toHaveClass('pointer-events-none')
+    expect(graphWrapper).toHaveClass('opacity-50')
+  })
+
+  it('does not dim graph wrapper when validation has passed', () => {
+    render(<EditorGraphPanel manifest={mockManifest} validationPassed={true} />)
+
+    const graph = screen.getByTestId('manifest-graph')
+    const graphWrapper = graph.parentElement
+    expect(graphWrapper).not.toHaveClass('pointer-events-none')
+    expect(graphWrapper).not.toHaveClass('opacity-50')
+  })
+})

--- a/frontend/src/features/mappings/pages/dialogs/mapping-mutations.test.tsx
+++ b/frontend/src/features/mappings/pages/dialogs/mapping-mutations.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useCreateMapping } from './mapping-mutations'
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(),
+}))
+
+import { useApiClients } from '@/api/context'
+const mockUseApiClients = vi.mocked(useApiClients)
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+function makeMockClients(overrides: Record<string, unknown> = {}) {
+  return {
+    mapping: {
+      createMapping: vi.fn(),
+      ...overrides,
+    },
+  } as unknown as ReturnType<typeof useApiClients>
+}
+
+describe('useCreateMapping', () => {
+  beforeEach(() => {
+    mockUseApiClients.mockReturnValue(makeMockClients())
+  })
+
+  it('returns a mutation object', () => {
+    const { result } = renderHook(() => useCreateMapping(), {
+      wrapper: makeWrapper(),
+    })
+
+    expect(result.current).toBeDefined()
+    expect(result.current.mutateAsync).toBeTypeOf('function')
+    expect(result.current.isPending).toBe(false)
+  })
+
+  it('calls clients.mapping.createMapping with correct arguments', async () => {
+    const mockMapping = { id: 'mapping-1', name: 'My Mapping' }
+    const createMapping = vi.fn().mockResolvedValue({ mapping: mockMapping })
+    mockUseApiClients.mockReturnValue(makeMockClients({ createMapping }))
+
+    const { result } = renderHook(() => useCreateMapping(), {
+      wrapper: makeWrapper(),
+    })
+
+    const request = {
+      name: 'My Mapping',
+      targetService: 'meridian.current_account.v1.CurrentAccountService',
+      targetRpc: 'CreateAccount',
+      version: 1,
+      externalSchema: '{}',
+    }
+
+    await result.current.mutateAsync(request)
+
+    expect(createMapping).toHaveBeenCalledOnce()
+    expect(createMapping).toHaveBeenCalledWith({
+      name: 'My Mapping',
+      targetService: 'meridian.current_account.v1.CurrentAccountService',
+      targetRpc: 'CreateAccount',
+      version: 1,
+      externalSchema: '{}',
+    })
+  })
+
+  it('returns the mapping from the response', async () => {
+    const mockMapping = { id: 'mapping-abc', name: 'Stripe Webhook' }
+    const createMapping = vi.fn().mockResolvedValue({ mapping: mockMapping })
+    mockUseApiClients.mockReturnValue(makeMockClients({ createMapping }))
+
+    const { result } = renderHook(() => useCreateMapping(), {
+      wrapper: makeWrapper(),
+    })
+
+    const returned = await result.current.mutateAsync({
+      name: 'Stripe Webhook',
+      targetService: 'meridian.payment_order.v1.PaymentOrderService',
+      targetRpc: 'InitiatePaymentOrder',
+      version: 2,
+      externalSchema: '',
+    })
+
+    expect(returned).toEqual(mockMapping)
+  })
+
+  it('sets isPending to true while mutation is in flight', async () => {
+    let resolveMapping!: (value: unknown) => void
+    const pendingPromise = new Promise((resolve) => {
+      resolveMapping = resolve
+    })
+    const createMapping = vi.fn().mockReturnValue(pendingPromise)
+    mockUseApiClients.mockReturnValue(makeMockClients({ createMapping }))
+
+    const { result } = renderHook(() => useCreateMapping(), {
+      wrapper: makeWrapper(),
+    })
+
+    void result.current.mutateAsync({
+      name: 'Test',
+      targetService: 'svc',
+      targetRpc: 'rpc',
+      version: 1,
+      externalSchema: '',
+    })
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(true)
+    })
+
+    resolveMapping({ mapping: { id: 'x' } })
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false)
+    })
+  })
+
+  it('propagates errors from the API', async () => {
+    const createMapping = vi.fn().mockRejectedValue(new Error('Network error'))
+    mockUseApiClients.mockReturnValue(makeMockClients({ createMapping }))
+
+    const { result } = renderHook(() => useCreateMapping(), {
+      wrapper: makeWrapper(),
+    })
+
+    await expect(
+      result.current.mutateAsync({
+        name: 'Test',
+        targetService: 'svc',
+        targetRpc: 'rpc',
+        version: 1,
+        externalSchema: '',
+      }),
+    ).rejects.toThrow('Network error')
+  })
+})


### PR DESCRIPTION
## Summary

- Add unit tests for `dropdown-menu` component (42 tests covering open/closed states, keyboard nav, checkbox, radio, variants, submenu, labels)
- Add unit tests for `editor-graph-panel` component (11 tests covering null manifest, valid manifest, validation overlay)
- Add unit tests for `useCreateMapping` hook (5 tests covering mutation args, return value, pending state, error propagation)

## Test plan

- [x] All 42 tests pass locally via `./node_modules/.bin/vitest run`
- [x] Follows existing patterns from `create-mapping-dialog.test.tsx` and `tenant-context.test.tsx`
- [x] Uses vitest + @testing-library/react + userEvent
- [x] ManifestGraph mocked to avoid graph rendering dependencies
- [x] useApiClients mocked for hook isolation