### PR TITLE
feat: add Resend email sender with circuit breaker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,7 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.25 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
+	github.com/resend/resend-go/v2 v2.28.0 // indirect
 	github.com/russellhaering/goxmldsig v1.6.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1191,6 +1191,8 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqn
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/resend/resend-go/v2 v2.28.0 h1:ttM1/VZR4fApBv3xI1TneSKi1pbfFsVrq7fXFlHKtj4=
+github.com/resend/resend-go/v2 v2.28.0/go.mod h1:3YCb8c8+pLiqhtRFXTyFwlLvfjQtluxOr9HEh2BwCkQ=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rodaine/protogofakeit v0.1.1 h1:ZKouljuRM3A+TArppfBqnH8tGZHOwM/pjvtXe9DaXH8=

--- a/shared/pkg/email/resend.go
+++ b/shared/pkg/email/resend.go
@@ -1,102 +1,106 @@
 package email
 
 import (
-    "context"
-    "fmt"
-    "log/slog"
-    "net/http"
-    "net/url"
-    "time"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"time"
 
-    resendgo "github.com/resend/resend-go/v2"
+	resendgo "github.com/resend/resend-go/v2"
 
-    "github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/meridianhub/meridian/shared/pkg/clients"
 )
+
+// ErrUnexpectedResponseType is returned when the circuit breaker yields an uncastable result.
+var ErrUnexpectedResponseType = errors.New("resend: unexpected response type")
 
 // ResendSender delivers email via the Resend API, wrapped with circuit breaker protection.
 type ResendSender struct {
-    client *resendgo.Client
-    cb     *clients.CircuitBreaker
-    logger *slog.Logger
+	client *resendgo.Client
+	cb     *clients.CircuitBreaker
+	logger *slog.Logger
 }
 
 // NewResendSender creates a Resend-backed Sender. It trips the circuit after 5
 // consecutive failures as per DefaultCircuitBreakerConfig.
 func NewResendSender(apiKey string, logger *slog.Logger) *ResendSender {
-    return NewResendSenderWithBaseURL(apiKey, logger, "")
+	return NewResendSenderWithBaseURL(apiKey, logger, "")
 }
 
 // NewResendSenderWithBaseURL creates a ResendSender with a custom API base URL.
 // Provide a non-empty baseURL only in tests; pass "" for production.
 func NewResendSenderWithBaseURL(apiKey string, logger *slog.Logger, baseURL string) *ResendSender {
-    if logger == nil {
-        logger = slog.Default()
-    }
-    cb := clients.NewCircuitBreaker(clients.DefaultCircuitBreakerConfig("resend-email"), logger)
-    c := resendgo.NewCustomClient(&http.Client{}, apiKey)
-    if baseURL != "" {
-        parsed, err := url.Parse(baseURL)
-        if err == nil {
-            c.BaseURL = parsed
-        }
-    }
-    return &ResendSender{
-        client: c,
-        cb:     cb,
-        logger: logger,
-    }
+	if logger == nil {
+		logger = slog.Default()
+	}
+	cb := clients.NewCircuitBreaker(clients.DefaultCircuitBreakerConfig("resend-email"), logger)
+	c := resendgo.NewCustomClient(&http.Client{}, apiKey)
+	if baseURL != "" {
+		parsed, err := url.Parse(baseURL)
+		if err == nil {
+			c.BaseURL = parsed
+		}
+	}
+	return &ResendSender{
+		client: c,
+		cb:     cb,
+		logger: logger,
+	}
 }
 
 // Send delivers msg via Resend, forwarding IdempotencyKey when set.
 func (s *ResendSender) Send(ctx context.Context, msg Message) (SendResult, error) {
-    params := buildSendEmailRequest(msg)
+	params := buildSendEmailRequest(msg)
 
-    raw, err := s.cb.Execute(ctx, func() (any, error) {
-        var opts *resendgo.SendEmailOptions
-        if msg.IdempotencyKey != "" {
-            opts = &resendgo.SendEmailOptions{IdempotencyKey: msg.IdempotencyKey}
-        }
-        if opts != nil {
-            return s.client.Emails.SendWithOptions(ctx, params, opts)
-        }
-        return s.client.Emails.SendWithContext(ctx, params)
-    })
-    if err != nil {
-        return SendResult{}, fmt.Errorf("resend send failed: %w", err)
-    }
+	raw, err := s.cb.Execute(ctx, func() (any, error) {
+		var opts *resendgo.SendEmailOptions
+		if msg.IdempotencyKey != "" {
+			opts = &resendgo.SendEmailOptions{IdempotencyKey: msg.IdempotencyKey}
+		}
+		if opts != nil {
+			return s.client.Emails.SendWithOptions(ctx, params, opts)
+		}
+		return s.client.Emails.SendWithContext(ctx, params)
+	})
+	if err != nil {
+		return SendResult{}, fmt.Errorf("resend send failed: %w", err)
+	}
 
-    resp, ok := raw.(*resendgo.SendEmailResponse)
-    if !ok || resp == nil {
-        return SendResult{}, fmt.Errorf("resend: unexpected response type")
-    }
+	resp, ok := raw.(*resendgo.SendEmailResponse)
+	if !ok || resp == nil {
+		return SendResult{}, ErrUnexpectedResponseType
+	}
 
-    return SendResult{
-        ProviderID: resp.Id,
-        SentAt:     time.Now().UTC(),
-    }, nil
+	return SendResult{
+		ProviderID: resp.Id,
+		SentAt:     time.Now().UTC(),
+	}, nil
 }
 
 func buildSendEmailRequest(msg Message) *resendgo.SendEmailRequest {
-    req := &resendgo.SendEmailRequest{
-        From:    msg.From,
-        To:      msg.To,
-        Subject: msg.Subject,
-        Html:    msg.HTMLBody,
-        Text:    msg.TextBody,
-        ReplyTo: msg.ReplyTo,
-        Headers: msg.Headers,
-    }
+	req := &resendgo.SendEmailRequest{
+		From:    msg.From,
+		To:      msg.To,
+		Subject: msg.Subject,
+		Html:    msg.HTMLBody,
+		Text:    msg.TextBody,
+		ReplyTo: msg.ReplyTo,
+		Headers: msg.Headers,
+	}
 
-    if len(msg.Attachments) > 0 {
-        req.Attachments = make([]*resendgo.Attachment, len(msg.Attachments))
-        for i, a := range msg.Attachments {
-            req.Attachments[i] = &resendgo.Attachment{
-                Filename:    a.Filename,
-                ContentType: a.ContentType,
-                Content:     a.Data,
-            }
-        }
-    }
+	if len(msg.Attachments) > 0 {
+		req.Attachments = make([]*resendgo.Attachment, len(msg.Attachments))
+		for i, a := range msg.Attachments {
+			req.Attachments[i] = &resendgo.Attachment{
+				Filename:    a.Filename,
+				ContentType: a.ContentType,
+				Content:     a.Data,
+			}
+		}
+	}
 
-    return req
+	return req
 }

