### PR TITLE
test: unit tests for mds_source, kafka_publisher, and applier bootstrap

### DIFF
--- a/services/api-gateway/cache/mds_source_test.go
+++ b/services/api-gateway/cache/mds_source_test.go
@@ -288,8 +288,8 @@ func TestMDSSource_GetForwardPriceRange_SkipsMalformedObservations(t *testing.T)
 					ObservedAt:  timestamppb.New(now),
 				},
 				{
-					Value:   "bad-value", // malformed - will be skipped with a warning
-					Quality: marketinformationv1.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+					Value:      "bad-value", // malformed - will be skipped with a warning
+					Quality:    marketinformationv1.QualityLevel_QUALITY_LEVEL_ESTIMATE,
 					ObservedAt: timestamppb.New(now.Add(time.Hour)),
 				},
 			},

--- a/services/api-gateway/cache/mds_source_test.go
+++ b/services/api-gateway/cache/mds_source_test.go
@@ -1,16 +1,24 @@
 package cache
 
 import (
+	"context"
+	"net"
 	"testing"
 	"time"
 
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
 	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
+	miclient "github.com/meridianhub/meridian/services/market-information/client"
 )
 
 func TestProtoToObservation(t *testing.T) {
@@ -75,4 +83,226 @@ func TestNewMDSSource(t *testing.T) {
 	source := NewMDSSource(nil, "ELEC_FORWARD", "GBP/kWh")
 	assert.Equal(t, "ELEC_FORWARD", source.datasetCode)
 	assert.Equal(t, "GBP/kWh", source.unit)
+}
+
+// testMIServer is a minimal MarketInformationService implementation for gRPC testing.
+type testMIServer struct {
+	marketinformationv1.UnimplementedMarketInformationServiceServer
+	listResp *marketinformationv1.ListObservationsResponse
+	listErr  error
+}
+
+func (m *testMIServer) ListObservations(_ context.Context, _ *marketinformationv1.ListObservationsRequest) (*marketinformationv1.ListObservationsResponse, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	return m.listResp, nil
+}
+
+// setupTestMDSSource creates an in-process gRPC server using bufconn and returns
+// an MDSSource backed by it, along with a cleanup function.
+func setupTestMDSSource(t *testing.T, srv *testMIServer, datasetCode, unit string) (*MDSSource, func()) {
+	t.Helper()
+
+	const bufSize = 1024 * 1024
+	lis := bufconn.Listen(bufSize)
+
+	grpcServer := grpc.NewServer()
+	marketinformationv1.RegisterMarketInformationServiceServer(grpcServer, srv)
+	go func() { _ = grpcServer.Serve(lis) }()
+
+	bufDialer := func(_ context.Context, _ string) (net.Conn, error) {
+		return lis.Dial()
+	}
+
+	client, cleanup, err := miclient.New(context.Background(), miclient.Config{
+		Target: "passthrough:///bufnet",
+		DialOptions: []grpc.DialOption{
+			grpc.WithContextDialer(bufDialer),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		},
+	})
+	require.NoError(t, err)
+
+	source := NewMDSSource(client, datasetCode, unit)
+
+	return source, func() {
+		_ = cleanup()
+		grpcServer.Stop()
+		_ = lis.Close()
+	}
+}
+
+func TestMDSSource_GetForwardPrice_Success(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := &testMIServer{
+		listResp: &marketinformationv1.ListObservationsResponse{
+			Observations: []*marketinformationv1.MarketPriceObservation{
+				{
+					Value:       "123.45",
+					DatasetCode: "ELEC_FORWARD",
+					SourceId:    "src-1",
+					Quality:     marketinformationv1.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+					ObservedAt:  timestamppb.New(now),
+				},
+			},
+		},
+	}
+
+	source, cleanup := setupTestMDSSource(t, srv, "ELEC_FORWARD", "GBP/kWh")
+	defer cleanup()
+
+	obs, err := source.GetForwardPrice(context.Background(), "PEAK_2026Q1", now)
+	require.NoError(t, err)
+	require.NotNil(t, obs)
+	assert.True(t, decimal.RequireFromString("123.45").Equal(obs.Value))
+	assert.Equal(t, "GBP/kWh", obs.Unit)
+	assert.Equal(t, "ELEC_FORWARD", obs.DataSetCode)
+}
+
+func TestMDSSource_GetForwardPrice_NotFound(t *testing.T) {
+	srv := &testMIServer{
+		listResp: &marketinformationv1.ListObservationsResponse{
+			Observations: nil,
+		},
+	}
+
+	source, cleanup := setupTestMDSSource(t, srv, "ELEC_FORWARD", "GBP/kWh")
+	defer cleanup()
+
+	_, err := source.GetForwardPrice(context.Background(), "PEAK_2026Q1", time.Now())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrObservationNotFound)
+}
+
+func TestMDSSource_GetForwardPrice_GRPCError(t *testing.T) {
+	srv := &testMIServer{
+		listErr: status.Error(codes.Internal, "database unavailable"),
+	}
+
+	source, cleanup := setupTestMDSSource(t, srv, "ELEC_FORWARD", "GBP/kWh")
+	defer cleanup()
+
+	_, err := source.GetForwardPrice(context.Background(), "PEAK_2026Q1", time.Now())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "query MDS for forward price")
+}
+
+func TestMDSSource_GetForwardPrice_MalformedValue(t *testing.T) {
+	srv := &testMIServer{
+		listResp: &marketinformationv1.ListObservationsResponse{
+			Observations: []*marketinformationv1.MarketPriceObservation{
+				{
+					Value:   "not-a-number",
+					Quality: marketinformationv1.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+				},
+			},
+		},
+	}
+
+	source, cleanup := setupTestMDSSource(t, srv, "ELEC_FORWARD", "GBP/kWh")
+	defer cleanup()
+
+	_, err := source.GetForwardPrice(context.Background(), "PEAK_2026Q1", time.Now())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse observation value")
+}
+
+func TestMDSSource_GetForwardPriceRange_Success(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := &testMIServer{
+		listResp: &marketinformationv1.ListObservationsResponse{
+			Observations: []*marketinformationv1.MarketPriceObservation{
+				{
+					Value:       "100.00",
+					DatasetCode: "ELEC_FORWARD",
+					SourceId:    "src-1",
+					Quality:     marketinformationv1.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+					ObservedAt:  timestamppb.New(now),
+				},
+				{
+					Value:       "105.00",
+					DatasetCode: "ELEC_FORWARD",
+					SourceId:    "src-2",
+					Quality:     marketinformationv1.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+					ObservedAt:  timestamppb.New(now.Add(time.Hour)),
+				},
+			},
+		},
+	}
+
+	source, cleanup := setupTestMDSSource(t, srv, "ELEC_FORWARD", "GBP/kWh")
+	defer cleanup()
+
+	observations, err := source.GetForwardPriceRange(context.Background(), "PEAK_2026Q1", now, now.Add(2*time.Hour))
+	require.NoError(t, err)
+	require.Len(t, observations, 2)
+	assert.Equal(t, "GBP/kWh", observations[0].Unit)
+	assert.Equal(t, "GBP/kWh", observations[1].Unit)
+	assert.True(t, decimal.RequireFromString("100.00").Equal(observations[0].Value))
+	assert.True(t, decimal.RequireFromString("105.00").Equal(observations[1].Value))
+}
+
+func TestMDSSource_GetForwardPriceRange_Empty(t *testing.T) {
+	srv := &testMIServer{
+		listResp: &marketinformationv1.ListObservationsResponse{
+			Observations: nil,
+		},
+	}
+
+	source, cleanup := setupTestMDSSource(t, srv, "ELEC_FORWARD", "GBP/kWh")
+	defer cleanup()
+
+	now := time.Now()
+	observations, err := source.GetForwardPriceRange(context.Background(), "PEAK_2026Q1", now, now.Add(time.Hour))
+	require.NoError(t, err)
+	assert.Empty(t, observations)
+}
+
+func TestMDSSource_GetForwardPriceRange_GRPCError(t *testing.T) {
+	srv := &testMIServer{
+		listErr: status.Error(codes.Unavailable, "service unavailable"),
+	}
+
+	source, cleanup := setupTestMDSSource(t, srv, "ELEC_FORWARD", "GBP/kWh")
+	defer cleanup()
+
+	now := time.Now()
+	_, err := source.GetForwardPriceRange(context.Background(), "PEAK_2026Q1", now, now.Add(time.Hour))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "query MDS for forward price range")
+}
+
+func TestMDSSource_GetForwardPriceRange_SkipsMalformedObservations(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := &testMIServer{
+		listResp: &marketinformationv1.ListObservationsResponse{
+			Observations: []*marketinformationv1.MarketPriceObservation{
+				{
+					Value:       "100.00",
+					DatasetCode: "ELEC_FORWARD",
+					Quality:     marketinformationv1.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+					ObservedAt:  timestamppb.New(now),
+				},
+				{
+					Value:   "bad-value", // malformed - will be skipped with a warning
+					Quality: marketinformationv1.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+					ObservedAt: timestamppb.New(now.Add(time.Hour)),
+				},
+			},
+		},
+	}
+
+	source, cleanup := setupTestMDSSource(t, srv, "ELEC_FORWARD", "GBP/kWh")
+	defer cleanup()
+
+	observations, err := source.GetForwardPriceRange(context.Background(), "PEAK_2026Q1", now, now.Add(2*time.Hour))
+	require.NoError(t, err)
+	// Malformed observation is skipped; only the valid one is returned
+	require.Len(t, observations, 1)
+	assert.True(t, decimal.RequireFromString("100.00").Equal(observations[0].Value))
+	assert.Equal(t, "GBP/kWh", observations[0].Unit)
 }

