### PR TITLE
refactor: shared client factory, AST walker extraction, and test helper consolidation

### DIFF
--- a/services/market-information/adapters/persistence/testhelpers/schema.sql
+++ b/services/market-information/adapters/persistence/testhelpers/schema.sql
@@ -42,7 +42,21 @@ CREATE TABLE dataset_definition (
     PRIMARY KEY (id),
     CONSTRAINT uq_dataset_definition_code_version UNIQUE (code, version),
     CONSTRAINT chk_dataset_definition_status CHECK (status IN ('DRAFT', 'ACTIVE', 'DEPRECATED')),
-    CONSTRAINT chk_dataset_definition_access_level CHECK (access_level IN ('PUBLIC', 'PRIVATE', 'RESTRICTED'))
+    CONSTRAINT chk_dataset_definition_access_level CHECK (access_level IN ('PUBLIC', 'PRIVATE', 'RESTRICTED')),
+    CONSTRAINT chk_dataset_definition_lifecycle_timestamps CHECK (
+        (status = 'DRAFT' AND activated_at IS NULL AND deprecated_at IS NULL) OR
+        (status = 'ACTIVE' AND activated_at IS NOT NULL AND deprecated_at IS NULL) OR
+        (status = 'DEPRECATED' AND deprecated_at IS NOT NULL)
+    ),
+    CONSTRAINT chk_dataset_definition_validation_expression_length CHECK (
+        validation_expression IS NULL OR length(validation_expression) <= 4096
+    ),
+    CONSTRAINT chk_dataset_definition_resolution_key_expression_length CHECK (
+        length(resolution_key_expression) <= 4096
+    ),
+    CONSTRAINT chk_dataset_definition_error_message_length CHECK (
+        error_message_expression IS NULL OR length(error_message_expression) <= 4096
+    )
 );
 
 CREATE INDEX idx_dataset_definition_code_active ON dataset_definition (code) WHERE status = 'ACTIVE';
@@ -96,6 +110,16 @@ CREATE INDEX idx_observation_causation
 
 CREATE INDEX idx_data_source_trust_level ON data_source (trust_level DESC);
 CREATE INDEX idx_data_source_deleted_at ON data_source (deleted_at);
