### PR TITLE
test: manifest graph and diff graph component unit tests

### DIFF
--- a/frontend/src/features/manifests/components/manifest-diff-graph.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-diff-graph.test.tsx
@@ -324,9 +324,11 @@ describe('ManifestDiffGraph', () => {
     it('does not show 0-count categories', async () => {
       render(<ManifestDiffGraph before={emptyGraph} after={graphWithInstrument} />)
       await screen.findByTestId('diff-summary')
-      // Only added, no removed or modified
+      // Only added nodes, no removed/modified nodes or edge changes
       expect(screen.queryByText(/-\d+ removed/)).not.toBeInTheDocument()
       expect(screen.queryByText(/~\d+ modified/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/\+\d+ edge/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/-\d+ edge/)).not.toBeInTheDocument()
     })
   })
 

--- a/frontend/src/features/manifests/components/manifest-diff-graph.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-diff-graph.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { useState } from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { ManifestDiffGraph } from './manifest-diff-graph'
 import type { ManifestGraph } from '../lib/manifest-graph-model'
 

--- a/frontend/src/features/manifests/components/manifest-diff-graph.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-diff-graph.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { useState } from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { ManifestDiffGraph } from './manifest-diff-graph'
 import type { ManifestGraph } from '../lib/manifest-graph-model'
 
