### PR TITLE
feat: add dedicated postgres for develop environment

### DIFF
--- a/deploy/demo/init-databases.sql
+++ b/deploy/demo/init-databases.sql
@@ -15,3 +15,4 @@ CREATE DATABASE meridian_forecasting;
 CREATE DATABASE meridian_reference_data;
 CREATE DATABASE meridian_identity;
 CREATE DATABASE meridian_operational_gateway;
+CREATE DATABASE meridian_financial_gateway;

--- a/deploy/develop/docker-compose.develop.yml
+++ b/deploy/develop/docker-compose.develop.yml
@@ -1,10 +1,11 @@
 # Meridian develop environment stack
 #
-# Runs meridian-develop and mcp-server-develop alongside the existing demo stack
-# on the same DigitalOcean droplet (68.183.40.239). Shares the demo stack's
-# postgres and caddy containers via the external meridian_default network.
+# Runs a fully isolated develop environment alongside the existing demo stack
+# on the same DigitalOcean droplet (68.183.40.239). Has its own postgres for
+# data isolation; shares caddy via the external meridian_default network.
 #
 # Services:
+#   postgres-develop    - PostgreSQL 16 (isolated from demo, not exposed to host)
 #   meridian-develop    - Unified binary (develop branch build)
 #   mcp-server-develop  - MCP server for AI integration (develop branch build)
 #
@@ -21,15 +22,45 @@
 #     jwt-signing-key.pem                               - RSA private key (SEPARATE from demo key)
 #
 # Prerequisites:
-#   - Demo stack must be running (provides postgres and caddy)
-#   - (Optional) If using a separate postgres, uncomment and run init-databases-develop.sql
+#   - Demo stack must be running (provides caddy)
 #   - Generate a SEPARATE JWT signing key for the develop environment
 
 services:
+  postgres-develop:
+    image: postgres:16-alpine
+    container_name: postgres-develop
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-meridian}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the env file}
+      POSTGRES_DB: ${POSTGRES_DB:-meridian}
+    volumes:
+      - postgres_develop_data:/var/lib/postgresql/data
+      - /opt/meridian-develop/init-databases-develop.sql:/docker-entrypoint-initdb.d/init-databases.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-meridian} -d ${POSTGRES_DB:-meridian}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    networks:
+      - develop-internal
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 128M
+
   meridian-develop:
     image: ${MERIDIAN_IMAGE:-ghcr.io/meridianhub/meridian:develop}
     container_name: meridian-develop
     restart: unless-stopped
+    depends_on:
+      postgres-develop:
+        condition: service_healthy
     environment:
       # --- Application ---
       ENVIRONMENT: ${ENVIRONMENT:-develop}
@@ -39,11 +70,8 @@ services:
       DB_DRIVER: postgres
 
       # --- Database ---
-      # Connects to the demo stack's postgres container via the shared network.
-      # NOTE: The app hardcodes per-service database names (meridian_platform, etc.)
-      # in ServiceDatabases, so develop and demo share the same databases when on
-      # the same postgres. For true isolation, use a separate postgres container.
-      DATABASE_URL: postgres://${POSTGRES_USER:-meridian}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the env file}@postgres:5432/${POSTGRES_DB:-meridian}?sslmode=disable
+      # Connects to the dedicated develop postgres container for full data isolation.
+      DATABASE_URL: postgres://${POSTGRES_USER:-meridian}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the env file}@postgres-develop:5432/${POSTGRES_DB:-meridian}?sslmode=disable
 
       # --- JWT Signing (SEPARATE key from demo for environment isolation) ---
       JWT_SIGNING_KEY_FILE: ${JWT_SIGNING_KEY_FILE:-}
@@ -86,6 +114,7 @@ services:
     volumes:
       - /opt/meridian-develop/secrets:/run/secrets:ro
     networks:
+      - develop-internal
       - meridian
     deploy:
       resources:
