### PR TITLE
fix: append BASE_DOMAIN suffix to tenant subdomain during registration

### DIFF
--- a/cmd/meridian/gateway.go
+++ b/cmd/meridian/gateway.go
@@ -195,16 +195,22 @@ var errNilTenantResponse = fmt.Errorf("InitiateTenant returned nil tenant")
 // loopbackTenantCreator adapts the tenant gRPC service client to the
 // gateway.TenantCreator interface used by RegistrationHandler.
 type loopbackTenantCreator struct {
-	client tenantv1.TenantServiceClient
-	logger *slog.Logger
+	client     tenantv1.TenantServiceClient
+	baseDomain string
+	logger     *slog.Logger
 }
 
 func (a *loopbackTenantCreator) CreateTenant(ctx context.Context, tenantID, slug, displayName string) (string, error) {
+	subdomain := slug
+	if a.baseDomain != "" {
+		subdomain = slug + "." + a.baseDomain
+	}
+
 	resp, err := a.client.InitiateTenant(ctx, &tenantv1.InitiateTenantRequest{
 		TenantId:        tenantID,
 		DisplayName:     displayName,
 		Slug:            slug,
-		Subdomain:       slug,
+		Subdomain:       subdomain,
 		SettlementAsset: "USD",
 	})
 	if err != nil {
@@ -240,7 +246,7 @@ func wireRegistration(identityDB, tenantDB *gorm.DB, rawConn *grpc.ClientConn, b
 	identityRepo := identitypersistence.NewRepository(identityDB)
 	tenantClient := tenantv1.NewTenantServiceClient(rawConn)
 
-	creator := &loopbackTenantCreator{client: tenantClient, logger: logger}
+	creator := &loopbackTenantCreator{client: tenantClient, baseDomain: baseDomain, logger: logger}
 	slugChecker := &loopbackSlugChecker{repo: tenantpersistence.NewRepository(tenantDB)}
 
 	handler, err := gateway.NewRegistrationHandler(gateway.RegistrationHandlerConfig{

--- a/cmd/meridian/registration_wiring_test.go
+++ b/cmd/meridian/registration_wiring_test.go
@@ -63,7 +63,11 @@ func TestLoopbackTenantCreator_CreateTenant(t *testing.T) {
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	creator := &loopbackTenantCreator{client: stub, logger: logger}
+	creator := &loopbackTenantCreator{
+		client:     stub,
+		baseDomain: "demo.meridianhub.cloud",
+		logger:     logger,
+	}
 
 	tenantID, err := creator.CreateTenant(context.Background(), "acme_corp", "acme-corp", "Acme Corp")
 
@@ -73,8 +77,30 @@ func TestLoopbackTenantCreator_CreateTenant(t *testing.T) {
 	assert.Equal(t, "acme_corp", stub.initiateReq.TenantId)
 	assert.Equal(t, "Acme Corp", stub.initiateReq.DisplayName)
 	assert.Equal(t, "acme-corp", stub.initiateReq.Slug)
-	assert.Equal(t, "acme-corp", stub.initiateReq.Subdomain)
+	assert.Equal(t, "acme-corp.demo.meridianhub.cloud", stub.initiateReq.Subdomain,
+		"subdomain should include BASE_DOMAIN suffix")
 	assert.NotEmpty(t, stub.initiateReq.SettlementAsset, "settlement_asset must be set (proto requires it)")
+}
+
+func TestLoopbackTenantCreator_CreateTenant_EmptyBaseDomain(t *testing.T) {
+	stub := &stubTenantServiceClient{
+		initiateResp: &tenantv1.InitiateTenantResponse{
+			Tenant: &tenantv1.Tenant{TenantId: "acme_corp"},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	creator := &loopbackTenantCreator{
+		client:     stub,
+		baseDomain: "",
+		logger:     logger,
+	}
+
+	_, err := creator.CreateTenant(context.Background(), "acme_corp", "acme-corp", "Acme Corp")
+
+	require.NoError(t, err)
+	assert.Equal(t, "acme-corp", stub.initiateReq.Subdomain,
+		"when baseDomain is empty, subdomain should be just the slug")
 }
 
 func TestLoopbackTenantCreator_CreateTenant_NilTenantInResponse(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `baseDomain` field to `loopbackTenantCreator` so self-service registration constructs the full subdomain (e.g., `acme-corp.demo.meridianhub.cloud`) instead of storing just the slug
- Falls back to slug-only when `baseDomain` is empty (local dev mode)
- Passes the existing `baseDomain` from `wireRegistration` into the creator

## Test plan

- [x] Updated `TestLoopbackTenantCreator_CreateTenant` to verify full subdomain construction with baseDomain = "demo.meridianhub.cloud"
- [x] Added `TestLoopbackTenantCreator_CreateTenant_EmptyBaseDomain` edge case test
- [x] All existing `cmd/meridian` tests pass