### PR TITLE
feat: add deploy-develop workflow and deploy gate

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -1,0 +1,297 @@
+name: Deploy Develop
+
+# Required secrets:
+#   DEPLOY_SSH_KEY  - Private SSH key (Ed25519 or RSA 4096+) for the deploy user on the Droplet
+#   DROPLET_IP      - IP address of the DigitalOcean Droplet (e.g. 143.198.xxx.xxx)
+#
+# The deploy user is created by deploy/demo/provision.sh with docker group membership
+# and ownership of /opt/meridian-develop/. Run provision.sh once as root to set up the server.
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-develop
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write  # Required for cosign keyless signing via OIDC
+    outputs:
+      image-digest: ${{ steps.build.outputs.digest }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.1'
+          cache: true
+
+      - name: Set up buf
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate protobuf files
+        run: buf generate
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=develop
+            type=sha,prefix=develop-,format=short
+
+      - name: Build and push Docker image
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./cmd/meridian/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp || github.event.repository.updated_at }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+
+      - name: Sign container image
+        run: |
+          cosign sign --yes \
+            ghcr.io/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+
+  build-frontend:
+    name: Build Frontend
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Set up buf
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Generate protobuf TypeScript clients
+        working-directory: frontend
+        run: |
+          export PATH="$PWD/node_modules/.bin:$PATH"
+          buf generate --template buf.gen.yaml ../api/proto
+
+      - name: Build frontend
+        working-directory: frontend
+        env:
+          VITE_API_BASE_URL: https://develop.meridianhub.cloud
+          VITE_BASE_DOMAIN: develop.meridianhub.cloud
+          VITE_BUILD_VERSION: ${{ github.ref_name }}
+          VITE_BUILD_COMMIT: ${{ github.sha }}
+        run: npx vite build
+
+      - name: Upload frontend artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: frontend-dist-develop
+          path: frontend/dist/
+          retention-days: 1
+
+  deploy:
+    name: Deploy to Develop Environment
+    needs: [build-and-push, build-frontend]
+    runs-on: ubuntu-latest
+    environment:
+      name: develop
+      url: https://develop.meridianhub.cloud
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+
+      - name: Verify container image signature
+        run: |
+          cosign verify \
+            --certificate-identity="https://github.com/${{ github.repository }}/.github/workflows/deploy-develop.yml@refs/heads/develop" \
+            --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+            ghcr.io/${{ env.IMAGE_NAME }}@${{ needs.build-and-push.outputs.image-digest }}
+
+      - name: Download frontend artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: frontend-dist-develop
+          path: frontend-dist/
+
+      - name: Deploy frontend via SCP
+        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1.0.0
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          source: "frontend-dist/*"
+          target: /opt/meridian-develop/frontend/
+          strip_components: 1
+          overwrite: true
+
+      - name: Deploy config files via SCP
+        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1.0.0
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          source: "deploy/develop/docker-compose.develop.yml,deploy/develop/init-databases-develop.sql"
+          target: /opt/meridian-develop/
+          strip_components: 2
+          overwrite: true
+
+      - name: Deploy Caddyfile to demo stack
+        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1.0.0
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          source: "deploy/demo/Caddyfile"
+          target: /opt/meridian/
+          strip_components: 2
+          overwrite: true
+
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        env:
+          IMAGE_DIGEST: ${{ needs.build-and-push.outputs.image-digest }}
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          envs: IMAGE_DIGEST
+          script: |
+            cd /opt/meridian-develop
+            # Pull the exact verified digest to prevent TOCTOU between verify and deploy
+            docker pull ghcr.io/meridianhub/meridian@${IMAGE_DIGEST}
+            docker tag ghcr.io/meridianhub/meridian@${IMAGE_DIGEST} ghcr.io/meridianhub/meridian:develop
+            docker compose -f docker-compose.develop.yml up -d --remove-orphans
+            # Reload Caddy from the demo stack (Caddy runs there, serves both environments)
+            docker compose -f /opt/meridian/docker-compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile
+            docker image prune -f
+
+      - name: Run migrations
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            docker exec meridian-develop /meridian --migrate
+
+      - name: Seed develop data
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            # Skip manifest on incremental deploys - manifest only needs to apply
+            # on fresh databases (handled by reset-develop.sh). Full idempotency for
+            # ApplyManifest is tracked as a follow-up.
+            docker exec meridian-develop /seed-dev \
+              --gateway-url=http://localhost:8090 \
+              --grpc-addr=localhost:50051 \
+              --tenant-id=volterra_energy \
+              --tenant-slug=volterra-energy \
+              --display-name='Volterra Energy' \
+              --subdomain=volterra-energy.develop.meridianhub.cloud \
+              --skip-manifest \
+              --with-fixtures
+
+      - name: Verify deployment health
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            max_attempts=30
+            attempt=0
+            until [ $attempt -ge $max_attempts ]; do
+              attempt=$((attempt+1))
+              echo "Health check attempt $attempt/$max_attempts"
+              if curl -sf http://localhost:80/healthz -H 'Host: develop.meridianhub.cloud' > /dev/null 2>&1; then
+                echo "Service is healthy"
+                exit 0
+              fi
+              sleep 5
+            done
+            echo "Health check failed after $max_attempts attempts"
+            cd /opt/meridian-develop && docker compose -f docker-compose.develop.yml logs --tail=50
+            exit 1
+
+  notify-failure:
+    name: Notify Deployment Failure
+    needs: [build-and-push, build-frontend, deploy]
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+
+    steps:
+      - name: Report deployment failure
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.sha,
+              state: 'failure',
+              context: 'deploy/develop',
+              description: 'Develop environment deployment failed',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            });