@@ -152,7 +181,11 @@ services:
           cpus: '0.25'
           memory: 128M
 
+volumes:
+  postgres_develop_data:
+
 networks:
+  develop-internal:
   meridian:
     external: true
     name: meridian_default

--- a/deploy/develop/docker-compose.develop.yml
+++ b/deploy/develop/docker-compose.develop.yml
@@ -186,6 +186,7 @@ volumes:
 
 networks:
   develop-internal:
+    internal: true
   meridian:
     external: true
     name: meridian_default

--- a/deploy/develop/init-databases-develop.sql
+++ b/deploy/develop/init-databases-develop.sql
@@ -1,32 +1,21 @@
 -- Database initialization for the Meridian develop environment.
 --
--- IMPORTANT: The application's ServiceDatabases map (internal/migrations/runner.go)
--- hardcodes database names (meridian_platform, meridian_current_account, etc.).
--- The newServiceConns function replaces only the database component of DATABASE_URL,
--- ignoring any prefix in the base DSN. This means the develop environment uses the
--- SAME databases as demo when sharing a postgres instance.
---
--- For true database isolation, either:
---   1. Run a separate postgres container for the develop stack, OR
---   2. Add a DB_NAME_PREFIX env var to the application (requires code change)
---
--- When sharing the demo stack's postgres (current approach), this script is NOT
--- needed - the databases are already created by the demo stack's init-databases.sql.
--- This file is retained as documentation of the database requirements.
---
--- If running a SEPARATE postgres for develop, uncomment the statements below:
+-- Creates per-service databases in the dedicated develop postgres container.
+-- These use the same names as demo (meridian_platform, etc.) because the
+-- application hardcodes database names in ServiceDatabases. Data isolation
+-- is achieved by running a separate postgres instance, not by name prefixing.
 
--- CREATE DATABASE meridian_platform;
--- CREATE DATABASE meridian_current_account;
--- CREATE DATABASE meridian_financial_accounting;
--- CREATE DATABASE meridian_position_keeping;
--- CREATE DATABASE meridian_payment_order;
--- CREATE DATABASE meridian_party;
--- CREATE DATABASE meridian_internal_bank_account;
--- CREATE DATABASE meridian_market_information;
--- CREATE DATABASE meridian_reconciliation;
--- CREATE DATABASE meridian_forecasting;
--- CREATE DATABASE meridian_reference_data;
--- CREATE DATABASE meridian_identity;
--- CREATE DATABASE meridian_operational_gateway;
--- CREATE DATABASE meridian_financial_gateway;
+CREATE DATABASE meridian_platform;
+CREATE DATABASE meridian_current_account;
+CREATE DATABASE meridian_financial_accounting;
+CREATE DATABASE meridian_position_keeping;
+CREATE DATABASE meridian_payment_order;
+CREATE DATABASE meridian_party;
+CREATE DATABASE meridian_internal_bank_account;
+CREATE DATABASE meridian_market_information;
+CREATE DATABASE meridian_reconciliation;
+CREATE DATABASE meridian_forecasting;
+CREATE DATABASE meridian_reference_data;
+CREATE DATABASE meridian_identity;
+CREATE DATABASE meridian_operational_gateway;
+CREATE DATABASE meridian_financial_gateway;

--- a/scripts/reset-develop.sh
+++ b/scripts/reset-develop.sh
@@ -32,7 +32,8 @@ set -euo pipefail
 
 DEVELOP_HOST="${DEVELOP_HOST:-meridian-develop-host}"
 DEVELOP_DIR="/opt/meridian-develop"
-PG_USER="meridian"
+PG_USER="${PG_USER:-meridian}"
+PG_DB="${PG_DB:-meridian}"
 PG_CONTAINER="postgres-develop"
 APP_CONTAINER="meridian-develop"
 COMPOSE_CMD="docker compose -f docker-compose.develop.yml"
