### PR TITLE
test: Party health Watch/component and lien idempotency coverage

### DIFF
--- a/services/internal-account/service/lien_idempotency_coverage_test.go
+++ b/services/internal-account/service/lien_idempotency_coverage_test.go
@@ -1,0 +1,161 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/internal_account/v1"
+	"github.com/meridianhub/meridian/shared/pkg/idempotency"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ---------------------------------------------------------------------------
+// ExecuteLien – MarkPending returns arbitrary error
+// ---------------------------------------------------------------------------
+
+// TestExecuteLien_MarkPendingFailed_ArbitraryError verifies that when MarkPending
+// returns a non-ErrOperationAlreadyProcessed error, the service returns Aborted
+// with a "failed to acquire idempotency lock" message.
+func TestExecuteLien_MarkPendingFailed_ArbitraryError(t *testing.T) {
+	repo := newMockRepository()
+	mockIdemp := newMockIdempotencyService()
+	mockIdemp.markPendingErr = assert.AnError
+
+	svc, err := NewServiceFull(repo, nil, nil, testLogger(), nil,
+		WithIdempotencyService(mockIdemp),
+		WithLienRepo(nil),
+	)
+	require.NoError(t, err)
+
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("test-tenant"))
+	lienID := uuid.New()
+
+	req := &pb.ExecuteLienRequest{
+		LienId:         lienID.String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "exec-mark-fail-001"},
+	}
+
+	_, err = svc.ExecuteLien(ctx, req)
+	require.Error(t, err)
+	assert.Equal(t, codes.Aborted, status.Code(err))
+	assert.Contains(t, err.Error(), "failed to acquire idempotency lock")
+}
+
+// ---------------------------------------------------------------------------
+// TerminateLien – MarkPending returns arbitrary error
+// ---------------------------------------------------------------------------
+
+// TestTerminateLien_MarkPendingFailed_ArbitraryError verifies that when MarkPending
+// returns a non-ErrOperationAlreadyProcessed error, the service returns Aborted.
+func TestTerminateLien_MarkPendingFailed_ArbitraryError(t *testing.T) {
+	repo := newMockRepository()
+	mockIdemp := newMockIdempotencyService()
+	mockIdemp.markPendingErr = assert.AnError
+
+	svc, err := NewServiceFull(repo, nil, nil, testLogger(), nil,
+		WithIdempotencyService(mockIdemp),
+		WithLienRepo(nil),
+	)
+	require.NoError(t, err)
+
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("test-tenant"))
+	lienID := uuid.New()
+
+	req := &pb.TerminateLienRequest{
+		LienId:         lienID.String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "term-mark-fail-001"},
+	}
+
+	_, err = svc.TerminateLien(ctx, req)
+	require.Error(t, err)
+	assert.Equal(t, codes.Aborted, status.Code(err))
+	assert.Contains(t, err.Error(), "failed to acquire idempotency lock")
+}
+
+// ---------------------------------------------------------------------------
+// ExecuteLien – cached result present but unmarshal fails (falls through)
+// ---------------------------------------------------------------------------
+
+// TestExecuteLien_CachedResultUnmarshalFails verifies that when a cached
+// idempotency result is present but the data cannot be unmarshalled, the
+// request falls through to the normal execution path.
+func TestExecuteLien_CachedResultUnmarshalFails(t *testing.T) {
+	repo := newMockRepository()
+	mockIdemp := newMockIdempotencyService()
+
+	svc, err := NewServiceFull(repo, nil, nil, testLogger(), nil,
+		WithIdempotencyService(mockIdemp),
+		WithLienRepo(nil), // nil lienRepo → FailedPrecondition after fallthrough
+	)
+	require.NoError(t, err)
+
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("test-tenant"))
+	lienID := uuid.New()
+
+	idempKey := idempotency.Key{
+		TenantID:  "test-tenant",
+		Namespace: idempotencyNamespace,
+		Operation: "execute_lien",
+		EntityID:  lienID.String(),
+		RequestID: "exec-corrupt-001",
+	}
+	// Store an invalid proto payload so unmarshal will fail
+	mockIdemp.setResult(idempKey, []byte("not-valid-proto-data"))
+
+	req := &pb.ExecuteLienRequest{
+		LienId:         lienID.String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "exec-corrupt-001"},
+	}
+
+	// Unmarshal fails → falls through → MarkPending succeeds → nil lienRepo → FailedPrecondition
+	_, err = svc.ExecuteLien(ctx, req)
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+// ---------------------------------------------------------------------------
+// TerminateLien – cached result present but unmarshal fails (falls through)
+// ---------------------------------------------------------------------------
+
+// TestTerminateLien_CachedResultUnmarshalFails verifies that when a cached
+// termination result cannot be unmarshalled, the request falls through to
+// the normal execution path.
+func TestTerminateLien_CachedResultUnmarshalFails(t *testing.T) {
+	repo := newMockRepository()
+	mockIdemp := newMockIdempotencyService()
+
+	svc, err := NewServiceFull(repo, nil, nil, testLogger(), nil,
+		WithIdempotencyService(mockIdemp),
+		WithLienRepo(nil), // nil lienRepo → FailedPrecondition after fallthrough
+	)
+	require.NoError(t, err)
+
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("test-tenant"))
+	lienID := uuid.New()
+
+	idempKey := idempotency.Key{
+		TenantID:  "test-tenant",
+		Namespace: idempotencyNamespace,
+		Operation: "terminate_lien",
+		EntityID:  lienID.String(),
+		RequestID: "term-corrupt-001",
+	}
+	// Store an invalid proto payload so unmarshal will fail
+	mockIdemp.setResult(idempKey, []byte("not-valid-proto-data"))
+
+	req := &pb.TerminateLienRequest{
+		LienId:         lienID.String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "term-corrupt-001"},
+	}
+
+	// Unmarshal fails → falls through → MarkPending succeeds → nil lienRepo → FailedPrecondition
+	_, err = svc.TerminateLien(ctx, req)
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}