--- a/shared/pkg/email/resend.go
+++ b/shared/pkg/email/resend.go
@@ -37,11 +37,13 @@ func NewResendSenderWithBaseURL(apiKey string, logger *slog.Logger, baseURL stri
 		logger = slog.Default()
 	}
 	cb := clients.NewCircuitBreaker(clients.DefaultCircuitBreakerConfig("resend-email"), logger)
-	c := resendgo.NewCustomClient(&http.Client{}, apiKey)
+	c := resendgo.NewCustomClient(&http.Client{Timeout: 30 * time.Second}, apiKey)
 	if baseURL != "" {
 		parsed, err := url.Parse(baseURL)
 		if err == nil {
 			c.BaseURL = parsed
+		} else {
+			logger.Warn("resend: failed to parse base URL, using default", "base_url", baseURL, "error", err)
 		}
 	}
 	return &ResendSender{

--- a/shared/pkg/email/resend.go
+++ b/shared/pkg/email/resend.go
@@ -1,0 +1,102 @@
+package email
+
+import (
+    "context"
+    "fmt"
+    "log/slog"
+    "net/http"
+    "net/url"
+    "time"
+
+    resendgo "github.com/resend/resend-go/v2"
+
+    "github.com/meridianhub/meridian/shared/pkg/clients"
+)
+
+// ResendSender delivers email via the Resend API, wrapped with circuit breaker protection.
+type ResendSender struct {
+    client *resendgo.Client
+    cb     *clients.CircuitBreaker
+    logger *slog.Logger
+}
+
+// NewResendSender creates a Resend-backed Sender. It trips the circuit after 5
+// consecutive failures as per DefaultCircuitBreakerConfig.
+func NewResendSender(apiKey string, logger *slog.Logger) *ResendSender {
+    return NewResendSenderWithBaseURL(apiKey, logger, "")
+}
+
+// NewResendSenderWithBaseURL creates a ResendSender with a custom API base URL.
+// Provide a non-empty baseURL only in tests; pass "" for production.
+func NewResendSenderWithBaseURL(apiKey string, logger *slog.Logger, baseURL string) *ResendSender {
+    if logger == nil {
+        logger = slog.Default()
+    }
+    cb := clients.NewCircuitBreaker(clients.DefaultCircuitBreakerConfig("resend-email"), logger)
+    c := resendgo.NewCustomClient(&http.Client{}, apiKey)
+    if baseURL != "" {
+        parsed, err := url.Parse(baseURL)
+        if err == nil {
+            c.BaseURL = parsed
+        }
+    }
+    return &ResendSender{
+        client: c,
+        cb:     cb,
+        logger: logger,
+    }
+}
+
+// Send delivers msg via Resend, forwarding IdempotencyKey when set.
+func (s *ResendSender) Send(ctx context.Context, msg Message) (SendResult, error) {
+    params := buildSendEmailRequest(msg)
+
+    raw, err := s.cb.Execute(ctx, func() (any, error) {
+        var opts *resendgo.SendEmailOptions
+        if msg.IdempotencyKey != "" {
+            opts = &resendgo.SendEmailOptions{IdempotencyKey: msg.IdempotencyKey}
+        }
+        if opts != nil {
+            return s.client.Emails.SendWithOptions(ctx, params, opts)
+        }
+        return s.client.Emails.SendWithContext(ctx, params)
+    })
+    if err != nil {
+        return SendResult{}, fmt.Errorf("resend send failed: %w", err)
+    }
+
+    resp, ok := raw.(*resendgo.SendEmailResponse)
+    if !ok || resp == nil {
+        return SendResult{}, fmt.Errorf("resend: unexpected response type")
+    }
+
+    return SendResult{
+        ProviderID: resp.Id,
+        SentAt:     time.Now().UTC(),
+    }, nil
+}
+
+func buildSendEmailRequest(msg Message) *resendgo.SendEmailRequest {
+    req := &resendgo.SendEmailRequest{
+        From:    msg.From,
+        To:      msg.To,
+        Subject: msg.Subject,
+        Html:    msg.HTMLBody,
+        Text:    msg.TextBody,
+        ReplyTo: msg.ReplyTo,
+        Headers: msg.Headers,
+    }
+
+    if len(msg.Attachments) > 0 {
+        req.Attachments = make([]*resendgo.Attachment, len(msg.Attachments))
+        for i, a := range msg.Attachments {
+            req.Attachments[i] = &resendgo.Attachment{
+                Filename:    a.Filename,
+                ContentType: a.ContentType,
+                Content:     a.Data,
+            }
+        }
+    }
+
+    return req
+}

--- a/shared/pkg/email/sender.go
+++ b/shared/pkg/email/sender.go
@@ -15,14 +15,15 @@ type Sender interface {
 
 // Message represents a fully rendered email ready for delivery.
 type Message struct {
-	To          []string
-	From        string
-	Subject     string
-	HTMLBody    string
-	TextBody    string
-	ReplyTo     string
-	Headers     map[string]string
-	Attachments []Attachment
+	To             []string
+	From           string
+	Subject        string
+	HTMLBody       string
+	TextBody       string
+	ReplyTo        string
+	Headers        map[string]string
+	Attachments    []Attachment
+	IdempotencyKey string
 }
 
 // Attachment represents a file attached to an email.

--- a/shared/pkg/email/sender_factory.go
+++ b/shared/pkg/email/sender_factory.go
@@ -1,0 +1,29 @@
+package email
+
+import (
+    "fmt"
+    "log/slog"
+    "os"
+)
+
+// NewSenderFromEnv constructs a Sender based on the EMAIL_MODE environment variable:
+//   - "disabled" - NoopSender (no side effects)
+//   - "log"      - LogSender (logs to slog)
+//   - "live" / "" (default) - ResendSender (requires RESEND_API_KEY)
+func NewSenderFromEnv(logger *slog.Logger) (Sender, error) {
+    mode := os.Getenv("EMAIL_MODE")
+    switch mode {
+    case "disabled":
+        return NewNoopSender(), nil
+    case "log":
+        return NewLogSender(logger), nil
+    case "live", "":
+        apiKey := os.Getenv("RESEND_API_KEY")
+        if apiKey == "" {
+            return nil, fmt.Errorf("EMAIL_MODE=%q requires RESEND_API_KEY to be set", mode)
+        }
+        return NewResendSender(apiKey, logger), nil
+    default:
+        return nil, fmt.Errorf("unknown EMAIL_MODE %q: expected disabled, log, or live", mode)
+    }
+}

--- a/shared/pkg/email/sender_factory.go
+++ b/shared/pkg/email/sender_factory.go
@@ -9,7 +9,7 @@ import (
 // ErrMissingResendAPIKey is returned when EMAIL_MODE is live or empty but RESEND_API_KEY is not set.
 var ErrMissingResendAPIKey = errors.New("RESEND_API_KEY must be set when EMAIL_MODE is live")
 
-// ErrUnknownEmailMode is returned when EMAIL_MODE contains an unrecognised value.
+// ErrUnknownEmailMode is returned when EMAIL_MODE contains an unrecognized value.
 var ErrUnknownEmailMode = errors.New("unknown EMAIL_MODE: expected disabled, log, or live")
 
 // NewSenderFromEnv constructs a Sender based on the EMAIL_MODE environment variable:

--- a/shared/pkg/email/sender_factory.go
+++ b/shared/pkg/email/sender_factory.go
@@ -1,29 +1,35 @@
 package email
 
 import (
-    "fmt"
-    "log/slog"
-    "os"
+	"errors"
+	"log/slog"
+	"os"
 )
+
+// ErrMissingResendAPIKey is returned when EMAIL_MODE is live or empty but RESEND_API_KEY is not set.
+var ErrMissingResendAPIKey = errors.New("RESEND_API_KEY must be set when EMAIL_MODE is live")
+
+// ErrUnknownEmailMode is returned when EMAIL_MODE contains an unrecognised value.
+var ErrUnknownEmailMode = errors.New("unknown EMAIL_MODE: expected disabled, log, or live")
 
 // NewSenderFromEnv constructs a Sender based on the EMAIL_MODE environment variable:
 //   - "disabled" - NoopSender (no side effects)
 //   - "log"      - LogSender (logs to slog)
 //   - "live" / "" (default) - ResendSender (requires RESEND_API_KEY)
 func NewSenderFromEnv(logger *slog.Logger) (Sender, error) {
-    mode := os.Getenv("EMAIL_MODE")
-    switch mode {
-    case "disabled":
-        return NewNoopSender(), nil
-    case "log":
-        return NewLogSender(logger), nil
-    case "live", "":
-        apiKey := os.Getenv("RESEND_API_KEY")
-        if apiKey == "" {
-            return nil, fmt.Errorf("EMAIL_MODE=%q requires RESEND_API_KEY to be set", mode)
-        }
-        return NewResendSender(apiKey, logger), nil
-    default:
-        return nil, fmt.Errorf("unknown EMAIL_MODE %q: expected disabled, log, or live", mode)
-    }
+	mode := os.Getenv("EMAIL_MODE")
+	switch mode {
+	case "disabled":
+		return NewNoopSender(), nil
+	case "log":
+		return NewLogSender(logger), nil
+	case "live", "":
+		apiKey := os.Getenv("RESEND_API_KEY")
+		if apiKey == "" {
+			return nil, ErrMissingResendAPIKey
+		}
+		return NewResendSender(apiKey, logger), nil
+	default:
+		return nil, ErrUnknownEmailMode
+	}
 }

--- a/shared/pkg/email/sender_factory_test.go
+++ b/shared/pkg/email/sender_factory_test.go
@@ -1,63 +1,60 @@
 package email_test
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-    "github.com/meridianhub/meridian/shared/pkg/email"
+	"github.com/meridianhub/meridian/shared/pkg/email"
 )
 
 func TestNewSenderFromEnv_Disabled(t *testing.T) {
-    t.Setenv("EMAIL_MODE", "disabled")
-    s, err := email.NewSenderFromEnv(nil)
-    require.NoError(t, err)
-    assert.IsType(t, &email.NoopSender{}, s)
+	t.Setenv("EMAIL_MODE", "disabled")
+	s, err := email.NewSenderFromEnv(nil)
+	require.NoError(t, err)
+	assert.IsType(t, &email.NoopSender{}, s)
 }
 
 func TestNewSenderFromEnv_Log(t *testing.T) {
-    t.Setenv("EMAIL_MODE", "log")
-    s, err := email.NewSenderFromEnv(nil)
-    require.NoError(t, err)
-    assert.IsType(t, &email.LogSender{}, s)
+	t.Setenv("EMAIL_MODE", "log")
+	s, err := email.NewSenderFromEnv(nil)
+	require.NoError(t, err)
+	assert.IsType(t, &email.LogSender{}, s)
 }
 
 func TestNewSenderFromEnv_Live_MissingKey(t *testing.T) {
-    t.Setenv("EMAIL_MODE", "live")
-    t.Setenv("RESEND_API_KEY", "")
-    _, err := email.NewSenderFromEnv(nil)
-    require.Error(t, err)
-    assert.Contains(t, err.Error(), "RESEND_API_KEY")
+	t.Setenv("EMAIL_MODE", "live")
+	t.Setenv("RESEND_API_KEY", "")
+	_, err := email.NewSenderFromEnv(nil)
+	require.ErrorIs(t, err, email.ErrMissingResendAPIKey)
 }
 
 func TestNewSenderFromEnv_Live_WithKey(t *testing.T) {
-    t.Setenv("EMAIL_MODE", "live")
-    t.Setenv("RESEND_API_KEY", "re_test_key")
-    s, err := email.NewSenderFromEnv(nil)
-    require.NoError(t, err)
-    assert.IsType(t, &email.ResendSender{}, s)
+	t.Setenv("EMAIL_MODE", "live")
+	t.Setenv("RESEND_API_KEY", "re_test_key")
+	s, err := email.NewSenderFromEnv(nil)
+	require.NoError(t, err)
+	assert.IsType(t, &email.ResendSender{}, s)
 }
 
 func TestNewSenderFromEnv_Default_MissingKey(t *testing.T) {
-    t.Setenv("EMAIL_MODE", "")
-    t.Setenv("RESEND_API_KEY", "")
-    _, err := email.NewSenderFromEnv(nil)
-    require.Error(t, err)
-    assert.Contains(t, err.Error(), "RESEND_API_KEY")
+	t.Setenv("EMAIL_MODE", "")
+	t.Setenv("RESEND_API_KEY", "")
+	_, err := email.NewSenderFromEnv(nil)
+	require.ErrorIs(t, err, email.ErrMissingResendAPIKey)
 }
 
 func TestNewSenderFromEnv_Default_WithKey(t *testing.T) {
-    t.Setenv("EMAIL_MODE", "")
-    t.Setenv("RESEND_API_KEY", "re_test_key")
-    s, err := email.NewSenderFromEnv(nil)
-    require.NoError(t, err)
-    assert.IsType(t, &email.ResendSender{}, s)
+	t.Setenv("EMAIL_MODE", "")
+	t.Setenv("RESEND_API_KEY", "re_test_key")
+	s, err := email.NewSenderFromEnv(nil)
+	require.NoError(t, err)
+	assert.IsType(t, &email.ResendSender{}, s)
 }
 
 func TestNewSenderFromEnv_UnknownMode(t *testing.T) {
-    t.Setenv("EMAIL_MODE", "invalid")
-    _, err := email.NewSenderFromEnv(nil)
-    require.Error(t, err)
-    assert.Contains(t, err.Error(), "unknown EMAIL_MODE")
+	t.Setenv("EMAIL_MODE", "invalid")
+	_, err := email.NewSenderFromEnv(nil)
+	require.ErrorIs(t, err, email.ErrUnknownEmailMode)
 }

--- a/shared/pkg/email/sender_factory_test.go
+++ b/shared/pkg/email/sender_factory_test.go
@@ -1,0 +1,63 @@
+package email_test
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+
+    "github.com/meridianhub/meridian/shared/pkg/email"
+)
+
+func TestNewSenderFromEnv_Disabled(t *testing.T) {
+    t.Setenv("EMAIL_MODE", "disabled")
+    s, err := email.NewSenderFromEnv(nil)
+    require.NoError(t, err)
+    assert.IsType(t, &email.NoopSender{}, s)
+}
+
+func TestNewSenderFromEnv_Log(t *testing.T) {
+    t.Setenv("EMAIL_MODE", "log")
+    s, err := email.NewSenderFromEnv(nil)
+    require.NoError(t, err)
+    assert.IsType(t, &email.LogSender{}, s)
+}
+
+func TestNewSenderFromEnv_Live_MissingKey(t *testing.T) {
+    t.Setenv("EMAIL_MODE", "live")
+    t.Setenv("RESEND_API_KEY", "")
+    _, err := email.NewSenderFromEnv(nil)
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "RESEND_API_KEY")
+}
+
+func TestNewSenderFromEnv_Live_WithKey(t *testing.T) {
+    t.Setenv("EMAIL_MODE", "live")
+    t.Setenv("RESEND_API_KEY", "re_test_key")
+    s, err := email.NewSenderFromEnv(nil)
+    require.NoError(t, err)
+    assert.IsType(t, &email.ResendSender{}, s)
+}
+
+func TestNewSenderFromEnv_Default_MissingKey(t *testing.T) {
+    t.Setenv("EMAIL_MODE", "")
+    t.Setenv("RESEND_API_KEY", "")
+    _, err := email.NewSenderFromEnv(nil)
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "RESEND_API_KEY")
+}
+
+func TestNewSenderFromEnv_Default_WithKey(t *testing.T) {
+    t.Setenv("EMAIL_MODE", "")
+    t.Setenv("RESEND_API_KEY", "re_test_key")
+    s, err := email.NewSenderFromEnv(nil)
+    require.NoError(t, err)
+    assert.IsType(t, &email.ResendSender{}, s)
+}
+
+func TestNewSenderFromEnv_UnknownMode(t *testing.T) {
+    t.Setenv("EMAIL_MODE", "invalid")
+    _, err := email.NewSenderFromEnv(nil)
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "unknown EMAIL_MODE")
+}

