### PR TITLE
feat: add verification and password reset token domain models and repositories

### DIFF
--- a/cmd/meridian/registration_wiring_test.go
+++ b/cmd/meridian/registration_wiring_test.go
@@ -259,3 +259,31 @@ func (n *noopIdentityRepo) SaveInvitation(_ context.Context, _ *identitydomain.I
 func (n *noopIdentityRepo) FindInvitationByTokenHash(_ context.Context, _ string) (*identitydomain.Invitation, error) {
 	return nil, fmt.Errorf("not implemented")
 }
+
+func (n *noopIdentityRepo) SaveVerificationToken(_ context.Context, _ *identitydomain.VerificationToken) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (n *noopIdentityRepo) FindVerificationTokenByHash(_ context.Context, _ string) (*identitydomain.VerificationToken, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (n *noopIdentityRepo) CountVerificationTokensInWindow(_ context.Context, _ uuid.UUID, _ time.Duration) (int, error) {
+	return 0, fmt.Errorf("not implemented")
+}
+
+func (n *noopIdentityRepo) SavePasswordResetToken(_ context.Context, _ *identitydomain.PasswordResetToken) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (n *noopIdentityRepo) FindPasswordResetTokenByHash(_ context.Context, _ string) (*identitydomain.PasswordResetToken, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (n *noopIdentityRepo) CountPasswordResetTokensInWindow(_ context.Context, _ uuid.UUID, _ time.Duration) (int, error) {
+	return 0, fmt.Errorf("not implemented")
+}
+
+func (n *noopIdentityRepo) InvalidatePasswordResetTokensForIdentity(_ context.Context, _ uuid.UUID) error {
+	return fmt.Errorf("not implemented")
+}

--- a/cmd/meridian/registration_wiring_test.go
+++ b/cmd/meridian/registration_wiring_test.go
@@ -284,6 +284,6 @@ func (n *noopIdentityRepo) CountPasswordResetTokensInWindow(_ context.Context, _
 	return 0, fmt.Errorf("not implemented")
 }
 
-func (n *noopIdentityRepo) InvalidatePasswordResetTokensForIdentity(_ context.Context, _ uuid.UUID) error {
+func (n *noopIdentityRepo) MarkPasswordResetTokensConsumedForIdentity(_ context.Context, _ uuid.UUID) error {
 	return fmt.Errorf("not implemented")
 }

--- a/services/api-gateway/registration_handler_test.go
+++ b/services/api-gateway/registration_handler_test.go
@@ -114,7 +114,7 @@ func (s *stubIdentityRepo) CountPasswordResetTokensInWindow(_ context.Context, _
 	return 0, nil
 }
 
-func (s *stubIdentityRepo) InvalidatePasswordResetTokensForIdentity(_ context.Context, _ uuid.UUID) error {
+func (s *stubIdentityRepo) MarkPasswordResetTokensConsumedForIdentity(_ context.Context, _ uuid.UUID) error {
 	return nil
 }
 

--- a/services/api-gateway/registration_handler_test.go
+++ b/services/api-gateway/registration_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	identitydomain "github.com/meridianhub/meridian/services/identity/domain"
@@ -87,6 +88,34 @@ func (s *stubIdentityRepo) SaveInvitation(_ context.Context, _ *identitydomain.I
 
 func (s *stubIdentityRepo) FindInvitationByTokenHash(_ context.Context, _ string) (*identitydomain.Invitation, error) {
 	return nil, identitydomain.ErrInvitationNotFound
+}
+
+func (s *stubIdentityRepo) SaveVerificationToken(_ context.Context, _ *identitydomain.VerificationToken) error {
+	return nil
+}
+
+func (s *stubIdentityRepo) FindVerificationTokenByHash(_ context.Context, _ string) (*identitydomain.VerificationToken, error) {
+	return nil, identitydomain.ErrVerificationTokenNotFound
+}
+
+func (s *stubIdentityRepo) CountVerificationTokensInWindow(_ context.Context, _ uuid.UUID, _ time.Duration) (int, error) {
+	return 0, nil
+}
+
+func (s *stubIdentityRepo) SavePasswordResetToken(_ context.Context, _ *identitydomain.PasswordResetToken) error {
+	return nil
+}
+
+func (s *stubIdentityRepo) FindPasswordResetTokenByHash(_ context.Context, _ string) (*identitydomain.PasswordResetToken, error) {
+	return nil, identitydomain.ErrPasswordResetTokenNotFound
+}
+
+func (s *stubIdentityRepo) CountPasswordResetTokensInWindow(_ context.Context, _ uuid.UUID, _ time.Duration) (int, error) {
+	return 0, nil
+}
+
+func (s *stubIdentityRepo) InvalidatePasswordResetTokensForIdentity(_ context.Context, _ uuid.UUID) error {
+	return nil
 }
 
 type stubSlugChecker struct {

--- a/services/identity/adapters/persistence/password_reset_token_entity.go
+++ b/services/identity/adapters/persistence/password_reset_token_entity.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/identity/domain"
 )
 
 // PasswordResetTokenEntity represents the database persistence model for password reset tokens.
@@ -21,4 +22,30 @@ type PasswordResetTokenEntity struct {
 // TableName overrides the default table name.
 func (PasswordResetTokenEntity) TableName() string {
 	return "password_reset_token"
+}
+
+// toPasswordResetTokenEntity converts a domain PasswordResetToken to a persistence entity.
+func toPasswordResetTokenEntity(prt *domain.PasswordResetToken) *PasswordResetTokenEntity {
+	return &PasswordResetTokenEntity{
+		ID:         prt.ID(),
+		TenantID:   prt.TenantID(),
+		IdentityID: prt.IdentityID(),
+		TokenHash:  prt.TokenHash(),
+		ExpiresAt:  prt.ExpiresAt(),
+		ConsumedAt: prt.ConsumedAt(),
+		CreatedAt:  prt.CreatedAt(),
+	}
+}
+
+// toPasswordResetTokenDomain converts a persistence entity to a domain PasswordResetToken.
+func toPasswordResetTokenDomain(entity *PasswordResetTokenEntity) *domain.PasswordResetToken {
+	return domain.ReconstructPasswordResetToken(
+		entity.ID,
+		entity.TenantID,
+		entity.IdentityID,
+		entity.TokenHash,
+		entity.ExpiresAt,
+		entity.ConsumedAt,
+		entity.CreatedAt,
+	)
 }

--- a/services/identity/adapters/persistence/repository.go
+++ b/services/identity/adapters/persistence/repository.go
@@ -455,9 +455,9 @@ func (r *Repository) CountPasswordResetTokensInWindow(ctx context.Context, ident
 	return count, err
 }
 
-// InvalidatePasswordResetTokensForIdentity marks all unconsumed password reset tokens
+// MarkPasswordResetTokensConsumedForIdentity marks all unconsumed password reset tokens
 // for the given identity as consumed.
-func (r *Repository) InvalidatePasswordResetTokensForIdentity(ctx context.Context, identityID uuid.UUID) error {
+func (r *Repository) MarkPasswordResetTokensConsumedForIdentity(ctx context.Context, identityID uuid.UUID) error {
 	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
 		now := time.Now()
 		return tx.Model(&PasswordResetTokenEntity{}).

--- a/services/identity/adapters/persistence/repository.go
+++ b/services/identity/adapters/persistence/repository.go
@@ -397,7 +397,7 @@ func (r *Repository) CountVerificationTokensInWindow(ctx context.Context, identi
 	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
 		var c int64
 		result := tx.Model(&EmailVerificationTokenEntity{}).
-			Where("identity_id = ? AND consumed_at IS NULL AND created_at > ?", identityID, time.Now().Add(-window)).
+			Where("identity_id = ? AND consumed_at IS NULL AND created_at >= ?", identityID, time.Now().Add(-window)).
 			Count(&c)
 		if result.Error != nil {
 			return result.Error
@@ -444,7 +444,7 @@ func (r *Repository) CountPasswordResetTokensInWindow(ctx context.Context, ident
 	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
 		var c int64
 		result := tx.Model(&PasswordResetTokenEntity{}).
-			Where("identity_id = ? AND consumed_at IS NULL AND created_at > ?", identityID, time.Now().Add(-window)).
+			Where("identity_id = ? AND consumed_at IS NULL AND created_at >= ?", identityID, time.Now().Add(-window)).
 			Count(&c)
 		if result.Error != nil {
 			return result.Error

--- a/services/identity/adapters/persistence/repository.go
+++ b/services/identity/adapters/persistence/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/services/identity/domain"
@@ -357,6 +358,111 @@ func (r *Repository) SaveRoleAssignments(ctx context.Context, assignments []*dom
 			}
 		}
 		return nil
+	})
+}
+
+// SaveVerificationToken persists a new verification token.
+func (r *Repository) SaveVerificationToken(ctx context.Context, token *domain.VerificationToken) error {
+	entity := toVerificationTokenEntity(token)
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		return tx.Create(entity).Error
+	})
+}
+
+// FindVerificationTokenByHash retrieves a verification token by its SHA256 hash.
+func (r *Repository) FindVerificationTokenByHash(ctx context.Context, hash string) (*domain.VerificationToken, error) {
+	var token *domain.VerificationToken
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var entity EmailVerificationTokenEntity
+		result := tx.Where("token_hash = ?", hash).First(&entity)
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return domain.ErrVerificationTokenNotFound
+		}
+		if result.Error != nil {
+			return result.Error
+		}
+		token = toVerificationTokenDomain(&entity)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return token, nil
+}
+
+// CountVerificationTokensInWindow counts unconsumed verification tokens created for
+// the given identity within the specified time window.
+func (r *Repository) CountVerificationTokensInWindow(ctx context.Context, identityID uuid.UUID, window time.Duration) (int, error) {
+	var count int
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var c int64
+		result := tx.Model(&EmailVerificationTokenEntity{}).
+			Where("identity_id = ? AND consumed_at IS NULL AND created_at > ?", identityID, time.Now().Add(-window)).
+			Count(&c)
+		if result.Error != nil {
+			return result.Error
+		}
+		count = int(c)
+		return nil
+	})
+	return count, err
+}
+
+// SavePasswordResetToken persists a new password reset token.
+func (r *Repository) SavePasswordResetToken(ctx context.Context, token *domain.PasswordResetToken) error {
+	entity := toPasswordResetTokenEntity(token)
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		return tx.Create(entity).Error
+	})
+}
+
+// FindPasswordResetTokenByHash retrieves a password reset token by its SHA256 hash.
+func (r *Repository) FindPasswordResetTokenByHash(ctx context.Context, hash string) (*domain.PasswordResetToken, error) {
+	var token *domain.PasswordResetToken
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var entity PasswordResetTokenEntity
+		result := tx.Where("token_hash = ?", hash).First(&entity)
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return domain.ErrPasswordResetTokenNotFound
+		}
+		if result.Error != nil {
+			return result.Error
+		}
+		token = toPasswordResetTokenDomain(&entity)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return token, nil
+}
+
+// CountPasswordResetTokensInWindow counts unconsumed password reset tokens created for
+// the given identity within the specified time window.
+func (r *Repository) CountPasswordResetTokensInWindow(ctx context.Context, identityID uuid.UUID, window time.Duration) (int, error) {
+	var count int
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var c int64
+		result := tx.Model(&PasswordResetTokenEntity{}).
+			Where("identity_id = ? AND consumed_at IS NULL AND created_at > ?", identityID, time.Now().Add(-window)).
+			Count(&c)
+		if result.Error != nil {
+			return result.Error
+		}
+		count = int(c)
+		return nil
+	})
+	return count, err
+}
+
+// InvalidatePasswordResetTokensForIdentity marks all unconsumed password reset tokens
+// for the given identity as consumed.
+func (r *Repository) InvalidatePasswordResetTokensForIdentity(ctx context.Context, identityID uuid.UUID) error {
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		now := time.Now()
+		return tx.Model(&PasswordResetTokenEntity{}).
+			Where("identity_id = ? AND consumed_at IS NULL", identityID).
+			Update("consumed_at", now).Error
 	})
 }
 

