### PR TITLE
feat: wire account lockout notification email

### DIFF
--- a/services/identity/connector/connector.go
+++ b/services/identity/connector/connector.go
@@ -20,9 +20,11 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/meridianhub/meridian/services/identity/domain"
 	"github.com/meridianhub/meridian/shared/pkg/credentials"
+	"github.com/meridianhub/meridian/shared/pkg/email"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
 
@@ -63,24 +65,47 @@ type PasswordConnector interface {
 // ErrRepositoryNil is returned by New when a nil repository is provided.
 var ErrRepositoryNil = errors.New("connector: repository must not be nil")
 
+// OutboxWriter queues an email for delivery. A narrow interface so the connector
+// does not depend on the full email.OutboxRepository.
+type OutboxWriter interface {
+	Enqueue(ctx context.Context, entry *email.OutboxEntry) error
+}
+
+// Option configures a Connector.
+type Option func(*Connector)
+
+// WithEmailOutbox sets the outbox writer used to queue notification emails.
+// If not provided (or nil), email notifications are silently skipped.
+func WithEmailOutbox(outbox OutboxWriter) Option {
+	return func(c *Connector) {
+		c.emailOutbox = outbox
+	}
+}
+
 // Connector is the local implementation of PasswordConnector.
 // It performs credential validation and role resolution directly against the
 // identity domain repository, avoiding any network hop.
 type Connector struct {
-	repo   domain.Repository
-	logger *slog.Logger
+	repo        domain.Repository
+	logger      *slog.Logger
+	emailOutbox OutboxWriter
 }
 
 // New creates a Connector with the given repository. If logger is nil a default
-// JSON logger writing to stdout is used.
-func New(repo domain.Repository, logger *slog.Logger) (*Connector, error) {
+// JSON logger writing to stdout is used. Optional Option functions may be
+// provided to configure additional behaviour such as email notifications.
+func New(repo domain.Repository, logger *slog.Logger, opts ...Option) (*Connector, error) {
 	if repo == nil {
 		return nil, ErrRepositoryNil
 	}
 	if logger == nil {
 		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	}
-	return &Connector{repo: repo, logger: logger}, nil
+	c := &Connector{repo: repo, logger: logger}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c, nil
 }
 
 // Login validates the supplied username (email) and password against the identity
@@ -147,10 +172,14 @@ func (c *Connector) Login(ctx context.Context, _ []string, username, password st
 	if err := credentials.ValidatePassword(password, identity.PasswordHash()); err != nil {
 		// Record the failed attempt; best-effort — do not surface save errors to caller.
 		_ = identity.RecordLoginAttempt(false)
+		justLocked := identity.IsLocked()
 		if saveErr := c.repo.Save(ctx, identity); saveErr != nil {
 			c.logger.ErrorContext(ctx, "connector: failed to persist failed login attempt",
 				"identity_id", identity.ID(),
 				"error", saveErr)
+		}
+		if justLocked {
+			c.queueLockoutEmail(ctx, identity, tenantID)
 		}
 		c.logger.InfoContext(ctx, "connector: invalid password",
 			"tenant_id", tenantID,
@@ -190,6 +219,36 @@ func (c *Connector) Login(ctx context.Context, _ []string, username, password st
 		"roles", groups)
 
 	return connIdentity, true, nil
+}
+
+// queueLockoutEmail enqueues an account-lockout notification for the given identity.
+// Best-effort: errors are logged but not surfaced to the caller.
+// ErrDuplicateIdempotency is silently ignored to handle concurrent lockout attempts.
+func (c *Connector) queueLockoutEmail(ctx context.Context, identity *domain.Identity, tenantID tenant.TenantID) {
+	if c.emailOutbox == nil {
+		return
+	}
+	entry := &email.OutboxEntry{
+		IdempotencyKey: "account-lockout:" + identity.ID().String(),
+		ToAddresses:    []string{identity.Email()},
+		Subject:        "Your account has been locked",
+		TemplateName:   "account-lockout",
+		TemplateData: map[string]any{
+			"TenantName":   string(tenantID),
+			"SupportEmail": "support@meridianhub.cloud",
+			"LockoutTime":  time.Now().UTC().Format(time.RFC3339),
+		},
+	}
+	if err := c.emailOutbox.Enqueue(ctx, entry); err != nil {
+		if errors.Is(err, email.ErrDuplicateIdempotency) {
+			c.logger.InfoContext(ctx, "connector: lockout email already queued (idempotent)",
+				"identity_id", identity.ID())
+			return
+		}
+		c.logger.ErrorContext(ctx, "connector: failed to queue lockout email",
+			"identity_id", identity.ID(),
+			"error", err)
+	}
 }
 
 // activeRoles returns the string role names for all non-revoked, non-expired

--- a/services/identity/connector/connector.go
+++ b/services/identity/connector/connector.go
@@ -103,7 +103,9 @@ func New(repo domain.Repository, logger *slog.Logger, opts ...Option) (*Connecto
 	}
 	c := &Connector{repo: repo, logger: logger}
 	for _, opt := range opts {
-		opt(c)
+		if opt != nil {
+			opt(c)
+		}
 	}
 	return c, nil
 }

--- a/services/identity/connector/connector.go
+++ b/services/identity/connector/connector.go
@@ -93,7 +93,7 @@ type Connector struct {
 
 // New creates a Connector with the given repository. If logger is nil a default
 // JSON logger writing to stdout is used. Optional Option functions may be
-// provided to configure additional behaviour such as email notifications.
+// provided to configure additional behavior such as email notifications.
 func New(repo domain.Repository, logger *slog.Logger, opts ...Option) (*Connector, error) {
 	if repo == nil {
 		return nil, ErrRepositoryNil

--- a/services/identity/connector/connector.go
+++ b/services/identity/connector/connector.go
@@ -177,8 +177,9 @@ func (c *Connector) Login(ctx context.Context, _ []string, username, password st
 			c.logger.ErrorContext(ctx, "connector: failed to persist failed login attempt",
 				"identity_id", identity.ID(),
 				"error", saveErr)
-		}
-		if justLocked {
+		} else if justLocked {
+			// Queue lockout email only after the lock state is successfully persisted.
+			// If save failed, the lock was not committed and no notification should be sent.
 			c.queueLockoutEmail(ctx, identity, tenantID)
 		}
 		c.logger.InfoContext(ctx, "connector: invalid password",
@@ -231,6 +232,7 @@ func (c *Connector) queueLockoutEmail(ctx context.Context, identity *domain.Iden
 	entry := &email.OutboxEntry{
 		IdempotencyKey: "account-lockout:" + identity.ID().String(),
 		ToAddresses:    []string{identity.Email()},
+		FromAddress:    "noreply@meridianhub.cloud",
 		Subject:        "Your account has been locked",
 		TemplateName:   "account-lockout",
 		TemplateData: map[string]any{

--- a/services/identity/connector/connector_lockout_integration_test.go
+++ b/services/identity/connector/connector_lockout_integration_test.go
@@ -3,7 +3,6 @@
 package connector_test
 
 import (
-	"fmt"
 	"io"
 	"log/slog"
 	"testing"
@@ -136,7 +135,7 @@ func TestLockout_Integration_IdempotentConcurrentLockout(t *testing.T) {
 	// Exactly one email should be in the outbox regardless.
 	var count int64
 	err = db.Table("email_outbox").
-		Where(fmt.Sprintf("tenant_id = '%s' AND template_name = 'account-lockout'", idempTenant)).
+		Where("tenant_id = ? AND template_name = ?", idempTenant, "account-lockout").
 		Count(&count).Error
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count, "concurrent lockout must produce exactly one outbox entry")

--- a/services/identity/connector/connector_lockout_integration_test.go
+++ b/services/identity/connector/connector_lockout_integration_test.go
@@ -118,14 +118,20 @@ func TestLockout_Integration_IdempotentConcurrentLockout(t *testing.T) {
 	infra.createActiveIdentity(t, ctx, "idemp@example.com", "IdempPass123!")
 
 	// Fail login 4 times to prime the counter.
-	for range 4 {
-		_, _, _ = conn.Login(ctx, nil, "idemp@example.com", "WrongPassword999!")
+	for i := range 4 {
+		_, valid, loginErr := conn.Login(ctx, nil, "idemp@example.com", "WrongPassword999!")
+		require.NoError(t, loginErr, "prime attempt %d should not return an error", i+1)
+		assert.False(t, valid, "prime attempt %d should return false", i+1)
 	}
 
 	// Two concurrent 5th failures: simulate by calling sequentially.
 	// First call locks and queues email; second call is rejected at status check (already locked).
-	_, _, _ = conn.Login(ctx, nil, "idemp@example.com", "WrongPassword999!")
-	_, _, _ = conn.Login(ctx, nil, "idemp@example.com", "WrongPassword999!")
+	_, valid, loginErr := conn.Login(ctx, nil, "idemp@example.com", "WrongPassword999!")
+	require.NoError(t, loginErr)
+	assert.False(t, valid)
+	_, valid, loginErr = conn.Login(ctx, nil, "idemp@example.com", "WrongPassword999!")
+	require.NoError(t, loginErr)
+	assert.False(t, valid)
 
 	// Exactly one email should be in the outbox regardless.
 	var count int64

--- a/services/identity/connector/connector_lockout_integration_test.go
+++ b/services/identity/connector/connector_lockout_integration_test.go
@@ -1,0 +1,137 @@
+//go:build integration
+
+package connector_test
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/identity/adapters/persistence"
+	"github.com/meridianhub/meridian/services/identity/connector"
+	emailpkg "github.com/meridianhub/meridian/shared/pkg/email"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// setupEmailOutboxTable creates the email_outbox table in the public schema.
+// The outbox is not tenant-schema-based; it lives in public with a tenant_id column.
+func setupEmailOutboxTable(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	ddl := `
+		CREATE TABLE IF NOT EXISTS email_outbox (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			tenant_id VARCHAR NOT NULL,
+			idempotency_key VARCHAR(255) NOT NULL,
+			to_addresses TEXT[] NOT NULL,
+			from_address VARCHAR(255) NOT NULL DEFAULT 'noreply@meridianhub.cloud',
+			subject VARCHAR(500) NOT NULL DEFAULT '',
+			template_name VARCHAR(100) NOT NULL DEFAULT '',
+			template_data JSONB NOT NULL DEFAULT '{}',
+			status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+			attempts INT NOT NULL DEFAULT 0,
+			max_attempts INT NOT NULL DEFAULT 5,
+			next_attempt_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+			last_error TEXT,
+			cancelled_at TIMESTAMP WITH TIME ZONE,
+			created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+			updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+			UNIQUE (tenant_id, idempotency_key)
+		)
+	`
+	require.NoError(t, db.Exec(ddl).Error)
+}
+
+func TestLockout_Integration_5FailuresQueuesEmailInOutbox(t *testing.T) {
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+	t.Cleanup(cleanup)
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+
+	// Set up identity schema for a single tenant.
+	const lockoutTenant = "lockout_test_tenant"
+	ctx := setupIdentitySchema(t, db, lockoutTenant)
+
+	// Set up email outbox table in public schema.
+	setupEmailOutboxTable(t, db)
+
+	repo := persistence.NewRepository(db)
+	outboxRepo := emailpkg.NewPostgresOutboxRepository(db)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	conn, err := connector.New(repo, logger, connector.WithEmailOutbox(outboxRepo))
+	require.NoError(t, err)
+
+	// Create active identity.
+	const lockoutEmail = "lockout-integ@example.com"
+	const lockoutPass = "LockoutPass123!"
+	infra := &multiTenantInfra{db: db, repo: repo, conn: conn}
+	infra.createActiveIdentity(t, ctx, lockoutEmail, lockoutPass)
+
+	// Fail login 5 times.
+	for i := range 5 {
+		_, valid, loginErr := conn.Login(ctx, nil, lockoutEmail, "WrongPassword999!")
+		require.NoError(t, loginErr, "attempt %d should not return an error", i+1)
+		assert.False(t, valid, "attempt %d should return false", i+1)
+	}
+
+	// Verify exactly one outbox entry was created.
+	var count int64
+	err = db.Table("email_outbox").
+		Where("tenant_id = ? AND template_name = ?", lockoutTenant, "account-lockout").
+		Count(&count).Error
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count, "expected one lockout email in outbox")
+
+	// Verify the email target.
+	var entry emailpkg.OutboxEntity
+	err = db.Table("email_outbox").
+		Where("tenant_id = ? AND template_name = ?", lockoutTenant, "account-lockout").
+		First(&entry).Error
+	require.NoError(t, err)
+	require.Len(t, []string(entry.ToAddresses), 1)
+	assert.Equal(t, lockoutEmail, []string(entry.ToAddresses)[0])
+	assert.Equal(t, "PENDING", entry.Status)
+}
+
+func TestLockout_Integration_IdempotentConcurrentLockout(t *testing.T) {
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+	t.Cleanup(cleanup)
+
+	const idempTenant = "idemp_lockout_tenant"
+	ctx := setupIdentitySchema(t, db, idempTenant)
+	setupEmailOutboxTable(t, db)
+
+	repo := persistence.NewRepository(db)
+	outboxRepo := emailpkg.NewPostgresOutboxRepository(db)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	conn, err := connector.New(repo, logger, connector.WithEmailOutbox(outboxRepo))
+	require.NoError(t, err)
+
+	infra := &multiTenantInfra{db: db, repo: repo, conn: conn}
+	infra.createActiveIdentity(t, ctx, "idemp@example.com", "IdempPass123!")
+
+	// Fail login 4 times to prime the counter.
+	for range 4 {
+		_, _, _ = conn.Login(ctx, nil, "idemp@example.com", "WrongPassword999!")
+	}
+
+	// Two concurrent 5th failures: simulate by calling sequentially.
+	// First call locks and queues email; second call is rejected at status check (already locked).
+	_, _, _ = conn.Login(ctx, nil, "idemp@example.com", "WrongPassword999!")
+	_, _, _ = conn.Login(ctx, nil, "idemp@example.com", "WrongPassword999!")
+
+	// Exactly one email should be in the outbox regardless.
+	var count int64
+	err = db.Table("email_outbox").
+		Where(fmt.Sprintf("tenant_id = '%s' AND template_name = 'account-lockout'", idempTenant)).
+		Count(&count).Error
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count, "concurrent lockout must produce exactly one outbox entry")
+}

--- a/services/identity/connector/connector_lockout_test.go
+++ b/services/identity/connector/connector_lockout_test.go
@@ -1,0 +1,141 @@
+package connector_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/identity/connector"
+	"github.com/meridianhub/meridian/services/identity/domain"
+	"github.com/meridianhub/meridian/shared/pkg/credentials"
+	"github.com/meridianhub/meridian/shared/pkg/email"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Mock outbox ---
+
+type mockOutbox struct {
+	entries []*email.OutboxEntry
+	err     error
+}
+
+func (m *mockOutbox) Enqueue(_ context.Context, entry *email.OutboxEntry) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.entries = append(m.entries, entry)
+	return nil
+}
+
+func newConnectorWithOutbox(t *testing.T, repo domain.Repository, outbox connector.OutboxWriter) *connector.Connector {
+	t.Helper()
+	c, err := connector.New(repo, nil, connector.WithEmailOutbox(outbox))
+	require.NoError(t, err)
+	return c
+}
+
+func makeIdentityWithNFailures(t *testing.T, email string, n int) *domain.Identity {
+	t.Helper()
+	id, err := domain.NewIdentity(connTestTID, email)
+	require.NoError(t, err)
+
+	hash, err := credentials.HashPassword(testPassword)
+	require.NoError(t, err)
+	require.NoError(t, id.SetPassword(hash))
+	require.NoError(t, id.Activate())
+
+	for range n {
+		err := id.RecordLoginAttempt(false)
+		require.NoError(t, err)
+	}
+	return id
+}
+
+// --- Lockout email: triggered on exact 5th failure ---
+
+func TestLogin_5thFailedAttempt_QueuesLockoutEmail(t *testing.T) {
+	// Identity already has 4 failed attempts; 5th will lock it.
+	identity := makeIdentityWithNFailures(t, "lockme@example.com", 4)
+	require.False(t, identity.IsLocked())
+
+	outbox := &mockOutbox{}
+	repo := &mockRepo{identity: identity}
+	c := newConnectorWithOutbox(t, repo, outbox)
+	ctx := ctxWithTenant(t, "volterra")
+
+	_, valid, err := c.Login(ctx, nil, "lockme@example.com", "WrongPassword999!")
+
+	require.NoError(t, err)
+	assert.False(t, valid)
+	require.Len(t, outbox.entries, 1, "expected exactly one lockout email queued")
+
+	entry := outbox.entries[0]
+	assert.Equal(t, "account-lockout", entry.TemplateName)
+	assert.Equal(t, []string{"lockme@example.com"}, entry.ToAddresses)
+	assert.True(t, strings.HasPrefix(entry.IdempotencyKey, "account-lockout:"),
+		"idempotency key should identify lockout event, got: %s", entry.IdempotencyKey)
+	assert.Contains(t, entry.TemplateData, "TenantName")
+	assert.Contains(t, entry.TemplateData, "SupportEmail")
+	assert.Contains(t, entry.TemplateData, "LockoutTime")
+}
+
+func TestLogin_4thFailedAttempt_DoesNotQueueLockoutEmail(t *testing.T) {
+	// Identity has 3 prior failures; 4th does not lock.
+	identity := makeIdentityWithNFailures(t, "notlocked@example.com", 3)
+
+	outbox := &mockOutbox{}
+	repo := &mockRepo{identity: identity}
+	c := newConnectorWithOutbox(t, repo, outbox)
+	ctx := ctxWithTenant(t, "volterra")
+
+	_, valid, err := c.Login(ctx, nil, "notlocked@example.com", "WrongPassword999!")
+
+	require.NoError(t, err)
+	assert.False(t, valid)
+	assert.Empty(t, outbox.entries, "no lockout email should be queued before threshold")
+}
+
+func TestLogin_NilEmailOutbox_NoPanic(t *testing.T) {
+	// When no outbox is wired, the 5th failure should still lock without panicking.
+	identity := makeIdentityWithNFailures(t, "noemail@example.com", 4)
+	repo := &mockRepo{identity: identity}
+
+	// Use basic connector without email outbox option.
+	c, err := connector.New(repo, nil)
+	require.NoError(t, err)
+	ctx := ctxWithTenant(t, "volterra")
+
+	_, valid, loginErr := c.Login(ctx, nil, "noemail@example.com", "WrongPassword999!")
+
+	require.NoError(t, loginErr)
+	assert.False(t, valid)
+}
+
+func TestLogin_IdempotentLockout_OutboxErrorIgnored(t *testing.T) {
+	// If the outbox returns ErrDuplicateIdempotency (concurrent lockout), login still returns false/nil.
+	identity := makeIdentityWithNFailures(t, "concurrent@example.com", 4)
+	outbox := &mockOutbox{err: email.ErrDuplicateIdempotency}
+	repo := &mockRepo{identity: identity}
+	c := newConnectorWithOutbox(t, repo, outbox)
+	ctx := ctxWithTenant(t, "volterra")
+
+	_, valid, err := c.Login(ctx, nil, "concurrent@example.com", "WrongPassword999!")
+
+	require.NoError(t, err)
+	assert.False(t, valid)
+}
+
+func TestLogin_OutboxEnqueueError_DoesNotFailLogin(t *testing.T) {
+	// A transient outbox failure must not bubble up as a login error.
+	identity := makeIdentityWithNFailures(t, "outboxerr@example.com", 4)
+	outbox := &mockOutbox{err: assert.AnError}
+	repo := &mockRepo{identity: identity}
+	c := newConnectorWithOutbox(t, repo, outbox)
+	ctx := ctxWithTenant(t, "volterra")
+
+	_, valid, err := c.Login(ctx, nil, "outboxerr@example.com", "WrongPassword999!")
+
+	require.NoError(t, err)
+	assert.False(t, valid)
+}

--- a/services/identity/connector/connector_lockout_test.go
+++ b/services/identity/connector/connector_lockout_test.go
@@ -139,3 +139,18 @@ func TestLogin_OutboxEnqueueError_DoesNotFailLogin(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, valid)
 }
+
+func TestLogin_SaveFailureOnLockout_DoesNotQueueEmail(t *testing.T) {
+	// If Save() fails, the lock is not persisted — no lockout email should be sent.
+	identity := makeIdentityWithNFailures(t, "savefail@example.com", 4)
+	outbox := &mockOutbox{}
+	repo := &mockRepo{identity: identity, saveErr: assert.AnError}
+	c := newConnectorWithOutbox(t, repo, outbox)
+	ctx := ctxWithTenant(t, "volterra")
+
+	_, valid, err := c.Login(ctx, nil, "savefail@example.com", "WrongPassword999!")
+
+	require.NoError(t, err)
+	assert.False(t, valid)
+	assert.Empty(t, outbox.entries, "no lockout email should be queued when save fails")
+}


### PR DESCRIPTION
## Summary

- Adds `OutboxWriter` interface to the connector package (narrow: `Enqueue` only)
- Adds `WithEmailOutbox` functional option to `connector.New` (backward-compatible - existing callers unchanged)
- On the 5th consecutive failed login attempt, queues an `account-lockout` email via the outbox
- Nil-safe: if no outbox is wired the connector behaves identically to before
- Idempotent: `ErrDuplicateIdempotency` from concurrent lockout attempts is silently absorbed

## Changes Made

- `services/identity/connector/connector.go` - `OutboxWriter` interface, `WithEmailOutbox` option, `queueLockoutEmail` helper, lockout detection in `Login`
- `services/identity/connector/connector_lockout_test.go` - Unit tests (5th failure queues email, 4th does not, nil outbox no-panic, idempotency error ignored, transient outbox error does not fail login)
- `services/identity/connector/connector_lockout_integration_test.go` - Integration tests against real CockroachDB (5 failures produce one outbox entry, idempotent sequential lockout)

## Testing

- All unit tests pass (`go test ./services/identity/connector/...`)
- Integration tests pass (`go test -tags=integration ./services/identity/connector/... -run TestLockout`)

## Risk Assessment

Low. The outbox call is best-effort (errors logged, not surfaced to the caller). If the outbox is nil or errors, login behaviour is unchanged.