--- a/services/api-gateway/cache/mds_source_test.go
+++ b/services/api-gateway/cache/mds_source_test.go
@@ -122,7 +122,11 @@ func setupTestMDSSource(t *testing.T, srv *testMIServer, datasetCode, unit strin
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		},
 	})
-	require.NoError(t, err)
+	if err != nil {
+		grpcServer.Stop()
+		_ = lis.Close()
+		t.Fatalf("failed to create miclient: %v", err)
+	}
 
 	source := NewMDSSource(client, datasetCode, unit)
 

--- a/services/control-plane/internal/applier/bootstrap_test.go
+++ b/services/control-plane/internal/applier/bootstrap_test.go
@@ -141,7 +141,11 @@ func newPlatformSagaPool(t *testing.T) *pgxpool.Pool {
 			description  text,
 			created_at   timestamptz  NOT NULL DEFAULT now(),
 			updated_at   timestamptz  NOT NULL DEFAULT now(),
-			PRIMARY KEY (id)
+			PRIMARY KEY (id),
+			CONSTRAINT chk_platform_saga_definition_version
+				CHECK (version ~ '^[0-9]+\.[0-9]+\.[0-9]+$'),
+			CONSTRAINT chk_platform_saga_definition_script_length
+				CHECK (length(script) <= 65536)
 		);
 		CREATE UNIQUE INDEX IF NOT EXISTS uq_platform_saga_definition_name_version
 			ON public.platform_saga_definition (name, version);

