### PR TITLE
feat: add billing repository queries and gRPC service handlers

### DIFF
--- a/services/control-plane/internal/applier/reference_data_client_test.go
+++ b/services/control-plane/internal/applier/reference_data_client_test.go
@@ -24,8 +24,8 @@ var _ ReferenceDataService = (*ReferenceDataClient)(nil)
 
 type fakeReferenceDataServer struct {
 	referencedatav1.UnimplementedReferenceDataServiceServer
-	activateInstrumentFn  func(context.Context, *referencedatav1.ActivateInstrumentRequest) (*referencedatav1.ActivateInstrumentResponse, error)
-	retrieveInstrumentFn  func(context.Context, *referencedatav1.RetrieveInstrumentRequest) (*referencedatav1.RetrieveInstrumentResponse, error)
+	activateInstrumentFn func(context.Context, *referencedatav1.ActivateInstrumentRequest) (*referencedatav1.ActivateInstrumentResponse, error)
+	retrieveInstrumentFn func(context.Context, *referencedatav1.RetrieveInstrumentRequest) (*referencedatav1.RetrieveInstrumentResponse, error)
 }
 
 func (f *fakeReferenceDataServer) RegisterInstrument(_ context.Context, req *referencedatav1.RegisterInstrumentRequest) (*referencedatav1.RegisterInstrumentResponse, error) {

--- a/services/payment-order/adapters/persistence/billing_list_test.go
+++ b/services/payment-order/adapters/persistence/billing_list_test.go
@@ -1,0 +1,255 @@
+package persistence
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBillingRepository_ListBillingRuns_Empty(t *testing.T) {
+	db, ctx, cleanup := setupBillingTestDB(t)
+	defer cleanup()
+
+	repo := NewBillingRepository(db)
+	page, err := repo.ListBillingRuns(ctx, BillingRunFilter{}, 10, "")
+	require.NoError(t, err)
+	assert.Empty(t, page.BillingRuns)
+	assert.Equal(t, int64(0), page.TotalCount)
+	assert.Empty(t, page.NextCursor)
+}
+
+func TestBillingRepository_ListBillingRuns_Pagination(t *testing.T) {
+	db, ctx, cleanup := setupBillingTestDB(t)
+	defer cleanup()
+
+	repo := NewBillingRepository(db)
+
+	// Create 5 billing runs with staggered times.
+	for i := range 5 {
+		start := time.Date(2026, time.Month(i+1), 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2026, time.Month(i+2), 1, 0, 0, 0, 0, time.UTC)
+		run, err := domain.NewBillingRun("tenant-list-test", start, end)
+		require.NoError(t, err)
+		require.NoError(t, repo.CreateBillingRun(ctx, run))
+	}
+
+	// First page of 2.
+	page1, err := repo.ListBillingRuns(ctx, BillingRunFilter{}, 2, "")
+	require.NoError(t, err)
+	assert.Len(t, page1.BillingRuns, 2)
+	assert.Equal(t, int64(5), page1.TotalCount)
+	assert.NotEmpty(t, page1.NextCursor)
+
+	// Second page.
+	page2, err := repo.ListBillingRuns(ctx, BillingRunFilter{}, 2, page1.NextCursor)
+	require.NoError(t, err)
+	assert.Len(t, page2.BillingRuns, 2)
+	assert.NotEmpty(t, page2.NextCursor)
+
+	// Third page (last item).
+	page3, err := repo.ListBillingRuns(ctx, BillingRunFilter{}, 2, page2.NextCursor)
+	require.NoError(t, err)
+	assert.Len(t, page3.BillingRuns, 1)
+	assert.Empty(t, page3.NextCursor)
+
+	// All IDs should be unique across pages.
+	allIDs := make(map[uuid.UUID]bool)
+	for _, r := range page1.BillingRuns {
+		allIDs[r.ID] = true
+	}
+	for _, r := range page2.BillingRuns {
+		allIDs[r.ID] = true
+	}
+	for _, r := range page3.BillingRuns {
+		allIDs[r.ID] = true
+	}
+	assert.Len(t, allIDs, 5)
+}
+
+func TestBillingRepository_ListBillingRuns_StatusFilter(t *testing.T) {
+	db, ctx, cleanup := setupBillingTestDB(t)
+	defer cleanup()
+
+	repo := NewBillingRepository(db)
+
+	// Create one INITIATED and one COMPLETED run.
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	run1, err := domain.NewBillingRun("tenant-filter", start, end)
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateBillingRun(ctx, run1))
+
+	start2 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	end2 := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	run2, err := domain.NewBillingRun("tenant-filter", start2, end2)
+	require.NoError(t, err)
+	require.NoError(t, run2.StartProcessing())
+	require.NoError(t, run2.Complete())
+	require.NoError(t, repo.CreateBillingRun(ctx, run2))
+
+	// Filter by COMPLETED only.
+	page, err := repo.ListBillingRuns(ctx, BillingRunFilter{
+		Statuses: []string{string(domain.BillingRunStatusCompleted)},
+	}, 10, "")
+	require.NoError(t, err)
+	assert.Len(t, page.BillingRuns, 1)
+	assert.Equal(t, domain.BillingRunStatusCompleted, page.BillingRuns[0].Status)
+}
+
+func TestBillingRepository_ListBillingRuns_InvalidCursor(t *testing.T) {
+	db, ctx, cleanup := setupBillingTestDB(t)
+	defer cleanup()
+
+	repo := NewBillingRepository(db)
+	_, err := repo.ListBillingRuns(ctx, BillingRunFilter{}, 10, "not-valid-base64!!!")
+	assert.ErrorIs(t, err, ErrInvalidBillingCursor)
+}
+
+func TestBillingRepository_ListInvoices_WithFilters(t *testing.T) {
+	db, ctx, cleanup := setupBillingTestDB(t)
+	defer cleanup()
+
+	repo := NewBillingRepository(db)
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	run, err := domain.NewBillingRun("tenant-inv-list", start, end)
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateBillingRun(ctx, run))
+
+	// Create invoices for different parties.
+	for i := range 3 {
+		inv := &domain.Invoice{
+			ID:            uuid.New(),
+			BillingRunID:  run.ID,
+			PartyID:       "party-A",
+			AccountID:     "acc-1",
+			InvoiceNumber: "INV-LIST-A" + string(rune('0'+i)),
+			PeriodStart:   start,
+			PeriodEnd:     end,
+			LineItems:     []domain.InvoiceLineItem{{Description: "Fee", Quantity: decimal.NewFromInt(1), UnitPriceCents: 100, TotalCents: 100}},
+			SubtotalCents: 100,
+			Currency:      "GBP",
+			Status:        domain.InvoiceStatusDraft,
+			CreatedAt:     time.Now().UTC(),
+		}
+		require.NoError(t, repo.CreateInvoice(ctx, inv))
+	}
+
+	inv := &domain.Invoice{
+		ID:            uuid.New(),
+		BillingRunID:  run.ID,
+		PartyID:       "party-B",
+		AccountID:     "acc-2",
+		InvoiceNumber: "INV-LIST-B0",
+		PeriodStart:   start,
+		PeriodEnd:     end,
+		LineItems:     []domain.InvoiceLineItem{{Description: "Fee", Quantity: decimal.NewFromInt(1), UnitPriceCents: 200, TotalCents: 200}},
+		SubtotalCents: 200,
+		Currency:      "GBP",
+		Status:        domain.InvoiceStatusDraft,
+		CreatedAt:     time.Now().UTC(),
+	}
+	require.NoError(t, repo.CreateInvoice(ctx, inv))
+
+	// List all.
+	page, err := repo.ListInvoices(ctx, InvoiceFilter{}, 10, "")
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), page.TotalCount)
+
+	// Filter by party.
+	page, err = repo.ListInvoices(ctx, InvoiceFilter{PartyID: "party-A"}, 10, "")
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), page.TotalCount)
+
+	// Filter by billing run.
+	page, err = repo.ListInvoices(ctx, InvoiceFilter{BillingRunID: run.ID.String()}, 10, "")
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), page.TotalCount)
+}
+
+func TestBillingRepository_CountInvoicesByBillingRun(t *testing.T) {
+	db, ctx, cleanup := setupBillingTestDB(t)
+	defer cleanup()
+
+	repo := NewBillingRepository(db)
+
+	start := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	run, err := domain.NewBillingRun("tenant-count", start, end)
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateBillingRun(ctx, run))
+
+	for i := range 3 {
+		inv := &domain.Invoice{
+			ID:            uuid.New(),
+			BillingRunID:  run.ID,
+			PartyID:       "party-1",
+			AccountID:     "acc-1",
+			InvoiceNumber: "INV-CNT-" + string(rune('0'+i)),
+			PeriodStart:   start,
+			PeriodEnd:     end,
+			LineItems:     []domain.InvoiceLineItem{{Description: "Fee", Quantity: decimal.NewFromInt(1), UnitPriceCents: 100, TotalCents: 100}},
+			SubtotalCents: 100,
+			Currency:      "GBP",
+			Status:        domain.InvoiceStatusDraft,
+			CreatedAt:     time.Now().UTC(),
+		}
+		require.NoError(t, repo.CreateInvoice(ctx, inv))
+	}
+
+	count, err := repo.CountInvoicesByBillingRun(ctx, run.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), count)
+
+	// Non-existent run.
+	count, err = repo.CountInvoicesByBillingRun(ctx, uuid.New())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestBillingRepository_SumInvoiceTotalsByBillingRun(t *testing.T) {
+	db, ctx, cleanup := setupBillingTestDB(t)
+	defer cleanup()
+
+	repo := NewBillingRepository(db)
+
+	start := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	run, err := domain.NewBillingRun("tenant-sum", start, end)
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateBillingRun(ctx, run))
+
+	amounts := []int64{1000, 2000, 3000}
+	for i, amt := range amounts {
+		inv := &domain.Invoice{
+			ID:            uuid.New(),
+			BillingRunID:  run.ID,
+			PartyID:       "party-1",
+			AccountID:     "acc-1",
+			InvoiceNumber: "INV-SUM-" + string(rune('0'+i)),
+			PeriodStart:   start,
+			PeriodEnd:     end,
+			LineItems:     []domain.InvoiceLineItem{{Description: "Fee", Quantity: decimal.NewFromInt(1), UnitPriceCents: amt, TotalCents: amt}},
+			SubtotalCents: amt,
+			Currency:      "GBP",
+			Status:        domain.InvoiceStatusDraft,
+			CreatedAt:     time.Now().UTC(),
+		}
+		require.NoError(t, repo.CreateInvoice(ctx, inv))
+	}
+
+	sum, err := repo.SumInvoiceTotalsByBillingRun(ctx, run.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(6000), sum)
+
+	// Non-existent run.
+	sum, err = repo.SumInvoiceTotalsByBillingRun(ctx, uuid.New())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), sum)
+}