--- a/shared/pkg/email/sender_log.go
+++ b/shared/pkg/email/sender_log.go
@@ -1,40 +1,40 @@
 package email
 
 import (
-    "context"
-    "fmt"
-    "log/slog"
-    "time"
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
 
-    "github.com/google/uuid"
+	"github.com/google/uuid"
 )
 
 // LogSender logs email details via slog instead of delivering them.
 // Intended for EMAIL_MODE=log environments (local dev, staging previews).
 type LogSender struct {
-    logger *slog.Logger
+	logger *slog.Logger
 }
 
 // NewLogSender creates a LogSender backed by the given logger.
 func NewLogSender(logger *slog.Logger) *LogSender {
-    if logger == nil {
-        logger = slog.Default()
-    }
-    return &LogSender{logger: logger}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &LogSender{logger: logger}
 }
 
 // Send logs the email and returns a fake delivery ID.
 func (s *LogSender) Send(_ context.Context, msg Message) (SendResult, error) {
-    fakeID := fmt.Sprintf("log-%s", uuid.NewString())
-    s.logger.Info("email send (log mode)",
-        "provider_id", fakeID,
-        "from", msg.From,
-        "to", msg.To,
-        "subject", msg.Subject,
-        "idempotency_key", msg.IdempotencyKey,
-    )
-    return SendResult{
-        ProviderID: fakeID,
-        SentAt:     time.Now().UTC(),
-    }, nil
+	fakeID := fmt.Sprintf("log-%s", uuid.NewString())
+	s.logger.Info("email send (log mode)",
+		"provider_id", fakeID,
+		"from", msg.From,
+		"to", msg.To,
+		"subject", msg.Subject,
+		"idempotency_key", msg.IdempotencyKey,
+	)
+	return SendResult{
+		ProviderID: fakeID,
+		SentAt:     time.Now().UTC(),
+	}, nil
 }

