### PR TITLE
feat: harden JWT as authoritative tenant source

### DIFF
--- a/shared/platform/auth/tenant_interceptor.go
+++ b/shared/platform/auth/tenant_interceptor.go
@@ -2,13 +2,33 @@ package auth
 
 import (
 	"context"
+	"log/slog"
+	"sync"
 
+	"github.com/meridianhub/meridian/shared/platform/env"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
 
+// warnOnceAuthEnabled emits a one-time warning when TenantExtractionInterceptor is
+// used with AUTH_ENABLED=true. This interceptor trusts headers without JWT validation,
+// so using it in production (where AUTH_ENABLED defaults to true) is a security risk.
+var warnOnceAuthEnabled sync.Once
+
+// checkAuthEnabled is the function used to check AUTH_ENABLED. Overridable in tests.
+var checkAuthEnabled = func() bool {
+	return env.GetEnvAsBool("AUTH_ENABLED", true)
+}
+
+// warnLogger is the logger used for tenant extraction warnings. Overridable in tests.
+var warnLogger = slog.Default
+
 // TenantExtractionInterceptor extracts tenant ID from gRPC metadata (x-tenant-id header).
+//
+// WARNING: This interceptor is for DEVELOPMENT/TESTING ONLY. It trusts the x-tenant-id
+// header without JWT validation. In production, use auth.Interceptor.UnaryInterceptor()
+// which validates the header against the JWT tenant_id claim.
 //
 // IMPORTANT: This interceptor is MUTUALLY EXCLUSIVE with auth.Interceptor.UnaryInterceptor().
 // Do NOT use both in the same interceptor chain.
@@ -30,6 +50,19 @@ import (
 // However, this interceptor does NOT validate tenant ownership - use auth.Interceptor
 // in production to ensure the JWT tenant matches the header.
 func TenantExtractionInterceptor() grpc.UnaryServerInterceptor {
+	// Emit a one-time warning if AUTH_ENABLED=true, since this interceptor
+	// should only be used in development/testing when auth is disabled.
+	warnOnceAuthEnabled.Do(func() {
+		if checkAuthEnabled() {
+			warnLogger().Warn("TenantExtractionInterceptor is active with AUTH_ENABLED=true; "+
+				"this interceptor trusts x-tenant-id headers without JWT validation "+
+				"and should only be used for development/testing",
+				"interceptor", "TenantExtractionInterceptor",
+				"recommendation", "use auth.Interceptor.UnaryInterceptor() for production",
+			)
+		}
+	})
+
 	return func(
 		ctx context.Context,
 		req interface{},
@@ -72,6 +105,18 @@ func TenantExtractionInterceptor() grpc.UnaryServerInterceptor {
 // However, this interceptor does NOT validate tenant ownership - use auth.Interceptor
 // in production to ensure the JWT tenant matches the header.
 func TenantExtractionStreamInterceptor() grpc.StreamServerInterceptor {
+	// Reuse the same sync.Once - warning only needs to fire once per process
+	warnOnceAuthEnabled.Do(func() {
+		if checkAuthEnabled() {
+			warnLogger().Warn("TenantExtractionStreamInterceptor is active with AUTH_ENABLED=true; "+
+				"this interceptor trusts x-tenant-id headers without JWT validation "+
+				"and should only be used for development/testing",
+				"interceptor", "TenantExtractionStreamInterceptor",
+				"recommendation", "use auth.Interceptor.StreamInterceptor() for production",
+			)
+		}
+	})
+
 	return func(
 		srv interface{},
 		ss grpc.ServerStream,

--- a/shared/platform/auth/tenant_interceptor_test.go
+++ b/shared/platform/auth/tenant_interceptor_test.go
@@ -18,12 +18,11 @@ import (
 func resetTenantExtractionWarning(t *testing.T, authEnabled bool) *bytes.Buffer {
 	t.Helper()
 
-	// Save originals
-	origOnce := warnOnceAuthEnabled
+	// Save originals (do NOT copy sync.Once - it must not be copied after first use)
 	origCheck := checkAuthEnabled
 	origLogger := warnLogger
 
-	// Reset
+	// Reset to fresh zero-value Once
 	warnOnceAuthEnabled = sync.Once{}
 	checkAuthEnabled = func() bool { return authEnabled }
 
@@ -32,7 +31,7 @@ func resetTenantExtractionWarning(t *testing.T, authEnabled bool) *bytes.Buffer 
 	warnLogger = func() *slog.Logger { return logger }
 
 	t.Cleanup(func() {
-		warnOnceAuthEnabled = origOnce
+		warnOnceAuthEnabled = sync.Once{}
 		checkAuthEnabled = origCheck
 		warnLogger = origLogger
 	})

--- a/shared/platform/auth/tenant_interceptor_test.go
+++ b/shared/platform/auth/tenant_interceptor_test.go
@@ -1,7 +1,10 @@
 package auth
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
+	"sync"
 	"testing"
 
 	"github.com/meridianhub/meridian/shared/platform/tenant"
@@ -9,6 +12,33 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
+
+// resetTenantExtractionWarning resets the sync.Once and overridable functions
+// for testing the AUTH_ENABLED warning. Returns a cleanup function.
+func resetTenantExtractionWarning(t *testing.T, authEnabled bool) *bytes.Buffer {
+	t.Helper()
+
+	// Save originals
+	origOnce := warnOnceAuthEnabled
+	origCheck := checkAuthEnabled
+	origLogger := warnLogger
+
+	// Reset
+	warnOnceAuthEnabled = sync.Once{}
+	checkAuthEnabled = func() bool { return authEnabled }
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	warnLogger = func() *slog.Logger { return logger }
+
+	t.Cleanup(func() {
+		warnOnceAuthEnabled = origOnce
+		checkAuthEnabled = origCheck
+		warnLogger = origLogger
+	})
+
+	return &buf
+}
 
 func TestTenantExtractionInterceptor(t *testing.T) {
 	t.Run("extracts tenant from metadata when not in context", func(t *testing.T) {
@@ -283,5 +313,39 @@ func TestTenantExtractionStreamInterceptor(t *testing.T) {
 		// Tenant should NOT be in context due to validation failure
 		_, ok := tenant.FromContext(capturedCtx)
 		assert.False(t, ok)
+	})
+}
+
+func TestTenantExtractionInterceptor_AuthEnabledWarning(t *testing.T) {
+	t.Run("logs warning when AUTH_ENABLED is true", func(t *testing.T) {
+		buf := resetTenantExtractionWarning(t, true)
+
+		_ = TenantExtractionInterceptor()
+
+		output := buf.String()
+		assert.Contains(t, output, "TenantExtractionInterceptor is active with AUTH_ENABLED=true")
+		assert.Contains(t, output, "development/testing")
+	})
+
+	t.Run("no warning when AUTH_ENABLED is false", func(t *testing.T) {
+		buf := resetTenantExtractionWarning(t, false)
+
+		_ = TenantExtractionInterceptor()
+
+		assert.Empty(t, buf.String())
+	})
+
+	t.Run("warning fires only once across unary and stream", func(t *testing.T) {
+		buf := resetTenantExtractionWarning(t, true)
+
+		_ = TenantExtractionInterceptor()
+		_ = TenantExtractionStreamInterceptor()
+
+		// Count warning occurrences - should be exactly one
+		output := buf.String()
+		assert.Contains(t, output, "AUTH_ENABLED=true")
+		// The sync.Once ensures only one warning line
+		lines := bytes.Count(buf.Bytes(), []byte("AUTH_ENABLED=true"))
+		assert.Equal(t, 1, lines, "warning should fire exactly once")
 	})
 }


### PR DESCRIPTION
## Summary

- Verified that JWT `x-tenant-id` claim is already the authoritative source of tenant context in the gRPC auth interceptor (mismatch detection, metrics, structured logging all in place)
- Verified that HTTP-layer tenant authorization already catches JWT/subdomain mismatches via `TenantAuthorizationMiddleware`
- Added runtime warning when `TenantExtractionInterceptor` (development-only, header-trusting interceptor) is used with `AUTH_ENABLED=true`, surfacing security misconfigurations early
- Verified `connector.BuildClaims()` correctly embeds `x-tenant-id` in JWT tokens

## Changes Made

- `shared/platform/auth/tenant_interceptor.go`: Added `sync.Once` warning at interceptor creation time when `AUTH_ENABLED=true` (production default). Both unary and stream variants share the same once-guard.
- `shared/platform/auth/tenant_interceptor_test.go`: Added tests for warning behavior (fires when auth enabled, silent when disabled, fires exactly once across both interceptor types).

## Test plan

- [x] `go test ./shared/platform/auth/... -count=1` - all pass
- [x] `go test ./services/api-gateway/auth/... -count=1` - all pass
- [x] Warning test: fires when AUTH_ENABLED=true
- [x] Warning test: silent when AUTH_ENABLED=false
- [x] Warning test: fires exactly once across unary+stream