### PR TITLE
chore: migrate buf-setup-action to buf-action for Node.js 24

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -31,8 +31,9 @@ jobs:
           cache: true
 
       - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
         with:
+          setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate protobuf files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,9 @@ jobs:
           cache: true
 
       - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
         with:
+          setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate protobuf files

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -74,8 +74,9 @@ jobs:
     # Set up buf for protobuf generation (pinned version for reproducibility)
     - name: Set up buf
       if: matrix.language == 'go'
-      uses: bufbuild/buf-setup-action@v1.50.0
+      uses: bufbuild/buf-action@v1
       with:
+        setup_only: true
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
     # Generate protobuf files before CodeQL analysis

--- a/.github/workflows/control-plane-ci.yml
+++ b/.github/workflows/control-plane-ci.yml
@@ -47,8 +47,9 @@ jobs:
           cache: true
 
       - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
         with:
+          setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate protobuf files
@@ -83,8 +84,9 @@ jobs:
           cache: true
 
       - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
         with:
+          setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install protoc-gen-jsonschema
@@ -119,8 +121,9 @@ jobs:
           cache: true
 
       - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
         with:
+          setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate protobuf files
@@ -164,8 +167,9 @@ jobs:
           cache: true
 
       - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
         with:
+          setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate protobuf files
@@ -207,8 +211,9 @@ jobs:
           cache: true
 
       - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
         with:
+          setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate protobuf files

--- a/.github/workflows/conventions.yml
+++ b/.github/workflows/conventions.yml
@@ -53,8 +53,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
         with:
+          setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -46,8 +46,9 @@ jobs:
           cache: true
 
       - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
         with:
+          setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate protobuf files
@@ -112,8 +113,9 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
         with:
+          setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -46,8 +46,9 @@ jobs:
           cache: true
 
       - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
         with:
+          setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate protobuf files
@@ -112,8 +113,9 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
         with:
+          setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,8 +42,9 @@ jobs:
           cache: true
 
       - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
         with:
+          setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,8 +33,9 @@ jobs:
           cache: true
 
       - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
         with:
+          setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate protobuf files
@@ -104,8 +105,9 @@ jobs:
         cache: true
 
     - name: Set up buf
-      uses: bufbuild/buf-setup-action@v1
+      uses: bufbuild/buf-action@v1
       with:
+        setup_only: true
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Generate protobuf files

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -37,8 +37,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
         with:
+          setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run buf lint
@@ -81,8 +82,9 @@ jobs:
 
       - name: Set up buf
         if: steps.check-label.outputs.skip != 'true'
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
         with:
+          setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check for breaking proto changes

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -72,8 +72,9 @@ jobs:
           cache: true
 
       - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
         with:
+          setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate protobuf files
@@ -101,8 +102,9 @@ jobs:
           cache: true
 
       - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
         with:
+          setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Regenerate proto files

--- a/.github/workflows/saga-validation.yml
+++ b/.github/workflows/saga-validation.yml
@@ -48,8 +48,9 @@ jobs:
           cache: true
 
       - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
         with:
+          setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate protobuf files

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,8 +34,9 @@ jobs:
         cache: true
 
     - name: Set up buf
-      uses: bufbuild/buf-setup-action@v1
+      uses: bufbuild/buf-action@v1
       with:
+        setup_only: true
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Generate protobuf files
@@ -84,8 +85,9 @@ jobs:
         cache: true
 
     - name: Set up buf
-      uses: bufbuild/buf-setup-action@v1
+      uses: bufbuild/buf-action@v1
       with:
+        setup_only: true
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Generate protobuf files
@@ -157,8 +159,9 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Set up buf
-      uses: bufbuild/buf-setup-action@v1
+      uses: bufbuild/buf-action@v1
       with:
+        setup_only: true
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Generate protobuf files
@@ -224,8 +227,9 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Set up buf
-      uses: bufbuild/buf-setup-action@v1
+      uses: bufbuild/buf-action@v1
       with:
+        setup_only: true
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Generate protobuf files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,8 +55,9 @@ jobs:
           cache: true
 
       - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
         with:
+          setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate protobuf files
@@ -134,8 +135,9 @@ jobs:
           cache: true
 
       - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-action@v1
         with:
+          setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate protobuf files


### PR DESCRIPTION
## Summary

- Replaces `bufbuild/buf-setup-action@v1` with `bufbuild/buf-action@v1` (with `setup_only: true`) across all 14 workflow files (27 occurrences)
- `buf-setup-action` is pinned to Node.js 20, which GitHub Actions will deprecate on June 2, 2026
- `buf-action` runs on Node.js 24 and supports `setup_only` mode as a drop-in replacement

## Test plan

- [ ] CI passes on this PR (the workflows themselves exercise the new action)
- [ ] Proto generation still works (buf generate step succeeds)
- [ ] No Node.js 20 deprecation warnings in CI annotations