### PR TITLE
feat: add Resend webhook endpoint for delivery status

### DIFF
--- a/cmd/meridian/gateway.go
+++ b/cmd/meridian/gateway.go
@@ -12,6 +12,7 @@ import (
 	"github.com/meridianhub/meridian/services/api-gateway/eventstream/adapters"
 	identitypersistence "github.com/meridianhub/meridian/services/identity/adapters/persistence"
 	tenantpersistence "github.com/meridianhub/meridian/services/tenant/adapters/persistence"
+	"github.com/meridianhub/meridian/shared/pkg/email"
 
 	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/env"
@@ -238,6 +239,21 @@ type loopbackSlugChecker struct {
 
 func (c *loopbackSlugChecker) IsSlugAvailable(ctx context.Context, slug string) (bool, error) {
 	return c.repo.IsSlugAvailable(ctx, slug)
+}
+
+// wireResendWebhook creates the Resend delivery status webhook handler and returns
+// a ServerOption. Returns nil if RESEND_WEBHOOK_SECRET is not set (webhook disabled).
+func wireResendWebhook(paymentOrderDB *gorm.DB, logger *slog.Logger) gateway.ServerOption {
+	secret := env.GetEnvOrDefault("RESEND_WEBHOOK_SECRET", "")
+	if secret == "" {
+		logger.Info("resend webhook disabled: RESEND_WEBHOOK_SECRET not set")
+		return nil
+	}
+
+	auditRepo := email.NewPostgresAuditRepository(paymentOrderDB)
+	handler := gateway.NewResendWebhookHandler(auditRepo, secret, logger)
+	logger.Info("resend webhook handler initialized")
+	return gateway.WithResendWebhookHandler(handler)
 }
 
 // wireRegistration creates the self-service registration handler and returns

--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -282,6 +282,11 @@ func run(logger *slog.Logger, grpcPort, httpPort int) error {
 		extraGWOpts = append(extraGWOpts, regOpt)
 	}
 
+	// Wire Resend webhook handler (public endpoint, Svix signature auth).
+	if webhookOpt := wireResendWebhook(conns.gormDB("payment-order"), logger); webhookOpt != nil {
+		extraGWOpts = append(extraGWOpts, webhookOpt)
+	}
+
 	gwServer, err := wireGateway(grpcPort, httpPort, platformDSN, conns.gormDB("tenant"), bffSigner, logger, extraGWOpts...)
 	if err != nil {
 		return fmt.Errorf("gateway init: %w", err)

--- a/services/api-gateway/resend_webhook_handler.go
+++ b/services/api-gateway/resend_webhook_handler.go
@@ -55,6 +55,22 @@ func NewResendWebhookHandler(auditRepo email.AuditRepository, webhookKey string,
 	}
 }
 
+// readAndVerifyWebhook reads the request body and verifies the Svix signature.
+// Returns the raw body or an error with the appropriate HTTP status code.
+func (h *ResendWebhookHandler) readAndVerifyWebhook(r *http.Request) ([]byte, int, error) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1 MiB limit
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if err := r.Body.Close(); err != nil {
+		h.logger.WarnContext(r.Context(), "resend webhook: failed to close request body", "error", err)
+	}
+	if err := verifySvixSignature(body, r.Header, h.webhookKey); err != nil {
+		return nil, http.StatusUnauthorized, err
+	}
+	return body, 0, nil
+}
+
 // ServeHTTP processes a Resend webhook delivery status callback.
 func (h *ResendWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -63,18 +79,10 @@ func (h *ResendWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1 MiB limit
+	body, status, err := h.readAndVerifyWebhook(r)
 	if err != nil {
-		http.Error(w, "Bad Request", http.StatusBadRequest)
-		return
-	}
-	if err := r.Body.Close(); err != nil {
-		h.logger.WarnContext(r.Context(), "resend webhook: failed to close request body", "error", err)
-	}
-
-	if err := verifySvixSignature(body, r.Header, h.webhookKey); err != nil {
-		h.logger.WarnContext(r.Context(), "resend webhook: signature verification failed", "error", err)
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		h.logger.WarnContext(r.Context(), "resend webhook: request rejected", "error", err)
+		http.Error(w, http.StatusText(status), status)
 		return
 	}
 

--- a/services/api-gateway/resend_webhook_handler.go
+++ b/services/api-gateway/resend_webhook_handler.go
@@ -19,11 +19,11 @@ import (
 
 // Sentinel errors for webhook verification.
 var (
-	ErrMissingSignatureHeaders      = errors.New("webhook: missing svix-id, svix-timestamp, or svix-signature header")
-	ErrInvalidTimestamp             = errors.New("webhook: invalid svix-timestamp value")
-	ErrTimestampOutsideTolerance    = errors.New("webhook: timestamp outside 5-minute tolerance window")
-	ErrSignatureVerificationFailed  = errors.New("webhook: no matching svix signature found")
-	ErrInvalidWebhookSecret         = errors.New("webhook: cannot decode webhook secret")
+	ErrMissingSignatureHeaders     = errors.New("webhook: missing svix-id, svix-timestamp, or svix-signature header")
+	ErrInvalidTimestamp            = errors.New("webhook: invalid svix-timestamp value")
+	ErrTimestampOutsideTolerance   = errors.New("webhook: timestamp outside 5-minute tolerance window")
+	ErrSignatureVerificationFailed = errors.New("webhook: no matching svix signature found")
+	ErrInvalidWebhookSecret        = errors.New("webhook: cannot decode webhook secret")
 )
 
 // resendWebhookPayload is the outer envelope of a Resend webhook event.
@@ -68,7 +68,9 @@ func (h *ResendWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}
-	defer r.Body.Close()
+	if err := r.Body.Close(); err != nil {
+		h.logger.WarnContext(r.Context(), "resend webhook: failed to close request body", "error", err)
+	}
 
 	if err := verifySvixSignature(body, r.Header, h.webhookKey); err != nil {
 		h.logger.WarnContext(r.Context(), "resend webhook: signature verification failed", "error", err)

--- a/services/api-gateway/resend_webhook_handler.go
+++ b/services/api-gateway/resend_webhook_handler.go
@@ -24,6 +24,7 @@ var (
 	ErrTimestampOutsideTolerance   = errors.New("webhook: timestamp outside 5-minute tolerance window")
 	ErrSignatureVerificationFailed = errors.New("webhook: no matching svix signature found")
 	ErrInvalidWebhookSecret        = errors.New("webhook: cannot decode webhook secret")
+	ErrRequestBodyTooLarge         = errors.New("webhook: request body too large")
 )
 
 // resendWebhookPayload is the outer envelope of a Resend webhook event.
@@ -68,7 +69,7 @@ func (h *ResendWebhookHandler) readAndVerifyWebhook(r *http.Request) ([]byte, in
 		h.logger.WarnContext(r.Context(), "resend webhook: failed to close request body", "error", err)
 	}
 	if len(body) > maxWebhookBody {
-		return nil, http.StatusRequestEntityTooLarge, errors.New("webhook: request body too large")
+		return nil, http.StatusRequestEntityTooLarge, ErrRequestBodyTooLarge
 	}
 	if err := verifySvixSignature(body, r.Header, h.webhookKey); err != nil {
 		return nil, http.StatusUnauthorized, err

--- a/services/api-gateway/resend_webhook_handler.go
+++ b/services/api-gateway/resend_webhook_handler.go
@@ -55,15 +55,20 @@ func NewResendWebhookHandler(auditRepo email.AuditRepository, webhookKey string,
 	}
 }
 
+const maxWebhookBody = 1 << 20 // 1 MiB
+
 // readAndVerifyWebhook reads the request body and verifies the Svix signature.
 // Returns the raw body or an error with the appropriate HTTP status code.
 func (h *ResendWebhookHandler) readAndVerifyWebhook(r *http.Request) ([]byte, int, error) {
-	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1 MiB limit
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxWebhookBody+1))
 	if err != nil {
 		return nil, http.StatusBadRequest, err
 	}
 	if err := r.Body.Close(); err != nil {
 		h.logger.WarnContext(r.Context(), "resend webhook: failed to close request body", "error", err)
+	}
+	if len(body) > maxWebhookBody {
+		return nil, http.StatusRequestEntityTooLarge, errors.New("webhook: request body too large")
 	}
 	if err := verifySvixSignature(body, r.Header, h.webhookKey); err != nil {
 		return nil, http.StatusUnauthorized, err

--- a/services/api-gateway/resend_webhook_handler.go
+++ b/services/api-gateway/resend_webhook_handler.go
@@ -1,0 +1,192 @@
+package gateway
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/pkg/email"
+)
+
+// Sentinel errors for webhook verification.
+var (
+	ErrMissingSignatureHeaders      = errors.New("webhook: missing svix-id, svix-timestamp, or svix-signature header")
+	ErrInvalidTimestamp             = errors.New("webhook: invalid svix-timestamp value")
+	ErrTimestampOutsideTolerance    = errors.New("webhook: timestamp outside 5-minute tolerance window")
+	ErrSignatureVerificationFailed  = errors.New("webhook: no matching svix signature found")
+	ErrInvalidWebhookSecret         = errors.New("webhook: cannot decode webhook secret")
+)
+
+// resendWebhookPayload is the outer envelope of a Resend webhook event.
+type resendWebhookPayload struct {
+	Type      string         `json:"type"`
+	CreatedAt string         `json:"created_at"`
+	Data      map[string]any `json:"data"`
+}
+
+// ResendWebhookHandler handles POST /api/v1/webhooks/resend.
+//
+// Resend uses Svix for webhook delivery. Each request carries three headers:
+// Svix-Id, Svix-Timestamp, and Svix-Signature. The handler verifies the
+// HMAC-SHA256 signature before processing the payload. No auth middleware
+// is applied to this route — the signature IS the authentication.
+type ResendWebhookHandler struct {
+	auditRepo  email.AuditRepository
+	webhookKey string
+	logger     *slog.Logger
+}
+
+// NewResendWebhookHandler creates a webhook handler.
+// webhookKey must be the raw secret from Resend (format: "whsec_<base64>").
+func NewResendWebhookHandler(auditRepo email.AuditRepository, webhookKey string, logger *slog.Logger) *ResendWebhookHandler {
+	return &ResendWebhookHandler{
+		auditRepo:  auditRepo,
+		webhookKey: webhookKey,
+		logger:     logger,
+	}
+}
+
+// ServeHTTP processes a Resend webhook delivery status callback.
+func (h *ResendWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1 MiB limit
+	if err != nil {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	if err := verifySvixSignature(body, r.Header, h.webhookKey); err != nil {
+		h.logger.WarnContext(r.Context(), "resend webhook: signature verification failed", "error", err)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var payload resendWebhookPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		h.logger.WarnContext(r.Context(), "resend webhook: failed to parse payload", "error", err)
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+
+	auditStatus, ok := resendEventToAuditStatus(payload.Type)
+	if !ok {
+		// Unknown event types are acknowledged without processing (Resend may
+		// add new event types in future; silently ignore to avoid retries).
+		h.logger.DebugContext(r.Context(), "resend webhook: unknown event type, ignoring", "type", payload.Type)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	providerID, _ := payload.Data["email_id"].(string)
+	if providerID == "" {
+		h.logger.WarnContext(r.Context(), "resend webhook: missing email_id in payload", "type", payload.Type)
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+
+	if err := h.auditRepo.RecordByProviderID(r.Context(), providerID, auditStatus, payload.Data); err != nil {
+		if errors.Is(err, email.ErrAuditEntryNotFound) {
+			// Not found: may be a replay of an old event or a race with cleanup.
+			h.logger.WarnContext(r.Context(), "resend webhook: no audit entry for provider ID",
+				"provider_id", providerID, "type", payload.Type)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		h.logger.ErrorContext(r.Context(), "resend webhook: failed to record audit entry",
+			"provider_id", providerID, "type", payload.Type, "error", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	h.logger.InfoContext(r.Context(), "resend webhook: recorded delivery status",
+		"provider_id", providerID, "type", payload.Type, "status", auditStatus)
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// resendEventToAuditStatus maps a Resend event type to an AuditStatus.
+// Returns (status, true) for known event types, ("", false) for unknown ones.
+func resendEventToAuditStatus(eventType string) (email.AuditStatus, bool) {
+	switch eventType {
+	case "email.delivered":
+		return email.AuditStatusDelivered, true
+	case "email.bounced":
+		return email.AuditStatusBounced, true
+	case "email.complained":
+		return email.AuditStatusComplained, true
+	default:
+		return "", false
+	}
+}
+
+// verifySvixSignature validates the Svix HMAC-SHA256 webhook signature.
+//
+// Svix signature verification algorithm:
+//  1. Read Svix-Id, Svix-Timestamp, Svix-Signature headers.
+//  2. Reject if timestamp is outside ±5 minutes to prevent replay attacks.
+//  3. Compute HMAC-SHA256("{msgId}.{timestamp}.{body}", key).
+//  4. key = base64.StdEncoding.Decode(secret after stripping "whsec_" prefix).
+//  5. Compare against each "v1,<base64sig>" token in Svix-Signature.
+func verifySvixSignature(payload []byte, headers http.Header, secret string) error {
+	msgID := headers.Get("svix-id")
+	msgTimestamp := headers.Get("svix-timestamp")
+	msgSignature := headers.Get("svix-signature")
+
+	if msgID == "" || msgTimestamp == "" || msgSignature == "" {
+		return ErrMissingSignatureHeaders
+	}
+
+	ts, err := strconv.ParseInt(msgTimestamp, 10, 64)
+	if err != nil {
+		return ErrInvalidTimestamp
+	}
+	delta := time.Now().Unix() - ts
+	if delta < -300 || delta > 300 {
+		return ErrTimestampOutsideTolerance
+	}
+
+	keyB64 := strings.TrimPrefix(secret, "whsec_")
+	key, err := base64.StdEncoding.DecodeString(keyB64)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidWebhookSecret, err)
+	}
+
+	toSign := fmt.Sprintf("%s.%s.%s", msgID, msgTimestamp, string(payload))
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(toSign))
+	computed := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+
+	for _, sig := range strings.Fields(msgSignature) {
+		parts := strings.SplitN(sig, ",", 2)
+		if len(parts) != 2 || parts[0] != "v1" {
+			continue
+		}
+		if hmac.Equal([]byte(parts[1]), []byte(computed)) {
+			return nil
+		}
+	}
+
+	return ErrSignatureVerificationFailed
+}
+
+// WithResendWebhookHandler registers the Resend delivery status webhook handler.
+func WithResendWebhookHandler(handler *ResendWebhookHandler) ServerOption {
+	return func(s *Server) {
+		s.resendWebhookHandler = handler
+	}
+}

--- a/services/api-gateway/resend_webhook_handler_test.go
+++ b/services/api-gateway/resend_webhook_handler_test.go
@@ -1,0 +1,307 @@
+package gateway_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/pkg/email"
+
+	gateway "github.com/meridianhub/meridian/services/api-gateway"
+)
+
+// ─── Fake AuditRepository ────────────────────────────────────────────────────
+
+type fakeAuditRepo struct {
+	recorded      []recordedCall
+	returnErr     error
+	notFoundOnIDs map[string]bool
+}
+
+type recordedCall struct {
+	providerID string
+	status     email.AuditStatus
+	payload    map[string]any
+}
+
+func (f *fakeAuditRepo) Record(_ context.Context, _ *email.AuditEntry) error {
+	return f.returnErr
+}
+
+func (f *fakeAuditRepo) FindByOutboxID(_ context.Context, _ uuid.UUID) ([]email.AuditEntry, error) {
+	return nil, nil
+}
+
+func (f *fakeAuditRepo) RecordByProviderID(_ context.Context, providerID string, status email.AuditStatus, payload map[string]any) error {
+	if f.notFoundOnIDs[providerID] {
+		return email.ErrAuditEntryNotFound
+	}
+	if f.returnErr != nil {
+		return f.returnErr
+	}
+	f.recorded = append(f.recorded, recordedCall{providerID: providerID, status: status, payload: payload})
+	return nil
+}
+
+// ─── Signature helpers ───────────────────────────────────────────────────────
+
+const testSecret = "whsec_dGVzdHNlY3JldGtleXRlc3RzZWNyZXRrZXk=" // base64("testsecretkeytestsecretkey" repeated)
+
+func signPayload(t *testing.T, body []byte, msgID, secret string) (svixID, svixTimestamp, svixSignature string) {
+	t.Helper()
+
+	svixID = msgID
+	svixTimestamp = fmt.Sprintf("%d", time.Now().Unix())
+
+	keyB64 := secret[len("whsec_"):]
+	key, err := base64.StdEncoding.DecodeString(keyB64)
+	if err != nil {
+		t.Fatalf("decode test secret: %v", err)
+	}
+
+	toSign := fmt.Sprintf("%s.%s.%s", svixID, svixTimestamp, string(body))
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(toSign))
+	sig := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+
+	svixSignature = "v1," + sig
+	return
+}
+
+// ─── Request builder ─────────────────────────────────────────────────────────
+
+func buildWebhookRequest(t *testing.T, body []byte, secret string, overrideHeaders ...func(h http.Header)) *http.Request {
+	t.Helper()
+	msgID, ts, sig := signPayload(t, body, "msg_"+uuid.New().String(), secret)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/resend", bytes.NewReader(body))
+	r.Header.Set("svix-id", msgID)
+	r.Header.Set("svix-timestamp", ts)
+	r.Header.Set("svix-signature", sig)
+	for _, fn := range overrideHeaders {
+		fn(r.Header)
+	}
+	return r
+}
+
+func buildPayload(t *testing.T, eventType, emailID string) []byte {
+	t.Helper()
+	p := map[string]any{
+		"type":       eventType,
+		"created_at": time.Now().UTC().Format(time.RFC3339),
+		"data": map[string]any{
+			"email_id": emailID,
+		},
+	}
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return b
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+func TestResendWebhookHandler_ValidSignature(t *testing.T) {
+	repo := &fakeAuditRepo{}
+	handler := gateway.NewResendWebhookHandler(repo, testSecret, slog.Default())
+
+	body := buildPayload(t, "email.delivered", "resend-id-001")
+	r := buildWebhookRequest(t, body, testSecret)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if len(repo.recorded) != 1 {
+		t.Fatalf("expected 1 recorded call, got %d", len(repo.recorded))
+	}
+	if repo.recorded[0].status != email.AuditStatusDelivered {
+		t.Errorf("expected DELIVERED, got %s", repo.recorded[0].status)
+	}
+	if repo.recorded[0].providerID != "resend-id-001" {
+		t.Errorf("expected providerID 'resend-id-001', got %s", repo.recorded[0].providerID)
+	}
+}
+
+func TestResendWebhookHandler_InvalidSignature(t *testing.T) {
+	repo := &fakeAuditRepo{}
+	handler := gateway.NewResendWebhookHandler(repo, testSecret, slog.Default())
+
+	body := buildPayload(t, "email.delivered", "resend-id-001")
+	r := buildWebhookRequest(t, body, testSecret, func(h http.Header) {
+		h.Set("svix-signature", "v1,invalidsignature")
+	})
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+	if len(repo.recorded) != 0 {
+		t.Errorf("expected no recorded calls, got %d", len(repo.recorded))
+	}
+}
+
+func TestResendWebhookHandler_MissingHeaders(t *testing.T) {
+	repo := &fakeAuditRepo{}
+	handler := gateway.NewResendWebhookHandler(repo, testSecret, slog.Default())
+
+	body := buildPayload(t, "email.delivered", "resend-id-001")
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/resend", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestResendWebhookHandler_EventTypesRouteCorrectly(t *testing.T) {
+	tests := []struct {
+		eventType      string
+		expectedStatus email.AuditStatus
+	}{
+		{"email.delivered", email.AuditStatusDelivered},
+		{"email.bounced", email.AuditStatusBounced},
+		{"email.complained", email.AuditStatusComplained},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.eventType, func(t *testing.T) {
+			repo := &fakeAuditRepo{}
+			handler := gateway.NewResendWebhookHandler(repo, testSecret, slog.Default())
+
+			body := buildPayload(t, tc.eventType, "resend-id-test")
+			r := buildWebhookRequest(t, body, testSecret)
+			w := httptest.NewRecorder()
+
+			handler.ServeHTTP(w, r)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", w.Code)
+			}
+			if len(repo.recorded) != 1 {
+				t.Fatalf("expected 1 recorded call, got %d", len(repo.recorded))
+			}
+			if repo.recorded[0].status != tc.expectedStatus {
+				t.Errorf("expected %s, got %s", tc.expectedStatus, repo.recorded[0].status)
+			}
+		})
+	}
+}
+
+func TestResendWebhookHandler_UnknownEventType_Returns200(t *testing.T) {
+	repo := &fakeAuditRepo{}
+	handler := gateway.NewResendWebhookHandler(repo, testSecret, slog.Default())
+
+	body := buildPayload(t, "email.opened", "resend-id-001") // unknown type
+	r := buildWebhookRequest(t, body, testSecret)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for unknown event type, got %d", w.Code)
+	}
+	if len(repo.recorded) != 0 {
+		t.Errorf("expected no recorded calls for unknown event type, got %d", len(repo.recorded))
+	}
+}
+
+func TestResendWebhookHandler_AuditEntryNotFound_Returns200(t *testing.T) {
+	repo := &fakeAuditRepo{notFoundOnIDs: map[string]bool{"missing-id": true}}
+	handler := gateway.NewResendWebhookHandler(repo, testSecret, slog.Default())
+
+	body := buildPayload(t, "email.delivered", "missing-id")
+	r := buildWebhookRequest(t, body, testSecret)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	// Not-found on a webhook should still be acknowledged (200) to avoid Resend retries.
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for not-found provider ID, got %d", w.Code)
+	}
+}
+
+func TestResendWebhookHandler_RepoError_Returns500(t *testing.T) {
+	repo := &fakeAuditRepo{returnErr: errors.New("db connection lost")}
+	handler := gateway.NewResendWebhookHandler(repo, testSecret, slog.Default())
+
+	body := buildPayload(t, "email.delivered", "resend-id-err")
+	r := buildWebhookRequest(t, body, testSecret)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestResendWebhookHandler_WrongMethod(t *testing.T) {
+	repo := &fakeAuditRepo{}
+	handler := gateway.NewResendWebhookHandler(repo, testSecret, slog.Default())
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/webhooks/resend", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestResendWebhookHandler_InvalidBody_Returns400(t *testing.T) {
+	repo := &fakeAuditRepo{}
+	handler := gateway.NewResendWebhookHandler(repo, testSecret, slog.Default())
+
+	body := []byte("not valid json")
+	r := buildWebhookRequest(t, body, testSecret)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid JSON, got %d", w.Code)
+	}
+}
+
+func TestResendWebhookHandler_MultipleSignatures_FirstInvalid(t *testing.T) {
+	// Svix may send multiple signatures (key rotation). Verification should pass
+	// if any of them match.
+	repo := &fakeAuditRepo{}
+	handler := gateway.NewResendWebhookHandler(repo, testSecret, slog.Default())
+
+	body := buildPayload(t, "email.delivered", "resend-id-multi")
+	msgID, ts, validSig := signPayload(t, body, "msg_multi", testSecret)
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/resend", bytes.NewReader(body))
+	r.Header.Set("svix-id", msgID)
+	r.Header.Set("svix-timestamp", ts)
+	// First token is invalid, second is valid.
+	r.Header.Set("svix-signature", "v1,invalidsig "+validSig)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 with valid signature in multi-sig header, got %d", w.Code)
+	}
+}

--- a/services/api-gateway/server.go
+++ b/services/api-gateway/server.go
@@ -39,6 +39,7 @@ type Server struct {
 	authHandler           *AuthHandler
 	ssoHandler            *SSOHandler
 	registrationHandler   *RegistrationHandler
+	resendWebhookHandler  *ResendWebhookHandler
 }
 
 // ServerOption is a functional option for configuring the server.
@@ -209,6 +210,11 @@ func (s *Server) registerRoutes() {
 	if s.registrationHandler != nil {
 		s.mux.Handle("POST /api/v1/register", http.HandlerFunc(s.registrationHandler.HandleRegister))
 		s.mux.Handle("GET /api/v1/slugs/{slug}/available", http.HandlerFunc(s.registrationHandler.HandleSlugAvailable))
+	}
+
+	// Resend delivery status webhook - NO middleware (Svix signature IS the auth).
+	if s.resendWebhookHandler != nil {
+		s.mux.Handle("POST /api/v1/webhooks/resend", s.resendWebhookHandler)
 	}
 
 	// API routes - with auth and tenant middleware chain.

--- a/services/payment-order/migrations/20260326000004_email_audit_provider_id_index.sql
+++ b/services/payment-order/migrations/20260326000004_email_audit_provider_id_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_email_audit_provider ON email_audit_log (provider_id) WHERE provider_id IS NOT NULL;

--- a/services/payment-order/migrations/atlas.sum
+++ b/services/payment-order/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:J6J8b29E6gkk6NnXMh5pOLykok8mJyb3c5HbD0OXRDk=
+h1:FEtO1kPnW0ggNmB/+dxvGpdZh2ur+GCkgSgsgedzzWc=
 20251216000001_initial.sql h1:9Pt9iC/k1YkmfjyO/F0ioNbPswzzgCP2aHtFlFHnSMY=
 20251217000001_audit_system.sql h1:YD9HdFm+NRTihCM/PBU7EYEmdttWjvGPCIE408A8HFg=
 20251223000001_fix_audit_schema_compatibility.sql h1:QxqR4DwdQ5cNXHCxTvtHgQmhSnD8xptkoFnxNcZ5ehY=
@@ -17,3 +17,4 @@ h1:J6J8b29E6gkk6NnXMh5pOLykok8mJyb3c5HbD0OXRDk=
 20260326000001_email_outbox.sql h1:UpwgKGZ6AJoDLcSPqG7SOOd9ogtd+0BybSmW7zUajic=
 20260326000002_email_outbox_index.sql h1:YkH+wCNp1EA5RxQuF3gG0WJA7h6ooO1NXEr4rG4NgyM=
 20260326000003_email_audit_log.sql h1:j8G5/uH6F2ZjOUsKfaYvp8/kGblS36E8oZOlkQ3Bo1M=
+20260326000004_email_audit_provider_id_index.sql h1:1NruszJ83yvkMnBTQr36juoM8yxjmX/JsX5bmuTZHlQ=

--- a/shared/pkg/email/audit_postgres.go
+++ b/shared/pkg/email/audit_postgres.go
@@ -3,6 +3,7 @@ package email
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -87,6 +88,49 @@ func (r *PostgresAuditRepository) FindByOutboxID(ctx context.Context, outboxID u
 		entries[i] = entityToAuditEntry(e)
 	}
 	return entries, nil
+}
+
+// RecordByProviderID looks up existing audit entries by providerID (without tenant scope),
+// resolves the tenant from the first match, then records a new status update entry.
+func (r *PostgresAuditRepository) RecordByProviderID(ctx context.Context, providerID string, status AuditStatus, payload map[string]any) error {
+	// Cross-tenant lookup: find any existing audit entry with this provider ID.
+	var existing AuditLogEntity
+	if err := r.db.Where("provider_id = ?", providerID).First(&existing).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrAuditEntryNotFound
+		}
+		return fmt.Errorf("email: lookup audit entry by provider ID: %w", err)
+	}
+
+	tid, err := tenant.NewTenantID(existing.TenantID)
+	if err != nil {
+		return fmt.Errorf("email: invalid tenant ID in audit entry: %w", err)
+	}
+	tenantCtx := tenant.WithTenant(ctx, tid)
+
+	now := time.Now().UTC()
+
+	var delivered *time.Time
+	var bounceReason *string
+	if status == AuditStatusDelivered {
+		delivered = &now
+	}
+
+	entry := &AuditEntry{
+		ID:               uuid.New(),
+		OutboxID:         existing.OutboxID,
+		ProviderID:       &providerID,
+		ToAddresses:      []string(existing.ToAddresses),
+		FromAddress:      existing.FromAddress,
+		Subject:          existing.Subject,
+		TemplateName:     existing.TemplateName,
+		Status:           status,
+		DeliveredAt:      delivered,
+		BounceReason:     bounceReason,
+		ProviderResponse: payload,
+	}
+
+	return r.Record(tenantCtx, entry)
 }
 
 func entityToAuditEntry(e AuditLogEntity) AuditEntry {

--- a/shared/pkg/email/repository.go
+++ b/shared/pkg/email/repository.go
@@ -2,6 +2,7 @@ package email
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/uuid"
 )
@@ -32,4 +33,13 @@ type AuditRepository interface {
 
 	// FindByOutboxID returns all audit entries for a given outbox entry.
 	FindByOutboxID(ctx context.Context, outboxID uuid.UUID) ([]AuditEntry, error)
+
+	// RecordByProviderID records a webhook delivery status update for the email
+	// identified by providerID. It looks up the tenant from existing audit entries
+	// and records a new status entry with the supplied payload. Returns
+	// ErrAuditEntryNotFound if no audit entry with the given providerID exists.
+	RecordByProviderID(ctx context.Context, providerID string, status AuditStatus, payload map[string]any) error
 }
+
+// ErrAuditEntryNotFound is returned when no audit entry matches the given criteria.
+var ErrAuditEntryNotFound = fmt.Errorf("email: audit entry not found")

--- a/shared/pkg/email/sender.go
+++ b/shared/pkg/email/sender.go
@@ -76,10 +76,11 @@ type AuditStatus string
 
 // Audit log delivery statuses.
 const (
-	AuditStatusSent      AuditStatus = "SENT"
-	AuditStatusDelivered AuditStatus = "DELIVERED"
-	AuditStatusBounced   AuditStatus = "BOUNCED"
-	AuditStatusFailed    AuditStatus = "FAILED"
+	AuditStatusSent       AuditStatus = "SENT"
+	AuditStatusDelivered  AuditStatus = "DELIVERED"
+	AuditStatusBounced    AuditStatus = "BOUNCED"
+	AuditStatusFailed     AuditStatus = "FAILED"
+	AuditStatusComplained AuditStatus = "COMPLAINED"
 )
 
 // AuditEntry represents a record in the email audit log.


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/webhooks/resend` to receive Resend email delivery status callbacks
- Verifies Svix HMAC-SHA256 signatures (no new external dependency — implemented inline using `crypto/hmac`)
- Routes `email.delivered`, `email.bounced`, `email.complained` events to `email_audit_log`
- Unknown event types return 200 to prevent Resend retry storms
- Handler is disabled when `RESEND_WEBHOOK_SECRET` is unset (opt-in via env var)

## Changes Made

- `shared/pkg/email/sender.go` - Added `AuditStatusComplained`
- `shared/pkg/email/repository.go` - Extended `AuditRepository` with `RecordByProviderID` for cross-tenant webhook lookup
- `shared/pkg/email/audit_postgres.go` - Implemented `RecordByProviderID` (queries without tenant scope, then records with resolved tenant context)
- `services/api-gateway/resend_webhook_handler.go` - New handler with Svix verification and event routing
- `services/api-gateway/server.go` - Added `resendWebhookHandler` field and route registration
- `cmd/meridian/gateway.go` - Added `wireResendWebhook` wiring function
- `cmd/meridian/main.go` - Called `wireResendWebhook` in the gateway boot path

## Technical Details

**Svix verification** follows the spec exactly: HMAC-SHA256 over `"{svix-id}.{svix-timestamp}.{body}"` with the base64-decoded secret. Supports multiple signatures (key rotation) and enforces a ±5-minute timestamp window against replay attacks.

**Cross-tenant webhook processing**: `RecordByProviderID` performs a global DB query by `provider_id`, resolves the tenant from the found entry, and records a new audit entry in the correct tenant scope. Returns `ErrAuditEntryNotFound` for unknown provider IDs (acknowledged 200 - no retry).

## Testing

10 unit tests covering:
- Valid signature → 200 + audit recorded
- Invalid / missing signatures → 401
- All three event types route to correct `AuditStatus`
- Unknown event type → 200 (no audit recorded)
- Provider ID not found → 200 (no retry)
- Repo error → 500
- Wrong HTTP method → 405
- Invalid JSON body → 400
- Multiple signatures (key rotation) → passes if any match

## Risk Assessment

Low. The route is public but protected by HMAC signature verification. The signature verification short-circuits before any DB access on invalid requests.