### PR TITLE
refactor: migrate client packages to shared gRPC client factory

### DIFF
--- a/services/current-account/client/client.go
+++ b/services/current-account/client/client.go
@@ -28,18 +28,15 @@ package client
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
-	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
 	"github.com/meridianhub/meridian/shared/pkg/validation"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
 
@@ -58,7 +55,7 @@ const (
 )
 
 // ErrTargetRequired is returned when neither Target nor ServiceName is provided.
-var ErrTargetRequired = errors.New("either Target or ServiceName must be provided")
+var ErrTargetRequired = clients.ErrConnTargetRequired
 
 // Config holds configuration for the CurrentAccount client.
 type Config struct {
@@ -122,7 +119,6 @@ type Client struct {
 //	}
 //	defer cleanup()
 func New(cfg Config) (*Client, func(), error) {
-	// Apply defaults
 	if cfg.Timeout == 0 {
 		cfg.Timeout = DefaultTimeout
 	}
@@ -133,81 +129,30 @@ func New(cfg Config) (*Client, func(), error) {
 		cfg.Namespace = DefaultNamespace
 	}
 
-	var conn *grpc.ClientConn
-	var err error
-
-	// Use platform gRPC factory when ServiceName is provided (preferred)
-	if cfg.ServiceName != "" {
-		dialOpts := cfg.DialOptions
-
-		// Add tracing interceptors if tracer is provided
-		// Use WithChainUnaryInterceptor/WithChainStreamInterceptor to properly chain
-		// multiple interceptors instead of overwriting them
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		// Use platform factory for DNS-based load balancing
-		conn, err = platformgrpc.NewClient(context.Background(), platformgrpc.ClientConfig{
-			ServiceName: cfg.ServiceName,
-			Namespace:   cfg.Namespace,
-			Port:        cfg.Port,
-			DialOptions: dialOpts,
-		})
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create current-account gRPC connection via platform factory: %w", err)
-		}
-	} else if cfg.Target != "" {
-		// Fallback to legacy direct connection for backward compatibility
-		dialOpts := cfg.DialOptions
-		if dialOpts == nil {
-			dialOpts = []grpc.DialOption{
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-			}
-		}
-
-		// Add tracing interceptors if tracer is provided
-		// Use WithChainUnaryInterceptor/WithChainStreamInterceptor to properly chain
-		// multiple interceptors instead of overwriting them
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		conn, err = grpc.NewClient(cfg.Target, dialOpts...)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create current-account gRPC connection to %s: %w", cfg.Target, err)
-		}
-	} else {
-		return nil, nil, ErrTargetRequired
+	conn, cleanup, err := clients.NewConn(context.Background(), clients.ConnConfig{
+		Target:      cfg.Target,
+		ServiceName: cfg.ServiceName,
+		Namespace:   cfg.Namespace,
+		Port:        cfg.Port,
+		Tracer:      cfg.Tracer,
+		DialOptions: cfg.DialOptions,
+	})
+	if err != nil {
+		return nil, nil, err
 	}
 
-	// Create resilient client if configuration is provided
 	var resilient *clients.ResilientClient
 	if cfg.Resilience != nil {
 		resilient = clients.NewResilientClient(*cfg.Resilience)
 	}
 
-	client := &Client{
+	return &Client{
 		conn:           conn,
 		currentAccount: currentaccountv1.NewCurrentAccountServiceClient(conn),
 		tracer:         cfg.Tracer,
 		resilient:      resilient,
 		timeout:        cfg.Timeout,
-	}
-
-	cleanup := func() {
-		if client.conn != nil {
-			_ = client.conn.Close()
-		}
-	}
-
-	return client, cleanup, nil
+	}, cleanup, nil
 }
 
 // InitiateCurrentAccount creates a new current account facility.

--- a/services/financial-accounting/client/client.go
+++ b/services/financial-accounting/client/client.go
@@ -27,16 +27,13 @@ package client
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
-	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 const (
@@ -54,7 +51,7 @@ const (
 )
 
 // ErrTargetRequired is returned when neither Target nor ServiceName is provided.
-var ErrTargetRequired = errors.New("either Target or ServiceName must be provided")
+var ErrTargetRequired = clients.ErrConnTargetRequired
 
 // Config holds configuration for the FinancialAccounting client.
 type Config struct {
@@ -118,7 +115,6 @@ type Client struct {
 //	}
 //	defer cleanup()
 func New(ctx context.Context, cfg Config) (*Client, func(), error) {
-	// Apply defaults
 	if cfg.Timeout == 0 {
 		cfg.Timeout = DefaultTimeout
 	}
@@ -129,81 +125,30 @@ func New(ctx context.Context, cfg Config) (*Client, func(), error) {
 		cfg.Namespace = DefaultNamespace
 	}
 
-	var conn *grpc.ClientConn
-	var err error
-
-	// Use platform gRPC factory when ServiceName is provided (preferred)
-	if cfg.ServiceName != "" {
-		dialOpts := cfg.DialOptions
-
-		// Add tracing interceptors if tracer is provided
-		// Use WithChainUnaryInterceptor/WithChainStreamInterceptor to properly chain
-		// multiple interceptors instead of overwriting them
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		// Use platform factory for DNS-based load balancing
-		conn, err = platformgrpc.NewClient(ctx, platformgrpc.ClientConfig{
-			ServiceName: cfg.ServiceName,
-			Namespace:   cfg.Namespace,
-			Port:        cfg.Port,
-			DialOptions: dialOpts,
-		})
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create financial-accounting gRPC connection via platform factory: %w", err)
-		}
-	} else if cfg.Target != "" {
-		// Fallback to legacy direct connection for backward compatibility
-		dialOpts := cfg.DialOptions
-		if dialOpts == nil {
-			dialOpts = []grpc.DialOption{
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-			}
-		}
-
-		// Add tracing interceptors if tracer is provided
-		// Use WithChainUnaryInterceptor/WithChainStreamInterceptor to properly chain
-		// multiple interceptors instead of overwriting them
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		conn, err = grpc.NewClient(cfg.Target, dialOpts...)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create financial-accounting gRPC connection to %s: %w", cfg.Target, err)
-		}
-	} else {
-		return nil, nil, ErrTargetRequired
+	conn, cleanup, err := clients.NewConn(ctx, clients.ConnConfig{
+		Target:      cfg.Target,
+		ServiceName: cfg.ServiceName,
+		Namespace:   cfg.Namespace,
+		Port:        cfg.Port,
+		Tracer:      cfg.Tracer,
+		DialOptions: cfg.DialOptions,
+	})
+	if err != nil {
+		return nil, nil, err
 	}
 
-	// Create resilient client if configuration is provided
 	var resilient *clients.ResilientClient
 	if cfg.Resilience != nil {
 		resilient = clients.NewResilientClient(*cfg.Resilience)
 	}
 
-	client := &Client{
+	return &Client{
 		conn:                conn,
 		financialAccounting: financialaccountingv1.NewFinancialAccountingServiceClient(conn),
 		tracer:              cfg.Tracer,
 		resilient:           resilient,
 		timeout:             cfg.Timeout,
-	}
-
-	cleanup := func() {
-		if client.conn != nil {
-			_ = client.conn.Close()
-		}
-	}
-
-	return client, cleanup, nil
+	}, cleanup, nil
 }
 
 // InitiateFinancialBookingLog creates a new financial booking log.

--- a/services/financial-gateway/client/client.go
+++ b/services/financial-gateway/client/client.go
@@ -27,16 +27,13 @@ package client
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	financialgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_gateway/v1"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
-	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 const (
@@ -54,7 +51,7 @@ const (
 )
 
 // ErrTargetRequired is returned when neither Target nor ServiceName is provided.
-var ErrTargetRequired = errors.New("either Target or ServiceName must be provided")
+var ErrTargetRequired = clients.ErrConnTargetRequired
 
 // Config holds configuration for the FinancialGateway client.
 type Config struct {
@@ -106,7 +103,6 @@ type Client struct {
 // Returns the client, a cleanup function to close the connection, and any error.
 // The cleanup function should be deferred immediately after checking the error.
 func New(cfg Config) (*Client, func(), error) {
-	// Apply defaults
 	if cfg.Timeout == 0 {
 		cfg.Timeout = DefaultTimeout
 	}
@@ -117,73 +113,30 @@ func New(cfg Config) (*Client, func(), error) {
 		cfg.Namespace = DefaultNamespace
 	}
 
-	var conn *grpc.ClientConn
-	var err error
-
-	// Use platform gRPC factory when ServiceName is provided (preferred)
-	if cfg.ServiceName != "" {
-		dialOpts := cfg.DialOptions
-
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		conn, err = platformgrpc.NewClient(context.Background(), platformgrpc.ClientConfig{
-			ServiceName: cfg.ServiceName,
-			Namespace:   cfg.Namespace,
-			Port:        cfg.Port,
-			DialOptions: dialOpts,
-		})
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create financial-gateway gRPC connection via platform factory: %w", err)
-		}
-	} else if cfg.Target != "" {
-		dialOpts := cfg.DialOptions
-		if dialOpts == nil {
-			dialOpts = []grpc.DialOption{
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-			}
-		}
-
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		conn, err = grpc.NewClient(cfg.Target, dialOpts...)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create financial-gateway gRPC connection to %s: %w", cfg.Target, err)
-		}
-	} else {
-		return nil, nil, ErrTargetRequired
+	conn, cleanup, err := clients.NewConn(context.Background(), clients.ConnConfig{
+		Target:      cfg.Target,
+		ServiceName: cfg.ServiceName,
+		Namespace:   cfg.Namespace,
+		Port:        cfg.Port,
+		Tracer:      cfg.Tracer,
+		DialOptions: cfg.DialOptions,
+	})
+	if err != nil {
+		return nil, nil, err
 	}
 
-	// Create resilient client if configuration is provided
 	var resilient *clients.ResilientClient
 	if cfg.Resilience != nil {
 		resilient = clients.NewResilientClient(*cfg.Resilience)
 	}
 
-	c := &Client{
+	return &Client{
 		conn:             conn,
 		financialGateway: financialgatewayv1.NewFinancialGatewayServiceClient(conn),
 		tracer:           cfg.Tracer,
 		resilient:        resilient,
 		timeout:          cfg.Timeout,
-	}
-
-	cleanup := func() {
-		if c.conn != nil {
-			_ = c.conn.Close()
-		}
-	}
-
-	return c, cleanup, nil
+	}, cleanup, nil
 }
 
 // DispatchPayment submits a payment for outbound dispatch via a payment rail.

--- a/services/internal-account/client/client.go
+++ b/services/internal-account/client/client.go
@@ -29,18 +29,15 @@ package client
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	internalaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_account/v1"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
-	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
 	"github.com/meridianhub/meridian/shared/pkg/validation"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
 
@@ -59,7 +56,7 @@ const (
 )
 
 // ErrTargetRequired is returned when neither Target nor ServiceName is provided.
-var ErrTargetRequired = errors.New("either Target or ServiceName must be provided")
+var ErrTargetRequired = clients.ErrConnTargetRequired
 
 // Config holds configuration for the InternalAccount client.
 type Config struct {
@@ -123,7 +120,6 @@ type Client struct {
 //	}
 //	defer cleanup()
 func New(cfg Config) (*Client, func(), error) {
-	// Apply defaults
 	if cfg.Timeout == 0 {
 		cfg.Timeout = DefaultTimeout
 	}
@@ -134,81 +130,30 @@ func New(cfg Config) (*Client, func(), error) {
 		cfg.Namespace = DefaultNamespace
 	}
 
-	var conn *grpc.ClientConn
-	var err error
-
-	// Use platform gRPC factory when ServiceName is provided (preferred)
-	if cfg.ServiceName != "" {
-		dialOpts := cfg.DialOptions
-
-		// Add tracing interceptors if tracer is provided
-		// Use WithChainUnaryInterceptor/WithChainStreamInterceptor to properly chain
-		// multiple interceptors instead of overwriting them
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		// Use platform factory for DNS-based load balancing
-		conn, err = platformgrpc.NewClient(context.Background(), platformgrpc.ClientConfig{
-			ServiceName: cfg.ServiceName,
-			Namespace:   cfg.Namespace,
-			Port:        cfg.Port,
-			DialOptions: dialOpts,
-		})
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create internal-account gRPC connection via platform factory: %w", err)
-		}
-	} else if cfg.Target != "" {
-		// Fallback to legacy direct connection for backward compatibility
-		dialOpts := cfg.DialOptions
-		if dialOpts == nil {
-			dialOpts = []grpc.DialOption{
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-			}
-		}
-
-		// Add tracing interceptors if tracer is provided
-		// Use WithChainUnaryInterceptor/WithChainStreamInterceptor to properly chain
-		// multiple interceptors instead of overwriting them
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		conn, err = grpc.NewClient(cfg.Target, dialOpts...)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create internal-account gRPC connection to %s: %w", cfg.Target, err)
-		}
-	} else {
-		return nil, nil, ErrTargetRequired
+	conn, cleanup, err := clients.NewConn(context.Background(), clients.ConnConfig{
+		Target:      cfg.Target,
+		ServiceName: cfg.ServiceName,
+		Namespace:   cfg.Namespace,
+		Port:        cfg.Port,
+		Tracer:      cfg.Tracer,
+		DialOptions: cfg.DialOptions,
+	})
+	if err != nil {
+		return nil, nil, err
 	}
 
-	// Create resilient client if configuration is provided
 	var resilient *clients.ResilientClient
 	if cfg.Resilience != nil {
 		resilient = clients.NewResilientClient(*cfg.Resilience)
 	}
 
-	client := &Client{
+	return &Client{
 		conn:            conn,
 		internalAccount: internalaccountv1.NewInternalAccountServiceClient(conn),
 		tracer:          cfg.Tracer,
 		resilient:       resilient,
 		timeout:         cfg.Timeout,
-	}
-
-	cleanup := func() {
-		if client.conn != nil {
-			_ = client.conn.Close()
-		}
-	}
-
-	return client, cleanup, nil
+	}, cleanup, nil
 }
 
 // Close terminates the gRPC connection gracefully.

--- a/services/market-information/client/client.go
+++ b/services/market-information/client/client.go
@@ -37,12 +37,10 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
-	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 )
 
@@ -99,7 +97,7 @@ type Config struct {
 }
 
 // ErrTargetRequired is returned when neither Target nor ServiceName is provided.
-var ErrTargetRequired = errors.New("either Target or ServiceName must be provided")
+var ErrTargetRequired = clients.ErrConnTargetRequired
 
 // ErrObservationNotFound is returned when no observation matches the query criteria.
 var ErrObservationNotFound = errors.New("observation not found")
@@ -139,12 +137,17 @@ func (cfg *Config) applyDefaults() {
 func New(ctx context.Context, cfg Config) (*Client, func() error, error) {
 	cfg.applyDefaults()
 
-	conn, err := createGRPCConnection(ctx, cfg)
+	conn, _, err := clients.NewConn(ctx, clients.ConnConfig{
+		Target:      cfg.Target,
+		ServiceName: cfg.ServiceName,
+		Namespace:   cfg.Namespace,
+		Port:        cfg.Port,
+		Tracer:      cfg.Tracer,
+		DialOptions: cfg.DialOptions,
+	})
 	if err != nil {
 		return nil, nil, err
 	}
-
-	grpcClient := marketinformationv1.NewMarketInformationServiceClient(conn)
 
 	var resilient *clients.ResilientClient
 	if cfg.Resilience != nil {
@@ -153,72 +156,13 @@ func New(ctx context.Context, cfg Config) (*Client, func() error, error) {
 
 	client := &Client{
 		conn:       conn,
-		grpcClient: grpcClient,
+		grpcClient: marketinformationv1.NewMarketInformationServiceClient(conn),
 		tracer:     cfg.Tracer,
 		resilient:  resilient,
 		timeout:    cfg.Timeout,
 	}
 
 	return client, client.Close, nil
-}
-
-// createGRPCConnection creates the gRPC connection based on configuration.
-func createGRPCConnection(ctx context.Context, cfg Config) (*grpc.ClientConn, error) {
-	// Use platform gRPC factory when ServiceName is provided (preferred)
-	if cfg.ServiceName != "" {
-		// Copy dial options to avoid mutating caller's slice
-		dialOpts := make([]grpc.DialOption, len(cfg.DialOptions))
-		copy(dialOpts, cfg.DialOptions)
-
-		// Add tracing interceptors if tracer is provided
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		conn, err := platformgrpc.NewClient(ctx, platformgrpc.ClientConfig{
-			ServiceName: cfg.ServiceName,
-			Namespace:   cfg.Namespace,
-			Port:        cfg.Port,
-			DialOptions: dialOpts,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("create grpc connection via platform factory: %w", err)
-		}
-		return conn, nil
-	}
-
-	if cfg.Target != "" {
-		// Fallback to legacy direct connection
-		// Copy dial options to avoid mutating caller's slice
-		var dialOpts []grpc.DialOption
-		if cfg.DialOptions != nil {
-			dialOpts = make([]grpc.DialOption, len(cfg.DialOptions))
-			copy(dialOpts, cfg.DialOptions)
-		} else {
-			dialOpts = []grpc.DialOption{
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-			}
-		}
-
-		// Add tracing interceptors if tracer is provided
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		conn, err := grpc.NewClient(cfg.Target, dialOpts...)
-		if err != nil {
-			return nil, fmt.Errorf("create grpc connection to %s: %w", cfg.Target, err)
-		}
-		return conn, nil
-	}
-
-	return nil, ErrTargetRequired
 }
 
 // GetRate retrieves a market rate observation for a specific dataset and resolution key

--- a/services/operational-gateway/client/client.go
+++ b/services/operational-gateway/client/client.go
@@ -26,16 +26,13 @@ package client
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
-	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 const (
@@ -53,7 +50,7 @@ const (
 )
 
 // ErrTargetRequired is returned when neither Target nor ServiceName is provided.
-var ErrTargetRequired = errors.New("either Target or ServiceName must be provided")
+var ErrTargetRequired = clients.ErrConnTargetRequired
 
 // Config holds configuration for the OperationalGateway client.
 type Config struct {
@@ -103,7 +100,6 @@ type Client struct {
 // Returns the client, a cleanup function to close the connection, and any error.
 // The cleanup function should be deferred immediately after checking the error.
 func New(cfg Config) (*Client, func(), error) {
-	// Apply defaults
 	if cfg.Timeout == 0 {
 		cfg.Timeout = DefaultTimeout
 	}
@@ -114,49 +110,16 @@ func New(cfg Config) (*Client, func(), error) {
 		cfg.Namespace = DefaultNamespace
 	}
 
-	var conn *grpc.ClientConn
-	var err error
-
-	if cfg.ServiceName != "" {
-		dialOpts := cfg.DialOptions
-
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		conn, err = platformgrpc.NewClient(context.Background(), platformgrpc.ClientConfig{
-			ServiceName: cfg.ServiceName,
-			Namespace:   cfg.Namespace,
-			Port:        cfg.Port,
-			DialOptions: dialOpts,
-		})
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create operational-gateway gRPC connection via platform factory: %w", err)
-		}
-	} else if cfg.Target != "" {
-		dialOpts := cfg.DialOptions
-		if len(dialOpts) == 0 {
-			dialOpts = []grpc.DialOption{
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-			}
-		}
-
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		conn, err = grpc.NewClient(cfg.Target, dialOpts...)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create operational-gateway gRPC connection to %s: %w", cfg.Target, err)
-		}
-	} else {
-		return nil, nil, ErrTargetRequired
+	conn, cleanup, err := clients.NewConn(context.Background(), clients.ConnConfig{
+		Target:      cfg.Target,
+		ServiceName: cfg.ServiceName,
+		Namespace:   cfg.Namespace,
+		Port:        cfg.Port,
+		Tracer:      cfg.Tracer,
+		DialOptions: cfg.DialOptions,
+	})
+	if err != nil {
+		return nil, nil, err
 	}
 
 	var resilient *clients.ResilientClient
@@ -164,21 +127,13 @@ func New(cfg Config) (*Client, func(), error) {
 		resilient = clients.NewResilientClient(*cfg.Resilience)
 	}
 
-	c := &Client{
+	return &Client{
 		conn:               conn,
 		operationalGateway: opgatewayv1.NewOperationalGatewayServiceClient(conn),
 		tracer:             cfg.Tracer,
 		resilient:          resilient,
 		timeout:            cfg.Timeout,
-	}
-
-	cleanup := func() {
-		if c.conn != nil {
-			_ = c.conn.Close()
-		}
-	}
-
-	return c, cleanup, nil
+	}, cleanup, nil
 }
 
 // DispatchInstruction submits a new instruction for outbound dispatch.

--- a/services/party/client/client.go
+++ b/services/party/client/client.go
@@ -27,16 +27,13 @@ package client
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
-	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 const (
@@ -54,7 +51,7 @@ const (
 )
 
 // ErrTargetRequired is returned when neither Target nor ServiceName is provided.
-var ErrTargetRequired = errors.New("either Target or ServiceName must be provided")
+var ErrTargetRequired = clients.ErrConnTargetRequired
 
 // Config holds configuration for the Party client.
 type Config struct {
@@ -118,7 +115,6 @@ type Client struct {
 //	}
 //	defer cleanup()
 func New(ctx context.Context, cfg Config) (*Client, func(), error) {
-	// Apply defaults
 	if cfg.Timeout == 0 {
 		cfg.Timeout = DefaultTimeout
 	}
@@ -129,81 +125,30 @@ func New(ctx context.Context, cfg Config) (*Client, func(), error) {
 		cfg.Namespace = DefaultNamespace
 	}
 
-	var conn *grpc.ClientConn
-	var err error
-
-	// Use platform gRPC factory when ServiceName is provided (preferred)
-	if cfg.ServiceName != "" {
-		dialOpts := cfg.DialOptions
-
-		// Add tracing interceptors if tracer is provided
-		// Use WithChainUnaryInterceptor/WithChainStreamInterceptor to properly chain
-		// multiple interceptors instead of overwriting them
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		// Use platform factory for DNS-based load balancing
-		conn, err = platformgrpc.NewClient(ctx, platformgrpc.ClientConfig{
-			ServiceName: cfg.ServiceName,
-			Namespace:   cfg.Namespace,
-			Port:        cfg.Port,
-			DialOptions: dialOpts,
-		})
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create party gRPC connection via platform factory: %w", err)
-		}
-	} else if cfg.Target != "" {
-		// Fallback to legacy direct connection for backward compatibility
-		dialOpts := cfg.DialOptions
-		if dialOpts == nil {
-			dialOpts = []grpc.DialOption{
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-			}
-		}
-
-		// Add tracing interceptors if tracer is provided
-		// Use WithChainUnaryInterceptor/WithChainStreamInterceptor to properly chain
-		// multiple interceptors instead of overwriting them
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		conn, err = grpc.NewClient(cfg.Target, dialOpts...)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create party gRPC connection to %s: %w", cfg.Target, err)
-		}
-	} else {
-		return nil, nil, ErrTargetRequired
+	conn, cleanup, err := clients.NewConn(ctx, clients.ConnConfig{
+		Target:      cfg.Target,
+		ServiceName: cfg.ServiceName,
+		Namespace:   cfg.Namespace,
+		Port:        cfg.Port,
+		Tracer:      cfg.Tracer,
+		DialOptions: cfg.DialOptions,
+	})
+	if err != nil {
+		return nil, nil, err
 	}
 
-	// Create resilient client if configuration is provided
 	var resilient *clients.ResilientClient
 	if cfg.Resilience != nil {
 		resilient = clients.NewResilientClient(*cfg.Resilience)
 	}
 
-	client := &Client{
+	return &Client{
 		conn:      conn,
 		party:     partyv1.NewPartyServiceClient(conn),
 		tracer:    cfg.Tracer,
 		resilient: resilient,
 		timeout:   cfg.Timeout,
-	}
-
-	cleanup := func() {
-		if client.conn != nil {
-			_ = client.conn.Close()
-		}
-	}
-
-	return client, cleanup, nil
+	}, cleanup, nil
 }
 
 // RegisterParty creates a new party in the reference data directory.

--- a/services/position-keeping/client/client.go
+++ b/services/position-keeping/client/client.go
@@ -28,16 +28,13 @@ package client
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
-	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 const (
@@ -55,7 +52,7 @@ const (
 )
 
 // ErrTargetRequired is returned when neither Target nor ServiceName is provided.
-var ErrTargetRequired = errors.New("either Target or ServiceName must be provided")
+var ErrTargetRequired = clients.ErrConnTargetRequired
 
 // Config holds configuration for the PositionKeeping client.
 type Config struct {
@@ -119,7 +116,6 @@ type Client struct {
 //	}
 //	defer cleanup()
 func New(ctx context.Context, cfg Config) (*Client, func(), error) {
-	// Apply defaults
 	if cfg.Timeout == 0 {
 		cfg.Timeout = DefaultTimeout
 	}
@@ -130,81 +126,30 @@ func New(ctx context.Context, cfg Config) (*Client, func(), error) {
 		cfg.Namespace = DefaultNamespace
 	}
 
-	var conn *grpc.ClientConn
-	var err error
-
-	// Use platform gRPC factory when ServiceName is provided (preferred)
-	if cfg.ServiceName != "" {
-		dialOpts := cfg.DialOptions
-
-		// Add tracing interceptors if tracer is provided
-		// Use WithChainUnaryInterceptor/WithChainStreamInterceptor to properly chain
-		// multiple interceptors instead of overwriting them
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		// Use platform factory for DNS-based load balancing
-		conn, err = platformgrpc.NewClient(ctx, platformgrpc.ClientConfig{
-			ServiceName: cfg.ServiceName,
-			Namespace:   cfg.Namespace,
-			Port:        cfg.Port,
-			DialOptions: dialOpts,
-		})
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create position-keeping gRPC connection via platform factory: %w", err)
-		}
-	} else if cfg.Target != "" {
-		// Fallback to legacy direct connection for backward compatibility
-		dialOpts := cfg.DialOptions
-		if dialOpts == nil {
-			dialOpts = []grpc.DialOption{
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-			}
-		}
-
-		// Add tracing interceptors if tracer is provided
-		// Use WithChainUnaryInterceptor/WithChainStreamInterceptor to properly chain
-		// multiple interceptors instead of overwriting them
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		conn, err = grpc.NewClient(cfg.Target, dialOpts...)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create position-keeping gRPC connection to %s: %w", cfg.Target, err)
-		}
-	} else {
-		return nil, nil, ErrTargetRequired
+	conn, cleanup, err := clients.NewConn(ctx, clients.ConnConfig{
+		Target:      cfg.Target,
+		ServiceName: cfg.ServiceName,
+		Namespace:   cfg.Namespace,
+		Port:        cfg.Port,
+		Tracer:      cfg.Tracer,
+		DialOptions: cfg.DialOptions,
+	})
+	if err != nil {
+		return nil, nil, err
 	}
 
-	// Create resilient client if configuration is provided
 	var resilient *clients.ResilientClient
 	if cfg.Resilience != nil {
 		resilient = clients.NewResilientClient(*cfg.Resilience)
 	}
 
-	client := &Client{
+	return &Client{
 		conn:            conn,
 		positionKeeping: positionkeepingv1.NewPositionKeepingServiceClient(conn),
 		tracer:          cfg.Tracer,
 		resilient:       resilient,
 		timeout:         cfg.Timeout,
-	}
-
-	cleanup := func() {
-		if client.conn != nil {
-			_ = client.conn.Close()
-		}
-	}
-
-	return client, cleanup, nil
+	}, cleanup, nil
 }
 
 // InitiateFinancialPositionLog creates a new financial position log.

--- a/services/reconciliation/client/client.go
+++ b/services/reconciliation/client/client.go
@@ -27,16 +27,13 @@ package client
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
-	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 const (
@@ -54,7 +51,7 @@ const (
 )
 
 // ErrTargetRequired is returned when neither Target nor ServiceName is provided.
-var ErrTargetRequired = errors.New("either Target or ServiceName must be provided")
+var ErrTargetRequired = clients.ErrConnTargetRequired
 
 // Config holds configuration for the AccountReconciliation client.
 type Config struct {
@@ -112,47 +109,16 @@ func New(cfg Config) (*Client, func(), error) {
 		cfg.Namespace = DefaultNamespace
 	}
 
-	var conn *grpc.ClientConn
-	var err error
-
-	if cfg.ServiceName != "" {
-		dialOpts := cfg.DialOptions
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		conn, err = platformgrpc.NewClient(context.Background(), platformgrpc.ClientConfig{
-			ServiceName: cfg.ServiceName,
-			Namespace:   cfg.Namespace,
-			Port:        cfg.Port,
-			DialOptions: dialOpts,
-		})
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create reconciliation gRPC connection via platform factory: %w", err)
-		}
-	} else if cfg.Target != "" {
-		dialOpts := cfg.DialOptions
-		if dialOpts == nil {
-			dialOpts = []grpc.DialOption{
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-			}
-		}
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		conn, err = grpc.NewClient(cfg.Target, dialOpts...)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create reconciliation gRPC connection to %s: %w", cfg.Target, err)
-		}
-	} else {
-		return nil, nil, ErrTargetRequired
+	conn, cleanup, err := clients.NewConn(context.Background(), clients.ConnConfig{
+		Target:      cfg.Target,
+		ServiceName: cfg.ServiceName,
+		Namespace:   cfg.Namespace,
+		Port:        cfg.Port,
+		Tracer:      cfg.Tracer,
+		DialOptions: cfg.DialOptions,
+	})
+	if err != nil {
+		return nil, nil, err
 	}
 
 	var resilient *clients.ResilientClient
@@ -160,21 +126,13 @@ func New(cfg Config) (*Client, func(), error) {
 		resilient = clients.NewResilientClient(*cfg.Resilience)
 	}
 
-	client := &Client{
+	return &Client{
 		conn:           conn,
 		reconciliation: reconciliationv1.NewAccountReconciliationServiceClient(conn),
 		tracer:         cfg.Tracer,
 		resilient:      resilient,
 		timeout:        cfg.Timeout,
-	}
-
-	cleanup := func() {
-		if client.conn != nil {
-			_ = client.conn.Close()
-		}
-	}
-
-	return client, cleanup, nil
+	}, cleanup, nil
 }
 
 // InitiateAccountReconciliation creates a new settlement run.

--- a/services/reference-data/client/client.go
+++ b/services/reference-data/client/client.go
@@ -36,13 +36,11 @@ import (
 
 	"github.com/redis/go-redis/v9"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
 	"github.com/meridianhub/meridian/services/reference-data/cache"
 	refcel "github.com/meridianhub/meridian/services/reference-data/cel"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
-	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 )
 
@@ -132,7 +130,7 @@ type Config struct {
 }
 
 // ErrTargetRequired is returned when neither Target nor ServiceName is provided.
-var ErrTargetRequired = errors.New("either Target or ServiceName must be provided")
+var ErrTargetRequired = clients.ErrConnTargetRequired
 
 // Client provides access to the Reference Data service with tiered caching.
 type Client struct {
@@ -212,7 +210,14 @@ func createL2Cache(ctx context.Context, cfg Config) (cache.L2Cache, *redis.Clien
 func New(ctx context.Context, cfg Config) (*Client, func() error, error) {
 	cfg.applyDefaults()
 
-	conn, err := createGRPCConnection(ctx, cfg)
+	conn, _, err := clients.NewConn(ctx, clients.ConnConfig{
+		Target:      cfg.Target,
+		ServiceName: cfg.ServiceName,
+		Namespace:   cfg.Namespace,
+		Port:        cfg.Port,
+		Tracer:      cfg.Tracer,
+		DialOptions: cfg.DialOptions,
+	})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -273,59 +278,6 @@ func New(ctx context.Context, cfg Config) (*Client, func() error, error) {
 	}
 
 	return client, cleanup, nil
-}
-
-// createGRPCConnection creates the gRPC connection based on configuration.
-func createGRPCConnection(ctx context.Context, cfg Config) (*grpc.ClientConn, error) {
-	// Use platform gRPC factory when ServiceName is provided (preferred)
-	if cfg.ServiceName != "" {
-		dialOpts := cfg.DialOptions
-
-		// Add tracing interceptors if tracer is provided
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		conn, err := platformgrpc.NewClient(ctx, platformgrpc.ClientConfig{
-			ServiceName: cfg.ServiceName,
-			Namespace:   cfg.Namespace,
-			Port:        cfg.Port,
-			DialOptions: dialOpts,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("create grpc connection via platform factory: %w", err)
-		}
-		return conn, nil
-	}
-
-	if cfg.Target != "" {
-		// Fallback to legacy direct connection
-		dialOpts := cfg.DialOptions
-		if dialOpts == nil {
-			dialOpts = []grpc.DialOption{
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-			}
-		}
-
-		// Add tracing interceptors if tracer is provided
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		conn, err := grpc.NewClient(cfg.Target, dialOpts...)
-		if err != nil {
-			return nil, fmt.Errorf("create grpc connection to %s: %w", cfg.Target, err)
-		}
-		return conn, nil
-	}
-
-	return nil, ErrTargetRequired
 }
 
 // GetInstrument retrieves an instrument with compiled CEL programs.

--- a/services/tenant/client/client.go
+++ b/services/tenant/client/client.go
@@ -28,16 +28,13 @@ package client
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	tenantv1 "github.com/meridianhub/meridian/api/proto/meridian/tenant/v1"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
-	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 const (
@@ -55,7 +52,7 @@ const (
 )
 
 // ErrTargetRequired is returned when neither Target nor ServiceName is provided.
-var ErrTargetRequired = errors.New("either Target or ServiceName must be provided")
+var ErrTargetRequired = clients.ErrConnTargetRequired
 
 // Config holds configuration for the Tenant client.
 type Config struct {
@@ -119,7 +116,6 @@ type Client struct {
 //	}
 //	defer cleanup()
 func New(cfg Config) (*Client, func(), error) {
-	// Apply defaults
 	if cfg.Timeout == 0 {
 		cfg.Timeout = DefaultTimeout
 	}
@@ -130,81 +126,30 @@ func New(cfg Config) (*Client, func(), error) {
 		cfg.Namespace = DefaultNamespace
 	}
 
-	var conn *grpc.ClientConn
-	var err error
-
-	// Use platform gRPC factory when ServiceName is provided (preferred)
-	if cfg.ServiceName != "" {
-		dialOpts := cfg.DialOptions
-
-		// Add tracing interceptors if tracer is provided
-		// Use WithChainUnaryInterceptor/WithChainStreamInterceptor to properly chain
-		// multiple interceptors instead of overwriting them
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		// Use platform factory for DNS-based load balancing
-		conn, err = platformgrpc.NewClient(context.Background(), platformgrpc.ClientConfig{
-			ServiceName: cfg.ServiceName,
-			Namespace:   cfg.Namespace,
-			Port:        cfg.Port,
-			DialOptions: dialOpts,
-		})
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create tenant gRPC connection via platform factory: %w", err)
-		}
-	} else if cfg.Target != "" {
-		// Fallback to legacy direct connection for backward compatibility
-		dialOpts := cfg.DialOptions
-		if dialOpts == nil {
-			dialOpts = []grpc.DialOption{
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-			}
-		}
-
-		// Add tracing interceptors if tracer is provided
-		// Use WithChainUnaryInterceptor/WithChainStreamInterceptor to properly chain
-		// multiple interceptors instead of overwriting them
-		if cfg.Tracer != nil {
-			dialOpts = append(dialOpts,
-				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
-				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
-			)
-		}
-
-		conn, err = grpc.NewClient(cfg.Target, dialOpts...)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create tenant gRPC connection to %s: %w", cfg.Target, err)
-		}
-	} else {
-		return nil, nil, ErrTargetRequired
+	conn, cleanup, err := clients.NewConn(context.Background(), clients.ConnConfig{
+		Target:      cfg.Target,
+		ServiceName: cfg.ServiceName,
+		Namespace:   cfg.Namespace,
+		Port:        cfg.Port,
+		Tracer:      cfg.Tracer,
+		DialOptions: cfg.DialOptions,
+	})
+	if err != nil {
+		return nil, nil, err
 	}
 
-	// Create resilient client if configuration is provided
 	var resilient *clients.ResilientClient
 	if cfg.Resilience != nil {
 		resilient = clients.NewResilientClient(*cfg.Resilience)
 	}
 
-	client := &Client{
+	return &Client{
 		conn:      conn,
 		tenant:    tenantv1.NewTenantServiceClient(conn),
 		tracer:    cfg.Tracer,
 		resilient: resilient,
 		timeout:   cfg.Timeout,
-	}
-
-	cleanup := func() {
-		if client.conn != nil {
-			_ = client.conn.Close()
-		}
-	}
-
-	return client, cleanup, nil
+	}, cleanup, nil
 }
 
 // InitiateTenant creates a new tenant in the platform registry (BIAN: Initiate).


### PR DESCRIPTION
## Summary
- Migrate all 11 service client packages to use `shared/pkg/clients.NewConn()` for gRPC connection setup
- Remove ~570 lines of duplicated connection boilerplate (DNS discovery, direct connections, tracing interceptors)
- Each client's `ErrTargetRequired` now aliases `clients.ErrConnTargetRequired` for backward compatibility

## Services migrated
current-account, financial-accounting, internal-account, party, position-keeping, tenant, reconciliation, market-information, operational-gateway, financial-gateway, reference-data

## Test plan
- [x] All 11 client package tests pass locally
- [x] Architecture function size test passes (457 -> 448 oversized functions)
- [ ] CI green