### PR TITLE
test: Add control plane applier, saga outbox, and causation visualizer unit tests

### DIFF
--- a/services/control-plane/internal/applier/market_information_client_test.go
+++ b/services/control-plane/internal/applier/market_information_client_test.go
@@ -1,12 +1,95 @@
 package applier
 
 import (
+	"context"
+	"net"
 	"testing"
 
 	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
 )
+
+// Compile-time interface satisfaction check.
+var _ MarketInformationService = (*MarketInformationClient)(nil)
+
+// ─── Mock gRPC server ──────────────────────────────────────────────────────
+
+type fakeMarketInformationServer struct {
+	marketinformationv1.UnimplementedMarketInformationServiceServer
+	registerDataSourceErr error
+	registerDataSetErr    error
+	activateDataSetErr    error
+}
+
+func (f *fakeMarketInformationServer) RegisterDataSource(_ context.Context, req *marketinformationv1.RegisterDataSourceRequest) (*marketinformationv1.RegisterDataSourceResponse, error) {
+	if f.registerDataSourceErr != nil {
+		return nil, f.registerDataSourceErr
+	}
+	return &marketinformationv1.RegisterDataSourceResponse{
+		Source: &marketinformationv1.DataSource{
+			Id:   "src-uuid-1",
+			Code: req.Code,
+		},
+	}, nil
+}
+
+func (f *fakeMarketInformationServer) RegisterDataSet(_ context.Context, req *marketinformationv1.RegisterDataSetRequest) (*marketinformationv1.RegisterDataSetResponse, error) {
+	if f.registerDataSetErr != nil {
+		return nil, f.registerDataSetErr
+	}
+	return &marketinformationv1.RegisterDataSetResponse{
+		Dataset: &marketinformationv1.DataSetDefinition{
+			Id:      "ds-uuid-1",
+			Code:    req.Code,
+			Version: 1,
+			Status:  marketinformationv1.DataSetStatus_DATA_SET_STATUS_DRAFT,
+		},
+	}, nil
+}
+
+func (f *fakeMarketInformationServer) ActivateDataSet(_ context.Context, req *marketinformationv1.ActivateDataSetRequest) (*marketinformationv1.ActivateDataSetResponse, error) {
+	if f.activateDataSetErr != nil {
+		return nil, f.activateDataSetErr
+	}
+	return &marketinformationv1.ActivateDataSetResponse{
+		Dataset: &marketinformationv1.DataSetDefinition{
+			Id:      "ds-uuid-1",
+			Code:    req.Code,
+			Version: req.Version,
+			Status:  marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
+		},
+	}, nil
+}
+
+// ─── Test setup ────────────────────────────────────────────────────────────
+
+func newMarketInformationTestServer(t *testing.T, srv *fakeMarketInformationServer) *grpc.ClientConn {
+	t.Helper()
+
+	lis := bufconn.Listen(1024 * 1024)
+	grpcSrv := grpc.NewServer()
+	marketinformationv1.RegisterMarketInformationServiceServer(grpcSrv, srv)
+
+	go func() { _ = grpcSrv.Serve(lis) }()
+	t.Cleanup(grpcSrv.GracefulStop)
+
+	conn, err := grpc.NewClient("passthrough:///bufconn",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return conn
+}
+
+// ─── parseDataCategory tests ───────────────────────────────────────────────
 
 func TestParseDataCategory_Empty(t *testing.T) {
 	cat, err := parseDataCategory("")
@@ -36,4 +119,188 @@ func TestParseDataCategory_Unknown(t *testing.T) {
 func TestNewMarketInformationClient(t *testing.T) {
 	c := NewMarketInformationClient(nil)
 	assert.NotNil(t, c)
+}
+
+// ─── RegisterDataSource tests ──────────────────────────────────────────────
+
+func TestMarketInformationClient_RegisterDataSource(t *testing.T) {
+	conn := newMarketInformationTestServer(t, &fakeMarketInformationServer{})
+	client := NewMarketInformationClient(conn)
+
+	result, err := client.RegisterDataSource(testStarlarkCtx(), map[string]any{
+		"code":        "BLOOMBERG",
+		"name":        "Bloomberg Data",
+		"description": "FX and commodity data",
+		"trust_level": int32(90),
+	})
+	require.NoError(t, err)
+
+	m := result.(map[string]any)
+	assert.Equal(t, "src-uuid-1", m["source_id"])
+	assert.Equal(t, "BLOOMBERG", m["code"])
+	assert.Equal(t, "REGISTERED", m["status"])
+}
+
+func TestMarketInformationClient_RegisterDataSource_MinimalParams(t *testing.T) {
+	conn := newMarketInformationTestServer(t, &fakeMarketInformationServer{})
+	client := NewMarketInformationClient(conn)
+
+	result, err := client.RegisterDataSource(testStarlarkCtx(), map[string]any{
+		"code": "MINIMAL",
+	})
+	require.NoError(t, err)
+
+	m := result.(map[string]any)
+	assert.Equal(t, "src-uuid-1", m["source_id"])
+	assert.Equal(t, "MINIMAL", m["code"])
+}
+
+func TestMarketInformationClient_RegisterDataSource_GRPCError(t *testing.T) {
+	srv := &fakeMarketInformationServer{
+		registerDataSourceErr: status.Error(codes.AlreadyExists, "data source already exists"),
+	}
+	conn := newMarketInformationTestServer(t, srv)
+	client := NewMarketInformationClient(conn)
+
+	_, err := client.RegisterDataSource(testStarlarkCtx(), map[string]any{
+		"code": "DUPLICATE",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "register data source")
+}
+
+// ─── RegisterDataSet tests ─────────────────────────────────────────────────
+
+func TestMarketInformationClient_RegisterDataSet(t *testing.T) {
+	conn := newMarketInformationTestServer(t, &fakeMarketInformationServer{})
+	client := NewMarketInformationClient(conn)
+
+	result, err := client.RegisterDataSet(testStarlarkCtx(), map[string]any{
+		"code":                      "USD_EUR_FX",
+		"unit":                      "USD/EUR",
+		"display_name":              "USD/EUR Spot Rate",
+		"description":               "Spot FX rate",
+		"category":                  "FX_RATE",
+		"resolution_key_expression": "observed_at",
+		"validation_expression":     "value > 0",
+	})
+	require.NoError(t, err)
+
+	m := result.(map[string]any)
+	assert.Equal(t, "ds-uuid-1", m["dataset_id"])
+	assert.Equal(t, "USD_EUR_FX", m["code"])
+	assert.Equal(t, int32(1), m["version"])
+	assert.Contains(t, m["status"].(string), "DRAFT")
+}
+
+func TestMarketInformationClient_RegisterDataSet_MinimalParams(t *testing.T) {
+	conn := newMarketInformationTestServer(t, &fakeMarketInformationServer{})
+	client := NewMarketInformationClient(conn)
+
+	result, err := client.RegisterDataSet(testStarlarkCtx(), map[string]any{
+		"code": "MINIMAL_DS",
+	})
+	require.NoError(t, err)
+
+	m := result.(map[string]any)
+	assert.Equal(t, "ds-uuid-1", m["dataset_id"])
+	assert.Equal(t, "MINIMAL_DS", m["code"])
+}
+
+func TestMarketInformationClient_RegisterDataSet_WithEffectiveFrom(t *testing.T) {
+	conn := newMarketInformationTestServer(t, &fakeMarketInformationServer{})
+	client := NewMarketInformationClient(conn)
+
+	result, err := client.RegisterDataSet(testStarlarkCtx(), map[string]any{
+		"code":           "TIMED_DS",
+		"effective_from": "2025-01-01T00:00:00Z",
+	})
+	require.NoError(t, err)
+
+	m := result.(map[string]any)
+	assert.Equal(t, "TIMED_DS", m["code"])
+}
+
+func TestMarketInformationClient_RegisterDataSet_InvalidEffectiveFrom(t *testing.T) {
+	conn := newMarketInformationTestServer(t, &fakeMarketInformationServer{})
+	client := NewMarketInformationClient(conn)
+
+	_, err := client.RegisterDataSet(testStarlarkCtx(), map[string]any{
+		"code":           "BAD_DATE",
+		"effective_from": "not-a-date",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid effective_from")
+}
+
+func TestMarketInformationClient_RegisterDataSet_InvalidCategory(t *testing.T) {
+	conn := newMarketInformationTestServer(t, &fakeMarketInformationServer{})
+	client := NewMarketInformationClient(conn)
+
+	_, err := client.RegisterDataSet(testStarlarkCtx(), map[string]any{
+		"code":     "BAD_CAT",
+		"category": "NONEXISTENT_CATEGORY",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnknownDataCategory)
+}
+
+func TestMarketInformationClient_RegisterDataSet_GRPCError(t *testing.T) {
+	srv := &fakeMarketInformationServer{
+		registerDataSetErr: status.Error(codes.Internal, "internal error"),
+	}
+	conn := newMarketInformationTestServer(t, srv)
+	client := NewMarketInformationClient(conn)
+
+	_, err := client.RegisterDataSet(testStarlarkCtx(), map[string]any{
+		"code": "WILL_FAIL",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "register data set")
+}
+
+// ─── ActivateDataSet tests ─────────────────────────────────────────────────
+
+func TestMarketInformationClient_ActivateDataSet(t *testing.T) {
+	conn := newMarketInformationTestServer(t, &fakeMarketInformationServer{})
+	client := NewMarketInformationClient(conn)
+
+	result, err := client.ActivateDataSet(testStarlarkCtx(), map[string]any{
+		"code":    "USD_EUR_FX",
+		"version": int32(1),
+	})
+	require.NoError(t, err)
+
+	m := result.(map[string]any)
+	assert.Equal(t, "ds-uuid-1", m["dataset_id"])
+	assert.Equal(t, "USD_EUR_FX", m["code"])
+	assert.Equal(t, int32(1), m["version"])
+	assert.Contains(t, m["status"].(string), "ACTIVE")
+}
+
+func TestMarketInformationClient_ActivateDataSet_MinimalParams(t *testing.T) {
+	conn := newMarketInformationTestServer(t, &fakeMarketInformationServer{})
+	client := NewMarketInformationClient(conn)
+
+	result, err := client.ActivateDataSet(testStarlarkCtx(), map[string]any{
+		"code": "MINIMAL",
+	})
+	require.NoError(t, err)
+
+	m := result.(map[string]any)
+	assert.Equal(t, "MINIMAL", m["code"])
+}
+
+func TestMarketInformationClient_ActivateDataSet_GRPCError(t *testing.T) {
+	srv := &fakeMarketInformationServer{
+		activateDataSetErr: status.Error(codes.NotFound, "data set not found"),
+	}
+	conn := newMarketInformationTestServer(t, srv)
+	client := NewMarketInformationClient(conn)
+
+	_, err := client.ActivateDataSet(testStarlarkCtx(), map[string]any{
+		"code": "MISSING",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "activate data set")
 }

--- a/shared/pkg/saga/outbox_repository_test.go
+++ b/shared/pkg/saga/outbox_repository_test.go
@@ -1,10 +1,99 @@
 package saga
 
 import (
+	"context"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/platform/events"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
+
+// setupTestGormDB creates an in-memory SQLite database with simplified tables
+// compatible with the GORM models used by the outbox repository.
+func setupTestGormDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared&_busy_timeout=5000"), &gorm.Config{})
+	require.NoError(t, err)
+
+	// Create tables with SQLite-compatible types (no uuid, jsonb, gen_random_uuid())
+	sqls := []string{
+		`CREATE TABLE IF NOT EXISTS saga_instances (
+			id TEXT PRIMARY KEY,
+			saga_definition_id TEXT NOT NULL,
+			saga_name TEXT,
+			saga_version INTEGER,
+			platform_saga_version_id TEXT,
+			script_hash_at_start TEXT,
+			input_snapshot TEXT,
+			status TEXT NOT NULL DEFAULT 'PENDING',
+			current_step_index INTEGER DEFAULT 0,
+			correlation_id TEXT,
+			causation_id TEXT,
+			tenant_id TEXT NOT NULL DEFAULT '',
+			party_type TEXT,
+			party_id TEXT,
+			knowledge_at DATETIME,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			claimed_by TEXT,
+			claimed_at DATETIME,
+			lease_expires_at DATETIME,
+			completed_at DATETIME,
+			timeout_seconds INTEGER DEFAULT 0,
+			original_input TEXT,
+			max_retries INTEGER DEFAULT 0,
+			retry_count INTEGER DEFAULT 0,
+			last_error TEXT,
+			parent_saga_instance_id TEXT,
+			is_child INTEGER DEFAULT 0
+		)`,
+		`CREATE TABLE IF NOT EXISTS saga_step_results (
+			id TEXT PRIMARY KEY,
+			saga_instance_id TEXT NOT NULL,
+			step_index INTEGER NOT NULL,
+			step_name TEXT,
+			idempotency_key TEXT NOT NULL UNIQUE,
+			result TEXT,
+			error TEXT,
+			status TEXT NOT NULL,
+			error_category TEXT,
+			causation_id TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (saga_instance_id) REFERENCES saga_instances(id) ON DELETE CASCADE
+		)`,
+		`CREATE TABLE IF NOT EXISTS event_outbox (
+			id TEXT PRIMARY KEY,
+			event_type TEXT NOT NULL,
+			aggregate_id TEXT NOT NULL,
+			aggregate_type TEXT NOT NULL,
+			event_payload BLOB NOT NULL,
+			correlation_id TEXT,
+			causation_id TEXT,
+			status TEXT NOT NULL,
+			topic TEXT NOT NULL,
+			partition_key TEXT,
+			created_at DATETIME NOT NULL,
+			processed_at DATETIME,
+			retry_count INTEGER NOT NULL DEFAULT 0,
+			last_error TEXT,
+			service_name TEXT NOT NULL,
+			tenant_id TEXT NOT NULL DEFAULT ''
+		)`,
+	}
+
+	for _, sql := range sqls {
+		require.NoError(t, db.Exec(sql).Error)
+	}
+
+	return db
+}
+
+// ─── Constructor tests ─────────────────────────────────────────────────────
 
 func TestNewGormTxContextWithOutbox(t *testing.T) {
 	ctx := NewGormTxContextWithOutbox(nil, "test-service")
@@ -16,4 +105,274 @@ func TestNewGormTransactionalRepositoryWithOutbox(t *testing.T) {
 	repo := NewGormTransactionalRepositoryWithOutbox(nil, "test-service")
 	assert.NotNil(t, repo)
 	assert.Equal(t, "test-service", repo.serviceName)
+}
+
+// ─── SaveStepResult tests ──────────────────────────────────────────────────
+
+func TestSaveStepResult_Success(t *testing.T) {
+	db := setupTestGormDB(t)
+
+	// Insert a saga instance for the FK
+	instanceID := uuid.New()
+	db.Exec("INSERT INTO saga_instances (id, saga_definition_id, saga_name, status) VALUES (?, ?, ?, ?)",
+		instanceID.String(), uuid.New().String(), "test_saga", "RUNNING")
+
+	tx := db.Begin()
+	txCtx := NewGormTxContextWithOutbox(tx, "test-service")
+
+	stepResult := &SagaStepResult{
+		ID:             uuid.New(),
+		SagaInstanceID: instanceID,
+		StepIndex:      0,
+		StepName:       "register_instrument",
+		IdempotencyKey: "saga_" + instanceID.String() + "_step_0",
+		Status:         "COMPLETED",
+	}
+
+	err := txCtx.SaveStepResult(context.Background(), stepResult)
+	require.NoError(t, err)
+
+	err = txCtx.Commit()
+	require.NoError(t, err)
+
+	// Verify persisted
+	var count int64
+	db.Model(&SagaStepResult{}).Where("id = ?", stepResult.ID).Count(&count)
+	assert.Equal(t, int64(1), count)
+}
+
+func TestSaveStepResult_DuplicateIdempotencyKey(t *testing.T) {
+	db := setupTestGormDB(t)
+
+	instanceID := uuid.New()
+	db.Exec("INSERT INTO saga_instances (id, saga_definition_id, saga_name, status) VALUES (?, ?, ?, ?)",
+		instanceID.String(), uuid.New().String(), "test_saga", "RUNNING")
+
+	key := "saga_" + instanceID.String() + "_step_0"
+
+	// Insert first
+	tx1 := db.Begin()
+	txCtx1 := NewGormTxContextWithOutbox(tx1, "test-service")
+	err := txCtx1.SaveStepResult(context.Background(), &SagaStepResult{
+		ID:             uuid.New(),
+		SagaInstanceID: instanceID,
+		StepIndex:      0,
+		StepName:       "step_one",
+		IdempotencyKey: key,
+		Status:         "COMPLETED",
+	})
+	require.NoError(t, err)
+	require.NoError(t, txCtx1.Commit())
+
+	// Insert duplicate - should fail on unique constraint
+	tx2 := db.Begin()
+	txCtx2 := NewGormTxContextWithOutbox(tx2, "test-service")
+	err = txCtx2.SaveStepResult(context.Background(), &SagaStepResult{
+		ID:             uuid.New(),
+		SagaInstanceID: instanceID,
+		StepIndex:      0,
+		StepName:       "step_one",
+		IdempotencyKey: key,
+		Status:         "COMPLETED",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "save step result")
+	_ = txCtx2.Rollback()
+}
+
+// ─── UpdateStepIndex tests ─────────────────────────────────────────────────
+
+func TestUpdateStepIndex_Success(t *testing.T) {
+	db := setupTestGormDB(t)
+
+	instanceID := uuid.New()
+	db.Exec("INSERT INTO saga_instances (id, saga_definition_id, saga_name, status, current_step_index) VALUES (?, ?, ?, ?, ?)",
+		instanceID.String(), uuid.New().String(), "test_saga", "RUNNING", 0)
+
+	tx := db.Begin()
+	txCtx := NewGormTxContextWithOutbox(tx, "test-service")
+
+	err := txCtx.UpdateStepIndex(context.Background(), instanceID, 3)
+	require.NoError(t, err)
+	require.NoError(t, txCtx.Commit())
+
+	// Verify updated
+	var instance SagaInstance
+	db.First(&instance, "id = ?", instanceID)
+	assert.Equal(t, 3, instance.CurrentStepIndex)
+}
+
+func TestUpdateStepIndex_NotFound(t *testing.T) {
+	db := setupTestGormDB(t)
+	tx := db.Begin()
+	txCtx := NewGormTxContextWithOutbox(tx, "test-service")
+
+	err := txCtx.UpdateStepIndex(context.Background(), uuid.New(), 1)
+	assert.ErrorIs(t, err, ErrSagaInstanceNotFound)
+	_ = txCtx.Rollback()
+}
+
+// ─── WriteOutboxEntry tests ────────────────────────────────────────────────
+
+func TestWriteOutboxEntry_Success(t *testing.T) {
+	db := setupTestGormDB(t)
+	tx := db.Begin()
+	txCtx := NewGormTxContextWithOutbox(tx, "saga-service")
+
+	entryID := uuid.New()
+	entry := &OutboxEntry{
+		ID:            entryID,
+		EventType:     "saga.step.completed",
+		AggregateID:   "agg-123",
+		AggregateType: "saga_instance",
+		EventPayload:  []byte(`{"step":"register_instrument"}`),
+		CorrelationID: uuid.New().String(),
+		CausationID:   uuid.New().String(),
+		Topic:         "saga-events",
+	}
+
+	err := txCtx.WriteOutboxEntry(context.Background(), entry)
+	require.NoError(t, err)
+	require.NoError(t, txCtx.Commit())
+
+	// Verify the platform EventOutbox was created
+	var outbox events.EventOutbox
+	result := db.First(&outbox, "id = ?", entryID)
+	require.NoError(t, result.Error)
+	assert.Equal(t, "saga.step.completed", outbox.EventType)
+	assert.Equal(t, "agg-123", outbox.AggregateID)
+	assert.Equal(t, "saga_instance", outbox.AggregateType)
+	assert.Equal(t, "saga-events", outbox.Topic)
+	assert.Equal(t, events.StatusPending, outbox.Status)
+	assert.Equal(t, "saga-service", outbox.ServiceName)
+	assert.Equal(t, "agg-123", outbox.PartitionKey) // Uses aggregate ID
+	assert.Equal(t, 0, outbox.RetryCount)
+}
+
+// ─── Commit / Rollback tests ──────────────────────────────────────────────
+
+func TestCommit_Success(t *testing.T) {
+	db := setupTestGormDB(t)
+
+	instanceID := uuid.New()
+	db.Exec("INSERT INTO saga_instances (id, saga_definition_id, saga_name, status) VALUES (?, ?, ?, ?)",
+		instanceID.String(), uuid.New().String(), "test_saga", "RUNNING")
+
+	tx := db.Begin()
+	txCtx := NewGormTxContextWithOutbox(tx, "test-service")
+
+	err := txCtx.SaveStepResult(context.Background(), &SagaStepResult{
+		ID:             uuid.New(),
+		SagaInstanceID: instanceID,
+		StepIndex:      0,
+		StepName:       "test_step",
+		IdempotencyKey: "key-commit-" + uuid.New().String(),
+		Status:         "COMPLETED",
+	})
+	require.NoError(t, err)
+
+	err = txCtx.Commit()
+	require.NoError(t, err)
+
+	// Verify data is visible
+	var count int64
+	db.Model(&SagaStepResult{}).Where("saga_instance_id = ?", instanceID).Count(&count)
+	assert.Equal(t, int64(1), count)
+}
+
+func TestRollback_DiscardsChanges(t *testing.T) {
+	db := setupTestGormDB(t)
+
+	instanceID := uuid.New()
+	db.Exec("INSERT INTO saga_instances (id, saga_definition_id, saga_name, status) VALUES (?, ?, ?, ?)",
+		instanceID.String(), uuid.New().String(), "test_saga", "RUNNING")
+
+	tx := db.Begin()
+	txCtx := NewGormTxContextWithOutbox(tx, "test-service")
+
+	err := txCtx.SaveStepResult(context.Background(), &SagaStepResult{
+		ID:             uuid.New(),
+		SagaInstanceID: instanceID,
+		StepIndex:      0,
+		StepName:       "test_step",
+		IdempotencyKey: "key-rollback-" + uuid.New().String(),
+		Status:         "COMPLETED",
+	})
+	require.NoError(t, err)
+
+	err = txCtx.Rollback()
+	require.NoError(t, err)
+
+	// Verify data is NOT visible
+	var count int64
+	db.Model(&SagaStepResult{}).Where("saga_instance_id = ?", instanceID).Count(&count)
+	assert.Equal(t, int64(0), count)
+}
+
+// ─── BeginTxWithOutbox tests ───────────────────────────────────────────────
+
+func TestBeginTxWithOutbox_Success(t *testing.T) {
+	db := setupTestGormDB(t)
+	repo := NewGormTransactionalRepositoryWithOutbox(db, "test-service")
+
+	txCtx, err := repo.BeginTxWithOutbox(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, txCtx)
+
+	// Should be able to rollback without error
+	err = txCtx.Rollback()
+	require.NoError(t, err)
+}
+
+func TestBeginTxWithOutbox_FullWorkflow(t *testing.T) {
+	db := setupTestGormDB(t)
+	repo := NewGormTransactionalRepositoryWithOutbox(db, "workflow-service")
+
+	instanceID := uuid.New()
+	db.Exec("INSERT INTO saga_instances (id, saga_definition_id, saga_name, status) VALUES (?, ?, ?, ?)",
+		instanceID.String(), uuid.New().String(), "test_saga", "RUNNING")
+
+	txCtx, err := repo.BeginTxWithOutbox(context.Background())
+	require.NoError(t, err)
+
+	// Save step result
+	err = txCtx.SaveStepResult(context.Background(), &SagaStepResult{
+		ID:             uuid.New(),
+		SagaInstanceID: instanceID,
+		StepIndex:      0,
+		StepName:       "full_workflow_step",
+		IdempotencyKey: "key-workflow-" + uuid.New().String(),
+		Status:         "COMPLETED",
+	})
+	require.NoError(t, err)
+
+	// Write outbox entry
+	err = txCtx.WriteOutboxEntry(context.Background(), &OutboxEntry{
+		ID:            uuid.New(),
+		EventType:     "saga.step.completed",
+		AggregateID:   instanceID.String(),
+		AggregateType: "saga_instance",
+		EventPayload:  []byte(`{}`),
+		Topic:         "saga-events",
+	})
+	require.NoError(t, err)
+
+	// Commit
+	err = txCtx.Commit()
+	require.NoError(t, err)
+
+	// Verify both records exist
+	var stepCount int64
+	db.Model(&SagaStepResult{}).Where("saga_instance_id = ?", instanceID).Count(&stepCount)
+	assert.Equal(t, int64(1), stepCount)
+
+	var outboxCount int64
+	db.Model(&events.EventOutbox{}).Where("aggregate_id = ?", instanceID.String()).Count(&outboxCount)
+	assert.Equal(t, int64(1), outboxCount)
+}
+
+// ─── Error sentinel tests ──────────────────────────────────────────────────
+
+func TestErrSagaInstanceNotFound(t *testing.T) {
+	assert.EqualError(t, ErrSagaInstanceNotFound, "saga instance not found")
 }


### PR DESCRIPTION
## Summary
- Expand market information client test coverage with bufconn-based gRPC tests for RegisterDataSource, RegisterDataSet, and ActivateDataSet (full params, minimal params, gRPC errors, invalid category, invalid date parsing)
- Add saga outbox repository unit tests using SQLite in-memory DB for SaveStepResult, UpdateStepIndex, WriteOutboxEntry, Commit/Rollback transactional semantics, and BeginTxWithOutbox full workflow
- Note: causation_visualizer.go and validate_fix.go do not exist in the codebase - those files were referenced in task descriptions but are not yet implemented

## Test plan
- [x] All new market information client tests pass (`go test ./services/control-plane/internal/applier/...`)
- [x] All new saga outbox repository tests pass (`go test ./shared/pkg/saga/...`)
- [x] Full existing test suites remain green (no regressions)