--- a/services/control-plane/internal/applier/bootstrap_test.go
+++ b/services/control-plane/internal/applier/bootstrap_test.go
@@ -1,8 +1,11 @@
 package applier
 
 import (
+	"context"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -119,6 +122,68 @@ func TestIsSemverGreater_EmptyB(t *testing.T) {
 	// When b is empty, always returns true (any version is greater than nothing)
 	assert.True(t, isSemverGreater("", ""))
 	assert.True(t, isSemverGreater("0.0.0", ""))
+}
+
+// newPlatformSagaPool creates a pgxpool.Pool backed by a PostgreSQL testcontainer
+// with the platform_saga_definition table already created.
+func newPlatformSagaPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	pool := testdb.NewTestPool(t)
+
+	_, err := pool.Exec(context.Background(), `
+		CREATE TABLE IF NOT EXISTS public.platform_saga_definition (
+			id           uuid         NOT NULL,
+			name         varchar(64)  NOT NULL,
+			version      varchar(16)  NOT NULL,
+			script       text         NOT NULL,
+			status       varchar(16)  NOT NULL DEFAULT 'ACTIVE',
+			display_name varchar(128),
+			description  text,
+			created_at   timestamptz  NOT NULL DEFAULT now(),
+			updated_at   timestamptz  NOT NULL DEFAULT now(),
+			PRIMARY KEY (id)
+		);
+		CREATE UNIQUE INDEX IF NOT EXISTS uq_platform_saga_definition_name_version
+			ON public.platform_saga_definition (name, version);
+	`)
+	require.NoError(t, err)
+
+	return pool
+}
+
+func TestEnsurePlatformSaga_InsertsNewRow(t *testing.T) {
+	pool := newPlatformSagaPool(t)
+
+	b := NewBootstrap(pool)
+	err := b.EnsurePlatformSaga(context.Background())
+	require.NoError(t, err)
+
+	var count int
+	err = pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM public.platform_saga_definition WHERE name = 'apply_manifest'`).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func TestEnsurePlatformSaga_Idempotent(t *testing.T) {
+	pool := newPlatformSagaPool(t)
+
+	b := NewBootstrap(pool)
+
+	// First call inserts the row.
+	err := b.EnsurePlatformSaga(context.Background())
+	require.NoError(t, err)
+
+	// Second call finds the existing row and returns nil without inserting.
+	err = b.EnsurePlatformSaga(context.Background())
+	require.NoError(t, err)
+
+	// Only one row should exist.
+	var count int
+	err = pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM public.platform_saga_definition WHERE name = 'apply_manifest'`).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
 }
 
 func TestLoadEmbeddedApplyManifest_ReturnsLatestVersion(t *testing.T) {

--- a/services/reconciliation/adapters/messaging/kafka_publisher_test.go
+++ b/services/reconciliation/adapters/messaging/kafka_publisher_test.go
@@ -2,6 +2,7 @@ package messaging
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 
 	"github.com/meridianhub/meridian/shared/platform/events/topics"
@@ -115,4 +116,70 @@ func TestNoopPublisher_WithNilLogger(t *testing.T) {
 	publisher := NewNoopPublisher(nil)
 	require.NotNil(t, publisher)
 	assert.NotNil(t, publisher.logger)
+}
+
+func TestNewKafkaPublisher_EmptyBrokers(t *testing.T) {
+	_, err := NewKafkaPublisher("", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "kafka producer")
+}
+
+func TestNewKafkaPublisher_ValidBrokers(t *testing.T) {
+	// kgo.NewClient connects lazily so this succeeds even without a running broker.
+	publisher, err := NewKafkaPublisher("localhost:9092", nil)
+	require.NoError(t, err)
+	require.NotNil(t, publisher)
+	// Flush has nothing to flush (no pending records) and returns quickly.
+	publisher.Close()
+}
+
+func TestNewKafkaPublisher_NilLoggerUsesDefault(t *testing.T) {
+	publisher, err := NewKafkaPublisher("localhost:9092", nil)
+	require.NoError(t, err)
+	require.NotNil(t, publisher)
+	assert.NotNil(t, publisher.logger)
+	publisher.Close()
+}
+
+func TestKafkaPublisher_Close(t *testing.T) {
+	publisher, err := NewKafkaPublisher("localhost:9092", slog.Default())
+	require.NoError(t, err)
+	// Should not panic; Flush returns immediately with no pending records.
+	publisher.Close()
+}
+
+func TestKafkaPublisher_PublishToTopic_MarshalError(t *testing.T) {
+	publisher, err := NewKafkaPublisher("localhost:9092", slog.Default())
+	require.NoError(t, err)
+	defer publisher.Close()
+
+	ctx := context.Background()
+	// Channels cannot be marshaled to JSON.
+	err = publisher.publishToTopic(ctx, TopicReconciliationRunStarted, make(chan int))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to marshal event")
+}
+
+func TestKafkaPublisher_Publish_MarshalError(t *testing.T) {
+	publisher, err := NewKafkaPublisher("localhost:9092", slog.Default())
+	require.NoError(t, err)
+	defer publisher.Close()
+
+	ctx := context.Background()
+	// Channels cannot be marshaled to JSON; Publish returns the marshal error.
+	err = publisher.Publish(ctx, TopicReconciliationRunStarted, make(chan int))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to marshal event")
+}
+
+func TestKafkaPublisher_Publish_MarshalError_NoDeprecatedPublish(t *testing.T) {
+	publisher, err := NewKafkaPublisher("localhost:9092", slog.Default())
+	require.NoError(t, err)
+	defer publisher.Close()
+
+	ctx := context.Background()
+	// Marshal error on primary topic should not attempt deprecated topic publish.
+	err = publisher.Publish(ctx, "unknown.topic", make(chan int))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to marshal event")
 }

--- a/services/reconciliation/adapters/messaging/kafka_publisher_test.go
+++ b/services/reconciliation/adapters/messaging/kafka_publisher_test.go
@@ -172,13 +172,13 @@ func TestKafkaPublisher_Publish_MarshalError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to marshal event")
 }
 
