### PR TITLE
fix: economy page crashes with 'T is not iterable' on market data

### DIFF
--- a/frontend/src/features/manifests/components/manifest-graph.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.test.tsx
@@ -576,9 +576,10 @@ describe('ManifestGraph', () => {
           { instructionType: 'payment', connectionId: 'conn-1' },
         ],
       },
-      marketData: [
-        { code: 'SPOT', name: 'Spot Price' },
-      ],
+      marketData: {
+        sources: [{ code: 'SPOT', name: 'Spot Price' }],
+        datasets: [],
+      },
       organizations: [
         { code: 'ACME', name: 'Acme Corp' },
       ],
@@ -667,9 +668,10 @@ describe('ManifestGraph', () => {
           { instructionType: 'payment', connectionId: 'conn-1' },
         ],
       },
-      marketData: [
-        { code: 'SPOT', name: 'Spot Price' },
-      ],
+      marketData: {
+        sources: [{ code: 'SPOT', name: 'Spot Price' }],
+        datasets: [],
+      },
       organizations: [
         { code: 'ACME', name: 'Acme Corp' },
       ],

--- a/frontend/src/features/manifests/lib/manifest-graph-model.ts
+++ b/frontend/src/features/manifests/lib/manifest-graph-model.ts
@@ -65,9 +65,15 @@ interface ManifestOperationalGateway {
   [key: string]: unknown
 }
 
-interface ManifestMarketData {
+interface ManifestMarketDataItem {
   code: string
   name: string
+  [key: string]: unknown
+}
+
+interface ManifestMarketDataConfig {
+  sources?: ManifestMarketDataItem[]
+  datasets?: ManifestMarketDataItem[]
   [key: string]: unknown
 }
 
@@ -93,7 +99,7 @@ interface ManifestInput {
   partyTypes?: ManifestPartyType[]
   mappings?: ManifestMapping[]
   operationalGateway?: ManifestOperationalGateway
-  marketData?: ManifestMarketData[]
+  marketData?: ManifestMarketDataConfig
   organizations?: ManifestOrganization[]
   internalAccounts?: ManifestInternalAccount[]
 }
@@ -179,7 +185,11 @@ export function buildManifestGraph(manifest: Manifest): ManifestGraph {
   const partyTypes = m.partyTypes ?? []
   const mappings = m.mappings ?? []
   const operationalGateway = m.operationalGateway
-  const marketDataItems = m.marketData ?? []
+  const marketDataConfig = m.marketData
+  const marketDataItems = [
+    ...(marketDataConfig?.sources ?? []),
+    ...(marketDataConfig?.datasets ?? []),
+  ]
   const organizations = m.organizations ?? []
   const internalAccounts = m.internalAccounts ?? []
 


### PR DESCRIPTION
## Summary

- Fixes the `/economy` page crash ("T is not iterable") caused by `buildManifestGraph` treating `marketData` as a flat array when the proto defines it as a `MarketDataConfig` wrapper message containing `sources[]` and `datasets[]`
- When the API returns a config object, `?? []` doesn't trigger (object is truthy), and `for...of` fails on the non-iterable object
- Now extracts and combines both `sources` and `datasets` from the config into the iterable list

## Test plan

- [x] All 516 manifest/economy tests pass (36 files)
- [x] Updated `manifest-graph.test.tsx` fixtures to use config object shape
- [ ] Verify `/economy` page loads on develop environment after deploy