### PR TITLE
fix: make dataset registration idempotent for manifest re-application

### DIFF
--- a/services/market-information/adapters/persistence/dataset_repository.go
+++ b/services/market-information/adapters/persistence/dataset_repository.go
@@ -24,7 +24,7 @@ func NewDataSetRepository(pool *pgxpool.Pool) *DataSetRepository {
 }
 
 // Save persists a new or updated dataset definition.
-// For new datasets, returns ErrDuplicateDataSetCode if the code already exists.
+// Idempotent for new datasets: returns nil if the code+version already exists.
 // For updates, returns ErrVersionMismatch on optimistic lock failure.
 func (r *DataSetRepository) Save(ctx context.Context, dataset domain.DataSetDefinition) error {
 	return r.withWriteTransaction(ctx, func(tx pgx.Tx) error {

--- a/services/market-information/adapters/persistence/dataset_repository.go
+++ b/services/market-information/adapters/persistence/dataset_repository.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/meridianhub/meridian/services/market-information/domain"
 )
@@ -61,7 +60,8 @@ func (r *DataSetRepository) insertDataSet(ctx context.Context, tx pgx.Tx, entity
 			$7, $8, $9,
 			$10, $11, $12, $13, $14, $15, $16,
 			$17, $18
-		)`
+		)
+		ON CONFLICT (code, version) DO NOTHING`
 
 	_, err := tx.Exec(ctx, query,
 		entity.ID,
@@ -84,10 +84,6 @@ func (r *DataSetRepository) insertDataSet(ctx context.Context, tx pgx.Tx, entity
 		nullTimePtr(entity.DeprecatedAt),
 	)
 	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-			return domain.ErrDuplicateDataSetCode
-		}
 		return fmt.Errorf("failed to insert dataset definition: %w", err)
 	}
 

--- a/services/market-information/adapters/persistence/dataset_repository_test.go
+++ b/services/market-information/adapters/persistence/dataset_repository_test.go
@@ -44,7 +44,7 @@ func TestDataSetRepository_Save_NewDataSet(t *testing.T) {
 	assert.Equal(t, 1, retrieved.Version())
 }
 
-func TestDataSetRepository_Save_DuplicateCode(t *testing.T) {
+func TestDataSetRepository_Save_DuplicateCode_IsIdempotent(t *testing.T) {
 	tc := testhelpers.SetupTestContainer(t)
 	defer tc.Cleanup(t)
 
@@ -65,7 +65,7 @@ func TestDataSetRepository_Save_DuplicateCode(t *testing.T) {
 	err = tc.Repos.DataSet.Save(ctx, dataset1)
 	require.NoError(t, err)
 
-	// Create second dataset with same code (should fail due to code+version unique constraint)
+	// Create second dataset with same code - should be idempotent (ON CONFLICT DO NOTHING)
 	dataset2, err := domain.NewDataSetDefinition(
 		"DUPLICATE_CODE",
 		"Second Dataset",
@@ -78,7 +78,7 @@ func TestDataSetRepository_Save_DuplicateCode(t *testing.T) {
 	require.NoError(t, err)
 
 	err = tc.Repos.DataSet.Save(ctx, dataset2)
-	assert.ErrorIs(t, err, domain.ErrDuplicateDataSetCode)
+	require.NoError(t, err, "duplicate dataset save should be idempotent")
 }
 
 func TestDataSetRepository_Save_UpdateWithOptimisticLocking(t *testing.T) {

--- a/services/market-information/domain/repository.go
+++ b/services/market-information/domain/repository.go
@@ -15,7 +15,7 @@ import (
 // Implementations must be thread-safe and handle tenant context from ctx.
 type DataSetRepository interface {
 	// Save persists a new or updated dataset definition.
-	// For new datasets, returns ErrDuplicateDataSetCode if the code already exists.
+	// Idempotent for new datasets: returns nil if the code+version already exists.
 	// For updates, returns ErrVersionMismatch on optimistic lock failure.
 	Save(ctx context.Context, dataset DataSetDefinition) error
 


### PR DESCRIPTION
## Summary

Fixes the last non-idempotent entity in the ApplyManifest flow. Dataset registration (WHOLESALE_ENERGY_GBP_KWH, CARBON_MARKET) failed with AlreadyExists when re-applying a manifest to an existing tenant.

## Changes

- Add `ON CONFLICT (code, version) DO NOTHING` to the dataset_definition INSERT query
- Remove dead `pgconn` import (unique_violation handler was the only usage)
- Update test to verify idempotent behavior instead of expecting error

## Context

This was discovered when testing the automated demo deploy pipeline (PR #1926). The instrument registration idempotency was fixed there, but the dataset registration had the same pattern. With this fix, `seed-dev --manifest --with-fixtures` works end-to-end on an existing tenant.

## Test plan

- [x] `TestDataSetRepository_Save_DuplicateCode_IsIdempotent` verifies duplicate save returns nil
- [x] All existing dataset repository tests pass
- [ ] CI: full test suite