-func TestKafkaPublisher_Publish_MarshalError_NoDeprecatedPublish(t *testing.T) {
+func TestKafkaPublisher_Publish_MarshalError_UnknownTopic(t *testing.T) {
 	publisher, err := NewKafkaPublisher("localhost:9092", slog.Default())
 	require.NoError(t, err)
 	defer publisher.Close()
 
 	ctx := context.Background()
-	// Marshal error on primary topic should not attempt deprecated topic publish.
+	// Marshal error is returned even for topics without deprecated mappings.
 	err = publisher.Publish(ctx, "unknown.topic", make(chan int))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to marshal event")


### PR DESCRIPTION
## Summary

- **mds_source.go** (api-gateway): Add 8 gRPC-based tests using bufconn in-process server covering `GetForwardPrice` (success, not-found, gRPC error, malformed value) and `GetForwardPriceRange` (success, empty, gRPC error, skips malformed observations)
- **kafka_publisher.go** (reconciliation): Add 7 tests covering `NewKafkaPublisher` success/failure, nil logger default, `Close`, and `publishToTopic`/`Publish` marshal error paths
- **applier/bootstrap.go** (control-plane): Add 2 integration tests for `EnsurePlatformSaga` using a PostgreSQL testcontainer - insert-new and idempotent call paths

## Test plan

- All new tests pass locally: `go test ./services/api-gateway/cache/... ./services/reconciliation/adapters/messaging/... ./services/control-plane/internal/applier/...`
- MDS tests use bufconn in-process gRPC (no external dependencies)
- Kafka tests use kgo lazy connection (no Kafka required)
- Bootstrap tests use PostgreSQL testcontainer via `testdb.NewTestPool`
- No `time.Sleep` used; no production code changed