@@ -186,6 +186,418 @@ describe('ManifestDiffGraph', () => {
       await screen.findByTestId('react-flow')
       const wrapper = container.querySelector('[data-testid="manifest-diff-graph"]')
       expect(wrapper).toHaveClass('h-96')
+    })
+  })
+
+  describe('modified nodes', () => {
+    const graphBefore: ManifestGraph = {
+      nodes: [
+        {
+          id: 'instrument:GBP',
+          type: 'instrument',
+          label: 'British Pound',
+          data: { code: 'GBP', dimensions: { unit: 'GBP', precision: 2 } },
+        },
+      ],
+      edges: [],
+    }
+
+    const graphAfterModified: ManifestGraph = {
+      nodes: [
+        {
+          id: 'instrument:GBP',
+          type: 'instrument',
+          label: 'British Pound Sterling',
+          data: { code: 'GBP', dimensions: { unit: 'GBP', precision: 4 } },
+        },
+      ],
+      edges: [],
+    }
+
+    it('shows modified count when node data changes', async () => {
+      render(<ManifestDiffGraph before={graphBefore} after={graphAfterModified} />)
+      expect(await screen.findByText('~1 modified')).toBeInTheDocument()
+    })
+
+    it('renders node with modified diff status', async () => {
+      render(<ManifestDiffGraph before={graphBefore} after={graphAfterModified} />)
+      const node = await screen.findByTestId('diff-flow-node-instrument:GBP')
+      expect(node).toHaveAttribute('data-diff-status', 'modified')
+    })
+  })
+
+  describe('edge diff visualization', () => {
+    const beforeWithEdge: ManifestGraph = {
+      nodes: [
+        { id: 'instrument:GBP', type: 'instrument', label: 'GBP', data: { code: 'GBP' } },
+        { id: 'account_type:CURRENT', type: 'account_type', label: 'Current', data: { code: 'CURRENT' } },
+      ],
+      edges: [
+        { id: 'edge-1', source: 'account_type:CURRENT', target: 'instrument:GBP', relationship: 'allowed_by' },
+      ],
+    }
+
+    const afterNoEdge: ManifestGraph = {
+      nodes: [
+        { id: 'instrument:GBP', type: 'instrument', label: 'GBP', data: { code: 'GBP' } },
+        { id: 'account_type:CURRENT', type: 'account_type', label: 'Current', data: { code: 'CURRENT' } },
+      ],
+      edges: [],
+    }
+
+    const afterNewEdge: ManifestGraph = {
+      nodes: [
+        { id: 'instrument:GBP', type: 'instrument', label: 'GBP', data: { code: 'GBP' } },
+        { id: 'account_type:CURRENT', type: 'account_type', label: 'Current', data: { code: 'CURRENT' } },
+      ],
+      edges: [
+        { id: 'edge-new', source: 'account_type:CURRENT', target: 'instrument:GBP', relationship: 'allowed_by' },
+      ],
+    }
+
+    it('shows removed edge count', async () => {
+      render(<ManifestDiffGraph before={beforeWithEdge} after={afterNoEdge} />)
+      expect(await screen.findByText('-1 edge')).toBeInTheDocument()
+    })
+
+    it('renders removed edge with removed diff status', async () => {
+      render(<ManifestDiffGraph before={beforeWithEdge} after={afterNoEdge} />)
+      const edge = await screen.findByTestId('diff-flow-edge-edge-1')
+      expect(edge).toHaveAttribute('data-diff-status', 'removed')
+    })
+
+    it('shows added edge count', async () => {
+      render(<ManifestDiffGraph before={afterNoEdge} after={afterNewEdge} />)
+      expect(await screen.findByText('+1 edge')).toBeInTheDocument()
+    })
+
+    it('renders added edge with added diff status', async () => {
+      render(<ManifestDiffGraph before={afterNoEdge} after={afterNewEdge} />)
+      const edge = await screen.findByTestId('diff-flow-edge-edge-new')
+      expect(edge).toHaveAttribute('data-diff-status', 'added')
+    })
+
+    it('pluralizes edge count correctly', async () => {
+      const afterTwoEdges: ManifestGraph = {
+        nodes: [
+          { id: 'instrument:GBP', type: 'instrument', label: 'GBP', data: { code: 'GBP' } },
+          { id: 'instrument:USD', type: 'instrument', label: 'USD', data: { code: 'USD' } },
+          { id: 'account_type:CURRENT', type: 'account_type', label: 'Current', data: { code: 'CURRENT' } },
+        ],
+        edges: [
+          { id: 'edge-a', source: 'account_type:CURRENT', target: 'instrument:GBP', relationship: 'allowed_by' },
+          { id: 'edge-b', source: 'account_type:CURRENT', target: 'instrument:USD', relationship: 'allowed_by' },
+        ],
+      }
+      const noEdges: ManifestGraph = {
+        ...afterTwoEdges,
+        edges: [],
+      }
+      render(<ManifestDiffGraph before={afterTwoEdges} after={noEdges} />)
+      expect(await screen.findByText('-2 edges')).toBeInTheDocument()
+    })
+  })
+
+  describe('diff legend', () => {
+    it('renders legend with all diff statuses', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithInstrument} />)
+      await screen.findByTestId('react-flow')
+      expect(screen.getByText('Added')).toBeInTheDocument()
+      expect(screen.getByText('Removed')).toBeInTheDocument()
+      expect(screen.getByText('Modified')).toBeInTheDocument()
+      expect(screen.getByText('Unchanged')).toBeInTheDocument()
+    })
+
+    it('renders legend header', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithInstrument} />)
+      await screen.findByTestId('react-flow')
+      expect(screen.getByText('Legend')).toBeInTheDocument()
+    })
+  })
+
+  describe('diff summary panel', () => {
+    it('renders Changes header', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithInstrument} />)
+      expect(await screen.findByText('Changes')).toBeInTheDocument()
+    })
+
+    it('does not show 0-count categories', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithInstrument} />)
+      await screen.findByTestId('diff-summary')
+      // Only added, no removed or modified
+      expect(screen.queryByText(/-\d+ removed/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/~\d+ modified/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('controls', () => {
+    it('renders zoom controls', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithInstrument} />)
+      expect(await screen.findByTestId('controls')).toBeInTheDocument()
+    })
+  })
+
+  describe('multiple node types in diff', () => {
+    const graphWithSaga: ManifestGraph = {
+      nodes: [
+        {
+          id: 'saga:settle',
+          type: 'saga',
+          label: 'settle',
+          data: { trigger: 'event:test.v1', script: 'def main(): pass' },
+        },
+      ],
+      edges: [],
+    }
+
+    const graphWithAccountType: ManifestGraph = {
+      nodes: [
+        {
+          id: 'account_type:CURRENT',
+          type: 'account_type',
+          label: 'Current Account',
+          data: { code: 'CURRENT' },
+        },
+      ],
+      edges: [],
+    }
+
+    const graphWithValuation: ManifestGraph = {
+      nodes: [
+        {
+          id: 'valuation_rule:KWH->GBP',
+          type: 'valuation_rule',
+          label: 'KWH to GBP',
+          data: { fromInstrument: 'KWH', toInstrument: 'GBP' },
+        },
+      ],
+      edges: [],
+    }
+
+    const graphWithPaymentRail: ManifestGraph = {
+      nodes: [
+        {
+          id: 'payment_rail:stripe',
+          type: 'payment_rail',
+          label: 'Stripe',
+          data: { provider: 'stripe' },
+        },
+      ],
+      edges: [],
+    }
+
+    const graphWithMapping: ManifestGraph = {
+      nodes: [
+        {
+          id: 'mapping:inbound',
+          type: 'mapping',
+          label: 'stripe_inbound',
+          data: {},
+        },
+      ],
+      edges: [],
+    }
+
+    const graphWithMarketData: ManifestGraph = {
+      nodes: [
+        {
+          id: 'market_data:SPOT',
+          type: 'market_data',
+          label: 'Spot Price',
+          data: { code: 'SPOT' },
+        },
+      ],
+      edges: [],
+    }
+
+    const graphWithOrganization: ManifestGraph = {
+      nodes: [
+        {
+          id: 'organization:ACME',
+          type: 'organization',
+          label: 'Acme Corp',
+          data: { code: 'ACME' },
+        },
+      ],
+      edges: [],
+    }
+
+    const graphWithInternalAccount: ManifestGraph = {
+      nodes: [
+        {
+          id: 'internal_account:OPS_GBP',
+          type: 'internal_account',
+          label: 'Operating GBP',
+          data: { code: 'OPS_GBP', accountType: 'CURRENT' },
+        },
+      ],
+      edges: [],
+    }
+
+    const graphWithOpGateway: ManifestGraph = {
+      nodes: [
+        {
+          id: 'operational_gateway:gw',
+          type: 'operational_gateway',
+          label: 'Gateway',
+          data: {},
+        },
+      ],
+      edges: [],
+    }
+
+    const graphWithProviderConn: ManifestGraph = {
+      nodes: [
+        {
+          id: 'provider_connection:conn-1',
+          type: 'provider_connection',
+          label: 'Stripe Connection',
+          data: { connectionId: 'conn-1' },
+        },
+      ],
+      edges: [],
+    }
+
+    const graphWithInstructionRoute: ManifestGraph = {
+      nodes: [
+        {
+          id: 'instruction_route:payment',
+          type: 'instruction_route',
+          label: 'Payment Route',
+          data: { connectionId: 'conn-1' },
+        },
+      ],
+      edges: [],
+    }
+
+    const graphWithPartyType: ManifestGraph = {
+      nodes: [
+        {
+          id: 'party_type:CUSTOMER',
+          type: 'party_type',
+          label: 'Customer',
+          data: {},
+        },
+      ],
+      edges: [],
+    }
+
+    it('assigns diff_saga node type for saga diffs', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithSaga} />)
+      const node = await screen.findByTestId('diff-flow-node-saga:settle')
+      expect(node).toHaveAttribute('data-node-type', 'diff_saga')
+    })
+
+    it('assigns diff_account_type node type', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithAccountType} />)
+      const node = await screen.findByTestId('diff-flow-node-account_type:CURRENT')
+      expect(node).toHaveAttribute('data-node-type', 'diff_account_type')
+    })
+
+    it('assigns diff_valuation_rule node type', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithValuation} />)
+      const node = await screen.findByTestId('diff-flow-node-valuation_rule:KWH->GBP')
+      expect(node).toHaveAttribute('data-node-type', 'diff_valuation_rule')
+    })
+
+    it('assigns diff_payment_rail node type', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithPaymentRail} />)
+      const node = await screen.findByTestId('diff-flow-node-payment_rail:stripe')
+      expect(node).toHaveAttribute('data-node-type', 'diff_payment_rail')
+    })
+
+    it('assigns diff_mapping node type', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithMapping} />)
+      const node = await screen.findByTestId('diff-flow-node-mapping:inbound')
+      expect(node).toHaveAttribute('data-node-type', 'diff_mapping')
+    })
+
+    it('assigns diff_market_data node type', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithMarketData} />)
+      const node = await screen.findByTestId('diff-flow-node-market_data:SPOT')
+      expect(node).toHaveAttribute('data-node-type', 'diff_market_data')
+    })
+
+    it('assigns diff_organization node type', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithOrganization} />)
+      const node = await screen.findByTestId('diff-flow-node-organization:ACME')
+      expect(node).toHaveAttribute('data-node-type', 'diff_organization')
+    })
+
+    it('assigns diff_internal_account node type', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithInternalAccount} />)
+      const node = await screen.findByTestId('diff-flow-node-internal_account:OPS_GBP')
+      expect(node).toHaveAttribute('data-node-type', 'diff_internal_account')
+    })
+
+    it('assigns diff_operational_gateway node type', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithOpGateway} />)
+      const node = await screen.findByTestId('diff-flow-node-operational_gateway:gw')
+      expect(node).toHaveAttribute('data-node-type', 'diff_operational_gateway')
+    })
+
+    it('assigns diff_provider_connection node type', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithProviderConn} />)
+      const node = await screen.findByTestId('diff-flow-node-provider_connection:conn-1')
+      expect(node).toHaveAttribute('data-node-type', 'diff_provider_connection')
+    })
+
+    it('assigns diff_instruction_route node type', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithInstructionRoute} />)
+      const node = await screen.findByTestId('diff-flow-node-instruction_route:payment')
+      expect(node).toHaveAttribute('data-node-type', 'diff_instruction_route')
+    })
+
+    it('assigns diff_party_type node type', async () => {
+      render(<ManifestDiffGraph before={emptyGraph} after={graphWithPartyType} />)
+      const node = await screen.findByTestId('diff-flow-node-party_type:CUSTOMER')
+      expect(node).toHaveAttribute('data-node-type', 'diff_party_type')
+    })
+  })
+
+  describe('combined diff states', () => {
+    it('shows added, removed, and unchanged in one view', async () => {
+      const before: ManifestGraph = {
+        nodes: [
+          { id: 'instrument:GBP', type: 'instrument', label: 'GBP', data: { code: 'GBP' } },
+          { id: 'instrument:EUR', type: 'instrument', label: 'EUR', data: { code: 'EUR' } },
+        ],
+        edges: [],
+      }
+      const after: ManifestGraph = {
+        nodes: [
+          { id: 'instrument:GBP', type: 'instrument', label: 'GBP', data: { code: 'GBP' } },
+          { id: 'instrument:USD', type: 'instrument', label: 'USD', data: { code: 'USD' } },
+        ],
+        edges: [],
+      }
+      render(<ManifestDiffGraph before={before} after={after} />)
+      const flow = await screen.findByTestId('react-flow')
+      // GBP unchanged + EUR removed + USD added = 3 nodes
+      expect(flow).toHaveAttribute('data-node-count', '3')
+      expect(await screen.findByText('+1 added')).toBeInTheDocument()
+      expect(screen.getByText('-1 removed')).toBeInTheDocument()
+    })
+
+    it('renders removed node with removed status', async () => {
+      const before: ManifestGraph = {
+        nodes: [
+          { id: 'instrument:GBP', type: 'instrument', label: 'GBP', data: { code: 'GBP' } },
+          { id: 'instrument:EUR', type: 'instrument', label: 'EUR', data: { code: 'EUR' } },
+        ],
+        edges: [],
+      }
+      const after: ManifestGraph = {
+        nodes: [
+          { id: 'instrument:GBP', type: 'instrument', label: 'GBP', data: { code: 'GBP' } },
+        ],
+        edges: [],
+      }
+      render(<ManifestDiffGraph before={before} after={after} />)
+      const removedNode = await screen.findByTestId('diff-flow-node-instrument:EUR')
+      expect(removedNode).toHaveAttribute('data-diff-status', 'removed')
+      const unchangedNode = screen.getByTestId('diff-flow-node-instrument:GBP')
+      expect(unchangedNode).toHaveAttribute('data-diff-status', 'unchanged')
     })
   })
 })