--- a/shared/pkg/email/sender_log.go
+++ b/shared/pkg/email/sender_log.go
@@ -1,0 +1,40 @@
+package email
+
+import (
+    "context"
+    "fmt"
+    "log/slog"
+    "time"
+
+    "github.com/google/uuid"
+)
+
+// LogSender logs email details via slog instead of delivering them.
+// Intended for EMAIL_MODE=log environments (local dev, staging previews).
+type LogSender struct {
+    logger *slog.Logger
+}
+
+// NewLogSender creates a LogSender backed by the given logger.
+func NewLogSender(logger *slog.Logger) *LogSender {
+    if logger == nil {
+        logger = slog.Default()
+    }
+    return &LogSender{logger: logger}
+}
+
+// Send logs the email and returns a fake delivery ID.
+func (s *LogSender) Send(_ context.Context, msg Message) (SendResult, error) {
+    fakeID := fmt.Sprintf("log-%s", uuid.NewString())
+    s.logger.Info("email send (log mode)",
+        "provider_id", fakeID,
+        "from", msg.From,
+        "to", msg.To,
+        "subject", msg.Subject,
+        "idempotency_key", msg.IdempotencyKey,
+    )
+    return SendResult{
+        ProviderID: fakeID,
+        SentAt:     time.Now().UTC(),
+    }, nil
+}

