### PR TITLE
feat: wire invoice email delivery in invoice generator

### DIFF
--- a/services/payment-order/adapters/clients/party_client.go
+++ b/services/payment-order/adapters/clients/party_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	"github.com/meridianhub/meridian/services/payment-order/worker"
 	"google.golang.org/grpc"
 )
 
@@ -34,27 +35,39 @@ func NewPartyClient(conn *grpc.ClientConn) *PartyClientWrapper {
 	}
 }
 
-// GetPartyEmail retrieves the contact email address for a party by looking up
-// the "email" attribute in the party's attribute list.
-func (c *PartyClientWrapper) GetPartyEmail(ctx context.Context, partyID string) (string, error) {
+// GetPartyContact retrieves the contact email and display name for a party.
+// Email is extracted from the party's "email" attribute. Name uses DisplayName if set,
+// falling back to LegalName.
+func (c *PartyClientWrapper) GetPartyContact(ctx context.Context, partyID string) (worker.PartyContact, error) {
 	resp, err := c.client.RetrieveParty(ctx, &partyv1.RetrievePartyRequest{
 		PartyId: partyID,
 	})
 	if err != nil {
-		return "", fmt.Errorf("retrieve party %s: %w", partyID, err)
+		return worker.PartyContact{}, fmt.Errorf("retrieve party %s: %w", partyID, err)
 	}
 
 	if resp.Party == nil {
-		return "", fmt.Errorf("%w: %s", ErrPartyNotFound, partyID)
+		return worker.PartyContact{}, fmt.Errorf("%w: %s", ErrPartyNotFound, partyID)
 	}
 
+	var email string
 	for _, attr := range resp.Party.Attributes {
 		if attr.Key == partyEmailAttributeKey && attr.Value != "" {
-			return attr.Value, nil
+			email = attr.Value
+			break
 		}
 	}
 
-	return "", fmt.Errorf("%w: party %s", ErrPartyEmailMissing, partyID)
+	if email == "" {
+		return worker.PartyContact{}, fmt.Errorf("%w: party %s", ErrPartyEmailMissing, partyID)
+	}
+
+	name := resp.Party.DisplayName
+	if name == "" {
+		name = resp.Party.LegalName
+	}
+
+	return worker.PartyContact{Email: email, Name: name}, nil
 }
 
 // Close terminates the gRPC connection.

--- a/services/payment-order/adapters/clients/party_client.go
+++ b/services/payment-order/adapters/clients/party_client.go
@@ -1,0 +1,66 @@
+package clients
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	"google.golang.org/grpc"
+)
+
+var (
+	// ErrPartyNotFound is returned when the party does not exist.
+	ErrPartyNotFound = errors.New("party not found")
+
+	// ErrPartyEmailMissing is returned when the party has no email attribute.
+	ErrPartyEmailMissing = errors.New("party has no email attribute")
+)
+
+// partyEmailAttributeKey is the attribute key used to store a party's contact email.
+const partyEmailAttributeKey = "email"
+
+// PartyClientWrapper wraps the gRPC client for the party service.
+type PartyClientWrapper struct {
+	conn   *grpc.ClientConn
+	client partyv1.PartyServiceClient
+}
+
+// NewPartyClient creates a new party client wrapper.
+func NewPartyClient(conn *grpc.ClientConn) *PartyClientWrapper {
+	return &PartyClientWrapper{
+		conn:   conn,
+		client: partyv1.NewPartyServiceClient(conn),
+	}
+}
+
+// GetPartyEmail retrieves the contact email address for a party by looking up
+// the "email" attribute in the party's attribute list.
+func (c *PartyClientWrapper) GetPartyEmail(ctx context.Context, partyID string) (string, error) {
+	resp, err := c.client.RetrieveParty(ctx, &partyv1.RetrievePartyRequest{
+		PartyId: partyID,
+	})
+	if err != nil {
+		return "", fmt.Errorf("retrieve party %s: %w", partyID, err)
+	}
+
+	if resp.Party == nil {
+		return "", fmt.Errorf("%w: %s", ErrPartyNotFound, partyID)
+	}
+
+	for _, attr := range resp.Party.Attributes {
+		if attr.Key == partyEmailAttributeKey && attr.Value != "" {
+			return attr.Value, nil
+		}
+	}
+
+	return "", fmt.Errorf("%w: party %s", ErrPartyEmailMissing, partyID)
+}
+
+// Close terminates the gRPC connection.
+func (c *PartyClientWrapper) Close() error {
+	if c.conn != nil {
+		return c.conn.Close()
+	}
+	return nil
+}

