### PR TITLE
feat: add non-fiat instruments and update seed script for multi-asset demo

### DIFF
--- a/internal/bootstrap/master_tenant_test.go
+++ b/internal/bootstrap/master_tenant_test.go
@@ -13,8 +13,8 @@ func TestLoadPlatformManifest(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, mf)
 
-	// Verify instruments (4 fiat + 1 commodity)
-	assert.Len(t, mf.Instruments, 5)
+	// Verify instruments (4 fiat + 4 commodity + 1 voucher)
+	assert.Len(t, mf.Instruments, 9)
 	codes := make([]string, len(mf.Instruments))
 	for i, inst := range mf.Instruments {
 		codes[i] = inst.Code
@@ -24,6 +24,10 @@ func TestLoadPlatformManifest(t *testing.T) {
 	assert.Contains(t, codes, "USD")
 	assert.Contains(t, codes, "NZD")
 	assert.Contains(t, codes, "ACTIVE_PARTY")
+	assert.Contains(t, codes, "KWH")
+	assert.Contains(t, codes, "TONNE_CO2E")
+	assert.Contains(t, codes, "GPU_HOUR")
+	assert.Contains(t, codes, "RICE_VOUCHER")
 
 	// Verify account types (3 standard + 3 platform billing)
 	assert.Len(t, mf.AccountTypes, 6)
@@ -38,8 +42,8 @@ func TestLoadPlatformManifest(t *testing.T) {
 	assert.Contains(t, acctCodes, "PLATFORM_RECEIVABLE")
 	assert.Contains(t, acctCodes, "PLATFORM_REVENUE")
 
-	// Verify valuation rules (3 FX + 1 usage pricing)
-	assert.Len(t, mf.ValuationRules, 4)
+	// Verify valuation rules (3 FX + 1 usage pricing + 4 non-fiat)
+	assert.Len(t, mf.ValuationRules, 8)
 
 	// Verify billing saga
 	assert.Len(t, mf.Sagas, 1)

--- a/internal/bootstrap/platform_manifest.json
+++ b/internal/bootstrap/platform_manifest.json
@@ -50,6 +50,42 @@
         "unit": "PARTY",
         "precision": 0
       }
+    },
+    {
+      "code": "KWH",
+      "name": "Kilowatt Hour",
+      "type": "INSTRUMENT_TYPE_COMMODITY",
+      "dimensions": {
+        "unit": "KWH",
+        "precision": 3
+      }
+    },
+    {
+      "code": "TONNE_CO2E",
+      "name": "Tonne of CO2 Equivalent",
+      "type": "INSTRUMENT_TYPE_COMMODITY",
+      "dimensions": {
+        "unit": "TONNE_CO2E",
+        "precision": 4
+      }
+    },
+    {
+      "code": "GPU_HOUR",
+      "name": "GPU Compute Hour",
+      "type": "INSTRUMENT_TYPE_COMMODITY",
+      "dimensions": {
+        "unit": "GPU_HOUR",
+        "precision": 6
+      }
+    },
+    {
+      "code": "RICE_VOUCHER",
+      "name": "Rice Distribution Voucher",
+      "type": "INSTRUMENT_TYPE_VOUCHER",
+      "dimensions": {
+        "unit": "RICE_VOUCHER",
+        "precision": 0
+      }
     }
   ],
   "accountTypes": [
@@ -132,6 +168,30 @@
       "toInstrument": "GBP",
       "method": "VALUATION_METHOD_FIXED",
       "source": "platform_pricing"
+    },
+    {
+      "fromInstrument": "KWH",
+      "toInstrument": "GBP",
+      "method": "VALUATION_METHOD_SPOT_RATE",
+      "source": "energy_market"
+    },
+    {
+      "fromInstrument": "TONNE_CO2E",
+      "toInstrument": "GBP",
+      "method": "VALUATION_METHOD_SPOT_RATE",
+      "source": "carbon_market"
+    },
+    {
+      "fromInstrument": "GPU_HOUR",
+      "toInstrument": "GBP",
+      "method": "VALUATION_METHOD_FIXED",
+      "source": "compute_pricing"
+    },
+    {
+      "fromInstrument": "RICE_VOUCHER",
+      "toInstrument": "GBP",
+      "method": "VALUATION_METHOD_FIXED",
+      "source": "voucher_pricing"
     }
   ],
   "sagas": [

--- a/scripts/demo-seed-data.sh
+++ b/scripts/demo-seed-data.sh
@@ -116,29 +116,16 @@ create_account_with_deposit() {
         metadata_args="-H x-tenant-id:${org_id}"
     fi
 
-    # Determine if this is a fiat currency (CURRENCY_ prefix) or non-fiat instrument
-    local is_fiat=false
-    local instrument_code="${instrument}"
-    if [[ "${instrument}" == CURRENCY_* ]]; then
-        is_fiat=true
-        instrument_code="${instrument#CURRENCY_}"
-    fi
+    # Strip CURRENCY_ prefix if present (legacy convention from fiat-only era)
+    local instrument_code="${instrument#CURRENCY_}"
 
     # Try to create account (will fail if exists - that's OK, idempotent)
-    local create_payload
-    if [ "$is_fiat" = true ]; then
-        create_payload="{
-            \"party_id\": \"${party_id}\",
-            \"account_identification\": \"${iban}\",
-            \"base_currency\": \"${instrument}\"
-        }"
-    else
-        create_payload="{
-            \"party_id\": \"${party_id}\",
-            \"account_identification\": \"${iban}\",
-            \"instrument_code\": \"${instrument_code}\"
-        }"
-    fi
+    # Proto field is instrument_code for all asset types (fiat and non-fiat)
+    local create_payload="{
+        \"party_id\": \"${party_id}\",
+        \"account_identification\": \"${iban}\",
+        \"instrument_code\": \"${instrument_code}\"
+    }"
 
     local create_result
     # shellcheck disable=SC2086 # metadata_args must word-split for grpcurl -H flag
