### PR TITLE
feat: wire invitation email via outbox pattern

### DIFF
--- a/cmd/meridian/wire_identity.go
+++ b/cmd/meridian/wire_identity.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"log/slog"
+
+	identityv1 "github.com/meridianhub/meridian/api/proto/meridian/identity/v1"
+	identitypersistence "github.com/meridianhub/meridian/services/identity/adapters/persistence"
+	identityservice "github.com/meridianhub/meridian/services/identity/service"
+	"github.com/meridianhub/meridian/shared/pkg/email"
+	"github.com/meridianhub/meridian/shared/platform/env"
+	"google.golang.org/grpc"
+	"gorm.io/gorm"
+)
+
+// wireIdentity wires the identity gRPC service into the shared server.
+func wireIdentity(server *grpc.Server, db *gorm.DB, logger *slog.Logger) error {
+	repo := identitypersistence.NewRepository(db)
+	baseURL := "https://" + env.GetEnvOrDefault("BASE_DOMAIN", "app.meridianhub.cloud")
+	svc, err := identityservice.NewService(repo, logger,
+		identityservice.WithEmailOutbox(email.NewPostgresOutboxRepository(db)),
+		identityservice.WithBaseURL(baseURL),
+	)
+	if err != nil {
+		return err
+	}
+	identityv1.RegisterIdentityServiceServer(server, svc)
+	logger.Info("registered identity service")
+	return nil
+}

