### PR TITLE
fix: restore --skip-manifest for demo deploys

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -228,6 +228,9 @@ jobs:
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           script: |
+            # Skip manifest on incremental deploys - activate_instrument is not
+            # yet idempotent so re-applying fails on already-ACTIVE instruments.
+            # Fresh databases are handled by reset-demo.sh.
             docker exec meridian-meridian-1 /seed-dev \
               --gateway-url=http://localhost:8090 \
               --grpc-addr=localhost:50051 \
@@ -235,7 +238,7 @@ jobs:
               --tenant-slug=volterra \
               --display-name='Volterra Energy' \
               --subdomain=volterra.demo.meridianhub.cloud \
-              --manifest=/app/examples/manifests/energy.json \
+              --skip-manifest \
               --with-fixtures
 
       - name: Verify deployment health


### PR DESCRIPTION
## Summary

- Restores `--skip-manifest` for demo deploy workflow only
- The `activate_instrument` saga handler is not yet idempotent - re-applying a manifest with already-ACTIVE instruments fails with `FailedPrecondition`
- PR #1978 made most handlers idempotent but missed this case
- Develop workflow keeps manifest enabled since its DB is recreated more frequently

## Test plan

- [ ] Demo deploy succeeds (seed step no longer fails on already-active instruments)