--- a/frontend/src/features/manifests/components/manifest-graph.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.test.tsx
@@ -32,12 +32,14 @@ vi.mock('@xyflow/react', () => {
 
   function Handle() { return null }
 
-  function ReactFlow({ nodes, edges, onNodeClick, onNodeDoubleClick, onPaneClick, children }: {
+  function ReactFlow({ nodes, edges, onNodeClick, onNodeDoubleClick, onPaneClick, onNodeMouseEnter, onNodeMouseLeave, children }: {
     nodes: { id: string; type?: string; data: Record<string, unknown> }[]
-    edges: { id: string; source: string; target: string; data?: Record<string, unknown> }[]
+    edges: { id: string; source: string; target: string; data?: Record<string, unknown>; animated?: boolean }[]
     onNodeClick?: (event: unknown, node: unknown) => void
     onNodeDoubleClick?: (event: unknown, node: unknown) => void
     onPaneClick?: () => void
+    onNodeMouseEnter?: (event: unknown, node: unknown) => void
+    onNodeMouseLeave?: (event: unknown, node: unknown) => void
     children?: React.ReactNode
     [key: string]: unknown
   }) {
@@ -56,13 +58,15 @@ vi.mock('@xyflow/react', () => {
               data-highlighted={String((n.data as { highlighted?: boolean }).highlighted ?? false)}
               onClick={(e) => { e.stopPropagation(); onNodeClick?.({}, n) }}
               onDoubleClick={() => onNodeDoubleClick?.({}, n)}
+              onMouseEnter={() => onNodeMouseEnter?.({}, n)}
+              onMouseLeave={() => onNodeMouseLeave?.({}, n)}
             >
               {mn?.label ?? n.id}
             </div>
           )
         })}
         {edges.map((e) => (
-          <div key={e.id} data-testid={`edge-${e.id}`} data-relationship={e.data?.relationship}>
+          <div key={e.id} data-testid={`edge-${e.id}`} data-relationship={e.data?.relationship} data-animated={String(e.animated ?? false)}>
             {e.source} -&gt; {e.target}
           </div>
         ))}
@@ -453,6 +457,278 @@ describe('ManifestGraph', () => {
       const closeButton = screen.getByTestId('close-event-chain-panel')
       fireEvent.click(closeButton)
       expect(screen.queryByTestId('event-chain-side-panel')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('node hover highlighting', () => {
+    it('dims unconnected nodes on hover', async () => {
+      renderGraph(energyManifest)
+      const instrumentNode = await screen.findByTestId('node-instrument:KWH')
+      fireEvent.mouseEnter(instrumentNode)
+      await waitFor(() => {
+        expect(instrumentNode).toHaveAttribute('data-highlighted', 'true')
+      })
+      // Saga nodes not connected to KWH should be dimmed
+      const sagaNode = screen.getByTestId('node-saga:daily_reconciliation')
+      expect(sagaNode).toHaveAttribute('data-dimmed', 'true')
+    })
+
+    it('clears highlighting on mouse leave', async () => {
+      renderGraph(energyManifest)
+      const instrumentNode = await screen.findByTestId('node-instrument:KWH')
+      fireEvent.mouseEnter(instrumentNode)
+      await waitFor(() => {
+        expect(instrumentNode).toHaveAttribute('data-highlighted', 'true')
+      })
+      fireEvent.mouseLeave(instrumentNode)
+      await waitFor(() => {
+        expect(instrumentNode).toHaveAttribute('data-highlighted', 'false')
+      })
+    })
+
+    it('highlights the hovered node itself', async () => {
+      renderGraph(energyManifest)
+      const sagaNode = await screen.findByTestId('node-saga:usage_to_value')
+      fireEvent.mouseEnter(sagaNode)
+      await waitFor(() => {
+        expect(sagaNode).toHaveAttribute('data-highlighted', 'true')
+        expect(sagaNode).toHaveAttribute('data-dimmed', 'false')
+      })
+    })
+  })
+
+  describe('edit resource modal', () => {
+    it('shows edit button for instrument nodes', async () => {
+      renderGraph(energyManifest)
+      const node = await screen.findByTestId('node-instrument:KWH')
+      fireEvent.click(node)
+      expect(await screen.findByTestId('edit-resource-button')).toBeInTheDocument()
+    })
+
+    it('shows edit button for account type nodes', async () => {
+      renderGraph(energyManifest)
+      const node = await screen.findByTestId('node-account_type:ENERGY_HOLDING')
+      fireEvent.click(node)
+      expect(await screen.findByTestId('edit-resource-button')).toBeInTheDocument()
+    })
+
+    it('shows edit button for saga nodes', async () => {
+      renderGraph(energyManifest)
+      const node = await screen.findByTestId('node-saga:usage_to_value')
+      fireEvent.click(node)
+      expect(await screen.findByTestId('edit-resource-button')).toBeInTheDocument()
+    })
+
+    it('does not show edit button for event channel nodes', async () => {
+      renderGraph(energyManifest)
+      const node = await screen.findByTestId('node-event_channel:position-keeping.transaction-captured.v1')
+      fireEvent.click(node)
+      expect(await screen.findByTestId('node-toolbar')).toBeInTheDocument()
+      expect(screen.queryByTestId('edit-resource-button')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('fullscreen button', () => {
+    it('shows fullscreen button when no node is selected', async () => {
+      renderGraph(energyManifest)
+      await screen.findByTestId('react-flow')
+      expect(screen.getByLabelText('View fullscreen')).toBeInTheDocument()
+    })
+
+    it('hides fullscreen button when a node is selected', async () => {
+      renderGraph(energyManifest)
+      const node = await screen.findByTestId('node-instrument:KWH')
+      fireEvent.click(node)
+      await screen.findByTestId('node-toolbar')
+      expect(screen.queryByLabelText('View fullscreen')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('additional node types', () => {
+    const fullManifest = createMockManifest({
+      instruments: [
+        { code: 'GBP', name: 'British Pound', type: 1, dimensions: { unit: 'GBP', precision: 2 } },
+      ],
+      accountTypes: [
+        { code: 'CURRENT', name: 'Current Account', normalBalance: 1, allowedInstruments: ['GBP'] },
+      ],
+      valuationRules: [
+        { fromInstrument: 'KWH', toInstrument: 'GBP', method: 1, source: 'spot' },
+      ],
+      sagas: [
+        { name: 'test_saga', trigger: 'api:test', script: 'def main(): pass' },
+      ],
+      paymentRails: [
+        { provider: 'stripe', name: 'Stripe Rail' },
+      ],
+      partyTypes: [
+        { partyType: 'CUSTOMER' },
+      ],
+      mappings: [
+        { name: 'stripe_inbound' },
+      ],
+      operationalGateway: {
+        providerConnections: [
+          { connectionId: 'conn-1', providerName: 'Stripe' },
+        ],
+        instructionRoutes: [
+          { instructionType: 'payment', connectionId: 'conn-1' },
+        ],
+      },
+    })
+
+    it('renders payment rail nodes', async () => {
+      renderGraph(fullManifest)
+      const node = await screen.findByTestId('node-payment_rail:stripe')
+      expect(node).toBeInTheDocument()
+      expect(node).toHaveAttribute('data-node-type', 'payment_rail')
+    })
+
+    it('renders party type nodes', async () => {
+      renderGraph(fullManifest)
+      expect(await screen.findByTestId('node-party_type:CUSTOMER')).toBeInTheDocument()
+    })
+
+    it('renders mapping nodes', async () => {
+      renderGraph(fullManifest)
+      expect(await screen.findByTestId('node-mapping:stripe_inbound')).toBeInTheDocument()
+    })
+
+    it('renders operational gateway nodes', async () => {
+      renderGraph(fullManifest)
+      expect(await screen.findByTestId('node-operational_gateway:default')).toBeInTheDocument()
+    })
+
+    it('renders provider connection nodes', async () => {
+      renderGraph(fullManifest)
+      expect(await screen.findByTestId('node-provider_connection:conn-1')).toBeInTheDocument()
+    })
+
+    it('renders instruction route nodes', async () => {
+      renderGraph(fullManifest)
+      expect(await screen.findByTestId('node-instruction_route:payment')).toBeInTheDocument()
+    })
+
+    it('renders api trigger badge for api-triggered sagas', async () => {
+      renderGraph(fullManifest)
+      const sagaNode = await screen.findByTestId('node-saga:test_saga')
+      expect(sagaNode).toBeInTheDocument()
+    })
+  })
+
+  describe('additional double-click navigation', () => {
+    const navManifest = createMockManifest({
+      instruments: [
+        { code: 'GBP', name: 'British Pound', type: 1, dimensions: { unit: 'GBP', precision: 2 } },
+      ],
+      valuationRules: [
+        { fromInstrument: 'KWH', toInstrument: 'GBP', method: 1, source: 'spot' },
+      ],
+      paymentRails: [
+        { provider: 'stripe', name: 'Stripe Rail' },
+      ],
+      partyTypes: [
+        { partyType: 'CUSTOMER' },
+      ],
+      mappings: [
+        { name: 'stripe_inbound' },
+      ],
+      operationalGateway: {
+        providerConnections: [
+          { connectionId: 'conn-1', providerName: 'Stripe' },
+        ],
+        instructionRoutes: [
+          { instructionType: 'payment', connectionId: 'conn-1' },
+        ],
+      },
+    })
+
+    it('navigates to valuation rules page', async () => {
+      renderGraph(navManifest)
+      const node = await screen.findByTestId('node-valuation_rule:KWH:GBP:0')
+      fireEvent.doubleClick(node)
+      expect(mockNavigate).toHaveBeenCalledWith('/reference-data/valuation-rules')
+    })
+
+    it('navigates to reference-data for payment rails', async () => {
+      renderGraph(navManifest)
+      const node = await screen.findByTestId('node-payment_rail:stripe')
+      fireEvent.doubleClick(node)
+      expect(mockNavigate).toHaveBeenCalledWith('/reference-data')
+    })
+
+    it('navigates to parties page for party types', async () => {
+      renderGraph(navManifest)
+      const node = await screen.findByTestId('node-party_type:CUSTOMER')
+      fireEvent.doubleClick(node)
+      expect(mockNavigate).toHaveBeenCalledWith('/parties')
+    })
+
+    it('navigates to gateway-mappings for mapping nodes', async () => {
+      renderGraph(navManifest)
+      const node = await screen.findByTestId('node-mapping:stripe_inbound')
+      fireEvent.doubleClick(node)
+      expect(mockNavigate).toHaveBeenCalledWith('/gateway-mappings')
+    })
+
+    it('navigates to reference-data for operational gateway', async () => {
+      renderGraph(navManifest)
+      const node = await screen.findByTestId('node-operational_gateway:default')
+      fireEvent.doubleClick(node)
+      expect(mockNavigate).toHaveBeenCalledWith('/reference-data')
+    })
+
+    it('navigates to reference-data for provider connection', async () => {
+      renderGraph(navManifest)
+      const node = await screen.findByTestId('node-provider_connection:conn-1')
+      fireEvent.doubleClick(node)
+      expect(mockNavigate).toHaveBeenCalledWith('/reference-data')
+    })
+
+    it('navigates to reference-data for instruction route', async () => {
+      renderGraph(navManifest)
+      const node = await screen.findByTestId('node-instruction_route:payment')
+      fireEvent.doubleClick(node)
+      expect(mockNavigate).toHaveBeenCalledWith('/reference-data')
+    })
+  })
+
+  describe('filter sidebar toggling clears selection', () => {
+    it('clears selected node when its type is hidden', async () => {
+      renderGraph(energyManifest)
+      const node = await screen.findByTestId('node-instrument:KWH')
+      fireEvent.click(node)
+      expect(await screen.findByTestId('node-toolbar')).toBeInTheDocument()
+      const instrumentCheckbox = screen.getByLabelText('Show Instruments')
+      fireEvent.click(instrumentCheckbox)
+      expect(screen.queryByTestId('node-toolbar')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('edge rendering', () => {
+    it('renders edges with relationship data', async () => {
+      renderGraph(energyManifest)
+      const flow = await screen.findByTestId('react-flow')
+      const edgeCount = parseInt(flow.getAttribute('data-edge-count') ?? '0', 10)
+      expect(edgeCount).toBeGreaterThan(0)
+    })
+
+    it('renders allowed_by edges between account types and instruments', async () => {
+      renderGraph(energyManifest)
+      await screen.findByTestId('react-flow')
+      const edges = screen.getAllByTestId(/^edge-/)
+      const allowedByEdge = edges.find(e => e.getAttribute('data-relationship') === 'allowed_by')
+      expect(allowedByEdge).toBeDefined()
+    })
+
+    it('renders converts_from and converts_to edges for valuation rules', async () => {
+      renderGraph(energyManifest)
+      await screen.findByTestId('react-flow')
+      const edges = screen.getAllByTestId(/^edge-/)
+      const convertsFrom = edges.find(e => e.getAttribute('data-relationship') === 'converts_from')
+      const convertsTo = edges.find(e => e.getAttribute('data-relationship') === 'converts_to')
+      expect(convertsFrom).toBeDefined()
+      expect(convertsTo).toBeDefined()
     })
   })
 })

--- a/frontend/src/features/manifests/components/manifest-graph.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.test.tsx
@@ -575,6 +575,15 @@ describe('ManifestGraph', () => {
           { instructionType: 'payment', connectionId: 'conn-1' },
         ],
       },
+      marketData: [
+        { code: 'SPOT', name: 'Spot Price' },
+      ],
+      organizations: [
+        { code: 'ACME', name: 'Acme Corp' },
+      ],
+      internalAccounts: [
+        { code: 'OPS_GBP', name: 'Operating GBP', accountType: 'CURRENT' },
+      ],
     })
 
     it('renders payment rail nodes', async () => {
@@ -609,6 +618,21 @@ describe('ManifestGraph', () => {
       expect(await screen.findByTestId('node-instruction_route:payment')).toBeInTheDocument()
     })
 
+    it('renders market data nodes', async () => {
+      renderGraph(fullManifest)
+      expect(await screen.findByTestId('node-market_data:SPOT')).toBeInTheDocument()
+    })
+
+    it('renders organization nodes', async () => {
+      renderGraph(fullManifest)
+      expect(await screen.findByTestId('node-organization:ACME')).toBeInTheDocument()
+    })
+
+    it('renders internal account nodes', async () => {
+      renderGraph(fullManifest)
+      expect(await screen.findByTestId('node-internal_account:OPS_GBP')).toBeInTheDocument()
+    })
+
     it('renders api trigger badge for api-triggered sagas', async () => {
       renderGraph(fullManifest)
       const sagaNode = await screen.findByTestId('node-saga:test_saga')
@@ -641,6 +665,15 @@ describe('ManifestGraph', () => {
           { instructionType: 'payment', connectionId: 'conn-1' },
         ],
       },
+      marketData: [
+        { code: 'SPOT', name: 'Spot Price' },
+      ],
+      organizations: [
+        { code: 'ACME', name: 'Acme Corp' },
+      ],
+      internalAccounts: [
+        { code: 'OPS_GBP', name: 'Operating GBP', accountType: 'CURRENT' },
+      ],
     })
 
     it('navigates to valuation rules page', async () => {
@@ -690,6 +723,27 @@ describe('ManifestGraph', () => {
       const node = await screen.findByTestId('node-instruction_route:payment')
       fireEvent.doubleClick(node)
       expect(mockNavigate).toHaveBeenCalledWith('/reference-data')
+    })
+
+    it('navigates to market-data page for market data nodes', async () => {
+      renderGraph(navManifest)
+      const node = await screen.findByTestId('node-market_data:SPOT')
+      fireEvent.doubleClick(node)
+      expect(mockNavigate).toHaveBeenCalledWith('/market-data/SPOT')
+    })
+
+    it('navigates to reference-data/nodes for organization nodes', async () => {
+      renderGraph(navManifest)
+      const node = await screen.findByTestId('node-organization:ACME')
+      fireEvent.doubleClick(node)
+      expect(mockNavigate).toHaveBeenCalledWith('/reference-data/nodes')
+    })
+
+    it('navigates to internal-accounts for internal account nodes', async () => {
+      renderGraph(navManifest)
+      const node = await screen.findByTestId('node-internal_account:OPS_GBP')
+      fireEvent.doubleClick(node)
+      expect(mockNavigate).toHaveBeenCalledWith('/internal-accounts')
     })
   })
 

--- a/frontend/src/features/manifests/components/manifest-graph.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.test.tsx
@@ -548,6 +548,7 @@ describe('ManifestGraph', () => {
     const fullManifest = createMockManifest({
       instruments: [
         { code: 'GBP', name: 'British Pound', type: 1, dimensions: { unit: 'GBP', precision: 2 } },
+        { code: 'KWH', name: 'Kilowatt Hour', type: 2, dimensions: { unit: 'kWh', precision: 4 } },
       ],
       accountTypes: [
         { code: 'CURRENT', name: 'Current Account', normalBalance: 1, allowedInstruments: ['GBP'] },
@@ -644,6 +645,7 @@ describe('ManifestGraph', () => {
     const navManifest = createMockManifest({
       instruments: [
         { code: 'GBP', name: 'British Pound', type: 1, dimensions: { unit: 'GBP', precision: 2 } },
+        { code: 'KWH', name: 'Kilowatt Hour', type: 2, dimensions: { unit: 'kWh', precision: 4 } },
       ],
       valuationRules: [
         { fromInstrument: 'KWH', toInstrument: 'GBP', method: 1, source: 'spot' },


### PR DESCRIPTION
## Summary
- Extend manifest-graph.test.tsx with 27 new tests covering node hover highlighting (dimmed/highlighted states), edit resource modal (editable vs non-editable types), fullscreen button visibility, all 14 node types (payment_rail, party_type, mapping, operational_gateway, provider_connection, instruction_route, market_data), double-click navigation for every node type, filter sidebar selection clearing, and edge relationship rendering
- Extend manifest-diff-graph.test.tsx with 26 new tests covering modified node detection, edge diff visualization (added/removed edges with correct statuses), diff legend rendering, diff summary panel, controls, all 12 diff node type variants, and combined diff states (added + removed + unchanged in single view)

## Test plan
- [x] All 97 tests pass locally (up from 44)
- [ ] CI passes