--- a/services/payment-order/worker/invoice_generator.go
+++ b/services/payment-order/worker/invoice_generator.go
@@ -35,10 +35,16 @@ type PositionKeepingClient interface {
 	GetPositionLogEntries(ctx context.Context, accountID string, periodStart, periodEnd time.Time) ([]PositionEntry, error)
 }
 
+// PartyContact holds the contact details for a party needed for email delivery.
+type PartyContact struct {
+	Email string
+	Name  string
+}
+
 // PartyClient defines the interface for retrieving party contact information.
 type PartyClient interface {
-	// GetPartyEmail retrieves the contact email address for a party.
-	GetPartyEmail(ctx context.Context, partyID string) (string, error)
+	// GetPartyContact retrieves the contact email and display name for a party.
+	GetPartyContact(ctx context.Context, partyID string) (PartyContact, error)
 }
 
 // AccountInfo holds basic account information for billing queries.
@@ -221,9 +227,9 @@ func (g *InvoiceGenerator) queueInvoiceEmail(ctx context.Context, inv *domain.In
 		return
 	}
 
-	partyEmail, err := g.partyClient.GetPartyEmail(ctx, inv.PartyID)
+	contact, err := g.partyClient.GetPartyContact(ctx, inv.PartyID)
 	if err != nil {
-		g.logger.Warn("could not resolve party email, skipping invoice email",
+		g.logger.Warn("could not resolve party contact, skipping invoice email",
 			"party_id", inv.PartyID,
 			"invoice_id", inv.ID,
 			"error", err)
@@ -239,24 +245,19 @@ func (g *InvoiceGenerator) queueInvoiceEmail(ctx context.Context, inv *domain.In
 	}
 
 	dueDate := time.Now().UTC().Add(invoiceEmailDueIn)
-	templateData := email.InvoiceData{
-		InvoiceNumber: inv.InvoiceNumber,
-		LineItems:     lineItems,
-		Total:         formatCents(inv.SubtotalCents, inv.Currency),
-		DueDate:       dueDate.Format("2006-01-02"),
-	}
 
 	entry := &email.OutboxEntry{
 		IdempotencyKey: "invoice-" + inv.ID.String(),
-		ToAddresses:    []string{partyEmail},
+		ToAddresses:    []string{contact.Email},
 		Subject:        "Invoice " + inv.InvoiceNumber,
 		TemplateName:   "invoice",
 		TemplateData: map[string]any{
-			"InvoiceNumber": templateData.InvoiceNumber,
-			"LineItems":     templateData.LineItems,
-			"Total":         templateData.Total,
-			"DueDate":       templateData.DueDate,
-			"PaymentLink":   templateData.PaymentLink,
+			"CustomerName":  contact.Name,
+			"InvoiceNumber": inv.InvoiceNumber,
+			"LineItems":     lineItems,
+			"Total":         formatCents(inv.SubtotalCents, inv.Currency),
+			"DueDate":       dueDate.Format("2006-01-02"),
+			"PaymentLink":   "",
 		},
 	}
 
@@ -268,14 +269,17 @@ func (g *InvoiceGenerator) queueInvoiceEmail(ctx context.Context, inv *domain.In
 	}
 }
 
-// formatCents formats an integer cent amount as a human-readable string with currency symbol.
+// formatCents formats an integer cent amount as a human-readable string with currency code.
+// Negative amounts are represented with a leading minus sign.
 func formatCents(cents int64, currency string) string {
+	sign := ""
+	if cents < 0 {
+		sign = "-"
+		cents = -cents
+	}
 	major := cents / 100
 	minor := cents % 100
-	if minor < 0 {
-		minor = -minor
-	}
-	return fmt.Sprintf("%s %d.%02d", currency, major, minor)
+	return fmt.Sprintf("%s%s %d.%02d", sign, currency, major, minor)
 }
 
 // buildLineItemsForParty queries position entries for all accounts belonging to a party

--- a/services/payment-order/worker/invoice_generator.go
+++ b/services/payment-order/worker/invoice_generator.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/meridianhub/meridian/services/payment-order/adapters/persistence"
 	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"github.com/meridianhub/meridian/shared/pkg/email"
 	"github.com/shopspring/decimal"
 )
 
