### PR TITLE
fix: Update isolation test assertion to match fail-fast schema check

### DIFF
--- a/tests/multi_tenant/isolation_test.go
+++ b/tests/multi_tenant/isolation_test.go
@@ -869,14 +869,17 @@ func TestOrganizationDatabaseScopeErrors(t *testing.T) {
 				return err
 			}
 
-			// SET LOCAL should succeed (PostgreSQL allows setting search_path to non-existent schemas)
-			// But querying tables should fail
+			// WithTenantScope fail-fast check prevents reaching this query
+			// when the tenant schema does not exist.
 			var count int
 			return tx.QueryRowContext(orgCtx, "SELECT COUNT(*) FROM accounts").Scan(&count)
 		})
 
 		require.Error(t, err, "query to non-existent schema should fail")
-		assert.Contains(t, err.Error(), "accounts", "error should mention missing table")
+		assert.ErrorIs(t, err, db.ErrTenantSchemaNotProvisioned,
+			"WithTenantScope should fail-fast when schema does not exist")
+		assert.Contains(t, err.Error(), "org_nonexistent_org",
+			"error should mention the missing schema")
 	})
 }
 


### PR DESCRIPTION
## Summary
- The fail-fast schema verification introduced in #1945 (`8ca48059`) returns `ErrTenantSchemaNotProvisioned` before the query reaches the accounts table
- `TestOrganizationDatabaseScopeErrors/non_existent_schema_query_fails_gracefully` was asserting the old behavior (error containing "accounts") but the new behavior correctly fails earlier with a schema-level error
- Updated the assertion to use `ErrorIs` for `ErrTenantSchemaNotProvisioned` and check for the schema name

## Evidence
- Failing Nightly run: https://github.com/meridianhub/meridian/actions/runs/23577704548
- Error: `"tenant schema not provisioned: schema does not exist in database: org_nonexistent_org" does not contain "accounts"`

## Test plan
- [ ] Nightly CI passes with updated assertion
- [ ] Build & Test passes