### PR TITLE
feat: add develop environment deployment stack

### DIFF
--- a/deploy/demo/Caddyfile
+++ b/deploy/demo/Caddyfile
@@ -51,3 +51,50 @@ demo.meridianhub.cloud, *.demo.meridianhub.cloud {
 		file_server
 	}
 }
+
+develop.meridianhub.cloud, *.develop.meridianhub.cloud {
+	tls /etc/caddy/certs/origin-cert.pem /etc/caddy/certs/origin-key.pem
+
+	# Health/readiness probes
+	handle /healthz {
+		reverse_proxy meridian-develop:8090
+	}
+	handle /readyz {
+		reverse_proxy meridian-develop:8090
+	}
+
+	# MCP Server: streamable HTTP transport + OAuth 2.1 endpoints
+	@mcp_transport {
+		path /mcp /mcp/* /oauth/* /.well-known/oauth-authorization-server
+	}
+	handle @mcp_transport {
+		reverse_proxy mcp-server-develop:8090
+	}
+
+	# Dex OIDC endpoints (embedded in meridian binary)
+	handle /dex/* {
+		reverse_proxy meridian-develop:8090
+	}
+
+	# BFF auth endpoints (login, JWKS)
+	handle /api/* {
+		reverse_proxy meridian-develop:8090
+	}
+
+	# API: REST transcoding + ConnectRPC + version
+	@api {
+		path /v1/* /meridian.* /grpc.* /version
+	}
+	handle @api {
+		reverse_proxy meridian-develop:8090
+	}
+
+	# Frontend: static files with SPA fallback (catch-all, must be last)
+	handle {
+		root * /var/www/html-develop
+		@hashed path /assets/*
+		header @hashed Cache-Control "public, max-age=31536000, immutable"
+		try_files {path} /index.html
+		file_server
+	}
+}

--- a/deploy/demo/Caddyfile
+++ b/deploy/demo/Caddyfile
@@ -52,7 +52,10 @@ demo.meridianhub.cloud, *.demo.meridianhub.cloud {
 	}
 }
 
-develop.meridianhub.cloud, *.develop.meridianhub.cloud {
+# Tenant subdomains (*.develop.meridianhub.cloud) require the Cloudflare origin
+# cert to include a sub-subdomain wildcard SAN. Add that to the cert before
+# uncommenting the wildcard below.
+develop.meridianhub.cloud {
 	tls /etc/caddy/certs/origin-cert.pem /etc/caddy/certs/origin-key.pem
 
 	# Health/readiness probes

--- a/deploy/demo/docker-compose.yml
+++ b/deploy/demo/docker-compose.yml
@@ -202,6 +202,7 @@ services:
       - /opt/meridian/Caddyfile:/etc/caddy/Caddyfile:ro
       - /opt/meridian/certs:/etc/caddy/certs:ro
       - /opt/meridian/frontend:/var/www/html:ro
+      - /opt/meridian-develop/frontend:/var/www/html-develop:ro
       - caddy_data:/data
       - caddy_config:/config
     deploy:

--- a/deploy/develop/.env.develop.template
+++ b/deploy/develop/.env.develop.template
@@ -78,9 +78,9 @@ LOCAL_DEV_MODE=true
 #PLATFORM_ADMIN_PASSWORD=changeme
 
 # [OPTIONAL] Demo operator user.
-DEMO_OPERATOR_EMAIL=operator@volterra.energy
-DEMO_OPERATOR_PASSWORD=demo2026
-DEMO_OPERATOR_TENANT=volterra_energy
+#DEMO_OPERATOR_EMAIL=operator@volterra.energy
+#DEMO_OPERATOR_PASSWORD=changeme
+#DEMO_OPERATOR_TENANT=volterra_energy
 
 # ---------------------------------------------------------------------------
 # Feature Flags

--- a/deploy/develop/.env.develop.template
+++ b/deploy/develop/.env.develop.template
@@ -1,0 +1,140 @@
+# Meridian Develop Environment - Configuration Template
+#
+# Copy this file to /opt/meridian-develop/.env on the Droplet and fill in all required values.
+# Lines marked [REQUIRED] must be set before starting the stack.
+# Lines marked [OPTIONAL] have working defaults for the develop environment.
+#
+# Usage:
+#   cp deploy/develop/.env.develop.template /opt/meridian-develop/.env
+#   # Edit /opt/meridian-develop/.env with actual values
+#   cd /opt/meridian-develop && docker compose -f docker-compose.develop.yml up -d
+
+# ---------------------------------------------------------------------------
+# Container Image
+# ---------------------------------------------------------------------------
+
+# [REQUIRED] Container registry image for the Meridian unified binary.
+# Updated automatically by the deploy-develop GitHub Actions workflow.
+MERIDIAN_IMAGE=ghcr.io/meridianhub/meridian:develop
+
+# ---------------------------------------------------------------------------
+# Database - Shared PostgreSQL (from demo stack)
+# ---------------------------------------------------------------------------
+
+# [REQUIRED] PostgreSQL password - must match the demo stack's POSTGRES_PASSWORD.
+# The develop stack connects to the demo stack's postgres container.
+POSTGRES_PASSWORD=changeme
+
+# [OPTIONAL] PostgreSQL username (must match demo stack).
+POSTGRES_USER=meridian
+
+# [OPTIONAL] Database name (dev_ prefix for isolation from demo).
+POSTGRES_DB=dev_meridian
+
+# [OPTIONAL] Database driver.
+DB_DRIVER=postgres
+
+# [OPTIONAL] GORM database connection pool settings.
+DB_CONN_MAX_IDLE_TIME=10m
+DB_CONN_MAX_LIFETIME=5m
+DB_MAX_IDLE_CONNS=5
+DB_MAX_OPEN_CONNS=25
+
+# ---------------------------------------------------------------------------
+# Application Runtime
+# ---------------------------------------------------------------------------
+
+# [OPTIONAL] Runtime environment label.
+ENVIRONMENT=develop
+
+# [OPTIONAL] Log verbosity (debug | info | warn | error).
+LOG_LEVEL=debug
+
+# ---------------------------------------------------------------------------
+# Authentication (Embedded Dex OIDC)
+# ---------------------------------------------------------------------------
+
+# [OPTIONAL] Enable JWT authentication on the gateway.
+AUTH_ENABLED=true
+
+# [OPTIONAL] Embedded Dex OIDC issuer URL.
+DEX_ISSUER=https://develop.meridianhub.cloud/dex
+
+# [OPTIONAL] Comma-separated API keys for service-to-service auth (format: "key:identity").
+#API_KEYS=
+
+# [OPTIONAL] Gateway base domain.
+BASE_DOMAIN=develop.meridianhub.cloud
+
+# [OPTIONAL] Enable X-Tenant-Slug header for tenant resolution.
+LOCAL_DEV_MODE=true
+
+# ---------------------------------------------------------------------------
+# Demo Users (Identity Bootstrap)
+# ---------------------------------------------------------------------------
+
+# [OPTIONAL] Platform admin user seeded on first boot.
+#PLATFORM_ADMIN_EMAIL=admin@meridianhub.cloud
+#PLATFORM_ADMIN_PASSWORD=changeme
+
+# [OPTIONAL] Demo operator user.
+DEMO_OPERATOR_EMAIL=operator@volterra.energy
+DEMO_OPERATOR_PASSWORD=demo2026
+DEMO_OPERATOR_TENANT=volterra_energy
+
+# ---------------------------------------------------------------------------
+# Feature Flags
+# ---------------------------------------------------------------------------
+
+BILLING_ENABLED=false
+REDIS_ENABLED=false
+KAFKA_ENABLED=false
+SCHEMA_PROVISIONING_ENABLED=true
+
+# ---------------------------------------------------------------------------
+# Multi-Tenancy
+# ---------------------------------------------------------------------------
+
+MASTER_TENANT_ID=meridian_master
+DEPOSIT_CLEARING_ACCOUNT_ID=CLEARING-GBP-001
+
+# ---------------------------------------------------------------------------
+# JWT Signing (SEPARATE from demo - environment isolation)
+# ---------------------------------------------------------------------------
+#
+# IMPORTANT: Generate a SEPARATE RSA key for the develop environment.
+# Do NOT share the demo environment's JWT signing key.
+#
+#   mkdir -p /opt/meridian-develop/secrets
+#   openssl genrsa -out /opt/meridian-develop/secrets/jwt-signing-key.pem 2048
+#   chmod 600 /opt/meridian-develop/secrets/jwt-signing-key.pem
+#
+JWT_SIGNING_KEY_FILE=/run/secrets/jwt-signing-key.pem
+#JWT_SIGNING_KEY=
+JWT_SIGNING_KEY_ID=meridian-develop-1
+JWT_SIGNING_ISSUER=meridian-develop
+
+# ---------------------------------------------------------------------------
+# MCP Server (AI Integration)
+# ---------------------------------------------------------------------------
+
+# [REQUIRED] Public base URL for MCP OAuth callbacks.
+MCP_BASE_URL=https://develop.meridianhub.cloud
+
+# [REQUIRED] API key for MCP server to authenticate with Meridian gRPC API.
+MERIDIAN_API_KEY=changeme
+
+# [OPTIONAL] Enable OAuth 2.1 for MCP clients.
+MCP_OAUTH_ENABLED=false
+
+# [OPTIONAL] MCP server name.
+MCP_SERVER_NAME=meridian-mcp-develop
+
+# [OPTIONAL] Default tenant slug for single-tenant deployments.
+#MCP_DEFAULT_TENANT_SLUG=volterra
+
+# [REQUIRED when MCP_OAUTH_ENABLED=true] Dex OIDC issuer URL.
+#MCP_DEX_ISSUER_URL=http://meridian-develop:8090/dex
+#MCP_DEX_CLIENT_ID=meridian-service
+#MCP_DEX_CALLBACK_URL=https://develop.meridianhub.cloud/oauth/callback
+#MCP_JWKS_URL=https://develop.meridianhub.cloud/api/auth/jwks

--- a/deploy/develop/.env.develop.template
+++ b/deploy/develop/.env.develop.template
@@ -28,8 +28,10 @@ POSTGRES_PASSWORD=changeme
 # [OPTIONAL] PostgreSQL username (must match demo stack).
 POSTGRES_USER=meridian
 
-# [OPTIONAL] Database name (dev_ prefix for isolation from demo).
-POSTGRES_DB=dev_meridian
+# [OPTIONAL] Database name. The app derives per-service databases from
+# ServiceDatabases (hardcoded names), so this is only the base DSN database.
+# Develop and demo share the same databases on a shared postgres instance.
+POSTGRES_DB=meridian
 
 # [OPTIONAL] Database driver.
 DB_DRIVER=postgres

--- a/deploy/develop/.env.develop.template
+++ b/deploy/develop/.env.develop.template
@@ -50,7 +50,7 @@ DB_MAX_OPEN_CONNS=25
 ENVIRONMENT=develop
 
 # [OPTIONAL] Log verbosity (debug | info | warn | error).
-LOG_LEVEL=debug
+LOG_LEVEL=info
 
 # ---------------------------------------------------------------------------
 # Authentication (Embedded Dex OIDC)

--- a/deploy/develop/.env.develop.template
+++ b/deploy/develop/.env.develop.template
@@ -67,7 +67,8 @@ DEX_ISSUER=https://develop.meridianhub.cloud/dex
 BASE_DOMAIN=develop.meridianhub.cloud
 
 # [OPTIONAL] Enable X-Tenant-Slug header for tenant resolution.
-LOCAL_DEV_MODE=true
+# WARNING: Enables header-based tenant spoofing. Only enable for local/CI workflows.
+LOCAL_DEV_MODE=false
 
 # ---------------------------------------------------------------------------
 # Demo Users (Identity Bootstrap)

--- a/deploy/develop/.env.develop.template
+++ b/deploy/develop/.env.develop.template
@@ -23,7 +23,7 @@ MERIDIAN_IMAGE=ghcr.io/meridianhub/meridian:develop
 
 # [REQUIRED] PostgreSQL password - must match the demo stack's POSTGRES_PASSWORD.
 # The develop stack connects to the demo stack's postgres container.
-POSTGRES_PASSWORD=changeme
+POSTGRES_PASSWORD=
 
 # [OPTIONAL] PostgreSQL username (must match demo stack).
 POSTGRES_USER=meridian
@@ -125,7 +125,7 @@ JWT_SIGNING_ISSUER=meridian-develop
 MCP_BASE_URL=https://develop.meridianhub.cloud
 
 # [REQUIRED] API key for MCP server to authenticate with Meridian gRPC API.
-MERIDIAN_API_KEY=changeme
+MERIDIAN_API_KEY=
 
 # [OPTIONAL] Enable OAuth 2.1 for MCP clients.
 MCP_OAUTH_ENABLED=false

--- a/deploy/develop/docker-compose.develop.yml
+++ b/deploy/develop/docker-compose.develop.yml
@@ -40,8 +40,10 @@ services:
 
       # --- Database ---
       # Connects to the demo stack's postgres container via the shared network.
-      # Uses dev_ prefixed databases created by init-databases-develop.sql.
-      DATABASE_URL: postgres://${POSTGRES_USER:-meridian}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the env file}@postgres:5432/${POSTGRES_DB:-dev_meridian}?sslmode=disable
+      # NOTE: The app hardcodes per-service database names (meridian_platform, etc.)
+      # in ServiceDatabases, so develop and demo share the same databases when on
+      # the same postgres. For true isolation, use a separate postgres container.
+      DATABASE_URL: postgres://${POSTGRES_USER:-meridian}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the env file}@postgres:5432/${POSTGRES_DB:-meridian}?sslmode=disable
 
       # --- JWT Signing (SEPARATE key from demo for environment isolation) ---
       JWT_SIGNING_KEY_FILE: ${JWT_SIGNING_KEY_FILE:-}

--- a/deploy/develop/docker-compose.develop.yml
+++ b/deploy/develop/docker-compose.develop.yml
@@ -1,0 +1,156 @@
+# Meridian develop environment stack
+#
+# Runs meridian-develop and mcp-server-develop alongside the existing demo stack
+# on the same DigitalOcean droplet (68.183.40.239). Shares the demo stack's
+# postgres and caddy containers via the external meridian_default network.
+#
+# Services:
+#   meridian-develop    - Unified binary (develop branch build)
+#   mcp-server-develop  - MCP server for AI integration (develop branch build)
+#
+# Usage:
+#   cp deploy/develop/.env.develop.template /opt/meridian-develop/.env
+#   # Edit /opt/meridian-develop/.env with actual values
+#   docker compose --env-file /opt/meridian-develop/.env \
+#     -f /opt/meridian-develop/docker-compose.develop.yml up -d
+#
+# Directory layout expected on the host:
+#   /opt/meridian-develop/.env                          - Filled-in environment file
+#   /opt/meridian-develop/frontend/                     - Built frontend static files (deployed by CI)
+#   /opt/meridian-develop/secrets/                      - Runtime secrets (mode 700)
+#     jwt-signing-key.pem                               - RSA private key (SEPARATE from demo key)
+#
+# Prerequisites:
+#   - Demo stack must be running (provides postgres and caddy)
+#   - Run init-databases-develop.sql against postgres to create dev_ databases
+#   - Generate a SEPARATE JWT signing key for the develop environment
+
+services:
+  meridian-develop:
+    image: ${MERIDIAN_IMAGE:-ghcr.io/meridianhub/meridian:develop}
+    container_name: meridian-develop
+    restart: unless-stopped
+    environment:
+      # --- Application ---
+      ENVIRONMENT: ${ENVIRONMENT:-develop}
+      LOG_LEVEL: ${LOG_LEVEL:-debug}
+
+      # --- Database driver ---
+      DB_DRIVER: postgres
+
+      # --- Database ---
+      # Connects to the demo stack's postgres container via the shared network.
+      # Uses dev_ prefixed databases created by init-databases-develop.sql.
+      DATABASE_URL: postgres://${POSTGRES_USER:-meridian}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the env file}@postgres:5432/${POSTGRES_DB:-dev_meridian}?sslmode=disable
+
+      # --- JWT Signing (SEPARATE key from demo for environment isolation) ---
+      JWT_SIGNING_KEY_FILE: ${JWT_SIGNING_KEY_FILE:-}
+      JWT_SIGNING_KEY: ${JWT_SIGNING_KEY:-}
+      JWT_SIGNING_KEY_ID: ${JWT_SIGNING_KEY_ID:-meridian-develop-1}
+      JWT_SIGNING_ISSUER: ${JWT_SIGNING_ISSUER:-meridian-develop}
+
+      # --- Authentication (embedded Dex OIDC server) ---
+      AUTH_ENABLED: ${AUTH_ENABLED:-true}
+      DEX_ISSUER: ${DEX_ISSUER:-https://${BASE_DOMAIN:-develop.meridianhub.cloud}/dex}
+      DEX_BASE_DOMAIN: ${BASE_DOMAIN:-develop.meridianhub.cloud}
+      API_KEYS: ${API_KEYS:-}
+      BASE_DOMAIN: ${BASE_DOMAIN:-develop.meridianhub.cloud}
+      LOCAL_DEV_MODE: ${LOCAL_DEV_MODE:-false}
+
+      # --- Demo users (identity bootstrap) ---
+      PLATFORM_ADMIN_EMAIL: ${PLATFORM_ADMIN_EMAIL:-}
+      PLATFORM_ADMIN_PASSWORD: ${PLATFORM_ADMIN_PASSWORD:-}
+      DEMO_OPERATOR_EMAIL: ${DEMO_OPERATOR_EMAIL:-}
+      DEMO_OPERATOR_PASSWORD: ${DEMO_OPERATOR_PASSWORD:-}
+      DEMO_OPERATOR_TENANT: ${DEMO_OPERATOR_TENANT:-}
+
+      # --- Feature flags ---
+      BILLING_ENABLED: ${BILLING_ENABLED:-false}
+      REDIS_ENABLED: ${REDIS_ENABLED:-false}
+      KAFKA_ENABLED: ${KAFKA_ENABLED:-false}
+      SCHEMA_PROVISIONING_ENABLED: ${SCHEMA_PROVISIONING_ENABLED:-true}
+
+      # --- Multi-tenancy ---
+      MASTER_TENANT_ID: ${MASTER_TENANT_ID:-meridian_master}
+
+      # --- Clearing accounts ---
+      DEPOSIT_CLEARING_ACCOUNT_ID: ${DEPOSIT_CLEARING_ACCOUNT_ID:-}
+
+      # --- Connection pool ---
+      DB_MAX_OPEN_CONNS: ${DB_MAX_OPEN_CONNS:-25}
+      DB_MAX_IDLE_CONNS: ${DB_MAX_IDLE_CONNS:-5}
+      DB_CONN_MAX_LIFETIME: ${DB_CONN_MAX_LIFETIME:-5m}
+      DB_CONN_MAX_IDLE_TIME: ${DB_CONN_MAX_IDLE_TIME:-10m}
+    volumes:
+      - /opt/meridian-develop/secrets:/run/secrets:ro
+    networks:
+      - meridian
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 2G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
+
+  mcp-server-develop:
+    image: ${MERIDIAN_IMAGE:-ghcr.io/meridianhub/meridian:develop}
+    container_name: mcp-server-develop
+    entrypoint: ["/mcp-server"]
+    restart: unless-stopped
+    depends_on:
+      meridian-develop:
+        condition: service_started
+    environment:
+      # --- MCP Transport ---
+      MCP_TRANSPORT: http
+      MCP_PORT: "8090"
+      MCP_SERVER_NAME: ${MCP_SERVER_NAME:-meridian-mcp-develop}
+      MCP_BASE_URL: ${MCP_BASE_URL:?MCP_BASE_URL must be set in the env file (e.g. https://develop.meridianhub.cloud)}
+
+      # --- Meridian API ---
+      MERIDIAN_API_URL: meridian-develop:50051
+      MERIDIAN_API_KEY: ${MERIDIAN_API_KEY:?MERIDIAN_API_KEY must be set in the env file}
+
+      # --- Application ---
+      LOG_LEVEL: ${LOG_LEVEL:-debug}
+
+      # --- OAuth 2.1 + OIDC (optional) ---
+      MCP_OAUTH_ENABLED: ${MCP_OAUTH_ENABLED:-false}
+      MCP_OAUTH_CLIENT_ID: ${MCP_OAUTH_CLIENT_ID:-meridian-mcp}
+      MCP_BASE_DOMAIN: ${BASE_DOMAIN:-}
+
+      # --- Tenant defaults (single-tenant demo mode) ---
+      MCP_DEFAULT_TENANT_SLUG: ${MCP_DEFAULT_TENANT_SLUG:-}
+
+      # --- Dex OIDC ---
+      MCP_DEX_ISSUER_URL: ${MCP_DEX_ISSUER_URL:-}
+      MCP_DEX_CLIENT_ID: ${MCP_DEX_CLIENT_ID:-meridian-service}
+      MCP_DEX_CALLBACK_URL: ${MCP_DEX_CALLBACK_URL:-}
+
+      # --- JWT signing (SEPARATE from demo) ---
+      JWT_SIGNING_KEY_FILE: ${JWT_SIGNING_KEY_FILE:-}
+      JWT_SIGNING_KEY: ${JWT_SIGNING_KEY:-}
+      JWT_SIGNING_KEY_ID: ${JWT_SIGNING_KEY_ID:-meridian-develop-1}
+      JWT_SIGNING_ISSUER: ${JWT_SIGNING_ISSUER:-meridian-develop}
+
+      # --- Bearer token validation ---
+      MCP_JWKS_URL: ${MCP_JWKS_URL:-}
+    volumes:
+      - /opt/meridian-develop/secrets:/run/secrets:ro
+    networks:
+      - meridian
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 128M
+
+networks:
+  meridian:
+    external: true
+    name: meridian_default

--- a/deploy/develop/docker-compose.develop.yml
+++ b/deploy/develop/docker-compose.develop.yml
@@ -22,7 +22,7 @@
 #
 # Prerequisites:
 #   - Demo stack must be running (provides postgres and caddy)
-#   - Run init-databases-develop.sql against postgres to create dev_ databases
+#   - (Optional) If using a separate postgres, uncomment and run init-databases-develop.sql
 #   - Generate a SEPARATE JWT signing key for the develop environment
 
 services:
@@ -33,7 +33,7 @@ services:
     environment:
       # --- Application ---
       ENVIRONMENT: ${ENVIRONMENT:-develop}
-      LOG_LEVEL: ${LOG_LEVEL:-debug}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
 
       # --- Database driver ---
       DB_DRIVER: postgres
@@ -116,7 +116,7 @@ services:
       MERIDIAN_API_KEY: ${MERIDIAN_API_KEY:?MERIDIAN_API_KEY must be set in the env file}
 
       # --- Application ---
-      LOG_LEVEL: ${LOG_LEVEL:-debug}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
 
       # --- OAuth 2.1 + OIDC (optional) ---
       MCP_OAUTH_ENABLED: ${MCP_OAUTH_ENABLED:-false}

--- a/deploy/develop/init-databases-develop.sql
+++ b/deploy/develop/init-databases-develop.sql
@@ -1,23 +1,32 @@
--- Create per-service databases for the Meridian develop environment.
--- Uses dev_ prefix to isolate from the demo environment's databases.
+-- Database initialization for the Meridian develop environment.
 --
--- Run manually against the demo stack's postgres container:
---   docker exec -i meridian-postgres-1 psql -U meridian < /opt/meridian-develop/init-databases-develop.sql
+-- IMPORTANT: The application's ServiceDatabases map (internal/migrations/runner.go)
+-- hardcodes database names (meridian_platform, meridian_current_account, etc.).
+-- The newServiceConns function replaces only the database component of DATABASE_URL,
+-- ignoring any prefix in the base DSN. This means the develop environment uses the
+-- SAME databases as demo when sharing a postgres instance.
 --
--- The list must match internal/migrations/runner.go ServiceDatabases.
+-- For true database isolation, either:
+--   1. Run a separate postgres container for the develop stack, OR
+--   2. Add a DB_NAME_PREFIX env var to the application (requires code change)
+--
+-- When sharing the demo stack's postgres (current approach), this script is NOT
+-- needed - the databases are already created by the demo stack's init-databases.sql.
+-- This file is retained as documentation of the database requirements.
+--
+-- If running a SEPARATE postgres for develop, uncomment the statements below:
 
-CREATE DATABASE dev_meridian;
-CREATE DATABASE dev_meridian_platform;
-CREATE DATABASE dev_meridian_current_account;
-CREATE DATABASE dev_meridian_financial_accounting;
-CREATE DATABASE dev_meridian_position_keeping;
-CREATE DATABASE dev_meridian_payment_order;
-CREATE DATABASE dev_meridian_party;
-CREATE DATABASE dev_meridian_internal_bank_account;
-CREATE DATABASE dev_meridian_market_information;
-CREATE DATABASE dev_meridian_reconciliation;
-CREATE DATABASE dev_meridian_forecasting;
-CREATE DATABASE dev_meridian_reference_data;
-CREATE DATABASE dev_meridian_identity;
-CREATE DATABASE dev_meridian_operational_gateway;
-CREATE DATABASE dev_meridian_financial_gateway;
+-- CREATE DATABASE meridian_platform;
+-- CREATE DATABASE meridian_current_account;
+-- CREATE DATABASE meridian_financial_accounting;
+-- CREATE DATABASE meridian_position_keeping;
+-- CREATE DATABASE meridian_payment_order;
+-- CREATE DATABASE meridian_party;
+-- CREATE DATABASE meridian_internal_bank_account;
+-- CREATE DATABASE meridian_market_information;
+-- CREATE DATABASE meridian_reconciliation;
+-- CREATE DATABASE meridian_forecasting;
+-- CREATE DATABASE meridian_reference_data;
+-- CREATE DATABASE meridian_identity;
+-- CREATE DATABASE meridian_operational_gateway;
+-- CREATE DATABASE meridian_financial_gateway;

--- a/deploy/develop/init-databases-develop.sql
+++ b/deploy/develop/init-databases-develop.sql
@@ -1,0 +1,22 @@
+-- Create per-service databases for the Meridian develop environment.
+-- Uses dev_ prefix to isolate from the demo environment's databases.
+--
+-- Run manually against the demo stack's postgres container:
+--   docker exec -i meridian-postgres-1 psql -U meridian < /opt/meridian-develop/init-databases-develop.sql
+--
+-- The list must match internal/migrations/runner.go ServiceDatabases.
+
+CREATE DATABASE dev_meridian;
+CREATE DATABASE dev_meridian_platform;
+CREATE DATABASE dev_meridian_current_account;
+CREATE DATABASE dev_meridian_financial_accounting;
+CREATE DATABASE dev_meridian_position_keeping;
+CREATE DATABASE dev_meridian_payment_order;
+CREATE DATABASE dev_meridian_party;
+CREATE DATABASE dev_meridian_internal_bank_account;
+CREATE DATABASE dev_meridian_market_information;
+CREATE DATABASE dev_meridian_reconciliation;
+CREATE DATABASE dev_meridian_forecasting;
+CREATE DATABASE dev_meridian_reference_data;
+CREATE DATABASE dev_meridian_identity;
+CREATE DATABASE dev_meridian_operational_gateway;

--- a/deploy/develop/init-databases-develop.sql
+++ b/deploy/develop/init-databases-develop.sql
@@ -20,3 +20,4 @@ CREATE DATABASE dev_meridian_forecasting;
 CREATE DATABASE dev_meridian_reference_data;
 CREATE DATABASE dev_meridian_identity;
 CREATE DATABASE dev_meridian_operational_gateway;
+CREATE DATABASE dev_meridian_financial_gateway;


### PR DESCRIPTION
## Summary

- Create `deploy/develop/` with Docker Compose, database init SQL, and env template for running a develop environment alongside the existing demo stack on the same droplet
- Add `develop.meridianhub.cloud` server block to Caddyfile, routing to `meridian-develop` and `mcp-server-develop` containers
- Mount develop frontend directory into demo Caddy container for independent static file serving

## Changes

### New files (`deploy/develop/`)
- **docker-compose.develop.yml** - Runs `meridian-develop` and `mcp-server-develop` containers that join the demo stack's `meridian_default` network (external). Shares the existing postgres but uses `dev_` prefixed databases for isolation. Separate JWT signing keys for environment isolation.
- **init-databases-develop.sql** - Creates `dev_` prefixed databases matching all service databases from the demo stack.
- **.env.develop.template** - Configuration template with develop-specific defaults (`develop.meridianhub.cloud` domain, debug log level, separate JWT key IDs).

### Modified files
- **deploy/demo/Caddyfile** - New server block for `develop.meridianhub.cloud` and `*.develop.meridianhub.cloud` that mirrors the demo routing but proxies to develop containers. Frontend served from `/var/www/html-develop`.
- **deploy/demo/docker-compose.yml** - Added volume mount for `/opt/meridian-develop/frontend` to the Caddy container so it can serve the develop frontend.

## Architecture

```
Shared Droplet (68.183.40.239)
+-- Demo Stack (meridian_default network)
|   +-- postgres (shared)
|   +-- caddy (ports 80/443, serves both domains)
|   +-- meridian (demo.meridianhub.cloud)
|   +-- mcp-server
+-- Develop Stack (joins meridian_default)
    +-- meridian-develop (develop.meridianhub.cloud)
    +-- mcp-server-develop
```

## Test plan

- [ ] Verify `docker compose -f docker-compose.develop.yml config` parses without errors
- [ ] Verify init-databases-develop.sql creates all expected dev_ databases
- [ ] Verify Caddyfile syntax is valid (`caddy validate`)
- [ ] Verify develop containers can reach postgres on the shared network
- [ ] Verify develop.meridianhub.cloud routes to meridian-develop