### PR TITLE
feat: add billing runs list page

### DIFF
--- a/frontend/src/features/billing/api/hooks.ts
+++ b/frontend/src/features/billing/api/hooks.ts
@@ -48,11 +48,21 @@ export function useBillingRunsTable() {
     if (!tenantSlug) return { items: [] }
 
     try {
+      const STATUS_ENUM: Record<string, number> = {
+        INITIATED: 1,
+        PROCESSING: 2,
+        COMPLETED: 3,
+        FAILED: 4,
+      }
+      const statusFilter = params.filters?.status
+      const statusEnum = statusFilter ? STATUS_ENUM[statusFilter] : undefined
+
       const response = await clients.billing.listBillingRuns({
         pagination: {
           pageSize: params.pageSize,
           pageToken: params.pageToken ?? '',
         },
+        ...(statusEnum !== undefined ? { status: [statusEnum as never] } : {}),
       })
 
       const items: BillingRun[] = (response.billingRuns ?? []).map((run) => ({

--- a/frontend/src/features/billing/index.ts
+++ b/frontend/src/features/billing/index.ts
@@ -9,3 +9,4 @@ export {
   useVoidInvoice,
 } from './api/hooks'
 export { EmailDeliveryStatusBadge } from './components/email-delivery-status-badge'
+export { BillingRunsPage } from './pages'

--- a/frontend/src/features/billing/pages/index.test.tsx
+++ b/frontend/src/features/billing/pages/index.test.tsx
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { AuthProvider } from '@/contexts/auth-context'
+import { TenantProvider } from '@/contexts/tenant-context'
+
+const mockQueryFn = vi.fn()
+
+vi.mock('../api/hooks', () => ({
+  useBillingRunsTable: vi.fn(() => ({
+    queryKey: ['test-tenant', 'billing-runs'],
+    queryFn: mockQueryFn,
+    tenantSlug: 'test-tenant',
+  })),
+}))
+
+import { BillingRunsPage } from './index'
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  })
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = makeQueryClient()
+  return (
+    <QueryClientProvider client={qc}>
+      <AuthProvider>
+        <TenantProvider>
+          <TooltipProvider>
+            <MemoryRouter>{children}</MemoryRouter>
+          </TooltipProvider>
+        </TenantProvider>
+      </AuthProvider>
+    </QueryClientProvider>
+  )
+}
+
+const sampleRuns = [
+  {
+    id: 'run-001',
+    billingPeriod: { start: '2025-01-01T00:00:00.000Z', end: '2025-01-31T23:59:59.000Z' },
+    status: 'COMPLETED',
+    dunningLevel: 0,
+    invoiceCount: 12,
+    totalAmountCents: 150000,
+    currency: 'GBP',
+    createdAt: '2025-02-01T10:00:00.000Z',
+  },
+  {
+    id: 'run-002',
+    billingPeriod: { start: '2025-02-01T00:00:00.000Z', end: '2025-02-28T23:59:59.000Z' },
+    status: 'FAILED',
+    dunningLevel: 1,
+    invoiceCount: 5,
+    totalAmountCents: 75000,
+    currency: 'GBP',
+    createdAt: '2025-03-01T10:00:00.000Z',
+  },
+]
+
+describe('BillingRunsPage - rendering', () => {
+  it('renders page heading', async () => {
+    mockQueryFn.mockResolvedValue({ items: [] })
+
+    render(
+      <Wrapper>
+        <BillingRunsPage />
+      </Wrapper>,
+    )
+
+    expect(screen.getByRole('heading', { name: /billing runs/i })).toBeInTheDocument()
+  })
+
+  it('renders column headers', async () => {
+    mockQueryFn.mockResolvedValue({ items: [] })
+
+    render(
+      <Wrapper>
+        <BillingRunsPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('columnheader', { name: /period/i })).toBeInTheDocument()
+      expect(screen.getByRole('columnheader', { name: /status/i })).toBeInTheDocument()
+      expect(screen.getByRole('columnheader', { name: /invoices/i })).toBeInTheDocument()
+      expect(screen.getByRole('columnheader', { name: /total amount/i })).toBeInTheDocument()
+      expect(screen.getByRole('columnheader', { name: /created/i })).toBeInTheDocument()
+    })
+  })
+
+  it('renders billing run rows with data', async () => {
+    mockQueryFn.mockResolvedValue({ items: sampleRuns })
+
+    render(
+      <Wrapper>
+        <BillingRunsPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('2025-01-01 – 2025-01-31')).toBeInTheDocument()
+      expect(screen.getByText('2025-02-01 – 2025-02-28')).toBeInTheDocument()
+    })
+  })
+
+  it('renders invoice counts', async () => {
+    mockQueryFn.mockResolvedValue({ items: sampleRuns })
+
+    render(
+      <Wrapper>
+        <BillingRunsPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('12')).toBeInTheDocument()
+      expect(screen.getByText('5')).toBeInTheDocument()
+    })
+  })
+
+  it('renders total amount using MoneyDisplay', async () => {
+    mockQueryFn.mockResolvedValue({ items: sampleRuns })
+
+    render(
+      <Wrapper>
+        <BillingRunsPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      // 150000 pence = £1,500.00
+      expect(screen.getByText('£1,500.00')).toBeInTheDocument()
+    })
+  })
+
+  it('renders status using StatusBadge', async () => {
+    mockQueryFn.mockResolvedValue({ items: sampleRuns })
+
+    render(
+      <Wrapper>
+        <BillingRunsPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('COMPLETED')).toBeInTheDocument()
+      expect(screen.getByText('FAILED')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('BillingRunsPage - navigation', () => {
+  it('calls onRowNavigate with the billing run id on row click', async () => {
+    mockQueryFn.mockResolvedValue({ items: sampleRuns })
+
+    const onNavigate = vi.fn()
+
+    render(
+      <Wrapper>
+        <BillingRunsPage onRowNavigate={onNavigate} />
+      </Wrapper>,
+    )
+
+    await waitFor(() => expect(screen.getByText('2025-01-01 – 2025-01-31')).toBeInTheDocument())
+    await userEvent.click(screen.getByText('2025-01-01 – 2025-01-31'))
+
+    expect(onNavigate).toHaveBeenCalledWith('run-001')
+  })
+})
+
+describe('BillingRunsPage - filters', () => {
+  it('renders status filter select', async () => {
+    mockQueryFn.mockResolvedValue({ items: [] })
+
+    render(
+      <Wrapper>
+        <BillingRunsPage />
+      </Wrapper>,
+    )
+
+    expect(screen.getByRole('combobox', { name: /status/i })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/billing/pages/index.tsx
+++ b/frontend/src/features/billing/pages/index.tsx
@@ -1,0 +1,120 @@
+import { useNavigate } from 'react-router-dom'
+import type { ColumnDef } from '@tanstack/react-table'
+import { DataTable } from '@/shared/data-table'
+import { MoneyDisplay } from '@/shared/money-display'
+import { StatusBadge } from '@/shared/status-badge'
+import { TimeDisplay } from '@/shared/time-display'
+import { PageHeader } from '@/shared/page-header'
+import { PageShell } from '@/shared/page-shell'
+import { Card } from '@/components/ui/card'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { useBillingRunsTable } from '../api/hooks'
+import type { BillingRun } from '../api/types'
+
+function isoToDate(iso: string): string {
+  if (!iso) return '—'
+  return iso.slice(0, 10)
+}
+
+function isoToTimestamp(iso: string): { seconds: number; nanos: number } | null {
+  if (!iso) return null
+  const ms = Date.parse(iso)
+  if (isNaN(ms)) return null
+  return { seconds: Math.floor(ms / 1000), nanos: (ms % 1000) * 1_000_000 }
+}
+
+const STATUS_OPTIONS = [
+  { label: 'Initiated', value: 'INITIATED' },
+  { label: 'Processing', value: 'PROCESSING' },
+  { label: 'Completed', value: 'COMPLETED' },
+  { label: 'Failed', value: 'FAILED' },
+]
+
+const FILTER_CONFIGS = [
+  {
+    field: 'status',
+    label: 'Status',
+    type: 'select' as const,
+    options: STATUS_OPTIONS,
+  },
+]
+
+const columns: ColumnDef<BillingRun>[] = [
+  {
+    accessorKey: 'billingPeriod',
+    header: 'Period',
+    cell: ({ row }) => {
+      const { start, end } = row.original.billingPeriod
+      return (
+        <span className="tabular-nums text-sm">
+          {isoToDate(start)} – {isoToDate(end)}
+        </span>
+      )
+    },
+  },
+  {
+    accessorKey: 'status',
+    header: 'Status',
+    cell: ({ row }) => <StatusBadge status={row.original.status} />,
+  },
+  {
+    accessorKey: 'invoiceCount',
+    header: 'Invoices',
+  },
+  {
+    accessorKey: 'totalAmountCents',
+    header: 'Total Amount',
+    cell: ({ row }) => (
+      <MoneyDisplay
+        amount={BigInt(Math.round(row.original.totalAmountCents))}
+        currency={row.original.currency}
+      />
+    ),
+  },
+  {
+    accessorKey: 'createdAt',
+    header: 'Created',
+    cell: ({ row }) => (
+      <TimeDisplay timestamp={isoToTimestamp(row.original.createdAt)} format="relative" />
+    ),
+  },
+]
+
+interface BillingRunsPageProps {
+  onRowNavigate?: (id: string) => void
+}
+
+export function BillingRunsPage({ onRowNavigate }: BillingRunsPageProps = {}) {
+  usePageTitle('Billing Runs')
+  const navigate = useNavigate()
+  const { queryKey, queryFn } = useBillingRunsTable()
+
+  function handleRowClick(row: BillingRun) {
+    if (onRowNavigate) {
+      onRowNavigate(row.id)
+    } else {
+      void navigate(`/billing/runs/${row.id}`)
+    }
+  }
+
+  return (
+    <PageShell>
+      <PageHeader title="Billing Runs" description="Billing run history and status" />
+      <Card>
+        <DataTable
+          queryKey={queryKey}
+          queryFn={queryFn}
+          columns={columns}
+          filters={FILTER_CONFIGS}
+          onRowClick={handleRowClick}
+          emptyState={
+            <div className="flex flex-col items-center gap-2 py-12 text-muted-foreground">
+              <span className="text-sm font-medium">No billing runs yet</span>
+              <span className="text-xs">Billing runs will appear here once initiated.</span>
+            </div>
+          }
+        />
+      </Card>
+    </PageShell>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `BillingRunsPage` component at `frontend/src/features/billing/pages/index.tsx`
- Displays billing runs in a DataTable with columns: Period, Status, Invoices, Total Amount, Created
- Status filter dropdown (INITIATED, PROCESSING, COMPLETED, FAILED)
- Row click navigates to `/billing/runs/:id`
- Exports `BillingRunsPage` from `frontend/src/features/billing/index.ts`

## Changes Made

- `frontend/src/features/billing/pages/index.tsx` - BillingRunsPage component
- `frontend/src/features/billing/pages/index.test.tsx` - Component tests (8 passing)
- `frontend/src/features/billing/index.ts` - Export BillingRunsPage

## Technical Details

- Uses `useBillingRunsTable` hook for data fetching via DataTable
- ISO date strings converted to `{ seconds, nanos }` format for TimeDisplay compatibility
- `totalAmountCents` converted to BigInt for MoneyDisplay
- `onRowNavigate` prop for testable navigation (same pattern as PaymentsPage)
- StatusBadge handles INITIATED/PROCESSING/COMPLETED/FAILED statuses

## Testing

- 8 unit tests covering: heading, column headers, row data, invoice counts, MoneyDisplay formatting, StatusBadge rendering, row navigation, status filter