--- a/shared/pkg/email/sender_noop.go
+++ b/shared/pkg/email/sender_noop.go
@@ -1,11 +1,11 @@
 package email
 
 import (
-    "context"
-    "fmt"
-    "time"
+	"context"
+	"fmt"
+	"time"
 
-    "github.com/google/uuid"
+	"github.com/google/uuid"
 )
 
 // NoopSender discards all emails silently.
@@ -14,13 +14,13 @@ type NoopSender struct{}
 
 // NewNoopSender creates a NoopSender.
 func NewNoopSender() *NoopSender {
-    return &NoopSender{}
+	return &NoopSender{}
 }
 
 // Send discards the message and returns a fake delivery ID.
 func (s *NoopSender) Send(_ context.Context, _ Message) (SendResult, error) {
-    return SendResult{
-        ProviderID: fmt.Sprintf("noop-%s", uuid.NewString()),
-        SentAt:     time.Now().UTC(),
-    }, nil
+	return SendResult{
+		ProviderID: fmt.Sprintf("noop-%s", uuid.NewString()),
+		SentAt:     time.Now().UTC(),
+	}, nil
 }

--- a/shared/pkg/email/sender_noop.go
+++ b/shared/pkg/email/sender_noop.go
@@ -1,0 +1,26 @@
+package email
+
+import (
+    "context"
+    "fmt"
+    "time"
+
+    "github.com/google/uuid"
+)
+
+// NoopSender discards all emails silently.
+// Intended for EMAIL_MODE=disabled environments (unit tests, CI).
+type NoopSender struct{}
+
+// NewNoopSender creates a NoopSender.
+func NewNoopSender() *NoopSender {
+    return &NoopSender{}
+}
+
+// Send discards the message and returns a fake delivery ID.
+func (s *NoopSender) Send(_ context.Context, _ Message) (SendResult, error) {
+    return SendResult{
+        ProviderID: fmt.Sprintf("noop-%s", uuid.NewString()),
+        SentAt:     time.Now().UTC(),
+    }, nil
+}

