### PR TITLE
fix: role constraint and manifest application on deploy

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -228,9 +228,6 @@ jobs:
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           script: |
-            # Skip manifest on incremental deploys - manifest only needs to apply
-            # on fresh databases (handled by reset-demo.sh). Full idempotency for
-            # ApplyManifest is tracked as a follow-up.
             docker exec meridian-meridian-1 /seed-dev \
               --gateway-url=http://localhost:8090 \
               --grpc-addr=localhost:50051 \
@@ -238,7 +235,7 @@ jobs:
               --tenant-slug=volterra \
               --display-name='Volterra Energy' \
               --subdomain=volterra.demo.meridianhub.cloud \
-              --skip-manifest \
+              --manifest=/app/examples/manifests/energy.json \
               --with-fixtures
 
       - name: Verify deployment health

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -262,7 +262,7 @@ jobs:
               --tenant-slug=volterra-energy \
               --display-name='Volterra Energy' \
               --subdomain=volterra-energy.develop.meridianhub.cloud \
-              --skip-manifest \
+              --manifest=/app/examples/manifests/energy.json \
               --with-fixtures
 
       - name: Verify deployment health

--- a/services/identity/migrations/20260327000005_drop_role_constraint.sql
+++ b/services/identity/migrations/20260327000005_drop_role_constraint.sql
@@ -1,0 +1,6 @@
+-- Drop the outdated role check constraint.
+-- The initial migration used uppercase values ('PLATFORM', 'TENANT_OWNER')
+-- but the Go domain uses lowercase kebab-case ('platform-admin', 'tenant-owner').
+-- A follow-up migration recreates the constraint with the correct values.
+
+ALTER TABLE "role_assignment" DROP CONSTRAINT IF EXISTS "chk_role_assignment_role";

