### PR TITLE
fix: Pass schema provisioner to tenant service for tenant isolation

### DIFF
--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -33,6 +33,7 @@ import (
 	masterbootstrap "github.com/meridianhub/meridian/internal/bootstrap"
 	"github.com/meridianhub/meridian/internal/migrations"
 	"github.com/meridianhub/meridian/services"
+	tenantprovisioner "github.com/meridianhub/meridian/services/tenant/provisioner"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
@@ -213,9 +214,18 @@ func run(logger *slog.Logger, grpcPort, httpPort int) error {
 		return fmt.Errorf("schema provisioner: %w", err)
 	}
 
+	// Guard against Go nil interface gotcha: a nil *PostgresProvisioner assigned
+	// to a SchemaProvisioner interface becomes non-nil (type set, value nil).
+	// Downstream code checks `provisioner != nil` to decide behavior, so we must
+	// keep the interface itself nil when provisioning is disabled.
+	var provIface tenantprovisioner.SchemaProvisioner
+	if schemaProvisioner != nil {
+		provIface = schemaProvisioner
+	}
+
 	// ─── Register All Services ──────────────────────────────────────────
 
-	if err := registerServices(ctx, grpcServer, conns, idempotencySvc, faEventPublisher, pkEventPublisher, outboxPublisher, outboxRepo, loopback, schemaProvisioner, tracer, logger); err != nil {
+	if err := registerServices(ctx, grpcServer, conns, idempotencySvc, faEventPublisher, pkEventPublisher, outboxPublisher, outboxRepo, loopback, provIface, tracer, logger); err != nil {
 		return err
 	}
 

--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -206,15 +206,22 @@ func run(logger *slog.Logger, grpcPort, httpPort int) error {
 	}
 	defer loopback.closeAll()
 
+	// ─── Schema Provisioner (optional, shared by tenant service + worker) ─
+
+	schemaProvisioner, err := createSchemaProvisioner(baseDSN, conns.gormDB("tenant"), logger)
+	if err != nil {
+		return fmt.Errorf("schema provisioner: %w", err)
+	}
+
 	// ─── Register All Services ──────────────────────────────────────────
 
-	if err := registerServices(ctx, grpcServer, conns, idempotencySvc, faEventPublisher, pkEventPublisher, outboxPublisher, outboxRepo, loopback, tracer, logger); err != nil {
+	if err := registerServices(ctx, grpcServer, conns, idempotencySvc, faEventPublisher, pkEventPublisher, outboxPublisher, outboxRepo, loopback, schemaProvisioner, tracer, logger); err != nil {
 		return err
 	}
 
 	// ─── Provisioning Worker (optional) ─────────────────────────────────
 
-	provisioningWorker, provisionerCleanup, err := startProvisioningWorker(ctx, baseDSN, conns.gormDB("tenant"), conns.gormDB("identity"), logger)
+	provisioningWorker, provisionerCleanup, err := startProvisioningWorker(ctx, schemaProvisioner, conns.gormDB("tenant"), conns.gormDB("identity"), logger)
 	if err != nil {
 		return fmt.Errorf("provisioning worker: %w", err)
 	}

--- a/cmd/meridian/wire_services.go
+++ b/cmd/meridian/wire_services.go
@@ -105,6 +105,7 @@ func registerServices(
 	outboxPublisher *events.OutboxPublisher,
 	outboxRepo *events.PostgresOutboxRepository,
 	loopback *loopbackClients,
+	schemaProvisioner tenantprovisioner.SchemaProvisioner,
 	tracer *observability.Tracer,
 	logger *slog.Logger,
 ) error {
@@ -123,7 +124,7 @@ func registerServices(
 			return err
 		}},
 		{"market-information", func() error { return wireMarketInformation(grpcServer, conns.pgxPool("market-information"), logger) }},
-		{"tenant", func() error { return wireTenant(grpcServer, conns.gormDB("tenant"), logger) }},
+		{"tenant", func() error { return wireTenant(grpcServer, conns.gormDB("tenant"), schemaProvisioner, logger) }},
 		{"internal-account", func() error {
 			return wireInternalAccount(grpcServer, conns.gormDB("internal-account"), refDataComps, logger)
 		}},
@@ -304,41 +305,53 @@ func wireMarketInformation(server *grpc.Server, pool *pgxpool.Pool, logger *slog
 	return nil
 }
 
-func wireTenant(server *grpc.Server, db *gorm.DB, logger *slog.Logger) error {
+func wireTenant(server *grpc.Server, db *gorm.DB, prov tenantprovisioner.SchemaProvisioner, logger *slog.Logger) error {
 	repo := tenantpersistence.NewRepository(db)
-	svc := tenantservice.NewService(repo, nil, nil, nil, logger)
+	svc := tenantservice.NewService(repo, prov, nil, nil, logger)
 	tenantv1.RegisterTenantServiceServer(server, svc)
-	logger.Info("registered tenant service")
+	logger.Info("registered tenant service", "provisioner_enabled", prov != nil)
 	return nil
 }
 
-// startProvisioningWorker initializes the tenant schema provisioning worker when
-// SCHEMA_PROVISIONING_ENABLED=true. It returns the worker (for graceful Stop)
-// and a cleanup function that closes provisioner database connections.
-// When provisioning is disabled both return values are nil.
-func startProvisioningWorker(ctx context.Context, baseDSN string, platformDB *gorm.DB, identityDB *gorm.DB, logger *slog.Logger) (*tenantworker.ProvisioningWorker, func(), error) {
+// createSchemaProvisioner creates the schema provisioner when SCHEMA_PROVISIONING_ENABLED=true.
+// The provisioner is shared between the tenant gRPC service (which sets initial tenant status
+// to PROVISIONING_PENDING) and the provisioning worker (which processes pending tenants).
+// Returns nil when provisioning is disabled.
+func createSchemaProvisioner(baseDSN string, platformDB *gorm.DB, logger *slog.Logger) (*tenantprovisioner.PostgresProvisioner, error) {
 	if env.GetEnvOrDefault("SCHEMA_PROVISIONING_ENABLED", "false") != "true" {
-		logger.Info("provisioning worker disabled",
-			"hint", "set SCHEMA_PROVISIONING_ENABLED=true to enable background provisioning")
-		return nil, nil, nil
+		logger.Info("schema provisioning disabled",
+			"hint", "set SCHEMA_PROVISIONING_ENABLED=true to enable tenant schema isolation")
+		return nil, nil
 	}
 
-	// Create provisioner config and derive service DSNs from the resolved baseDSN.
+	// Derive service DSNs from the resolved baseDSN.
 	// DefaultConfig() falls back to cockroachdb:26257 when per-service env vars
 	// are unset. The unified binary derives all connections from a single base DSN,
 	// so we override each service's DatabaseURL to match.
 	config, err := DeriveProvisionerConfig(baseDSN)
 	if err != nil {
-		return nil, nil, fmt.Errorf("provisioner config: %w", err)
+		return nil, fmt.Errorf("provisioner config: %w", err)
 	}
 	prov, err := tenantprovisioner.NewPostgresProvisioner(platformDB, config)
 	if err != nil {
-		return nil, nil, fmt.Errorf("create schema provisioner: %w", err)
+		return nil, fmt.Errorf("create schema provisioner: %w", err)
 	}
 
 	logger.Info("schema provisioner initialized",
 		"services", len(config.Services),
 		"provisioning_timeout", config.ProvisioningTimeout)
+
+	return prov, nil
+}
+
+// startProvisioningWorker creates and starts the background provisioning worker
+// using an already-initialized provisioner. Returns the worker (for graceful Stop)
+// and a cleanup function that closes provisioner database connections.
+// When prov is nil (provisioning disabled) both return values are nil.
+func startProvisioningWorker(ctx context.Context, prov *tenantprovisioner.PostgresProvisioner, platformDB *gorm.DB, identityDB *gorm.DB, logger *slog.Logger) (*tenantworker.ProvisioningWorker, func(), error) {
+	if prov == nil {
+		return nil, nil, nil
+	}
 
 	// Build worker config from environment (mirrors standalone tenant service).
 	repo := tenantpersistence.NewRepository(platformDB)

--- a/cmd/meridian/wire_services.go
+++ b/cmd/meridian/wire_services.go
@@ -321,7 +321,7 @@ func createSchemaProvisioner(baseDSN string, platformDB *gorm.DB, logger *slog.L
 	if env.GetEnvOrDefault("SCHEMA_PROVISIONING_ENABLED", "false") != "true" {
 		logger.Info("schema provisioning disabled",
 			"hint", "set SCHEMA_PROVISIONING_ENABLED=true to enable tenant schema isolation")
-		return nil, nil
+		return nil, nil //nolint:nilnil // nil provisioner is the expected "disabled" signal
 	}
 
 	// Derive service DSNs from the resolved baseDSN.

--- a/cmd/meridian/wire_services.go
+++ b/cmd/meridian/wire_services.go
@@ -313,9 +313,7 @@ func wireTenant(server *grpc.Server, db *gorm.DB, prov tenantprovisioner.SchemaP
 	return nil
 }
 
-// createSchemaProvisioner creates the schema provisioner when SCHEMA_PROVISIONING_ENABLED=true.
-// The provisioner is shared between the tenant gRPC service (which sets initial tenant status
-// to PROVISIONING_PENDING) and the provisioning worker (which processes pending tenants).
+// createSchemaProvisioner creates the provisioner when SCHEMA_PROVISIONING_ENABLED=true.
 // Returns nil when provisioning is disabled.
 func createSchemaProvisioner(baseDSN string, platformDB *gorm.DB, logger *slog.Logger) (*tenantprovisioner.PostgresProvisioner, error) {
 	if env.GetEnvOrDefault("SCHEMA_PROVISIONING_ENABLED", "false") != "true" {
@@ -324,10 +322,6 @@ func createSchemaProvisioner(baseDSN string, platformDB *gorm.DB, logger *slog.L
 		return nil, nil //nolint:nilnil // nil provisioner is the expected "disabled" signal
 	}
 
-	// Derive service DSNs from the resolved baseDSN.
-	// DefaultConfig() falls back to cockroachdb:26257 when per-service env vars
-	// are unset. The unified binary derives all connections from a single base DSN,
-	// so we override each service's DatabaseURL to match.
 	config, err := DeriveProvisionerConfig(baseDSN)
 	if err != nil {
 		return nil, fmt.Errorf("provisioner config: %w", err)
@@ -336,24 +330,19 @@ func createSchemaProvisioner(baseDSN string, platformDB *gorm.DB, logger *slog.L
 	if err != nil {
 		return nil, fmt.Errorf("create schema provisioner: %w", err)
 	}
-
 	logger.Info("schema provisioner initialized",
 		"services", len(config.Services),
 		"provisioning_timeout", config.ProvisioningTimeout)
-
 	return prov, nil
 }
 
-// startProvisioningWorker creates and starts the background provisioning worker
-// using an already-initialized provisioner. Returns the worker (for graceful Stop)
-// and a cleanup function that closes provisioner database connections.
+// startProvisioningWorker starts the background worker using an initialized provisioner.
 // When prov is nil (provisioning disabled) both return values are nil.
 func startProvisioningWorker(ctx context.Context, prov *tenantprovisioner.PostgresProvisioner, platformDB *gorm.DB, identityDB *gorm.DB, logger *slog.Logger) (*tenantworker.ProvisioningWorker, func(), error) {
 	if prov == nil {
 		return nil, nil, nil
 	}
 
-	// Build worker config from environment (mirrors standalone tenant service).
 	repo := tenantpersistence.NewRepository(platformDB)
 	w, err := tenantworker.NewProvisioningWorker(
 		repo,
@@ -368,12 +357,10 @@ func startProvisioningWorker(ctx context.Context, prov *tenantprovisioner.Postgr
 		logger,
 	)
 	if err != nil {
-		// Close provisioner connections on worker creation failure.
 		_ = prov.Close()
 		return nil, nil, fmt.Errorf("create provisioning worker: %w", err)
 	}
 
-	// Register post-provisioning hooks before starting the worker.
 	identityRepo := identitypersistence.NewRepository(identityDB)
 	w.RegisterPostProvisioningHook("admin-identity", identitybootstrap.AsPostProvisioningHook(identityRepo))
 


### PR DESCRIPTION
## Summary

- **Root cause**: `wireTenant()` passed `nil` as the provisioner to `tenantservice.NewService()`, so `InitiateTenant` always set tenant status to `ACTIVE` instead of `PROVISIONING_PENDING`. The provisioning worker polled for pending tenants but never found any - schemas were never created.
- Split `startProvisioningWorker` into `createSchemaProvisioner` (before service registration) and `startProvisioningWorker` (after), so the provisioner is shared between the tenant gRPC service and the background worker.
- The tenant service now correctly gates initial status on `provisioner != nil`, queuing tenants for schema creation when provisioning is enabled.

## Changes Made

- `cmd/meridian/wire_services.go`: Added `schemaProvisioner` parameter to `registerServices` and `wireTenant`. Split provisioner creation into `createSchemaProvisioner`. `wireTenant` now passes the provisioner to `NewService`.
- `cmd/meridian/main.go`: Create schema provisioner before `registerServices`, pass it through to both service registration and worker startup.

## Test plan

- [x] `go build ./cmd/meridian/` compiles cleanly
- [x] `TestCompilation` passes
- [x] `TestDeriveProvisionerConfig_*` tests pass
- [ ] CI passes (compilation, unit tests, integration tests)
- [ ] After deploy to demo: verify `InitiateTenant` creates tenants with `PROVISIONING_PENDING` status
- [ ] After deploy to demo: verify provisioning worker picks up pending tenants and creates `org_*` schemas