--- a/shared/pkg/email/sender_test.go
+++ b/shared/pkg/email/sender_test.go
@@ -1,0 +1,119 @@
+package email_test
+
+import (
+    "context"
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "strings"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    resendgo "github.com/resend/resend-go/v2"
+
+    "github.com/meridianhub/meridian/shared/pkg/email"
+)
+
+// --- NoopSender ---
+
+func TestNoopSender_Send_ReturnsResult(t *testing.T) {
+    s := email.NewNoopSender()
+    result, err := s.Send(context.Background(), email.Message{
+        To:      []string{"user@example.com"},
+        From:    "noreply@example.com",
+        Subject: "Hello",
+    })
+    require.NoError(t, err)
+    assert.True(t, strings.HasPrefix(result.ProviderID, "noop-"))
+    assert.False(t, result.SentAt.IsZero())
+}
+
+// --- LogSender ---
+
+func TestLogSender_Send_ReturnsResult(t *testing.T) {
+    s := email.NewLogSender(nil)
+    result, err := s.Send(context.Background(), email.Message{
+        To:             []string{"user@example.com"},
+        From:           "noreply@example.com",
+        Subject:        "Hello",
+        IdempotencyKey: "idem-123",
+    })
+    require.NoError(t, err)
+    assert.True(t, strings.HasPrefix(result.ProviderID, "log-"))
+    assert.False(t, result.SentAt.IsZero())
+}
+
+// --- ResendSender ---
+
+func TestResendSender_Send_Success(t *testing.T) {
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        assert.Equal(t, "/emails", r.URL.Path)
+        assert.Equal(t, "test-idem-key", r.Header.Get("Idempotency-Key"))
+        w.Header().Set("Content-Type", "application/json")
+        w.WriteHeader(http.StatusOK)
+        json.NewEncoder(w).Encode(map[string]string{"id": "provider-abc"})
+    }))
+    defer srv.Close()
+
+    t.Setenv("RESEND_BASE_URL", srv.URL+"/")
+    c := resendgo.NewClient("test-api-key")
+    _ = c // just validating SDK initialises; use our helper below
+
+    s := email.NewResendSenderWithBaseURL("test-api-key", nil, srv.URL+"/")
+    result, err := s.Send(context.Background(), email.Message{
+        To:             []string{"user@example.com"},
+        From:           "noreply@example.com",
+        Subject:        "Test",
+        IdempotencyKey: "test-idem-key",
+    })
+    require.NoError(t, err)
+    assert.Equal(t, "provider-abc", result.ProviderID)
+    assert.False(t, result.SentAt.IsZero())
+}
+
+func TestResendSender_Send_NoIdempotencyKey(t *testing.T) {
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        assert.Empty(t, r.Header.Get("Idempotency-Key"))
+        w.Header().Set("Content-Type", "application/json")
+        w.WriteHeader(http.StatusOK)
+        json.NewEncoder(w).Encode(map[string]string{"id": "provider-xyz"})
+    }))
+    defer srv.Close()
+
+    s := email.NewResendSenderWithBaseURL("test-api-key", nil, srv.URL+"/")
+    result, err := s.Send(context.Background(), email.Message{
+        To:      []string{"user@example.com"},
+        From:    "noreply@example.com",
+        Subject: "Test",
+    })
+    require.NoError(t, err)
+    assert.Equal(t, "provider-xyz", result.ProviderID)
+}
+
+func TestResendSender_Send_ServerError_TripsCircuitBreaker(t *testing.T) {
+    callCount := 0
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        callCount++
+        w.WriteHeader(http.StatusInternalServerError)
+    }))
+    defer srv.Close()
+
+    s := email.NewResendSenderWithBaseURL("test-api-key", nil, srv.URL+"/")
+    msg := email.Message{
+        To:      []string{"user@example.com"},
+        From:    "noreply@example.com",
+        Subject: "Test",
+    }
+
+    // 5 consecutive failures should trip the circuit breaker
+    for i := 0; i < 5; i++ {
+        _, err := s.Send(context.Background(), msg)
+        require.Error(t, err)
+    }
+
+    // Next call should be rejected by circuit breaker (open state) without hitting server
+    _, err := s.Send(context.Background(), msg)
+    require.Error(t, err)
+    assert.Equal(t, 5, callCount, "circuit breaker should stop calls after 5 failures")
+}

