### PR TITLE
feat: wire email worker into unified binary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -148,6 +148,15 @@ LOCAL_DEV_MODE="true"                              # [optional] Allow X-Tenant-S
 # GATEWAY_ACCOUNT_MAPPING_FILE=""                  # [service-specific] Path to gateway account mapping config
 
 # -----------------------------------------------------------------------------
+# Email Dispatch Worker
+# -----------------------------------------------------------------------------
+EMAIL_MODE="disabled"                              # [optional] disabled | log | live (default: disabled in dev)
+# RESEND_API_KEY=""                                # [required for EMAIL_MODE=live] Resend API key
+# RESEND_WEBHOOK_SECRET=""                         # [optional] Svix signature secret for delivery webhooks
+# EMAIL_WORKER_BATCH_SIZE="50"                     # [optional] Max emails to dispatch per poll cycle
+# EMAIL_WORKER_POLL_INTERVAL="5s"                  # [optional] Interval between outbox poll cycles
+
+# -----------------------------------------------------------------------------
 # Financial Gateway Service
 # -----------------------------------------------------------------------------
 # STRIPE_SECRET_KEY=""                             # [service-specific] Stripe API secret key for payment dispatch

--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -34,6 +34,9 @@ import (
 	"github.com/meridianhub/meridian/internal/migrations"
 	"github.com/meridianhub/meridian/services"
 	tenantprovisioner "github.com/meridianhub/meridian/services/tenant/provisioner"
+	"github.com/meridianhub/meridian/shared/pkg/dispatch"
+	"github.com/meridianhub/meridian/shared/pkg/email"
+	emailworker "github.com/meridianhub/meridian/shared/pkg/email/worker"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
@@ -42,6 +45,8 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/observability"
 
 	pkdomain "github.com/meridianhub/meridian/services/position-keeping/domain"
+
+	"gorm.io/gorm"
 )
 
 // Version information injected at build time via ldflags.