--- a/services/identity/migrations/20260327000006_add_role_constraint.sql
+++ b/services/identity/migrations/20260327000006_add_role_constraint.sql
@@ -1,6 +1,7 @@
--- Recreate role check constraint with kebab-case values matching the Go domain,
--- plus uppercase values for backwards compatibility with existing data.
--- Also adds 'auditor', 'service', and 'super-admin' which were missing.
+-- Recreate role check constraint accepting both encoding conventions:
+-- - Uppercase (identity domain): VIEWER, OPERATOR, ADMIN, TENANT_OWNER, PLATFORM
+-- - Kebab-case (auth package): viewer, operator, admin, tenant-owner, platform-admin
+-- Also adds auditor, service, and super-admin used by the auth RBAC layer.
 
 ALTER TABLE "role_assignment" ADD CONSTRAINT "chk_role_assignment_role"
   CHECK (role IN ('viewer', 'operator', 'admin', 'auditor', 'service', 'tenant-owner', 'platform-admin', 'super-admin',

--- a/services/identity/migrations/20260327000006_add_role_constraint.sql
+++ b/services/identity/migrations/20260327000006_add_role_constraint.sql
@@ -1,0 +1,7 @@
+-- Recreate role check constraint with kebab-case values matching the Go domain,
+-- plus uppercase values for backwards compatibility with existing data.
+-- Also adds 'auditor', 'service', and 'super-admin' which were missing.
+
+ALTER TABLE "role_assignment" ADD CONSTRAINT "chk_role_assignment_role"
+  CHECK (role IN ('viewer', 'operator', 'admin', 'auditor', 'service', 'tenant-owner', 'platform-admin', 'super-admin',
+                  'VIEWER', 'OPERATOR', 'ADMIN', 'TENANT_OWNER', 'PLATFORM'));

--- a/services/identity/migrations/atlas.sum
+++ b/services/identity/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:tj3Jg1uQyVH9Ifmwj4cCnngqDLNdgtYsdgERYfS7aOs=
+h1:xbgRG8E+zdJyGcRwycP8LbFHdnIROS2nl4g6f4WXnyg=
 20260302000001_initial.sql h1:SsQN4cGTrm/6qs12GD9YXoSO6QyKTIpNZrM+4rRBWJA=
 20260326000001_add_tenant_id.sql h1:+/NF9LBhT7EjKVqu5gxY1B+vJ+YDM9acG8lLSXGJEWs=
 20260326000002_add_tenant_id_indexes.sql h1:Ov5Wfsl+MTIrtNdnqdh9p5qGpaeBW/wBPXILN4JvuvM=
@@ -6,3 +6,5 @@ h1:tj3Jg1uQyVH9Ifmwj4cCnngqDLNdgtYsdgERYfS7aOs=
 20260327000002_add_pending_verification_status.sql h1:U138QbPEfysvyueXoWetj2yVZu2vhHRHLeRa+N8qckc=
 20260327000003_email_verification_tokens.sql h1:WZD2iEMMvwG5A3kVyv5oK2Nso7A+LTuOkCnsXJvDkZQ=
 20260327000004_password_reset_tokens.sql h1:KbLBrcNV5fCjyj04r6YNETLkNXg1dwSUGL4ZHk1pqqQ=
+20260327000005_drop_role_constraint.sql h1:d4mxJFQHkcJEtDEZ+ztR+U1j7Z47eud+KorVVr50TUQ=
+20260327000006_add_role_constraint.sql h1:e30q9QI8eubEtiAY4KimBmpD/DKRUbLSfCO/uEJaEUw=

--- a/services/identity/migrations/atlas.sum
+++ b/services/identity/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:xbgRG8E+zdJyGcRwycP8LbFHdnIROS2nl4g6f4WXnyg=
+h1:HbreHZ7DfYjRRTYEAvjljVJTg+KizbMvh1A0wMA0WcU=
 20260302000001_initial.sql h1:SsQN4cGTrm/6qs12GD9YXoSO6QyKTIpNZrM+4rRBWJA=
 20260326000001_add_tenant_id.sql h1:+/NF9LBhT7EjKVqu5gxY1B+vJ+YDM9acG8lLSXGJEWs=
 20260326000002_add_tenant_id_indexes.sql h1:Ov5Wfsl+MTIrtNdnqdh9p5qGpaeBW/wBPXILN4JvuvM=
@@ -7,4 +7,4 @@ h1:xbgRG8E+zdJyGcRwycP8LbFHdnIROS2nl4g6f4WXnyg=
 20260327000003_email_verification_tokens.sql h1:WZD2iEMMvwG5A3kVyv5oK2Nso7A+LTuOkCnsXJvDkZQ=
 20260327000004_password_reset_tokens.sql h1:KbLBrcNV5fCjyj04r6YNETLkNXg1dwSUGL4ZHk1pqqQ=
 20260327000005_drop_role_constraint.sql h1:d4mxJFQHkcJEtDEZ+ztR+U1j7Z47eud+KorVVr50TUQ=
-20260327000006_add_role_constraint.sql h1:e30q9QI8eubEtiAY4KimBmpD/DKRUbLSfCO/uEJaEUw=
+20260327000006_add_role_constraint.sql h1:WAiUQF0nKzDyrc506KuT1RGEkVeWbMEIfPYd/c+gfuM=


### PR DESCRIPTION
## Summary

- **Role constraint mismatch**: The `chk_role_assignment_role` constraint in the identity service only accepted uppercase values (`PLATFORM`, `TENANT_OWNER`) but the Go domain uses kebab-case (`platform-admin`, `tenant-owner`). This caused bootstrap and post-provisioning hooks to fail silently, preventing admin users from being created on fresh tenant provisioning.
- **Manifest not applied on deploy**: Both deploy workflows used `--skip-manifest`, which meant the economy endpoint returned empty after fresh provisioning. Now that ApplyManifest is idempotent (#1978), the flag is removed so manifests are applied on every deploy.

These two issues combined caused:
1. Demo deploy CI failures (seed-dev couldn't find tenant schemas)
2. Economy endpoint on develop showing no manifest despite data existing in the DB

## Changes

1. New migration `20260327000003_fix_role_constraint.sql` - updates the constraint to accept both kebab-case (new) and uppercase (existing data) role values, and adds missing roles (auditor, service, super-admin)
2. Remove `--skip-manifest` from `deploy-demo.yml` and `deploy-develop.yml`

## Test plan

- [ ] CI passes (migration validates with Atlas)
- [ ] Deploy to develop - verify economy endpoint shows manifest
- [ ] Deploy to demo - verify seed-dev completes without schema errors