### PR TITLE
feat: add invoice list page, detail page, and actions component

### DIFF
--- a/frontend/src/features/billing/api/hooks.ts
+++ b/frontend/src/features/billing/api/hooks.ts
@@ -6,6 +6,15 @@ import { tenantKeys } from '@/lib/query-keys'
 import type { DataTableQueryParams, DataTableResult } from '@/shared/data-table'
 import type { BillingRun, Invoice, InvoiceEmail, EmailDeliveryStatus } from './types'
 import type { Timestamp } from '@bufbuild/protobuf/wkt'
+import { InvoiceStatus } from '@/api/gen/meridian/billing/v1/billing_pb'
+
+const INVOICE_STATUS_MAP: Record<string, InvoiceStatus> = {
+  DRAFT: InvoiceStatus.INVOICE_STATUS_DRAFT,
+  ISSUED: InvoiceStatus.INVOICE_STATUS_ISSUED,
+  PAID: InvoiceStatus.INVOICE_STATUS_PAID,
+  VOID: InvoiceStatus.INVOICE_STATUS_VOID,
+  OVERDUE: InvoiceStatus.INVOICE_STATUS_OVERDUE,
+}
 
 function timestampToISO(ts?: Timestamp): string {
   if (!ts) return ''
@@ -109,6 +118,9 @@ export function useInvoicesTable() {
         },
         ...(params.filters?.billing_run_id ? { billingRunId: params.filters.billing_run_id } : {}),
         ...(params.filters?.party_id ? { partyId: params.filters.party_id } : {}),
+        ...(params.filters?.status && INVOICE_STATUS_MAP[params.filters.status] !== undefined
+          ? { status: [INVOICE_STATUS_MAP[params.filters.status]] }
+          : {}),
       })
 
       const items: Invoice[] = (response.invoices ?? []).map((inv) => ({

--- a/frontend/src/features/billing/components/invoice-actions.tsx
+++ b/frontend/src/features/billing/components/invoice-actions.tsx
@@ -1,0 +1,241 @@
+import * as React from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { handleConnectError } from '@/lib/error-handling'
+import { useResendInvoiceEmail, useMarkInvoicePaid, useVoidInvoice } from '../api/hooks'
+import type { Invoice } from '../api/types'
+
+const ACTIONABLE_STATUSES = new Set<Invoice['status']>(['ISSUED', 'OVERDUE'])
+
+interface InvoiceActionsProps {
+  invoiceId: string
+  status: Invoice['status']
+  onActionSuccess?: () => void
+}
+
+export function InvoiceActions({ invoiceId, status, onActionSuccess }: InvoiceActionsProps) {
+  const [resendOpen, setResendOpen] = React.useState(false)
+  const [markPaidOpen, setMarkPaidOpen] = React.useState(false)
+  const [voidOpen, setVoidOpen] = React.useState(false)
+
+  const showActionableButtons = ACTIONABLE_STATUSES.has(status)
+
+  return (
+    <>
+      <div className="flex gap-2">
+        <Button variant="outline" size="sm" onClick={() => setResendOpen(true)}>
+          Resend Email
+        </Button>
+        {showActionableButtons && (
+          <>
+            <Button variant="outline" size="sm" onClick={() => setMarkPaidOpen(true)}>
+              Mark as Paid
+            </Button>
+            <Button variant="destructive" size="sm" onClick={() => setVoidOpen(true)}>
+              Void Invoice
+            </Button>
+          </>
+        )}
+      </div>
+
+      <ResendEmailDialog
+        open={resendOpen}
+        onOpenChange={setResendOpen}
+        invoiceId={invoiceId}
+        onSuccess={onActionSuccess}
+      />
+      <MarkPaidDialog
+        open={markPaidOpen}
+        onOpenChange={setMarkPaidOpen}
+        invoiceId={invoiceId}
+        onSuccess={onActionSuccess}
+      />
+      <VoidInvoiceDialog
+        open={voidOpen}
+        onOpenChange={setVoidOpen}
+        invoiceId={invoiceId}
+        onSuccess={onActionSuccess}
+      />
+    </>
+  )
+}
+
+interface ActionDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  invoiceId: string
+  onSuccess?: () => void
+}
+
+function ResendEmailDialog({ open, onOpenChange, invoiceId, onSuccess }: ActionDialogProps) {
+  const resend = useResendInvoiceEmail()
+  const [error, setError] = React.useState<string | undefined>()
+
+  React.useEffect(() => {
+    if (!open) {
+      setError(undefined)
+      resend.reset()
+    }
+  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function handleConfirm() {
+    try {
+      await resend.mutateAsync(invoiceId)
+      onSuccess?.()
+      onOpenChange(false)
+    } catch (err) {
+      const result = handleConnectError(err)
+      setError(result.message)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Resend Invoice Email</DialogTitle>
+          <DialogDescription>
+            Resend the invoice email for this invoice. The recipient will receive a new copy.
+          </DialogDescription>
+        </DialogHeader>
+
+        {error && (
+          <div
+            role="alert"
+            className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          >
+            {error}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleConfirm()} disabled={resend.isPending}>
+            {resend.isPending ? 'Sending...' : 'Resend Email'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function MarkPaidDialog({ open, onOpenChange, invoiceId, onSuccess }: ActionDialogProps) {
+  const markPaid = useMarkInvoicePaid()
+  const [error, setError] = React.useState<string | undefined>()
+
+  React.useEffect(() => {
+    if (!open) {
+      setError(undefined)
+      markPaid.reset()
+    }
+  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function handleConfirm() {
+    try {
+      await markPaid.mutateAsync(invoiceId)
+      onSuccess?.()
+      onOpenChange(false)
+    } catch (err) {
+      const result = handleConnectError(err)
+      setError(result.message)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Mark Invoice as Paid</DialogTitle>
+          <DialogDescription>
+            Confirm that this invoice has been paid. This will update the invoice status to PAID.
+          </DialogDescription>
+        </DialogHeader>
+
+        {error && (
+          <div
+            role="alert"
+            className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          >
+            {error}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleConfirm()} disabled={markPaid.isPending}>
+            {markPaid.isPending ? 'Updating...' : 'Mark as Paid'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function VoidInvoiceDialog({ open, onOpenChange, invoiceId, onSuccess }: ActionDialogProps) {
+  const voidInvoice = useVoidInvoice()
+  const [error, setError] = React.useState<string | undefined>()
+
+  React.useEffect(() => {
+    if (!open) {
+      setError(undefined)
+      voidInvoice.reset()
+    }
+  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function handleConfirm() {
+    try {
+      await voidInvoice.mutateAsync(invoiceId)
+      onSuccess?.()
+      onOpenChange(false)
+    } catch (err) {
+      const result = handleConnectError(err)
+      setError(result.message)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Void Invoice</DialogTitle>
+          <DialogDescription>
+            Void this invoice and cancel any pending email deliveries. This action cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+
+        {error && (
+          <div
+            role="alert"
+            className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          >
+            {error}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => void handleConfirm()}
+            disabled={voidInvoice.isPending}
+          >
+            {voidInvoice.isPending ? 'Voiding...' : 'Void Invoice'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/features/billing/components/invoice-actions.tsx
+++ b/frontend/src/features/billing/components/invoice-actions.tsx
@@ -79,11 +79,11 @@ function ResendEmailDialog({ open, onOpenChange, invoiceId, onSuccess }: ActionD
   const [error, setError] = React.useState<string | undefined>()
 
   React.useEffect(() => {
-    if (!open) {
+    if (!open && !resend.isPending) {
       setError(undefined)
       resend.reset()
     }
-  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [open, resend.isPending]) // eslint-disable-line react-hooks/exhaustive-deps
 
   async function handleConfirm() {
     try {
@@ -133,11 +133,11 @@ function MarkPaidDialog({ open, onOpenChange, invoiceId, onSuccess }: ActionDial
   const [error, setError] = React.useState<string | undefined>()
 
   React.useEffect(() => {
-    if (!open) {
+    if (!open && !markPaid.isPending) {
       setError(undefined)
       markPaid.reset()
     }
-  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [open, markPaid.isPending]) // eslint-disable-line react-hooks/exhaustive-deps
 
   async function handleConfirm() {
     try {
@@ -187,11 +187,11 @@ function VoidInvoiceDialog({ open, onOpenChange, invoiceId, onSuccess }: ActionD
   const [error, setError] = React.useState<string | undefined>()
 
   React.useEffect(() => {
-    if (!open) {
+    if (!open && !voidInvoice.isPending) {
       setError(undefined)
       voidInvoice.reset()
     }
-  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [open, voidInvoice.isPending]) // eslint-disable-line react-hooks/exhaustive-deps
 
   async function handleConfirm() {
     try {

--- a/frontend/src/features/billing/components/invoice-actions.tsx
+++ b/frontend/src/features/billing/components/invoice-actions.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import type { UseMutationResult } from '@tanstack/react-query'
 import {
   Dialog,
   DialogContent,
@@ -25,6 +26,10 @@ export function InvoiceActions({ invoiceId, status, onActionSuccess }: InvoiceAc
   const [markPaidOpen, setMarkPaidOpen] = React.useState(false)
   const [voidOpen, setVoidOpen] = React.useState(false)
 
+  const resend = useResendInvoiceEmail()
+  const markPaid = useMarkInvoicePaid()
+  const voidInvoice = useVoidInvoice()
+
   const showActionableButtons = ACTIONABLE_STATUSES.has(status)
 
   return (
@@ -45,23 +50,39 @@ export function InvoiceActions({ invoiceId, status, onActionSuccess }: InvoiceAc
         )}
       </div>
 
-      <ResendEmailDialog
+      <ActionDialog
         open={resendOpen}
         onOpenChange={setResendOpen}
         invoiceId={invoiceId}
         onSuccess={onActionSuccess}
+        mutation={resend}
+        title="Resend Invoice Email"
+        description="Resend the invoice email for this invoice. The recipient will receive a new copy."
+        confirmLabel="Resend Email"
+        pendingLabel="Sending..."
       />
-      <MarkPaidDialog
+      <ActionDialog
         open={markPaidOpen}
         onOpenChange={setMarkPaidOpen}
         invoiceId={invoiceId}
         onSuccess={onActionSuccess}
+        mutation={markPaid}
+        title="Mark Invoice as Paid"
+        description="Confirm that this invoice has been paid. This will update the invoice status to PAID."
+        confirmLabel="Mark as Paid"
+        pendingLabel="Updating..."
       />
-      <VoidInvoiceDialog
+      <ActionDialog
         open={voidOpen}
         onOpenChange={setVoidOpen}
         invoiceId={invoiceId}
         onSuccess={onActionSuccess}
+        mutation={voidInvoice}
+        title="Void Invoice"
+        description="Void this invoice and cancel any pending email deliveries. This action cannot be undone."
+        confirmLabel="Void Invoice"
+        pendingLabel="Voiding..."
+        confirmVariant="destructive"
       />
     </>
   )
@@ -72,22 +93,39 @@ interface ActionDialogProps {
   onOpenChange: (open: boolean) => void
   invoiceId: string
   onSuccess?: () => void
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mutation: UseMutationResult<any, Error, string>
+  title: string
+  description: string
+  confirmLabel: string
+  pendingLabel: string
+  confirmVariant?: 'default' | 'destructive' | 'outline'
 }
 
-function ResendEmailDialog({ open, onOpenChange, invoiceId, onSuccess }: ActionDialogProps) {
-  const resend = useResendInvoiceEmail()
+function ActionDialog({
+  open,
+  onOpenChange,
+  invoiceId,
+  onSuccess,
+  mutation,
+  title,
+  description,
+  confirmLabel,
+  pendingLabel,
+  confirmVariant = 'default',
+}: ActionDialogProps) {
   const [error, setError] = React.useState<string | undefined>()
 
   React.useEffect(() => {
-    if (!open && !resend.isPending) {
+    if (!open && !mutation.isPending) {
       setError(undefined)
-      resend.reset()
+      mutation.reset()
     }
-  }, [open, resend.isPending]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [open, mutation.isPending]) // eslint-disable-line react-hooks/exhaustive-deps
 
   async function handleConfirm() {
     try {
-      await resend.mutateAsync(invoiceId)
+      await mutation.mutateAsync(invoiceId)
       onSuccess?.()
       onOpenChange(false)
     } catch (err) {
@@ -100,118 +138,8 @@ function ResendEmailDialog({ open, onOpenChange, invoiceId, onSuccess }: ActionD
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Resend Invoice Email</DialogTitle>
-          <DialogDescription>
-            Resend the invoice email for this invoice. The recipient will receive a new copy.
-          </DialogDescription>
-        </DialogHeader>
-
-        {error && (
-          <div
-            role="alert"
-            className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
-          >
-            {error}
-          </div>
-        )}
-
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button onClick={() => void handleConfirm()} disabled={resend.isPending}>
-            {resend.isPending ? 'Sending...' : 'Resend Email'}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  )
-}
-
-function MarkPaidDialog({ open, onOpenChange, invoiceId, onSuccess }: ActionDialogProps) {
-  const markPaid = useMarkInvoicePaid()
-  const [error, setError] = React.useState<string | undefined>()
-
-  React.useEffect(() => {
-    if (!open && !markPaid.isPending) {
-      setError(undefined)
-      markPaid.reset()
-    }
-  }, [open, markPaid.isPending]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  async function handleConfirm() {
-    try {
-      await markPaid.mutateAsync(invoiceId)
-      onSuccess?.()
-      onOpenChange(false)
-    } catch (err) {
-      const result = handleConnectError(err)
-      setError(result.message)
-    }
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Mark Invoice as Paid</DialogTitle>
-          <DialogDescription>
-            Confirm that this invoice has been paid. This will update the invoice status to PAID.
-          </DialogDescription>
-        </DialogHeader>
-
-        {error && (
-          <div
-            role="alert"
-            className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
-          >
-            {error}
-          </div>
-        )}
-
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button onClick={() => void handleConfirm()} disabled={markPaid.isPending}>
-            {markPaid.isPending ? 'Updating...' : 'Mark as Paid'}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  )
-}
-
-function VoidInvoiceDialog({ open, onOpenChange, invoiceId, onSuccess }: ActionDialogProps) {
-  const voidInvoice = useVoidInvoice()
-  const [error, setError] = React.useState<string | undefined>()
-
-  React.useEffect(() => {
-    if (!open && !voidInvoice.isPending) {
-      setError(undefined)
-      voidInvoice.reset()
-    }
-  }, [open, voidInvoice.isPending]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  async function handleConfirm() {
-    try {
-      await voidInvoice.mutateAsync(invoiceId)
-      onSuccess?.()
-      onOpenChange(false)
-    } catch (err) {
-      const result = handleConnectError(err)
-      setError(result.message)
-    }
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Void Invoice</DialogTitle>
-          <DialogDescription>
-            Void this invoice and cancel any pending email deliveries. This action cannot be undone.
-          </DialogDescription>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
 
         {error && (
@@ -228,11 +156,11 @@ function VoidInvoiceDialog({ open, onOpenChange, invoiceId, onSuccess }: ActionD
             Cancel
           </Button>
           <Button
-            variant="destructive"
+            variant={confirmVariant}
             onClick={() => void handleConfirm()}
-            disabled={voidInvoice.isPending}
+            disabled={mutation.isPending}
           >
-            {voidInvoice.isPending ? 'Voiding...' : 'Void Invoice'}
+            {mutation.isPending ? pendingLabel : confirmLabel}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/features/billing/components/invoice-actions.tsx
+++ b/frontend/src/features/billing/components/invoice-actions.tsx
@@ -116,6 +116,14 @@ function ActionDialog({
 }: ActionDialogProps) {
   const [error, setError] = React.useState<string | undefined>()
 
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      if (mutation.isPending) return
+      onOpenChange(nextOpen)
+    },
+    [mutation.isPending, onOpenChange],
+  )
+
   React.useEffect(() => {
     if (!open && !mutation.isPending) {
       setError(undefined)
@@ -135,7 +143,7 @@ function ActionDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
@@ -152,7 +160,11 @@ function ActionDialog({
         )}
 
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
+          <Button
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={mutation.isPending}
+          >
             Cancel
           </Button>
           <Button

--- a/frontend/src/features/billing/index.ts
+++ b/frontend/src/features/billing/index.ts
@@ -9,3 +9,6 @@ export {
   useVoidInvoice,
 } from './api/hooks'
 export { EmailDeliveryStatusBadge } from './components/email-delivery-status-badge'
+export { InvoiceActions } from './components/invoice-actions'
+export { InvoicesPage } from './pages/invoices'
+export { InvoiceDetailPage } from './pages/invoice-detail'

--- a/frontend/src/features/billing/pages/invoice-detail.tsx
+++ b/frontend/src/features/billing/pages/invoice-detail.tsx
@@ -43,7 +43,11 @@ function DetailRow({ label, children }: { label: string; children: React.ReactNo
 
 function formatDate(iso: string | undefined): string {
   if (!iso) return '-'
-  const d = new Date(iso)
+  // Parse YYYY-MM-DD as local midnight to avoid UTC-offset day shifts
+  const parts = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso)
+  const d = parts
+    ? new Date(Number(parts[1]), Number(parts[2]) - 1, Number(parts[3]))
+    : new Date(iso)
   if (isNaN(d.getTime())) return '-'
   return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
 }

--- a/frontend/src/features/billing/pages/invoice-detail.tsx
+++ b/frontend/src/features/billing/pages/invoice-detail.tsx
@@ -1,0 +1,273 @@
+import * as React from 'react'
+import { useParams } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { MoneyDisplay } from '@/shared/money-display'
+import { StatusBadge } from '@/shared/status-badge'
+import { Breadcrumbs, PageShell, ErrorState } from '@/shared'
+import { tenantKeys } from '@/lib/query-keys'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { useInvoiceDetail, useInvoiceEmails } from '../api/hooks'
+import { EmailDeliveryStatusBadge } from '../components/email-delivery-status-badge'
+import { InvoiceActions } from '../components/invoice-actions'
+import type { InvoiceEmail } from '../api/types'
+
+function InvoiceDetailSkeleton() {
+  return (
+    <div data-testid="invoice-detail-skeleton" className="p-6 space-y-6">
+      <div className="h-5 w-32 animate-pulse rounded bg-muted" />
+      <div className="h-8 w-64 animate-pulse rounded bg-muted" />
+      <div className="h-48 w-full animate-pulse rounded-xl bg-muted" />
+    </div>
+  )
+}
+
+function DetailRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-[180px_1fr] gap-4 py-2 border-b last:border-0">
+      <span className="text-sm font-medium text-muted-foreground">{label}</span>
+      <span className="text-sm">{children}</span>
+    </div>
+  )
+}
+
+function formatDate(iso: string | undefined): string {
+  if (!iso) return '-'
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return '-'
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+function formatDateTime(iso: string | undefined): string {
+  if (!iso) return '-'
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return '-'
+  return d.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function EmailHistoryRow({ email }: { email: InvoiceEmail }) {
+  const deliveryStatus = {
+    status: email.status,
+    sentAt: email.sentAt,
+    deliveredAt: email.deliveredAt,
+    bounceReason: email.bounceReason,
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-[1fr_1fr_auto] gap-4 py-3 border-b last:border-0 items-center">
+      <div>
+        <p className="text-sm font-medium">{email.templateName}</p>
+        <p className="text-xs text-muted-foreground">{email.toAddresses.join(', ')}</p>
+      </div>
+      <div className="text-sm text-muted-foreground">
+        {email.sentAt ? formatDateTime(email.sentAt) : '-'}
+      </div>
+      <EmailDeliveryStatusBadge status={deliveryStatus} />
+    </div>
+  )
+}
+
+export function InvoiceDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const tenantSlug = useTenantSlug()
+  const queryClient = useQueryClient()
+
+  const { data, isLoading, isError } = useInvoiceDetail(id)
+  const { data: emails = [], isLoading: emailsLoading } = useInvoiceEmails(id)
+
+  usePageTitle(data ? `Invoice ${data.invoiceNumber}` : 'Invoice')
+
+  const queryKey = tenantSlug && id ? tenantKeys.invoice(tenantSlug, id) : ['invoices', id]
+
+  function handleActionSuccess() {
+    void queryClient.invalidateQueries({ queryKey })
+  }
+
+  if (isLoading) {
+    return <InvoiceDetailSkeleton />
+  }
+
+  if (isError || !data) {
+    return (
+      <div data-testid="invoice-detail-error">
+        <PageShell className="p-6">
+          <Breadcrumbs
+            items={[
+              { label: 'Billing', href: '/billing' },
+              { label: 'Invoices', href: '/billing/invoices' },
+              { label: 'Error' },
+            ]}
+          />
+          <ErrorState message="Failed to load invoice details." />
+        </PageShell>
+      </div>
+    )
+  }
+
+  return (
+    <PageShell className="p-6">
+      <Breadcrumbs
+        items={[
+          { label: 'Billing', href: '/billing' },
+          { label: 'Invoices', href: '/billing/invoices' },
+          { label: data.invoiceNumber },
+        ]}
+      />
+
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex items-center gap-4">
+          <h1 className="text-2xl font-semibold">{data.invoiceNumber}</h1>
+          <StatusBadge status={data.status} />
+        </div>
+
+        <InvoiceActions
+          invoiceId={data.id}
+          status={data.status}
+          onActionSuccess={handleActionSuccess}
+        />
+      </div>
+
+      <Tabs defaultValue="overview">
+        <TabsList>
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="line-items">Line Items</TabsTrigger>
+          <TabsTrigger value="email-history">
+            Email History
+            {emails.length > 0 && (
+              <span className="ml-1.5 rounded-full bg-muted px-1.5 py-0.5 text-xs font-medium">
+                {emails.length}
+              </span>
+            )}
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview">
+          <Card>
+            <CardHeader>
+              <CardTitle>Invoice Details</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="divide-y">
+                <DetailRow label="Invoice Number">{data.invoiceNumber}</DetailRow>
+                <DetailRow label="Party">{data.partyId}</DetailRow>
+                <DetailRow label="Billing Run">{data.billingRunId}</DetailRow>
+                <DetailRow label="Status">
+                  <StatusBadge status={data.status} />
+                </DetailRow>
+                <DetailRow label="Total Amount">
+                  <MoneyDisplay
+                    amount={String(data.subtotalCents)}
+                    currency={data.currency}
+                  />
+                </DetailRow>
+                <DetailRow label="Due Date">{formatDate(data.dueDate)}</DetailRow>
+                <DetailRow label="Created">{formatDateTime(data.createdAt)}</DetailRow>
+                <DetailRow label="Updated">{formatDateTime(data.updatedAt)}</DetailRow>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="line-items">
+          <Card>
+            <CardHeader>
+              <CardTitle>Line Items</CardTitle>
+            </CardHeader>
+            <CardContent className="p-0">
+              {data.lineItems.length === 0 ? (
+                <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+                  No line items
+                </div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Description</TableHead>
+                      <TableHead className="text-right">Quantity</TableHead>
+                      <TableHead className="text-right">Unit Price</TableHead>
+                      <TableHead className="text-right">Amount</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {data.lineItems.map((item, index) => (
+                      <TableRow key={index}>
+                        <TableCell>{item.description}</TableCell>
+                        <TableCell className="text-right">{item.quantity}</TableCell>
+                        <TableCell className="text-right">
+                          <MoneyDisplay
+                            amount={String(item.unitPriceCents)}
+                            currency={data.currency}
+                          />
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <MoneyDisplay
+                            amount={String(item.totalCents)}
+                            currency={data.currency}
+                          />
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                    <TableRow className="font-medium">
+                      <TableCell colSpan={3} className="text-right">
+                        Total
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <MoneyDisplay
+                          amount={String(data.subtotalCents)}
+                          currency={data.currency}
+                        />
+                      </TableCell>
+                    </TableRow>
+                  </TableBody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="email-history">
+          <Card>
+            <CardHeader>
+              <CardTitle>Email History</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {emailsLoading ? (
+                <div className="space-y-3">
+                  {[1, 2].map((i) => (
+                    <div key={i} className="h-12 animate-pulse rounded bg-muted" />
+                  ))}
+                </div>
+              ) : emails.length === 0 ? (
+                <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+                  No email history
+                </div>
+              ) : (
+                <div className="divide-y">
+                  {emails.map((email) => (
+                    <EmailHistoryRow key={email.idempotencyKey} email={email} />
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </PageShell>
+  )
+}

--- a/frontend/src/features/billing/pages/invoice-detail.tsx
+++ b/frontend/src/features/billing/pages/invoice-detail.tsx
@@ -107,7 +107,7 @@ export function InvoiceDetailPage() {
     return <InvoiceDetailSkeleton />
   }
 
-  if (isError || !data) {
+  if (isError) {
     return (
       <div data-testid="invoice-detail-error">
         <PageShell className="p-6">
@@ -119,6 +119,23 @@ export function InvoiceDetailPage() {
             ]}
           />
           <ErrorState message="Failed to load invoice details." />
+        </PageShell>
+      </div>
+    )
+  }
+
+  if (!data) {
+    return (
+      <div data-testid="invoice-detail-not-found">
+        <PageShell className="p-6">
+          <Breadcrumbs
+            items={[
+              { label: 'Billing', href: '/billing' },
+              { label: 'Invoices', href: '/billing/invoices' },
+              { label: 'Not found' },
+            ]}
+          />
+          <ErrorState message="Invoice not found." />
         </PageShell>
       </div>
     )

--- a/frontend/src/features/billing/pages/invoice-detail.tsx
+++ b/frontend/src/features/billing/pages/invoice-detail.tsx
@@ -100,7 +100,7 @@ export function InvoiceDetailPage() {
   const queryKey = tenantKeys.invoice(tenantSlug ?? '', id ?? '')
 
   function handleActionSuccess() {
-    void queryClient.invalidateQueries({ queryKey })
+    void queryClient.invalidateQueries({ queryKey, exact: true })
   }
 
   if (isLoading) {

--- a/frontend/src/features/billing/pages/invoice-detail.tsx
+++ b/frontend/src/features/billing/pages/invoice-detail.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/components/ui/table'
 import { MoneyDisplay } from '@/shared/money-display'
 import { StatusBadge } from '@/shared/status-badge'
-import { Breadcrumbs, PageShell, ErrorState } from '@/shared'
+import { Breadcrumbs, PageHeader, PageShell, ErrorState } from '@/shared'
 import { tenantKeys } from '@/lib/query-keys'
 import { useTenantSlug } from '@/hooks/use-tenant-context'
 import { usePageTitle } from '@/hooks/use-page-title'
@@ -134,18 +134,19 @@ export function InvoiceDetailPage() {
         ]}
       />
 
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <div className="flex items-center gap-4">
-          <h1 className="text-2xl font-semibold">{data.invoiceNumber}</h1>
-          <StatusBadge status={data.status} />
-        </div>
-
-        <InvoiceActions
-          invoiceId={data.id}
-          status={data.status}
-          onActionSuccess={handleActionSuccess}
-        />
-      </div>
+      <PageHeader
+        title={data.invoiceNumber}
+        actions={
+          <>
+            <StatusBadge status={data.status} />
+            <InvoiceActions
+              invoiceId={data.id}
+              status={data.status}
+              onActionSuccess={handleActionSuccess}
+            />
+          </>
+        }
+      />
 
       <Tabs defaultValue="overview">
         <TabsList>

--- a/frontend/src/features/billing/pages/invoices.tsx
+++ b/frontend/src/features/billing/pages/invoices.tsx
@@ -1,0 +1,152 @@
+import { useNavigate } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import type { ColumnDef } from '@tanstack/react-table'
+import { DataTable } from '@/shared/data-table'
+import type { FilterConfig } from '@/shared/data-table'
+import { MoneyDisplay } from '@/shared/money-display'
+import { StatusBadge } from '@/shared/status-badge'
+import { PageHeader } from '@/shared/page-header'
+import { PageShell } from '@/shared/page-shell'
+import { Card } from '@/components/ui/card'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { useApiClients } from '@/api/context'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+import { ConnectError, Code } from '@connectrpc/connect'
+import { useInvoicesTable } from '../api/hooks'
+import { EmailDeliveryStatusBadge } from '../components/email-delivery-status-badge'
+import type { Invoice } from '../api/types'
+
+const STATUS_OPTIONS = [
+  { label: 'Draft', value: 'DRAFT' },
+  { label: 'Issued', value: 'ISSUED' },
+  { label: 'Paid', value: 'PAID' },
+  { label: 'Void', value: 'VOID' },
+  { label: 'Overdue', value: 'OVERDUE' },
+]
+
+function useBillingRunOptions() {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+
+  const { data: runs = [] } = useQuery({
+    queryKey: [...tenantKeys.billingRuns(tenantSlug ?? ''), 'filter-options'],
+    queryFn: async () => {
+      if (!tenantSlug) return []
+      try {
+        const response = await clients.billing.listBillingRuns({
+          pagination: { pageSize: 100, pageToken: '' },
+        })
+        return response.billingRuns ?? []
+      } catch (error) {
+        if (
+          error instanceof ConnectError &&
+          (error.code === Code.NotFound || error.code === Code.Unimplemented)
+        ) {
+          return []
+        }
+        throw error
+      }
+    },
+    enabled: Boolean(tenantSlug),
+  })
+
+  return runs.map((run) => ({
+    label: run.id ?? '',
+    value: run.id ?? '',
+  }))
+}
+
+const columns: ColumnDef<Invoice>[] = [
+  {
+    accessorKey: 'invoiceNumber',
+    header: 'Invoice #',
+  },
+  {
+    accessorKey: 'partyId',
+    header: 'Party',
+  },
+  {
+    accessorKey: 'subtotalCents',
+    header: 'Amount',
+    cell: ({ row }) => (
+      <MoneyDisplay amount={String(row.original.subtotalCents)} currency={row.original.currency} />
+    ),
+  },
+  {
+    accessorKey: 'status',
+    header: 'Status',
+    cell: ({ row }) => <StatusBadge status={row.original.status} />,
+  },
+  {
+    id: 'email',
+    header: 'Email',
+    cell: () => <EmailDeliveryStatusBadge status={undefined} />,
+  },
+  {
+    accessorKey: 'dueDate',
+    header: 'Due Date',
+    cell: ({ row }) => {
+      const dueDate = row.original.dueDate
+      if (!dueDate) return <span className="text-muted-foreground">-</span>
+      const d = new Date(dueDate)
+      return isNaN(d.getTime()) ? (
+        <span>{dueDate}</span>
+      ) : (
+        <span>{d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })}</span>
+      )
+    },
+  },
+]
+
+export function InvoicesPage() {
+  usePageTitle('Invoices')
+  const navigate = useNavigate()
+  const { queryKey, queryFn } = useInvoicesTable()
+  const billingRunOptions = useBillingRunOptions()
+
+  const filterConfigs: FilterConfig[] = [
+    {
+      field: 'status',
+      label: 'Status',
+      type: 'select',
+      options: STATUS_OPTIONS,
+    },
+    {
+      field: 'party_id',
+      label: 'Party',
+      type: 'text',
+    },
+    {
+      field: 'billing_run_id',
+      label: 'Billing Run',
+      type: 'select',
+      options: billingRunOptions,
+    },
+  ]
+
+  function handleRowClick(row: Invoice) {
+    void navigate(`/billing/invoices/${row.id}`)
+  }
+
+  return (
+    <PageShell>
+      <PageHeader title="Invoices" />
+      <Card>
+        <DataTable
+          queryKey={queryKey}
+          queryFn={queryFn}
+          columns={columns}
+          filters={filterConfigs}
+          onRowClick={handleRowClick}
+          emptyState={
+            <div className="flex flex-col items-center gap-2 py-12 text-muted-foreground">
+              <span className="text-sm font-medium">No invoices yet</span>
+              <span className="text-xs">Invoices will appear here once billing runs are processed.</span>
+            </div>
+          }
+        />
+      </Card>
+    </PageShell>
+  )
+}

--- a/frontend/src/features/billing/pages/invoices.tsx
+++ b/frontend/src/features/billing/pages/invoices.tsx
@@ -14,7 +14,6 @@ import { useTenantSlug } from '@/hooks/use-tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
 import { ConnectError, Code } from '@connectrpc/connect'
 import { useInvoicesTable } from '../api/hooks'
-import { EmailDeliveryStatusBadge } from '../components/email-delivery-status-badge'
 import type { Invoice } from '../api/types'
 
 const STATUS_OPTIONS = [
@@ -34,10 +33,16 @@ function useBillingRunOptions() {
     queryFn: async () => {
       if (!tenantSlug) return []
       try {
-        const response = await clients.billing.listBillingRuns({
-          pagination: { pageSize: 100, pageToken: '' },
-        })
-        return response.billingRuns ?? []
+        const allRuns = []
+        let pageToken = ''
+        do {
+          const response = await clients.billing.listBillingRuns({
+            pagination: { pageSize: 100, pageToken },
+          })
+          allRuns.push(...(response.billingRuns ?? []))
+          pageToken = response.pagination?.nextPageToken ?? ''
+        } while (pageToken)
+        return allRuns
       } catch (error) {
         if (
           error instanceof ConnectError &&
@@ -77,11 +82,6 @@ const columns: ColumnDef<Invoice>[] = [
     accessorKey: 'status',
     header: 'Status',
     cell: ({ row }) => <StatusBadge status={row.original.status} />,
-  },
-  {
-    id: 'email',
-    header: 'Email',
-    cell: () => <EmailDeliveryStatusBadge status={undefined} />,
   },
   {
     accessorKey: 'dueDate',

--- a/frontend/src/features/billing/pages/invoices.tsx
+++ b/frontend/src/features/billing/pages/invoices.tsx
@@ -89,7 +89,11 @@ const columns: ColumnDef<Invoice>[] = [
     cell: ({ row }) => {
       const dueDate = row.original.dueDate
       if (!dueDate) return <span className="text-muted-foreground">-</span>
-      const d = new Date(dueDate)
+      // Parse YYYY-MM-DD as local midnight to avoid UTC-offset day shifts
+      const parts = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dueDate)
+      const d = parts
+        ? new Date(Number(parts[1]), Number(parts[2]) - 1, Number(parts[3]))
+        : new Date(dueDate)
       return isNaN(d.getTime()) ? (
         <span>{dueDate}</span>
       ) : (


### PR DESCRIPTION
## Summary

- Adds `InvoicesPage` with paginated table (Invoice #, Party, Amount, Status, Email, Due Date columns), status/party/billing-run filters, and row-click navigation to `/billing/invoices/:id`
- Adds `InvoiceDetailPage` with breadcrumbs (Billing > Invoices > {invoiceNumber}), tabbed view: Overview (invoice header + party + status + due date), Line Items (table with totals), Email History (EmailHistoryRow entries)
- Adds `InvoiceActions` component with Resend Email (always), Mark as Paid + Void Invoice (ISSUED/OVERDUE only) with confirmation dialogs
- Exports all three from the billing feature index

## Technical Details

- Uses `useInvoicesTable`, `useInvoiceDetail`, `useInvoiceEmails` hooks from billing API
- Billing run filter dropdown fetches runs via a local `useQuery` against the billing API
- Confirmation dialogs follow the same pattern as payment dialogs (Dialog + error state + pending state)
- No cross-imports with the billing runs page (task 6)