@@ -171,32 +158,16 @@ create_account_with_deposit() {
             target_account_id="${account_id}"
         fi
 
-        # Build deposit payload - use input field for non-fiat, legacy amount for fiat
-        local deposit_payload
-        if [ "$is_fiat" = true ]; then
-            deposit_payload="{
-                \"account_id\": \"${target_account_id}\",
-                \"amount\": {
-                    \"amount\": {
-                        \"currency_code\": \"${instrument_code}\",
-                        \"units\": ${deposit_amount},
-                        \"nanos\": 0
-                    }
-                },
-                \"description\": \"${description}\",
-                \"reference\": \"DEMO-SEED-${org_id}-${RANDOM}\"
-            }"
-        else
-            deposit_payload="{
-                \"account_id\": \"${target_account_id}\",
-                \"input\": {
-                    \"amount\": \"${deposit_amount}\",
-                    \"instrument_code\": \"${instrument_code}\"
-                },
-                \"description\": \"${description}\",
-                \"reference\": \"DEMO-SEED-${org_id}-${RANDOM}\"
-            }"
-        fi
+        # Use input (InstrumentAmount) for all asset types - works for both fiat and non-fiat
+        local deposit_payload="{
+            \"account_id\": \"${target_account_id}\",
+            \"input\": {
+                \"amount\": \"${deposit_amount}\",
+                \"instrument_code\": \"${instrument_code}\"
+            },
+            \"description\": \"${description}\",
+            \"reference\": \"DEMO-SEED-${org_id}-${RANDOM}\"
+        }"
 
         local deposit_result
         # shellcheck disable=SC2086 # metadata_args must word-split for grpcurl -H flag

--- a/scripts/demo-seed-data.sh
+++ b/scripts/demo-seed-data.sh
@@ -3,8 +3,8 @@
 # Multi-Organization Demo - Seed Data
 # Creates demo accounts and balances for each organization:
 # 1. Post Office: 5 customer accounts with GBP balances
-# 2. Motive: 3 provider accounts with GPU-HOUR balances
-# 3. UN WFP: 10 beneficiary accounts with RICE-VOUCHER balances
+# 2. Motive: 3 provider accounts with GPU_HOUR balances (non-fiat commodity)
+# 3. UN WFP: 10 beneficiary accounts with RICE_VOUCHER balances (non-fiat voucher)
 # 4. Meridian: 1 treasury account for control plane (USD)
 #
 # Requires: grpcurl, jq, running Tilt cluster with Keycloak configured
@@ -97,12 +97,14 @@ wait_for_current_account() {
 }
 
 # Create account and deposit funds (idempotent via deterministic IDs)