--- a/services/identity/adapters/persistence/token_repository_test.go
+++ b/services/identity/adapters/persistence/token_repository_test.go
@@ -229,7 +229,7 @@ func TestRepository_CountPasswordResetTokensInWindow_ExcludesConsumed(t *testing
 	assert.Equal(t, 1, count)
 }
 
-func TestRepository_InvalidatePasswordResetTokensForIdentity(t *testing.T) {
+func TestRepository_MarkPasswordResetTokensConsumedForIdentity(t *testing.T) {
 	db, ctx, cleanup := setupTokenRepoTestDB(t)
 	defer cleanup()
 	repo := NewRepository(db)
@@ -244,7 +244,7 @@ func TestRepository_InvalidatePasswordResetTokensForIdentity(t *testing.T) {
 		hashes = append(hashes, prt.TokenHash())
 	}
 
-	err := repo.InvalidatePasswordResetTokensForIdentity(ctx, identity.ID())
+	err := repo.MarkPasswordResetTokensConsumedForIdentity(ctx, identity.ID())
 	require.NoError(t, err)
 
 	for _, hash := range hashes {
@@ -258,7 +258,7 @@ func TestRepository_InvalidatePasswordResetTokensForIdentity(t *testing.T) {
 	assert.Equal(t, 0, count)
 }
 
-func TestRepository_InvalidatePasswordResetTokensForIdentity_DoesNotAffectOther(t *testing.T) {
+func TestRepository_MarkPasswordResetTokensConsumedForIdentity_DoesNotAffectOther(t *testing.T) {
 	db, ctx, cleanup := setupTokenRepoTestDB(t)
 	defer cleanup()
 	repo := NewRepository(db)
@@ -275,7 +275,7 @@ func TestRepository_InvalidatePasswordResetTokensForIdentity_DoesNotAffectOther(
 	err = repo.SavePasswordResetToken(ctx, prt2)
 	require.NoError(t, err)
 
-	err = repo.InvalidatePasswordResetTokensForIdentity(ctx, identity1.ID())
+	err = repo.MarkPasswordResetTokensConsumedForIdentity(ctx, identity1.ID())
 	require.NoError(t, err)
 
 	found1, err := repo.FindPasswordResetTokenByHash(ctx, prt1.TokenHash())

--- a/services/identity/adapters/persistence/token_repository_test.go
+++ b/services/identity/adapters/persistence/token_repository_test.go
@@ -1,0 +1,288 @@
+package persistence
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/identity/domain"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+const tokenRepoTestTenantID = "test_tenant_token_repo"
+
+func setupTokenRepoTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
+	t.Helper()
+	return testdb.SetupTestDB(t,
+		testdb.WithModels(
+			&IdentityEntity{},
+			&EmailVerificationTokenEntity{},
+			&PasswordResetTokenEntity{},
+		),
+		testdb.WithTenant(tokenRepoTestTenantID),
+	)
+}
+
+func createTestIdentityForTokens(t *testing.T, repo *Repository, ctx context.Context) *domain.Identity {
+	t.Helper()
+	identity, err := domain.NewIdentity(tokenRepoTestTenantID, "test-"+uuid.New().String()+"@example.com")
+	require.NoError(t, err)
+	err = identity.SetPassword("$2a$10$somehash")
+	require.NoError(t, err)
+	err = repo.Save(ctx, identity)
+	require.NoError(t, err)
+	return identity
+}
+
+// --- Verification Token Repository Tests ---
+
+func TestRepository_SaveVerificationToken(t *testing.T) {
+	db, ctx, cleanup := setupTokenRepoTestDB(t)
+	defer cleanup()
+	repo := NewRepository(db)
+	identity := createTestIdentityForTokens(t, repo, ctx)
+
+	vt, _, err := domain.NewVerificationToken(tokenRepoTestTenantID, identity.ID())
+	require.NoError(t, err)
+
+	err = repo.SaveVerificationToken(ctx, vt)
+	require.NoError(t, err)
+}
+
+func TestRepository_FindVerificationTokenByHash(t *testing.T) {
+	db, ctx, cleanup := setupTokenRepoTestDB(t)
+	defer cleanup()
+	repo := NewRepository(db)
+	identity := createTestIdentityForTokens(t, repo, ctx)
+
+	vt, _, err := domain.NewVerificationToken(tokenRepoTestTenantID, identity.ID())
+	require.NoError(t, err)
+	err = repo.SaveVerificationToken(ctx, vt)
+	require.NoError(t, err)
+
+	found, err := repo.FindVerificationTokenByHash(ctx, vt.TokenHash())
+	require.NoError(t, err)
+	assert.Equal(t, vt.ID(), found.ID())
+	assert.Equal(t, vt.TenantID(), found.TenantID())
+	assert.Equal(t, vt.IdentityID(), found.IdentityID())
+	assert.Equal(t, vt.TokenHash(), found.TokenHash())
+	assert.Nil(t, found.ConsumedAt())
+}
+
+func TestRepository_FindVerificationTokenByHash_NotFound(t *testing.T) {
+	db, ctx, cleanup := setupTokenRepoTestDB(t)
+	defer cleanup()
+	repo := NewRepository(db)
+
+	_, err := repo.FindVerificationTokenByHash(ctx, "nonexistent")
+	assert.ErrorIs(t, err, domain.ErrVerificationTokenNotFound)
+}
+
+func TestRepository_CountVerificationTokensInWindow(t *testing.T) {
+	db, ctx, cleanup := setupTokenRepoTestDB(t)
+	defer cleanup()
+	repo := NewRepository(db)
+	identity := createTestIdentityForTokens(t, repo, ctx)
+
+	for i := 0; i < 3; i++ {
+		vt, _, err := domain.NewVerificationToken(tokenRepoTestTenantID, identity.ID())
+		require.NoError(t, err)
+		err = repo.SaveVerificationToken(ctx, vt)
+		require.NoError(t, err)
+	}
+
+	count, err := repo.CountVerificationTokensInWindow(ctx, identity.ID(), 1*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+}
+
+func TestRepository_CountVerificationTokensInWindow_ExcludesConsumed(t *testing.T) {
+	db, ctx, cleanup := setupTokenRepoTestDB(t)
+	defer cleanup()
+	repo := NewRepository(db)
+	identity := createTestIdentityForTokens(t, repo, ctx)
+
+	// Create and consume one token
+	vt1, _, err := domain.NewVerificationToken(tokenRepoTestTenantID, identity.ID())
+	require.NoError(t, err)
+	err = vt1.Consume()
+	require.NoError(t, err)
+	err = repo.SaveVerificationToken(ctx, vt1)
+	require.NoError(t, err)
+
+	// Create one unconsumed token
+	vt2, _, err := domain.NewVerificationToken(tokenRepoTestTenantID, identity.ID())
+	require.NoError(t, err)
+	err = repo.SaveVerificationToken(ctx, vt2)
+	require.NoError(t, err)
+
+	count, err := repo.CountVerificationTokensInWindow(ctx, identity.ID(), 1*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func TestRepository_CountVerificationTokensInWindow_DifferentIdentity(t *testing.T) {
+	db, ctx, cleanup := setupTokenRepoTestDB(t)
+	defer cleanup()
+	repo := NewRepository(db)
+	identity1 := createTestIdentityForTokens(t, repo, ctx)
+	identity2 := createTestIdentityForTokens(t, repo, ctx)
+
+	vt, _, err := domain.NewVerificationToken(tokenRepoTestTenantID, identity1.ID())
+	require.NoError(t, err)
+	err = repo.SaveVerificationToken(ctx, vt)
+	require.NoError(t, err)
+
+	count, err := repo.CountVerificationTokensInWindow(ctx, identity2.ID(), 1*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+// --- Password Reset Token Repository Tests ---
+
+func TestRepository_SavePasswordResetToken(t *testing.T) {
+	db, ctx, cleanup := setupTokenRepoTestDB(t)
+	defer cleanup()
+	repo := NewRepository(db)
+	identity := createTestIdentityForTokens(t, repo, ctx)
+
+	prt, _, err := domain.NewPasswordResetToken(tokenRepoTestTenantID, identity.ID())
+	require.NoError(t, err)
+
+	err = repo.SavePasswordResetToken(ctx, prt)
+	require.NoError(t, err)
+}
+
+func TestRepository_FindPasswordResetTokenByHash(t *testing.T) {
+	db, ctx, cleanup := setupTokenRepoTestDB(t)
+	defer cleanup()
+	repo := NewRepository(db)
+	identity := createTestIdentityForTokens(t, repo, ctx)
+
+	prt, _, err := domain.NewPasswordResetToken(tokenRepoTestTenantID, identity.ID())
+	require.NoError(t, err)
+	err = repo.SavePasswordResetToken(ctx, prt)
+	require.NoError(t, err)
+
+	found, err := repo.FindPasswordResetTokenByHash(ctx, prt.TokenHash())
+	require.NoError(t, err)
+	assert.Equal(t, prt.ID(), found.ID())
+	assert.Equal(t, prt.TenantID(), found.TenantID())
+	assert.Equal(t, prt.IdentityID(), found.IdentityID())
+	assert.Equal(t, prt.TokenHash(), found.TokenHash())
+	assert.Nil(t, found.ConsumedAt())
+}
+
+func TestRepository_FindPasswordResetTokenByHash_NotFound(t *testing.T) {
+	db, ctx, cleanup := setupTokenRepoTestDB(t)
+	defer cleanup()
+	repo := NewRepository(db)
+
+	_, err := repo.FindPasswordResetTokenByHash(ctx, "nonexistent")
+	assert.ErrorIs(t, err, domain.ErrPasswordResetTokenNotFound)
+}
+
+func TestRepository_CountPasswordResetTokensInWindow(t *testing.T) {
+	db, ctx, cleanup := setupTokenRepoTestDB(t)
+	defer cleanup()
+	repo := NewRepository(db)
+	identity := createTestIdentityForTokens(t, repo, ctx)
+
+	for i := 0; i < 3; i++ {
+		prt, _, err := domain.NewPasswordResetToken(tokenRepoTestTenantID, identity.ID())
+		require.NoError(t, err)
+		err = repo.SavePasswordResetToken(ctx, prt)
+		require.NoError(t, err)
+	}
+
+	count, err := repo.CountPasswordResetTokensInWindow(ctx, identity.ID(), 1*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+}
+
+func TestRepository_CountPasswordResetTokensInWindow_ExcludesConsumed(t *testing.T) {
+	db, ctx, cleanup := setupTokenRepoTestDB(t)
+	defer cleanup()
+	repo := NewRepository(db)
+	identity := createTestIdentityForTokens(t, repo, ctx)
+
+	// Create and consume one token
+	prt1, _, err := domain.NewPasswordResetToken(tokenRepoTestTenantID, identity.ID())
+	require.NoError(t, err)
+	err = prt1.Consume()
+	require.NoError(t, err)
+	err = repo.SavePasswordResetToken(ctx, prt1)
+	require.NoError(t, err)
+
+	// Create one unconsumed token
+	prt2, _, err := domain.NewPasswordResetToken(tokenRepoTestTenantID, identity.ID())
+	require.NoError(t, err)
+	err = repo.SavePasswordResetToken(ctx, prt2)
+	require.NoError(t, err)
+
+	count, err := repo.CountPasswordResetTokensInWindow(ctx, identity.ID(), 1*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func TestRepository_InvalidatePasswordResetTokensForIdentity(t *testing.T) {
+	db, ctx, cleanup := setupTokenRepoTestDB(t)
+	defer cleanup()
+	repo := NewRepository(db)
+	identity := createTestIdentityForTokens(t, repo, ctx)
+
+	var hashes []string
+	for i := 0; i < 3; i++ {
+		prt, _, err := domain.NewPasswordResetToken(tokenRepoTestTenantID, identity.ID())
+		require.NoError(t, err)
+		err = repo.SavePasswordResetToken(ctx, prt)
+		require.NoError(t, err)
+		hashes = append(hashes, prt.TokenHash())
+	}
+
+	err := repo.InvalidatePasswordResetTokensForIdentity(ctx, identity.ID())
+	require.NoError(t, err)
+
+	for _, hash := range hashes {
+		found, err := repo.FindPasswordResetTokenByHash(ctx, hash)
+		require.NoError(t, err)
+		assert.NotNil(t, found.ConsumedAt(), "token %s should be consumed", hash)
+	}
+
+	count, err := repo.CountPasswordResetTokensInWindow(ctx, identity.ID(), 1*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestRepository_InvalidatePasswordResetTokensForIdentity_DoesNotAffectOther(t *testing.T) {
+	db, ctx, cleanup := setupTokenRepoTestDB(t)
+	defer cleanup()
+	repo := NewRepository(db)
+	identity1 := createTestIdentityForTokens(t, repo, ctx)
+	identity2 := createTestIdentityForTokens(t, repo, ctx)
+
+	prt1, _, err := domain.NewPasswordResetToken(tokenRepoTestTenantID, identity1.ID())
+	require.NoError(t, err)
+	err = repo.SavePasswordResetToken(ctx, prt1)
+	require.NoError(t, err)
+
+	prt2, _, err := domain.NewPasswordResetToken(tokenRepoTestTenantID, identity2.ID())
+	require.NoError(t, err)
+	err = repo.SavePasswordResetToken(ctx, prt2)
+	require.NoError(t, err)
+
+	err = repo.InvalidatePasswordResetTokensForIdentity(ctx, identity1.ID())
+	require.NoError(t, err)
+
+	found1, err := repo.FindPasswordResetTokenByHash(ctx, prt1.TokenHash())
+	require.NoError(t, err)
+	assert.NotNil(t, found1.ConsumedAt())
+
+	found2, err := repo.FindPasswordResetTokenByHash(ctx, prt2.TokenHash())
+	require.NoError(t, err)
+	assert.Nil(t, found2.ConsumedAt())
+}

--- a/services/identity/adapters/persistence/verification_token_entity.go
+++ b/services/identity/adapters/persistence/verification_token_entity.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/identity/domain"
 )
 
 // EmailVerificationTokenEntity represents the database persistence model for email verification tokens.
@@ -21,4 +22,30 @@ type EmailVerificationTokenEntity struct {
 // TableName overrides the default table name.
 func (EmailVerificationTokenEntity) TableName() string {
 	return "email_verification_token"
+}
+
+// toVerificationTokenEntity converts a domain VerificationToken to a persistence entity.
+func toVerificationTokenEntity(vt *domain.VerificationToken) *EmailVerificationTokenEntity {
+	return &EmailVerificationTokenEntity{
+		ID:         vt.ID(),
+		TenantID:   vt.TenantID(),
+		IdentityID: vt.IdentityID(),
+		TokenHash:  vt.TokenHash(),
+		ExpiresAt:  vt.ExpiresAt(),
+		ConsumedAt: vt.ConsumedAt(),
+		CreatedAt:  vt.CreatedAt(),
+	}
+}
+
+// toVerificationTokenDomain converts a persistence entity to a domain VerificationToken.
+func toVerificationTokenDomain(entity *EmailVerificationTokenEntity) *domain.VerificationToken {
+	return domain.ReconstructVerificationToken(
+		entity.ID,
+		entity.TenantID,
+		entity.IdentityID,
+		entity.TokenHash,
+		entity.ExpiresAt,
+		entity.ConsumedAt,
+		entity.CreatedAt,
+	)
 }

--- a/services/identity/bootstrap/demo_users_test.go
+++ b/services/identity/bootstrap/demo_users_test.go
@@ -117,7 +117,7 @@ func (f *fakeRepo) CountPasswordResetTokensInWindow(_ context.Context, _ uuid.UU
 	return 0, nil
 }
 
-func (f *fakeRepo) InvalidatePasswordResetTokensForIdentity(_ context.Context, _ uuid.UUID) error {
+func (f *fakeRepo) MarkPasswordResetTokensConsumedForIdentity(_ context.Context, _ uuid.UUID) error {
 	return nil
 }
 

--- a/services/identity/bootstrap/demo_users_test.go
+++ b/services/identity/bootstrap/demo_users_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/services/identity/domain"
@@ -90,6 +91,34 @@ func (f *fakeRepo) SaveInvitation(_ context.Context, _ *domain.Invitation) error
 
 func (f *fakeRepo) FindInvitationByTokenHash(_ context.Context, _ string) (*domain.Invitation, error) {
 	return nil, errors.New("not found")
+}
+
+func (f *fakeRepo) SaveVerificationToken(_ context.Context, _ *domain.VerificationToken) error {
+	return nil
+}
+
+func (f *fakeRepo) FindVerificationTokenByHash(_ context.Context, _ string) (*domain.VerificationToken, error) {
+	return nil, domain.ErrVerificationTokenNotFound
+}
+
+func (f *fakeRepo) CountVerificationTokensInWindow(_ context.Context, _ uuid.UUID, _ time.Duration) (int, error) {
+	return 0, nil
+}
+
+func (f *fakeRepo) SavePasswordResetToken(_ context.Context, _ *domain.PasswordResetToken) error {
+	return nil
+}
+
+func (f *fakeRepo) FindPasswordResetTokenByHash(_ context.Context, _ string) (*domain.PasswordResetToken, error) {
+	return nil, domain.ErrPasswordResetTokenNotFound
+}
+
+func (f *fakeRepo) CountPasswordResetTokensInWindow(_ context.Context, _ uuid.UUID, _ time.Duration) (int, error) {
+	return 0, nil
+}
+
+func (f *fakeRepo) InvalidatePasswordResetTokensForIdentity(_ context.Context, _ uuid.UUID) error {
+	return nil
 }
 
 // --- Tests for DemoUser and loadDemoUsers ---

--- a/services/identity/connector/connector_test.go
+++ b/services/identity/connector/connector_test.go
@@ -112,7 +112,7 @@ func (m *mockRepo) CountPasswordResetTokensInWindow(_ context.Context, _ uuid.UU
 	return 0, nil
 }
 
-func (m *mockRepo) InvalidatePasswordResetTokensForIdentity(_ context.Context, _ uuid.UUID) error {
+func (m *mockRepo) MarkPasswordResetTokensConsumedForIdentity(_ context.Context, _ uuid.UUID) error {
 	return nil
 }
 

--- a/services/identity/connector/connector_test.go
+++ b/services/identity/connector/connector_test.go
@@ -88,6 +88,34 @@ func (m *mockRepo) FindInvitationByTokenHash(_ context.Context, _ string) (*doma
 	return nil, errors.New("not implemented")
 }
 
+func (m *mockRepo) SaveVerificationToken(_ context.Context, _ *domain.VerificationToken) error {
+	return nil
+}
+
+func (m *mockRepo) FindVerificationTokenByHash(_ context.Context, _ string) (*domain.VerificationToken, error) {
+	return nil, domain.ErrVerificationTokenNotFound
+}
+
+func (m *mockRepo) CountVerificationTokensInWindow(_ context.Context, _ uuid.UUID, _ time.Duration) (int, error) {
+	return 0, nil
+}
+
+func (m *mockRepo) SavePasswordResetToken(_ context.Context, _ *domain.PasswordResetToken) error {
+	return nil
+}
+
+func (m *mockRepo) FindPasswordResetTokenByHash(_ context.Context, _ string) (*domain.PasswordResetToken, error) {
+	return nil, domain.ErrPasswordResetTokenNotFound
+}
+
+func (m *mockRepo) CountPasswordResetTokensInWindow(_ context.Context, _ uuid.UUID, _ time.Duration) (int, error) {
+	return 0, nil
+}
+
+func (m *mockRepo) InvalidatePasswordResetTokensForIdentity(_ context.Context, _ uuid.UUID) error {
+	return nil
+}
+
 // --- Helpers ---
 
 const testPassword = "ValidPassword1!"

--- a/services/identity/domain/errors.go
+++ b/services/identity/domain/errors.go
@@ -22,4 +22,14 @@ var (
 	ErrTenantIDRequired            = errors.New("tenant ID is required")
 	ErrNotPendingVerification      = errors.New("identity is not in PENDING_VERIFICATION status")
 	ErrEmailNotVerified            = errors.New("email address has not been verified")
+
+	// Verification token errors
+	ErrVerificationTokenNotFound        = errors.New("verification token not found")
+	ErrVerificationTokenExpired         = errors.New("verification token has expired")
+	ErrVerificationTokenAlreadyConsumed = errors.New("verification token has already been consumed")
+
+	// Password reset token errors
+	ErrPasswordResetTokenNotFound        = errors.New("password reset token not found")
+	ErrPasswordResetTokenExpired         = errors.New("password reset token has expired")
+	ErrPasswordResetTokenAlreadyConsumed = errors.New("password reset token has already been consumed")
 )

--- a/services/identity/domain/password_reset_token.go
+++ b/services/identity/domain/password_reset_token.go
@@ -65,10 +65,10 @@ func (prt *PasswordResetToken) Consume() error {
 	if prt.consumedAt != nil {
 		return ErrPasswordResetTokenAlreadyConsumed
 	}
-	if !time.Now().Before(prt.expiresAt) {
+	now := time.Now()
+	if !now.Before(prt.expiresAt) {
 		return ErrPasswordResetTokenExpired
 	}
-	now := time.Now()
 	prt.consumedAt = &now
 	return nil
 }

--- a/services/identity/domain/password_reset_token.go
+++ b/services/identity/domain/password_reset_token.go
@@ -1,0 +1,95 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/pkg/tokens"
+)
+
+// PasswordResetToken represents a password reset token issued during the forgot-password flow.
+type PasswordResetToken struct {
+	id         uuid.UUID
+	tenantID   string
+	identityID uuid.UUID
+	tokenHash  string
+	expiresAt  time.Time
+	consumedAt *time.Time
+	createdAt  time.Time
+}
+
+// NewPasswordResetToken creates a new password reset token and returns both the domain object
+// and the plaintext token that must be delivered to the user. The plaintext token is never
+// stored; only its SHA256 hash is persisted.
+func NewPasswordResetToken(tenantID string, identityID uuid.UUID) (*PasswordResetToken, string, error) {
+	plaintext, hash, err := tokens.GenerateToken(tokens.PasswordResetTokenLength)
+	if err != nil {
+		return nil, "", err
+	}
+
+	now := time.Now()
+	prt := &PasswordResetToken{
+		id:         uuid.New(),
+		tenantID:   tenantID,
+		identityID: identityID,
+		tokenHash:  hash,
+		expiresAt:  now.Add(tokens.PasswordResetTokenTTL),
+		createdAt:  now,
+	}
+	return prt, plaintext, nil
+}
+
+// ReconstructPasswordResetToken recreates a PasswordResetToken from persistence layer data.
+func ReconstructPasswordResetToken(
+	id uuid.UUID,
+	tenantID string,
+	identityID uuid.UUID,
+	tokenHash string,
+	expiresAt time.Time,
+	consumedAt *time.Time,
+	createdAt time.Time,
+) *PasswordResetToken {
+	return &PasswordResetToken{
+		id:         id,
+		tenantID:   tenantID,
+		identityID: identityID,
+		tokenHash:  tokenHash,
+		expiresAt:  expiresAt,
+		consumedAt: consumedAt,
+		createdAt:  createdAt,
+	}
+}
+
+// Consume marks the token as consumed. Returns an error if expired or already consumed.
+func (prt *PasswordResetToken) Consume() error {
+	if prt.consumedAt != nil {
+		return ErrPasswordResetTokenAlreadyConsumed
+	}
+	if !time.Now().Before(prt.expiresAt) {
+		return ErrPasswordResetTokenExpired
+	}
+	now := time.Now()
+	prt.consumedAt = &now
+	return nil
+}
+
+// ID returns the token's unique identifier.
+func (prt *PasswordResetToken) ID() uuid.UUID { return prt.id }
+
+// TenantID returns the tenant this token belongs to.
+func (prt *PasswordResetToken) TenantID() string { return prt.tenantID }
+
+// IdentityID returns the identity this token is for.
+func (prt *PasswordResetToken) IdentityID() uuid.UUID { return prt.identityID }
+
+// TokenHash returns the SHA256 hash of the password reset token.
+func (prt *PasswordResetToken) TokenHash() string { return prt.tokenHash }
+
+// ExpiresAt returns when the token expires.
+func (prt *PasswordResetToken) ExpiresAt() time.Time { return prt.expiresAt }
+
+// ConsumedAt returns when the token was consumed, or nil if not yet consumed.
+func (prt *PasswordResetToken) ConsumedAt() *time.Time { return prt.consumedAt }
+
+// CreatedAt returns when the token was created.
+func (prt *PasswordResetToken) CreatedAt() time.Time { return prt.createdAt }

--- a/services/identity/domain/password_reset_token_test.go
+++ b/services/identity/domain/password_reset_token_test.go
@@ -1,0 +1,95 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/pkg/tokens"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPasswordResetToken(t *testing.T) {
+	tenantID := "test-tenant"
+	identityID := uuid.New()
+
+	prt, plaintext, err := NewPasswordResetToken(tenantID, identityID)
+
+	require.NoError(t, err)
+	assert.NotNil(t, prt)
+	assert.NotEmpty(t, plaintext)
+	assert.NotEqual(t, uuid.Nil, prt.ID())
+	assert.Equal(t, tenantID, prt.TenantID())
+	assert.Equal(t, identityID, prt.IdentityID())
+	assert.NotEmpty(t, prt.TokenHash())
+	assert.Nil(t, prt.ConsumedAt())
+	assert.WithinDuration(t, time.Now().Add(tokens.PasswordResetTokenTTL), prt.ExpiresAt(), 2*time.Second)
+	assert.WithinDuration(t, time.Now(), prt.CreatedAt(), 2*time.Second)
+
+	// Plaintext hashes to stored hash
+	assert.True(t, tokens.ValidateTokenHash(plaintext, prt.TokenHash()))
+}
+
+func TestPasswordResetToken_Consume(t *testing.T) {
+	tenantID := "test-tenant"
+	identityID := uuid.New()
+
+	prt, _, err := NewPasswordResetToken(tenantID, identityID)
+	require.NoError(t, err)
+
+	err = prt.Consume()
+	require.NoError(t, err)
+	assert.NotNil(t, prt.ConsumedAt())
+	assert.WithinDuration(t, time.Now(), *prt.ConsumedAt(), 2*time.Second)
+}
+
+func TestPasswordResetToken_Consume_AlreadyConsumed(t *testing.T) {
+	tenantID := "test-tenant"
+	identityID := uuid.New()
+
+	prt, _, err := NewPasswordResetToken(tenantID, identityID)
+	require.NoError(t, err)
+
+	err = prt.Consume()
+	require.NoError(t, err)
+
+	err = prt.Consume()
+	assert.ErrorIs(t, err, ErrPasswordResetTokenAlreadyConsumed)
+}
+
+func TestPasswordResetToken_Consume_Expired(t *testing.T) {
+	prt := ReconstructPasswordResetToken(
+		uuid.New(),
+		"test-tenant",
+		uuid.New(),
+		"somehash",
+		time.Now().Add(-1*time.Minute), // expired
+		nil,
+		time.Now().Add(-2*time.Hour),
+	)
+
+	err := prt.Consume()
+	assert.ErrorIs(t, err, ErrPasswordResetTokenExpired)
+}
+
+func TestReconstructPasswordResetToken(t *testing.T) {
+	id := uuid.New()
+	tenantID := "test-tenant"
+	identityID := uuid.New()
+	hash := "abc123"
+	expiresAt := time.Now().Add(1 * time.Hour)
+	now := time.Now()
+	consumedAt := &now
+	createdAt := time.Now().Add(-30 * time.Minute)
+
+	prt := ReconstructPasswordResetToken(id, tenantID, identityID, hash, expiresAt, consumedAt, createdAt)
+
+	assert.Equal(t, id, prt.ID())
+	assert.Equal(t, tenantID, prt.TenantID())
+	assert.Equal(t, identityID, prt.IdentityID())
+	assert.Equal(t, hash, prt.TokenHash())
+	assert.Equal(t, expiresAt, prt.ExpiresAt())
+	assert.Equal(t, consumedAt, prt.ConsumedAt())
+	assert.Equal(t, createdAt, prt.CreatedAt())
+}

--- a/services/identity/domain/repository.go
+++ b/services/identity/domain/repository.go
@@ -84,7 +84,7 @@ type Repository interface {
 	// for the given identity within the specified time window. Used for rate limiting.
 	CountPasswordResetTokensInWindow(ctx context.Context, identityID uuid.UUID, window time.Duration) (int, error)
 
-	// InvalidatePasswordResetTokensForIdentity marks all unconsumed password reset tokens
+	// MarkPasswordResetTokensConsumedForIdentity marks all unconsumed password reset tokens
 	// for the given identity as consumed. Used when a password is successfully reset.
-	InvalidatePasswordResetTokensForIdentity(ctx context.Context, identityID uuid.UUID) error
+	MarkPasswordResetTokensConsumedForIdentity(ctx context.Context, identityID uuid.UUID) error
 }

--- a/services/identity/domain/repository.go
+++ b/services/identity/domain/repository.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -56,4 +57,34 @@ type Repository interface {
 	// FindInvitationByTokenHash retrieves an invitation by the SHA256 hash of its token.
 	// Returns ErrInvitationNotFound if no matching invitation exists.
 	FindInvitationByTokenHash(ctx context.Context, tokenHash string) (*Invitation, error)
+
+	// Verification token operations
+
+	// SaveVerificationToken persists a new verification token.
+	SaveVerificationToken(ctx context.Context, token *VerificationToken) error
+
+	// FindVerificationTokenByHash retrieves a verification token by its SHA256 hash.
+	// Returns ErrVerificationTokenNotFound if no matching token exists.
+	FindVerificationTokenByHash(ctx context.Context, hash string) (*VerificationToken, error)
+
+	// CountVerificationTokensInWindow counts unconsumed verification tokens created
+	// for the given identity within the specified time window. Used for rate limiting.
+	CountVerificationTokensInWindow(ctx context.Context, identityID uuid.UUID, window time.Duration) (int, error)
+
+	// Password reset token operations
+
+	// SavePasswordResetToken persists a new password reset token.
+	SavePasswordResetToken(ctx context.Context, token *PasswordResetToken) error
+
+	// FindPasswordResetTokenByHash retrieves a password reset token by its SHA256 hash.
+	// Returns ErrPasswordResetTokenNotFound if no matching token exists.
+	FindPasswordResetTokenByHash(ctx context.Context, hash string) (*PasswordResetToken, error)
+
+	// CountPasswordResetTokensInWindow counts unconsumed password reset tokens created
+	// for the given identity within the specified time window. Used for rate limiting.
+	CountPasswordResetTokensInWindow(ctx context.Context, identityID uuid.UUID, window time.Duration) (int, error)
+
+	// InvalidatePasswordResetTokensForIdentity marks all unconsumed password reset tokens
+	// for the given identity as consumed. Used when a password is successfully reset.
+	InvalidatePasswordResetTokensForIdentity(ctx context.Context, identityID uuid.UUID) error
 }

--- a/services/identity/domain/verification_token.go
+++ b/services/identity/domain/verification_token.go
@@ -1,0 +1,95 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/pkg/tokens"
+)
+
+// VerificationToken represents an email verification token issued during self-registration.
+type VerificationToken struct {
+	id         uuid.UUID
+	tenantID   string
+	identityID uuid.UUID
+	tokenHash  string
+	expiresAt  time.Time
+	consumedAt *time.Time
+	createdAt  time.Time
+}
+
+// NewVerificationToken creates a new verification token and returns both the domain object
+// and the plaintext token that must be delivered to the user. The plaintext token is never
+// stored; only its SHA256 hash is persisted.
+func NewVerificationToken(tenantID string, identityID uuid.UUID) (*VerificationToken, string, error) {
+	plaintext, hash, err := tokens.GenerateToken(tokens.EmailVerificationTokenLength)
+	if err != nil {
+		return nil, "", err
+	}
+
+	now := time.Now()
+	vt := &VerificationToken{
+		id:         uuid.New(),
+		tenantID:   tenantID,
+		identityID: identityID,
+		tokenHash:  hash,
+		expiresAt:  now.Add(tokens.EmailVerificationTokenTTL),
+		createdAt:  now,
+	}
+	return vt, plaintext, nil
+}
+
+// ReconstructVerificationToken recreates a VerificationToken from persistence layer data.
+func ReconstructVerificationToken(
+	id uuid.UUID,
+	tenantID string,
+	identityID uuid.UUID,
+	tokenHash string,
+	expiresAt time.Time,
+	consumedAt *time.Time,
+	createdAt time.Time,
+) *VerificationToken {
+	return &VerificationToken{
+		id:         id,
+		tenantID:   tenantID,
+		identityID: identityID,
+		tokenHash:  tokenHash,
+		expiresAt:  expiresAt,
+		consumedAt: consumedAt,
+		createdAt:  createdAt,
+	}
+}
+
+// Consume marks the token as consumed. Returns an error if expired or already consumed.
+func (vt *VerificationToken) Consume() error {
+	if vt.consumedAt != nil {
+		return ErrVerificationTokenAlreadyConsumed
+	}
+	if !time.Now().Before(vt.expiresAt) {
+		return ErrVerificationTokenExpired
+	}
+	now := time.Now()
+	vt.consumedAt = &now
+	return nil
+}
+
+// ID returns the token's unique identifier.
+func (vt *VerificationToken) ID() uuid.UUID { return vt.id }
+
+// TenantID returns the tenant this token belongs to.
+func (vt *VerificationToken) TenantID() string { return vt.tenantID }
+
+// IdentityID returns the identity this token is for.
+func (vt *VerificationToken) IdentityID() uuid.UUID { return vt.identityID }
+
+// TokenHash returns the SHA256 hash of the verification token.
+func (vt *VerificationToken) TokenHash() string { return vt.tokenHash }
+
+// ExpiresAt returns when the token expires.
+func (vt *VerificationToken) ExpiresAt() time.Time { return vt.expiresAt }
+
+// ConsumedAt returns when the token was consumed, or nil if not yet consumed.
+func (vt *VerificationToken) ConsumedAt() *time.Time { return vt.consumedAt }
+
+// CreatedAt returns when the token was created.
+func (vt *VerificationToken) CreatedAt() time.Time { return vt.createdAt }

--- a/services/identity/domain/verification_token.go
+++ b/services/identity/domain/verification_token.go
@@ -65,10 +65,10 @@ func (vt *VerificationToken) Consume() error {
 	if vt.consumedAt != nil {
 		return ErrVerificationTokenAlreadyConsumed
 	}
-	if !time.Now().Before(vt.expiresAt) {
+	now := time.Now()
+	if !now.Before(vt.expiresAt) {
 		return ErrVerificationTokenExpired
 	}
-	now := time.Now()
 	vt.consumedAt = &now
 	return nil
 }

--- a/services/identity/domain/verification_token_test.go
+++ b/services/identity/domain/verification_token_test.go
@@ -1,0 +1,96 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/pkg/tokens"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewVerificationToken(t *testing.T) {
+	tenantID := "test-tenant"
+	identityID := uuid.New()
+
+	vt, plaintext, err := NewVerificationToken(tenantID, identityID)
+
+	require.NoError(t, err)
+	assert.NotNil(t, vt)
+	assert.NotEmpty(t, plaintext)
+	assert.NotEqual(t, uuid.Nil, vt.ID())
+	assert.Equal(t, tenantID, vt.TenantID())
+	assert.Equal(t, identityID, vt.IdentityID())
+	assert.NotEmpty(t, vt.TokenHash())
+	assert.Nil(t, vt.ConsumedAt())
+	assert.WithinDuration(t, time.Now().Add(tokens.EmailVerificationTokenTTL), vt.ExpiresAt(), 2*time.Second)
+	assert.WithinDuration(t, time.Now(), vt.CreatedAt(), 2*time.Second)
+
+	// Plaintext hashes to stored hash
+	assert.True(t, tokens.ValidateTokenHash(plaintext, vt.TokenHash()))
+}
+
+func TestVerificationToken_Consume(t *testing.T) {
+	tenantID := "test-tenant"
+	identityID := uuid.New()
+
+	vt, _, err := NewVerificationToken(tenantID, identityID)
+	require.NoError(t, err)
+
+	err = vt.Consume()
+	require.NoError(t, err)
+	assert.NotNil(t, vt.ConsumedAt())
+	assert.WithinDuration(t, time.Now(), *vt.ConsumedAt(), 2*time.Second)
+}
+
+func TestVerificationToken_Consume_AlreadyConsumed(t *testing.T) {
+	tenantID := "test-tenant"
+	identityID := uuid.New()
+
+	vt, _, err := NewVerificationToken(tenantID, identityID)
+	require.NoError(t, err)
+
+	err = vt.Consume()
+	require.NoError(t, err)
+
+	err = vt.Consume()
+	assert.ErrorIs(t, err, ErrVerificationTokenAlreadyConsumed)
+}
+
+func TestVerificationToken_Consume_Expired(t *testing.T) {
+	// Reconstruct an already-expired token
+	vt := ReconstructVerificationToken(
+		uuid.New(),
+		"test-tenant",
+		uuid.New(),
+		"somehash",
+		time.Now().Add(-1*time.Hour), // expired 1 hour ago
+		nil,
+		time.Now().Add(-25*time.Hour),
+	)
+
+	err := vt.Consume()
+	assert.ErrorIs(t, err, ErrVerificationTokenExpired)
+}
+
+func TestReconstructVerificationToken(t *testing.T) {
+	id := uuid.New()
+	tenantID := "test-tenant"
+	identityID := uuid.New()
+	hash := "abc123"
+	expiresAt := time.Now().Add(24 * time.Hour)
+	now := time.Now()
+	consumedAt := &now
+	createdAt := time.Now().Add(-1 * time.Hour)
+
+	vt := ReconstructVerificationToken(id, tenantID, identityID, hash, expiresAt, consumedAt, createdAt)
+
+	assert.Equal(t, id, vt.ID())
+	assert.Equal(t, tenantID, vt.TenantID())
+	assert.Equal(t, identityID, vt.IdentityID())
+	assert.Equal(t, hash, vt.TokenHash())
+	assert.Equal(t, expiresAt, vt.ExpiresAt())
+	assert.Equal(t, consumedAt, vt.ConsumedAt())
+	assert.Equal(t, createdAt, vt.CreatedAt())
+}

--- a/services/identity/service/grpc_service_test.go
+++ b/services/identity/service/grpc_service_test.go
@@ -185,7 +185,7 @@ func (m *mockRepository) CountPasswordResetTokensInWindow(_ context.Context, _ u
 	return 0, nil
 }
 
-func (m *mockRepository) InvalidatePasswordResetTokensForIdentity(_ context.Context, _ uuid.UUID) error {
+func (m *mockRepository) MarkPasswordResetTokensConsumedForIdentity(_ context.Context, _ uuid.UUID) error {
 	return nil
 }
 

--- a/services/identity/service/grpc_service_test.go
+++ b/services/identity/service/grpc_service_test.go
@@ -161,6 +161,34 @@ func (m *mockRepository) FindInvitationByTokenHash(_ context.Context, tokenHash 
 	return inv, nil
 }
 
+func (m *mockRepository) SaveVerificationToken(_ context.Context, _ *domain.VerificationToken) error {
+	return nil
+}
+
+func (m *mockRepository) FindVerificationTokenByHash(_ context.Context, _ string) (*domain.VerificationToken, error) {
+	return nil, domain.ErrVerificationTokenNotFound
+}
+
+func (m *mockRepository) CountVerificationTokensInWindow(_ context.Context, _ uuid.UUID, _ time.Duration) (int, error) {
+	return 0, nil
+}
+
+func (m *mockRepository) SavePasswordResetToken(_ context.Context, _ *domain.PasswordResetToken) error {
+	return nil
+}
+
+func (m *mockRepository) FindPasswordResetTokenByHash(_ context.Context, _ string) (*domain.PasswordResetToken, error) {
+	return nil, domain.ErrPasswordResetTokenNotFound
+}
+
+func (m *mockRepository) CountPasswordResetTokensInWindow(_ context.Context, _ uuid.UUID, _ time.Duration) (int, error) {
+	return 0, nil
+}
+
+func (m *mockRepository) InvalidatePasswordResetTokensForIdentity(_ context.Context, _ uuid.UUID) error {
+	return nil
+}
+
 // addIdentity is a test helper to insert an identity directly into the mock.
 func (m *mockRepository) addIdentity(identity *domain.Identity) {
 	m.identities[identity.ID()] = identity

--- a/shared/pkg/tokens/expiry.go
+++ b/shared/pkg/tokens/expiry.go
@@ -4,9 +4,9 @@ import "time"
 
 // TTL constants for different token types.
 const (
-	InvitationTokenTTL         = 72 * time.Hour
-	PasswordResetTokenTTL      = 1 * time.Hour
-	EmailVerificationTokenTTL  = 24 * time.Hour
+	InvitationTokenTTL        = 72 * time.Hour
+	PasswordResetTokenTTL     = 1 * time.Hour
+	EmailVerificationTokenTTL = 24 * time.Hour
 )
 
 // TokenWithExpiry pairs a stored token hash with its expiry time.

--- a/shared/pkg/tokens/expiry.go
+++ b/shared/pkg/tokens/expiry.go
@@ -4,8 +4,9 @@ import "time"
 
 // TTL constants for different token types.
 const (
-	InvitationTokenTTL    = 72 * time.Hour
-	PasswordResetTokenTTL = 1 * time.Hour
+	InvitationTokenTTL         = 72 * time.Hour
+	PasswordResetTokenTTL      = 1 * time.Hour
+	EmailVerificationTokenTTL  = 24 * time.Hour
 )
 
 // TokenWithExpiry pairs a stored token hash with its expiry time.

--- a/shared/pkg/tokens/token.go
+++ b/shared/pkg/tokens/token.go
@@ -16,8 +16,9 @@ var ErrInvalidLength = errors.New("token length must be positive")
 
 // Token length constants for different use cases.
 const (
-	InvitationTokenLength    = 32
-	PasswordResetTokenLength = 32
+	InvitationTokenLength         = 32
+	PasswordResetTokenLength      = 32
+	EmailVerificationTokenLength  = 32
 )
 
 // GenerateToken generates a cryptographically secure random token of the given byte length.

--- a/shared/pkg/tokens/token.go
+++ b/shared/pkg/tokens/token.go
@@ -16,9 +16,9 @@ var ErrInvalidLength = errors.New("token length must be positive")
 
 // Token length constants for different use cases.
 const (
-	InvitationTokenLength         = 32
-	PasswordResetTokenLength      = 32
-	EmailVerificationTokenLength  = 32
+	InvitationTokenLength        = 32
+	PasswordResetTokenLength     = 32
+	EmailVerificationTokenLength = 32
 )
 
 // GenerateToken generates a cryptographically secure random token of the given byte length.


### PR DESCRIPTION
## Summary

- Add `VerificationToken` and `PasswordResetToken` domain models with constructors, `Consume()` methods, and reconstruction functions following existing `Invitation` patterns
- Extend `Repository` interface with 7 new methods: save, find-by-hash, count-in-window (rate limiting) for both token types, plus `InvalidatePasswordResetTokensForIdentity`
- Implement all repository methods in GORM persistence layer using tenant-scoped transactions
- Add entity-to-domain mapping functions for both token types
- Add `EmailVerificationTokenLength` and `EmailVerificationTokenTTL` (24h) constants to `shared/pkg/tokens`

## Changes

### Domain layer (`services/identity/domain/`)
- `verification_token.go` - VerificationToken domain model (24h TTL)
- `password_reset_token.go` - PasswordResetToken domain model (1h TTL)
- `errors.go` - 6 new domain errors for token not-found, expired, already-consumed
- `repository.go` - 7 new interface methods for token persistence

### Persistence layer (`services/identity/adapters/persistence/`)
- `verification_token_entity.go` - Added entity-to-domain mapping functions
- `password_reset_token_entity.go` - Added entity-to-domain mapping functions
- `repository.go` - Implemented all 7 new repository methods

### Shared
- `shared/pkg/tokens/token.go` - Added `EmailVerificationTokenLength`
- `shared/pkg/tokens/expiry.go` - Added `EmailVerificationTokenTTL`

### Test updates
- Updated mock repositories in `bootstrap`, `connector`, and `service` packages to satisfy expanded interface
- New domain unit tests for both token types
- New integration tests for all repository operations using testcontainers

## Test plan

- [x] Domain unit tests: NewToken, Consume, expiry, already-consumed for both types
- [x] Integration tests: Save, FindByHash, FindByHash_NotFound for both types
- [x] Integration tests: CountInWindow, CountInWindow_ExcludesConsumed, CountInWindow_DifferentIdentity
- [x] Integration tests: InvalidateForIdentity, InvalidateForIdentity_DoesNotAffectOther
- [x] All existing identity service tests still pass