--- a/services/internal-account/service/lien_idempotency_test.go
+++ b/services/internal-account/service/lien_idempotency_test.go
@@ -20,12 +20,13 @@ import (
 
 // mockIdempotencyService implements idempotency.Service for unit testing.
 type mockIdempotencyService struct {
-	mu        sync.Mutex
-	results   map[string]*idempotency.Result
-	pending   map[string]bool
-	checkErr  error
-	storeErr  error
-	deleteErr error
+	mu             sync.Mutex
+	results        map[string]*idempotency.Result
+	pending        map[string]bool
+	checkErr       error
+	storeErr       error
+	deleteErr      error
+	markPendingErr error
 }
 
 func newMockIdempotencyService() *mockIdempotencyService {
@@ -56,6 +57,10 @@ func (m *mockIdempotencyService) Check(_ context.Context, key idempotency.Key) (
 func (m *mockIdempotencyService) MarkPending(_ context.Context, key idempotency.Key, _ time.Duration) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	if m.markPendingErr != nil {
+		return m.markPendingErr
+	}
 
 	keyStr := key.String()
 	if m.pending[keyStr] {

--- a/services/party/service/health_watch_test.go
+++ b/services/party/service/health_watch_test.go
@@ -1,0 +1,172 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/pkg/health"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+)
+
+// mockHealthWatchStream implements grpc_health_v1.Health_WatchServer for unit testing.
+type mockHealthWatchStream struct {
+	ctx     context.Context
+	sends   []*grpc_health_v1.HealthCheckResponse
+	sendErr error
+}
+
+func (m *mockHealthWatchStream) Send(resp *grpc_health_v1.HealthCheckResponse) error {
+	if m.sendErr != nil {
+		return m.sendErr
+	}
+	m.sends = append(m.sends, resp)
+	return nil
+}
+
+func (m *mockHealthWatchStream) Context() context.Context     { return m.ctx }
+func (m *mockHealthWatchStream) SetHeader(metadata.MD) error  { return nil }
+func (m *mockHealthWatchStream) SendHeader(metadata.MD) error { return nil }
+func (m *mockHealthWatchStream) SetTrailer(metadata.MD)       {}
+func (m *mockHealthWatchStream) SendMsg(any) error            { return nil }
+func (m *mockHealthWatchStream) RecvMsg(any) error            { return nil }
+
+// mockHealthChecker is a simple health.Checker for testing aggregator lookups.
+type mockHealthChecker struct {
+	name   string
+	status health.Status
+}
+
+func (m *mockHealthChecker) Name() string { return m.name }
+func (m *mockHealthChecker) Check(_ context.Context) health.ComponentResult {
+	return health.ComponentResult{
+		Name:      m.name,
+		Status:    m.status,
+		Message:   "mock",
+		CheckedAt: time.Now(),
+	}
+}
+
+// TestHealthChecker_Check_ComponentFound tests the path where a specific
+// component name is requested and found in the aggregator.
+func TestHealthChecker_Check_ComponentFound(t *testing.T) {
+	t.Parallel()
+
+	checker := &mockHealthChecker{name: "database", status: health.StatusHealthy}
+	aggregator := health.NewAggregator([]health.Checker{checker})
+
+	hc := &HealthChecker{
+		logger:       newTestService(newMockRepository()).logger,
+		aggregator:   aggregator,
+		serviceName:  "party",
+		checkTimeout: 5 * time.Second,
+	}
+
+	resp, err := hc.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
+		Service: "database",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
+}
+
+// TestHealthChecker_Check_ComponentFound_Unhealthy tests the path where a
+// specific component is found but reports an unhealthy status.
+func TestHealthChecker_Check_ComponentFound_Unhealthy(t *testing.T) {
+	t.Parallel()
+
+	checker := &mockHealthChecker{name: "database", status: health.StatusUnhealthy}
+	aggregator := health.NewAggregator([]health.Checker{checker})
+
+	hc := &HealthChecker{
+		logger:       newTestService(newMockRepository()).logger,
+		aggregator:   aggregator,
+		serviceName:  "party",
+		checkTimeout: 5 * time.Second,
+	}
+
+	resp, err := hc.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
+		Service: "database",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_NOT_SERVING, resp.Status)
+}
+
+// TestHealthChecker_Watch_InitialSendError tests that Watch returns an error
+// when the initial health check response cannot be sent to the stream.
+func TestHealthChecker_Watch_InitialSendError(t *testing.T) {
+	t.Parallel()
+
+	sendErr := errors.New("stream closed")
+	stream := &mockHealthWatchStream{
+		ctx:     context.Background(),
+		sendErr: sendErr,
+	}
+
+	aggregator := health.NewAggregator([]health.Checker{})
+	hc := &HealthChecker{
+		logger:       newTestService(newMockRepository()).logger,
+		aggregator:   aggregator,
+		serviceName:  "party",
+		checkTimeout: 5 * time.Second,
+	}
+
+	err := hc.Watch(&grpc_health_v1.HealthCheckRequest{Service: ""}, stream)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to send initial health status")
+}
+
+// TestHealthChecker_Watch_ContextCancellation tests that Watch exits cleanly
+// when the stream context is cancelled after the initial response is sent.
+func TestHealthChecker_Watch_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	callCount := 0
+	stream := &mockHealthWatchStream{ctx: ctx}
+
+	aggregator := health.NewAggregator([]health.Checker{})
+	hc := &HealthChecker{
+		logger:       newTestService(newMockRepository()).logger,
+		aggregator:   aggregator,
+		serviceName:  "party",
+		checkTimeout: 100 * time.Millisecond,
+	}
+
+	// Replace Send to cancel context after initial response
+	origSend := stream
+	_ = origSend
+
+	// Use a custom stream that cancels context after first send
+	cancellingStream := &cancelAfterFirstSendStream{
+		mockHealthWatchStream: mockHealthWatchStream{ctx: ctx},
+		cancel:                cancel,
+		sendCount:             &callCount,
+	}
+
+	err := hc.Watch(&grpc_health_v1.HealthCheckRequest{Service: ""}, cancellingStream)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "health watch context cancelled")
+}
+
+// cancelAfterFirstSendStream cancels its context after the first successful send.
+type cancelAfterFirstSendStream struct {
+	mockHealthWatchStream
+	cancel    context.CancelFunc
+	sendCount *int
+}
+
+func (c *cancelAfterFirstSendStream) Send(resp *grpc_health_v1.HealthCheckResponse) error {
+	*c.sendCount++
+	c.mockHealthWatchStream.sends = append(c.mockHealthWatchStream.sends, resp)
+	if *c.sendCount == 1 {
+		c.cancel()
+	}
+	return nil
+}

--- a/services/party/service/health_watch_test.go
+++ b/services/party/service/health_watch_test.go
@@ -129,7 +129,6 @@ func TestHealthChecker_Watch_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	callCount := 0
-	stream := &mockHealthWatchStream{ctx: ctx}
 
 	aggregator := health.NewAggregator([]health.Checker{})
 	hc := &HealthChecker{
@@ -138,10 +137,6 @@ func TestHealthChecker_Watch_ContextCancellation(t *testing.T) {
 		serviceName:  "party",
 		checkTimeout: 100 * time.Millisecond,
 	}
-
-	// Replace Send to cancel context after initial response
-	origSend := stream
-	_ = origSend
 
 	// Use a custom stream that cancels context after first send
 	cancellingStream := &cancelAfterFirstSendStream{
@@ -164,7 +159,7 @@ type cancelAfterFirstSendStream struct {
 
 func (c *cancelAfterFirstSendStream) Send(resp *grpc_health_v1.HealthCheckResponse) error {
 	*c.sendCount++
-	c.mockHealthWatchStream.sends = append(c.mockHealthWatchStream.sends, resp)
+	c.sends = append(c.sends, resp)
 	if *c.sendCount == 1 {
 		c.cancel()
 	}


### PR DESCRIPTION
## Summary

- **`services/party/service`**: Adds `health_watch_test.go` with unit tests for `HealthChecker.Watch()` (initial send error, context cancellation) and `HealthChecker.Check()` component-found paths using a `mockHealthChecker` and `mockHealthWatchStream`
- **`services/internal-account/service`**: Adds `markPendingErr` field to `mockIdempotencyService` and a new `lien_idempotency_coverage_test.go` covering `MarkPending` arbitrary-error and cached-result unmarshal-failure fallthrough paths for both `ExecuteLien` and `TerminateLien`

## Test plan

- [ ] `go test ./services/party/service/... -run TestHealthChecker` passes locally
- [ ] `go test ./services/internal-account/service/... -run "TestExecuteLien_MarkPending|TestTerminateLien_MarkPending|TestExecuteLien_Cached|TestTerminateLien_Cached"` passes locally
- [ ] CI passes