+# For fiat currencies, pass instrument as "CURRENCY_GBP" etc.
+# For non-fiat instruments, pass the instrument code directly (e.g., "KWH", "GPU_HOUR").
 create_account_with_deposit() {
     local org_id=$1
     local account_id=$2
     local party_id=$3
     local iban=$4
-    local currency=$5
+    local instrument=$5
     local deposit_amount=$6
     local description=$7
 
@@ -114,15 +116,34 @@ create_account_with_deposit() {
         metadata_args="-H x-tenant-id:${org_id}"
     fi
 
+    # Determine if this is a fiat currency (CURRENCY_ prefix) or non-fiat instrument
+    local is_fiat=false
+    local instrument_code="${instrument}"
+    if [[ "${instrument}" == CURRENCY_* ]]; then
+        is_fiat=true
+        instrument_code="${instrument#CURRENCY_}"
+    fi
+
     # Try to create account (will fail if exists - that's OK, idempotent)
+    local create_payload
+    if [ "$is_fiat" = true ]; then
+        create_payload="{
+            \"party_id\": \"${party_id}\",
+            \"account_identification\": \"${iban}\",
+            \"base_currency\": \"${instrument}\"
+        }"
+    else
+        create_payload="{
+            \"party_id\": \"${party_id}\",
+            \"account_identification\": \"${iban}\",
+            \"instrument_code\": \"${instrument_code}\"
+        }"
+    fi
+
     local create_result
     # shellcheck disable=SC2086 # metadata_args must word-split for grpcurl -H flag
     create_result=$(grpcurl -plaintext ${metadata_args} \
-        -d "{
-            \"party_id\": \"${party_id}\",
-            \"account_identification\": \"${iban}\",
-            \"base_currency\": \"${currency}\"
-        }" \
+        -d "${create_payload}" \
         "${CURRENT_ACCOUNT_URL}" \
         meridian.current_account.v1.CurrentAccountService/InitiateCurrentAccount 2>&1) || true
 
@@ -137,39 +158,50 @@ create_account_with_deposit() {
         echo -e "${YELLOW}    ⚠ Account creation result: ${create_result}${NC}"
     fi
 
-    # Retrieve account to get its ID (in case it already existed)
-    # Note: This is a simplified flow - in production you'd query by IBAN
-    # For demo, we'll use a consistent ID pattern
-
     # Execute deposit
     if [ "$deposit_amount" -gt 0 ]; then
-        echo -e "${CYAN}  Depositing ${deposit_amount} ${currency}${NC}"
+        echo -e "${CYAN}  Depositing ${deposit_amount} ${instrument_code}${NC}"
 
         # Extract account_id from create response or use the IBAN-derived ID
         local target_account_id
         target_account_id=$(echo "$create_result" | jq -r '.account_id // .facility.account_id // empty' 2>/dev/null || echo "")
 
         if [ -z "$target_account_id" ]; then
-            # Account may already exist - try to find it by listing
             echo -e "${YELLOW}    Using account lookup by IBAN pattern...${NC}"
             target_account_id="${account_id}"
         fi
 
-        local deposit_result
-        # shellcheck disable=SC2086 # metadata_args must word-split for grpcurl -H flag
-        deposit_result=$(grpcurl -plaintext ${metadata_args} \
-            -d "{
+        # Build deposit payload - use input field for non-fiat, legacy amount for fiat
+        local deposit_payload
+        if [ "$is_fiat" = true ]; then
+            deposit_payload="{
                 \"account_id\": \"${target_account_id}\",
                 \"amount\": {
                     \"amount\": {
-                        \"currency_code\": \"${currency#CURRENCY_}\",
+                        \"currency_code\": \"${instrument_code}\",
                         \"units\": ${deposit_amount},
                         \"nanos\": 0
                     }
                 },
                 \"description\": \"${description}\",
                 \"reference\": \"DEMO-SEED-${org_id}-${RANDOM}\"
