### PR TITLE
feat: multi-tenant demo operator seeding

### DIFF
--- a/deploy/demo/.env.demo.example
+++ b/deploy/demo/.env.demo.example
@@ -99,10 +99,11 @@ LOCAL_DEV_MODE=true
 
 # [OPTIONAL] Demo operator user seeded on first boot.
 # If both EMAIL and PASSWORD are set, the user is created idempotently
-# in the specified tenant with the OPERATOR role.
+# in the specified tenant(s) with the OPERATOR role.
+# Supports comma-separated tenant IDs for multi-tenant demos.
 DEMO_OPERATOR_EMAIL=operator@volterra.energy
 DEMO_OPERATOR_PASSWORD=demo2026
-DEMO_OPERATOR_TENANT=volterra_energy
+DEMO_OPERATOR_TENANT=volterra_energy,payg_energy
 
 # ---------------------------------------------------------------------------
 # Billing

--- a/services/identity/bootstrap/bootstrap.go
+++ b/services/identity/bootstrap/bootstrap.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -159,6 +160,10 @@ type DemoUser struct {
 
 // loadDemoUsers reads demo user configuration from environment variables.
 // Returns an empty slice if required variables are not set.
+//
+// DEMO_OPERATOR_TENANT supports comma-separated tenant IDs to create
+// the same operator identity across multiple tenants (e.g., "volterra_energy,payg_energy").
+// Each tenant gets its own namespaced identity with the same email and password.
 func loadDemoUsers() []DemoUser {
 	email := os.Getenv("DEMO_OPERATOR_EMAIL")
 	password := os.Getenv("DEMO_OPERATOR_PASSWORD")
@@ -171,12 +176,21 @@ func loadDemoUsers() []DemoUser {
 		tenantID = "volterra"
 	}
 
-	return []DemoUser{{
-		Email:    email,
-		Password: password,
-		TenantID: tenantID,
-		Role:     string(domain.RoleOperator),
-	}}
+	tenants := strings.Split(tenantID, ",")
+	users := make([]DemoUser, 0, len(tenants))
+	for _, tid := range tenants {
+		tid = strings.TrimSpace(tid)
+		if tid == "" {
+			continue
+		}
+		users = append(users, DemoUser{
+			Email:    email,
+			Password: password,
+			TenantID: tid,
+			Role:     string(domain.RoleOperator),
+		})
+	}
+	return users
 }
 
 // SeedDemoUsers creates demo user identities from environment variables.
@@ -185,7 +199,7 @@ func loadDemoUsers() []DemoUser {
 // Environment variables:
 //   - DEMO_OPERATOR_EMAIL: Email address for the demo operator
 //   - DEMO_OPERATOR_PASSWORD: Password for the demo operator
-//   - DEMO_OPERATOR_TENANT: Tenant ID (default: "volterra")
+//   - DEMO_OPERATOR_TENANT: Tenant ID or comma-separated list (e.g., "volterra_energy,payg_energy")
 func SeedDemoUsers(ctx context.Context, repo domain.Repository) error {
 	if repo == nil {
 		return ErrNilRepository


### PR DESCRIPTION
## Summary

Support comma-separated tenant IDs in `DEMO_OPERATOR_TENANT` env var, enabling the same operator identity across multiple demo tenants.

**Before:** `DEMO_OPERATOR_TENANT=volterra_energy` - one operator, one tenant.
**After:** `DEMO_OPERATOR_TENANT=volterra_energy,payg_energy` - same email/password, both tenants.

Each tenant gets its own namespaced identity. Login with `operator@volterra.energy` / `demo2026` on either tenant.

## Changes

- `services/identity/bootstrap/bootstrap.go`: `loadDemoUsers` splits comma-separated tenant IDs
- `deploy/demo/.env.demo.example`: Updated example with both tenants

## Test plan

- [x] `go test ./services/identity/bootstrap/` passes
- [x] `go build ./services/identity/...` compiles
- [ ] Deploy and verify login on both tenants