### PR TITLE
fix: use --skip-manifest in deploy-demo workflow

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -226,6 +226,9 @@ jobs:
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           script: |
+            # Skip manifest on incremental deploys - manifest only needs to apply
+            # on fresh databases (handled by reset-demo.sh). Full idempotency for
+            # ApplyManifest is tracked as a follow-up.
             docker exec meridian-meridian-1 /seed-dev \
               --gateway-url=http://localhost:8090 \
               --grpc-addr=localhost:50051 \
@@ -233,7 +236,7 @@ jobs:
               --tenant-slug=volterra \
               --display-name='Volterra Energy' \
               --subdomain=volterra.demo.meridianhub.cloud \
-              --manifest=/app/examples/manifests/energy.json \
+              --skip-manifest \
               --with-fixtures
 
       - name: Verify deployment health


### PR DESCRIPTION
## Summary

Uses `--skip-manifest` for incremental demo deploys. The ApplyManifest saga's register+activate pattern has pre-checks in gRPC handlers that reject AlreadyExists before reaching the DB layer, making the full manifest pipeline non-idempotent on existing tenants.

Manifests only need to apply on fresh databases (handled by `reset-demo.sh`). Fixture seeding (customers, accounts, associations, transactions) is already idempotent.

## Test plan

- [ ] CI passes
- [ ] Deploy workflow succeeds end-to-end on push to demo