-            }" \
+            }"
+        else
+            deposit_payload="{
+                \"account_id\": \"${target_account_id}\",
+                \"input\": {
+                    \"amount\": \"${deposit_amount}\",
+                    \"instrument_code\": \"${instrument_code}\"
+                },
+                \"description\": \"${description}\",
+                \"reference\": \"DEMO-SEED-${org_id}-${RANDOM}\"
+            }"
+        fi
+
+        local deposit_result
+        # shellcheck disable=SC2086 # metadata_args must word-split for grpcurl -H flag
+        deposit_result=$(grpcurl -plaintext ${metadata_args} \
+            -d "${deposit_payload}" \
             "${CURRENT_ACCOUNT_URL}" \
             meridian.current_account.v1.CurrentAccountService/ExecuteDeposit 2>&1) || true
 
@@ -212,10 +244,10 @@ seed_post_office() {
     echo ""
 }
 
-# Seed Motive accounts (GPU-HOUR - mapped to USD for demo)
+# Seed Motive accounts (GPU_HOUR)
 seed_motive() {
     echo -e "${BLUE}═══════════════════════════════════════════════════════════════════${NC}"
-    echo -e "${BLUE}  Motive AI - Creating 3 Provider Accounts (GPU-HOUR → USD proxy)${NC}"
+    echo -e "${BLUE}  Motive AI - Creating 3 Provider Accounts (GPU_HOUR)${NC}"
     echo -e "${BLUE}═══════════════════════════════════════════════════════════════════${NC}"
     echo ""
 
@@ -226,26 +258,24 @@ seed_motive() {
         local party_id="MOT-PROV-$(printf '%05d' "$i")"
         local iban="GB82MOTI1234500000$(printf '%03d' "$i")"
 
-        # Note: GPU-HOUR is a non-standard currency, we use USD as proxy.
-        # In production, use actual asset codes from the Dynamic Asset Registry.
         create_account_with_deposit \
             "${org_id}" \
             "${acc_id}" \
             "${party_id}" \
             "${iban}" \
-            "CURRENCY_USD" \
+            "GPU_HOUR" \
             100 \
-            "Initial GPU-hour inventory for provider ${i} (100 GPU-hours)"
+            "Initial GPU compute inventory for provider ${i} (100 GPU-hours)"
     done
 
     echo -e "${GREEN}✓ Motive seeding complete: 3 accounts with 100 GPU-hours each${NC}"
     echo ""
 }
 
-# Seed UN WFP accounts (RICE-VOUCHER - mapped to USD for demo)
+# Seed UN WFP accounts (RICE_VOUCHER)
 seed_un_wfp() {
     echo -e "${BLUE}═══════════════════════════════════════════════════════════════════${NC}"
-    echo -e "${BLUE}  UN WFP - Creating 10 Beneficiary Accounts (RICE-VOUCHER → USD proxy)${NC}"
+    echo -e "${BLUE}  UN WFP - Creating 10 Beneficiary Accounts (RICE_VOUCHER)${NC}"
     echo -e "${BLUE}═══════════════════════════════════════════════════════════════════${NC}"
     echo ""
 
@@ -256,15 +286,13 @@ seed_un_wfp() {
         local party_id="WFP-BEN-$(printf '%05d' "$i")"
         local iban="GB82UNWF1234500000$(printf '%03d' "$i")"
 
-        # Note: RICE-VOUCHER is a non-standard currency, we use USD as proxy.
-        # In production, use actual asset codes from the Dynamic Asset Registry.
         # Balance of 1000 supports the cross-org settlement demo (500 voucher transaction).
         create_account_with_deposit \
             "${org_id}" \
             "${acc_id}" \
             "${party_id}" \
             "${iban}" \
-            "CURRENCY_USD" \
+            "RICE_VOUCHER" \
             1000 \
             "Initial rice voucher allocation for beneficiary ${i} (1000 vouchers)"
     done


### PR DESCRIPTION
## Summary
- Add KWH, TONNE_CO2E, GPU_HOUR (commodity) and RICE_VOUCHER (voucher) instrument definitions to the platform manifest with appropriate precision values and valuation rules
- Update demo seed script to create accounts using native non-fiat instrument codes instead of USD proxies, using the `input` (InstrumentAmount) field for non-fiat deposits
- Update manifest test to reflect new instrument and valuation rule counts

## Test plan
- [x] `TestLoadPlatformManifest` passes with updated instrument/valuation counts
- [x] `TestLoadPlatformManifest_ValidJSON` passes
- [x] `TestValidatePlatformManifest` passes
- [x] Shell script syntax validated (`bash -n`)
- [x] JSON validated (`jq .`)
- [ ] CI green