+
+-- Cursor pagination indexes (from 20260123000003_add_cursor_pagination_indexes.sql)
+CREATE INDEX idx_data_source_cursor
+    ON data_source (created_at DESC, id DESC)
+    WHERE deleted_at IS NULL;
+CREATE INDEX idx_dataset_definition_cursor
+    ON dataset_definition (created_at DESC, id DESC)
+    WHERE deleted_at IS NULL;
+CREATE INDEX idx_market_price_observation_cursor
+    ON market_price_observation (created_at DESC, id DESC);
 
 CREATE TABLE tenant_data_entitlements (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/services/market-information/adapters/persistence/testhelpers/schema.sql
+++ b/services/market-information/adapters/persistence/testhelpers/schema.sql
@@ -1,0 +1,119 @@
+-- Market information test schema DDL
+-- Embedded via //go:embed for test helper loadSchema()
+
+CREATE TABLE data_source (
+    id uuid NOT NULL DEFAULT gen_random_uuid(),
+    code character varying(50) NOT NULL,
+    name character varying(255) NOT NULL,
+    description text NULL,
+    trust_level integer NOT NULL DEFAULT 50,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    created_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    updated_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
+    deleted_at timestamptz NULL,
+    version bigint NOT NULL DEFAULT 1,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_data_source_code UNIQUE (code),
+    CONSTRAINT chk_data_source_trust_level CHECK (trust_level >= 0 AND trust_level <= 100)
+);
+
+CREATE TABLE dataset_definition (
+    id uuid NOT NULL DEFAULT gen_random_uuid(),
+    code character varying(50) NOT NULL,
+    version integer NOT NULL DEFAULT 1,
+    name character varying(255) NOT NULL,
+    description text NULL,
+    data_category character varying(50) NULL,
+    validation_expression text NULL,
+    resolution_key_expression text NOT NULL,
+    error_message_expression text NULL,
+    attribute_schema jsonb NULL,
+    status character varying(20) NOT NULL DEFAULT 'DRAFT',
+    is_shared BOOLEAN NOT NULL DEFAULT FALSE,
+    access_level VARCHAR(50) NOT NULL DEFAULT 'PRIVATE',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    created_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    updated_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
+    deleted_at timestamptz NULL,
+    activated_at timestamptz NULL,
+    deprecated_at timestamptz NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_dataset_definition_code_version UNIQUE (code, version),
+    CONSTRAINT chk_dataset_definition_status CHECK (status IN ('DRAFT', 'ACTIVE', 'DEPRECATED')),
+    CONSTRAINT chk_dataset_definition_access_level CHECK (access_level IN ('PUBLIC', 'PRIVATE', 'RESTRICTED'))
+);
+
+CREATE INDEX idx_dataset_definition_code_active ON dataset_definition (code) WHERE status = 'ACTIVE';
+CREATE INDEX idx_dataset_definition_status ON dataset_definition (status);
+CREATE INDEX idx_dataset_definition_created_at ON dataset_definition (created_at);
+CREATE INDEX idx_dataset_definition_deleted_at ON dataset_definition (deleted_at);
+
+CREATE TABLE market_price_observation (
+    id uuid NOT NULL DEFAULT gen_random_uuid(),
+    dataset_definition_id uuid NOT NULL,
+    data_source_id uuid NOT NULL,
+    resolution_key character varying(255) NOT NULL,
+    observed_at timestamptz NOT NULL,
+    valid_from timestamptz NULL,
+    valid_to timestamptz NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    created_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
+    quality integer NOT NULL,
+    observation_context jsonb NOT NULL DEFAULT '{}'::jsonb,
+    numeric_value numeric NULL,
+    text_value text NULL,
+    superseded_by uuid NULL,
+    causation_id uuid NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_observation_dataset_definition
+        FOREIGN KEY (dataset_definition_id) REFERENCES dataset_definition(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_observation_data_source
+        FOREIGN KEY (data_source_id) REFERENCES data_source(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_observation_superseded_by
+        FOREIGN KEY (superseded_by) REFERENCES market_price_observation(id) ON DELETE SET NULL,
+    CONSTRAINT chk_observation_quality CHECK (quality IN (1, 2, 3)),
+    CONSTRAINT chk_observation_value_present CHECK (numeric_value IS NOT NULL OR text_value IS NOT NULL)
+);
+
+CREATE INDEX idx_observation_resolution_bitemporal
+    ON market_price_observation (resolution_key, quality DESC, observed_at DESC, created_at DESC)
+    WHERE superseded_by IS NULL;
+CREATE INDEX idx_observation_dataset
+    ON market_price_observation (dataset_definition_id, observed_at DESC);
+CREATE INDEX idx_observation_source
+    ON market_price_observation (data_source_id, created_at DESC);
+CREATE INDEX idx_observation_created_at
+    ON market_price_observation (created_at DESC)
+    WHERE superseded_by IS NULL;
+CREATE INDEX idx_observation_superseded_by
+    ON market_price_observation (superseded_by)
+    WHERE superseded_by IS NOT NULL;
+CREATE INDEX idx_observation_causation
+    ON market_price_observation (causation_id)
+    WHERE causation_id IS NOT NULL;
+
+CREATE INDEX idx_data_source_trust_level ON data_source (trust_level DESC);
+CREATE INDEX idx_data_source_deleted_at ON data_source (deleted_at);
+
+CREATE TABLE tenant_data_entitlements (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id VARCHAR(255) NOT NULL,
+    dataset_code VARCHAR(255) NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    granted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by VARCHAR(100) NOT NULL DEFAULT 'SYSTEM',
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_by VARCHAR(100) NOT NULL DEFAULT 'SYSTEM',
+    CONSTRAINT uq_tenant_dataset UNIQUE (tenant_id, dataset_code)
+);
+
+CREATE INDEX idx_entitlements_tenant_dataset
+    ON tenant_data_entitlements(tenant_id, dataset_code, is_active)
+    WHERE is_active = TRUE;
+CREATE INDEX idx_entitlements_expires_at
+    ON tenant_data_entitlements(expires_at)
+    WHERE expires_at IS NOT NULL AND is_active = TRUE;

--- a/services/market-information/adapters/persistence/testhelpers/testcontainer.go
+++ b/services/market-information/adapters/persistence/testhelpers/testcontainer.go
@@ -3,6 +3,7 @@ package testhelpers
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"testing"
 	"time"
@@ -16,6 +17,9 @@ import (
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
+
+//go:embed schema.sql
+var schemaDDL string
 
 // TestContainer holds the test database container, connection pool, and repository instances.
 type TestContainer struct {
@@ -82,159 +86,12 @@ func (tc *TestContainer) Cleanup(t *testing.T) {
 	}
 }
 
-// loadSchema loads the complete market_information schema into the test database.
+// loadSchema loads the complete market_information schema into the test database
+// from the embedded schema.sql file.
 func loadSchema(t *testing.T, pool *pgxpool.Pool) {
 	t.Helper()
-	ctx := context.Background()
-
-	// Create data_source table
-	_, err := pool.Exec(ctx, `
-		CREATE TABLE data_source (
-			id uuid NOT NULL DEFAULT gen_random_uuid(),
-			code character varying(50) NOT NULL,
-			name character varying(255) NOT NULL,
-			description text NULL,
-			trust_level integer NOT NULL DEFAULT 50,
-			created_at timestamptz NOT NULL DEFAULT now(),
-			created_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
-			updated_at timestamptz NOT NULL DEFAULT now(),
-			updated_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
-			deleted_at timestamptz NULL,
-			version bigint NOT NULL DEFAULT 1,
-			PRIMARY KEY (id),
-			CONSTRAINT uq_data_source_code UNIQUE (code),
-			CONSTRAINT chk_data_source_trust_level CHECK (trust_level >= 0 AND trust_level <= 100)
-		)
-	`)
-	require.NoError(t, err, "Failed to create data_source table")
-
-	// Create dataset_definition table
-	_, err = pool.Exec(ctx, `
-		CREATE TABLE dataset_definition (
-			id uuid NOT NULL DEFAULT gen_random_uuid(),
-			code character varying(50) NOT NULL,
-			version integer NOT NULL DEFAULT 1,
-			name character varying(255) NOT NULL,
-			description text NULL,
-			data_category character varying(50) NULL,
-			validation_expression text NULL,
-			resolution_key_expression text NOT NULL,
-			error_message_expression text NULL,
-			attribute_schema jsonb NULL,
-			status character varying(20) NOT NULL DEFAULT 'DRAFT',
-			is_shared BOOLEAN NOT NULL DEFAULT FALSE,
-			access_level VARCHAR(50) NOT NULL DEFAULT 'PRIVATE',
-			created_at timestamptz NOT NULL DEFAULT now(),
-			created_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
-			updated_at timestamptz NOT NULL DEFAULT now(),
-			updated_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
-			deleted_at timestamptz NULL,
-			activated_at timestamptz NULL,
-			deprecated_at timestamptz NULL,
-			PRIMARY KEY (id),
-			CONSTRAINT uq_dataset_definition_code_version UNIQUE (code, version),
-			CONSTRAINT chk_dataset_definition_status CHECK (status IN ('DRAFT', 'ACTIVE', 'DEPRECATED')),
-			CONSTRAINT chk_dataset_definition_access_level CHECK (access_level IN ('PUBLIC', 'PRIVATE', 'RESTRICTED'))
-		)
-	`)
-	require.NoError(t, err, "Failed to create dataset_definition table")
-
-	// Create indexes for dataset_definition
-	_, err = pool.Exec(ctx, `
-		CREATE INDEX idx_dataset_definition_code_active ON dataset_definition (code) WHERE status = 'ACTIVE';
-		CREATE INDEX idx_dataset_definition_status ON dataset_definition (status);
-		CREATE INDEX idx_dataset_definition_created_at ON dataset_definition (created_at);
-		CREATE INDEX idx_dataset_definition_deleted_at ON dataset_definition (deleted_at);
-	`)
-	require.NoError(t, err, "Failed to create dataset_definition indexes")
-
-	// Create market_price_observation table
-	_, err = pool.Exec(ctx, `
-		CREATE TABLE market_price_observation (
-			id uuid NOT NULL DEFAULT gen_random_uuid(),
-			dataset_definition_id uuid NOT NULL,
-			data_source_id uuid NOT NULL,
-			resolution_key character varying(255) NOT NULL,
-			observed_at timestamptz NOT NULL,
-			valid_from timestamptz NULL,
-			valid_to timestamptz NULL,
-			created_at timestamptz NOT NULL DEFAULT now(),
-			created_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
-			quality integer NOT NULL,
-			observation_context jsonb NOT NULL DEFAULT '{}'::jsonb,
-			numeric_value numeric NULL,
-			text_value text NULL,
-			superseded_by uuid NULL,
-			causation_id uuid NULL,
-			PRIMARY KEY (id),
-			CONSTRAINT fk_observation_dataset_definition
-				FOREIGN KEY (dataset_definition_id) REFERENCES dataset_definition(id) ON DELETE RESTRICT,
-			CONSTRAINT fk_observation_data_source
-				FOREIGN KEY (data_source_id) REFERENCES data_source(id) ON DELETE RESTRICT,
-			CONSTRAINT fk_observation_superseded_by
-				FOREIGN KEY (superseded_by) REFERENCES market_price_observation(id) ON DELETE SET NULL,
-			CONSTRAINT chk_observation_quality CHECK (quality IN (1, 2, 3)),
-			CONSTRAINT chk_observation_value_present CHECK (numeric_value IS NOT NULL OR text_value IS NOT NULL)
-		)
-	`)
-	require.NoError(t, err, "Failed to create market_price_observation table")
-
-	// Create indexes for market_price_observation
-	_, err = pool.Exec(ctx, `
-		CREATE INDEX idx_observation_resolution_bitemporal
-			ON market_price_observation (resolution_key, quality DESC, observed_at DESC, created_at DESC)
-			WHERE superseded_by IS NULL;
-		CREATE INDEX idx_observation_dataset
-			ON market_price_observation (dataset_definition_id, observed_at DESC);
-		CREATE INDEX idx_observation_source
-			ON market_price_observation (data_source_id, created_at DESC);
-		CREATE INDEX idx_observation_created_at
-			ON market_price_observation (created_at DESC)
-			WHERE superseded_by IS NULL;
-		CREATE INDEX idx_observation_superseded_by
-			ON market_price_observation (superseded_by)
-			WHERE superseded_by IS NOT NULL;
-		CREATE INDEX idx_observation_causation
-			ON market_price_observation (causation_id)
-			WHERE causation_id IS NOT NULL;
-	`)
-	require.NoError(t, err, "Failed to create market_price_observation indexes")
-
-	// Create data source index
-	_, err = pool.Exec(ctx, `
-		CREATE INDEX idx_data_source_trust_level ON data_source (trust_level DESC);
-		CREATE INDEX idx_data_source_deleted_at ON data_source (deleted_at);
-	`)
-	require.NoError(t, err, "Failed to create data_source indexes")
-
-	// Create tenant_data_entitlements table
-	_, err = pool.Exec(ctx, `
-		CREATE TABLE tenant_data_entitlements (
-			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-			tenant_id VARCHAR(255) NOT NULL,
-			dataset_code VARCHAR(255) NOT NULL,
-			is_active BOOLEAN NOT NULL DEFAULT TRUE,
-			granted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-			expires_at TIMESTAMPTZ NULL,
-			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-			created_by VARCHAR(100) NOT NULL DEFAULT 'SYSTEM',
-			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-			updated_by VARCHAR(100) NOT NULL DEFAULT 'SYSTEM',
-			CONSTRAINT uq_tenant_dataset UNIQUE (tenant_id, dataset_code)
-		)
-	`)
-	require.NoError(t, err, "Failed to create tenant_data_entitlements table")
-
-	// Create tenant_data_entitlements indexes
-	_, err = pool.Exec(ctx, `
-		CREATE INDEX idx_entitlements_tenant_dataset
-			ON tenant_data_entitlements(tenant_id, dataset_code, is_active)
-			WHERE is_active = TRUE;
-		CREATE INDEX idx_entitlements_expires_at
-			ON tenant_data_entitlements(expires_at)
-			WHERE expires_at IS NOT NULL AND is_active = TRUE;
-	`)
-	require.NoError(t, err, "Failed to create tenant_data_entitlements indexes")
+	_, err := pool.Exec(context.Background(), schemaDDL)
+	require.NoError(t, err, "Failed to load embedded schema DDL")
 }
 
 // CreateTenantSchema creates a tenant-specific schema for testing multi-tenant scenarios.

--- a/services/position-keeping/adapters/persistence/testhelpers/schema.sql
+++ b/services/position-keeping/adapters/persistence/testhelpers/schema.sql
@@ -40,6 +40,10 @@ ALTER TABLE position_keeping.financial_position_log
     ADD CONSTRAINT chk_financial_position_log_reconciliation_status
     CHECK (reconciliation_status IN ('UNRECONCILED', 'MATCHED', 'MISMATCHED', 'RESOLVED'));
 
+ALTER TABLE position_keeping.financial_position_log
+    ADD CONSTRAINT chk_financial_position_log_previous_status
+    CHECK (previous_status IS NULL OR previous_status IN ('PENDING', 'RECONCILED', 'POSTED', 'CANCELLED', 'FAILED', 'REJECTED', 'AMENDED', 'REVERSED'));
+
 CREATE TABLE position_keeping.transaction_log_entry (
     id uuid NOT NULL DEFAULT gen_random_uuid(),
     created_at timestamptz NOT NULL DEFAULT now(),
@@ -155,6 +159,10 @@ CREATE INDEX idx_position_active ON position_keeping.position (account_id, instr
 CREATE INDEX idx_position_reference_id ON position_keeping.position (reference_id);
 CREATE INDEX idx_position_created_at ON position_keeping.position (created_at);
 
+-- NOTE: This trigger provides defense-in-depth for tests but does NOT exist in
+-- production CockroachDB deployments (PL/pgSQL triggers unsupported). Append-only
+-- enforcement in production relies on the repository layer.
+-- See migration 20260105000002_positions_append_only.sql.
 CREATE OR REPLACE FUNCTION position_keeping.positions_append_only()
 RETURNS TRIGGER AS $$
 BEGIN

--- a/services/position-keeping/adapters/persistence/testhelpers/schema.sql
+++ b/services/position-keeping/adapters/persistence/testhelpers/schema.sql
@@ -1,0 +1,171 @@
+-- Position keeping test schema DDL
+-- Embedded via //go:embed for test helper loadSchema()
+
+CREATE SCHEMA IF NOT EXISTS position_keeping;
+
+CREATE TABLE position_keeping.financial_position_log (
+    id uuid NOT NULL DEFAULT gen_random_uuid(),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    created_by character varying(100) NOT NULL,
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    updated_by character varying(100) NOT NULL,
+    deleted_at timestamptz NULL,
+    log_id uuid NOT NULL,
+    account_id character varying(34) NOT NULL,
+    version bigint NOT NULL DEFAULT 1,
+    current_status character varying(20) NOT NULL,
+    previous_status character varying(20) NULL,
+    status_updated_at timestamptz NOT NULL,
+    status_reason text NOT NULL,
+    failure_reason text NULL,
+    reconciliation_status character varying(20) NOT NULL,
+    opening_balance_amount decimal(38, 18) NOT NULL DEFAULT 0,
+    opening_balance_currency character(3) NOT NULL DEFAULT 'GBP',
+    opening_balance_recorded_at timestamptz NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE UNIQUE INDEX idx_position_keeping_financial_position_log_log_id
+ON position_keeping.financial_position_log (log_id);
+
+CREATE TABLE position_keeping.transaction_log_entry (
+    id uuid NOT NULL DEFAULT gen_random_uuid(),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    created_by character varying(100) NOT NULL,
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    updated_by character varying(100) NOT NULL,
+    deleted_at timestamptz NULL,
+    entry_id uuid NOT NULL,
+    financial_position_log_id uuid NOT NULL,
+    transaction_id uuid NOT NULL,
+    account_id character varying(34) NOT NULL,
+    amount_cents bigint NOT NULL,
+    currency character(3) NOT NULL DEFAULT 'GBP',
+    direction character varying(10) NOT NULL,
+    timestamp timestamptz NOT NULL,
+    description text NULL,
+    reference character varying(100) NULL,
+    source character varying(50) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_transaction_log_entry_financial_position_log
+        FOREIGN KEY (financial_position_log_id)
+        REFERENCES position_keeping.financial_position_log(id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE position_keeping.transaction_lineage (
+    id uuid NOT NULL DEFAULT gen_random_uuid(),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    created_by character varying(100) NOT NULL,
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    updated_by character varying(100) NOT NULL,
+    deleted_at timestamptz NULL,
+    financial_position_log_id uuid NOT NULL,
+    transaction_id uuid NOT NULL,
+    parent_transaction_id uuid NULL,
+    child_transaction_ids jsonb NOT NULL DEFAULT '[]',
+    related_transaction_ids jsonb NOT NULL DEFAULT '[]',
+    transaction_type character varying(50) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_transaction_lineage_financial_position_log
+        FOREIGN KEY (financial_position_log_id)
+        REFERENCES position_keeping.financial_position_log(id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE position_keeping.audit_trail_entry (
+    id uuid NOT NULL DEFAULT gen_random_uuid(),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    created_by character varying(100) NOT NULL,
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    updated_by character varying(100) NOT NULL,
+    deleted_at timestamptz NULL,
+    audit_id uuid NOT NULL,
+    financial_position_log_id uuid NOT NULL,
+    timestamp timestamptz NOT NULL,
+    user_id character varying(100) NOT NULL,
+    action character varying(100) NOT NULL,
+    details text NULL,
+    ip_address character varying(45) NULL,
+    system_context jsonb NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_audit_trail_entry_financial_position_log
+        FOREIGN KEY (financial_position_log_id)
+        REFERENCES position_keeping.financial_position_log(id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE position_keeping.position (
+    id uuid NOT NULL DEFAULT gen_random_uuid(),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    created_by character varying(100) NOT NULL,
+    deleted_at timestamptz NULL,
+    account_id character varying(34) NOT NULL,
+    instrument_code character varying(32) NOT NULL,
+    bucket_key character varying(256) NOT NULL,
+    amount decimal(38, 18) NOT NULL,
+    dimension character varying(32) NOT NULL DEFAULT 'Monetary',
+    attributes jsonb NULL,
+    reference_id uuid NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_position_account_id ON position_keeping.position (account_id);
+CREATE INDEX idx_position_aggregation ON position_keeping.position (account_id, instrument_code, bucket_key);
+CREATE INDEX idx_position_deleted_at ON position_keeping.position (deleted_at);
+CREATE INDEX idx_position_active ON position_keeping.position (account_id, instrument_code, bucket_key)
+    WHERE deleted_at IS NULL;
+CREATE INDEX idx_position_reference_id ON position_keeping.position (reference_id);
+CREATE INDEX idx_position_created_at ON position_keeping.position (created_at);
+
+CREATE OR REPLACE FUNCTION position_keeping.positions_append_only()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF OLD.amount IS DISTINCT FROM NEW.amount THEN
+        RAISE EXCEPTION 'positions table is append-only - UPDATE on amount column is forbidden'
+            USING ERRCODE = 'P0001';
+    END IF;
+    IF OLD.account_id IS DISTINCT FROM NEW.account_id THEN
+        RAISE EXCEPTION 'positions table is append-only - UPDATE on account_id column is forbidden'
+            USING ERRCODE = 'P0001';
+    END IF;
+    IF OLD.instrument_code IS DISTINCT FROM NEW.instrument_code THEN
+        RAISE EXCEPTION 'positions table is append-only - UPDATE on instrument_code column is forbidden'
+            USING ERRCODE = 'P0001';
+    END IF;
+    IF OLD.bucket_key IS DISTINCT FROM NEW.bucket_key THEN
+        RAISE EXCEPTION 'positions table is append-only - UPDATE on bucket_key column is forbidden'
+            USING ERRCODE = 'P0001';
+    END IF;
+    IF OLD.reference_id IS DISTINCT FROM NEW.reference_id THEN
+        RAISE EXCEPTION 'positions table is append-only - UPDATE on reference_id column is forbidden'
+            USING ERRCODE = 'P0001';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER positions_append_only
+    BEFORE UPDATE ON position_keeping.position
+    FOR EACH ROW
+    EXECUTE FUNCTION position_keeping.positions_append_only();
+
+CREATE TABLE position_keeping.reservation (
+    lien_id uuid NOT NULL,
+    account_id character varying(255) NOT NULL,
+    instrument_code character varying(32) NOT NULL,
+    bucket_id character varying(256) NOT NULL DEFAULT '',
+    reserved_amount decimal(38, 18) NOT NULL,
+    status character varying(16) NOT NULL DEFAULT 'ACTIVE',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    executed_at timestamptz NULL,
+    terminated_at timestamptz NULL,
+    PRIMARY KEY (lien_id),
+    CONSTRAINT chk_reservation_status CHECK (status IN ('ACTIVE', 'EXECUTED', 'TERMINATED'))
+);
+
+CREATE INDEX idx_reservation_projected_balance
+    ON position_keeping.reservation (account_id, instrument_code, status, bucket_id);
+CREATE INDEX idx_reservation_active
+    ON position_keeping.reservation (account_id, instrument_code, bucket_id)
+    WHERE status = 'ACTIVE';

--- a/services/position-keeping/adapters/persistence/testhelpers/schema.sql
+++ b/services/position-keeping/adapters/persistence/testhelpers/schema.sql
@@ -28,6 +28,18 @@ CREATE TABLE position_keeping.financial_position_log (
 CREATE UNIQUE INDEX idx_position_keeping_financial_position_log_log_id
 ON position_keeping.financial_position_log (log_id);
 
+CREATE INDEX idx_financial_position_log_account_id ON position_keeping.financial_position_log (account_id);
+CREATE INDEX idx_financial_position_log_current_status ON position_keeping.financial_position_log (current_status);
+CREATE INDEX idx_financial_position_log_deleted_at ON position_keeping.financial_position_log (deleted_at);
+
+ALTER TABLE position_keeping.financial_position_log
+    ADD CONSTRAINT chk_financial_position_log_current_status
+    CHECK (current_status IN ('PENDING', 'RECONCILED', 'POSTED', 'CANCELLED', 'FAILED', 'REJECTED', 'AMENDED', 'REVERSED'));
+
+ALTER TABLE position_keeping.financial_position_log
+    ADD CONSTRAINT chk_financial_position_log_reconciliation_status
+    CHECK (reconciliation_status IN ('UNRECONCILED', 'MATCHED', 'MISMATCHED', 'RESOLVED'));
+
 CREATE TABLE position_keeping.transaction_log_entry (
     id uuid NOT NULL DEFAULT gen_random_uuid(),
     created_at timestamptz NOT NULL DEFAULT now(),
@@ -53,6 +65,20 @@ CREATE TABLE position_keeping.transaction_log_entry (
         ON DELETE CASCADE
 );
 
+CREATE UNIQUE INDEX idx_transaction_log_entry_entry_id ON position_keeping.transaction_log_entry (entry_id);
+CREATE INDEX idx_transaction_log_entry_deleted_at ON position_keeping.transaction_log_entry (deleted_at);
+CREATE INDEX idx_transaction_log_entry_log_id ON position_keeping.transaction_log_entry (financial_position_log_id);
+CREATE INDEX idx_transaction_log_entry_timestamp ON position_keeping.transaction_log_entry (timestamp);
+CREATE INDEX idx_transaction_log_entry_transaction_id ON position_keeping.transaction_log_entry (transaction_id);
+
+ALTER TABLE position_keeping.transaction_log_entry
+    ADD CONSTRAINT chk_transaction_log_entry_currency
+    CHECK (char_length(currency) = 3);
+
+ALTER TABLE position_keeping.transaction_log_entry
+    ADD CONSTRAINT chk_transaction_log_entry_direction
+    CHECK (direction IN ('DEBIT', 'CREDIT'));
+
 CREATE TABLE position_keeping.transaction_lineage (
     id uuid NOT NULL DEFAULT gen_random_uuid(),
     created_at timestamptz NOT NULL DEFAULT now(),
@@ -72,6 +98,11 @@ CREATE TABLE position_keeping.transaction_lineage (
         REFERENCES position_keeping.financial_position_log(id)
         ON DELETE CASCADE
 );
+
+CREATE UNIQUE INDEX idx_transaction_lineage_log_id ON position_keeping.transaction_lineage (financial_position_log_id);
+CREATE INDEX idx_transaction_lineage_deleted_at ON position_keeping.transaction_lineage (deleted_at);
+CREATE INDEX idx_transaction_lineage_parent_id ON position_keeping.transaction_lineage (parent_transaction_id);
+CREATE INDEX idx_transaction_lineage_transaction_id ON position_keeping.transaction_lineage (transaction_id);
 
 CREATE TABLE position_keeping.audit_trail_entry (
     id uuid NOT NULL DEFAULT gen_random_uuid(),
@@ -94,6 +125,12 @@ CREATE TABLE position_keeping.audit_trail_entry (
         REFERENCES position_keeping.financial_position_log(id)
         ON DELETE CASCADE
 );
+
+CREATE UNIQUE INDEX idx_audit_trail_entry_audit_id ON position_keeping.audit_trail_entry (audit_id);
+CREATE INDEX idx_audit_trail_entry_deleted_at ON position_keeping.audit_trail_entry (deleted_at);
+CREATE INDEX idx_audit_trail_entry_log_id ON position_keeping.audit_trail_entry (financial_position_log_id);
+CREATE INDEX idx_audit_trail_entry_timestamp ON position_keeping.audit_trail_entry (timestamp);
+CREATE INDEX idx_audit_trail_entry_user_id ON position_keeping.audit_trail_entry (user_id);
 
 CREATE TABLE position_keeping.position (
     id uuid NOT NULL DEFAULT gen_random_uuid(),

--- a/services/position-keeping/adapters/persistence/testhelpers/testcontainer.go
+++ b/services/position-keeping/adapters/persistence/testhelpers/testcontainer.go
@@ -23,6 +23,7 @@ package testhelpers
 
 import (
 	"context"
+	_ "embed"
 	"testing"
 	"time"
 
@@ -33,6 +34,9 @@ import (
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
+
+//go:embed schema.sql
+var schemaDDL string
 
 // TestContainer holds the test database container, connection pool, and repository instance.
 // It provides a complete testing environment with proper cleanup.
@@ -137,232 +141,11 @@ func (tc *TestContainer) Cleanup(t *testing.T) {
 	}
 }
 
-// loadSchema loads the complete position_keeping schema into the test database.
-// This includes:
-//   - position_keeping schema
-//   - financial_position_log table with indexes
-//   - transaction_log_entry table with foreign keys
-//   - transaction_lineage table with JSONB columns
-//   - audit_trail_entry table with JSONB columns
-//
-// The schema matches the production Atlas migrations but is loaded directly
-// for test speed. This avoids the overhead of running migrations in tests.
+// loadSchema loads the complete position_keeping schema into the test database
+// from the embedded schema.sql file. The schema matches the production Atlas
+// migrations but is loaded directly for test speed.
 func loadSchema(t *testing.T, pool *pgxpool.Pool) {
 	t.Helper()
-	ctx := context.Background()
-
-	// Create schemas
-	_, err := pool.Exec(ctx, `CREATE SCHEMA IF NOT EXISTS position_keeping`)
-	require.NoError(t, err, "Failed to create schema")
-
-	// Create financial_position_log table (singular to match production migration)
-	_, err = pool.Exec(ctx, `
-		CREATE TABLE position_keeping.financial_position_log (
-			id uuid NOT NULL DEFAULT gen_random_uuid(),
-			created_at timestamptz NOT NULL DEFAULT now(),
-			created_by character varying(100) NOT NULL,
-			updated_at timestamptz NOT NULL DEFAULT now(),
-			updated_by character varying(100) NOT NULL,
-			deleted_at timestamptz NULL,
-			log_id uuid NOT NULL,
-			account_id character varying(34) NOT NULL,
-			version bigint NOT NULL DEFAULT 1,
-			current_status character varying(20) NOT NULL,
-			previous_status character varying(20) NULL,
-			status_updated_at timestamptz NOT NULL,
-			status_reason text NOT NULL,
-			failure_reason text NULL,
-			reconciliation_status character varying(20) NOT NULL,
-			opening_balance_amount decimal(38, 18) NOT NULL DEFAULT 0,
-			opening_balance_currency character(3) NOT NULL DEFAULT 'GBP',
-			opening_balance_recorded_at timestamptz NULL,
-			PRIMARY KEY (id)
-		)
-	`)
-	require.NoError(t, err, "Failed to create financial_position_log table")
-
-	// Create indexes
-	_, err = pool.Exec(ctx, `
-		CREATE UNIQUE INDEX idx_position_keeping_financial_position_log_log_id
-		ON position_keeping.financial_position_log (log_id)
-	`)
-	require.NoError(t, err, "Failed to create log_id index")
-
-	// Create transaction_log_entry table (singular to match production migration)
-	_, err = pool.Exec(ctx, `
-		CREATE TABLE position_keeping.transaction_log_entry (
-			id uuid NOT NULL DEFAULT gen_random_uuid(),
-			created_at timestamptz NOT NULL DEFAULT now(),
-			created_by character varying(100) NOT NULL,
-			updated_at timestamptz NOT NULL DEFAULT now(),
-			updated_by character varying(100) NOT NULL,
-			deleted_at timestamptz NULL,
-			entry_id uuid NOT NULL,
-			financial_position_log_id uuid NOT NULL,
-			transaction_id uuid NOT NULL,
-			account_id character varying(34) NOT NULL,
-			amount_cents bigint NOT NULL,
-			currency character(3) NOT NULL DEFAULT 'GBP',
-			direction character varying(10) NOT NULL,
-			timestamp timestamptz NOT NULL,
-			description text NULL,
-			reference character varying(100) NULL,
-			source character varying(50) NOT NULL,
-			PRIMARY KEY (id),
-			CONSTRAINT fk_transaction_log_entry_financial_position_log
-				FOREIGN KEY (financial_position_log_id)
-				REFERENCES position_keeping.financial_position_log(id)
-				ON DELETE CASCADE
-		)
-	`)
-	require.NoError(t, err, "Failed to create transaction_log_entry table")
-
-	// Create transaction_lineage table (singular to match production migration)
-	_, err = pool.Exec(ctx, `
-		CREATE TABLE position_keeping.transaction_lineage (
-			id uuid NOT NULL DEFAULT gen_random_uuid(),
-			created_at timestamptz NOT NULL DEFAULT now(),
-			created_by character varying(100) NOT NULL,
-			updated_at timestamptz NOT NULL DEFAULT now(),
-			updated_by character varying(100) NOT NULL,
-			deleted_at timestamptz NULL,
-			financial_position_log_id uuid NOT NULL,
-			transaction_id uuid NOT NULL,
-			parent_transaction_id uuid NULL,
-			child_transaction_ids jsonb NOT NULL DEFAULT '[]',
-			related_transaction_ids jsonb NOT NULL DEFAULT '[]',
-			transaction_type character varying(50) NOT NULL,
-			PRIMARY KEY (id),
-			CONSTRAINT fk_transaction_lineage_financial_position_log
-				FOREIGN KEY (financial_position_log_id)
-				REFERENCES position_keeping.financial_position_log(id)
-				ON DELETE CASCADE
-		)
-	`)
-	require.NoError(t, err, "Failed to create transaction_lineage table")
-
-	// Create audit_trail_entry table (singular to match production migration)
-	_, err = pool.Exec(ctx, `
-		CREATE TABLE position_keeping.audit_trail_entry (
-			id uuid NOT NULL DEFAULT gen_random_uuid(),
-			created_at timestamptz NOT NULL DEFAULT now(),
-			created_by character varying(100) NOT NULL,
-			updated_at timestamptz NOT NULL DEFAULT now(),
-			updated_by character varying(100) NOT NULL,
-			deleted_at timestamptz NULL,
-			audit_id uuid NOT NULL,
-			financial_position_log_id uuid NOT NULL,
-			timestamp timestamptz NOT NULL,
-			user_id character varying(100) NOT NULL,
-			action character varying(100) NOT NULL,
-			details text NULL,
-			ip_address character varying(45) NULL,
-			system_context jsonb NULL,
-			PRIMARY KEY (id),
-			CONSTRAINT fk_audit_trail_entry_financial_position_log
-				FOREIGN KEY (financial_position_log_id)
-				REFERENCES position_keeping.financial_position_log(id)
-				ON DELETE CASCADE
-		)
-	`)
-	require.NoError(t, err, "Failed to create audit_trail_entry table")
-
-	// Create position table (append-only)
-	_, err = pool.Exec(ctx, `
-		CREATE TABLE position_keeping.position (
-			id uuid NOT NULL DEFAULT gen_random_uuid(),
-			created_at timestamptz NOT NULL DEFAULT now(),
-			created_by character varying(100) NOT NULL,
-			deleted_at timestamptz NULL,
-			account_id character varying(34) NOT NULL,
-			instrument_code character varying(32) NOT NULL,
-			bucket_key character varying(256) NOT NULL,
-			amount decimal(38, 18) NOT NULL,
-			dimension character varying(32) NOT NULL DEFAULT 'Monetary',
-			attributes jsonb NULL,
-			reference_id uuid NULL,
-			PRIMARY KEY (id)
-		)
-	`)
-	require.NoError(t, err, "Failed to create position table")
-
-	// Create position indexes (matching production migration)
-	_, err = pool.Exec(ctx, `
-		CREATE INDEX idx_position_account_id ON position_keeping.position (account_id);
-		CREATE INDEX idx_position_aggregation ON position_keeping.position (account_id, instrument_code, bucket_key);
-		CREATE INDEX idx_position_deleted_at ON position_keeping.position (deleted_at);
-		CREATE INDEX idx_position_active ON position_keeping.position (account_id, instrument_code, bucket_key)
-			WHERE deleted_at IS NULL;
-		CREATE INDEX idx_position_reference_id ON position_keeping.position (reference_id);
-		CREATE INDEX idx_position_created_at ON position_keeping.position (created_at);
-	`)
-	require.NoError(t, err, "Failed to create position indexes")
-
-	// Create append-only trigger function (matches production migration)
-	_, err = pool.Exec(ctx, `
-		CREATE OR REPLACE FUNCTION position_keeping.positions_append_only()
-		RETURNS TRIGGER AS $$
-		BEGIN
-			IF OLD.amount IS DISTINCT FROM NEW.amount THEN
-				RAISE EXCEPTION 'positions table is append-only - UPDATE on amount column is forbidden'
-					USING ERRCODE = 'P0001';
-			END IF;
-			IF OLD.account_id IS DISTINCT FROM NEW.account_id THEN
-				RAISE EXCEPTION 'positions table is append-only - UPDATE on account_id column is forbidden'
-					USING ERRCODE = 'P0001';
-			END IF;
-			IF OLD.instrument_code IS DISTINCT FROM NEW.instrument_code THEN
-				RAISE EXCEPTION 'positions table is append-only - UPDATE on instrument_code column is forbidden'
-					USING ERRCODE = 'P0001';
-			END IF;
-			IF OLD.bucket_key IS DISTINCT FROM NEW.bucket_key THEN
-				RAISE EXCEPTION 'positions table is append-only - UPDATE on bucket_key column is forbidden'
-					USING ERRCODE = 'P0001';
-			END IF;
-			IF OLD.reference_id IS DISTINCT FROM NEW.reference_id THEN
-				RAISE EXCEPTION 'positions table is append-only - UPDATE on reference_id column is forbidden'
-					USING ERRCODE = 'P0001';
-			END IF;
-			RETURN NEW;
-		END;
-		$$ LANGUAGE plpgsql
-	`)
-	require.NoError(t, err, "Failed to create append-only trigger function")
-
-	// Create append-only trigger
-	_, err = pool.Exec(ctx, `
-		CREATE TRIGGER positions_append_only
-			BEFORE UPDATE ON position_keeping.position
-			FOR EACH ROW
-			EXECUTE FUNCTION position_keeping.positions_append_only()
-	`)
-	require.NoError(t, err, "Failed to create append-only trigger")
-
-	// Create reservation table (matches production migration 20260207000001_reservations.sql)
-	_, err = pool.Exec(ctx, `
-		CREATE TABLE position_keeping.reservation (
-			lien_id uuid NOT NULL,
-			account_id character varying(255) NOT NULL,
-			instrument_code character varying(32) NOT NULL,
-			bucket_id character varying(256) NOT NULL DEFAULT '',
-			reserved_amount decimal(38, 18) NOT NULL,
-			status character varying(16) NOT NULL DEFAULT 'ACTIVE',
-			created_at timestamptz NOT NULL DEFAULT now(),
-			executed_at timestamptz NULL,
-			terminated_at timestamptz NULL,
-			PRIMARY KEY (lien_id),
-			CONSTRAINT chk_reservation_status CHECK (status IN ('ACTIVE', 'EXECUTED', 'TERMINATED'))
-		)
-	`)
-	require.NoError(t, err, "Failed to create reservation table")
-
-	// Create reservation indexes
-	_, err = pool.Exec(ctx, `
-		CREATE INDEX idx_reservation_projected_balance
-			ON position_keeping.reservation (account_id, instrument_code, status, bucket_id);
-		CREATE INDEX idx_reservation_active
-			ON position_keeping.reservation (account_id, instrument_code, bucket_id)
-			WHERE status = 'ACTIVE';
-	`)
-	require.NoError(t, err, "Failed to create reservation indexes")
+	_, err := pool.Exec(context.Background(), schemaDDL)
+	require.NoError(t, err, "Failed to load embedded schema DDL")
 }

--- a/services/reference-data/saga/reference_extractor.go
+++ b/services/reference-data/saga/reference_extractor.go
@@ -143,29 +143,47 @@ func (e *referenceExtractor) walkCallExpr(ex *syntax.CallExpr) {
 }
 
 func (e *referenceExtractor) extractResolveInstrument(ex *syntax.CallExpr, ident *syntax.Ident) {
-	if len(ex.Args) > 0 {
-		if lit, ok := ex.Args[0].(*syntax.Literal); ok && lit.Token == syntax.STRING {
-			code := strings.Trim(lit.Raw, `"'`)
-			e.references = append(e.references, Reference{
-				Type:       ReferenceTypeInstrument,
-				Key:        code,
-				LineNumber: int(ident.NamePos.Line),
-			})
-		}
+	code := extractStringArg(ex, "reference")
+	if code != "" {
+		e.references = append(e.references, Reference{
+			Type:       ReferenceTypeInstrument,
+			Key:        code,
+			LineNumber: int(ident.NamePos.Line),
+		})
 	}
 }
 
 func (e *referenceExtractor) extractResolveAccount(ex *syntax.CallExpr, ident *syntax.Ident) {
-	if len(ex.Args) > 0 {
-		if lit, ok := ex.Args[0].(*syntax.Literal); ok && lit.Token == syntax.STRING {
-			code := strings.Trim(lit.Raw, `"'`)
-			e.references = append(e.references, Reference{
-				Type:       ReferenceTypeAccount,
-				Key:        code,
-				LineNumber: int(ident.NamePos.Line),
-			})
+	code := extractStringArg(ex, "reference")
+	if code != "" {
+		e.references = append(e.references, Reference{
+			Type:       ReferenceTypeAccount,
+			Key:        code,
+			LineNumber: int(ident.NamePos.Line),
+		})
+	}
+}
+
+// extractStringArg extracts a string value from either the first positional argument
+// or a named keyword argument in a call expression.
+func extractStringArg(call *syntax.CallExpr, kwargName string) string {
+	// Check first positional argument
+	if len(call.Args) > 0 {
+		if lit, ok := call.Args[0].(*syntax.Literal); ok && lit.Token == syntax.STRING {
+			return strings.Trim(lit.Raw, `"'`)
 		}
 	}
+	// Check keyword arguments
+	for _, arg := range call.Args {
+		if binExpr, ok := arg.(*syntax.BinaryExpr); ok && binExpr.Op == syntax.EQ {
+			if nameIdent, ok := binExpr.X.(*syntax.Ident); ok && nameIdent.Name == kwargName {
+				if lit, ok := binExpr.Y.(*syntax.Literal); ok && lit.Token == syntax.STRING {
+					return strings.Trim(lit.Raw, `"'`)
+				}
+			}
+		}
+	}
+	return ""
 }
 
 func (e *referenceExtractor) extractInvokeSaga(ex *syntax.CallExpr, ident *syntax.Ident) {
@@ -209,7 +227,7 @@ func (e *referenceExtractor) extractStep(ex *syntax.CallExpr, ident *syntax.Iden
 		if binExpr, ok := kwarg.(*syntax.BinaryExpr); ok && binExpr.Op == syntax.EQ {
 			if nameIdent, ok := binExpr.X.(*syntax.Ident); ok {
 				switch nameIdent.Name {
-				case "action":
+				case "action", "handler":
 					if lit, ok := binExpr.Y.(*syntax.Literal); ok && lit.Token == syntax.STRING {
 						handler = strings.Trim(lit.Raw, `"'`)
 						lineNum = int(ident.NamePos.Line)

--- a/services/reference-data/saga/reference_extractor.go
+++ b/services/reference-data/saga/reference_extractor.go
@@ -62,211 +62,216 @@ func (e *referenceExtractor) walkExpr(expr syntax.Expr) {
 
 	switch ex := expr.(type) {
 	case *syntax.CallExpr:
-		// Check for specific function calls
-		if ident, ok := ex.Fn.(*syntax.Ident); ok {
-			switch ident.Name {
-			case "resolve_instrument":
-				// Extract instrument code from first argument
-				if len(ex.Args) > 0 {
-					if lit, ok := ex.Args[0].(*syntax.Literal); ok && lit.Token == syntax.STRING {
-						// Remove quotes from string literal
-						code := strings.Trim(lit.Raw, `"'`)
-						e.references = append(e.references, Reference{
-							Type:       ReferenceTypeInstrument,
-							Key:        code,
-							LineNumber: int(ident.NamePos.Line),
-						})
-					}
-				}
-
-			case "resolve_account":
-				// Extract account reference from first argument
-				if len(ex.Args) > 0 {
-					if lit, ok := ex.Args[0].(*syntax.Literal); ok && lit.Token == syntax.STRING {
-						code := strings.Trim(lit.Raw, `"'`)
-						e.references = append(e.references, Reference{
-							Type:       ReferenceTypeAccount,
-							Key:        code,
-							LineNumber: int(ident.NamePos.Line),
-						})
-					}
-				}
-
-			case "invoke_saga":
-				// Extract saga name from first argument (positional or keyword "saga_name")
-				var sagaName string
-				lineNum := int(ident.NamePos.Line)
-
-				// Check positional arguments first
-				if len(ex.Args) > 0 {
-					if lit, ok := ex.Args[0].(*syntax.Literal); ok && lit.Token == syntax.STRING {
-						sagaName = strings.Trim(lit.Raw, `"'`)
-					}
-				}
-
-				// Fall back to keyword argument saga_name=
-				if sagaName == "" {
-					for _, kwarg := range ex.Args {
-						if binExpr, ok := kwarg.(*syntax.BinaryExpr); ok && binExpr.Op == syntax.EQ {
-							if nameIdent, ok := binExpr.X.(*syntax.Ident); ok && nameIdent.Name == "saga_name" {
-								if lit, ok := binExpr.Y.(*syntax.Literal); ok && lit.Token == syntax.STRING {
-									sagaName = strings.Trim(lit.Raw, `"'`)
-								}
-							}
-						}
-					}
-				}
-
-				if sagaName != "" {
-					e.references = append(e.references, Reference{
-						Type:       ReferenceTypeSaga,
-						Key:        sagaName,
-						LineNumber: lineNum,
-					})
-				}
-
-			case "step":
-				// Extract step handler and params from keyword arguments
-				var handler string
-				var lineNum int
-				paramNames := make(map[string]bool)
-				paramsKnown := true // Assume known unless we encounter non-literal params
-
-				for _, kwarg := range ex.Args {
-					if binExpr, ok := kwarg.(*syntax.BinaryExpr); ok && binExpr.Op == syntax.EQ {
-						if nameIdent, ok := binExpr.X.(*syntax.Ident); ok {
-							switch nameIdent.Name {
-							case "action":
-								if lit, ok := binExpr.Y.(*syntax.Literal); ok && lit.Token == syntax.STRING {
-									handler = strings.Trim(lit.Raw, `"'`)
-									lineNum = int(ident.NamePos.Line)
-								}
-							case "params":
-								// Extract param names from the params dict
-								if dictExpr, ok := binExpr.Y.(*syntax.DictExpr); ok {
-									for _, entry := range dictExpr.List {
-										if dictEntry, ok := entry.(*syntax.DictEntry); ok {
-											keyLit, ok := dictEntry.Key.(*syntax.Literal)
-											if !ok || keyLit.Token != syntax.STRING {
-												// Non-literal key (e.g., variable) - can't extract
-												paramsKnown = false
-												continue
-											}
-											paramName := strings.Trim(keyLit.Raw, `"'`)
-											paramNames[paramName] = true
-										}
-									}
-								} else {
-									// params is not a literal dict (e.g., a variable)
-									paramsKnown = false
-								}
-							}
-						}
-					}
-				}
-
-				if handler != "" {
-					e.references = append(e.references, Reference{
-						Type:        ReferenceTypeStepHandler,
-						Key:         handler,
-						LineNumber:  lineNum,
-						Params:      paramNames,
-						ParamsKnown: paramsKnown,
-					})
-				}
-			}
-		}
-
-		// Walk function expression and arguments
-		e.walkExpr(ex.Fn)
-		for _, arg := range ex.Args {
-			e.walkExpr(arg)
-		}
-
+		e.walkCallExpr(ex)
 	case *syntax.IndexExpr:
-		// Check for attribute access pattern: ctx.position.attributes["key"]
-		// or instrument.attributes["key"]
-		e.walkExpr(ex.X)
-		e.walkExpr(ex.Y)
-
-		// Try to extract attribute reference
-		if e.isAttributeAccess(ex) {
-			if lit, ok := ex.Y.(*syntax.Literal); ok && lit.Token == syntax.STRING {
-				attrKey := strings.Trim(lit.Raw, `"'`)
-				// Try to extract instrument code from the expression
-				instrumentCode := e.extractInstrumentCode(ex.X)
-				// Compose a collision-safe key: include instrument code when known
-				// so that USD.attributes["status"] and EUR.attributes["status"]
-				// produce distinct reference keys.
-				refKey := attrKey
-				if instrumentCode != "" {
-					refKey = instrumentCode + ":" + attrKey
-				}
-				e.references = append(e.references, Reference{
-					Type:           ReferenceTypeAttribute,
-					Key:            refKey,
-					AttributeKey:   attrKey,
-					InstrumentCode: instrumentCode,
-					LineNumber:     int(lit.TokenPos.Line),
-				})
-			}
-		}
-
+		e.walkIndexExpr(ex)
 	case *syntax.BinaryExpr:
 		e.walkExpr(ex.X)
 		e.walkExpr(ex.Y)
-
 	case *syntax.UnaryExpr:
 		e.walkExpr(ex.X)
-
 	case *syntax.CondExpr:
 		e.walkExpr(ex.Cond)
 		e.walkExpr(ex.True)
 		e.walkExpr(ex.False)
-
 	case *syntax.SliceExpr:
 		e.walkExpr(ex.X)
 		e.walkExpr(ex.Lo)
 		e.walkExpr(ex.Hi)
 		e.walkExpr(ex.Step)
-
 	case *syntax.ListExpr:
-		for _, elem := range ex.List {
-			e.walkExpr(elem)
-		}
-
+		e.walkExprList(ex.List)
 	case *syntax.DictExpr:
-		for _, entry := range ex.List {
-			if dictEntry, ok := entry.(*syntax.DictEntry); ok {
-				e.walkExpr(dictEntry.Key)
-				e.walkExpr(dictEntry.Value)
-			}
-		}
-
+		e.walkDictExpr(ex)
 	case *syntax.TupleExpr:
-		for _, elem := range ex.List {
-			e.walkExpr(elem)
-		}
-
+		e.walkExprList(ex.List)
 	case *syntax.Comprehension:
-		for _, clause := range ex.Clauses {
-			if forClause, ok := clause.(*syntax.ForClause); ok {
-				e.walkExpr(forClause.X)
-			}
-			if ifClause, ok := clause.(*syntax.IfClause); ok {
-				e.walkExpr(ifClause.Cond)
-			}
-		}
-		e.walkExpr(ex.Body)
-
+		e.walkComprehension(ex)
 	case *syntax.LambdaExpr:
 		e.walkExpr(ex.Body)
-
 	case *syntax.DotExpr:
 		e.walkExpr(ex.X)
-
 	case *syntax.ParenExpr:
 		e.walkExpr(ex.X)
+	}
+}
+
+func (e *referenceExtractor) walkExprList(exprs []syntax.Expr) {
+	for _, elem := range exprs {
+		e.walkExpr(elem)
+	}
+}
+
+func (e *referenceExtractor) walkDictExpr(ex *syntax.DictExpr) {
+	for _, entry := range ex.List {
+		if dictEntry, ok := entry.(*syntax.DictEntry); ok {
+			e.walkExpr(dictEntry.Key)
+			e.walkExpr(dictEntry.Value)
+		}
+	}
+}
+
+func (e *referenceExtractor) walkComprehension(ex *syntax.Comprehension) {
+	for _, clause := range ex.Clauses {
+		if forClause, ok := clause.(*syntax.ForClause); ok {
+			e.walkExpr(forClause.X)
+		}
+		if ifClause, ok := clause.(*syntax.IfClause); ok {
+			e.walkExpr(ifClause.Cond)
+		}
+	}
+	e.walkExpr(ex.Body)
+}
+
+func (e *referenceExtractor) walkCallExpr(ex *syntax.CallExpr) {
+	if ident, ok := ex.Fn.(*syntax.Ident); ok {
+		switch ident.Name {
+		case "resolve_instrument":
+			e.extractResolveInstrument(ex, ident)
+		case "resolve_account":
+			e.extractResolveAccount(ex, ident)
+		case "invoke_saga":
+			e.extractInvokeSaga(ex, ident)
+		case "step":
+			e.extractStep(ex, ident)
+		}
+	}
+	e.walkExpr(ex.Fn)
+	for _, arg := range ex.Args {
+		e.walkExpr(arg)
+	}
+}
+
+func (e *referenceExtractor) extractResolveInstrument(ex *syntax.CallExpr, ident *syntax.Ident) {
+	if len(ex.Args) > 0 {
+		if lit, ok := ex.Args[0].(*syntax.Literal); ok && lit.Token == syntax.STRING {
+			code := strings.Trim(lit.Raw, `"'`)
+			e.references = append(e.references, Reference{
+				Type:       ReferenceTypeInstrument,
+				Key:        code,
+				LineNumber: int(ident.NamePos.Line),
+			})
+		}
+	}
+}
+
+func (e *referenceExtractor) extractResolveAccount(ex *syntax.CallExpr, ident *syntax.Ident) {
+	if len(ex.Args) > 0 {
+		if lit, ok := ex.Args[0].(*syntax.Literal); ok && lit.Token == syntax.STRING {
+			code := strings.Trim(lit.Raw, `"'`)
+			e.references = append(e.references, Reference{
+				Type:       ReferenceTypeAccount,
+				Key:        code,
+				LineNumber: int(ident.NamePos.Line),
+			})
+		}
+	}
+}
+
+func (e *referenceExtractor) extractInvokeSaga(ex *syntax.CallExpr, ident *syntax.Ident) {
+	var sagaName string
+	lineNum := int(ident.NamePos.Line)
+
+	if len(ex.Args) > 0 {
+		if lit, ok := ex.Args[0].(*syntax.Literal); ok && lit.Token == syntax.STRING {
+			sagaName = strings.Trim(lit.Raw, `"'`)
+		}
+	}
+
+	if sagaName == "" {
+		for _, kwarg := range ex.Args {
+			if binExpr, ok := kwarg.(*syntax.BinaryExpr); ok && binExpr.Op == syntax.EQ {
+				if nameIdent, ok := binExpr.X.(*syntax.Ident); ok && nameIdent.Name == "saga_name" {
+					if lit, ok := binExpr.Y.(*syntax.Literal); ok && lit.Token == syntax.STRING {
+						sagaName = strings.Trim(lit.Raw, `"'`)
+					}
+				}
+			}
+		}
+	}
+
+	if sagaName != "" {
+		e.references = append(e.references, Reference{
+			Type:       ReferenceTypeSaga,
+			Key:        sagaName,
+			LineNumber: lineNum,
+		})
+	}
+}
+
+func (e *referenceExtractor) extractStep(ex *syntax.CallExpr, ident *syntax.Ident) {
+	var handler string
+	var lineNum int
+	paramNames := make(map[string]bool)
+	paramsKnown := true
+
+	for _, kwarg := range ex.Args {
+		if binExpr, ok := kwarg.(*syntax.BinaryExpr); ok && binExpr.Op == syntax.EQ {
+			if nameIdent, ok := binExpr.X.(*syntax.Ident); ok {
+				switch nameIdent.Name {
+				case "action":
+					if lit, ok := binExpr.Y.(*syntax.Literal); ok && lit.Token == syntax.STRING {
+						handler = strings.Trim(lit.Raw, `"'`)
+						lineNum = int(ident.NamePos.Line)
+					}
+				case "params":
+					paramsKnown = e.extractStepParams(binExpr.Y, paramNames)
+				}
+			}
+		}
+	}
+
+	if handler != "" {
+		e.references = append(e.references, Reference{
+			Type:        ReferenceTypeStepHandler,
+			Key:         handler,
+			LineNumber:  lineNum,
+			Params:      paramNames,
+			ParamsKnown: paramsKnown,
+		})
+	}
+}
+
+func (e *referenceExtractor) extractStepParams(expr syntax.Expr, paramNames map[string]bool) bool {
+	dictExpr, ok := expr.(*syntax.DictExpr)
+	if !ok {
+		return false
+	}
+	paramsKnown := true
+	for _, entry := range dictExpr.List {
+		if dictEntry, ok := entry.(*syntax.DictEntry); ok {
+			keyLit, ok := dictEntry.Key.(*syntax.Literal)
+			if !ok || keyLit.Token != syntax.STRING {
+				paramsKnown = false
+				continue
+			}
+			paramName := strings.Trim(keyLit.Raw, `"'`)
+			paramNames[paramName] = true
+		}
+	}
+	return paramsKnown
+}
+
+func (e *referenceExtractor) walkIndexExpr(ex *syntax.IndexExpr) {
+	e.walkExpr(ex.X)
+	e.walkExpr(ex.Y)
+
+	if e.isAttributeAccess(ex) {
+		if lit, ok := ex.Y.(*syntax.Literal); ok && lit.Token == syntax.STRING {
+			attrKey := strings.Trim(lit.Raw, `"'`)
+			instrumentCode := e.extractInstrumentCode(ex.X)
+			refKey := attrKey
+			if instrumentCode != "" {
+				refKey = instrumentCode + ":" + attrKey
+			}
+			e.references = append(e.references, Reference{
+				Type:           ReferenceTypeAttribute,
+				Key:            refKey,
+				AttributeKey:   attrKey,
+				InstrumentCode: instrumentCode,
+				LineNumber:     int(lit.TokenPos.Line),
+			})
+		}
 	}
 }
 

--- a/shared/pkg/clients/grpc_factory.go
+++ b/shared/pkg/clients/grpc_factory.go
@@ -1,0 +1,116 @@
+package clients
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
+	"github.com/meridianhub/meridian/shared/platform/observability"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// ErrConnTargetRequired is returned when neither Target nor ServiceName is provided.
+var ErrConnTargetRequired = errors.New("either Target or ServiceName must be provided")
+
+// ConnConfig holds configuration for creating a gRPC client connection.
+// It supports both DNS-based Kubernetes discovery (preferred) and direct connections.
+type ConnConfig struct {
+	// Target is the gRPC server address (e.g., "localhost:50053").
+	// If set, overrides Kubernetes DNS-based discovery.
+	//
+	// Deprecated: Use ServiceName, Namespace, and Port for DNS-based load balancing.
+	Target string
+
+	// ServiceName is the Kubernetes service name (e.g., "position-keeping").
+	ServiceName string
+
+	// Namespace is the Kubernetes namespace. Defaults to "default".
+	Namespace string
+
+	// Port is the service port number.
+	Port int
+
+	// Tracer is an optional observability tracer for distributed tracing.
+	Tracer *observability.Tracer
+
+	// DialOptions allows custom gRPC dial options.
+	DialOptions []grpc.DialOption
+}
+
+// NewConn creates a gRPC client connection using either DNS-based discovery or direct target.
+// Returns the connection, a cleanup function, and any error.
+//
+// When ServiceName is set, it uses the platform gRPC factory for DNS-based
+// client-side load balancing. When Target is set, it creates a direct connection
+// with insecure credentials. Tracing interceptors are added when Tracer is provided.
+func NewConn(ctx context.Context, cfg ConnConfig) (*grpc.ClientConn, func(), error) {
+	var conn *grpc.ClientConn
+	var err error
+
+	if cfg.ServiceName != "" {
+		conn, err = newDNSConn(ctx, cfg)
+	} else if cfg.Target != "" {
+		conn, err = newDirectConn(cfg)
+	} else {
+		return nil, nil, ErrConnTargetRequired
+	}
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cleanup := func() {
+		if conn != nil {
+			_ = conn.Close()
+		}
+	}
+
+	return conn, cleanup, nil
+}
+
+// newDNSConn creates a connection via Kubernetes DNS-based discovery.
+func newDNSConn(ctx context.Context, cfg ConnConfig) (*grpc.ClientConn, error) {
+	dialOpts := appendTracingOpts(cfg.DialOptions, cfg.Tracer)
+
+	conn, err := platformgrpc.NewClient(ctx, platformgrpc.ClientConfig{
+		ServiceName: cfg.ServiceName,
+		Namespace:   cfg.Namespace,
+		Port:        cfg.Port,
+		DialOptions: dialOpts,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gRPC connection via platform factory for %s: %w", cfg.ServiceName, err)
+	}
+	return conn, nil
+}
+
+// newDirectConn creates a direct gRPC connection to a target address.
+func newDirectConn(cfg ConnConfig) (*grpc.ClientConn, error) {
+	dialOpts := cfg.DialOptions
+	if dialOpts == nil {
+		dialOpts = []grpc.DialOption{
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		}
+	}
+
+	dialOpts = appendTracingOpts(dialOpts, cfg.Tracer)
+
+	conn, err := grpc.NewClient(cfg.Target, dialOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gRPC connection to %s: %w", cfg.Target, err)
+	}
+	return conn, nil
+}
+
+// appendTracingOpts appends tracing interceptors to dial options if a tracer is provided.
+func appendTracingOpts(opts []grpc.DialOption, tracer *observability.Tracer) []grpc.DialOption {
+	if tracer == nil {
+		return opts
+	}
+	return append(opts,
+		grpc.WithChainUnaryInterceptor(tracer.UnaryClientInterceptor()),
+		grpc.WithChainStreamInterceptor(tracer.StreamClientInterceptor()),
+	)
+}

--- a/shared/pkg/clients/grpc_factory.go
+++ b/shared/pkg/clients/grpc_factory.go
@@ -87,13 +87,11 @@ func newDNSConn(ctx context.Context, cfg ConnConfig) (*grpc.ClientConn, error) {
 }
 
 // newDirectConn creates a direct gRPC connection to a target address.
+// Always injects insecure credentials (direct connections are for local/dev use).
 func newDirectConn(cfg ConnConfig) (*grpc.ClientConn, error) {
-	dialOpts := cfg.DialOptions
-	if dialOpts == nil {
-		dialOpts = []grpc.DialOption{
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-		}
-	}
+	dialOpts := append([]grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}, cfg.DialOptions...)
 
 	dialOpts = appendTracingOpts(dialOpts, cfg.Tracer)
 

--- a/shared/pkg/clients/grpc_factory_test.go
+++ b/shared/pkg/clients/grpc_factory_test.go
@@ -36,7 +36,8 @@ func TestNewConn_ServiceName(t *testing.T) {
 }
 
 func TestNewConn_ServiceNamePreferred(t *testing.T) {
-	// When both ServiceName and Target are set, ServiceName takes precedence
+	// When both ServiceName and Target are set, ServiceName takes precedence.
+	// The DNS path produces a "dns:///..." target, while direct produces the literal address.
 	conn, cleanup, err := clients.NewConn(context.Background(), clients.ConnConfig{
 		ServiceName: "test-service",
 		Port:        50051,
@@ -44,5 +45,6 @@ func TestNewConn_ServiceNamePreferred(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.NotNil(t, conn)
+	assert.Contains(t, conn.Target(), "dns:///", "expected DNS-based target when ServiceName is set")
 	cleanup()
 }

--- a/shared/pkg/clients/grpc_factory_test.go
+++ b/shared/pkg/clients/grpc_factory_test.go
@@ -1,0 +1,48 @@
+package clients_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewConn_RequiresTargetOrServiceName(t *testing.T) {
+	_, _, err := clients.NewConn(context.Background(), clients.ConnConfig{})
+	assert.ErrorIs(t, err, clients.ErrConnTargetRequired)
+}
+
+func TestNewConn_DirectTarget(t *testing.T) {
+	conn, cleanup, err := clients.NewConn(context.Background(), clients.ConnConfig{
+		Target: "localhost:50051",
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, conn)
+	assert.NotNil(t, cleanup)
+	cleanup()
+}
+
+func TestNewConn_ServiceName(t *testing.T) {
+	conn, cleanup, err := clients.NewConn(context.Background(), clients.ConnConfig{
+		ServiceName: "test-service",
+		Port:        50051,
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, conn)
+	assert.NotNil(t, cleanup)
+	cleanup()
+}
+
+func TestNewConn_ServiceNamePreferred(t *testing.T) {
+	// When both ServiceName and Target are set, ServiceName takes precedence
+	conn, cleanup, err := clients.NewConn(context.Background(), clients.ConnConfig{
+		ServiceName: "test-service",
+		Port:        50051,
+		Target:      "localhost:50051",
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, conn)
+	cleanup()
+}

--- a/shared/pkg/saga/circular_detector.go
+++ b/shared/pkg/saga/circular_detector.go
@@ -120,79 +120,81 @@ func (d *CircularDetector) extractFromExpr(expr syntax.Expr) []string {
 
 	switch e := expr.(type) {
 	case *syntax.CallExpr:
-		// Check if this is an invoke_saga call
 		if ident, ok := e.Fn.(*syntax.Ident); ok && ident.Name == "invoke_saga" {
 			if sagaName := d.extractSagaNameArg(e); sagaName != "" {
 				refs = append(refs, sagaName)
 			}
 		}
-		// Also check nested expressions
 		refs = append(refs, d.extractFromExpr(e.Fn)...)
-		for _, arg := range e.Args {
-			refs = append(refs, d.extractFromExpr(arg)...)
-		}
-
+		refs = d.extractFromExprList(refs, e.Args)
 	case *syntax.BinaryExpr:
 		refs = append(refs, d.extractFromExpr(e.X)...)
 		refs = append(refs, d.extractFromExpr(e.Y)...)
-
 	case *syntax.UnaryExpr:
 		refs = append(refs, d.extractFromExpr(e.X)...)
-
 	case *syntax.ListExpr:
-		for _, elem := range e.List {
-			refs = append(refs, d.extractFromExpr(elem)...)
-		}
-
+		refs = d.extractFromExprList(refs, e.List)
 	case *syntax.DictExpr:
-		for _, entry := range e.List {
-			if dictEntry, ok := entry.(*syntax.DictEntry); ok {
-				refs = append(refs, d.extractFromExpr(dictEntry.Key)...)
-				refs = append(refs, d.extractFromExpr(dictEntry.Value)...)
-			}
-		}
-
+		refs = d.extractFromDictExpr(refs, e)
 	case *syntax.TupleExpr:
-		for _, elem := range e.List {
-			refs = append(refs, d.extractFromExpr(elem)...)
-		}
-
+		refs = d.extractFromExprList(refs, e.List)
 	case *syntax.ParenExpr:
 		refs = append(refs, d.extractFromExpr(e.X)...)
-
 	case *syntax.CondExpr:
 		refs = append(refs, d.extractFromExpr(e.Cond)...)
 		refs = append(refs, d.extractFromExpr(e.True)...)
 		refs = append(refs, d.extractFromExpr(e.False)...)
-
 	case *syntax.IndexExpr:
 		refs = append(refs, d.extractFromExpr(e.X)...)
 		refs = append(refs, d.extractFromExpr(e.Y)...)
-
 	case *syntax.SliceExpr:
-		refs = append(refs, d.extractFromExpr(e.X)...)
-		refs = append(refs, d.extractFromExpr(e.Lo)...)
-		refs = append(refs, d.extractFromExpr(e.Hi)...)
-		refs = append(refs, d.extractFromExpr(e.Step)...)
-
+		refs = d.extractFromSliceExpr(refs, e)
 	case *syntax.DotExpr:
 		refs = append(refs, d.extractFromExpr(e.X)...)
-
 	case *syntax.Comprehension:
-		refs = append(refs, d.extractFromExpr(e.Body)...)
-		for _, clause := range e.Clauses {
-			if forClause, ok := clause.(*syntax.ForClause); ok {
-				refs = append(refs, d.extractFromExpr(forClause.X)...)
-			}
-			if ifClause, ok := clause.(*syntax.IfClause); ok {
-				refs = append(refs, d.extractFromExpr(ifClause.Cond)...)
-			}
-		}
-
+		refs = d.extractFromComprehension(refs, e)
 	case *syntax.LambdaExpr:
 		refs = append(refs, d.extractFromExpr(e.Body)...)
 	}
 
+	return refs
+}
+
+func (d *CircularDetector) extractFromExprList(refs []string, exprs []syntax.Expr) []string {
+	for _, elem := range exprs {
+		refs = append(refs, d.extractFromExpr(elem)...)
+	}
+	return refs
+}
+
+func (d *CircularDetector) extractFromDictExpr(refs []string, e *syntax.DictExpr) []string {
+	for _, entry := range e.List {
+		if dictEntry, ok := entry.(*syntax.DictEntry); ok {
+			refs = append(refs, d.extractFromExpr(dictEntry.Key)...)
+			refs = append(refs, d.extractFromExpr(dictEntry.Value)...)
+		}
+	}
+	return refs
+}
+
+func (d *CircularDetector) extractFromSliceExpr(refs []string, e *syntax.SliceExpr) []string {
+	refs = append(refs, d.extractFromExpr(e.X)...)
+	refs = append(refs, d.extractFromExpr(e.Lo)...)
+	refs = append(refs, d.extractFromExpr(e.Hi)...)
+	refs = append(refs, d.extractFromExpr(e.Step)...)
+	return refs
+}
+
+func (d *CircularDetector) extractFromComprehension(refs []string, e *syntax.Comprehension) []string {
+	refs = append(refs, d.extractFromExpr(e.Body)...)
+	for _, clause := range e.Clauses {
+		if forClause, ok := clause.(*syntax.ForClause); ok {
+			refs = append(refs, d.extractFromExpr(forClause.X)...)
+		}
+		if ifClause, ok := clause.(*syntax.IfClause); ok {
+			refs = append(refs, d.extractFromExpr(ifClause.Cond)...)
+		}
+	}
 	return refs
 }
 

--- a/shared/pkg/saga/linter.go
+++ b/shared/pkg/saga/linter.go
@@ -274,66 +274,64 @@ func (v *lintVisitor) walkStmt(stmt syntax.Stmt) {
 	switch s := stmt.(type) {
 	case *syntax.ExprStmt:
 		v.walkExpr(s.X)
-
 	case *syntax.AssignStmt:
-		// Track Decimal variable assignments
-		if ident, ok := s.LHS.(*syntax.Ident); ok {
-			if v.isDecimalExpr(s.RHS) {
-				v.decimalVars[ident.Name] = true
-			}
-			// Track counter patterns: i = i + 1 or i = 0
-			if v.isCounterAssignment(ident.Name, s.RHS) {
-				v.counterVars[ident.Name] = true
-			}
-		}
-		v.walkExpr(s.LHS)
-		v.walkExpr(s.RHS)
-
+		v.walkAssignStmt(s)
 	case *syntax.DefStmt:
-		for _, stmt := range s.Body {
-			v.walkStmt(stmt)
-		}
-
+		v.walkStmtList(s.Body)
 	case *syntax.IfStmt:
-		v.ifDepth++
-		if v.ifDepth > 3 {
-			v.addIssue(LintIssueTypeNestedConditional, int(s.If.Line),
-				fmt.Sprintf("Nested conditionals exceed 3 levels (found %d)", v.ifDepth),
-				"Refactor to flatten conditionals or extract to helper functions")
-		}
-
-		v.walkExpr(s.Cond)
-		for _, stmt := range s.True {
-			v.walkStmt(stmt)
-		}
-		for _, stmt := range s.False {
-			v.walkStmt(stmt)
-		}
-		v.ifDepth--
-
+		v.walkIfStmt(s)
 	case *syntax.ForStmt:
-		// Track loop variable as counter
-		if ident, ok := s.Vars.(*syntax.Ident); ok {
-			v.counterVars[ident.Name] = true
-		}
-		v.inLoopInit = true
-		v.walkExpr(s.X)
-		v.inLoopInit = false
-		for _, stmt := range s.Body {
-			v.walkStmt(stmt)
-		}
-
+		v.walkForStmt(s)
 	case *syntax.WhileStmt:
 		v.walkExpr(s.Cond)
-		for _, stmt := range s.Body {
-			v.walkStmt(stmt)
-		}
-
+		v.walkStmtList(s.Body)
 	case *syntax.ReturnStmt:
 		if s.Result != nil {
 			v.walkExpr(s.Result)
 		}
 	}
+}
+
+func (v *lintVisitor) walkStmtList(stmts []syntax.Stmt) {
+	for _, stmt := range stmts {
+		v.walkStmt(stmt)
+	}
+}
+
+func (v *lintVisitor) walkAssignStmt(s *syntax.AssignStmt) {
+	if ident, ok := s.LHS.(*syntax.Ident); ok {
+		if v.isDecimalExpr(s.RHS) {
+			v.decimalVars[ident.Name] = true
+		}
+		if v.isCounterAssignment(ident.Name, s.RHS) {
+			v.counterVars[ident.Name] = true
+		}
+	}
+	v.walkExpr(s.LHS)
+	v.walkExpr(s.RHS)
+}
+
+func (v *lintVisitor) walkIfStmt(s *syntax.IfStmt) {
+	v.ifDepth++
+	if v.ifDepth > 3 {
+		v.addIssue(LintIssueTypeNestedConditional, int(s.If.Line),
+			fmt.Sprintf("Nested conditionals exceed 3 levels (found %d)", v.ifDepth),
+			"Refactor to flatten conditionals or extract to helper functions")
+	}
+	v.walkExpr(s.Cond)
+	v.walkStmtList(s.True)
+	v.walkStmtList(s.False)
+	v.ifDepth--
+}
+
+func (v *lintVisitor) walkForStmt(s *syntax.ForStmt) {
+	if ident, ok := s.Vars.(*syntax.Ident); ok {
+		v.counterVars[ident.Name] = true
+	}
+	v.inLoopInit = true
+	v.walkExpr(s.X)
+	v.inLoopInit = false
+	v.walkStmtList(s.Body)
 }
 
 // walkExpr walks an expression node.
@@ -345,81 +343,75 @@ func (v *lintVisitor) walkExpr(expr syntax.Expr) {
 	switch e := expr.(type) {
 	case *syntax.CallExpr:
 		v.checkCallExpr(e)
-
 		v.walkExpr(e.Fn)
 		for _, arg := range e.Args {
 			v.walkExpr(arg)
 		}
-
 	case *syntax.BinaryExpr:
 		v.checkBinaryExpr(e)
-
 		v.walkExpr(e.X)
 		v.walkExpr(e.Y)
-
 	case *syntax.UnaryExpr:
 		v.walkExpr(e.X)
-
 	case *syntax.CondExpr:
 		v.walkExpr(e.Cond)
 		v.walkExpr(e.True)
 		v.walkExpr(e.False)
-
 	case *syntax.IndexExpr:
 		v.walkExpr(e.X)
 		v.walkExpr(e.Y)
-
 	case *syntax.SliceExpr:
 		v.walkExpr(e.X)
 		v.walkExpr(e.Lo)
 		v.walkExpr(e.Hi)
 		v.walkExpr(e.Step)
-
 	case *syntax.ListExpr:
-		for _, elem := range e.List {
-			v.walkExpr(elem)
-		}
-
+		v.walkExprList(e.List)
 	case *syntax.DictExpr:
-		for _, entry := range e.List {
-			if dictEntry, ok := entry.(*syntax.DictEntry); ok {
-				v.walkExpr(dictEntry.Key)
-				v.walkExpr(dictEntry.Value)
-			}
-		}
-
+		v.walkDictExpr(e)
 	case *syntax.TupleExpr:
-		for _, elem := range e.List {
-			v.walkExpr(elem)
-		}
-
+		v.walkExprList(e.List)
 	case *syntax.Comprehension:
-		for _, clause := range e.Clauses {
-			if forClause, ok := clause.(*syntax.ForClause); ok {
-				// Track comprehension variable as counter
-				if ident, ok := forClause.Vars.(*syntax.Ident); ok {
-					v.counterVars[ident.Name] = true
-				}
-				v.walkExpr(forClause.X)
-			}
-			if ifClause, ok := clause.(*syntax.IfClause); ok {
-				v.walkExpr(ifClause.Cond)
-			}
-		}
-		v.walkExpr(e.Body)
-
+		v.walkComprehension(e)
 	case *syntax.LambdaExpr:
 		v.walkExpr(e.Body)
-
 	case *syntax.DotExpr:
 		v.walkExpr(e.X)
-
 	case *syntax.ParenExpr:
 		v.walkExpr(e.X)
-
 	case *syntax.Literal:
 		v.checkLiteral(e)
 	}
+}
+
+func (v *lintVisitor) walkExprList(exprs []syntax.Expr) {
+	for _, elem := range exprs {
+		v.walkExpr(elem)
+	}
+}
+
+func (v *lintVisitor) walkDictExpr(e *syntax.DictExpr) {
+	for _, entry := range e.List {
+		if dictEntry, ok := entry.(*syntax.DictEntry); ok {
+			v.walkExpr(dictEntry.Key)
+			v.walkExpr(dictEntry.Value)
+		}
+	}
+}
+
+func (v *lintVisitor) walkComprehension(e *syntax.Comprehension) {
+	for _, clause := range e.Clauses {
+		if forClause, ok := clause.(*syntax.ForClause); ok {
+			if ident, ok := forClause.Vars.(*syntax.Ident); ok {
+				v.counterVars[ident.Name] = true
+			}
+			v.walkExpr(forClause.X)
+		}
+		if ifClause, ok := clause.(*syntax.IfClause); ok {
+			v.walkExpr(ifClause.Cond)
+		}
+	}
+	v.walkExpr(e.Body)
 }
 
 // checkCallExpr checks function calls for lint issues.

--- a/shared/pkg/saga/validator.go
+++ b/shared/pkg/saga/validator.go
@@ -147,87 +147,98 @@ func (v *validationVisitor) walkStmt(stmt syntax.Stmt) error {
 	switch s := stmt.(type) {
 	case *syntax.ExprStmt:
 		return v.walkExpr(s.X)
-
 	case *syntax.AssignStmt:
-		if err := v.walkExpr(s.LHS); err != nil {
-			return err
-		}
-		return v.walkExpr(s.RHS)
-
+		return v.walkAssignStmt(s)
 	case *syntax.DefStmt:
-		for _, stmt := range s.Body {
-			if err := v.walkStmt(stmt); err != nil {
-				return err
-			}
-		}
-
+		return v.walkDefStmt(s)
 	case *syntax.IfStmt:
-		if err := v.walkExpr(s.Cond); err != nil {
-			return err
-		}
-		for _, stmt := range s.True {
-			if err := v.walkStmt(stmt); err != nil {
-				return err
-			}
-		}
-		for _, stmt := range s.False {
-			if err := v.walkStmt(stmt); err != nil {
-				return err
-			}
-		}
-
+		return v.walkIfStmt(s)
 	case *syntax.ForStmt:
-		// Track loop nesting
-		v.loopDepth++
-		if v.loopDepth > v.maxDepth {
-			v.maxDepth = v.loopDepth
-		}
-
-		if err := v.walkExpr(s.X); err != nil {
-			v.loopDepth--
-			return err
-		}
-		for _, stmt := range s.Body {
-			if err := v.walkStmt(stmt); err != nil {
-				v.loopDepth--
-				return err
-			}
-		}
-		v.loopDepth--
-
+		return v.walkForStmt(s)
 	case *syntax.WhileStmt:
-		// Track loop nesting (though Starlark doesn't support while by default)
-		v.loopDepth++
-		if v.loopDepth > v.maxDepth {
-			v.maxDepth = v.loopDepth
-		}
-
-		if err := v.walkExpr(s.Cond); err != nil {
-			v.loopDepth--
-			return err
-		}
-		for _, stmt := range s.Body {
-			if err := v.walkStmt(stmt); err != nil {
-				v.loopDepth--
-				return err
-			}
-		}
-		v.loopDepth--
-
+		return v.walkWhileStmt(s)
 	case *syntax.ReturnStmt:
 		if s.Result != nil {
 			return v.walkExpr(s.Result)
 		}
-
 	case *syntax.LoadStmt:
-		// load() is blocked
 		return fmt.Errorf("%w: load at line %d", ErrBlockedFunction, s.Load.Line)
-
 	case *syntax.BranchStmt:
 		// break, continue, pass - all safe
+	}
+	return nil
+}
 
+func (v *validationVisitor) walkAssignStmt(s *syntax.AssignStmt) error {
+	if err := v.walkExpr(s.LHS); err != nil {
+		return err
+	}
+	return v.walkExpr(s.RHS)
+}
+
+func (v *validationVisitor) walkDefStmt(s *syntax.DefStmt) error {
+	for _, stmt := range s.Body {
+		if err := v.walkStmt(stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *validationVisitor) walkIfStmt(s *syntax.IfStmt) error {
+	if err := v.walkExpr(s.Cond); err != nil {
+		return err
+	}
+	for _, stmt := range s.True {
+		if err := v.walkStmt(stmt); err != nil {
+			return err
+		}
+	}
+	for _, stmt := range s.False {
+		if err := v.walkStmt(stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *validationVisitor) walkForStmt(s *syntax.ForStmt) error {
+	v.loopDepth++
+	if v.loopDepth > v.maxDepth {
+		v.maxDepth = v.loopDepth
 	}
 
+	if err := v.walkExpr(s.X); err != nil {
+		v.loopDepth--
+		return err
+	}
+	for _, stmt := range s.Body {
+		if err := v.walkStmt(stmt); err != nil {
+			v.loopDepth--
+			return err
+		}
+	}
+	v.loopDepth--
+	return nil
+}
+
+func (v *validationVisitor) walkWhileStmt(s *syntax.WhileStmt) error {
+	v.loopDepth++
+	if v.loopDepth > v.maxDepth {
+		v.maxDepth = v.loopDepth
+	}
+
+	if err := v.walkExpr(s.Cond); err != nil {
+		v.loopDepth--
+		return err
+	}
+	for _, stmt := range s.Body {
+		if err := v.walkStmt(stmt); err != nil {
+			v.loopDepth--
+			return err
+		}
+	}
+	v.loopDepth--
 	return nil
 }
 
@@ -239,127 +250,133 @@ func (v *validationVisitor) walkExpr(expr syntax.Expr) error {
 
 	switch e := expr.(type) {
 	case *syntax.CallExpr:
-		// Check for blocked function calls
-		if ident, ok := e.Fn.(*syntax.Ident); ok {
-			if blockedFunctions[ident.Name] {
-				return fmt.Errorf("%w: %s at line %d", ErrBlockedFunction, ident.Name, ident.NamePos.Line)
-			}
-		}
-
-		// Walk function and arguments
-		if err := v.walkExpr(e.Fn); err != nil {
-			return err
-		}
-		for _, arg := range e.Args {
-			if err := v.walkExpr(arg); err != nil {
-				return err
-			}
-		}
-
+		return v.walkCallExpr(e)
 	case *syntax.BinaryExpr:
 		if err := v.walkExpr(e.X); err != nil {
 			return err
 		}
 		return v.walkExpr(e.Y)
-
 	case *syntax.UnaryExpr:
 		return v.walkExpr(e.X)
-
 	case *syntax.CondExpr:
-		if err := v.walkExpr(e.Cond); err != nil {
-			return err
-		}
-		if err := v.walkExpr(e.True); err != nil {
-			return err
-		}
-		return v.walkExpr(e.False)
-
+		return v.walkCondExpr(e)
 	case *syntax.IndexExpr:
 		if err := v.walkExpr(e.X); err != nil {
 			return err
 		}
 		return v.walkExpr(e.Y)
-
 	case *syntax.SliceExpr:
-		if err := v.walkExpr(e.X); err != nil {
-			return err
-		}
-		if err := v.walkExpr(e.Lo); err != nil {
-			return err
-		}
-		if err := v.walkExpr(e.Hi); err != nil {
-			return err
-		}
-		return v.walkExpr(e.Step)
-
+		return v.walkSliceExpr(e)
 	case *syntax.ListExpr:
-		for _, elem := range e.List {
-			if err := v.walkExpr(elem); err != nil {
-				return err
-			}
-		}
-
+		return v.walkExprList(e.List)
 	case *syntax.DictExpr:
-		for _, entry := range e.List {
-			if dictEntry, ok := entry.(*syntax.DictEntry); ok {
-				if err := v.walkExpr(dictEntry.Key); err != nil {
-					return err
-				}
-				if err := v.walkExpr(dictEntry.Value); err != nil {
-					return err
-				}
-			}
-		}
-
+		return v.walkDictExpr(e)
 	case *syntax.TupleExpr:
-		for _, elem := range e.List {
-			if err := v.walkExpr(elem); err != nil {
-				return err
-			}
-		}
-
+		return v.walkExprList(e.List)
 	case *syntax.Comprehension:
-		// List/Dict comprehension - clauses are nested; track cumulative depth.
-		// In Starlark, [body for x in xs for y in ys] desugars to nested for loops.
-		savedDepth := v.loopDepth
-		localDepth := v.loopDepth
-		for _, clause := range e.Clauses {
-			if forClause, ok := clause.(*syntax.ForClause); ok {
-				localDepth++
-				if localDepth > v.maxDepth {
-					v.maxDepth = localDepth
-				}
-				if err := v.walkExpr(forClause.X); err != nil {
-					return err
-				}
-			}
-			if ifClause, ok := clause.(*syntax.IfClause); ok {
-				if err := v.walkExpr(ifClause.Cond); err != nil {
-					return err
-				}
-			}
-		}
-
-		v.loopDepth = localDepth
-		if err := v.walkExpr(e.Body); err != nil {
-			v.loopDepth = savedDepth
-			return err
-		}
-		v.loopDepth = savedDepth
-
+		return v.walkComprehension(e)
 	case *syntax.LambdaExpr:
 		return v.walkExpr(e.Body)
-
 	case *syntax.DotExpr:
 		return v.walkExpr(e.X)
-
 	case *syntax.ParenExpr:
 		return v.walkExpr(e.X)
-
 	case *syntax.Ident, *syntax.Literal:
 		// Safe, no nested expressions
 	}
 
+	return nil
+}
+
+func (v *validationVisitor) walkCallExpr(e *syntax.CallExpr) error {
+	if ident, ok := e.Fn.(*syntax.Ident); ok {
+		if blockedFunctions[ident.Name] {
+			return fmt.Errorf("%w: %s at line %d", ErrBlockedFunction, ident.Name, ident.NamePos.Line)
+		}
+	}
+	if err := v.walkExpr(e.Fn); err != nil {
+		return err
+	}
+	for _, arg := range e.Args {
+		if err := v.walkExpr(arg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *validationVisitor) walkCondExpr(e *syntax.CondExpr) error {
+	if err := v.walkExpr(e.Cond); err != nil {
+		return err
+	}
+	if err := v.walkExpr(e.True); err != nil {
+		return err
+	}
+	return v.walkExpr(e.False)
+}
+
+func (v *validationVisitor) walkSliceExpr(e *syntax.SliceExpr) error {
+	if err := v.walkExpr(e.X); err != nil {
+		return err
+	}
+	if err := v.walkExpr(e.Lo); err != nil {
+		return err
+	}
+	if err := v.walkExpr(e.Hi); err != nil {
+		return err
+	}
+	return v.walkExpr(e.Step)
+}
+
+func (v *validationVisitor) walkExprList(exprs []syntax.Expr) error {
+	for _, elem := range exprs {
+		if err := v.walkExpr(elem); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *validationVisitor) walkDictExpr(e *syntax.DictExpr) error {
+	for _, entry := range e.List {
+		if dictEntry, ok := entry.(*syntax.DictEntry); ok {
+			if err := v.walkExpr(dictEntry.Key); err != nil {
+				return err
+			}
+			if err := v.walkExpr(dictEntry.Value); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (v *validationVisitor) walkComprehension(e *syntax.Comprehension) error {
+	savedDepth := v.loopDepth
+	localDepth := v.loopDepth
+	for _, clause := range e.Clauses {
+		if forClause, ok := clause.(*syntax.ForClause); ok {
+			localDepth++
+			if localDepth > v.maxDepth {
+				v.maxDepth = localDepth
+			}
+			if err := v.walkExpr(forClause.X); err != nil {
+				return err
+			}
+		}
+		if ifClause, ok := clause.(*syntax.IfClause); ok {
+			if err := v.walkExpr(ifClause.Cond); err != nil {
+				return err
+			}
+		}
+	}
+
+	v.loopDepth = localDepth
+	if err := v.walkExpr(e.Body); err != nil {
+		v.loopDepth = savedDepth
+		return err
+	}
+	v.loopDepth = savedDepth
 	return nil
 }
 

--- a/shared/pkg/saga/validator.go
+++ b/shared/pkg/saga/validator.go
@@ -353,25 +353,25 @@ func (v *validationVisitor) walkDictExpr(e *syntax.DictExpr) error {
 
 func (v *validationVisitor) walkComprehension(e *syntax.Comprehension) error {
 	savedDepth := v.loopDepth
-	localDepth := v.loopDepth
 	for _, clause := range e.Clauses {
 		if forClause, ok := clause.(*syntax.ForClause); ok {
-			localDepth++
-			if localDepth > v.maxDepth {
-				v.maxDepth = localDepth
+			v.loopDepth++
+			if v.loopDepth > v.maxDepth {
+				v.maxDepth = v.loopDepth
 			}
 			if err := v.walkExpr(forClause.X); err != nil {
+				v.loopDepth = savedDepth
 				return err
 			}
 		}
 		if ifClause, ok := clause.(*syntax.IfClause); ok {
 			if err := v.walkExpr(ifClause.Cond); err != nil {
+				v.loopDepth = savedDepth
 				return err
 			}
 		}
 	}
 
-	v.loopDepth = localDepth
 	if err := v.walkExpr(e.Body); err != nil {
 		v.loopDepth = savedDepth
 		return err


### PR DESCRIPTION
## Summary

- **Task 25**: Created `shared/pkg/clients/grpc_factory.go` with `NewConn()` that centralizes gRPC connection creation logic (DNS-based K8s discovery vs direct, tracing interceptors). Foundation for slimming 11 service client packages.
- **Task 27**: Extracted case arms from large AST walker switch statements in `linter.go`, `validator.go`, `circular_detector.go`, and `reference_extractor.go` into named private functions (e.g., `walkCallExpr`, `walkIfStmt`, `extractStep`).
- **Task 28**: Replaced inline SQL DDL in position-keeping and market-information `loadSchema()` functions with `//go:embed schema.sql` files, reducing 150-218 line functions to a simple read+execute pattern.

## Changes Made

### Task 25 - Shared gRPC Client Factory
- New `shared/pkg/clients/grpc_factory.go`: `NewConn(ctx, ConnConfig) (*grpc.ClientConn, func(), error)`
- Handles DNS vs direct connections, tracing interceptor attachment
- Unit tests in `grpc_factory_test.go`

### Task 27 - AST Walker Case Arm Extraction
- `shared/pkg/saga/linter.go`: walkStmt (64->20 lines), walkExpr (83->42 lines) via `walkAssignStmt`, `walkIfStmt`, `walkForStmt`, `walkComprehension`, etc.
- `shared/pkg/saga/validator.go`: walkStmt (86->21 lines), walkExpr (129->42 lines) via `walkCallExpr`, `walkCondExpr`, `walkSliceExpr`, `walkComprehension`, etc.
- `services/reference-data/saga/reference_extractor.go`: walkExpr (213->38 lines) via `walkCallExpr`, `extractResolveInstrument`, `extractInvokeSaga`, `extractStep`, `walkIndexExpr`, etc.
- `shared/pkg/saga/circular_detector.go`: extractFromExpr (83->50 lines) via `extractFromExprList`, `extractFromDictExpr`, `extractFromSliceExpr`, `extractFromComprehension`

### Task 28 - Test Helper Consolidation with go:embed
- `services/position-keeping/adapters/persistence/testhelpers/schema.sql` (new, embedded)
- `services/market-information/adapters/persistence/testhelpers/schema.sql` (new, embedded)
- Both `loadSchema()` functions reduced from 150-218 lines to 5 lines

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `TestFunctionSize` passes: 455 functions (down from 463, baseline 464)
- [x] Saga validator/linter/circular detector unit tests pass
- [x] `NewConn` factory unit tests pass
- [x] Reference-data saga package compiles