@@ -72,23 +73,23 @@ echo "=== Step 3: Drop and recreate databases ==="
 
 # Terminate active connections to meridian_* databases
 # (develop has its own postgres, so all meridian_* databases belong to us)
-ssh "${DEVELOP_HOST}" "docker exec ${PG_CONTAINER} psql -U ${PG_USER} -d ${PG_USER} -c \"
+ssh "${DEVELOP_HOST}" "docker exec ${PG_CONTAINER} psql -U ${PG_USER} -d ${PG_DB} -c \"
   SELECT pg_terminate_backend(pid) FROM pg_stat_activity
-  WHERE datname LIKE 'meridian_%' AND pid <> pg_backend_pid();
+  WHERE datname LIKE 'meridian\\_%' ESCAPE '\\' AND pid <> pg_backend_pid();
 \" 2>/dev/null || true"
 
 # Drop all meridian_* per-service databases
-ssh "${DEVELOP_HOST}" "docker exec ${PG_CONTAINER} psql -U ${PG_USER} -d ${PG_USER} -tc \"
-  SELECT datname FROM pg_database WHERE datname LIKE 'meridian_%' AND datname != 'meridian';
+ssh "${DEVELOP_HOST}" "docker exec ${PG_CONTAINER} psql -U ${PG_USER} -d ${PG_DB} -tc \"
+  SELECT datname FROM pg_database WHERE datname LIKE 'meridian\\_%' ESCAPE '\\' AND datname != 'meridian';
 \" | while read -r db; do
   db=\$(echo \"\$db\" | xargs)
   [ -z \"\$db\" ] && continue
   echo \"  Dropping: \$db\"
-  docker exec ${PG_CONTAINER} psql -U ${PG_USER} -d ${PG_USER} -c \"DROP DATABASE IF EXISTS \\\"\$db\\\";\"
+  docker exec ${PG_CONTAINER} psql -U ${PG_USER} -d ${PG_DB} -c \"DROP DATABASE IF EXISTS \\\"\$db\\\";\"
 done"
 
 # Re-run init-databases to recreate empty per-service databases
-ssh "${DEVELOP_HOST}" "docker exec ${PG_CONTAINER} psql -U ${PG_USER} -d ${PG_USER} -f /docker-entrypoint-initdb.d/init-databases.sql"
+ssh "${DEVELOP_HOST}" "docker exec ${PG_CONTAINER} psql -U ${PG_USER} -d ${PG_DB} -f /docker-entrypoint-initdb.d/init-databases.sql"
 
 echo ""
 echo "=== Step 4: Run pre-migration scripts ==="

--- a/scripts/reset-develop.sh
+++ b/scripts/reset-develop.sh
@@ -26,14 +26,14 @@
 #   - The develop stack must already be deployed (docker-compose.develop.yml in /opt/meridian-develop)
 #
 # Container names use custom container_name values defined in docker-compose.develop.yml.
-# The postgres user is "meridian" (shared with demo stack).
+# The develop stack has its own postgres container (postgres-develop).
 
 set -euo pipefail
 
 DEVELOP_HOST="${DEVELOP_HOST:-meridian-develop-host}"
 DEVELOP_DIR="/opt/meridian-develop"
 PG_USER="meridian"
-PG_CONTAINER="meridian-postgres-1"
+PG_CONTAINER="postgres-develop"
 APP_CONTAINER="meridian-develop"
 COMPOSE_CMD="docker compose -f docker-compose.develop.yml"
 
@@ -70,15 +70,16 @@ ssh "${DEVELOP_HOST}" "cd ${DEVELOP_DIR} && ${COMPOSE_CMD} stop meridian-develop
 echo ""
 echo "=== Step 3: Drop and recreate databases ==="
 
-# Terminate active connections to dev_* databases
+# Terminate active connections to meridian_* databases
+# (develop has its own postgres, so all meridian_* databases belong to us)
 ssh "${DEVELOP_HOST}" "docker exec ${PG_CONTAINER} psql -U ${PG_USER} -d ${PG_USER} -c \"
   SELECT pg_terminate_backend(pid) FROM pg_stat_activity
-  WHERE datname LIKE 'dev\_%' ESCAPE '\' AND pid <> pg_backend_pid();
+  WHERE datname LIKE 'meridian_%' AND pid <> pg_backend_pid();
 \" 2>/dev/null || true"
 
-# Drop all dev_* per-service databases
+# Drop all meridian_* per-service databases
 ssh "${DEVELOP_HOST}" "docker exec ${PG_CONTAINER} psql -U ${PG_USER} -d ${PG_USER} -tc \"
-  SELECT datname FROM pg_database WHERE datname LIKE 'dev\_%' ESCAPE '\';
+  SELECT datname FROM pg_database WHERE datname LIKE 'meridian_%' AND datname != 'meridian';
 \" | while read -r db; do
   db=\$(echo \"\$db\" | xargs)
   [ -z \"\$db\" ] && continue
@@ -86,15 +87,15 @@ ssh "${DEVELOP_HOST}" "docker exec ${PG_CONTAINER} psql -U ${PG_USER} -d ${PG_US
   docker exec ${PG_CONTAINER} psql -U ${PG_USER} -d ${PG_USER} -c \"DROP DATABASE IF EXISTS \\\"\$db\\\";\"
 done"
 
-# Re-run init-databases-develop.sql to recreate empty per-service databases
-ssh "${DEVELOP_HOST}" "docker exec ${PG_CONTAINER} psql -U ${PG_USER} -d ${PG_USER} -f /docker-entrypoint-initdb.d/init-databases-develop.sql"
+# Re-run init-databases to recreate empty per-service databases
+ssh "${DEVELOP_HOST}" "docker exec ${PG_CONTAINER} psql -U ${PG_USER} -d ${PG_USER} -f /docker-entrypoint-initdb.d/init-databases.sql"
 
 echo ""
 echo "=== Step 4: Run pre-migration scripts ==="
 # PostgreSQL requires ALTER TABLE DROP CONSTRAINT for constraint-backed unique indexes.
 # CockroachDB uses DROP INDEX CASCADE instead. This pre-migration resolves the divergence.
 # See deploy/demo/pg-pre-migration.sql for details.
-ssh "${DEVELOP_HOST}" "docker exec ${PG_CONTAINER} psql -U ${PG_USER} -d dev_reference_data -c \"ALTER TABLE IF EXISTS public.platform_saga_definition DROP CONSTRAINT IF EXISTS uq_platform_saga_definition_name;\""
+ssh "${DEVELOP_HOST}" "docker exec ${PG_CONTAINER} psql -U ${PG_USER} -d meridian_reference_data -c \"ALTER TABLE IF EXISTS public.platform_saga_definition DROP CONSTRAINT IF EXISTS uq_platform_saga_definition_name;\""
 
 echo ""
 echo "=== Step 5: Start meridian-develop and run migrations ==="


### PR DESCRIPTION
## Summary
- Add `postgres-develop` container to develop compose stack for full data isolation from demo
- Update DATABASE_URL to point at `postgres-develop` instead of shared `postgres`
- Uncomment init-databases-develop.sql (uses standard `meridian_*` names since it's an isolated instance)
- Update reset-develop.sh to target `postgres-develop` container and `meridian_*` databases
- Add `develop-internal` network for postgres-develop <-> meridian-develop communication

## Why
Both environments shared the same postgres and hardcoded database names, so develop and demo had identical data. ~512MB RAM cost for full isolation.

## Test plan
- [ ] Deploy to droplet, verify `postgres-develop` container starts healthy
- [ ] Verify `meridian-develop` connects to `postgres-develop` (not demo's `postgres`)
- [ ] Verify demo data unaffected after develop reset
- [ ] Run `reset-develop.sh` to seed fresh develop data