@@ -34,6 +35,12 @@ type PositionKeepingClient interface {
 	GetPositionLogEntries(ctx context.Context, accountID string, periodStart, periodEnd time.Time) ([]PositionEntry, error)
 }
 
+// PartyClient defines the interface for retrieving party contact information.
+type PartyClient interface {
+	// GetPartyEmail retrieves the contact email address for a party.
+	GetPartyEmail(ctx context.Context, partyID string) (string, error)
+}
+
 // AccountInfo holds basic account information for billing queries.
 type AccountInfo struct {
 	AccountID string
@@ -52,10 +59,13 @@ type PositionEntry struct {
 
 // InvoiceGenerator creates invoices from position-keeping data during a billing run.
 type InvoiceGenerator struct {
-	posClient PositionKeepingClient
-	repo      persistence.BillingRepository
-	metrics   *BillingMetrics
-	logger    *slog.Logger
+	posClient   PositionKeepingClient
+	partyClient PartyClient
+	emailRepo   email.OutboxRepository
+	repo        persistence.BillingRepository
+	metrics     *BillingMetrics
+	shadowMode  bool
+	logger      *slog.Logger
 }
 
 // NewInvoiceGenerator creates a new invoice generator.
@@ -71,6 +81,20 @@ func NewInvoiceGenerator(
 		metrics:   metrics,
 		logger:    logger.With("component", "invoice_generator"),
 	}
+}
+
+// WithEmailDelivery configures the invoice generator to queue invoice emails
+// after successful invoice creation. When partyClient or emailRepo is nil,
+// email delivery is disabled.
+func (g *InvoiceGenerator) WithEmailDelivery(
+	partyClient PartyClient,
+	emailRepo email.OutboxRepository,
+	shadowMode bool,
+) *InvoiceGenerator {
+	g.partyClient = partyClient
+	g.emailRepo = emailRepo
+	g.shadowMode = shadowMode
+	return g
 }
 
 // GenerateInvoices queries position-keeping for accounts with negative balances (amounts owed),
@@ -161,6 +185,8 @@ func (g *InvoiceGenerator) GenerateInvoices(ctx context.Context, billingRun *dom
 		g.metrics.RecordAmountCollected(inv.SubtotalCents)
 		invoices = append(invoices, inv)
 
+		g.queueInvoiceEmail(ctx, inv)
+
 		g.logger.Info("invoice created",
 			"invoice_id", inv.ID,
 			"party_id", partyID,
@@ -178,6 +204,78 @@ func (g *InvoiceGenerator) GenerateInvoices(ctx context.Context, billingRun *dom
 		return invoices, fmt.Errorf("%w: %d parties", ErrPartialInvoiceGeneration, errCount)
 	}
 	return invoices, nil
+}
+
+// invoiceEmailDueIn is the payment due period shown on invoice emails.
+const invoiceEmailDueIn = 30 * 24 * time.Hour
+
+// queueInvoiceEmail enqueues an invoice notification email to the outbox.
+// Errors are non-fatal: the invoice was already created successfully, so
+// a failure here only means the email won't be sent automatically.
+func (g *InvoiceGenerator) queueInvoiceEmail(ctx context.Context, inv *domain.Invoice) {
+	if g.shadowMode {
+		g.logger.Debug("shadow mode: skipping invoice email", "invoice_id", inv.ID)
+		return
+	}
+	if g.partyClient == nil || g.emailRepo == nil {
+		return
+	}
+
+	partyEmail, err := g.partyClient.GetPartyEmail(ctx, inv.PartyID)
+	if err != nil {
+		g.logger.Warn("could not resolve party email, skipping invoice email",
+			"party_id", inv.PartyID,
+			"invoice_id", inv.ID,
+			"error", err)
+		return
+	}
+
+	lineItems := make([]email.LineItem, len(inv.LineItems))
+	for i, li := range inv.LineItems {
+		lineItems[i] = email.LineItem{
+			Description: li.Description,
+			Amount:      formatCents(li.TotalCents, inv.Currency),
+		}
+	}
+
+	dueDate := time.Now().UTC().Add(invoiceEmailDueIn)
+	templateData := email.InvoiceData{
+		InvoiceNumber: inv.InvoiceNumber,
+		LineItems:     lineItems,
+		Total:         formatCents(inv.SubtotalCents, inv.Currency),
+		DueDate:       dueDate.Format("2006-01-02"),
+	}
+
+	entry := &email.OutboxEntry{
+		IdempotencyKey: "invoice-" + inv.ID.String(),
+		ToAddresses:    []string{partyEmail},
+		Subject:        "Invoice " + inv.InvoiceNumber,
+		TemplateName:   "invoice",
+		TemplateData: map[string]any{
+			"InvoiceNumber": templateData.InvoiceNumber,
+			"LineItems":     templateData.LineItems,
+			"Total":         templateData.Total,
+			"DueDate":       templateData.DueDate,
+			"PaymentLink":   templateData.PaymentLink,
+		},
+	}
+
+	if enqueueErr := g.emailRepo.Enqueue(ctx, entry); enqueueErr != nil {
+		g.logger.Error("failed to queue invoice email, invoice already created",
+			"invoice_id", inv.ID,
+			"party_id", inv.PartyID,
+			"error", enqueueErr)
+	}
+}
+
+// formatCents formats an integer cent amount as a human-readable string with currency symbol.
+func formatCents(cents int64, currency string) string {
+	major := cents / 100
+	minor := cents % 100
+	if minor < 0 {
+		minor = -minor
+	}
+	return fmt.Sprintf("%s %d.%02d", currency, major, minor)
 }
 
 // buildLineItemsForParty queries position entries for all accounts belonging to a party

--- a/services/payment-order/worker/invoice_generator.go
+++ b/services/payment-order/worker/invoice_generator.go
@@ -235,6 +235,12 @@ func (g *InvoiceGenerator) queueInvoiceEmail(ctx context.Context, inv *domain.In
 			"error", err)
 		return
 	}
+	if contact.Email == "" {
+		g.logger.Warn("party has no email address, skipping invoice email",
+			"party_id", inv.PartyID,
+			"invoice_id", inv.ID)
+		return
+	}
 
 	lineItems := make([]email.LineItem, len(inv.LineItems))
 	for i, li := range inv.LineItems {
@@ -244,7 +250,8 @@ func (g *InvoiceGenerator) queueInvoiceEmail(ctx context.Context, inv *domain.In
 		}
 	}
 
-	dueDate := time.Now().UTC().Add(invoiceEmailDueIn)
+	// Derive due date from invoice creation time so it is stable across retries.
+	dueDate := inv.CreatedAt.UTC().Add(invoiceEmailDueIn)
 
 	entry := &email.OutboxEntry{
 		IdempotencyKey: "invoice-" + inv.ID.String(),

--- a/services/payment-order/worker/invoice_generator_email_test.go
+++ b/services/payment-order/worker/invoice_generator_email_test.go
@@ -18,25 +18,25 @@ import (
 // --- Mock PartyClient ---
 
 type mockPartyClient struct {
-	mu       sync.Mutex
-	emails   map[string]string
-	emailErr map[string]error
+	mu         sync.Mutex
+	contacts   map[string]PartyContact
+	contactErr map[string]error
 }
 
 func newMockPartyClient() *mockPartyClient {
 	return &mockPartyClient{
-		emails:   make(map[string]string),
-		emailErr: make(map[string]error),
+		contacts:   make(map[string]PartyContact),
+		contactErr: make(map[string]error),
 	}
 }
 
-func (m *mockPartyClient) GetPartyEmail(_ context.Context, partyID string) (string, error) {
+func (m *mockPartyClient) GetPartyContact(_ context.Context, partyID string) (PartyContact, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if err, ok := m.emailErr[partyID]; ok {
-		return "", err
+	if err, ok := m.contactErr[partyID]; ok {
+		return PartyContact{}, err
 	}
-	return m.emails[partyID], nil
+	return m.contacts[partyID], nil
 }
 
 // --- Mock OutboxRepository ---
@@ -103,7 +103,7 @@ func makeInvoiceWithLineItems(t *testing.T, billingRunID uuid.UUID, partyID stri
 func TestQueueInvoiceEmail_ShadowMode(t *testing.T) {
 	ctx := context.Background()
 	partyClient := newMockPartyClient()
-	partyClient.emails["party-a"] = "customer@example.com"
+	partyClient.contacts["party-a"] = PartyContact{Email: "customer@example.com", Name: "Acme Corp"}
 	outbox := &mockEmailOutbox{}
 
 	repo := newMockBillingRepo()
@@ -122,10 +122,10 @@ func TestQueueInvoiceEmail_ShadowMode(t *testing.T) {
 	assert.Empty(t, outbox.entries, "shadow mode should skip email queueing")
 }
 
-func TestQueueInvoiceEmail_MissingPartyEmail(t *testing.T) {
+func TestQueueInvoiceEmail_MissingPartyContact(t *testing.T) {
 	ctx := context.Background()
 	partyClient := newMockPartyClient()
-	partyClient.emailErr["party-missing"] = errors.New("party not found")
+	partyClient.contactErr["party-missing"] = errors.New("party not found")
 	outbox := &mockEmailOutbox{}
 
 	repo := newMockBillingRepo()
@@ -148,7 +148,7 @@ func TestQueueInvoiceEmail_MissingPartyEmail(t *testing.T) {
 func TestQueueInvoiceEmail_EnqueueFailure_NonFatal(t *testing.T) {
 	ctx := context.Background()
 	partyClient := newMockPartyClient()
-	partyClient.emails["party-a"] = "customer@example.com"
+	partyClient.contacts["party-a"] = PartyContact{Email: "customer@example.com", Name: "Acme Corp"}
 	outbox := &mockEmailOutbox{enqueueErr: errors.New("database unavailable")}
 
 	periodStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -180,7 +180,7 @@ func TestQueueInvoiceEmail_EnqueueFailure_NonFatal(t *testing.T) {
 func TestQueueInvoiceEmail_Success(t *testing.T) {
 	ctx := context.Background()
 	partyClient := newMockPartyClient()
-	partyClient.emails["party-a"] = "customer@example.com"
+	partyClient.contacts["party-a"] = PartyContact{Email: "customer@example.com", Name: "Acme Corp"}
 	outbox := &mockEmailOutbox{}
 
 	periodStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -218,6 +218,7 @@ func TestQueueInvoiceEmail_Success(t *testing.T) {
 	assert.Contains(t, entry.Subject, invoices[0].InvoiceNumber)
 
 	data := entry.TemplateData
+	assert.Equal(t, "Acme Corp", data["CustomerName"])
 	assert.Equal(t, invoices[0].InvoiceNumber, data["InvoiceNumber"])
 	assert.Equal(t, "GBP 50.00", data["Total"])
 }

--- a/services/payment-order/worker/invoice_generator_email_test.go
+++ b/services/payment-order/worker/invoice_generator_email_test.go
@@ -223,6 +223,29 @@ func TestQueueInvoiceEmail_Success(t *testing.T) {
 	assert.Equal(t, "GBP 50.00", data["Total"])
 }
 
+func TestQueueInvoiceEmail_EmptyEmail(t *testing.T) {
+	ctx := context.Background()
+	partyClient := newMockPartyClient()
+	// Party resolved successfully but with no email address
+	partyClient.contacts["party-no-email"] = PartyContact{Email: "", Name: "Acme Corp"}
+	outbox := &mockEmailOutbox{}
+
+	repo := newMockBillingRepo()
+	gen := NewInvoiceGenerator(
+		&mockPositionClient{},
+		repo,
+		testInvoiceMetrics(t),
+		testInvoiceLogger(),
+	).WithEmailDelivery(partyClient, outbox, false)
+
+	inv := makeInvoiceWithLineItems(t, uuid.New(), "party-no-email")
+	gen.queueInvoiceEmail(ctx, inv)
+
+	outbox.mu.Lock()
+	defer outbox.mu.Unlock()
+	assert.Empty(t, outbox.entries, "empty email should log warning and not enqueue")
+}
+
 func TestQueueInvoiceEmail_NoEmailClient(t *testing.T) {
 	ctx := context.Background()
 	// No WithEmailDelivery call — email delivery not configured

--- a/services/payment-order/worker/invoice_generator_email_test.go
+++ b/services/payment-order/worker/invoice_generator_email_test.go
@@ -18,8 +18,8 @@ import (
 // --- Mock PartyClient ---
 
 type mockPartyClient struct {
-	mu      sync.Mutex
-	emails  map[string]string
+	mu       sync.Mutex
+	emails   map[string]string
 	emailErr map[string]error
 }
 
@@ -42,8 +42,8 @@ func (m *mockPartyClient) GetPartyEmail(_ context.Context, partyID string) (stri
 // --- Mock OutboxRepository ---
 
 type mockEmailOutbox struct {
-	mu      sync.Mutex
-	entries []*email.OutboxEntry
+	mu         sync.Mutex
+	entries    []*email.OutboxEntry
 	enqueueErr error
 }
 

--- a/services/payment-order/worker/invoice_generator_email_test.go
+++ b/services/payment-order/worker/invoice_generator_email_test.go
@@ -67,8 +67,10 @@ func (m *mockEmailOutbox) MarkFailed(_ context.Context, _ uuid.UUID, _ string) e
 
 func (m *mockEmailOutbox) Cancel(_ context.Context, _ uuid.UUID) error { return nil }
 
-var _ email.OutboxRepository = (*mockEmailOutbox)(nil)
-var _ PartyClient = (*mockPartyClient)(nil)
+var (
+	_ email.OutboxRepository = (*mockEmailOutbox)(nil)
+	_ PartyClient            = (*mockPartyClient)(nil)
+)
 
 // --- Helpers ---
 

--- a/services/payment-order/worker/invoice_generator_email_test.go
+++ b/services/payment-order/worker/invoice_generator_email_test.go
@@ -1,0 +1,237 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"github.com/meridianhub/meridian/shared/pkg/email"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Mock PartyClient ---
+
+type mockPartyClient struct {
+	mu      sync.Mutex
+	emails  map[string]string
+	emailErr map[string]error
+}
+
+func newMockPartyClient() *mockPartyClient {
+	return &mockPartyClient{
+		emails:   make(map[string]string),
+		emailErr: make(map[string]error),
+	}
+}
+
+func (m *mockPartyClient) GetPartyEmail(_ context.Context, partyID string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err, ok := m.emailErr[partyID]; ok {
+		return "", err
+	}
+	return m.emails[partyID], nil
+}
+
+// --- Mock OutboxRepository ---
+
+type mockEmailOutbox struct {
+	mu      sync.Mutex
+	entries []*email.OutboxEntry
+	enqueueErr error
+}
+
+func (m *mockEmailOutbox) Enqueue(_ context.Context, entry *email.OutboxEntry) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.enqueueErr != nil {
+		return m.enqueueErr
+	}
+	m.entries = append(m.entries, entry)
+	return nil
+}
+
+func (m *mockEmailOutbox) FetchDispatchable(_ context.Context, _ int) ([]email.OutboxEntry, error) {
+	return nil, nil
+}
+
+func (m *mockEmailOutbox) MarkSent(_ context.Context, _ uuid.UUID) error { return nil }
+
+func (m *mockEmailOutbox) MarkFailed(_ context.Context, _ uuid.UUID, _ string) error { return nil }
+
+func (m *mockEmailOutbox) Cancel(_ context.Context, _ uuid.UUID) error { return nil }
+
+var _ email.OutboxRepository = (*mockEmailOutbox)(nil)
+var _ PartyClient = (*mockPartyClient)(nil)
+
+// --- Helpers ---
+
+func makeInvoiceWithLineItems(t *testing.T, billingRunID uuid.UUID, partyID string) *domain.Invoice {
+	t.Helper()
+	lineItems := []domain.InvoiceLineItem{
+		{
+			Description:    "Service fee",
+			Quantity:       decimal.NewFromInt(1),
+			UnitPriceCents: 5000,
+			TotalCents:     5000,
+		},
+	}
+	inv, err := domain.NewInvoice(
+		billingRunID,
+		partyID,
+		"acct-1",
+		"INV-tenant-2026-01-0001",
+		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+		lineItems,
+		"GBP",
+	)
+	require.NoError(t, err)
+	return inv
+}
+
+// --- Tests ---
+
+func TestQueueInvoiceEmail_ShadowMode(t *testing.T) {
+	ctx := context.Background()
+	partyClient := newMockPartyClient()
+	partyClient.emails["party-a"] = "customer@example.com"
+	outbox := &mockEmailOutbox{}
+
+	repo := newMockBillingRepo()
+	gen := NewInvoiceGenerator(
+		&mockPositionClient{},
+		repo,
+		testInvoiceMetrics(t),
+		testInvoiceLogger(),
+	).WithEmailDelivery(partyClient, outbox, true /* shadowMode */)
+
+	inv := makeInvoiceWithLineItems(t, uuid.New(), "party-a")
+	gen.queueInvoiceEmail(ctx, inv)
+
+	outbox.mu.Lock()
+	defer outbox.mu.Unlock()
+	assert.Empty(t, outbox.entries, "shadow mode should skip email queueing")
+}
+
+func TestQueueInvoiceEmail_MissingPartyEmail(t *testing.T) {
+	ctx := context.Background()
+	partyClient := newMockPartyClient()
+	partyClient.emailErr["party-missing"] = errors.New("party not found")
+	outbox := &mockEmailOutbox{}
+
+	repo := newMockBillingRepo()
+	gen := NewInvoiceGenerator(
+		&mockPositionClient{},
+		repo,
+		testInvoiceMetrics(t),
+		testInvoiceLogger(),
+	).WithEmailDelivery(partyClient, outbox, false)
+
+	inv := makeInvoiceWithLineItems(t, uuid.New(), "party-missing")
+	// Should not panic or return error — logs warning and returns
+	gen.queueInvoiceEmail(ctx, inv)
+
+	outbox.mu.Lock()
+	defer outbox.mu.Unlock()
+	assert.Empty(t, outbox.entries, "missing email should log warning and not enqueue")
+}
+
+func TestQueueInvoiceEmail_EnqueueFailure_NonFatal(t *testing.T) {
+	ctx := context.Background()
+	partyClient := newMockPartyClient()
+	partyClient.emails["party-a"] = "customer@example.com"
+	outbox := &mockEmailOutbox{enqueueErr: errors.New("database unavailable")}
+
+	periodStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	repo := newMockBillingRepo()
+	posClient := &mockPositionClient{
+		accounts: []AccountInfo{
+			{AccountID: "acct-1", PartyID: "party-a", Currency: "GBP"},
+		},
+		entries: map[string][]PositionEntry{
+			"acct-1": {
+				{Description: "Service fee", AmountCents: 5000, Quantity: decimal.NewFromInt(1), UnitPriceCents: 5000},
+			},
+		},
+	}
+
+	billingRun := createTestBillingRun(t, "tenant-1", periodStart, periodEnd)
+	require.NoError(t, repo.CreateBillingRun(ctx, billingRun))
+
+	gen := NewInvoiceGenerator(posClient, repo, testInvoiceMetrics(t), testInvoiceLogger()).
+		WithEmailDelivery(partyClient, outbox, false)
+
+	// Invoice generation should succeed even when email queueing fails
+	invoices, err := gen.GenerateInvoices(ctx, billingRun)
+	require.NoError(t, err)
+	assert.Len(t, invoices, 1, "invoice should be created even if email queueing fails")
+}
+
+func TestQueueInvoiceEmail_Success(t *testing.T) {
+	ctx := context.Background()
+	partyClient := newMockPartyClient()
+	partyClient.emails["party-a"] = "customer@example.com"
+	outbox := &mockEmailOutbox{}
+
+	periodStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	repo := newMockBillingRepo()
+	posClient := &mockPositionClient{
+		accounts: []AccountInfo{
+			{AccountID: "acct-1", PartyID: "party-a", Currency: "GBP"},
+		},
+		entries: map[string][]PositionEntry{
+			"acct-1": {
+				{Description: "Service fee", AmountCents: 5000, Quantity: decimal.NewFromInt(1), UnitPriceCents: 5000},
+			},
+		},
+	}
+
+	billingRun := createTestBillingRun(t, "tenant-1", periodStart, periodEnd)
+	require.NoError(t, repo.CreateBillingRun(ctx, billingRun))
+
+	gen := NewInvoiceGenerator(posClient, repo, testInvoiceMetrics(t), testInvoiceLogger()).
+		WithEmailDelivery(partyClient, outbox, false)
+
+	invoices, err := gen.GenerateInvoices(ctx, billingRun)
+	require.NoError(t, err)
+	require.Len(t, invoices, 1)
+
+	outbox.mu.Lock()
+	defer outbox.mu.Unlock()
+	require.Len(t, outbox.entries, 1, "one email should be queued per invoice")
+
+	entry := outbox.entries[0]
+	assert.Equal(t, []string{"customer@example.com"}, entry.ToAddresses)
+	assert.Equal(t, "invoice", entry.TemplateName)
+	assert.Equal(t, "invoice-"+invoices[0].ID.String(), entry.IdempotencyKey)
+	assert.Contains(t, entry.Subject, invoices[0].InvoiceNumber)
+
+	data := entry.TemplateData
+	assert.Equal(t, invoices[0].InvoiceNumber, data["InvoiceNumber"])
+	assert.Equal(t, "GBP 50.00", data["Total"])
+}
+
+func TestQueueInvoiceEmail_NoEmailClient(t *testing.T) {
+	ctx := context.Background()
+	// No WithEmailDelivery call — email delivery not configured
+	repo := newMockBillingRepo()
+	gen := NewInvoiceGenerator(
+		&mockPositionClient{},
+		repo,
+		testInvoiceMetrics(t),
+		testInvoiceLogger(),
+	)
+
+	inv := makeInvoiceWithLineItems(t, uuid.New(), "party-a")
+	// Should be a no-op, no panic
+	gen.queueInvoiceEmail(ctx, inv)
+}


### PR DESCRIPTION
## Summary

- Adds `PartyClient` interface to `InvoiceGenerator` for resolving party email addresses
- Adds `email.OutboxRepository` dependency for reliable email delivery via the outbox pattern
- Queues an invoice notification email after each invoice is successfully persisted
- Implements `PartyClientWrapper` that calls `RetrieveParty` and extracts the `"email"` attribute

## Changes Made

**`services/payment-order/worker/invoice_generator.go`**
- Added `PartyClient` interface with `GetPartyEmail` method
- Extended `InvoiceGenerator` struct with `partyClient`, `emailRepo`, and `shadowMode` fields
- Added `WithEmailDelivery` fluent setter to preserve backwards compatibility with existing callers
- Added `queueInvoiceEmail` helper - non-fatal, logs errors but does not fail invoice creation
- Added `formatCents` utility for human-readable amount strings

**`services/payment-order/adapters/clients/party_client.go`**
- New `PartyClientWrapper` implementing `PartyClient` via the party gRPC service
- Extracts `"email"` from `attributes` on `RetrieveParty` response

**`services/payment-order/worker/invoice_generator_email_test.go`**
- Unit tests covering: shadow mode skip, missing party email (non-fatal warning), enqueue failure (invoice still created), success case (correct idempotency key, template name, addresses), and no-op when email not configured

## Technical Details

- Shadow mode: skips email queueing entirely
- Missing party email: logs `Warn` and returns - invoice already committed
- Email queue failure: logs `Error` and returns - invoice already committed
- Idempotency key: `invoice-{invoiceID}` prevents duplicate sends on retry
- Template name: `"invoice"` (matches `shared/pkg/email` embedded templates)

## Testing

All existing worker tests pass. New tests added for all email delivery paths.