### PR TITLE
feat: make ApplyManifest fully idempotent for re-application

### DIFF
--- a/services/control-plane/internal/applier/internal_account_client.go
+++ b/services/control-plane/internal/applier/internal_account_client.go
@@ -6,6 +6,8 @@ import (
 	internalaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_account/v1"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // InternalAccountClient wraps the internal-account gRPC client to implement
@@ -38,6 +40,14 @@ func (c *InternalAccountClient) InitiateAccount(ctx *saga.StarlarkContext, param
 	callCtx := prepareCallContext(ctx)
 	resp, err := c.client.InitiateInternalAccount(callCtx, req)
 	if err != nil {
+		// Idempotency: treat AlreadyExists as success for manifest re-apply scenarios
+		// where the account was already created by a previous apply.
+		if status.Code(err) == codes.AlreadyExists {
+			return map[string]any{
+				"account_code": req.AccountCode,
+				"status":       "ACCOUNT_STATUS_ACTIVE",
+			}, nil
+		}
 		return nil, fmt.Errorf("initiate internal account: %w", err)
 	}
 

--- a/services/control-plane/internal/applier/internal_account_client.go
+++ b/services/control-plane/internal/applier/internal_account_client.go
@@ -1,6 +1,7 @@
 package applier
 
 import (
+	"context"
 	"fmt"
 
 	internalaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_account/v1"
@@ -42,11 +43,9 @@ func (c *InternalAccountClient) InitiateAccount(ctx *saga.StarlarkContext, param
 	if err != nil {
 		// Idempotency: treat AlreadyExists as success for manifest re-apply scenarios
 		// where the account was already created by a previous apply.
+		// Look up the existing account to return account_id (required by the saga script).
 		if status.Code(err) == codes.AlreadyExists {
-			return map[string]any{
-				"account_code": req.AccountCode,
-				"status":       "ACCOUNT_STATUS_ACTIVE",
-			}, nil
+			return c.handleAlreadyExists(callCtx, req.AccountCode)
 		}
 		return nil, fmt.Errorf("initiate internal account: %w", err)
 	}
@@ -55,6 +54,25 @@ func (c *InternalAccountClient) InitiateAccount(ctx *saga.StarlarkContext, param
 		"account_id":   resp.GetAccountId(),
 		"account_code": req.AccountCode,
 		"status":       resp.GetFacility().GetAccountStatus().String(),
+	}, nil
+}
+
+// handleAlreadyExists resolves the existing account by code so that
+// downstream saga steps receive account_id. The RetrieveInternalAccount
+// RPC accepts account_code as well as UUID.
+func (c *InternalAccountClient) handleAlreadyExists(ctx context.Context, accountCode string) (any, error) {
+	resp, err := c.client.RetrieveInternalAccount(ctx, &internalaccountv1.RetrieveInternalAccountRequest{
+		AccountId: accountCode,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("initiate internal account: account already exists but lookup failed: %w", err)
+	}
+
+	facility := resp.GetFacility()
+	return map[string]any{
+		"account_id":   facility.GetAccountId(),
+		"account_code": facility.GetAccountCode(),
+		"status":       facility.GetAccountStatus().String(),
 	}, nil
 }
 

--- a/services/control-plane/internal/applier/internal_account_client_test.go
+++ b/services/control-plane/internal/applier/internal_account_client_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -21,9 +23,13 @@ var _ InternalAccountService = (*InternalAccountClient)(nil)
 
 type fakeInternalAccountServer struct {
 	internalaccountv1.UnimplementedInternalAccountServiceServer
+	initiateFn func(context.Context, *internalaccountv1.InitiateInternalAccountRequest) (*internalaccountv1.InitiateInternalAccountResponse, error)
 }
 
-func (f *fakeInternalAccountServer) InitiateInternalAccount(_ context.Context, req *internalaccountv1.InitiateInternalAccountRequest) (*internalaccountv1.InitiateInternalAccountResponse, error) {
+func (f *fakeInternalAccountServer) InitiateInternalAccount(ctx context.Context, req *internalaccountv1.InitiateInternalAccountRequest) (*internalaccountv1.InitiateInternalAccountResponse, error) {
+	if f.initiateFn != nil {
+		return f.initiateFn(ctx, req)
+	}
 	return &internalaccountv1.InitiateInternalAccountResponse{
 		AccountId: "ia-uuid-1",
 		Facility: &internalaccountv1.InternalAccountFacility{
@@ -35,12 +41,12 @@ func (f *fakeInternalAccountServer) InitiateInternalAccount(_ context.Context, r
 
 // ─── Test setup ────────────────────────────────────────────────────────────
 
-func newInternalAccountTestServer(t *testing.T) *grpc.ClientConn {
+func newInternalAccountTestServerWith(t *testing.T, fakeSrv *fakeInternalAccountServer) *grpc.ClientConn {
 	t.Helper()
 
 	lis := bufconn.Listen(1024 * 1024)
 	srv := grpc.NewServer()
-	internalaccountv1.RegisterInternalAccountServiceServer(srv, &fakeInternalAccountServer{})
+	internalaccountv1.RegisterInternalAccountServiceServer(srv, fakeSrv)
 
 	go func() { _ = srv.Serve(lis) }()
 	t.Cleanup(srv.GracefulStop)
@@ -53,6 +59,10 @@ func newInternalAccountTestServer(t *testing.T) *grpc.ClientConn {
 	t.Cleanup(func() { _ = conn.Close() })
 
 	return conn
+}
+
+func newInternalAccountTestServer(t *testing.T) *grpc.ClientConn {
+	return newInternalAccountTestServerWith(t, &fakeInternalAccountServer{})
 }
 
 // ─── Tests ─────────────────────────────────────────────────────────────────
@@ -90,4 +100,42 @@ func TestInternalAccountClient_InitiateAccount_MinimalParams(t *testing.T) {
 	m := result.(map[string]any)
 	assert.Equal(t, "ia-uuid-1", m["account_id"])
 	assert.Equal(t, "MINIMAL", m["account_code"])
+}
+
+// ─── Idempotency tests ──────────────────────────────────────────────────────
+
+func TestInternalAccountClient_InitiateAccount_AlreadyExists_TreatedAsSuccess(t *testing.T) {
+	srv := &fakeInternalAccountServer{
+		initiateFn: func(_ context.Context, _ *internalaccountv1.InitiateInternalAccountRequest) (*internalaccountv1.InitiateInternalAccountResponse, error) {
+			return nil, status.Error(codes.AlreadyExists, "account code already exists: CLEARING_GBP")
+		},
+	}
+	conn := newInternalAccountTestServerWith(t, srv)
+	client := NewInternalAccountClient(conn)
+
+	ctx := &saga.StarlarkContext{Context: context.Background()}
+	result, err := client.InitiateAccount(ctx, map[string]any{
+		"account_code": "CLEARING_GBP",
+	})
+	require.NoError(t, err, "AlreadyExists should be treated as idempotent success")
+	m := result.(map[string]any)
+	assert.Equal(t, "CLEARING_GBP", m["account_code"])
+	assert.Equal(t, "ACCOUNT_STATUS_ACTIVE", m["status"])
+}
+
+func TestInternalAccountClient_InitiateAccount_OtherError_Propagated(t *testing.T) {
+	srv := &fakeInternalAccountServer{
+		initiateFn: func(_ context.Context, _ *internalaccountv1.InitiateInternalAccountRequest) (*internalaccountv1.InitiateInternalAccountResponse, error) {
+			return nil, status.Error(codes.Internal, "database unavailable")
+		},
+	}
+	conn := newInternalAccountTestServerWith(t, srv)
+	client := NewInternalAccountClient(conn)
+
+	ctx := &saga.StarlarkContext{Context: context.Background()}
+	_, err := client.InitiateAccount(ctx, map[string]any{
+		"account_code": "WILL_FAIL",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database unavailable")
 }

--- a/services/control-plane/internal/applier/internal_account_client_test.go
+++ b/services/control-plane/internal/applier/internal_account_client_test.go
@@ -24,6 +24,7 @@ var _ InternalAccountService = (*InternalAccountClient)(nil)
 type fakeInternalAccountServer struct {
 	internalaccountv1.UnimplementedInternalAccountServiceServer
 	initiateFn func(context.Context, *internalaccountv1.InitiateInternalAccountRequest) (*internalaccountv1.InitiateInternalAccountResponse, error)
+	retrieveFn func(context.Context, *internalaccountv1.RetrieveInternalAccountRequest) (*internalaccountv1.RetrieveInternalAccountResponse, error)
 }
 
 func (f *fakeInternalAccountServer) InitiateInternalAccount(ctx context.Context, req *internalaccountv1.InitiateInternalAccountRequest) (*internalaccountv1.InitiateInternalAccountResponse, error) {
@@ -34,6 +35,19 @@ func (f *fakeInternalAccountServer) InitiateInternalAccount(ctx context.Context,
 		AccountId: "ia-uuid-1",
 		Facility: &internalaccountv1.InternalAccountFacility{
 			AccountCode:   req.AccountCode,
+			AccountStatus: internalaccountv1.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_ACTIVE,
+		},
+	}, nil
+}
+
+func (f *fakeInternalAccountServer) RetrieveInternalAccount(ctx context.Context, req *internalaccountv1.RetrieveInternalAccountRequest) (*internalaccountv1.RetrieveInternalAccountResponse, error) {
+	if f.retrieveFn != nil {
+		return f.retrieveFn(ctx, req)
+	}
+	return &internalaccountv1.RetrieveInternalAccountResponse{
+		Facility: &internalaccountv1.InternalAccountFacility{
+			AccountId:     "existing-ia-uuid",
+			AccountCode:   req.AccountId, // The service accepts code as account_id
 			AccountStatus: internalaccountv1.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_ACTIVE,
 		},
 	}, nil
@@ -119,8 +133,29 @@ func TestInternalAccountClient_InitiateAccount_AlreadyExists_TreatedAsSuccess(t 
 	})
 	require.NoError(t, err, "AlreadyExists should be treated as idempotent success")
 	m := result.(map[string]any)
+	assert.Equal(t, "existing-ia-uuid", m["account_id"])
 	assert.Equal(t, "CLEARING_GBP", m["account_code"])
-	assert.Equal(t, "ACCOUNT_STATUS_ACTIVE", m["status"])
+	assert.Contains(t, m["status"], "ACTIVE")
+}
+
+func TestInternalAccountClient_InitiateAccount_AlreadyExists_LookupFails(t *testing.T) {
+	srv := &fakeInternalAccountServer{
+		initiateFn: func(_ context.Context, _ *internalaccountv1.InitiateInternalAccountRequest) (*internalaccountv1.InitiateInternalAccountResponse, error) {
+			return nil, status.Error(codes.AlreadyExists, "account code already exists")
+		},
+		retrieveFn: func(_ context.Context, _ *internalaccountv1.RetrieveInternalAccountRequest) (*internalaccountv1.RetrieveInternalAccountResponse, error) {
+			return nil, status.Error(codes.NotFound, "account not found")
+		},
+	}
+	conn := newInternalAccountTestServerWith(t, srv)
+	client := NewInternalAccountClient(conn)
+
+	ctx := &saga.StarlarkContext{Context: context.Background()}
+	_, err := client.InitiateAccount(ctx, map[string]any{
+		"account_code": "MISSING",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lookup failed")
 }
 
 func TestInternalAccountClient_InitiateAccount_OtherError_Propagated(t *testing.T) {

--- a/services/control-plane/internal/applier/market_information_client.go
+++ b/services/control-plane/internal/applier/market_information_client.go
@@ -1,6 +1,7 @@
 package applier
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -8,6 +9,8 @@ import (
 	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -44,6 +47,13 @@ func (c *MarketInformationClient) RegisterDataSource(ctx *saga.StarlarkContext, 
 	callCtx := prepareCallContext(ctx)
 	resp, err := c.client.RegisterDataSource(callCtx, req)
 	if err != nil {
+		// Idempotency: treat AlreadyExists as success for manifest re-apply scenarios.
+		if status.Code(err) == codes.AlreadyExists {
+			return map[string]any{
+				"code":   req.Code,
+				"status": "REGISTERED",
+			}, nil
+		}
 		return nil, fmt.Errorf("register data source: %w", err)
 	}
 
@@ -86,6 +96,11 @@ func (c *MarketInformationClient) RegisterDataSet(ctx *saga.StarlarkContext, par
 	callCtx := prepareCallContext(ctx)
 	resp, err := c.client.RegisterDataSet(callCtx, req)
 	if err != nil {
+		// Idempotency: treat AlreadyExists as success for manifest re-apply scenarios.
+		// Attempt to retrieve the existing data set to return its details.
+		if status.Code(err) == codes.AlreadyExists {
+			return c.handleDataSetAlreadyExists(callCtx, req.Code)
+		}
 		return nil, fmt.Errorf("register data set: %w", err)
 	}
 
@@ -110,6 +125,11 @@ func (c *MarketInformationClient) ActivateDataSet(ctx *saga.StarlarkContext, par
 	callCtx := prepareCallContext(ctx)
 	resp, err := c.client.ActivateDataSet(callCtx, req)
 	if err != nil {
+		// Idempotency: treat FailedPrecondition as success when the data set is already ACTIVE.
+		// The service returns FailedPrecondition for invalid status transitions (e.g., ACTIVE -> ACTIVE).
+		if status.Code(err) == codes.FailedPrecondition {
+			return c.handleDataSetAlreadyExists(callCtx, req.Code)
+		}
 		return nil, fmt.Errorf("activate data set: %w", err)
 	}
 
@@ -119,6 +139,29 @@ func (c *MarketInformationClient) ActivateDataSet(ctx *saga.StarlarkContext, par
 		"code":       ds.GetCode(),
 		"version":    ds.GetVersion(),
 		"status":     ds.GetStatus().String(),
+	}, nil
+}
+
+// handleDataSetAlreadyExists retrieves an existing data set by code so that
+// downstream saga steps receive dataset_id. Falls back to a best-effort
+// result without dataset_id if the lookup fails.
+func (c *MarketInformationClient) handleDataSetAlreadyExists(ctx context.Context, code string) (any, error) {
+	resp, err := c.client.RetrieveDataSet(ctx, &marketinformationv1.RetrieveDataSetRequest{
+		Code: code,
+	})
+	if err == nil {
+		ds := resp.GetDataset()
+		return map[string]any{
+			"dataset_id": ds.GetId(),
+			"code":       ds.GetCode(),
+			"version":    ds.GetVersion(),
+			"status":     ds.GetStatus().String(),
+		}, nil
+	}
+	// Best-effort fallback when lookup fails
+	return map[string]any{
+		"code":   code,
+		"status": "DATA_SET_STATUS_ACTIVE",
 	}, nil
 }
 

--- a/services/control-plane/internal/applier/market_information_client.go
+++ b/services/control-plane/internal/applier/market_information_client.go
@@ -125,10 +125,18 @@ func (c *MarketInformationClient) ActivateDataSet(ctx *saga.StarlarkContext, par
 	callCtx := prepareCallContext(ctx)
 	resp, err := c.client.ActivateDataSet(callCtx, req)
 	if err != nil {
-		// Idempotency: treat FailedPrecondition as success when the data set is already ACTIVE.
-		// The service returns FailedPrecondition for invalid status transitions (e.g., ACTIVE -> ACTIVE).
+		// Idempotency: on FailedPrecondition, check if the data set is already ACTIVE.
+		// Only treat as success if the dataset has reached the desired state.
 		if status.Code(err) == codes.FailedPrecondition {
-			return c.handleDataSetAlreadyExists(callCtx, req.Code)
+			existing, lookupErr := c.retrieveDataSet(callCtx, req.Code)
+			if lookupErr == nil && existing.GetStatus() == marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE {
+				return map[string]any{
+					"dataset_id": existing.GetId(),
+					"code":       existing.GetCode(),
+					"version":    existing.GetVersion(),
+					"status":     existing.GetStatus().String(),
+				}, nil
+			}
 		}
 		return nil, fmt.Errorf("activate data set: %w", err)
 	}
@@ -143,26 +151,29 @@ func (c *MarketInformationClient) ActivateDataSet(ctx *saga.StarlarkContext, par
 }
 
 // handleDataSetAlreadyExists retrieves an existing data set by code so that
-// downstream saga steps receive dataset_id. Falls back to a best-effort
-// result without dataset_id if the lookup fails.
+// downstream saga steps receive dataset_id. Returns an error if the lookup fails.
 func (c *MarketInformationClient) handleDataSetAlreadyExists(ctx context.Context, code string) (any, error) {
+	ds, err := c.retrieveDataSet(ctx, code)
+	if err != nil {
+		return nil, fmt.Errorf("register data set: dataset already exists but lookup failed: %w", err)
+	}
+	return map[string]any{
+		"dataset_id": ds.GetId(),
+		"code":       ds.GetCode(),
+		"version":    ds.GetVersion(),
+		"status":     ds.GetStatus().String(),
+	}, nil
+}
+
+// retrieveDataSet looks up a data set by code. Returns the proto definition or an error.
+func (c *MarketInformationClient) retrieveDataSet(ctx context.Context, code string) (*marketinformationv1.DataSetDefinition, error) {
 	resp, err := c.client.RetrieveDataSet(ctx, &marketinformationv1.RetrieveDataSetRequest{
 		Code: code,
 	})
-	if err == nil {
-		ds := resp.GetDataset()
-		return map[string]any{
-			"dataset_id": ds.GetId(),
-			"code":       ds.GetCode(),
-			"version":    ds.GetVersion(),
-			"status":     ds.GetStatus().String(),
-		}, nil
+	if err != nil {
+		return nil, err
 	}
-	// Best-effort fallback when lookup fails
-	return map[string]any{
-		"code":   code,
-		"status": "DATA_SET_STATUS_ACTIVE",
-	}, nil
+	return resp.GetDataset(), nil
 }
 
 // parseDataCategory converts a string category name to the proto enum value.

--- a/services/control-plane/internal/applier/market_information_client_test.go
+++ b/services/control-plane/internal/applier/market_information_client_test.go
@@ -355,9 +355,27 @@ func TestMarketInformationClient_RegisterDataSet_AlreadyExists_TreatedAsSuccess(
 	assert.Equal(t, int32(1), m["version"])
 }
 
-func TestMarketInformationClient_ActivateDataSet_FailedPrecondition_TreatedAsSuccess(t *testing.T) {
+func TestMarketInformationClient_RegisterDataSet_AlreadyExists_LookupFails(t *testing.T) {
+	srv := &fakeMarketInformationServer{
+		registerDataSetErr: status.Error(codes.AlreadyExists, "dataset already exists"),
+		retrieveDataSetFn: func(_ context.Context, _ *marketinformationv1.RetrieveDataSetRequest) (*marketinformationv1.RetrieveDataSetResponse, error) {
+			return nil, status.Error(codes.NotFound, "dataset not found")
+		},
+	}
+	conn := newMarketInformationTestServer(t, srv)
+	client := NewMarketInformationClient(conn)
+
+	_, err := client.RegisterDataSet(testStarlarkCtx(), map[string]any{
+		"code": "GHOST_DS",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lookup failed")
+}
+
+func TestMarketInformationClient_ActivateDataSet_AlreadyActive_TreatedAsSuccess(t *testing.T) {
 	srv := &fakeMarketInformationServer{
 		activateDataSetErr: status.Error(codes.FailedPrecondition, "invalid status transition: ACTIVE to ACTIVE"),
+		// RetrieveDataSet returns ACTIVE status, confirming idempotent completion
 	}
 	conn := newMarketInformationTestServer(t, srv)
 	client := NewMarketInformationClient(conn)
@@ -370,4 +388,29 @@ func TestMarketInformationClient_ActivateDataSet_FailedPrecondition_TreatedAsSuc
 	m := result.(map[string]any)
 	assert.Equal(t, "ds-existing-uuid", m["dataset_id"])
 	assert.Equal(t, "ALREADY_ACTIVE", m["code"])
+}
+
+func TestMarketInformationClient_ActivateDataSet_NotActive_ErrorPropagated(t *testing.T) {
+	srv := &fakeMarketInformationServer{
+		activateDataSetErr: status.Error(codes.FailedPrecondition, "invalid status transition: DEPRECATED to ACTIVE"),
+		retrieveDataSetFn: func(_ context.Context, req *marketinformationv1.RetrieveDataSetRequest) (*marketinformationv1.RetrieveDataSetResponse, error) {
+			return &marketinformationv1.RetrieveDataSetResponse{
+				Dataset: &marketinformationv1.DataSetDefinition{
+					Id:      "ds-uuid-1",
+					Code:    req.Code,
+					Version: 1,
+					Status:  marketinformationv1.DataSetStatus_DATA_SET_STATUS_DEPRECATED,
+				},
+			}, nil
+		},
+	}
+	conn := newMarketInformationTestServer(t, srv)
+	client := NewMarketInformationClient(conn)
+
+	_, err := client.ActivateDataSet(testStarlarkCtx(), map[string]any{
+		"code":    "DEPRECATED_DS",
+		"version": int32(1),
+	})
+	require.Error(t, err, "FailedPrecondition for non-ACTIVE should propagate")
+	assert.Contains(t, err.Error(), "activate data set")
 }

--- a/services/control-plane/internal/applier/market_information_client_test.go
+++ b/services/control-plane/internal/applier/market_information_client_test.go
@@ -25,6 +25,7 @@ type fakeMarketInformationServer struct {
 	registerDataSourceErr error
 	registerDataSetErr    error
 	activateDataSetErr    error
+	retrieveDataSetFn     func(context.Context, *marketinformationv1.RetrieveDataSetRequest) (*marketinformationv1.RetrieveDataSetResponse, error)
 }
 
 func (f *fakeMarketInformationServer) RegisterDataSource(_ context.Context, req *marketinformationv1.RegisterDataSourceRequest) (*marketinformationv1.RegisterDataSourceResponse, error) {
@@ -62,6 +63,20 @@ func (f *fakeMarketInformationServer) ActivateDataSet(_ context.Context, req *ma
 			Id:      "ds-uuid-1",
 			Code:    req.Code,
 			Version: req.Version,
+			Status:  marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
+		},
+	}, nil
+}
+
+func (f *fakeMarketInformationServer) RetrieveDataSet(ctx context.Context, req *marketinformationv1.RetrieveDataSetRequest) (*marketinformationv1.RetrieveDataSetResponse, error) {
+	if f.retrieveDataSetFn != nil {
+		return f.retrieveDataSetFn(ctx, req)
+	}
+	return &marketinformationv1.RetrieveDataSetResponse{
+		Dataset: &marketinformationv1.DataSetDefinition{
+			Id:      "ds-existing-uuid",
+			Code:    req.Code,
+			Version: 1,
 			Status:  marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
 		},
 	}, nil
@@ -155,15 +170,31 @@ func TestMarketInformationClient_RegisterDataSource_MinimalParams(t *testing.T) 
 	assert.Equal(t, "MINIMAL", m["code"])
 }
 
-func TestMarketInformationClient_RegisterDataSource_GRPCError(t *testing.T) {
+func TestMarketInformationClient_RegisterDataSource_AlreadyExists_TreatedAsSuccess(t *testing.T) {
 	srv := &fakeMarketInformationServer{
 		registerDataSourceErr: status.Error(codes.AlreadyExists, "data source already exists"),
 	}
 	conn := newMarketInformationTestServer(t, srv)
 	client := NewMarketInformationClient(conn)
 
-	_, err := client.RegisterDataSource(testStarlarkCtx(), map[string]any{
+	result, err := client.RegisterDataSource(testStarlarkCtx(), map[string]any{
 		"code": "DUPLICATE",
+	})
+	require.NoError(t, err, "AlreadyExists should be treated as idempotent success")
+	m := result.(map[string]any)
+	assert.Equal(t, "DUPLICATE", m["code"])
+	assert.Equal(t, "REGISTERED", m["status"])
+}
+
+func TestMarketInformationClient_RegisterDataSource_OtherError_Propagated(t *testing.T) {
+	srv := &fakeMarketInformationServer{
+		registerDataSourceErr: status.Error(codes.Internal, "database unavailable"),
+	}
+	conn := newMarketInformationTestServer(t, srv)
+	client := NewMarketInformationClient(conn)
+
+	_, err := client.RegisterDataSource(testStarlarkCtx(), map[string]any{
+		"code": "WILL_FAIL",
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "register data source")
@@ -303,4 +334,40 @@ func TestMarketInformationClient_ActivateDataSet_GRPCError(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "activate data set")
+}
+
+// ─── Idempotency tests ──────────────────────────────────────────────────────
+
+func TestMarketInformationClient_RegisterDataSet_AlreadyExists_TreatedAsSuccess(t *testing.T) {
+	srv := &fakeMarketInformationServer{
+		registerDataSetErr: status.Error(codes.AlreadyExists, "dataset already exists"),
+	}
+	conn := newMarketInformationTestServer(t, srv)
+	client := NewMarketInformationClient(conn)
+
+	result, err := client.RegisterDataSet(testStarlarkCtx(), map[string]any{
+		"code": "EXISTING_DS",
+	})
+	require.NoError(t, err, "AlreadyExists should be treated as idempotent success")
+	m := result.(map[string]any)
+	assert.Equal(t, "ds-existing-uuid", m["dataset_id"])
+	assert.Equal(t, "EXISTING_DS", m["code"])
+	assert.Equal(t, int32(1), m["version"])
+}
+
+func TestMarketInformationClient_ActivateDataSet_FailedPrecondition_TreatedAsSuccess(t *testing.T) {
+	srv := &fakeMarketInformationServer{
+		activateDataSetErr: status.Error(codes.FailedPrecondition, "invalid status transition: ACTIVE to ACTIVE"),
+	}
+	conn := newMarketInformationTestServer(t, srv)
+	client := NewMarketInformationClient(conn)
+
+	result, err := client.ActivateDataSet(testStarlarkCtx(), map[string]any{
+		"code":    "ALREADY_ACTIVE",
+		"version": int32(1),
+	})
+	require.NoError(t, err, "FailedPrecondition for already-active should be treated as idempotent success")
+	m := result.(map[string]any)
+	assert.Equal(t, "ds-existing-uuid", m["dataset_id"])
+	assert.Equal(t, "ALREADY_ACTIVE", m["code"])
 }

--- a/services/control-plane/internal/applier/reference_data_client.go
+++ b/services/control-plane/internal/applier/reference_data_client.go
@@ -265,24 +265,19 @@ func (c *ReferenceDataClient) RegisterSagaDefinition(ctx *saga.StarlarkContext, 
 }
 
 // handleSagaAlreadyExists resolves the existing active saga by name so that
-// downstream saga steps receive the saga_id. Falls back to a best-effort
-// result without saga_id if the lookup fails.
+// downstream saga steps receive the saga_id. Returns an error if the lookup fails.
 func (c *ReferenceDataClient) handleSagaAlreadyExists(ctx context.Context, name string) (any, error) {
 	resp, err := c.sagas.GetActiveSaga(ctx, &sagav1.GetActiveSagaRequest{
 		Name: name,
 	})
-	if err == nil {
-		s := resp.GetSaga()
-		return map[string]any{
-			"saga_name": s.GetName(),
-			"saga_id":   s.GetId(),
-			"status":    s.GetStatus().String(),
-		}, nil
+	if err != nil {
+		return nil, fmt.Errorf("create saga draft: saga already exists but lookup failed: %w", err)
 	}
-	// Best-effort fallback when lookup fails
+	s := resp.GetSaga()
 	return map[string]any{
-		"saga_name": name,
-		"status":    "ACTIVE",
+		"saga_name": s.GetName(),
+		"saga_id":   s.GetId(),
+		"status":    s.GetStatus().String(),
 	}, nil
 }
 

--- a/services/control-plane/internal/applier/reference_data_client.go
+++ b/services/control-plane/internal/applier/reference_data_client.go
@@ -10,7 +10,9 @@ import (
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 // prepareCallContext enriches the gRPC call context with saga metadata:
@@ -236,6 +238,11 @@ func (c *ReferenceDataClient) RegisterSagaDefinition(ctx *saga.StarlarkContext, 
 	callCtx := prepareCallContext(ctx)
 	draftResp, err := c.sagas.CreateSagaDraft(callCtx, draftReq)
 	if err != nil {
+		// Idempotency: treat AlreadyExists as success for manifest re-apply scenarios.
+		// Look up the existing active saga by name to return its details.
+		if status.Code(err) == codes.AlreadyExists {
+			return c.handleSagaAlreadyExists(callCtx, draftReq.Name)
+		}
 		return nil, fmt.Errorf("create saga draft: %w", err)
 	}
 
@@ -254,6 +261,28 @@ func (c *ReferenceDataClient) RegisterSagaDefinition(ctx *saga.StarlarkContext, 
 		"saga_name": activeSaga.GetName(),
 		"saga_id":   activeSaga.GetId(),
 		"status":    activeSaga.GetStatus().String(),
+	}, nil
+}
+
+// handleSagaAlreadyExists resolves the existing active saga by name so that
+// downstream saga steps receive the saga_id. Falls back to a best-effort
+// result without saga_id if the lookup fails.
+func (c *ReferenceDataClient) handleSagaAlreadyExists(ctx context.Context, name string) (any, error) {
+	resp, err := c.sagas.GetActiveSaga(ctx, &sagav1.GetActiveSagaRequest{
+		Name: name,
+	})
+	if err == nil {
+		s := resp.GetSaga()
+		return map[string]any{
+			"saga_name": s.GetName(),
+			"saga_id":   s.GetId(),
+			"status":    s.GetStatus().String(),
+		}, nil
+	}
+	// Best-effort fallback when lookup fails
+	return map[string]any{
+		"saga_name": name,
+		"status":    "ACTIVE",
 	}, nil
 }
 

--- a/services/control-plane/internal/applier/reference_data_client_test.go
+++ b/services/control-plane/internal/applier/reference_data_client_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -96,9 +98,14 @@ func (f *fakeAccountTypeServer) DeprecateAccountType(_ context.Context, req *ref
 
 type fakeSagaRegistryServer struct {
 	sagav1.UnimplementedSagaRegistryServiceServer
+	createDraftFn  func(context.Context, *sagav1.CreateSagaDraftRequest) (*sagav1.CreateSagaDraftResponse, error)
+	getActiveFn    func(context.Context, *sagav1.GetActiveSagaRequest) (*sagav1.GetActiveSagaResponse, error)
 }
 
-func (f *fakeSagaRegistryServer) CreateSagaDraft(_ context.Context, req *sagav1.CreateSagaDraftRequest) (*sagav1.CreateSagaDraftResponse, error) {
+func (f *fakeSagaRegistryServer) CreateSagaDraft(ctx context.Context, req *sagav1.CreateSagaDraftRequest) (*sagav1.CreateSagaDraftResponse, error) {
+	if f.createDraftFn != nil {
+		return f.createDraftFn(ctx, req)
+	}
 	return &sagav1.CreateSagaDraftResponse{
 		Saga: &sagav1.SagaDefinition{
 			Id:     "saga-uuid-1",
@@ -118,16 +125,33 @@ func (f *fakeSagaRegistryServer) ActivateSaga(_ context.Context, req *sagav1.Act
 	}, nil
 }
 
+func (f *fakeSagaRegistryServer) GetActiveSaga(ctx context.Context, req *sagav1.GetActiveSagaRequest) (*sagav1.GetActiveSagaResponse, error) {
+	if f.getActiveFn != nil {
+		return f.getActiveFn(ctx, req)
+	}
+	return &sagav1.GetActiveSagaResponse{
+		Saga: &sagav1.SagaDefinition{
+			Id:     "existing-saga-uuid",
+			Name:   req.Name,
+			Status: sagav1.SagaStatus_SAGA_STATUS_ACTIVE,
+		},
+	}, nil
+}
+
 // ─── Test setup ────────────────────────────────────────────────────────────
 
 func newRefDataTestServer(t *testing.T) *grpc.ClientConn {
+	return newRefDataTestServerWith(t, &fakeSagaRegistryServer{})
+}
+
+func newRefDataTestServerWith(t *testing.T, sagaSrv *fakeSagaRegistryServer) *grpc.ClientConn {
 	t.Helper()
 
 	lis := bufconn.Listen(1024 * 1024)
 	srv := grpc.NewServer()
 	referencedatav1.RegisterReferenceDataServiceServer(srv, &fakeReferenceDataServer{})
 	referencedatav1.RegisterAccountTypeRegistryServiceServer(srv, &fakeAccountTypeServer{})
-	sagav1.RegisterSagaRegistryServiceServer(srv, &fakeSagaRegistryServer{})
+	sagav1.RegisterSagaRegistryServiceServer(srv, sagaSrv)
 
 	go func() { _ = srv.Serve(lis) }()
 	t.Cleanup(srv.GracefulStop)
@@ -313,4 +337,43 @@ func TestParseNormalBalance(t *testing.T) {
 			assert.Equal(t, tt.expected, parseNormalBalance(tt.input))
 		})
 	}
+}
+
+// ─── Idempotency tests ──────────────────────────────────────────────────────
+
+func TestReferenceDataClient_RegisterSagaDefinition_AlreadyExists_TreatedAsSuccess(t *testing.T) {
+	sagaSrv := &fakeSagaRegistryServer{
+		createDraftFn: func(_ context.Context, _ *sagav1.CreateSagaDraftRequest) (*sagav1.CreateSagaDraftResponse, error) {
+			return nil, status.Error(codes.AlreadyExists, "saga already exists: test-saga")
+		},
+	}
+	conn := newRefDataTestServerWith(t, sagaSrv)
+	client := NewReferenceDataClient(conn, conn)
+
+	result, err := client.RegisterSagaDefinition(testStarlarkCtx(), map[string]any{
+		"saga_name":    "test-saga",
+		"display_name": "Test Saga",
+		"script":       "def execute(): pass",
+	})
+	require.NoError(t, err, "AlreadyExists should be treated as idempotent success")
+	m := result.(map[string]any)
+	assert.Equal(t, "existing-saga-uuid", m["saga_id"])
+	assert.Equal(t, "test-saga", m["saga_name"])
+	assert.Contains(t, m["status"].(string), "ACTIVE")
+}
+
+func TestReferenceDataClient_RegisterSagaDefinition_OtherError_Propagated(t *testing.T) {
+	sagaSrv := &fakeSagaRegistryServer{
+		createDraftFn: func(_ context.Context, _ *sagav1.CreateSagaDraftRequest) (*sagav1.CreateSagaDraftResponse, error) {
+			return nil, status.Error(codes.Internal, "database unavailable")
+		},
+	}
+	conn := newRefDataTestServerWith(t, sagaSrv)
+	client := NewReferenceDataClient(conn, conn)
+
+	_, err := client.RegisterSagaDefinition(testStarlarkCtx(), map[string]any{
+		"saga_name": "test-saga",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create saga draft")
 }

--- a/services/control-plane/internal/applier/reference_data_client_test.go
+++ b/services/control-plane/internal/applier/reference_data_client_test.go
@@ -362,6 +362,25 @@ func TestReferenceDataClient_RegisterSagaDefinition_AlreadyExists_TreatedAsSucce
 	assert.Contains(t, m["status"].(string), "ACTIVE")
 }
 
+func TestReferenceDataClient_RegisterSagaDefinition_AlreadyExists_LookupFails(t *testing.T) {
+	sagaSrv := &fakeSagaRegistryServer{
+		createDraftFn: func(_ context.Context, _ *sagav1.CreateSagaDraftRequest) (*sagav1.CreateSagaDraftResponse, error) {
+			return nil, status.Error(codes.AlreadyExists, "saga already exists")
+		},
+		getActiveFn: func(_ context.Context, _ *sagav1.GetActiveSagaRequest) (*sagav1.GetActiveSagaResponse, error) {
+			return nil, status.Error(codes.NotFound, "no active saga found")
+		},
+	}
+	conn := newRefDataTestServerWith(t, sagaSrv)
+	client := NewReferenceDataClient(conn, conn)
+
+	_, err := client.RegisterSagaDefinition(testStarlarkCtx(), map[string]any{
+		"saga_name": "test-saga",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lookup failed")
+}
+
 func TestReferenceDataClient_RegisterSagaDefinition_OtherError_Propagated(t *testing.T) {
 	sagaSrv := &fakeSagaRegistryServer{
 		createDraftFn: func(_ context.Context, _ *sagav1.CreateSagaDraftRequest) (*sagav1.CreateSagaDraftResponse, error) {

--- a/services/control-plane/internal/applier/reference_data_client_test.go
+++ b/services/control-plane/internal/applier/reference_data_client_test.go
@@ -98,8 +98,8 @@ func (f *fakeAccountTypeServer) DeprecateAccountType(_ context.Context, req *ref
 
 type fakeSagaRegistryServer struct {
 	sagav1.UnimplementedSagaRegistryServiceServer
-	createDraftFn  func(context.Context, *sagav1.CreateSagaDraftRequest) (*sagav1.CreateSagaDraftResponse, error)
-	getActiveFn    func(context.Context, *sagav1.GetActiveSagaRequest) (*sagav1.GetActiveSagaResponse, error)
+	createDraftFn func(context.Context, *sagav1.CreateSagaDraftRequest) (*sagav1.CreateSagaDraftResponse, error)
+	getActiveFn   func(context.Context, *sagav1.GetActiveSagaRequest) (*sagav1.GetActiveSagaResponse, error)
 }
 
 func (f *fakeSagaRegistryServer) CreateSagaDraft(ctx context.Context, req *sagav1.CreateSagaDraftRequest) (*sagav1.CreateSagaDraftResponse, error) {


### PR DESCRIPTION
## Summary

- Make all ApplyManifest saga handlers idempotent so re-applying the same manifest succeeds without errors
- Add `AlreadyExists` handling to `InternalAccountClient`, `MarketInformationClient`, and `ReferenceDataClient` adapters
- Add `FailedPrecondition` handling for `ActivateDataSet` (already-ACTIVE transitions)
- Follow the existing `PartyClient.handleAlreadyExists` pattern: catch the error, look up the existing resource, return its details

## Changes Made

**Handlers made idempotent:**

| Handler | Error Caught | Recovery |
|---------|-------------|----------|
| `RegisterSagaDefinition` | `AlreadyExists` | `GetActiveSaga` by name |
| `InitiateAccount` | `AlreadyExists` | Best-effort (no code-based lookup RPC) |
| `RegisterDataSource` | `AlreadyExists` | Best-effort with code |
| `RegisterDataSet` | `AlreadyExists` | `RetrieveDataSet` by code |
| `ActivateDataSet` | `FailedPrecondition` | `RetrieveDataSet` by code |

**Already idempotent (no changes needed):**
- `RegisterInstrument` - DB-level `ON CONFLICT DO NOTHING`
- `ActivateInstrument` - no-op if already ACTIVE
- `RegisterAccountType` - DB-level `ON CONFLICT DO NOTHING` + idempotent activate
- `RegisterValuationRule` - acknowledgment-only handler
- `UpsertConnection/UpsertRoute` - upsert semantics
- `RegisterOrganization` - already had `handleAlreadyExists`

## Test plan

- [x] Unit tests for each adapter's idempotency behavior (AlreadyExists -> success)
- [x] Unit tests verifying non-AlreadyExists errors still propagate
- [x] All existing tests pass (full `applier` package suite green)
- [ ] CI passes