### PR TITLE
fix: restart meridian-develop after migrations before seeding

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -265,7 +265,7 @@ jobs:
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           script: |
-            # seed-dev has its own gateway health polling (2-minute timeout, 2s interval)
+            # seed-dev has its own gateway health polling (60s timeout, 2s interval)
             # so no extra wait needed between restart and seed.
             docker exec meridian-develop /seed-dev \
               --gateway-url=http://localhost:8090 \

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -245,6 +245,19 @@ jobs:
           script: |
             docker exec meridian-develop /meridian --migrate
 
+      - name: Restart meridian-develop post-migration
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            # Restart so the app picks up migrated schemas and provisions tenant
+            # schemas (SCHEMA_PROVISIONING_ENABLED=true). Without this, seed-dev
+            # fails on fresh databases because tenant schemas don't exist yet.
+            cd /opt/meridian-develop
+            docker compose -f docker-compose.develop.yml restart meridian-develop
+
       - name: Seed develop data
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
@@ -252,9 +265,8 @@ jobs:
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           script: |
-            # Skip manifest on incremental deploys - manifest only needs to apply
-            # on fresh databases (handled by reset-develop.sh). Full idempotency for
-            # ApplyManifest is tracked as a follow-up.
+            # seed-dev has its own gateway health polling (2-minute timeout, 2s interval)
+            # so no extra wait needed between restart and seed.
             docker exec meridian-develop /seed-dev \
               --gateway-url=http://localhost:8090 \
               --grpc-addr=localhost:50051 \


### PR DESCRIPTION
## Summary
- Add restart step between migrations and seeding in deploy-develop.yml
- On fresh databases, tenant schemas aren't provisioned until the app starts post-migration
- Without restart, seed-dev fails with "schema does not exist in database: org_volterra_energy"

## Why
The previous deploy failed at the seed step because the app hadn't provisioned tenant schemas yet. `reset-demo.sh` already does this restart - the deploy workflow was missing it.

## Test plan
- [ ] Re-run deploy-develop - seed should succeed after restart