@@ -117,6 +122,7 @@ func setDevDefaults() {
 	defaults := map[string]string{
 		"AUTH_MODE":       "disabled",
 		"BILLING_ENABLED": "false",
+		"EMAIL_MODE":      "disabled",
 		"ENVIRONMENT":     "development",
 		"REDIS_ENABLED":   "false",
 		"KAFKA_ENABLED":   "false",
@@ -239,6 +245,10 @@ func run(logger *slog.Logger, grpcPort, httpPort int) error {
 		defer provisionerCleanup()
 	}
 
+	// ─── Email Dispatch Worker (optional) ───────────────────────────────
+
+	emailWorker := startEmailWorker(ctx, conns.gormDB("payment-order"), logger)
+
 	// ─── Start gRPC Server ───────────────────────────────────────────────
 
 	grpcAddr := fmt.Sprintf(":%d", grpcPort)
@@ -318,10 +328,14 @@ func run(logger *slog.Logger, grpcPort, httpPort int) error {
 		return fmt.Errorf("gateway server: %w", err)
 	}
 
-	// Stop provisioning worker first (drains in-flight work)
+	// Stop workers first (drain in-flight work)
 	if provisioningWorker != nil {
 		provisioningWorker.Stop()
 		logger.Info("provisioning worker stopped")
+	}
+	if emailWorker != nil {
+		emailWorker.Stop()
+		logger.Info("email worker stopped")
 	}
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -335,6 +349,47 @@ func run(logger *slog.Logger, grpcPort, httpPort int) error {
 	logger.Info("servers stopped")
 
 	return nil
+}
+
+// ─── Email Worker ────────────────────────────────────────────────────────────
+
+// startEmailWorker creates and starts the email dispatch worker if email is
+// configured (EMAIL_MODE != "disabled"). Returns the worker for graceful shutdown,
+// or nil if email is disabled or misconfigured.
+func startEmailWorker(ctx context.Context, paymentOrderDB *gorm.DB, logger *slog.Logger) *dispatch.Worker[*emailworker.OutboxInstruction] {
+	sender, err := email.NewSenderFromEnv(logger)
+	if err != nil {
+		logger.Info("email worker disabled", "reason", err.Error())
+		return nil
+	}
+
+	renderer, err := email.NewEmbeddedRenderer()
+	if err != nil {
+		logger.Error("email renderer init failed, email worker disabled", "error", err)
+		return nil
+	}
+
+	outboxRepo := email.NewPostgresOutboxRepository(paymentOrderDB)
+	auditRepo := email.NewPostgresAuditRepository(paymentOrderDB)
+	metrics := email.NewMetrics()
+
+	w := emailworker.NewEmailWorker(
+		outboxRepo,
+		auditRepo,
+		renderer,
+		sender,
+		nil, // invoiceChecker - not wired yet (dunning validation)
+		metrics,
+		dispatch.WorkerConfig{
+			BatchSize:    env.GetEnvAsInt("EMAIL_WORKER_BATCH_SIZE", dispatch.DefaultBatchSize),
+			PollInterval: env.GetEnvAsDuration("EMAIL_WORKER_POLL_INTERVAL", 5*time.Second),
+		},
+		logger.With("component", "email-worker"),
+	)
+
+	w.Start(ctx)
+	logger.Info("email worker started")
+	return w
 }
 
 // ─── Bootstrap ──────────────────────────────────────────────────────────────

--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -354,12 +354,22 @@ func run(logger *slog.Logger, grpcPort, httpPort int) error {
 // ─── Email Worker ────────────────────────────────────────────────────────────
 
 // startEmailWorker creates and starts the email dispatch worker if email is
-// configured (EMAIL_MODE != "disabled"). Returns the worker for graceful shutdown,
-// or nil if email is disabled or misconfigured.
+// configured (EMAIL_MODE is "log" or "live"). Returns the worker for graceful
+// shutdown, or nil if email is disabled or misconfigured.
+//
+// When EMAIL_MODE is "disabled" (the dev default), the worker is not started at
+// all. This prevents the NoopSender from silently consuming outbox entries and
+// marking them as sent without actual delivery.
 func startEmailWorker(ctx context.Context, paymentOrderDB *gorm.DB, logger *slog.Logger) *dispatch.Worker[*emailworker.OutboxInstruction] {
+	mode := os.Getenv("EMAIL_MODE")
+	if mode == "disabled" {
+		logger.Info("email worker disabled", "email_mode", mode)
+		return nil
+	}
+
 	sender, err := email.NewSenderFromEnv(logger)
 	if err != nil {
-		logger.Info("email worker disabled", "reason", err.Error())
+		logger.Warn("email sender not configured, email worker disabled", "error", err)
 		return nil
 	}
 

--- a/docs/runbooks/email-infrastructure.md
+++ b/docs/runbooks/email-infrastructure.md
@@ -1,0 +1,137 @@
+# Email Infrastructure Runbook
+
+## Overview
+
+Meridian sends transactional emails (payment confirmations, dunning notices) via the email dispatch worker. Emails are queued in an outbox table in the payment-order database and dispatched by a background worker that polls for pending entries.
+
+**Provider**: [Resend](https://resend.com) (HTTP API, Svix-signed webhooks for delivery status).
+
+## Architecture
+
+```
+Saga/Service -> OutboxRepository (INSERT) -> email_outbox table
+                                                  |
+                                          Email Worker (polls)
+                                                  |
+                                          TemplateRenderer (embed.FS)
+                                                  |
+                                          Sender (Resend / Log / Noop)
+                                                  |
+                                          AuditRepository (INSERT)
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `EMAIL_MODE` | No | `disabled` (dev) | `disabled` / `log` / `live` |
+| `RESEND_API_KEY` | For `live` | - | Resend API key |
+| `RESEND_WEBHOOK_SECRET` | No | - | Svix signature secret for delivery webhooks |
+| `EMAIL_WORKER_BATCH_SIZE` | No | `50` | Max emails per poll cycle |
+| `EMAIL_WORKER_POLL_INTERVAL` | No | `5s` | Outbox poll interval |
+
+### Modes
+
+- **disabled**: No-op sender, worker does not start. Default in local dev.
+- **log**: Logs email content to stdout via slog. Useful for integration testing.
+- **live**: Sends real emails via Resend API. Requires `RESEND_API_KEY`.
+
+## DNS Setup (meridianhub.cloud)
+
+Configure these DNS records for the sending domain:
+
+### SPF
+
+```
+TXT  meridianhub.cloud  "v=spf1 include:amazonses.com ~all"
+```
+
+### DKIM
+
+Add the DKIM records provided by Resend during domain verification. Typically three CNAME records:
+
+```
+CNAME  resend._domainkey.meridianhub.cloud  -> (value from Resend)
+CNAME  s1._domainkey.meridianhub.cloud      -> (value from Resend)
+CNAME  s2._domainkey.meridianhub.cloud      -> (value from Resend)
+```
+
+### DMARC
+
+```
+TXT  _dmarc.meridianhub.cloud  "v=DMARC1; p=quarantine; rua=mailto:dmarc@meridianhub.cloud"
+```
+
+### Verification
+
+After adding records, verify in the Resend dashboard (Settings > Domains). DNS propagation may take up to 48 hours.
+
+## Resend Account Setup
+
+1. Create account at [resend.com](https://resend.com)
+2. Add and verify sending domain (meridianhub.cloud)
+3. Create an API key with "Sending access" permission
+4. Set `RESEND_API_KEY` in the deployment environment
+5. (Optional) Configure webhook endpoint at `https://<domain>/webhooks/resend` and set `RESEND_WEBHOOK_SECRET`
+
+## Troubleshooting
+
+### Worker not starting
+
+Check logs for `email worker disabled`. Common causes:
+- `EMAIL_MODE=disabled` (intentional in dev)
+- `EMAIL_MODE=live` but `RESEND_API_KEY` not set
+- Template parsing failure (check embedded templates)
+
+### Dead-lettered emails
+
+Emails that exhaust all retry attempts are moved to `dead_letter` status. Query:
+
+```sql
+SELECT id, tenant_id, template_name, recipient_email, last_error, attempts, max_attempts
+FROM email_outbox
+WHERE status = 'dead_letter'
+ORDER BY updated_at DESC
+LIMIT 20;
+```
+
+To retry dead-lettered emails, reset their status:
+
+```sql
+UPDATE email_outbox
+SET status = 'pending', attempts = 0, last_error = NULL
+WHERE id = '<uuid>';
+```
+
+### Circuit breaker open
+
+The email processor includes a circuit breaker that opens after repeated send failures. When open, all sends are skipped until the half-open timeout expires.
+
+Monitor via Prometheus metric: `meridian_email_outbox_circuit_breaker_state` (0=closed, 1=half-open, 2=open).
+
+### Webhook delivery failures
+
+If the Resend webhook is not updating delivery status:
+- Verify `RESEND_WEBHOOK_SECRET` matches the signing secret in the Resend dashboard
+- Check that the webhook endpoint is accessible: `POST /webhooks/resend`
+- Review audit table for received events:
+
+```sql
+SELECT id, resend_email_id, event_type, created_at
+FROM email_audit
+ORDER BY created_at DESC
+LIMIT 20;
+```
+
+## Metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `meridian_email_outbox_pending_total` | Gauge | Current pending outbox entries |
+| `meridian_email_outbox_send_duration_seconds` | Histogram | Email send API call duration |
+| `meridian_email_outbox_send_errors_total` | Counter | Failed sends by template and error type |
+| `meridian_email_outbox_dead_letter_total` | Counter | Emails exhausting all retries |
+| `meridian_email_outbox_cancelled_total` | Counter | Cancelled emails (e.g., paid invoices) |
+| `meridian_email_outbox_circuit_breaker_state` | Gauge | Circuit breaker state (0/1/2) |

--- a/docs/runbooks/email-infrastructure.md
+++ b/docs/runbooks/email-infrastructure.md
@@ -110,7 +110,9 @@ WHERE id = '<uuid>';
 
 ### Circuit breaker open
 
-The email processor includes a circuit breaker that opens after repeated send failures. When open, all sends are skipped until the half-open timeout expires.
+The email processor includes a circuit breaker that opens after repeated
+send failures. When open, all sends are skipped until the half-open
+timeout expires.
 
 Monitor via Prometheus metric:
 `meridian_email_outbox_circuit_breaker_state` (0=closed, 1=half-open, 2=open).

--- a/docs/runbooks/email-infrastructure.md
+++ b/docs/runbooks/email-infrastructure.md
@@ -2,13 +2,16 @@
 
 ## Overview
 
-Meridian sends transactional emails (payment confirmations, dunning notices) via the email dispatch worker. Emails are queued in an outbox table in the payment-order database and dispatched by a background worker that polls for pending entries.
+Meridian sends transactional emails (payment confirmations, dunning notices)
+via the email dispatch worker. Emails are queued in an outbox table in the
+payment-order database and dispatched by a background worker that polls for
+pending entries.
 
 **Provider**: [Resend](https://resend.com) (HTTP API, Svix-signed webhooks for delivery status).
 
 ## Architecture
 
-```
+```text
 Saga/Service -> OutboxRepository (INSERT) -> email_outbox table
                                                   |
                                           Email Worker (polls)
@@ -44,7 +47,7 @@ Configure these DNS records for the sending domain:
 
 ### SPF
 
-```
+```text
 TXT  meridianhub.cloud  "v=spf1 include:amazonses.com ~all"
 ```
 
@@ -52,7 +55,7 @@ TXT  meridianhub.cloud  "v=spf1 include:amazonses.com ~all"
 
 Add the DKIM records provided by Resend during domain verification. Typically three CNAME records:
 
-```
+```text
 CNAME  resend._domainkey.meridianhub.cloud  -> (value from Resend)
 CNAME  s1._domainkey.meridianhub.cloud      -> (value from Resend)
 CNAME  s2._domainkey.meridianhub.cloud      -> (value from Resend)
@@ -60,7 +63,7 @@ CNAME  s2._domainkey.meridianhub.cloud      -> (value from Resend)
 
 ### DMARC
 
-```
+```text
 TXT  _dmarc.meridianhub.cloud  "v=DMARC1; p=quarantine; rua=mailto:dmarc@meridianhub.cloud"
 ```
 
@@ -109,7 +112,8 @@ WHERE id = '<uuid>';
 
 The email processor includes a circuit breaker that opens after repeated send failures. When open, all sends are skipped until the half-open timeout expires.
 
-Monitor via Prometheus metric: `meridian_email_outbox_circuit_breaker_state` (0=closed, 1=half-open, 2=open).
+Monitor via Prometheus metric:
+`meridian_email_outbox_circuit_breaker_state` (0=closed, 1=half-open, 2=open).
 
 ### Webhook delivery failures
 

--- a/docs/runbooks/email-infrastructure.md
+++ b/docs/runbooks/email-infrastructure.md
@@ -38,7 +38,7 @@ Saga/Service -> OutboxRepository (INSERT) -> email_outbox table
 ### Modes
 
 - **disabled**: No-op sender, worker does not start. Default in local dev.
-- **log**: Logs email content to stdout via slog. Useful for integration testing.
+- **log**: Logs email content to stdout via slog. Local dev and CI only.
 - **live**: Sends real emails via Resend API. Requires `RESEND_API_KEY`.
 
 ## DNS Setup (meridianhub.cloud)
@@ -93,9 +93,9 @@ Check logs for `email worker disabled`. Common causes:
 Emails that exhaust all retry attempts are moved to `dead_letter` status. Query:
 
 ```sql
-SELECT id, tenant_id, template_name, recipient_email, last_error, attempts, max_attempts
+SELECT id, tenant_id, template_name, to_addresses, last_error, attempts, max_attempts
 FROM email_outbox
-WHERE status = 'dead_letter'
+WHERE status = 'DEAD_LETTER'
 ORDER BY updated_at DESC
 LIMIT 20;
 ```
@@ -104,7 +104,7 @@ To retry dead-lettered emails, reset their status:
 
 ```sql
 UPDATE email_outbox
-SET status = 'pending', attempts = 0, last_error = NULL
+SET status = 'PENDING', attempts = 0, last_error = NULL
 WHERE id = '<uuid>';
 ```
 
@@ -125,8 +125,8 @@ If the Resend webhook is not updating delivery status:
 - Review audit table for received events:
 
 ```sql
-SELECT id, resend_email_id, event_type, created_at
-FROM email_audit
+SELECT id, outbox_id, provider_id, template_name, status, created_at
+FROM email_audit_log
 ORDER BY created_at DESC
 LIMIT 20;
 ```


### PR DESCRIPTION
## Summary

- Registers the email dispatch worker in `cmd/meridian/main.go` with graceful shutdown
- Worker controlled by `EMAIL_MODE` env var (disabled/log/live), defaults to `disabled` in dev
- Polls the payment-order database outbox table for pending emails
- Adds `EMAIL_*` environment variables to `.env.example`
- Adds email infrastructure runbook covering DNS setup, Resend configuration, troubleshooting, and metrics

## Changes Made

- `cmd/meridian/main.go`: Added `startEmailWorker()` function, wired into binary lifecycle with `Start()`/`Stop()`, added `EMAIL_MODE=disabled` to dev defaults
- `.env.example`: Added email dispatch worker configuration section
- `docs/runbooks/email-infrastructure.md`: New runbook for email operations

## Technical Details

The email worker follows the same pattern as the provisioning worker:
1. Created after service registration
2. Started via `Start(ctx)` in background goroutine
3. Stopped during graceful shutdown before gRPC server stops

When `EMAIL_MODE=disabled` (the dev default), `NewSenderFromEnv` returns a `NoopSender` and the worker skips initialization entirely. When `EMAIL_MODE=live`, the worker requires `RESEND_API_KEY` and sends real emails.

## Test Plan

- [ ] Binary compiles successfully (`go build ./cmd/meridian/`)
- [ ] Worker starts in `log` mode (set `EMAIL_MODE=log`, check for startup log)
- [ ] Worker disabled by default (no env vars needed, logs "email worker disabled")
- [ ] Graceful shutdown stops the worker cleanly
- [ ] CI passes (EMAIL_MODE not set in tests, worker code not exercised by unit tests)