--- a/services/payment-order/adapters/persistence/billing_repository.go
+++ b/services/payment-order/adapters/persistence/billing_repository.go
@@ -390,33 +390,23 @@ func (r *BillingRepositoryImpl) ListBillingRuns(ctx context.Context, filter Bill
 
 	var page *BillingRunPage
 	err = r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
-		query := tx.Model(&BillingRunEntity{})
-		if len(filter.Statuses) > 0 {
-			query = query.Where("status IN ?", filter.Statuses)
+		applyFilter := func(q *gorm.DB) *gorm.DB {
+			if len(filter.Statuses) > 0 {
+				q = q.Where("status IN ?", filter.Statuses)
+			}
+			return q
 		}
 
-		var totalCount int64
-		if countErr := query.Count(&totalCount).Error; countErr != nil {
+		totalCount, countErr := countWithFilter(tx, &BillingRunEntity{}, applyFilter)
+		if countErr != nil {
 			return countErr
 		}
-
 		if totalCount == 0 {
 			page = &BillingRunPage{BillingRuns: []*domain.BillingRun{}, TotalCount: 0}
 			return nil
 		}
 
-		// Re-build query for rows (Count mutates the query builder).
-		rowQuery := tx.Model(&BillingRunEntity{})
-		if len(filter.Statuses) > 0 {
-			rowQuery = rowQuery.Where("status IN ?", filter.Statuses)
-		}
-		if !cursorTime.IsZero() {
-			rowQuery = rowQuery.Where(
-				"(created_at < ?) OR (created_at = ? AND id < ?)",
-				cursorTime, cursorTime, cursorID,
-			)
-		}
-
+		rowQuery := applyCursor(applyFilter(tx.Model(&BillingRunEntity{})), cursorTime, cursorID)
 		var entities []BillingRunEntity
 		if findErr := rowQuery.Order("created_at DESC, id DESC").Limit(pageSize + 1).Find(&entities).Error; findErr != nil {
 			return findErr
@@ -437,7 +427,6 @@ func (r *BillingRepositoryImpl) ListBillingRuns(ctx context.Context, filter Bill
 			last := entities[len(entities)-1]
 			nextCursor = encodeBillingCursor(last.CreatedAt, last.ID)
 		}
-
 		page = &BillingRunPage{
 			BillingRuns: runs,
 			NextCursor:  nextCursor,
@@ -460,28 +449,18 @@ func (r *BillingRepositoryImpl) ListInvoices(ctx context.Context, filter Invoice
 
 	var page *InvoicePage
 	err = r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
-		query := tx.Model(&InvoiceEntity{})
-		query = applyInvoiceFilter(query, filter)
+		applyFilter := func(q *gorm.DB) *gorm.DB { return applyInvoiceFilter(q, filter) }
 
-		var totalCount int64
-		if countErr := query.Count(&totalCount).Error; countErr != nil {
+		totalCount, countErr := countWithFilter(tx, &InvoiceEntity{}, applyFilter)
+		if countErr != nil {
 			return countErr
 		}
-
 		if totalCount == 0 {
 			page = &InvoicePage{Invoices: []*domain.Invoice{}, TotalCount: 0}
 			return nil
 		}
 
-		rowQuery := tx.Model(&InvoiceEntity{})
-		rowQuery = applyInvoiceFilter(rowQuery, filter)
-		if !cursorTime.IsZero() {
-			rowQuery = rowQuery.Where(
-				"(created_at < ?) OR (created_at = ? AND id < ?)",
-				cursorTime, cursorTime, cursorID,
-			)
-		}
-
+		rowQuery := applyCursor(applyFilter(tx.Model(&InvoiceEntity{})), cursorTime, cursorID)
 		var entities []InvoiceEntity
 		if findErr := rowQuery.Order("created_at DESC, id DESC").Limit(pageSize + 1).Find(&entities).Error; findErr != nil {
 			return findErr
@@ -506,7 +485,6 @@ func (r *BillingRepositoryImpl) ListInvoices(ctx context.Context, filter Invoice
 			last := entities[len(entities)-1]
 			nextCursor = encodeBillingCursor(last.CreatedAt, last.ID)
 		}
-
 		page = &InvoicePage{
 			Invoices:   invoices,
 			NextCursor: nextCursor,
@@ -529,6 +507,26 @@ func applyInvoiceFilter(query *gorm.DB, filter InvoiceFilter) *gorm.DB {
 	}
 	if filter.BillingRunID != "" {
 		query = query.Where("billing_run_id = ?", filter.BillingRunID)
+	}
+	return query
+}
+
+// countWithFilter counts rows with an applied filter, returning 0 on empty sets.
+func countWithFilter(tx *gorm.DB, model any, applyFilter func(*gorm.DB) *gorm.DB) (int64, error) {
+	var count int64
+	if err := applyFilter(tx.Model(model)).Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// applyCursor adds cursor-based pagination conditions to the query.
+func applyCursor(query *gorm.DB, cursorTime time.Time, cursorID uuid.UUID) *gorm.DB {
+	if !cursorTime.IsZero() {
+		query = query.Where(
+			"(created_at < ?) OR (created_at = ? AND id < ?)",
+			cursorTime, cursorTime, cursorID,
+		)
 	}
 	return query
 }

--- a/services/payment-order/adapters/persistence/billing_repository.go
+++ b/services/payment-order/adapters/persistence/billing_repository.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"github.com/meridianhub/meridian/shared/pkg/email"
 	"github.com/meridianhub/meridian/shared/platform/db"
 	"gorm.io/gorm"
 )
@@ -20,7 +22,45 @@ var (
 	ErrBillingRunDuplicate   = errors.New("billing run already exists for this tenant and period")
 	ErrInvoiceNotFound       = errors.New("invoice not found")
 	ErrInvoiceNumberConflict = errors.New("invoice with this number already exists")
+	ErrInvalidBillingCursor  = errors.New("invalid billing pagination cursor")
 )
+
+// BillingRunFilter specifies criteria for listing billing runs.
+type BillingRunFilter struct {
+	Statuses []string // Filter by billing run statuses; empty means all.
+}
+
+// InvoiceFilter specifies criteria for listing invoices.
+type InvoiceFilter struct {
+	Statuses     []string // Filter by invoice statuses; empty means all.
+	PartyID      string   // Filter by party ID; empty means all.
+	BillingRunID string   // Filter by billing run ID; empty means all.
+}
+
+// BillingRunPage holds a page of billing run results.
+type BillingRunPage struct {
+	BillingRuns []*domain.BillingRun
+	NextCursor  string
+	TotalCount  int64
+}
+
+// InvoicePage holds a page of invoice results.
+type InvoicePage struct {
+	Invoices   []*domain.Invoice
+	NextCursor string
+	TotalCount int64
+}
+
+// EmailAuditEntry represents an email audit record linked to an invoice.
+type EmailAuditEntry struct {
+	IdempotencyKey string
+	TemplateName   string
+	ToAddresses    []string
+	Status         string
+	SentAt         *time.Time
+	DeliveredAt    *time.Time
+	BounceReason   *string
+}
 
 // BillingRepository defines the contract for billing persistence.
 type BillingRepository interface {
@@ -32,6 +72,15 @@ type BillingRepository interface {
 	FindInvoiceByID(ctx context.Context, id uuid.UUID) (*domain.Invoice, error)
 	FindInvoicesByBillingRunID(ctx context.Context, billingRunID uuid.UUID) ([]*domain.Invoice, error)
 	UpdateInvoice(ctx context.Context, inv *domain.Invoice) error
+
+	// List methods with cursor-based pagination.
+	ListBillingRuns(ctx context.Context, filter BillingRunFilter, pageSize int, pageToken string) (*BillingRunPage, error)
+	ListInvoices(ctx context.Context, filter InvoiceFilter, pageSize int, pageToken string) (*InvoicePage, error)
+	CountInvoicesByBillingRun(ctx context.Context, billingRunID uuid.UUID) (int64, error)
+	SumInvoiceTotalsByBillingRun(ctx context.Context, billingRunID uuid.UUID) (int64, error)
+
+	// Email audit log queries.
+	ListEmailsByInvoice(ctx context.Context, invoiceID uuid.UUID) ([]*EmailAuditEntry, error)
 }
 
 // BillingRepositoryImpl provides persistence operations for billing entities.
@@ -295,4 +344,253 @@ func invoiceToDomain(entity *InvoiceEntity) (*domain.Invoice, error) {
 		PaymentOrderID: entity.PaymentOrderID,
 		CreatedAt:      entity.CreatedAt,
 	}, nil
+}
+
+// encodeBillingCursor encodes a (created_at, id) composite cursor as a base64 page token.
+func encodeBillingCursor(createdAt time.Time, id uuid.UUID) string {
+	data := createdAt.Format(time.RFC3339Nano) + "|" + id.String()
+	return base64.URLEncoding.EncodeToString([]byte(data))
+}
+
+// decodeBillingCursor decodes a base64 page token into (created_at, id).
+func decodeBillingCursor(token string) (time.Time, uuid.UUID, error) {
+	if token == "" {
+		return time.Time{}, uuid.Nil, nil
+	}
+
+	data, err := base64.URLEncoding.DecodeString(token)
+	if err != nil {
+		return time.Time{}, uuid.Nil, ErrInvalidBillingCursor
+	}
+
+	parts := strings.SplitN(string(data), "|", 2)
+	if len(parts) != 2 {
+		return time.Time{}, uuid.Nil, ErrInvalidBillingCursor
+	}
+
+	createdAt, err := time.Parse(time.RFC3339Nano, parts[0])
+	if err != nil {
+		return time.Time{}, uuid.Nil, ErrInvalidBillingCursor
+	}
+
+	id, err := uuid.Parse(parts[1])
+	if err != nil {
+		return time.Time{}, uuid.Nil, ErrInvalidBillingCursor
+	}
+
+	return createdAt, id, nil
+}
+
+// ListBillingRuns returns a paginated list of billing runs with optional status filtering.
+func (r *BillingRepositoryImpl) ListBillingRuns(ctx context.Context, filter BillingRunFilter, pageSize int, pageToken string) (*BillingRunPage, error) {
+	cursorTime, cursorID, err := decodeBillingCursor(pageToken)
+	if err != nil {
+		return nil, err
+	}
+
+	var page *BillingRunPage
+	err = r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		query := tx.Model(&BillingRunEntity{})
+		if len(filter.Statuses) > 0 {
+			query = query.Where("status IN ?", filter.Statuses)
+		}
+
+		var totalCount int64
+		if countErr := query.Count(&totalCount).Error; countErr != nil {
+			return countErr
+		}
+
+		if totalCount == 0 {
+			page = &BillingRunPage{BillingRuns: []*domain.BillingRun{}, TotalCount: 0}
+			return nil
+		}
+
+		// Re-build query for rows (Count mutates the query builder).
+		rowQuery := tx.Model(&BillingRunEntity{})
+		if len(filter.Statuses) > 0 {
+			rowQuery = rowQuery.Where("status IN ?", filter.Statuses)
+		}
+		if !cursorTime.IsZero() {
+			rowQuery = rowQuery.Where(
+				"(created_at < ?) OR (created_at = ? AND id < ?)",
+				cursorTime, cursorTime, cursorID,
+			)
+		}
+
+		var entities []BillingRunEntity
+		if findErr := rowQuery.Order("created_at DESC, id DESC").Limit(pageSize + 1).Find(&entities).Error; findErr != nil {
+			return findErr
+		}
+
+		hasMore := len(entities) > pageSize
+		if hasMore {
+			entities = entities[:pageSize]
+		}
+
+		runs := make([]*domain.BillingRun, 0, len(entities))
+		for i := range entities {
+			runs = append(runs, billingRunToDomain(&entities[i]))
+		}
+
+		var nextCursor string
+		if hasMore && len(entities) > 0 {
+			last := entities[len(entities)-1]
+			nextCursor = encodeBillingCursor(last.CreatedAt, last.ID)
+		}
+
+		page = &BillingRunPage{
+			BillingRuns: runs,
+			NextCursor:  nextCursor,
+			TotalCount:  totalCount,
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return page, nil
+}
+
+// ListInvoices returns a paginated list of invoices with optional filtering.
+func (r *BillingRepositoryImpl) ListInvoices(ctx context.Context, filter InvoiceFilter, pageSize int, pageToken string) (*InvoicePage, error) {
+	cursorTime, cursorID, err := decodeBillingCursor(pageToken)
+	if err != nil {
+		return nil, err
+	}
+
+	var page *InvoicePage
+	err = r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		query := tx.Model(&InvoiceEntity{})
+		query = applyInvoiceFilter(query, filter)
+
+		var totalCount int64
+		if countErr := query.Count(&totalCount).Error; countErr != nil {
+			return countErr
+		}
+
+		if totalCount == 0 {
+			page = &InvoicePage{Invoices: []*domain.Invoice{}, TotalCount: 0}
+			return nil
+		}
+
+		rowQuery := tx.Model(&InvoiceEntity{})
+		rowQuery = applyInvoiceFilter(rowQuery, filter)
+		if !cursorTime.IsZero() {
+			rowQuery = rowQuery.Where(
+				"(created_at < ?) OR (created_at = ? AND id < ?)",
+				cursorTime, cursorTime, cursorID,
+			)
+		}
+
+		var entities []InvoiceEntity
+		if findErr := rowQuery.Order("created_at DESC, id DESC").Limit(pageSize + 1).Find(&entities).Error; findErr != nil {
+			return findErr
+		}
+
+		hasMore := len(entities) > pageSize
+		if hasMore {
+			entities = entities[:pageSize]
+		}
+
+		invoices := make([]*domain.Invoice, 0, len(entities))
+		for i := range entities {
+			inv, domainErr := invoiceToDomain(&entities[i])
+			if domainErr != nil {
+				return domainErr
+			}
+			invoices = append(invoices, inv)
+		}
+
+		var nextCursor string
+		if hasMore && len(entities) > 0 {
+			last := entities[len(entities)-1]
+			nextCursor = encodeBillingCursor(last.CreatedAt, last.ID)
+		}
+
+		page = &InvoicePage{
+			Invoices:   invoices,
+			NextCursor: nextCursor,
+			TotalCount: totalCount,
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return page, nil
+}
+
+func applyInvoiceFilter(query *gorm.DB, filter InvoiceFilter) *gorm.DB {
+	if len(filter.Statuses) > 0 {
+		query = query.Where("status IN ?", filter.Statuses)
+	}
+	if filter.PartyID != "" {
+		query = query.Where("party_id = ?", filter.PartyID)
+	}
+	if filter.BillingRunID != "" {
+		query = query.Where("billing_run_id = ?", filter.BillingRunID)
+	}
+	return query
+}
+
+// CountInvoicesByBillingRun returns the number of invoices for a billing run.
+func (r *BillingRepositoryImpl) CountInvoicesByBillingRun(ctx context.Context, billingRunID uuid.UUID) (int64, error) {
+	var count int64
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		return tx.Model(&InvoiceEntity{}).Where("billing_run_id = ?", billingRunID).Count(&count).Error
+	})
+	return count, err
+}
+
+// SumInvoiceTotalsByBillingRun returns the total subtotal_cents for all invoices in a billing run.
+func (r *BillingRepositoryImpl) SumInvoiceTotalsByBillingRun(ctx context.Context, billingRunID uuid.UUID) (int64, error) {
+	var sum int64
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var result struct{ Total *int64 }
+		if selectErr := tx.Model(&InvoiceEntity{}).
+			Select("COALESCE(SUM(subtotal_cents), 0) as total").
+			Where("billing_run_id = ?", billingRunID).
+			Scan(&result).Error; selectErr != nil {
+			return selectErr
+		}
+		if result.Total != nil {
+			sum = *result.Total
+		}
+		return nil
+	})
+	return sum, err
+}
+
+// ListEmailsByInvoice returns email audit entries for the given invoice.
+// It finds outbox entries whose idempotency_key starts with "invoice-{invoiceID}"
+// to build the email audit trail.
+func (r *BillingRepositoryImpl) ListEmailsByInvoice(ctx context.Context, invoiceID uuid.UUID) ([]*EmailAuditEntry, error) {
+	pattern := "invoice-" + invoiceID.String() + "%"
+	var entries []*EmailAuditEntry
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var outboxEntities []email.OutboxEntity
+		if findErr := tx.Where("idempotency_key LIKE ?", pattern).
+			Order("created_at DESC").
+			Find(&outboxEntities).Error; findErr != nil {
+			return findErr
+		}
+
+		entries = make([]*EmailAuditEntry, 0, len(outboxEntities))
+		for i := range outboxEntities {
+			e := &outboxEntities[i]
+			entry := &EmailAuditEntry{
+				IdempotencyKey: e.IdempotencyKey,
+				TemplateName:   e.TemplateName,
+				ToAddresses:    []string(e.ToAddresses),
+				Status:         e.Status,
+			}
+			entries = append(entries, entry)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return entries, nil
 }

--- a/services/payment-order/adapters/persistence/billing_repository.go
+++ b/services/payment-order/adapters/persistence/billing_repository.go
@@ -52,14 +52,14 @@ type InvoicePage struct {
 }
 
 // EmailAuditEntry represents an email audit record linked to an invoice.
+// Delivery status fields (SentAt, DeliveredAt, BounceReason) live on the
+// AuditLogEntity and are not yet surfaced here - this maps from the outbox only.
 type EmailAuditEntry struct {
 	IdempotencyKey string
 	TemplateName   string
 	ToAddresses    []string
 	Status         string
-	SentAt         *time.Time
-	DeliveredAt    *time.Time
-	BounceReason   *string
+	CreatedAt      time.Time
 }
 
 // BillingRepository defines the contract for billing persistence.
@@ -584,6 +584,7 @@ func (r *BillingRepositoryImpl) ListEmailsByInvoice(ctx context.Context, invoice
 				TemplateName:   e.TemplateName,
 				ToAddresses:    []string(e.ToAddresses),
 				Status:         e.Status,
+				CreatedAt:      e.CreatedAt,
 			}
 			entries = append(entries, entry)
 		}

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	billingpb "github.com/meridianhub/meridian/api/proto/meridian/billing/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
 	webhookhttp "github.com/meridianhub/meridian/services/payment-order/adapters/http"
 	pomessaging "github.com/meridianhub/meridian/services/payment-order/adapters/messaging"
@@ -516,6 +517,12 @@ func run(logger *slog.Logger) error {
 
 	// Register gRPC services
 	pb.RegisterPaymentOrderServiceServer(grpcServer, paymentOrderService)
+
+	// Register billing gRPC service (uses same billing repo + optional email outbox)
+	billingRepo := persistence.NewBillingRepository(db)
+	billingGRPCService := service.NewBillingService(billingRepo, nil, logger)
+	billingpb.RegisterBillingServiceServer(grpcServer, billingGRPCService)
+
 	grpc_health_v1.RegisterHealthServer(grpcServer, &simpleHealthServer{})
 	reflection.Register(grpcServer)
 	logger.Info("gRPC services registered")

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -518,9 +518,10 @@ func run(logger *slog.Logger) error {
 	// Register gRPC services
 	pb.RegisterPaymentOrderServiceServer(grpcServer, paymentOrderService)
 
-	// Register billing gRPC service (uses same billing repo + optional email outbox)
+	// Register billing gRPC service. Email outbox is nil until the email worker
+	// is wired into this service; ResendInvoiceEmail returns Unavailable until then.
 	billingRepo := persistence.NewBillingRepository(db)
-	billingGRPCService := service.NewBillingService(billingRepo, nil, logger)
+	billingGRPCService := service.NewBillingService(billingRepo, nil /* emailRepo */, logger)
 	billingpb.RegisterBillingServiceServer(grpcServer, billingGRPCService)
 
 	grpc_health_v1.RegisterHealthServer(grpcServer, &simpleHealthServer{})

--- a/services/payment-order/rbac/method_permissions.go
+++ b/services/payment-order/rbac/method_permissions.go
@@ -30,6 +30,39 @@ var MethodPermissions = auth.MethodRBACConfig{
 	},
 }
 
+// BillingMethodPermissions defines RBAC permissions for BillingService gRPC methods.
+var BillingMethodPermissions = auth.MethodRBACConfig{
+	Permissions: map[string]auth.MethodPermission{
+		// Read operations: admin, operator, auditor
+		"/meridian.billing.v1.BillingService/ListBillingRuns": {
+			AllowedRoles: []auth.Role{auth.RoleAdmin, auth.RoleOperator, auth.RoleAuditor},
+		},
+		"/meridian.billing.v1.BillingService/GetBillingRun": {
+			AllowedRoles: []auth.Role{auth.RoleAdmin, auth.RoleOperator, auth.RoleAuditor},
+		},
+		"/meridian.billing.v1.BillingService/ListInvoices": {
+			AllowedRoles: []auth.Role{auth.RoleAdmin, auth.RoleOperator, auth.RoleAuditor},
+		},
+		"/meridian.billing.v1.BillingService/GetInvoice": {
+			AllowedRoles: []auth.Role{auth.RoleAdmin, auth.RoleOperator, auth.RoleAuditor},
+		},
+		"/meridian.billing.v1.BillingService/ListInvoiceEmails": {
+			AllowedRoles: []auth.Role{auth.RoleAdmin, auth.RoleOperator, auth.RoleAuditor},
+		},
+
+		// Write operations: admin, operator
+		"/meridian.billing.v1.BillingService/ResendInvoiceEmail": {
+			AllowedRoles: []auth.Role{auth.RoleAdmin, auth.RoleOperator},
+		},
+		"/meridian.billing.v1.BillingService/MarkInvoicePaid": {
+			AllowedRoles: []auth.Role{auth.RoleAdmin, auth.RoleOperator},
+		},
+		"/meridian.billing.v1.BillingService/VoidInvoice": {
+			AllowedRoles: []auth.Role{auth.RoleAdmin, auth.RoleOperator},
+		},
+	},
+}
+
 // ExpectedMethods lists all gRPC methods expected to be registered for this service.
 var ExpectedMethods = []string{
 	"/meridian.payment_order.v1.PaymentOrderService/InitiatePaymentOrder",
@@ -38,4 +71,16 @@ var ExpectedMethods = []string{
 	"/meridian.payment_order.v1.PaymentOrderService/CancelPaymentOrder",
 	"/meridian.payment_order.v1.PaymentOrderService/ListPaymentOrders",
 	"/meridian.payment_order.v1.PaymentOrderService/ReversePaymentOrder",
+}
+
+// BillingExpectedMethods lists all gRPC methods expected for the BillingService.
+var BillingExpectedMethods = []string{
+	"/meridian.billing.v1.BillingService/ListBillingRuns",
+	"/meridian.billing.v1.BillingService/GetBillingRun",
+	"/meridian.billing.v1.BillingService/ListInvoices",
+	"/meridian.billing.v1.BillingService/GetInvoice",
+	"/meridian.billing.v1.BillingService/ResendInvoiceEmail",
+	"/meridian.billing.v1.BillingService/MarkInvoicePaid",
+	"/meridian.billing.v1.BillingService/VoidInvoice",
+	"/meridian.billing.v1.BillingService/ListInvoiceEmails",
 }

--- a/services/payment-order/service/billing_grpc.go
+++ b/services/payment-order/service/billing_grpc.go
@@ -195,8 +195,13 @@ func (s *BillingService) ResendInvoiceEmail(ctx context.Context, req *billingpb.
 		return nil, status.Error(codes.FailedPrecondition, "cannot resend email for voided invoice")
 	}
 
-	idempKey := req.GetIdempotencyKey().GetKey()
-	if idempKey == "" {
+	// Always namespace under the invoice prefix so VoidInvoice's cancel pattern
+	// and ListInvoiceEmails can find all emails for this invoice.
+	callerKey := req.GetIdempotencyKey().GetKey()
+	var idempKey string
+	if callerKey != "" {
+		idempKey = fmt.Sprintf("invoice-%s-%s", invoiceID, callerKey)
+	} else {
 		idempKey = fmt.Sprintf("invoice-%s-resend-%s", invoiceID, uuid.New().String())
 	}
 

--- a/services/payment-order/service/billing_grpc.go
+++ b/services/payment-order/service/billing_grpc.go
@@ -209,10 +209,24 @@ func (s *BillingService) ResendInvoiceEmail(ctx context.Context, req *billingpb.
 		return nil, status.Error(codes.Unavailable, "email delivery not configured")
 	}
 
+	if enqueueErr := s.enqueueInvoiceEmail(ctx, inv, idempKey); enqueueErr != nil {
+		return nil, enqueueErr
+	}
+
+	return &billingpb.ResendInvoiceEmailResponse{
+		Email: &billingpb.InvoiceEmail{
+			IdempotencyKey: idempKey,
+			TemplateName:   "invoice_issued",
+			Status:         billingpb.EmailStatus_EMAIL_STATUS_PENDING,
+		},
+	}, nil
+}
+
+func (s *BillingService) enqueueInvoiceEmail(ctx context.Context, inv *domain.Invoice, idempKey string) error {
 	entry := &email.OutboxEntry{
 		IdempotencyKey: idempKey,
 		TemplateName:   "invoice_issued",
-		ToAddresses:    []string{}, // Will be resolved by the email worker via party lookup.
+		ToAddresses:    []string{}, // Resolved by the email worker via party lookup.
 		Subject:        fmt.Sprintf("Invoice %s", inv.InvoiceNumber),
 		TemplateData: map[string]any{
 			"invoice_id":     inv.ID.String(),
@@ -226,19 +240,12 @@ func (s *BillingService) ResendInvoiceEmail(ctx context.Context, req *billingpb.
 	if enqueueErr := s.emailRepo.Enqueue(ctx, entry); enqueueErr != nil {
 		if errors.Is(enqueueErr, email.ErrDuplicateIdempotency) {
 			s.logger.Info("duplicate email resend request", "idempotency_key", idempKey)
-		} else {
-			s.logger.Error("failed to enqueue invoice email", "error", enqueueErr)
-			return nil, status.Error(codes.Internal, "failed to queue email")
+			return nil
 		}
+		s.logger.Error("failed to enqueue invoice email", "error", enqueueErr)
+		return status.Error(codes.Internal, "failed to queue email")
 	}
-
-	return &billingpb.ResendInvoiceEmailResponse{
-		Email: &billingpb.InvoiceEmail{
-			IdempotencyKey: idempKey,
-			TemplateName:   "invoice_issued",
-			Status:         billingpb.EmailStatus_EMAIL_STATUS_PENDING,
-		},
-	}, nil
+	return nil
 }
 
 // MarkInvoicePaid transitions an invoice to paid status. Idempotent if already paid.

--- a/services/payment-order/service/billing_grpc.go
+++ b/services/payment-order/service/billing_grpc.go
@@ -104,10 +104,16 @@ func (s *BillingService) GetBillingRun(ctx context.Context, req *billingpb.GetBi
 
 	pbRun := billingRunToProto(run)
 
-	count, _ := s.billingRepo.CountInvoicesByBillingRun(ctx, id)
+	count, countErr := s.billingRepo.CountInvoicesByBillingRun(ctx, id)
+	if countErr != nil {
+		s.logger.Error("failed to count invoices for billing run", "billing_run_id", id, "error", countErr)
+	}
 	pbRun.InvoiceCount = int32(count)
 
-	total, _ := s.billingRepo.SumInvoiceTotalsByBillingRun(ctx, id)
+	total, totalErr := s.billingRepo.SumInvoiceTotalsByBillingRun(ctx, id)
+	if totalErr != nil {
+		s.logger.Error("failed to sum invoice totals for billing run", "billing_run_id", id, "error", totalErr)
+	}
 	pbRun.TotalAmountCents = total
 
 	return &billingpb.GetBillingRunResponse{

--- a/services/payment-order/service/billing_grpc.go
+++ b/services/payment-order/service/billing_grpc.go
@@ -41,6 +41,7 @@ func NewBillingService(billingRepo persistence.BillingRepository, emailRepo emai
 	}
 }
 
+// ListBillingRuns returns a paginated list of billing runs with optional status filtering.
 func (s *BillingService) ListBillingRuns(ctx context.Context, req *billingpb.ListBillingRunsRequest) (*billingpb.ListBillingRunsResponse, error) {
 	pageSize, pageToken := parsePagination(req.GetPagination())
 
@@ -85,6 +86,7 @@ func (s *BillingService) ListBillingRuns(ctx context.Context, req *billingpb.Lis
 	}, nil
 }
 
+// GetBillingRun retrieves a single billing run by ID, enriched with invoice summary.
 func (s *BillingService) GetBillingRun(ctx context.Context, req *billingpb.GetBillingRunRequest) (*billingpb.GetBillingRunResponse, error) {
 	id, err := uuid.Parse(req.GetId())
 	if err != nil {
@@ -113,6 +115,7 @@ func (s *BillingService) GetBillingRun(ctx context.Context, req *billingpb.GetBi
 	}, nil
 }
 
+// ListInvoices returns a paginated list of invoices with optional filtering.
 func (s *BillingService) ListInvoices(ctx context.Context, req *billingpb.ListInvoicesRequest) (*billingpb.ListInvoicesResponse, error) {
 	pageSize, pageToken := parsePagination(req.GetPagination())
 
@@ -145,6 +148,7 @@ func (s *BillingService) ListInvoices(ctx context.Context, req *billingpb.ListIn
 	}, nil
 }
 
+// GetInvoice retrieves a single invoice by ID.
 func (s *BillingService) GetInvoice(ctx context.Context, req *billingpb.GetInvoiceRequest) (*billingpb.GetInvoiceResponse, error) {
 	id, err := uuid.Parse(req.GetId())
 	if err != nil {
@@ -165,6 +169,7 @@ func (s *BillingService) GetInvoice(ctx context.Context, req *billingpb.GetInvoi
 	}, nil
 }
 
+// ResendInvoiceEmail enqueues an invoice email for re-delivery.
 func (s *BillingService) ResendInvoiceEmail(ctx context.Context, req *billingpb.ResendInvoiceEmailRequest) (*billingpb.ResendInvoiceEmailResponse, error) {
 	invoiceID, err := uuid.Parse(req.GetInvoiceId())
 	if err != nil {
@@ -225,6 +230,7 @@ func (s *BillingService) ResendInvoiceEmail(ctx context.Context, req *billingpb.
 	}, nil
 }
 
+// MarkInvoicePaid transitions an invoice to paid status. Idempotent if already paid.
 func (s *BillingService) MarkInvoicePaid(ctx context.Context, req *billingpb.MarkInvoicePaidRequest) (*billingpb.MarkInvoicePaidResponse, error) {
 	invoiceID, err := uuid.Parse(req.GetInvoiceId())
 	if err != nil {
@@ -262,6 +268,7 @@ func (s *BillingService) MarkInvoicePaid(ctx context.Context, req *billingpb.Mar
 	}, nil
 }
 
+// VoidInvoice cancels an invoice and any pending email deliveries. Idempotent if already voided.
 func (s *BillingService) VoidInvoice(ctx context.Context, req *billingpb.VoidInvoiceRequest) (*billingpb.VoidInvoiceResponse, error) {
 	invoiceID, err := uuid.Parse(req.GetInvoiceId())
 	if err != nil {
@@ -309,6 +316,7 @@ func (s *BillingService) VoidInvoice(ctx context.Context, req *billingpb.VoidInv
 	}, nil
 }
 
+// ListInvoiceEmails returns the email delivery audit log for an invoice.
 func (s *BillingService) ListInvoiceEmails(ctx context.Context, req *billingpb.ListInvoiceEmailsRequest) (*billingpb.ListInvoiceEmailsResponse, error) {
 	invoiceID, err := uuid.Parse(req.GetInvoiceId())
 	if err != nil {

--- a/services/payment-order/service/billing_grpc.go
+++ b/services/payment-order/service/billing_grpc.go
@@ -1,0 +1,350 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/google/uuid"
+	billingpb "github.com/meridianhub/meridian/api/proto/meridian/billing/v1"
+	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	"github.com/meridianhub/meridian/services/payment-order/adapters/persistence"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"github.com/meridianhub/meridian/shared/pkg/email"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	billingDefaultPageSize = 50
+	billingMaxPageSize     = 1000
+)
+
+// BillingService implements the BillingService gRPC server.
+type BillingService struct {
+	billingpb.UnimplementedBillingServiceServer
+	billingRepo persistence.BillingRepository
+	emailRepo   email.OutboxRepository
+	logger      *slog.Logger
+}
+
+// NewBillingService creates a new billing gRPC service.
+func NewBillingService(billingRepo persistence.BillingRepository, emailRepo email.OutboxRepository, logger *slog.Logger) *BillingService {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &BillingService{
+		billingRepo: billingRepo,
+		emailRepo:   emailRepo,
+		logger:      logger,
+	}
+}
+
+func (s *BillingService) ListBillingRuns(ctx context.Context, req *billingpb.ListBillingRunsRequest) (*billingpb.ListBillingRunsResponse, error) {
+	pageSize, pageToken := parsePagination(req.GetPagination())
+
+	filter := persistence.BillingRunFilter{
+		Statuses: mapProtoBillingRunStatuses(req.GetStatus()),
+	}
+
+	page, err := s.billingRepo.ListBillingRuns(ctx, filter, pageSize, pageToken)
+	if err != nil {
+		if errors.Is(err, persistence.ErrInvalidBillingCursor) {
+			return nil, status.Error(codes.InvalidArgument, "invalid page_token")
+		}
+		s.logger.Error("failed to list billing runs", "error", err)
+		return nil, status.Error(codes.Internal, "failed to list billing runs")
+	}
+
+	runs := make([]*billingpb.BillingRun, 0, len(page.BillingRuns))
+	for _, run := range page.BillingRuns {
+		pbRun := billingRunToProto(run)
+		// Enrich with invoice summary.
+		count, countErr := s.billingRepo.CountInvoicesByBillingRun(ctx, run.ID)
+		if countErr != nil {
+			s.logger.Error("failed to count invoices", "billing_run_id", run.ID, "error", countErr)
+		} else {
+			pbRun.InvoiceCount = int32(count)
+		}
+		total, totalErr := s.billingRepo.SumInvoiceTotalsByBillingRun(ctx, run.ID)
+		if totalErr != nil {
+			s.logger.Error("failed to sum invoice totals", "billing_run_id", run.ID, "error", totalErr)
+		} else {
+			pbRun.TotalAmountCents = total
+		}
+		runs = append(runs, pbRun)
+	}
+
+	return &billingpb.ListBillingRunsResponse{
+		BillingRuns: runs,
+		Pagination: &commonpb.PaginationResponse{
+			NextPageToken: page.NextCursor,
+			TotalCount:    page.TotalCount,
+		},
+	}, nil
+}
+
+func (s *BillingService) GetBillingRun(ctx context.Context, req *billingpb.GetBillingRunRequest) (*billingpb.GetBillingRunResponse, error) {
+	id, err := uuid.Parse(req.GetId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid billing run ID: %v", err)
+	}
+
+	run, err := s.billingRepo.FindBillingRunByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, persistence.ErrBillingRunNotFound) {
+			return nil, status.Errorf(codes.NotFound, "billing run not found: %s", req.GetId())
+		}
+		s.logger.Error("failed to get billing run", "error", err)
+		return nil, status.Error(codes.Internal, "failed to get billing run")
+	}
+
+	pbRun := billingRunToProto(run)
+
+	count, _ := s.billingRepo.CountInvoicesByBillingRun(ctx, id)
+	pbRun.InvoiceCount = int32(count)
+
+	total, _ := s.billingRepo.SumInvoiceTotalsByBillingRun(ctx, id)
+	pbRun.TotalAmountCents = total
+
+	return &billingpb.GetBillingRunResponse{
+		BillingRun: pbRun,
+	}, nil
+}
+
+func (s *BillingService) ListInvoices(ctx context.Context, req *billingpb.ListInvoicesRequest) (*billingpb.ListInvoicesResponse, error) {
+	pageSize, pageToken := parsePagination(req.GetPagination())
+
+	filter := persistence.InvoiceFilter{
+		Statuses:     mapProtoInvoiceStatuses(req.GetStatus()),
+		PartyID:      req.GetPartyId(),
+		BillingRunID: req.GetBillingRunId(),
+	}
+
+	page, err := s.billingRepo.ListInvoices(ctx, filter, pageSize, pageToken)
+	if err != nil {
+		if errors.Is(err, persistence.ErrInvalidBillingCursor) {
+			return nil, status.Error(codes.InvalidArgument, "invalid page_token")
+		}
+		s.logger.Error("failed to list invoices", "error", err)
+		return nil, status.Error(codes.Internal, "failed to list invoices")
+	}
+
+	invoices := make([]*billingpb.Invoice, 0, len(page.Invoices))
+	for _, inv := range page.Invoices {
+		invoices = append(invoices, invoiceToProto(inv))
+	}
+
+	return &billingpb.ListInvoicesResponse{
+		Invoices: invoices,
+		Pagination: &commonpb.PaginationResponse{
+			NextPageToken: page.NextCursor,
+			TotalCount:    page.TotalCount,
+		},
+	}, nil
+}
+
+func (s *BillingService) GetInvoice(ctx context.Context, req *billingpb.GetInvoiceRequest) (*billingpb.GetInvoiceResponse, error) {
+	id, err := uuid.Parse(req.GetId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid invoice ID: %v", err)
+	}
+
+	inv, err := s.billingRepo.FindInvoiceByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, persistence.ErrInvoiceNotFound) {
+			return nil, status.Errorf(codes.NotFound, "invoice not found: %s", req.GetId())
+		}
+		s.logger.Error("failed to get invoice", "error", err)
+		return nil, status.Error(codes.Internal, "failed to get invoice")
+	}
+
+	return &billingpb.GetInvoiceResponse{
+		Invoice: invoiceToProto(inv),
+	}, nil
+}
+
+func (s *BillingService) ResendInvoiceEmail(ctx context.Context, req *billingpb.ResendInvoiceEmailRequest) (*billingpb.ResendInvoiceEmailResponse, error) {
+	invoiceID, err := uuid.Parse(req.GetInvoiceId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid invoice ID: %v", err)
+	}
+
+	inv, err := s.billingRepo.FindInvoiceByID(ctx, invoiceID)
+	if err != nil {
+		if errors.Is(err, persistence.ErrInvoiceNotFound) {
+			return nil, status.Errorf(codes.NotFound, "invoice not found: %s", req.GetInvoiceId())
+		}
+		s.logger.Error("failed to find invoice for email resend", "error", err)
+		return nil, status.Error(codes.Internal, "failed to find invoice")
+	}
+
+	if inv.IsTerminal() && inv.Status == domain.InvoiceStatusVoid {
+		return nil, status.Error(codes.FailedPrecondition, "cannot resend email for voided invoice")
+	}
+
+	idempKey := req.GetIdempotencyKey().GetKey()
+	if idempKey == "" {
+		idempKey = fmt.Sprintf("invoice-%s-resend-%s", invoiceID, uuid.New().String())
+	}
+
+	if s.emailRepo == nil {
+		return nil, status.Error(codes.Unavailable, "email delivery not configured")
+	}
+
+	entry := &email.OutboxEntry{
+		IdempotencyKey: idempKey,
+		TemplateName:   "invoice_issued",
+		ToAddresses:    []string{}, // Will be resolved by the email worker via party lookup.
+		Subject:        fmt.Sprintf("Invoice %s", inv.InvoiceNumber),
+		TemplateData: map[string]any{
+			"invoice_id":     inv.ID.String(),
+			"invoice_number": inv.InvoiceNumber,
+			"amount_cents":   inv.SubtotalCents,
+			"currency":       inv.Currency,
+		},
+		MaxAttempts: 5,
+	}
+
+	if enqueueErr := s.emailRepo.Enqueue(ctx, entry); enqueueErr != nil {
+		if errors.Is(enqueueErr, email.ErrDuplicateIdempotency) {
+			s.logger.Info("duplicate email resend request", "idempotency_key", idempKey)
+		} else {
+			s.logger.Error("failed to enqueue invoice email", "error", enqueueErr)
+			return nil, status.Error(codes.Internal, "failed to queue email")
+		}
+	}
+
+	return &billingpb.ResendInvoiceEmailResponse{
+		Email: &billingpb.InvoiceEmail{
+			IdempotencyKey: idempKey,
+			TemplateName:   "invoice_issued",
+			Status:         billingpb.EmailStatus_EMAIL_STATUS_PENDING,
+		},
+	}, nil
+}
+
+func (s *BillingService) MarkInvoicePaid(ctx context.Context, req *billingpb.MarkInvoicePaidRequest) (*billingpb.MarkInvoicePaidResponse, error) {
+	invoiceID, err := uuid.Parse(req.GetInvoiceId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid invoice ID: %v", err)
+	}
+
+	inv, err := s.billingRepo.FindInvoiceByID(ctx, invoiceID)
+	if err != nil {
+		if errors.Is(err, persistence.ErrInvoiceNotFound) {
+			return nil, status.Errorf(codes.NotFound, "invoice not found: %s", req.GetInvoiceId())
+		}
+		s.logger.Error("failed to find invoice", "error", err)
+		return nil, status.Error(codes.Internal, "failed to find invoice")
+	}
+
+	// Idempotent: already paid.
+	if inv.Status == domain.InvoiceStatusPaid {
+		return &billingpb.MarkInvoicePaidResponse{
+			Invoice: invoiceToProto(inv),
+		}, nil
+	}
+
+	syntheticPOID := uuid.New()
+	if markErr := inv.MarkPaid(syntheticPOID); markErr != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "cannot mark invoice as paid: %v", markErr)
+	}
+
+	if updateErr := s.billingRepo.UpdateInvoice(ctx, inv); updateErr != nil {
+		s.logger.Error("failed to update invoice", "error", updateErr)
+		return nil, status.Error(codes.Internal, "failed to update invoice")
+	}
+
+	return &billingpb.MarkInvoicePaidResponse{
+		Invoice: invoiceToProto(inv),
+	}, nil
+}
+
+func (s *BillingService) VoidInvoice(ctx context.Context, req *billingpb.VoidInvoiceRequest) (*billingpb.VoidInvoiceResponse, error) {
+	invoiceID, err := uuid.Parse(req.GetInvoiceId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid invoice ID: %v", err)
+	}
+
+	inv, err := s.billingRepo.FindInvoiceByID(ctx, invoiceID)
+	if err != nil {
+		if errors.Is(err, persistence.ErrInvoiceNotFound) {
+			return nil, status.Errorf(codes.NotFound, "invoice not found: %s", req.GetInvoiceId())
+		}
+		s.logger.Error("failed to find invoice", "error", err)
+		return nil, status.Error(codes.Internal, "failed to find invoice")
+	}
+
+	// Idempotent: already voided.
+	if inv.Status == domain.InvoiceStatusVoid {
+		return &billingpb.VoidInvoiceResponse{
+			Invoice: invoiceToProto(inv),
+		}, nil
+	}
+
+	if voidErr := inv.Void(); voidErr != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "cannot void invoice: %v", voidErr)
+	}
+
+	if updateErr := s.billingRepo.UpdateInvoice(ctx, inv); updateErr != nil {
+		s.logger.Error("failed to update invoice", "error", updateErr)
+		return nil, status.Error(codes.Internal, "failed to update invoice")
+	}
+
+	// Cancel pending email deliveries for this invoice.
+	if s.emailRepo != nil {
+		pattern := "invoice-" + invoiceID.String() + "%"
+		cancelled, cancelErr := s.emailRepo.CancelByIdempotencyKeyPattern(ctx, pattern)
+		if cancelErr != nil {
+			s.logger.Error("failed to cancel pending emails", "invoice_id", invoiceID, "error", cancelErr)
+		} else if cancelled > 0 {
+			s.logger.Info("cancelled pending emails for voided invoice", "invoice_id", invoiceID, "count", cancelled)
+		}
+	}
+
+	return &billingpb.VoidInvoiceResponse{
+		Invoice: invoiceToProto(inv),
+	}, nil
+}
+
+func (s *BillingService) ListInvoiceEmails(ctx context.Context, req *billingpb.ListInvoiceEmailsRequest) (*billingpb.ListInvoiceEmailsResponse, error) {
+	invoiceID, err := uuid.Parse(req.GetInvoiceId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid invoice ID: %v", err)
+	}
+
+	entries, err := s.billingRepo.ListEmailsByInvoice(ctx, invoiceID)
+	if err != nil {
+		s.logger.Error("failed to list invoice emails", "error", err)
+		return nil, status.Error(codes.Internal, "failed to list invoice emails")
+	}
+
+	emails := make([]*billingpb.InvoiceEmail, 0, len(entries))
+	for _, entry := range entries {
+		emails = append(emails, emailAuditToProto(entry))
+	}
+
+	return &billingpb.ListInvoiceEmailsResponse{
+		Emails: emails,
+		Pagination: &commonpb.PaginationResponse{
+			TotalCount: int64(len(emails)),
+		},
+	}, nil
+}
+
+func parsePagination(p *commonpb.Pagination) (int, string) {
+	pageSize := billingDefaultPageSize
+	var pageToken string
+	if p != nil {
+		if p.PageSize > 0 {
+			pageSize = int(p.PageSize)
+			if pageSize > billingMaxPageSize {
+				pageSize = billingMaxPageSize
+			}
+		}
+		pageToken = p.PageToken
+	}
+	return pageSize, pageToken
+}

--- a/services/payment-order/service/billing_grpc_mappers.go
+++ b/services/payment-order/service/billing_grpc_mappers.go
@@ -1,0 +1,169 @@
+package service
+
+import (
+	billingpb "github.com/meridianhub/meridian/api/proto/meridian/billing/v1"
+	"github.com/meridianhub/meridian/services/payment-order/adapters/persistence"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func billingRunToProto(run *domain.BillingRun) *billingpb.BillingRun {
+	pb := &billingpb.BillingRun{
+		Id:            run.ID.String(),
+		TenantId:      run.TenantID,
+		PeriodStart:   timestamppb.New(run.CycleStart),
+		PeriodEnd:     timestamppb.New(run.CycleEnd),
+		Status:        mapBillingRunStatusToProto(run.Status),
+		DunningLevel:  int32(run.DunningLevel),
+		FailureReason: run.FailureReason,
+		CreatedAt:     timestamppb.New(run.CreatedAt),
+		UpdatedAt:     timestamppb.New(run.UpdatedAt),
+	}
+	return pb
+}
+
+func invoiceToProto(inv *domain.Invoice) *billingpb.Invoice {
+	pb := &billingpb.Invoice{
+		Id:            inv.ID.String(),
+		BillingRunId:  inv.BillingRunID.String(),
+		PartyId:       inv.PartyID,
+		AccountId:     inv.AccountID,
+		InvoiceNumber: inv.InvoiceNumber,
+		PeriodStart:   timestamppb.New(inv.PeriodStart),
+		PeriodEnd:     timestamppb.New(inv.PeriodEnd),
+		SubtotalCents: inv.SubtotalCents,
+		Currency:      inv.Currency,
+		Status:        mapInvoiceStatusToProto(inv.Status),
+		CreatedAt:     timestamppb.New(inv.CreatedAt),
+	}
+
+	for _, li := range inv.LineItems {
+		pbItem := &billingpb.InvoiceLineItem{
+			Description:    li.Description,
+			Quantity:       li.Quantity.String(),
+			UnitPriceCents: li.UnitPriceCents,
+			TotalCents:     li.TotalCents,
+		}
+		if len(li.ValuationAnalysis) > 0 {
+			pbItem.ValuationAnalysis, _ = structpb.NewStruct(li.ValuationAnalysis)
+		}
+		pb.LineItems = append(pb.LineItems, pbItem)
+	}
+
+	return pb
+}
+
+func emailAuditToProto(entry *persistence.EmailAuditEntry) *billingpb.InvoiceEmail {
+	pb := &billingpb.InvoiceEmail{
+		IdempotencyKey: entry.IdempotencyKey,
+		TemplateName:   entry.TemplateName,
+		ToAddresses:    entry.ToAddresses,
+		Status:         mapEmailStatusToProto(entry.Status),
+	}
+	if entry.SentAt != nil {
+		pb.SentAt = timestamppb.New(*entry.SentAt)
+	}
+	if entry.DeliveredAt != nil {
+		pb.DeliveredAt = timestamppb.New(*entry.DeliveredAt)
+	}
+	if entry.BounceReason != nil {
+		pb.BounceReason = *entry.BounceReason
+	}
+	return pb
+}
+
+func mapBillingRunStatusToProto(s domain.BillingRunStatus) billingpb.BillingRunStatus {
+	switch s {
+	case domain.BillingRunStatusInitiated:
+		return billingpb.BillingRunStatus_BILLING_RUN_STATUS_INITIATED
+	case domain.BillingRunStatusProcessing:
+		return billingpb.BillingRunStatus_BILLING_RUN_STATUS_PROCESSING
+	case domain.BillingRunStatusCompleted:
+		return billingpb.BillingRunStatus_BILLING_RUN_STATUS_COMPLETED
+	case domain.BillingRunStatusFailed:
+		return billingpb.BillingRunStatus_BILLING_RUN_STATUS_FAILED
+	default:
+		return billingpb.BillingRunStatus_BILLING_RUN_STATUS_UNSPECIFIED
+	}
+}
+
+func mapInvoiceStatusToProto(s domain.InvoiceStatus) billingpb.InvoiceStatus {
+	switch s {
+	case domain.InvoiceStatusDraft:
+		return billingpb.InvoiceStatus_INVOICE_STATUS_DRAFT
+	case domain.InvoiceStatusIssued:
+		return billingpb.InvoiceStatus_INVOICE_STATUS_ISSUED
+	case domain.InvoiceStatusPaid:
+		return billingpb.InvoiceStatus_INVOICE_STATUS_PAID
+	case domain.InvoiceStatusVoid:
+		return billingpb.InvoiceStatus_INVOICE_STATUS_VOID
+	case domain.InvoiceStatusOverdue:
+		return billingpb.InvoiceStatus_INVOICE_STATUS_OVERDUE
+	default:
+		return billingpb.InvoiceStatus_INVOICE_STATUS_UNSPECIFIED
+	}
+}
+
+func mapEmailStatusToProto(s string) billingpb.EmailStatus {
+	switch s {
+	case "PENDING":
+		return billingpb.EmailStatus_EMAIL_STATUS_PENDING
+	case "SENT", "SENDING":
+		return billingpb.EmailStatus_EMAIL_STATUS_SENT
+	case "DELIVERED":
+		return billingpb.EmailStatus_EMAIL_STATUS_DELIVERED
+	case "BOUNCED":
+		return billingpb.EmailStatus_EMAIL_STATUS_BOUNCED
+	case "DEAD_LETTER", "FAILED":
+		return billingpb.EmailStatus_EMAIL_STATUS_DEAD_LETTER
+	case "CANCELLED":
+		return billingpb.EmailStatus_EMAIL_STATUS_CANCELLED
+	default:
+		return billingpb.EmailStatus_EMAIL_STATUS_UNSPECIFIED
+	}
+}
+
+// mapProtoBillingRunStatuses converts proto billing run status enums to domain status strings.
+func mapProtoBillingRunStatuses(statuses []billingpb.BillingRunStatus) []string {
+	if len(statuses) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(statuses))
+	for _, s := range statuses {
+		switch s {
+		case billingpb.BillingRunStatus_BILLING_RUN_STATUS_INITIATED:
+			result = append(result, string(domain.BillingRunStatusInitiated))
+		case billingpb.BillingRunStatus_BILLING_RUN_STATUS_PROCESSING:
+			result = append(result, string(domain.BillingRunStatusProcessing))
+		case billingpb.BillingRunStatus_BILLING_RUN_STATUS_COMPLETED:
+			result = append(result, string(domain.BillingRunStatusCompleted))
+		case billingpb.BillingRunStatus_BILLING_RUN_STATUS_FAILED:
+			result = append(result, string(domain.BillingRunStatusFailed))
+		}
+	}
+	return result
+}
+
+// mapProtoInvoiceStatuses converts proto invoice status enums to domain status strings.
+func mapProtoInvoiceStatuses(statuses []billingpb.InvoiceStatus) []string {
+	if len(statuses) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(statuses))
+	for _, s := range statuses {
+		switch s {
+		case billingpb.InvoiceStatus_INVOICE_STATUS_DRAFT:
+			result = append(result, string(domain.InvoiceStatusDraft))
+		case billingpb.InvoiceStatus_INVOICE_STATUS_ISSUED:
+			result = append(result, string(domain.InvoiceStatusIssued))
+		case billingpb.InvoiceStatus_INVOICE_STATUS_PAID:
+			result = append(result, string(domain.InvoiceStatusPaid))
+		case billingpb.InvoiceStatus_INVOICE_STATUS_VOID:
+			result = append(result, string(domain.InvoiceStatusVoid))
+		case billingpb.InvoiceStatus_INVOICE_STATUS_OVERDUE:
+			result = append(result, string(domain.InvoiceStatusOverdue))
+		}
+	}
+	return result
+}

--- a/services/payment-order/service/billing_grpc_mappers.go
+++ b/services/payment-order/service/billing_grpc_mappers.go
@@ -140,6 +140,8 @@ func mapProtoBillingRunStatuses(statuses []billingpb.BillingRunStatus) []string 
 			result = append(result, string(domain.BillingRunStatusCompleted))
 		case billingpb.BillingRunStatus_BILLING_RUN_STATUS_FAILED:
 			result = append(result, string(domain.BillingRunStatusFailed))
+		case billingpb.BillingRunStatus_BILLING_RUN_STATUS_UNSPECIFIED:
+			// Skip unspecified status.
 		}
 	}
 	return result
@@ -163,6 +165,8 @@ func mapProtoInvoiceStatuses(statuses []billingpb.InvoiceStatus) []string {
 			result = append(result, string(domain.InvoiceStatusVoid))
 		case billingpb.InvoiceStatus_INVOICE_STATUS_OVERDUE:
 			result = append(result, string(domain.InvoiceStatusOverdue))
+		case billingpb.InvoiceStatus_INVOICE_STATUS_UNSPECIFIED:
+			// Skip unspecified status.
 		}
 	}
 	return result

--- a/services/payment-order/service/billing_grpc_mappers.go
+++ b/services/payment-order/service/billing_grpc_mappers.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"log/slog"
+
 	billingpb "github.com/meridianhub/meridian/api/proto/meridian/billing/v1"
 	"github.com/meridianhub/meridian/services/payment-order/adapters/persistence"
 	"github.com/meridianhub/meridian/services/payment-order/domain"
@@ -46,7 +48,11 @@ func invoiceToProto(inv *domain.Invoice) *billingpb.Invoice {
 			TotalCents:     li.TotalCents,
 		}
 		if len(li.ValuationAnalysis) > 0 {
-			pbItem.ValuationAnalysis, _ = structpb.NewStruct(li.ValuationAnalysis)
+			s, err := structpb.NewStruct(li.ValuationAnalysis)
+			if err != nil {
+				slog.Warn("failed to convert valuation analysis to proto", "error", err)
+			}
+			pbItem.ValuationAnalysis = s
 		}
 		pb.LineItems = append(pb.LineItems, pbItem)
 	}
@@ -55,22 +61,12 @@ func invoiceToProto(inv *domain.Invoice) *billingpb.Invoice {
 }
 
 func emailAuditToProto(entry *persistence.EmailAuditEntry) *billingpb.InvoiceEmail {
-	pb := &billingpb.InvoiceEmail{
+	return &billingpb.InvoiceEmail{
 		IdempotencyKey: entry.IdempotencyKey,
 		TemplateName:   entry.TemplateName,
 		ToAddresses:    entry.ToAddresses,
 		Status:         mapEmailStatusToProto(entry.Status),
 	}
-	if entry.SentAt != nil {
-		pb.SentAt = timestamppb.New(*entry.SentAt)
-	}
-	if entry.DeliveredAt != nil {
-		pb.DeliveredAt = timestamppb.New(*entry.DeliveredAt)
-	}
-	if entry.BounceReason != nil {
-		pb.BounceReason = *entry.BounceReason
-	}
-	return pb
 }
 
 func mapBillingRunStatusToProto(s domain.BillingRunStatus) billingpb.BillingRunStatus {

--- a/services/payment-order/service/billing_grpc_test.go
+++ b/services/payment-order/service/billing_grpc_test.go
@@ -1,0 +1,379 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	billingpb "github.com/meridianhub/meridian/api/proto/meridian/billing/v1"
+	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	"github.com/meridianhub/meridian/services/payment-order/adapters/persistence"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// mockBillingRepo implements persistence.BillingRepository for unit testing.
+type mockBillingRepo struct {
+	billingRuns  map[uuid.UUID]*domain.BillingRun
+	invoices     map[uuid.UUID]*domain.Invoice
+	invoiceCount int64
+	invoiceSum   int64
+	updateErr    error
+}
+
+func newMockBillingRepo() *mockBillingRepo {
+	return &mockBillingRepo{
+		billingRuns: make(map[uuid.UUID]*domain.BillingRun),
+		invoices:    make(map[uuid.UUID]*domain.Invoice),
+	}
+}
+
+func (m *mockBillingRepo) CreateBillingRun(_ context.Context, run *domain.BillingRun) error {
+	m.billingRuns[run.ID] = run
+	return nil
+}
+
+func (m *mockBillingRepo) FindBillingRunByID(_ context.Context, id uuid.UUID) (*domain.BillingRun, error) {
+	run, ok := m.billingRuns[id]
+	if !ok {
+		return nil, persistence.ErrBillingRunNotFound
+	}
+	return run, nil
+}
+
+func (m *mockBillingRepo) FindBillingRunByTenantAndPeriod(_ context.Context, _ string, _, _ time.Time) (*domain.BillingRun, error) {
+	return nil, persistence.ErrBillingRunNotFound
+}
+
+func (m *mockBillingRepo) UpdateBillingRun(_ context.Context, _ *domain.BillingRun) error {
+	return nil
+}
+
+func (m *mockBillingRepo) CreateInvoice(_ context.Context, inv *domain.Invoice) error {
+	m.invoices[inv.ID] = inv
+	return nil
+}
+
+func (m *mockBillingRepo) FindInvoiceByID(_ context.Context, id uuid.UUID) (*domain.Invoice, error) {
+	inv, ok := m.invoices[id]
+	if !ok {
+		return nil, persistence.ErrInvoiceNotFound
+	}
+	return inv, nil
+}
+
+func (m *mockBillingRepo) FindInvoicesByBillingRunID(_ context.Context, _ uuid.UUID) ([]*domain.Invoice, error) {
+	return nil, nil
+}
+
+func (m *mockBillingRepo) UpdateInvoice(_ context.Context, inv *domain.Invoice) error {
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	m.invoices[inv.ID] = inv
+	return nil
+}
+
+func (m *mockBillingRepo) ListBillingRuns(_ context.Context, _ persistence.BillingRunFilter, pageSize int, _ string) (*persistence.BillingRunPage, error) {
+	runs := make([]*domain.BillingRun, 0)
+	for _, r := range m.billingRuns {
+		runs = append(runs, r)
+		if len(runs) >= pageSize {
+			break
+		}
+	}
+	return &persistence.BillingRunPage{
+		BillingRuns: runs,
+		TotalCount:  int64(len(m.billingRuns)),
+	}, nil
+}
+
+func (m *mockBillingRepo) ListInvoices(_ context.Context, _ persistence.InvoiceFilter, pageSize int, _ string) (*persistence.InvoicePage, error) {
+	invoices := make([]*domain.Invoice, 0)
+	for _, inv := range m.invoices {
+		invoices = append(invoices, inv)
+		if len(invoices) >= pageSize {
+			break
+		}
+	}
+	return &persistence.InvoicePage{
+		Invoices:   invoices,
+		TotalCount: int64(len(m.invoices)),
+	}, nil
+}
+
+func (m *mockBillingRepo) CountInvoicesByBillingRun(_ context.Context, _ uuid.UUID) (int64, error) {
+	return m.invoiceCount, nil
+}
+
+func (m *mockBillingRepo) SumInvoiceTotalsByBillingRun(_ context.Context, _ uuid.UUID) (int64, error) {
+	return m.invoiceSum, nil
+}
+
+func (m *mockBillingRepo) ListEmailsByInvoice(_ context.Context, _ uuid.UUID) ([]*persistence.EmailAuditEntry, error) {
+	return []*persistence.EmailAuditEntry{}, nil
+}
+
+// Compile-time check.
+var _ persistence.BillingRepository = (*mockBillingRepo)(nil)
+
+func TestBillingGRPC_GetBillingRun(t *testing.T) {
+	repo := newMockBillingRepo()
+	svc := NewBillingService(repo, nil, nil)
+
+	run := &domain.BillingRun{
+		ID:       uuid.New(),
+		TenantID: "tenant-1",
+		Status:   domain.BillingRunStatusCompleted,
+	}
+	repo.billingRuns[run.ID] = run
+	repo.invoiceCount = 5
+	repo.invoiceSum = 50000
+
+	resp, err := svc.GetBillingRun(context.Background(), &billingpb.GetBillingRunRequest{
+		Id: run.ID.String(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, run.ID.String(), resp.BillingRun.Id)
+	assert.Equal(t, billingpb.BillingRunStatus_BILLING_RUN_STATUS_COMPLETED, resp.BillingRun.Status)
+	assert.Equal(t, int32(5), resp.BillingRun.InvoiceCount)
+	assert.Equal(t, int64(50000), resp.BillingRun.TotalAmountCents)
+}
+
+func TestBillingGRPC_GetBillingRun_NotFound(t *testing.T) {
+	repo := newMockBillingRepo()
+	svc := NewBillingService(repo, nil, nil)
+
+	_, err := svc.GetBillingRun(context.Background(), &billingpb.GetBillingRunRequest{
+		Id: uuid.New().String(),
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func TestBillingGRPC_GetBillingRun_InvalidID(t *testing.T) {
+	repo := newMockBillingRepo()
+	svc := NewBillingService(repo, nil, nil)
+
+	_, err := svc.GetBillingRun(context.Background(), &billingpb.GetBillingRunRequest{
+		Id: "not-a-uuid",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestBillingGRPC_ListBillingRuns(t *testing.T) {
+	repo := newMockBillingRepo()
+	svc := NewBillingService(repo, nil, nil)
+
+	run := &domain.BillingRun{ID: uuid.New(), TenantID: "t1", Status: domain.BillingRunStatusInitiated}
+	repo.billingRuns[run.ID] = run
+
+	resp, err := svc.ListBillingRuns(context.Background(), &billingpb.ListBillingRunsRequest{
+		Pagination: &commonpb.Pagination{PageSize: 10},
+	})
+	require.NoError(t, err)
+	assert.Len(t, resp.BillingRuns, 1)
+	assert.Equal(t, int64(1), resp.Pagination.TotalCount)
+}
+
+func TestBillingGRPC_GetInvoice(t *testing.T) {
+	repo := newMockBillingRepo()
+	svc := NewBillingService(repo, nil, nil)
+
+	inv := &domain.Invoice{
+		ID:            uuid.New(),
+		BillingRunID:  uuid.New(),
+		PartyID:       "p1",
+		AccountID:     "a1",
+		InvoiceNumber: "INV-001",
+		SubtotalCents: 5000,
+		Currency:      "GBP",
+		Status:        domain.InvoiceStatusDraft,
+	}
+	repo.invoices[inv.ID] = inv
+
+	resp, err := svc.GetInvoice(context.Background(), &billingpb.GetInvoiceRequest{
+		Id: inv.ID.String(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, inv.ID.String(), resp.Invoice.Id)
+	assert.Equal(t, "INV-001", resp.Invoice.InvoiceNumber)
+	assert.Equal(t, int64(5000), resp.Invoice.SubtotalCents)
+}
+
+func TestBillingGRPC_GetInvoice_NotFound(t *testing.T) {
+	repo := newMockBillingRepo()
+	svc := NewBillingService(repo, nil, nil)
+
+	_, err := svc.GetInvoice(context.Background(), &billingpb.GetInvoiceRequest{
+		Id: uuid.New().String(),
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func TestBillingGRPC_MarkInvoicePaid(t *testing.T) {
+	repo := newMockBillingRepo()
+	svc := NewBillingService(repo, nil, nil)
+
+	inv := &domain.Invoice{
+		ID:            uuid.New(),
+		BillingRunID:  uuid.New(),
+		InvoiceNumber: "INV-PAY",
+		Status:        domain.InvoiceStatusIssued,
+	}
+	repo.invoices[inv.ID] = inv
+
+	resp, err := svc.MarkInvoicePaid(context.Background(), &billingpb.MarkInvoicePaidRequest{
+		InvoiceId: inv.ID.String(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, billingpb.InvoiceStatus_INVOICE_STATUS_PAID, resp.Invoice.Status)
+}
+
+func TestBillingGRPC_MarkInvoicePaid_AlreadyPaid(t *testing.T) {
+	repo := newMockBillingRepo()
+	svc := NewBillingService(repo, nil, nil)
+
+	inv := &domain.Invoice{
+		ID:     uuid.New(),
+		Status: domain.InvoiceStatusPaid,
+	}
+	repo.invoices[inv.ID] = inv
+
+	resp, err := svc.MarkInvoicePaid(context.Background(), &billingpb.MarkInvoicePaidRequest{
+		InvoiceId: inv.ID.String(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, billingpb.InvoiceStatus_INVOICE_STATUS_PAID, resp.Invoice.Status)
+}
+
+func TestBillingGRPC_MarkInvoicePaid_InvalidTransition(t *testing.T) {
+	repo := newMockBillingRepo()
+	svc := NewBillingService(repo, nil, nil)
+
+	inv := &domain.Invoice{
+		ID:     uuid.New(),
+		Status: domain.InvoiceStatusVoid,
+	}
+	repo.invoices[inv.ID] = inv
+
+	_, err := svc.MarkInvoicePaid(context.Background(), &billingpb.MarkInvoicePaidRequest{
+		InvoiceId: inv.ID.String(),
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+func TestBillingGRPC_VoidInvoice(t *testing.T) {
+	repo := newMockBillingRepo()
+	svc := NewBillingService(repo, nil, nil)
+
+	inv := &domain.Invoice{
+		ID:     uuid.New(),
+		Status: domain.InvoiceStatusDraft,
+	}
+	repo.invoices[inv.ID] = inv
+
+	resp, err := svc.VoidInvoice(context.Background(), &billingpb.VoidInvoiceRequest{
+		InvoiceId: inv.ID.String(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, billingpb.InvoiceStatus_INVOICE_STATUS_VOID, resp.Invoice.Status)
+}
+
+func TestBillingGRPC_VoidInvoice_AlreadyVoided(t *testing.T) {
+	repo := newMockBillingRepo()
+	svc := NewBillingService(repo, nil, nil)
+
+	inv := &domain.Invoice{
+		ID:     uuid.New(),
+		Status: domain.InvoiceStatusVoid,
+	}
+	repo.invoices[inv.ID] = inv
+
+	resp, err := svc.VoidInvoice(context.Background(), &billingpb.VoidInvoiceRequest{
+		InvoiceId: inv.ID.String(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, billingpb.InvoiceStatus_INVOICE_STATUS_VOID, resp.Invoice.Status)
+}
+
+func TestBillingGRPC_VoidInvoice_InvalidTransition(t *testing.T) {
+	repo := newMockBillingRepo()
+	svc := NewBillingService(repo, nil, nil)
+
+	inv := &domain.Invoice{
+		ID:     uuid.New(),
+		Status: domain.InvoiceStatusPaid,
+	}
+	repo.invoices[inv.ID] = inv
+
+	_, err := svc.VoidInvoice(context.Background(), &billingpb.VoidInvoiceRequest{
+		InvoiceId: inv.ID.String(),
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+func TestBillingGRPC_ListInvoiceEmails(t *testing.T) {
+	repo := newMockBillingRepo()
+	svc := NewBillingService(repo, nil, nil)
+
+	resp, err := svc.ListInvoiceEmails(context.Background(), &billingpb.ListInvoiceEmailsRequest{
+		InvoiceId: uuid.New().String(),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Emails)
+}
+
+func TestBillingGRPC_ListInvoiceEmails_InvalidID(t *testing.T) {
+	repo := newMockBillingRepo()
+	svc := NewBillingService(repo, nil, nil)
+
+	_, err := svc.ListInvoiceEmails(context.Background(), &billingpb.ListInvoiceEmailsRequest{
+		InvoiceId: "bad",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestBillingGRPC_ResendInvoiceEmail_NoEmailRepo(t *testing.T) {
+	repo := newMockBillingRepo()
+	svc := NewBillingService(repo, nil, nil)
+
+	inv := &domain.Invoice{
+		ID:            uuid.New(),
+		InvoiceNumber: "INV-RESEND",
+		Status:        domain.InvoiceStatusIssued,
+	}
+	repo.invoices[inv.ID] = inv
+
+	_, err := svc.ResendInvoiceEmail(context.Background(), &billingpb.ResendInvoiceEmailRequest{
+		InvoiceId: inv.ID.String(),
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.Unavailable, status.Code(err))
+}
+
+func TestBillingGRPC_ResendInvoiceEmail_VoidedInvoice(t *testing.T) {
+	repo := newMockBillingRepo()
+	svc := NewBillingService(repo, nil, nil)
+
+	inv := &domain.Invoice{
+		ID:     uuid.New(),
+		Status: domain.InvoiceStatusVoid,
+	}
+	repo.invoices[inv.ID] = inv
+
+	_, err := svc.ResendInvoiceEmail(context.Background(), &billingpb.ResendInvoiceEmailRequest{
+		InvoiceId: inv.ID.String(),
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}

--- a/services/payment-order/worker/billing_scheduler_test.go
+++ b/services/payment-order/worker/billing_scheduler_test.go
@@ -125,6 +125,26 @@ func (m *mockBillingRepo) UpdateInvoice(_ context.Context, inv *domain.Invoice) 
 	return nil
 }
 
+func (m *mockBillingRepo) ListBillingRuns(_ context.Context, _ persistence.BillingRunFilter, _ int, _ string) (*persistence.BillingRunPage, error) {
+	return &persistence.BillingRunPage{}, nil
+}
+
+func (m *mockBillingRepo) ListInvoices(_ context.Context, _ persistence.InvoiceFilter, _ int, _ string) (*persistence.InvoicePage, error) {
+	return &persistence.InvoicePage{}, nil
+}
+
+func (m *mockBillingRepo) CountInvoicesByBillingRun(_ context.Context, _ uuid.UUID) (int64, error) {
+	return 0, nil
+}
+
+func (m *mockBillingRepo) SumInvoiceTotalsByBillingRun(_ context.Context, _ uuid.UUID) (int64, error) {
+	return 0, nil
+}
+
+func (m *mockBillingRepo) ListEmailsByInvoice(_ context.Context, _ uuid.UUID) ([]*persistence.EmailAuditEntry, error) {
+	return nil, nil
+}
+
 func (m *mockBillingRepo) getRunCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
## Summary

- Extend `BillingRepository` with cursor-based `ListBillingRuns` and `ListInvoices` (with status/party/billing-run filters), `CountInvoicesByBillingRun`, `SumInvoiceTotalsByBillingRun`, and `ListEmailsByInvoice` (idempotency key pattern matching against email outbox)
- Implement `BillingService` gRPC server with all 8 proto methods: `ListBillingRuns`, `GetBillingRun`, `ListInvoices`, `GetInvoice`, `ResendInvoiceEmail`, `MarkInvoicePaid`, `VoidInvoice`, `ListInvoiceEmails`
- Add RBAC permissions for billing methods (read: admin/operator/auditor, write: admin/operator)
- Register `BillingService` in `cmd/main.go` alongside `PaymentOrderService`

## Test plan

- [ ] Repository integration tests: pagination, status filtering, invalid cursor, count/sum aggregates
- [ ] gRPC unit tests: all 8 handlers with happy path, not found, invalid ID, idempotent transitions, invalid transitions
- [ ] Full `go build ./...` passes
- [ ] Existing billing repository tests still pass