--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -5,8 +5,12 @@ name: Deploy Gate
 # environment before reaching demo.
 #
 # Runs on push to demo branch. If the latest deploy-develop run for the same
-# commit (or its parent on develop) failed or hasn't run, this check fails,
-# blocking the demo deployment pipeline.
+# commit (or its parent on develop) failed or hasn't run, this check fails.
+#
+# IMPORTANT: This workflow runs in parallel with deploy-demo.yml - it does not
+# inherently block the demo deployment. To enforce the gate, add
+# "check-develop-deploy" as a required status check in the branch protection
+# rules for the demo branch.
 
 on:
   push:

--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -1,0 +1,73 @@
+name: Deploy Gate
+
+# Checks that the latest deploy-develop workflow run succeeded before allowing
+# a deploy-demo run to proceed. This ensures code is validated in the develop
+# environment before reaching demo.
+#
+# Runs on push to demo branch. If the latest deploy-develop run for the same
+# commit (or its parent on develop) failed or hasn't run, this check fails,
+# blocking the demo deployment pipeline.
+
+on:
+  push:
+    branches: [demo]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  check-develop-deploy:
+    name: Verify Develop Deployment
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check latest deploy-develop status
+        uses: actions/github-script@v8
+        with:
+          script: |
+            // Find the most recent deploy-develop workflow run on the develop branch
+            const workflows = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'deploy-develop.yml',
+              branch: 'develop',
+              per_page: 1,
+              status: 'completed'
+            });
+
+            if (workflows.data.total_count === 0) {
+              core.setFailed('No completed deploy-develop workflow runs found. Deploy to develop first.');
+              return;
+            }
+
+            const latestRun = workflows.data.workflow_runs[0];
+            const runUrl = latestRun.html_url;
+
+            core.info(`Latest deploy-develop run: ${latestRun.id}`);
+            core.info(`Status: ${latestRun.conclusion}`);
+            core.info(`Commit: ${latestRun.head_sha}`);
+            core.info(`URL: ${runUrl}`);
+
+            if (latestRun.conclusion !== 'success') {
+              core.setFailed(
+                `Latest deploy-develop run did not succeed (conclusion: ${latestRun.conclusion}). ` +
+                `Fix the develop deployment before deploying to demo. Run: ${runUrl}`
+              );
+              return;
+            }
+
+            // Check that the develop deployment is reasonably recent (within 24 hours)
+            const runDate = new Date(latestRun.updated_at);
+            const now = new Date();
+            const hoursAgo = (now - runDate) / (1000 * 60 * 60);
+
+            if (hoursAgo > 24) {
+              core.warning(
+                `Latest successful deploy-develop run is ${Math.round(hoursAgo)} hours old. ` +
+                `Consider re-deploying to develop first. Run: ${runUrl}`
+              );
+            }
+
+            core.info(`Deploy gate passed. Latest develop deployment succeeded ${Math.round(hoursAgo)} hours ago.`);

--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -4,8 +4,9 @@ name: Deploy Gate
 # a deploy-demo run to proceed. This ensures code is validated in the develop
 # environment before reaching demo.
 #
-# Runs on push to demo branch. If the latest deploy-develop run for the same
-# commit (or its parent on develop) failed or hasn't run, this check fails.
+# Runs on push to demo branch. If the latest deploy-develop run failed or
+# hasn't completed, this check fails. Note: this checks the most recent
+# develop deployment regardless of commit ancestry.
 #
 # IMPORTANT: This workflow runs in parallel with deploy-demo.yml - it does not
 # inherently block the demo deployment. To enforce the gate, add


### PR DESCRIPTION
## Summary

- Add `deploy-develop.yml` GitHub Actions workflow that mirrors `deploy-demo.yml` for the develop environment, building and deploying the `:develop` Docker image to `/opt/meridian-develop/`
- Add `deploy-gate.yml` that verifies the latest develop deployment succeeded before allowing demo deployments (push to `demo` branch)
- Include `notify-failure` job in deploy-develop.yml that sets a commit status on deployment failure

## Key differences from deploy-demo.yml

| Aspect | Demo | Develop |
|--------|------|---------|
| Trigger branch | `demo` | `develop` |
| Image tag | `:demo` | `:develop` |
| Frontend VITE_BASE_DOMAIN | `demo.meridianhub.cloud` | `develop.meridianhub.cloud` |
| Config deployment path | `/opt/meridian/` | `/opt/meridian-develop/` |
| Container name | `meridian-meridian-1` | `meridian-develop` |
| Compose command | `docker compose up -d` | `docker compose -f docker-compose.develop.yml up -d` |
| Concurrency group | `deploy-demo` | `deploy-develop` |

The develop workflow also deploys the updated Caddyfile to the demo stack's `/opt/meridian/` directory and reloads Caddy there, since Caddy runs in the demo compose stack and serves both environments.

## Test plan

- [ ] Verify workflow YAML is valid (CI lint check)
- [ ] Verify deploy-develop.yml triggers on push to develop branch
- [ ] Verify deploy-gate.yml triggers on push to demo branch
- [ ] Verify cosign certificate identity references deploy-develop.yml
- [ ] Verify frontend artifact name uses `frontend-dist-develop` to avoid collision with demo
- [ ] Verify Caddyfile is deployed to both `/opt/meridian/` and Caddy is reloaded from demo stack
- [ ] Verify seed command uses volterra-energy slug consistent with reset-develop.sh