--- a/shared/pkg/email/sender_test.go
+++ b/shared/pkg/email/sender_test.go
@@ -1,119 +1,119 @@
 package email_test
 
 import (
-    "context"
-    "encoding/json"
-    "net/http"
-    "net/http/httptest"
-    "strings"
-    "testing"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
 
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/require"
-    resendgo "github.com/resend/resend-go/v2"
+	resendgo "github.com/resend/resend-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-    "github.com/meridianhub/meridian/shared/pkg/email"
+	"github.com/meridianhub/meridian/shared/pkg/email"
 )
 
 // --- NoopSender ---
 
 func TestNoopSender_Send_ReturnsResult(t *testing.T) {
-    s := email.NewNoopSender()
-    result, err := s.Send(context.Background(), email.Message{
-        To:      []string{"user@example.com"},
-        From:    "noreply@example.com",
-        Subject: "Hello",
-    })
-    require.NoError(t, err)
-    assert.True(t, strings.HasPrefix(result.ProviderID, "noop-"))
-    assert.False(t, result.SentAt.IsZero())
+	s := email.NewNoopSender()
+	result, err := s.Send(context.Background(), email.Message{
+		To:      []string{"user@example.com"},
+		From:    "noreply@example.com",
+		Subject: "Hello",
+	})
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(result.ProviderID, "noop-"))
+	assert.False(t, result.SentAt.IsZero())
 }
 
 // --- LogSender ---
 
 func TestLogSender_Send_ReturnsResult(t *testing.T) {
-    s := email.NewLogSender(nil)
-    result, err := s.Send(context.Background(), email.Message{
-        To:             []string{"user@example.com"},
-        From:           "noreply@example.com",
-        Subject:        "Hello",
-        IdempotencyKey: "idem-123",
-    })
-    require.NoError(t, err)
-    assert.True(t, strings.HasPrefix(result.ProviderID, "log-"))
-    assert.False(t, result.SentAt.IsZero())
+	s := email.NewLogSender(nil)
+	result, err := s.Send(context.Background(), email.Message{
+		To:             []string{"user@example.com"},
+		From:           "noreply@example.com",
+		Subject:        "Hello",
+		IdempotencyKey: "idem-123",
+	})
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(result.ProviderID, "log-"))
+	assert.False(t, result.SentAt.IsZero())
 }
 
 // --- ResendSender ---
 
 func TestResendSender_Send_Success(t *testing.T) {
-    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        assert.Equal(t, "/emails", r.URL.Path)
-        assert.Equal(t, "test-idem-key", r.Header.Get("Idempotency-Key"))
-        w.Header().Set("Content-Type", "application/json")
-        w.WriteHeader(http.StatusOK)
-        json.NewEncoder(w).Encode(map[string]string{"id": "provider-abc"})
-    }))
-    defer srv.Close()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/emails", r.URL.Path)
+		assert.Equal(t, "test-idem-key", r.Header.Get("Idempotency-Key"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"id": "provider-abc"})
+	}))
+	defer srv.Close()
 
-    t.Setenv("RESEND_BASE_URL", srv.URL+"/")
-    c := resendgo.NewClient("test-api-key")
-    _ = c // just validating SDK initialises; use our helper below
+	t.Setenv("RESEND_BASE_URL", srv.URL+"/")
+	c := resendgo.NewClient("test-api-key")
+	_ = c // just validating SDK initializes; use our helper below
 
