### PR TITLE
fix: enable wildcard routing for develop tenant subdomains

### DIFF
--- a/deploy/demo/Caddyfile
+++ b/deploy/demo/Caddyfile
@@ -52,10 +52,7 @@ demo.meridianhub.cloud, *.demo.meridianhub.cloud {
 	}
 }
 
-# Tenant subdomains (*.develop.meridianhub.cloud) require the Cloudflare origin
-# cert to include a sub-subdomain wildcard SAN. Add that to the cert before
-# uncommenting the wildcard below.
-develop.meridianhub.cloud {
+develop.meridianhub.cloud, *.develop.meridianhub.cloud {
 	tls /etc/caddy/certs/origin-cert.pem /etc/caddy/certs/origin-key.pem
 
 	# Health/readiness probes


### PR DESCRIPTION
## Summary
- Enable `*.develop.meridianhub.cloud` wildcard in Caddyfile for tenant subdomain routing
- Cloudflare Full mode accepts the existing `*.meridianhub.cloud` origin cert for sub-subdomains, so no cert change needed
- Remove the stale comment about needing a cert SAN update

## Test plan
- [x] Verified `volterra-energy.develop.meridianhub.cloud/healthz` returns 200 on live droplet
- [x] Verified `develop.meridianhub.cloud/healthz` still works
- [x] Verified demo subdomain routing unaffected