--- a/cmd/meridian/wire_services.go
+++ b/cmd/meridian/wire_services.go
@@ -15,7 +15,6 @@ import (
 	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
 	forecastingv1 "github.com/meridianhub/meridian/api/proto/meridian/forecasting/v1"
-	identityv1 "github.com/meridianhub/meridian/api/proto/meridian/identity/v1"
 	internalaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_account/v1"
 	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
 	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
@@ -44,7 +43,6 @@ import (
 	identitybootstrap "github.com/meridianhub/meridian/services/identity/bootstrap"
 	identityconnector "github.com/meridianhub/meridian/services/identity/connector"
 	identitydex "github.com/meridianhub/meridian/services/identity/dex"
-	identityservice "github.com/meridianhub/meridian/services/identity/service"
 	internalaccountpersistence "github.com/meridianhub/meridian/services/internal-account/adapters/persistence"
 	internalaccountservice "github.com/meridianhub/meridian/services/internal-account/service"
 	marketinformationpersistence "github.com/meridianhub/meridian/services/market-information/adapters/persistence"
@@ -79,7 +77,6 @@ import (
 	gateway "github.com/meridianhub/meridian/services/api-gateway"
 
 	// Shared platform
-	"github.com/meridianhub/meridian/shared/pkg/email"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/defaults"
@@ -648,27 +645,6 @@ func wireAudit(server *grpc.Server, db *gorm.DB, logger *slog.Logger) error {
 	return nil
 }
 
-// ─── Identity Wiring ─────────────────────────────────────────────────────────
-
-func wireIdentity(server *grpc.Server, db *gorm.DB, logger *slog.Logger) error {
-	repo := identitypersistence.NewRepository(db)
-
-	baseDomain := env.GetEnvOrDefault("BASE_DOMAIN", "app.meridianhub.cloud")
-	baseURL := "https://" + baseDomain
-
-	emailOutboxRepo := email.NewPostgresOutboxRepository(db)
-
-	svc, err := identityservice.NewService(repo, logger,
-		identityservice.WithEmailOutbox(emailOutboxRepo),
-		identityservice.WithBaseURL(baseURL),
-	)
-	if err != nil {
-		return err
-	}
-	identityv1.RegisterIdentityServiceServer(server, svc)
-	logger.Info("registered identity service")
-	return nil
-}
 
 // wireEmbeddedDex creates the embedded Dex OIDC server and returns a gateway
 // ServerOption that mounts its HTTP handler at /dex/*. When DEX_ISSUER is not

--- a/cmd/meridian/wire_services.go
+++ b/cmd/meridian/wire_services.go
@@ -645,7 +645,6 @@ func wireAudit(server *grpc.Server, db *gorm.DB, logger *slog.Logger) error {
 	return nil
 }
 
-
 // wireEmbeddedDex creates the embedded Dex OIDC server and returns a gateway
 // ServerOption that mounts its HTTP handler at /dex/*. When DEX_ISSUER is not
 // set, returns a no-op option (Dex is opt-in).

--- a/cmd/meridian/wire_services.go
+++ b/cmd/meridian/wire_services.go
@@ -79,6 +79,7 @@ import (
 	gateway "github.com/meridianhub/meridian/services/api-gateway"
 
 	// Shared platform
+	"github.com/meridianhub/meridian/shared/pkg/email"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/defaults"
@@ -651,7 +652,16 @@ func wireAudit(server *grpc.Server, db *gorm.DB, logger *slog.Logger) error {
 
 func wireIdentity(server *grpc.Server, db *gorm.DB, logger *slog.Logger) error {
 	repo := identitypersistence.NewRepository(db)
-	svc, err := identityservice.NewService(repo, logger)
+
+	baseDomain := env.GetEnvOrDefault("BASE_DOMAIN", "app.meridianhub.cloud")
+	baseURL := "https://" + baseDomain
+
+	emailOutboxRepo := email.NewPostgresOutboxRepository(db)
+
+	svc, err := identityservice.NewService(repo, logger,
+		identityservice.WithEmailOutbox(emailOutboxRepo),
+		identityservice.WithBaseURL(baseURL),
+	)
 	if err != nil {
 		return err
 	}

--- a/services/identity/service/grpc_service_test.go
+++ b/services/identity/service/grpc_service_test.go
@@ -1922,7 +1922,7 @@ func TestRoleAssignmentToProto_WithRevocation(t *testing.T) {
 // --- mockOutbox ---
 
 type mockOutbox struct {
-	entries  []*email.OutboxEntry
+	entries    []*email.OutboxEntry
 	enqueueErr error
 }
 

--- a/services/identity/service/grpc_service_test.go
+++ b/services/identity/service/grpc_service_test.go
@@ -11,6 +11,7 @@ import (
 	pb "github.com/meridianhub/meridian/api/proto/meridian/identity/v1"
 	"github.com/meridianhub/meridian/services/identity/domain"
 	"github.com/meridianhub/meridian/shared/pkg/credentials"
+	"github.com/meridianhub/meridian/shared/pkg/email"
 	"github.com/meridianhub/meridian/shared/pkg/tokens"
 	"github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
@@ -1916,4 +1917,93 @@ func TestRoleAssignmentToProto_WithRevocation(t *testing.T) {
 	assert.True(t, proto.Revoked)
 	assert.NotNil(t, proto.RevokedAt)
 	assert.Equal(t, revokedBy.String(), proto.RevokedBy)
+}
+
+// --- mockOutbox ---
+
+type mockOutbox struct {
+	entries  []*email.OutboxEntry
+	enqueueErr error
+}
+
+func (m *mockOutbox) Enqueue(_ context.Context, entry *email.OutboxEntry) error {
+	if m.enqueueErr != nil {
+		return m.enqueueErr
+	}
+	m.entries = append(m.entries, entry)
+	return nil
+}
+
+func newTestServiceWithOutbox(t *testing.T) (*Service, *mockRepository, *mockOutbox) {
+	t.Helper()
+	repo := newMockRepository()
+	outbox := &mockOutbox{}
+	svc, err := NewService(repo, slog.Default(), WithEmailOutbox(outbox), WithBaseURL("https://app.example.com"))
+	require.NoError(t, err)
+	return svc, repo, outbox
+}
+
+// --- InviteUser email outbox tests ---
+
+func TestInviteUser_QueuesInvitationEmail(t *testing.T) {
+	svc, repo, outbox := newTestServiceWithOutbox(t)
+
+	inviterID := uuid.New()
+	inviter := domain.ReconstructIdentity(
+		inviterID, svcTestTID, "inviter@example.com",
+		domain.IdentityStatusActive, "", "", "", 0,
+		time.Now(), time.Now(), 0,
+	)
+	repo.addIdentity(inviter)
+
+	ctx := contextWithAuth(inviterID, []string{"ADMIN"})
+	resp, err := svc.InviteUser(ctx, &pb.InviteUserRequest{
+		Email: "invited@example.com",
+		Role:  pb.Role_ROLE_OPERATOR,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, resp.Invitation)
+	require.Len(t, outbox.entries, 1)
+
+	entry := outbox.entries[0]
+	assert.Equal(t, "invite-user", entry.TemplateName)
+	assert.Equal(t, []string{"invited@example.com"}, entry.ToAddresses)
+	assert.Equal(t, "inviter@example.com", entry.TemplateData["InviterEmail"])
+	assert.NotEmpty(t, entry.TemplateData["AcceptLink"])
+	assert.Contains(t, entry.TemplateData["AcceptLink"].(string), resp.InvitationToken)
+	assert.Equal(t, string(svcTestTID), entry.TemplateData["TenantName"])
+}
+
+func TestInviteUser_NilOutbox_NoEmailQueued(t *testing.T) {
+	// No WithEmailOutbox option - outbox is nil, no panic, invitation still created.
+	svc, repo := newTestService(t)
+
+	inviterID := uuid.New()
+	ctx := contextWithAuth(inviterID, []string{"ADMIN"})
+	resp, err := svc.InviteUser(ctx, &pb.InviteUserRequest{
+		Email: "invited@example.com",
+		Role:  pb.Role_ROLE_OPERATOR,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, resp.Invitation)
+	assert.Len(t, repo.invitations, 1)
+}
+
+func TestInviteUser_OutboxError_InvitationStillSucceeds(t *testing.T) {
+	// Outbox enqueue failure must not fail the RPC - email is best-effort.
+	svc, repo, outbox := newTestServiceWithOutbox(t)
+	outbox.enqueueErr = errors.New("db unavailable")
+
+	inviterID := uuid.New()
+	ctx := contextWithAuth(inviterID, []string{"ADMIN"})
+	resp, err := svc.InviteUser(ctx, &pb.InviteUserRequest{
+		Email: "invited@example.com",
+		Role:  pb.Role_ROLE_OPERATOR,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, resp.Invitation)
+	assert.Len(t, repo.invitations, 1)
 }

--- a/services/identity/service/server.go
+++ b/services/identity/service/server.go
@@ -6,6 +6,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 
@@ -13,6 +14,7 @@ import (
 	pb "github.com/meridianhub/meridian/api/proto/meridian/identity/v1"
 	"github.com/meridianhub/meridian/services/identity/domain"
 	"github.com/meridianhub/meridian/shared/pkg/credentials"
+	"github.com/meridianhub/meridian/shared/pkg/email"
 	"github.com/meridianhub/meridian/shared/pkg/tokens"
 	"github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
@@ -26,25 +28,57 @@ var (
 	ErrRepositoryNil = errors.New("repository cannot be nil")
 )
 
+// OutboxWriter queues an email for delivery. A narrow interface so the service
+// does not depend on the full email.OutboxRepository.
+type OutboxWriter interface {
+	Enqueue(ctx context.Context, entry *email.OutboxEntry) error
+}
+
+// Option configures a Service.
+type Option func(*Service)
+
+// WithEmailOutbox sets the outbox writer used to queue notification emails.
+// If not provided (or nil), email notifications are silently skipped.
+func WithEmailOutbox(outbox OutboxWriter) Option {
+	return func(s *Service) {
+		s.emailOutbox = outbox
+	}
+}
+
+// WithBaseURL sets the base URL used to construct invitation accept links.
+// Defaults to "https://app.meridianhub.cloud" if not provided.
+func WithBaseURL(baseURL string) Option {
+	return func(s *Service) {
+		s.baseURL = baseURL
+	}
+}
+
 // Service implements the IdentityService gRPC service.
 type Service struct {
 	pb.UnimplementedIdentityServiceServer
-	repo   domain.Repository
-	logger *slog.Logger
+	repo        domain.Repository
+	logger      *slog.Logger
+	emailOutbox OutboxWriter
+	baseURL     string
 }
 
 // NewService creates a new identity service with the required repository dependency.
-func NewService(repo domain.Repository, logger *slog.Logger) (*Service, error) {
+func NewService(repo domain.Repository, logger *slog.Logger, opts ...Option) (*Service, error) {
 	if repo == nil {
 		return nil, ErrRepositoryNil
 	}
 	if logger == nil {
 		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	}
-	return &Service{
-		repo:   repo,
-		logger: logger,
-	}, nil
+	svc := &Service{
+		repo:    repo,
+		logger:  logger,
+		baseURL: "https://app.meridianhub.cloud",
+	}
+	for _, opt := range opts {
+		opt(svc)
+	}
+	return svc, nil
 }
 
 // --- Identity CRUD ---
@@ -625,6 +659,8 @@ func (s *Service) InviteUser(ctx context.Context, req *pb.InviteUserRequest) (*p
 	s.logger.InfoContext(ctx, "invitation created",
 		"identity_id", identity.ID())
 
+	s.queueInvitationEmail(ctx, identity, inviterID, plaintextToken, tenantID)
+
 	// Grant the initial role if specified.
 	if req.GetRole() != pb.Role_ROLE_UNSPECIFIED {
 		granterRole := s.getCallerHighestRole(ctx)
@@ -900,5 +936,52 @@ func mapDomainError(err error, entity string) error {
 		return status.Errorf(codes.Aborted, "version conflict: resource was modified by another transaction")
 	default:
 		return status.Errorf(codes.Internal, "internal error")
+	}
+}
+
+// queueInvitationEmail enqueues an invitation email for the given invitee.
+// Best-effort: errors are logged but not surfaced to the caller.
+// The inviter's email is looked up by inviterID; if the lookup fails, "unknown" is used.
+func (s *Service) queueInvitationEmail(ctx context.Context, invitee *domain.Identity, inviterID uuid.UUID, plaintextToken string, tenantID tenant.TenantID) {
+	if s.emailOutbox == nil {
+		return
+	}
+
+	inviterEmail := "unknown"
+	if inviter, err := s.repo.FindByID(ctx, inviterID); err == nil {
+		inviterEmail = inviter.Email()
+	}
+
+	tenantSlug := string(tenantID)
+	if slug, ok := tenant.SlugFromContext(ctx); ok {
+		tenantSlug = slug
+	}
+
+	acceptLink := fmt.Sprintf("%s/auth/accept-invitation?token=%s", s.baseURL, plaintextToken)
+
+	entry := &email.OutboxEntry{
+		IdempotencyKey: "invite-user:" + invitee.ID().String(),
+		ToAddresses:    []string{invitee.Email()},
+		FromAddress:    "noreply@meridianhub.cloud",
+		Subject:        "You've been invited",
+		TemplateName:   "invite-user",
+		TemplateData: map[string]any{
+			"TenantName":   string(tenantID),
+			"TenantSlug":   tenantSlug,
+			"InviterEmail": inviterEmail,
+			"AcceptLink":   acceptLink,
+			"SupportEmail": "support@meridianhub.cloud",
+		},
+	}
+
+	if err := s.emailOutbox.Enqueue(ctx, entry); err != nil {
+		if errors.Is(err, email.ErrDuplicateIdempotency) {
+			s.logger.InfoContext(ctx, "invitation email already queued (idempotent)",
+				"identity_id", invitee.ID())
+			return
+		}
+		s.logger.ErrorContext(ctx, "failed to queue invitation email",
+			"identity_id", invitee.ID(),
+			"error", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `OutboxWriter` interface and functional options (`WithEmailOutbox`, `WithBaseURL`) to the identity `Service`
- Queue an `invite-user` email via the outbox after successful `InviteUser` call
- Email is best-effort: outbox errors are logged but do not fail the RPC; nil outbox is silently skipped
- Wire email outbox and base URL in `wireIdentity` using the identity DB's outbox repository

## Changes Made

- `services/identity/service/server.go`: Add `OutboxWriter` interface, `Option` func type, `WithEmailOutbox`/`WithBaseURL` options, `emailOutbox`/`baseURL` fields on `Service`, variadic opts in `NewService`, `queueInvitationEmail` helper, call it in `InviteUser`
- `services/identity/service/grpc_service_test.go`: Add `mockOutbox`, `newTestServiceWithOutbox` helper, three new tests covering: queues email with correct fields, nil outbox no-ops safely, outbox error does not fail the RPC
- `cmd/meridian/wire_services.go`: Create `email.NewPostgresOutboxRepository` for identity DB, pass `WithEmailOutbox` and `WithBaseURL` to `NewService`

## Testing

- `TestInviteUser_QueuesInvitationEmail`: verifies template name, recipient, inviter email lookup, accept link contains token, tenant name
- `TestInviteUser_NilOutbox_NoEmailQueued`: no panic when no outbox configured, invitation still created
- `TestInviteUser_OutboxError_InvitationStillSucceeds`: outbox failure is best-effort, RPC returns success

## Risk Assessment

Low. Email is fire-and-forget after the invitation is persisted. No change to the happy-path data flow. Existing tests unchanged.