-    s := email.NewResendSenderWithBaseURL("test-api-key", nil, srv.URL+"/")
-    result, err := s.Send(context.Background(), email.Message{
-        To:             []string{"user@example.com"},
-        From:           "noreply@example.com",
-        Subject:        "Test",
-        IdempotencyKey: "test-idem-key",
-    })
-    require.NoError(t, err)
-    assert.Equal(t, "provider-abc", result.ProviderID)
-    assert.False(t, result.SentAt.IsZero())
+	s := email.NewResendSenderWithBaseURL("test-api-key", nil, srv.URL+"/")
+	result, err := s.Send(context.Background(), email.Message{
+		To:             []string{"user@example.com"},
+		From:           "noreply@example.com",
+		Subject:        "Test",
+		IdempotencyKey: "test-idem-key",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "provider-abc", result.ProviderID)
+	assert.False(t, result.SentAt.IsZero())
 }
 
 func TestResendSender_Send_NoIdempotencyKey(t *testing.T) {
-    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        assert.Empty(t, r.Header.Get("Idempotency-Key"))
-        w.Header().Set("Content-Type", "application/json")
-        w.WriteHeader(http.StatusOK)
-        json.NewEncoder(w).Encode(map[string]string{"id": "provider-xyz"})
-    }))
-    defer srv.Close()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get("Idempotency-Key"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"id": "provider-xyz"})
+	}))
+	defer srv.Close()
 
-    s := email.NewResendSenderWithBaseURL("test-api-key", nil, srv.URL+"/")
-    result, err := s.Send(context.Background(), email.Message{
-        To:      []string{"user@example.com"},
-        From:    "noreply@example.com",
-        Subject: "Test",
-    })
-    require.NoError(t, err)
-    assert.Equal(t, "provider-xyz", result.ProviderID)
+	s := email.NewResendSenderWithBaseURL("test-api-key", nil, srv.URL+"/")
+	result, err := s.Send(context.Background(), email.Message{
+		To:      []string{"user@example.com"},
+		From:    "noreply@example.com",
+		Subject: "Test",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "provider-xyz", result.ProviderID)
 }
 
 func TestResendSender_Send_ServerError_TripsCircuitBreaker(t *testing.T) {
-    callCount := 0
-    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        callCount++
-        w.WriteHeader(http.StatusInternalServerError)
-    }))
-    defer srv.Close()
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
 
-    s := email.NewResendSenderWithBaseURL("test-api-key", nil, srv.URL+"/")
-    msg := email.Message{
-        To:      []string{"user@example.com"},
-        From:    "noreply@example.com",
-        Subject: "Test",
-    }
+	s := email.NewResendSenderWithBaseURL("test-api-key", nil, srv.URL+"/")
+	msg := email.Message{
+		To:      []string{"user@example.com"},
+		From:    "noreply@example.com",
+		Subject: "Test",
+	}
 
-    // 5 consecutive failures should trip the circuit breaker
-    for i := 0; i < 5; i++ {
-        _, err := s.Send(context.Background(), msg)
-        require.Error(t, err)
-    }
+	// 5 consecutive failures should trip the circuit breaker
+	for i := 0; i < 5; i++ {
+		_, err := s.Send(context.Background(), msg)
+		require.Error(t, err)
+	}
 
-    // Next call should be rejected by circuit breaker (open state) without hitting server
-    _, err := s.Send(context.Background(), msg)
-    require.Error(t, err)
-    assert.Equal(t, 5, callCount, "circuit breaker should stop calls after 5 failures")
+	// Next call should be rejected by circuit breaker (open state) without hitting server
+	_, err := s.Send(context.Background(), msg)
+	require.Error(t, err)
+	assert.Equal(t, 5, callCount, "circuit breaker should stop calls after 5 failures")
 }

--- a/shared/pkg/email/sender_test.go
+++ b/shared/pkg/email/sender_test.go
@@ -93,7 +93,7 @@ func TestResendSender_Send_NoIdempotencyKey(t *testing.T) {
 
 func TestResendSender_Send_ServerError_TripsCircuitBreaker(t *testing.T) {
 	callCount := 0
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		callCount++
 		w.WriteHeader(http.StatusInternalServerError)
 	}))


### PR DESCRIPTION
## Summary

- Add `ResendSender` wrapping the `resend-go/v2` SDK with circuit breaker protection (trips after 5 consecutive failures via `DefaultCircuitBreakerConfig`)
- Forward `msg.IdempotencyKey` as the `Idempotency-Key` header when set
- Add `LogSender` for `EMAIL_MODE=log` (logs via slog, returns fake delivery ID)
- Add `NoopSender` for `EMAIL_MODE=disabled` (no side effects, returns fake delivery ID)
- Add `NewSenderFromEnv` factory that selects the correct sender from environment
- Add `IdempotencyKey` field to `Message` struct

## Changes Made

- `shared/pkg/email/sender.go` - Added `IdempotencyKey` to `Message`
- `shared/pkg/email/resend.go` - `ResendSender` with circuit breaker; `NewResendSenderWithBaseURL` constructor for test injection
- `shared/pkg/email/sender_log.go` - `LogSender`
- `shared/pkg/email/sender_noop.go` - `NoopSender`
- `shared/pkg/email/sender_factory.go` - `NewSenderFromEnv` factory
- `shared/pkg/email/sender_test.go` - Tests for all senders including circuit breaker trip
- `shared/pkg/email/sender_factory_test.go` - Tests for factory with all modes

## Test plan

- [ ] All new unit tests pass (`TestNoop*`, `TestLog*`, `TestResend*`, `TestNewSenderFromEnv*`)
- [ ] Circuit breaker trips after 5 consecutive 500 responses (verified in test)
- [ ] Idempotency-Key header forwarded only when set
- [ ] Factory returns correct type per EMAIL_MODE; errors without RESEND_API_KEY in live/default mode