### PR TITLE
refactor: extract remaining run() functions to container pattern

### DIFF
--- a/services/current-account/app/container.go
+++ b/services/current-account/app/container.go
@@ -1,0 +1,295 @@
+// Package app provides application configuration and dependency injection for the current-account service.
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/redis/go-redis/v9"
+	"gorm.io/gorm"
+
+	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
+	currentaccountclient "github.com/meridianhub/meridian/services/current-account/client"
+	"github.com/meridianhub/meridian/services/current-account/config"
+	caobservability "github.com/meridianhub/meridian/services/current-account/observability"
+	"github.com/meridianhub/meridian/services/current-account/service"
+	"github.com/meridianhub/meridian/shared/pkg/idempotency"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/meridianhub/meridian/shared/platform/bootstrap"
+	"github.com/meridianhub/meridian/shared/platform/defaults"
+	"github.com/meridianhub/meridian/shared/platform/env"
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"github.com/meridianhub/meridian/shared/platform/observability"
+	"github.com/meridianhub/meridian/shared/platform/ports"
+)
+
+// ErrContainerCloseFailures is returned when one or more resources fail to close.
+var ErrContainerCloseFailures = errors.New("container close encountered failures")
+
+// ErrRedisRequiredInProduction is returned when Redis is unavailable in production environments.
+var ErrRedisRequiredInProduction = errors.New("redis required for idempotency in production environment")
+
+// Container holds all application dependencies for the current-account service.
+// It manages the lifecycle of infrastructure, repositories, external clients, and
+// background workers, providing a clean separation between wiring and business logic.
+type Container struct {
+	Logger *slog.Logger
+
+	// Infrastructure
+	Tracer          *observability.Tracer
+	DB              *gorm.DB
+	RedisClient     *redis.Client
+	AuthInterceptor *auth.Interceptor
+
+	// Repositories
+	AccountRepo    *persistence.Repository
+	LienRepo       *persistence.LienRepository
+	WithdrawalRepo *persistence.WithdrawalRepository
+	OutboxRepo     *events.PostgresOutboxRepository
+
+	// Idempotency
+	IdempotencyService idempotency.Service
+
+	// Starlark
+	HandlerRegistry *saga.HandlerRegistry
+
+	// Service
+	Service *service.Service
+
+	// BootstrapServers is the Kafka bootstrap servers string, exposed so that
+	// run() can decide whether to create the outbox worker and event consumer.
+	BootstrapServers string
+
+	// UsingNoopIdempotency tracks whether the service is running with degraded
+	// idempotency (noop) for health reporting.
+	UsingNoopIdempotency bool
+
+	// cleanups accumulates cleanup functions from external client connections.
+	cleanups []func()
+}
+
+// NewContainer creates and initializes a new dependency injection container.
+// It initializes infrastructure, repositories, external clients, and auth in
+// dependency order. The caller is responsible for calling Close when the
+// container is no longer needed.
+func NewContainer(ctx context.Context, logger *slog.Logger, version string) (*Container, error) {
+	c := &Container{
+		Logger: logger,
+	}
+
+	// If initialization fails partway, close already-initialized resources.
+	succeeded := false
+	defer func() { //nolint:contextcheck // Close manages its own shutdown contexts
+		if !succeeded {
+			c.Close()
+		}
+	}()
+
+	if err := c.initTracer(ctx, version); err != nil {
+		return nil, err
+	}
+
+	if err := c.initDatabase(ctx); err != nil {
+		return nil, err
+	}
+
+	c.initRepositories()
+
+	if err := c.initRedis(ctx); err != nil {
+		return nil, err
+	}
+
+	if err := c.initServiceClients(ctx); err != nil {
+		return nil, err
+	}
+
+	if err := c.initAuth(ctx); err != nil {
+		return nil, err
+	}
+
+	c.BootstrapServers = env.GetEnvOrDefault("KAFKA_BOOTSTRAP_SERVERS", "")
+
+	succeeded = true
+	logger.Info("dependency container initialized successfully")
+	return c, nil
+}
+
+// initTracer initializes the OpenTelemetry tracer.
+func (c *Container) initTracer(ctx context.Context, version string) error {
+	tracer, err := bootstrap.NewTracer(ctx, bootstrap.TracerConfig{
+		ServiceName:    "current-account-service",
+		ServiceVersion: version,
+		Logger:         c.Logger,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to initialize tracer: %w", err)
+	}
+	c.Tracer = tracer
+	return nil
+}
+
+// initDatabase initializes the GORM database connection.
+func (c *Container) initDatabase(ctx context.Context) error {
+	dbConfig := bootstrap.DefaultDatabaseConfig()
+	dbConfig.Logger = c.Logger
+	db, err := bootstrap.NewDatabase(ctx, dbConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize database: %w", err)
+	}
+	c.DB = db
+	c.Logger.Info("database connection established")
+	return nil
+}
+
+// initRepositories creates all persistence repositories.
+func (c *Container) initRepositories() {
+	c.AccountRepo = persistence.NewRepository(c.DB)
+	c.LienRepo = persistence.NewLienRepository(c.DB)
+	c.WithdrawalRepo = persistence.NewWithdrawalRepository(c.DB)
+	c.OutboxRepo = events.NewPostgresOutboxRepository(c.DB)
+	c.Logger.Info("repositories initialized")
+}
+
+// initRedis initializes the Redis client and idempotency service.
+// In production, Redis is required (fails fast). In non-production, falls back to NoopService.
+func (c *Container) initRedis(_ context.Context) error {
+	redisConfig := bootstrap.DefaultRedisConfig()
+	redisConfig.Logger = c.Logger
+	redisClient, redisErr := bootstrap.NewRedisClient(context.Background(), redisConfig) //nolint:contextcheck // NewRedisClient manages its own timeout context
+	if redisErr != nil {
+		if env.IsProduction() {
+			c.Logger.Error("CRITICAL: Redis unavailable in production - failing fast",
+				"error", redisErr)
+			return bootstrap.Permanent(fmt.Errorf("%w: %w", ErrRedisRequiredInProduction, redisErr))
+		}
+		c.Logger.Warn("Redis not available at startup, using noop idempotency service - DEVELOPMENT ONLY",
+			"error", redisErr,
+			"environment", os.Getenv("ENVIRONMENT"))
+		c.IdempotencyService = idempotency.NewNoopService(c.Logger)
+		c.UsingNoopIdempotency = true
+		caobservability.SetNoopIdempotencyActive(true)
+		caobservability.RecordServiceDegradation(caobservability.ComponentIdempotency, caobservability.DegradationReasonStartupFallback)
+	} else {
+		c.RedisClient = redisClient
+		c.IdempotencyService = idempotency.NewRedisService(redisClient)
+		caobservability.SetNoopIdempotencyActive(false)
+		c.Logger.Info("idempotency service initialized with Redis")
+	}
+	return nil
+}
+
+// initServiceClients creates the current-account service with its handler registry
+// and self-referential Starlark client. Cross-service clients (party, position-keeping,
+// financial-accounting) are NOT created here - they belong in the saga orchestration layer.
+func (c *Container) initServiceClients(_ context.Context) error {
+	// Load account configuration for clearing accounts (enables double-entry bookkeeping).
+	// If not configured, the service operates in single-entry mode without clearing account postings.
+	accountConfig, cfgErr := config.LoadAccountConfig()
+	if cfgErr != nil {
+		c.Logger.Warn("account configuration not loaded, operating in single-entry mode",
+			"error", cfgErr)
+		accountConfig = nil
+	} else {
+		c.Logger.Info("account configuration loaded",
+			"deposit_clearing_account_id", accountConfig.DepositClearingAccountID)
+	}
+
+	// Create service without cross-service clients.
+	// Cross-service operations (position logging, ledger posting, party validation,
+	// clearing account resolution) are handled by the saga orchestration layer.
+	svc, err := service.NewServiceWithExistingClients(
+		c.AccountRepo,
+		c.LienRepo,
+		c.WithdrawalRepo,
+		c.OutboxRepo,
+		c.DB,
+		nil, // posKeepingClient - delegated to saga layer
+		nil, // finAcctClient - delegated to saga layer
+		nil, // partyClient - delegated to saga layer
+		accountConfig,
+		c.IdempotencyService,
+		c.Logger,
+		c.Tracer,
+		nil, // accountResolver - delegated to saga layer
+		nil, // fungibilityValidator - delegated to saga layer
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create service: %w", err)
+	}
+	c.Service = svc
+
+	// Create Starlark handler registry with self-referential service client handlers.
+	// Cross-service handlers (position-keeping, financial-accounting) are registered
+	// at the saga orchestration layer, not here.
+	c.HandlerRegistry = saga.NewHandlerRegistry()
+
+	namespace := env.GetEnvOrDefault("K8S_NAMESPACE", "default")
+
+	// Register current-account handlers (for self-referential operations in sagas)
+	currentAcctClient, currentAcctCleanup, clientErr := currentaccountclient.New(currentaccountclient.Config{
+		ServiceName: currentaccountclient.ServiceName,
+		Namespace:   namespace,
+		Port:        ports.CurrentAccount,
+		Timeout:     defaults.DefaultRPCTimeout,
+		Tracer:      c.Tracer,
+	})
+	if clientErr != nil {
+		c.Logger.Warn("failed to create current-account client for Starlark handlers",
+			"error", clientErr)
+	} else {
+		c.cleanups = append(c.cleanups, currentAcctCleanup)
+		if regErr := currentaccountclient.RegisterStarlarkHandlers(c.HandlerRegistry, currentAcctClient); regErr != nil {
+			c.Logger.Warn("failed to register current-account handlers", "error", regErr)
+		}
+	}
+
+	c.Logger.Info("Starlark handler registry initialized",
+		"registered_handlers", len(c.HandlerRegistry.List()))
+
+	c.Logger.Info("service boundary mode: standalone (cross-service calls delegated to saga layer)",
+		"namespace", namespace)
+
+	return nil
+}
+
+// initAuth initializes the auth interceptor.
+func (c *Container) initAuth(ctx context.Context) error {
+	authConfig := bootstrap.DefaultAuthConfig(c.Logger)
+	interceptor, err := bootstrap.NewAuthInterceptor(ctx, authConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize auth: %w", err)
+	}
+	c.AuthInterceptor = interceptor
+	return nil
+}
+
+// Close gracefully shuts down all container resources in reverse initialization order.
+func (c *Container) Close() {
+	c.Logger.Info("closing container resources...")
+
+	// Run client cleanups in reverse order (service clients)
+	for i := len(c.cleanups) - 1; i >= 0; i-- {
+		c.cleanups[i]()
+	}
+
+	// Close Redis client
+	if c.RedisClient != nil {
+		if err := c.RedisClient.Close(); err != nil {
+			c.Logger.Error("failed to close Redis client", "error", err)
+		} else {
+			c.Logger.Info("redis client closed")
+		}
+	}
+
+	// Close database
+	bootstrap.CloseDatabase(c.DB, c.Logger)
+
+	// Shutdown tracer
+	bootstrap.ShutdownTracer(c.Tracer, c.Logger)
+
+	c.Logger.Info("container resources closed")
+}

--- a/services/current-account/app/container.go
+++ b/services/current-account/app/container.go
@@ -230,7 +230,7 @@ func (c *Container) initServiceClients(_ context.Context) error {
 	namespace := env.GetEnvOrDefault("K8S_NAMESPACE", "default")
 
 	// Register current-account handlers (for self-referential operations in sagas)
-	currentAcctClient, currentAcctCleanup, clientErr := currentaccountclient.New(currentaccountclient.Config{
+	currentAcctClient, currentAcctCleanup, clientErr := currentaccountclient.New(currentaccountclient.Config{ //nolint:contextcheck // uses background dial
 		ServiceName: currentaccountclient.ServiceName,
 		Namespace:   namespace,
 		Port:        ports.CurrentAccount,
@@ -242,7 +242,7 @@ func (c *Container) initServiceClients(_ context.Context) error {
 			"error", clientErr)
 	} else {
 		c.cleanups = append(c.cleanups, currentAcctCleanup)
-		if regErr := currentaccountclient.RegisterStarlarkHandlers(c.HandlerRegistry, currentAcctClient); regErr != nil {
+		if regErr := currentaccountclient.RegisterStarlarkHandlers(c.HandlerRegistry, currentAcctClient); regErr != nil { //nolint:contextcheck // no ctx needed
 			c.Logger.Warn("failed to register current-account handlers", "error", regErr)
 		}
 	}

--- a/services/current-account/app/container.go
+++ b/services/current-account/app/container.go
@@ -27,9 +27,6 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/ports"
 )
 
-// ErrContainerCloseFailures is returned when one or more resources fail to close.
-var ErrContainerCloseFailures = errors.New("container close encountered failures")
-
 // ErrRedisRequiredInProduction is returned when Redis is unavailable in production environments.
 var ErrRedisRequiredInProduction = errors.New("redis required for idempotency in production environment")
 
@@ -189,10 +186,12 @@ func (c *Container) initServiceClients(_ context.Context) error {
 	// Load account configuration for clearing accounts (enables double-entry bookkeeping).
 	// If not configured, the service operates in single-entry mode without clearing account postings.
 	accountConfig, cfgErr := config.LoadAccountConfig()
-	if cfgErr != nil {
+	if errors.Is(cfgErr, config.ErrEmptyDepositClearingAccountID) {
 		c.Logger.Warn("account configuration not loaded, operating in single-entry mode",
 			"error", cfgErr)
 		accountConfig = nil
+	} else if cfgErr != nil {
+		return fmt.Errorf("failed to load account configuration: %w", cfgErr)
 	} else {
 		c.Logger.Info("account configuration loaded",
 			"deposit_clearing_account_id", accountConfig.DepositClearingAccountID)

--- a/services/current-account/cmd/main.go
+++ b/services/current-account/cmd/main.go
@@ -3,7 +3,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -13,23 +12,16 @@ import (
 	"time"
 
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
-	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
-	currentaccountclient "github.com/meridianhub/meridian/services/current-account/client"
-	"github.com/meridianhub/meridian/services/current-account/config"
-	caobservability "github.com/meridianhub/meridian/services/current-account/observability"
+	"github.com/meridianhub/meridian/services/current-account/app"
 	"github.com/meridianhub/meridian/services/current-account/service"
-	"github.com/meridianhub/meridian/shared/pkg/idempotency"
-	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
 	"github.com/meridianhub/meridian/shared/platform/defaults"
 	"github.com/meridianhub/meridian/shared/platform/env"
 	"github.com/meridianhub/meridian/shared/platform/events"
 	"github.com/meridianhub/meridian/shared/platform/kafka"
-	"github.com/meridianhub/meridian/shared/platform/observability"
 	"github.com/meridianhub/meridian/shared/platform/ports"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
-	"gorm.io/gorm"
 )
 
 // Build information set via ldflags during compilation
@@ -37,11 +29,6 @@ var (
 	Version   = "dev"
 	Commit    = "unknown"
 	BuildDate = "unknown"
-)
-
-// Static errors for production environment requirements
-var (
-	ErrRedisRequiredInProduction = errors.New("redis required for idempotency in production environment")
 )
 
 func main() {
@@ -76,97 +63,23 @@ func run(logger *slog.Logger) error {
 	ctx, runCancel := context.WithCancel(context.Background())
 	defer runCancel()
 
-	// Initialize OpenTelemetry tracer
-	tracer, err := bootstrap.NewTracer(ctx, bootstrap.TracerConfig{
-		ServiceName:    "current-account-service",
-		ServiceVersion: Version,
-		Logger:         logger,
-	})
+	// Initialize dependency container
+	container, err := app.NewContainer(ctx, logger, Version)
 	if err != nil {
-		return fmt.Errorf("failed to initialize tracer: %w", err)
+		return err
 	}
-	defer bootstrap.ShutdownTracer(tracer, logger)
-
-	// Initialize database connection
-	dbConfig := bootstrap.DefaultDatabaseConfig()
-	dbConfig.Logger = logger
-	db, err := bootstrap.NewDatabase(ctx, dbConfig)
-	if err != nil {
-		return fmt.Errorf("failed to initialize database: %w", err)
-	}
-
-	logger.Info("database connection established")
-
-	// Create repositories
-	repo := persistence.NewRepository(db)
-	lienRepo := persistence.NewLienRepository(db)
-	withdrawalRepo := persistence.NewWithdrawalRepository(db)
-	outboxRepo := events.NewPostgresOutboxRepository(db)
-
-	// Create Redis client and idempotency service.
-	// In production: fail fast if Redis is unavailable (idempotency is critical).
-	// In non-production: use NoopService for graceful degradation with metrics.
-	var idempotencyService idempotency.Service
-	redisConfig := bootstrap.DefaultRedisConfig()
-	redisConfig.Logger = logger
-	redisClient, redisErr := bootstrap.NewRedisClient(ctx, redisConfig)
-	if redisErr != nil {
-		if env.IsProduction() {
-			logger.Error("CRITICAL: Redis unavailable in production - failing fast", "error", redisErr)
-			return bootstrap.Permanent(fmt.Errorf("%w: %w", ErrRedisRequiredInProduction, redisErr))
-		}
-		logger.Warn("Redis not available at startup, using noop idempotency service - DEVELOPMENT ONLY",
-			"error", redisErr,
-			"environment", os.Getenv("ENVIRONMENT"))
-		idempotencyService = idempotency.NewNoopService(logger)
-		caobservability.SetNoopIdempotencyActive(true)
-		caobservability.RecordServiceDegradation(caobservability.ComponentIdempotency, caobservability.DegradationReasonStartupFallback)
-	} else {
-		idempotencyService = idempotency.NewRedisService(redisClient)
-		caobservability.SetNoopIdempotencyActive(false)
-		logger.Info("idempotency service initialized with Redis")
-		defer func() {
-			if err := redisClient.Close(); err != nil {
-				logger.Error("failed to close Redis client", "error", err)
-			}
-		}()
-	}
-
-	// Get Kubernetes namespace from environment (defaults to "default")
-	namespace := env.GetEnvOrDefault("K8S_NAMESPACE", "default")
-
-	logger.Info("service boundary mode: standalone (cross-service calls delegated to saga layer)",
-		"namespace", namespace)
-
-	// Create service with external clients and capture the clients for health checking
-	currentAccountService, svcClients, err := createServiceWithClients(
-		repo,
-		lienRepo,
-		withdrawalRepo,
-		outboxRepo,
-		db,
-		namespace,
-		logger,
-		tracer,
-		idempotencyService,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create service: %w", err)
-	}
-
-	logger.Info("service initialized with external clients")
+	defer container.Close()
 
 	// Initialize Kafka producer lazily for outbox worker (optional - graceful degradation).
 	// Channels communicate the outbox stop function and Kafka cleanup function back to the
 	// main goroutine to avoid data races.
 	outboxStopCh := make(chan func(), 1)
 	kafkaCleanupCh := make(chan func(), 1)
-	kafkaBootstrapServers := env.GetEnvOrDefault("KAFKA_BOOTSTRAP_SERVERS", "")
-	if kafkaBootstrapServers != "" {
+	if container.BootstrapServers != "" {
 		lazyKafka := bootstrap.NewLazyClient(ctx, "kafka-producer",
 			func(_ context.Context) (*kafka.ProtoProducer, func(), error) {
 				producer, err := kafka.NewProtoProducer(kafka.ProducerConfig{
-					BootstrapServers: kafkaBootstrapServers,
+					BootstrapServers: container.BootstrapServers,
 					ClientID:         "current-account-outbox-worker",
 					Acks:             "all",
 					Retries:          5,
@@ -197,14 +110,14 @@ func run(logger *slog.Logger) error {
 				producer, err := lazyKafka.Get()
 				if err == nil {
 					w := events.NewWorker(
-						outboxRepo,
+						container.OutboxRepo,
 						producer,
 						events.DefaultWorkerConfig("current-account"),
 						logger.With("component", "outbox_worker"),
 					)
 					w.Start(ctx)
 					logger.Info("outbox worker started",
-						"kafka_brokers", kafkaBootstrapServers)
+						"kafka_brokers", container.BootstrapServers)
 					outboxStopCh <- w.Stop
 					return
 				}
@@ -219,30 +132,23 @@ func run(logger *slog.Logger) error {
 		logger.Warn("KAFKA_BOOTSTRAP_SERVERS not configured, outbox pattern disabled")
 	}
 
-	// Initialize auth interceptor (optional - based on AUTH_ENABLED)
-	authConfig := bootstrap.DefaultAuthConfig(logger)
-	authInterceptor, err := bootstrap.NewAuthInterceptor(ctx, authConfig)
-	if err != nil {
-		return fmt.Errorf("failed to initialize auth: %w", err)
-	}
-
 	// Create gRPC server with interceptor chain
 	// Order is handled by bootstrap: tracing -> auth -> recovery
-	grpcServer, err := bootstrap.NewGrpcServerBuilder(tracer, logger).
-		WithAuthInterceptor(authInterceptor).
+	grpcServer, err := bootstrap.NewGrpcServerBuilder(container.Tracer, logger).
+		WithAuthInterceptor(container.AuthInterceptor).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to build grpc server: %w", err)
 	}
 
 	// Register services
-	pb.RegisterCurrentAccountServiceServer(grpcServer, currentAccountService)
+	pb.RegisterCurrentAccountServiceServer(grpcServer, container.Service)
 
 	// Register health check service with database dependency checking.
 	// Cross-service health checks (position-keeping, financial-accounting) are not
 	// wired here - each service is independently deployable.
 	healthChecker, err := service.NewHealthChecker(service.HealthCheckerConfig{
-		Repository:   repo,
+		Repository:   container.AccountRepo,
 		Logger:       logger,
 		ServiceName:  "current-account",
 		CheckTimeout: defaults.DefaultHealthCheckTimeout,
@@ -302,22 +208,6 @@ func run(logger *slog.Logger) error {
 		return nil
 	})
 
-	// Register cleanup functions (LIFO order - external clients, then Redis, then database)
-	// Register external client cleanup functions first (they get called last in LIFO)
-	for _, cleanup := range svcClients.cleanupFuncs {
-		fn := cleanup // capture for closure
-		orchestrator.AddCleanup(func() error {
-			fn()
-			return nil
-		})
-	}
-
-	// No additional Redis cleanup needed here — Redis client is closed via defer above when available
-	orchestrator.AddCleanup(func() error {
-		bootstrap.CloseDatabase(db, logger)
-		return nil
-	})
-
 	// Cancel run-scoped context last (runs first in LIFO) to stop lazy resolution goroutines
 	// before other cleanup proceeds. This prevents orphan goroutines across RunWithRetry retries.
 	orchestrator.AddCleanup(func() error {
@@ -341,105 +231,4 @@ func parseLogLevel(levelStr string) slog.Level {
 	default:
 		return slog.LevelInfo
 	}
-}
-
-// serviceClients holds the clients created by createServiceWithClients.
-// Cross-service clients (party, position-keeping, financial-accounting, internal-account)
-// are NOT wired here - they belong in the saga orchestration layer.
-type serviceClients struct {
-	// HandlerRegistry for Starlark saga execution with service client handlers.
-	// This registry contains handlers that call real gRPC services (not mocks).
-	// See PRD: docs/prd/starlark-service-bindings.md
-	handlerRegistry *saga.HandlerRegistry
-	// Cleanup functions for graceful shutdown
-	cleanupFuncs []func()
-}
-
-// createServiceWithClients creates the service and returns it along with any self-referential
-// clients needed for Starlark saga handler registration.
-//
-// Cross-service clients (party, position-keeping, financial-accounting, internal-account,
-// reference-data) are NOT created here. Cross-service coordination belongs in the saga
-// orchestration layer, not in individual service binaries.
-func createServiceWithClients(
-	repo *persistence.Repository,
-	lienRepo *persistence.LienRepository,
-	withdrawalRepo *persistence.WithdrawalRepository,
-	outboxRepo events.OutboxRepository,
-	db *gorm.DB,
-	namespace string,
-	logger *slog.Logger,
-	tracer *observability.Tracer,
-	idempotencyService idempotency.Service,
-) (*service.Service, *serviceClients, error) {
-	// Load account configuration for clearing accounts (enables double-entry bookkeeping).
-	// If not configured, the service operates in single-entry mode without clearing account postings.
-	accountConfig, cfgErr := config.LoadAccountConfig()
-	if cfgErr != nil {
-		logger.Warn("account configuration not loaded, operating in single-entry mode",
-			"error", cfgErr)
-		accountConfig = nil
-	} else {
-		logger.Info("account configuration loaded",
-			"deposit_clearing_account_id", accountConfig.DepositClearingAccountID)
-	}
-
-	// Track cleanup functions for graceful shutdown
-	var cleanupFuncs []func()
-
-	// Create service without cross-service clients.
-	// Cross-service operations (position logging, ledger posting, party validation,
-	// clearing account resolution) are handled by the saga orchestration layer.
-	svc, err := service.NewServiceWithExistingClients(
-		repo,
-		lienRepo,
-		withdrawalRepo,
-		outboxRepo, // Outbox repository for reliable event delivery
-		db,         // Database connection for transaction management
-		nil,        // posKeepingClient - delegated to saga layer
-		nil,        // finAcctClient - delegated to saga layer
-		nil,        // partyClient - delegated to saga layer
-		accountConfig,
-		idempotencyService,
-		logger,
-		tracer,
-		nil, // accountResolver - delegated to saga layer
-		nil, // fungibilityValidator - delegated to saga layer
-	)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create service: %w", err)
-	}
-
-	// Create Starlark handler registry with self-referential service client handlers.
-	// Cross-service handlers (position-keeping, financial-accounting) are registered
-	// at the saga orchestration layer, not here.
-	handlerRegistry := saga.NewHandlerRegistry()
-
-	// Register current-account handlers (for self-referential operations in sagas)
-	currentAcctClient, currentAcctCleanup, err := currentaccountclient.New(currentaccountclient.Config{
-		ServiceName: currentaccountclient.ServiceName,
-		Namespace:   namespace,
-		Port:        ports.CurrentAccount,
-		Timeout:     defaults.DefaultRPCTimeout,
-		Tracer:      tracer,
-	})
-	if err != nil {
-		logger.Warn("failed to create current-account client for Starlark handlers",
-			"error", err)
-	} else {
-		cleanupFuncs = append(cleanupFuncs, currentAcctCleanup)
-		if regErr := currentaccountclient.RegisterStarlarkHandlers(handlerRegistry, currentAcctClient); regErr != nil {
-			logger.Warn("failed to register current-account handlers", "error", regErr)
-		}
-	}
-
-	logger.Info("Starlark handler registry initialized",
-		"registered_handlers", len(handlerRegistry.List()))
-
-	svcClients := &serviceClients{
-		handlerRegistry: handlerRegistry,
-		cleanupFuncs:    cleanupFuncs,
-	}
-
-	return svc, svcClients, nil
 }

--- a/services/current-account/cmd/main.go
+++ b/services/current-account/cmd/main.go
@@ -61,14 +61,17 @@ func run(logger *slog.Logger) error {
 	// Use a run-scoped context so lazy resolution goroutines stop when run() returns
 	// (e.g., during RunWithRetry retries or shutdown).
 	ctx, runCancel := context.WithCancel(context.Background())
-	defer runCancel()
 
 	// Initialize dependency container
 	container, err := app.NewContainer(ctx, logger, Version)
 	if err != nil {
+		runCancel()
 		return err
 	}
-	defer container.Close()
+	defer func() {
+		runCancel()
+		container.Close()
+	}()
 
 	// Initialize Kafka producer lazily for outbox worker (optional - graceful degradation).
 	// Channels communicate the outbox stop function and Kafka cleanup function back to the

--- a/services/internal-account/app/container.go
+++ b/services/internal-account/app/container.go
@@ -1,0 +1,219 @@
+// Package app provides application configuration and dependency injection for the internal-account service.
+package app
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"gorm.io/gorm"
+
+	"github.com/meridianhub/meridian/services/internal-account/adapters/persistence"
+	"github.com/meridianhub/meridian/services/internal-account/service"
+	"github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/meridianhub/meridian/shared/platform/bootstrap"
+	"github.com/meridianhub/meridian/shared/platform/env"
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"github.com/meridianhub/meridian/shared/platform/kafka"
+	"github.com/meridianhub/meridian/shared/platform/observability"
+)
+
+// Container holds all application dependencies for the internal-account service.
+type Container struct {
+	Logger *slog.Logger
+
+	// Infrastructure
+	Tracer *observability.Tracer
+	DB     *gorm.DB
+
+	// Auth
+	AuthInterceptor *auth.Interceptor
+
+	// Repositories
+	Repo *persistence.Repository
+
+	// Messaging
+	OutboxRepo      *events.PostgresOutboxRepository
+	OutboxPublisher *events.OutboxPublisher
+	OutboxWorker    *events.Worker
+	kafkaProducer   *kafka.ProtoProducer
+
+	// Service
+	Service *service.Service
+
+	// Internal config
+	BootstrapServers string
+}
+
+// NewContainer creates and initializes a new dependency injection container.
+func NewContainer(ctx context.Context, logger *slog.Logger, version string) (*Container, error) {
+	c := &Container{
+		Logger: logger,
+	}
+
+	// If initialization fails partway, close already-initialized resources.
+	succeeded := false
+	defer func() { //nolint:contextcheck // Close manages its own shutdown contexts
+		if !succeeded {
+			c.Close()
+		}
+	}()
+
+	if err := c.initTracer(ctx, version); err != nil {
+		return nil, err
+	}
+
+	if err := c.initDatabase(ctx); err != nil {
+		return nil, err
+	}
+
+	c.initRepositories()
+
+	if err := c.initService(); err != nil {
+		return nil, err
+	}
+
+	if err := c.initKafka(ctx); err != nil {
+		return nil, err
+	}
+
+	if err := c.initAuth(ctx); err != nil {
+		return nil, err
+	}
+
+	succeeded = true
+	logger.Info("dependency container initialized successfully")
+	return c, nil
+}
+
+// initTracer initializes the OpenTelemetry tracer.
+func (c *Container) initTracer(ctx context.Context, version string) error {
+	tracer, err := bootstrap.NewTracer(ctx, bootstrap.TracerConfig{
+		ServiceName:    "internal-account-service",
+		ServiceVersion: version,
+		Logger:         c.Logger,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to initialize tracer: %w", err)
+	}
+	c.Tracer = tracer
+	return nil
+}
+
+// initDatabase initializes the GORM database connection.
+func (c *Container) initDatabase(ctx context.Context) error {
+	dbConfig := bootstrap.DefaultDatabaseConfig()
+	dbConfig.Logger = c.Logger
+	db, err := bootstrap.NewDatabase(ctx, dbConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize database: %w", err)
+	}
+	c.DB = db
+	c.Logger.Info("database connection established")
+	return nil
+}
+
+// initRepositories creates persistence repositories and the outbox publisher.
+func (c *Container) initRepositories() {
+	c.Repo = persistence.NewRepository(c.DB)
+	c.OutboxRepo = events.NewPostgresOutboxRepository(c.DB)
+	c.OutboxPublisher = events.NewOutboxPublisher("internal-account")
+	c.Logger.Info("repositories initialized")
+}
+
+// initService creates the internal-account service and wires the outbox publisher.
+func (c *Container) initService() error {
+	svc, err := service.NewServiceWithClients(
+		c.Repo,
+		nil, // posKeepingClient - delegated to saga layer
+		nil, // referenceDataClient - not wired yet
+		c.Logger,
+		c.Tracer,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create service: %w", err)
+	}
+
+	svc.SetOutboxPublisher(c.OutboxPublisher, c.DB)
+	c.Service = svc
+
+	c.Logger.Info("service initialized")
+	return nil
+}
+
+// initKafka initializes the Kafka producer and outbox worker (optional - depends on KAFKA_BOOTSTRAP_SERVERS).
+func (c *Container) initKafka(ctx context.Context) error {
+	c.BootstrapServers = env.GetEnvOrDefault("KAFKA_BOOTSTRAP_SERVERS", "")
+	if c.BootstrapServers == "" {
+		c.Logger.Warn("KAFKA_BOOTSTRAP_SERVERS not configured, outbox worker disabled - events will be persisted but not published",
+			"environment", os.Getenv("ENVIRONMENT"))
+		return nil
+	}
+
+	producer, err := kafka.NewProtoProducer(kafka.ProducerConfig{
+		BootstrapServers: c.BootstrapServers,
+		ClientID:         "internal-account-outbox-worker",
+		Acks:             "all",
+		Retries:          3,
+		Compression:      "snappy",
+	})
+	if err != nil {
+		c.Logger.Warn("failed to create Kafka producer for outbox worker - events will be persisted but not published",
+			"error", err)
+		return nil
+	}
+
+	c.kafkaProducer = producer
+
+	workerConfig := events.DefaultWorkerConfig("internal-account")
+	c.OutboxWorker = events.NewWorker(c.OutboxRepo, c.kafkaProducer, workerConfig, c.Logger)
+	c.OutboxWorker.Start(ctx)
+
+	c.Logger.Info("outbox worker started",
+		"bootstrap_servers", c.BootstrapServers,
+		"batch_size", workerConfig.BatchSize,
+		"poll_interval", workerConfig.PollInterval)
+	return nil
+}
+
+// initAuth initializes the auth interceptor.
+func (c *Container) initAuth(ctx context.Context) error {
+	authConfig := bootstrap.DefaultAuthConfig(c.Logger)
+	interceptor, err := bootstrap.NewAuthInterceptor(ctx, authConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize auth: %w", err)
+	}
+	c.AuthInterceptor = interceptor
+	return nil
+}
+
+// Close gracefully shuts down all container resources.
+func (c *Container) Close() {
+	c.Logger.Info("closing container resources...")
+
+	// Stop outbox worker
+	if c.OutboxWorker != nil {
+		c.Logger.Info("stopping outbox worker...")
+		c.OutboxWorker.Stop()
+		c.Logger.Info("outbox worker stopped")
+	}
+
+	// Close Kafka producer
+	if c.kafkaProducer != nil {
+		c.Logger.Info("flushing and closing Kafka producer...")
+		if remaining := c.kafkaProducer.FlushWithTimeout(5000); remaining > 0 {
+			c.Logger.Warn("some messages not delivered before close", "remaining", remaining)
+		}
+		c.kafkaProducer.Close()
+		c.Logger.Info("Kafka producer closed")
+	}
+
+	// Close database
+	bootstrap.CloseDatabase(c.DB, c.Logger)
+
+	// Shutdown tracer
+	bootstrap.ShutdownTracer(c.Tracer, c.Logger)
+
+	c.Logger.Info("container resources closed")
+}

--- a/services/internal-account/cmd/main.go
+++ b/services/internal-account/cmd/main.go
@@ -13,14 +13,11 @@ import (
 	"strings"
 
 	pb "github.com/meridianhub/meridian/api/proto/meridian/internal_account/v1"
-	"github.com/meridianhub/meridian/services/internal-account/adapters/persistence"
+	"github.com/meridianhub/meridian/services/internal-account/app"
 	"github.com/meridianhub/meridian/services/internal-account/service"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
 	"github.com/meridianhub/meridian/shared/platform/defaults"
 	"github.com/meridianhub/meridian/shared/platform/env"
-	"github.com/meridianhub/meridian/shared/platform/events"
-	"github.com/meridianhub/meridian/shared/platform/kafka"
-	"github.com/meridianhub/meridian/shared/platform/observability"
 	"github.com/meridianhub/meridian/shared/platform/ports"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -62,96 +59,28 @@ func main() {
 func run(logger *slog.Logger) error {
 	ctx := context.Background()
 
-	// Initialize OpenTelemetry tracer
-	tracer, err := bootstrap.NewTracer(ctx, bootstrap.TracerConfig{
-		ServiceName:    "internal-account-service",
-		ServiceVersion: Version,
-		Logger:         logger,
-	})
+	// Initialize dependency container
+	container, err := app.NewContainer(ctx, logger, Version)
 	if err != nil {
-		return fmt.Errorf("failed to initialize tracer: %w", err)
+		return err
 	}
-	defer bootstrap.ShutdownTracer(tracer, logger)
-
-	// Initialize database connection
-	dbConfig := bootstrap.DefaultDatabaseConfig()
-	dbConfig.Logger = logger
-	db, err := bootstrap.NewDatabase(ctx, dbConfig)
-	if err != nil {
-		return fmt.Errorf("failed to initialize database: %w", err)
-	}
-
-	logger.Info("database connection established")
-
-	// Create repository
-	repo := persistence.NewRepository(db)
-
-	// Create outbox repository and publisher for event publishing
-	outboxRepo := events.NewPostgresOutboxRepository(db)
-	outboxPublisher := events.NewOutboxPublisher("internal-account")
-
-	// Create service (no cross-service clients - each service is independently deployable)
-	internalAccountService, svcClients, err := createServiceWithClients(
-		repo,
-		logger,
-		tracer,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create service: %w", err)
-	}
-
-	// Wire outbox publisher for domain event publishing
-	internalAccountService.SetOutboxPublisher(outboxPublisher, db)
-
-	logger.Info("service initialized with external clients")
-
-	// Start outbox worker for Kafka event delivery (optional - depends on KAFKA_BOOTSTRAP_SERVERS)
-	var outboxWorkerStop func()
-	bootstrapServers := env.GetEnvOrDefault("KAFKA_BOOTSTRAP_SERVERS", "")
-	if bootstrapServers != "" {
-		producer, err := kafka.NewProtoProducer(kafka.ProducerConfig{
-			BootstrapServers: bootstrapServers,
-			ClientID:         "internal-account-outbox-worker",
-			Acks:             "all",
-			Retries:          3,
-			Compression:      "snappy",
-		})
-		if err != nil {
-			logger.Warn("failed to create Kafka producer for outbox worker - events will be persisted but not published",
-				"error", err)
-		} else {
-			w := events.NewWorker(outboxRepo, producer, events.DefaultWorkerConfig("internal-account"), logger)
-			w.Start(ctx)
-			outboxWorkerStop = w.Stop
-			logger.Info("outbox worker started")
-		}
-	} else {
-		logger.Warn("KAFKA_BOOTSTRAP_SERVERS not configured, outbox worker disabled - events will be persisted but not published")
-	}
-
-	// Initialize auth interceptor (optional - based on AUTH_ENABLED)
-	authConfig := bootstrap.DefaultAuthConfig(logger)
-	authInterceptor, err := bootstrap.NewAuthInterceptor(ctx, authConfig)
-	if err != nil {
-		return fmt.Errorf("failed to initialize auth: %w", err)
-	}
+	defer container.Close()
 
 	// Create gRPC server with interceptor chain
 	// Order is handled by bootstrap: tracing -> auth -> recovery
-	grpcServer, err := bootstrap.NewGrpcServerBuilder(tracer, logger).
-		WithAuthInterceptor(authInterceptor).
+	grpcServer, err := bootstrap.NewGrpcServerBuilder(container.Tracer, logger).
+		WithAuthInterceptor(container.AuthInterceptor).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to build grpc server: %w", err)
 	}
 
 	// Register services
-	pb.RegisterInternalAccountServiceServer(grpcServer, internalAccountService)
+	pb.RegisterInternalAccountServiceServer(grpcServer, container.Service)
 
-	// Register health check service with database dependency checking.
-	// Cross-service health checks (position-keeping) are not wired here.
+	// Register health check service with database dependency checking
 	healthChecker, err := service.NewHealthChecker(service.HealthCheckerConfig{
-		Repository:   repo,
+		Repository:   container.Repo,
 		Logger:       logger,
 		ServiceName:  "internal-account",
 		CheckTimeout: defaults.DefaultHealthCheckTimeout,
@@ -252,7 +181,7 @@ func run(logger *slog.Logger) error {
 	// Wait for shutdown signal and orchestrate graceful shutdown
 	orchestrator := bootstrap.NewShutdownOrchestrator(grpcServer, logger)
 
-	// Register cleanup functions (LIFO order - HTTP server first, then external clients, then database)
+	// Register cleanup functions (LIFO order - HTTP server first, database etc handled by container.Close())
 	orchestrator.AddCleanup(func() error {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), defaults.DefaultGracefulShutdown)
 		defer cancel()
@@ -261,26 +190,6 @@ func run(logger *slog.Logger) error {
 			return err
 		}
 		logger.Info("HTTP server stopped")
-		return nil
-	})
-
-	if outboxWorkerStop != nil {
-		orchestrator.AddCleanup(func() error {
-			outboxWorkerStop()
-			return nil
-		})
-	}
-
-	for _, cleanup := range svcClients.cleanupFuncs {
-		fn := cleanup // capture for closure
-		orchestrator.AddCleanup(func() error {
-			fn()
-			return nil
-		})
-	}
-
-	orchestrator.AddCleanup(func() error {
-		bootstrap.CloseDatabase(db, logger)
 		return nil
 	})
 
@@ -300,39 +209,4 @@ func parseLogLevel(levelStr string) slog.Level {
 	default:
 		return slog.LevelInfo
 	}
-}
-
-// serviceClients holds any clients created by createServiceWithClients.
-// Cross-service clients (position-keeping) are NOT wired here - they belong
-// in the saga orchestration layer.
-type serviceClients struct {
-	// Cleanup functions for graceful shutdown
-	cleanupFuncs []func()
-}
-
-// createServiceWithClients creates the service without cross-service clients.
-// Cross-service coordination (position-keeping for balance hydration) belongs
-// in the saga orchestration layer or the frontend.
-func createServiceWithClients(
-	repo *persistence.Repository,
-	logger *slog.Logger,
-	tracer *observability.Tracer,
-) (*service.Service, *serviceClients, error) {
-	// Create service without cross-service clients
-	svc, err := service.NewServiceWithClients(
-		repo,
-		nil, // posKeepingClient - delegated to saga layer
-		nil, // referenceDataClient - not wired yet
-		logger,
-		tracer,
-	)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create service: %w", err)
-	}
-
-	svcClients := &serviceClients{
-		cleanupFuncs: nil,
-	}
-
-	return svc, svcClients, nil
 }

--- a/services/market-information/app/container.go
+++ b/services/market-information/app/container.go
@@ -120,7 +120,7 @@ func (c *Container) initDatabase(ctx context.Context) error {
 		return fmt.Errorf("failed to ping database: %w", err)
 	}
 	c.DBPool = dbPool
-	c.Logger.Info("database connection established", "url", dbURL)
+	c.Logger.Info("database connection established")
 
 	// GORM for outbox pattern
 	gormDBConfig := bootstrap.DefaultDatabaseConfig()

--- a/services/market-information/app/container.go
+++ b/services/market-information/app/container.go
@@ -1,0 +1,248 @@
+// Package app provides application configuration and dependency injection for the market-information service.
+package app
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"gorm.io/gorm"
+
+	"github.com/meridianhub/meridian/services/market-information/adapters/persistence"
+	"github.com/meridianhub/meridian/services/market-information/config"
+	"github.com/meridianhub/meridian/services/market-information/service"
+	"github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/meridianhub/meridian/shared/platform/bootstrap"
+	"github.com/meridianhub/meridian/shared/platform/env"
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"github.com/meridianhub/meridian/shared/platform/kafka"
+	"github.com/meridianhub/meridian/shared/platform/observability"
+)
+
+// Container holds all application dependencies for the market-information service.
+type Container struct {
+	Logger *slog.Logger
+	Config config.Config
+
+	// Infrastructure
+	Tracer *observability.Tracer
+	DBPool *pgxpool.Pool
+	GormDB *gorm.DB
+
+	// Auth
+	AuthInterceptor *auth.Interceptor
+
+	// Repositories
+	Repos *persistence.Repositories
+
+	// Messaging
+	OutboxRepo      *events.PostgresOutboxRepository
+	OutboxPublisher *events.OutboxPublisher
+	OutboxWorker    *events.Worker
+	kafkaProducer   *kafka.ProtoProducer
+
+	// Domain
+	EventPublisher         *service.OutboxEventPublisher
+	MarketInformationServer *service.Server
+}
+
+// NewContainer creates and initializes a new dependency injection container.
+func NewContainer(ctx context.Context, logger *slog.Logger, version string) (*Container, error) {
+	c := &Container{
+		Logger: logger,
+		Config: config.LoadConfig(),
+	}
+
+	// If initialization fails partway, close already-initialized resources.
+	succeeded := false
+	defer func() { //nolint:contextcheck // Close manages its own shutdown contexts
+		if !succeeded {
+			c.Close()
+		}
+	}()
+
+	if err := c.initTracer(ctx, version); err != nil {
+		return nil, err
+	}
+
+	if err := c.initDatabase(ctx); err != nil {
+		return nil, err
+	}
+
+	if err := c.initKafka(ctx); err != nil {
+		return nil, err
+	}
+
+	c.initRepositories()
+
+	if err := c.initService(); err != nil {
+		return nil, err
+	}
+
+	if err := c.initAuth(ctx); err != nil {
+		return nil, err
+	}
+
+	succeeded = true
+	logger.Info("dependency container initialized successfully")
+	return c, nil
+}
+
+// initTracer initializes the OpenTelemetry tracer.
+func (c *Container) initTracer(ctx context.Context, version string) error {
+	tracer, err := bootstrap.NewTracer(ctx, bootstrap.TracerConfig{
+		ServiceName:    "market-information-service",
+		ServiceVersion: version,
+		Logger:         c.Logger,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to initialize tracer: %w", err)
+	}
+	c.Tracer = tracer
+	return nil
+}
+
+// initDatabase initializes both the pgxpool connection (for domain persistence)
+// and the GORM connection (for outbox pattern).
+func (c *Container) initDatabase(ctx context.Context) error {
+	dbURL := env.GetEnvOrDefault("DATABASE_URL", "postgres://meridian_user@localhost:26257/meridian?sslmode=disable")
+
+	// pgxpool for domain persistence
+	dbPool, err := pgxpool.New(ctx, dbURL)
+	if err != nil {
+		return fmt.Errorf("failed to create database connection pool: %w", err)
+	}
+
+	if err := dbPool.Ping(ctx); err != nil {
+		dbPool.Close()
+		return fmt.Errorf("failed to ping database: %w", err)
+	}
+	c.DBPool = dbPool
+	c.Logger.Info("database connection established", "url", dbURL)
+
+	// GORM for outbox pattern
+	gormDBConfig := bootstrap.DefaultDatabaseConfig()
+	gormDBConfig.DSN = dbURL
+	gormDBConfig.Logger = c.Logger
+	gormDB, err := bootstrap.NewDatabase(ctx, gormDBConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GORM database for outbox: %w", err)
+	}
+	c.GormDB = gormDB
+
+	return nil
+}
+
+// initKafka initializes the outbox repository, publisher, Kafka producer, and outbox worker.
+func (c *Container) initKafka(ctx context.Context) error {
+	c.OutboxRepo = events.NewPostgresOutboxRepository(c.GormDB)
+	c.OutboxPublisher = events.NewOutboxPublisher("market-information")
+
+	bootstrapServers := env.GetEnvOrDefault("KAFKA_BOOTSTRAP_SERVERS", "")
+	if bootstrapServers == "" {
+		c.Logger.Warn("outbox worker disabled - KAFKA_BOOTSTRAP_SERVERS not set")
+		return nil
+	}
+
+	producer, err := kafka.NewProtoProducer(kafka.ProducerConfig{
+		BootstrapServers: bootstrapServers,
+		ClientID:         "market-information-outbox-worker",
+		Acks:             "all",
+		Retries:          3,
+		Compression:      "snappy",
+	})
+	if err != nil {
+		c.Logger.Warn("failed to create Kafka producer for outbox worker",
+			"error", err,
+			"environment", os.Getenv("ENVIRONMENT"))
+		return nil
+	}
+
+	c.kafkaProducer = producer
+
+	workerConfig := events.DefaultWorkerConfig("market-information")
+	c.OutboxWorker = events.NewWorker(c.OutboxRepo, c.kafkaProducer, workerConfig, c.Logger)
+	c.OutboxWorker.Start(ctx)
+	c.Logger.Info("outbox worker started",
+		"bootstrap_servers", bootstrapServers,
+		"batch_size", workerConfig.BatchSize,
+		"poll_interval", workerConfig.PollInterval)
+
+	return nil
+}
+
+// initRepositories creates the persistence repositories.
+func (c *Container) initRepositories() {
+	masterTenantID := env.GetEnvOrDefault("MASTER_TENANT_ID", "meridian_master")
+	c.Repos = persistence.NewRepositories(c.DBPool, masterTenantID)
+	c.Logger.Info("repositories initialized", "master_tenant_id", masterTenantID)
+}
+
+// initService creates the outbox event publisher and market information server.
+func (c *Container) initService() error {
+	c.EventPublisher = service.NewOutboxEventPublisher(c.GormDB, c.OutboxPublisher)
+
+	server, err := service.NewServer(
+		c.Repos.DataSet,
+		c.Repos.Observation,
+		c.Repos.Source,
+		service.WithEventPublisher(c.EventPublisher),
+		service.WithLogger(c.Logger.With("component", "market_information_server")),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create market information server: %w", err)
+	}
+	c.MarketInformationServer = server
+	c.Logger.Info("market information server created")
+
+	return nil
+}
+
+// initAuth initializes the auth interceptor.
+func (c *Container) initAuth(ctx context.Context) error {
+	authConfig := bootstrap.DefaultAuthConfig(c.Logger)
+	interceptor, err := bootstrap.NewAuthInterceptor(ctx, authConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize auth: %w", err)
+	}
+	c.AuthInterceptor = interceptor
+	return nil
+}
+
+// Close gracefully shuts down all container resources.
+func (c *Container) Close() {
+	c.Logger.Info("closing container resources...")
+
+	// Stop outbox worker
+	if c.OutboxWorker != nil {
+		c.Logger.Info("stopping outbox worker...")
+		c.OutboxWorker.Stop()
+		c.Logger.Info("outbox worker stopped")
+	}
+
+	// Close Kafka producer
+	if c.kafkaProducer != nil {
+		c.Logger.Info("flushing and closing Kafka producer...")
+		if remaining := c.kafkaProducer.FlushWithTimeout(5000); remaining > 0 {
+			c.Logger.Warn("some messages not delivered before close", "remaining", remaining)
+		}
+		c.kafkaProducer.Close()
+		c.Logger.Info("Kafka producer closed")
+	}
+
+	// Close GORM database
+	bootstrap.CloseDatabase(c.GormDB, c.Logger)
+
+	// Close pgxpool
+	if c.DBPool != nil {
+		c.DBPool.Close()
+		c.Logger.Info("database connection pool closed")
+	}
+
+	// Shutdown tracer
+	bootstrap.ShutdownTracer(c.Tracer, c.Logger)
+
+	c.Logger.Info("container resources closed")
+}

--- a/services/market-information/app/container.go
+++ b/services/market-information/app/container.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"gorm.io/gorm"
@@ -154,10 +153,7 @@ func (c *Container) initKafka(ctx context.Context) error {
 		Compression:      "snappy",
 	})
 	if err != nil {
-		c.Logger.Warn("failed to create Kafka producer for outbox worker",
-			"error", err,
-			"environment", os.Getenv("ENVIRONMENT"))
-		return nil
+		return fmt.Errorf("failed to create Kafka producer for outbox worker: %w", err)
 	}
 
 	c.kafkaProducer = producer

--- a/services/market-information/app/container.go
+++ b/services/market-information/app/container.go
@@ -44,7 +44,7 @@ type Container struct {
 	kafkaProducer   *kafka.ProtoProducer
 
 	// Domain
-	EventPublisher         *service.OutboxEventPublisher
+	EventPublisher          *service.OutboxEventPublisher
 	MarketInformationServer *service.Server
 }
 

--- a/services/market-information/cmd/main.go
+++ b/services/market-information/cmd/main.go
@@ -14,17 +14,13 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/jackc/pgx/v5/pgxpool"
 	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
 	"github.com/meridianhub/meridian/services/market-information/adapters/external/ecb"
-	"github.com/meridianhub/meridian/services/market-information/adapters/persistence"
-	"github.com/meridianhub/meridian/services/market-information/config"
+	"github.com/meridianhub/meridian/services/market-information/app"
 	"github.com/meridianhub/meridian/services/market-information/service"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
 	"github.com/meridianhub/meridian/shared/platform/defaults"
 	"github.com/meridianhub/meridian/shared/platform/env"
-	"github.com/meridianhub/meridian/shared/platform/events"
-	"github.com/meridianhub/meridian/shared/platform/kafka"
 	"github.com/meridianhub/meridian/shared/platform/ports"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -66,122 +62,30 @@ func main() {
 func run(logger *slog.Logger) error {
 	ctx := context.Background()
 
-	// Load service configuration
-	cfg := config.LoadConfig()
-
-	// Initialize OpenTelemetry tracer
-	tracer, err := bootstrap.NewTracer(ctx, bootstrap.TracerConfig{
-		ServiceName:    "market-information-service",
-		ServiceVersion: Version,
-		Logger:         logger,
-	})
+	// Initialize dependency container
+	container, err := app.NewContainer(ctx, logger, Version)
 	if err != nil {
-		return fmt.Errorf("failed to initialize tracer: %w", err)
+		return err
 	}
-	defer bootstrap.ShutdownTracer(tracer, logger)
-
-	// Initialize database connection using pgxpool
-	dbURL := env.GetEnvOrDefault("DATABASE_URL", "postgres://meridian_user@localhost:26257/meridian?sslmode=disable")
-	dbPool, err := pgxpool.New(ctx, dbURL)
-	if err != nil {
-		return fmt.Errorf("failed to create database connection pool: %w", err)
-	}
-	defer dbPool.Close()
-
-	// Verify database connectivity
-	if err := dbPool.Ping(ctx); err != nil {
-		return fmt.Errorf("failed to ping database: %w", err)
-	}
-	logger.Info("database connection established", "url", dbURL)
-
-	// Initialize GORM database connection for outbox pattern.
-	// The existing pgxpool connection is retained for domain persistence operations.
-	gormDBConfig := bootstrap.DefaultDatabaseConfig()
-	gormDBConfig.DSN = dbURL
-	gormDBConfig.Logger = logger
-	gormDB, err := bootstrap.NewDatabase(ctx, gormDBConfig)
-	if err != nil {
-		return fmt.Errorf("failed to initialize GORM database for outbox: %w", err)
-	}
-	defer bootstrap.CloseDatabase(gormDB, logger)
-
-	// Initialize outbox publisher and worker for transactional event publishing
-	outboxRepo := events.NewPostgresOutboxRepository(gormDB)
-	outboxPublisher := events.NewOutboxPublisher("market-information")
-
-	var outboxWorker *events.Worker
-	var kafkaProducer *kafka.ProtoProducer
-	bootstrapServers := env.GetEnvOrDefault("KAFKA_BOOTSTRAP_SERVERS", "")
-	if bootstrapServers != "" {
-		producer, kafkaErr := kafka.NewProtoProducer(kafka.ProducerConfig{
-			BootstrapServers: bootstrapServers,
-			ClientID:         "market-information-outbox-worker",
-			Acks:             "all",
-			Retries:          3,
-			Compression:      "snappy",
-		})
-		if kafkaErr != nil {
-			logger.Warn("failed to create Kafka producer for outbox worker",
-				"error", kafkaErr)
-		} else {
-			kafkaProducer = producer
-			defer kafkaProducer.Close()
-			workerConfig := events.DefaultWorkerConfig("market-information")
-			outboxWorker = events.NewWorker(outboxRepo, kafkaProducer, workerConfig, logger)
-			outboxWorker.Start(ctx)
-			defer outboxWorker.Stop()
-			logger.Info("outbox worker started",
-				"bootstrap_servers", bootstrapServers)
-		}
-	} else {
-		logger.Warn("outbox worker disabled - KAFKA_BOOTSTRAP_SERVERS not set")
-	}
-
-	// Create outbox-based event publisher (replaces KafkaObservationPublisher)
-	outboxEventPublisher := service.NewOutboxEventPublisher(gormDB, outboxPublisher)
-
-	// Create repositories for persistence
-	masterTenantID := env.GetEnvOrDefault("MASTER_TENANT_ID", "meridian_master")
-	repos := persistence.NewRepositories(dbPool, masterTenantID)
-	logger.Info("repositories initialized", "master_tenant_id", masterTenantID)
-
-	// Create Market Information service server
-	marketInformationServer, err := service.NewServer(
-		repos.DataSet,
-		repos.Observation,
-		repos.Source,
-		service.WithEventPublisher(outboxEventPublisher),
-		service.WithLogger(logger.With("component", "market_information_server")),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create market information server: %w", err)
-	}
-	logger.Info("market information server created")
-
-	// Initialize auth interceptor (optional - based on AUTH_ENABLED)
-	authConfig := bootstrap.DefaultAuthConfig(logger)
-	authInterceptor, err := bootstrap.NewAuthInterceptor(ctx, authConfig)
-	if err != nil {
-		return fmt.Errorf("failed to initialize auth: %w", err)
-	}
+	defer container.Close()
 
 	// Create gRPC server with interceptor chain
-	grpcServer, err := bootstrap.NewGrpcServerBuilder(tracer, logger).
-		WithAuthInterceptor(authInterceptor).
+	grpcServer, err := bootstrap.NewGrpcServerBuilder(container.Tracer, logger).
+		WithAuthInterceptor(container.AuthInterceptor).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to build grpc server: %w", err)
 	}
 
 	// Register Market Information service
-	marketinformationv1.RegisterMarketInformationServiceServer(grpcServer, marketInformationServer)
+	marketinformationv1.RegisterMarketInformationServiceServer(grpcServer, container.MarketInformationServer)
 
 	// Register health check service
 	healthChecker := service.NewHealthChecker(service.HealthCheckerConfig{
 		Logger:        logger,
 		ServiceName:   "market-information",
 		CheckTimeout:  defaults.DefaultHealthCheckTimeout,
-		ServiceConfig: cfg,
+		ServiceConfig: container.Config,
 	})
 	grpc_health_v1.RegisterHealthServer(grpcServer, healthChecker)
 
@@ -276,10 +180,9 @@ func run(logger *slog.Logger) error {
 	// Wait for shutdown signal and orchestrate graceful shutdown
 	orchestrator := bootstrap.NewShutdownOrchestrator(grpcServer, logger)
 
-	// Outbox worker and Kafka producer are cleaned up via defer.
-
 	// Initialize ECB adapter worker (if enabled)
 	// Note: The ECB worker calls RecordObservation on the Server to ingest FX rates.
+	cfg := container.Config
 	if cfg.ECB.Enabled {
 		ecbClient := ecb.NewClient(ecb.Config{
 			Endpoint: cfg.ECB.Endpoint,
@@ -288,7 +191,7 @@ func run(logger *slog.Logger) error {
 
 		ecbWorker := ecb.NewWorker(
 			ecbClient,
-			marketInformationServer, // Server implements MarketInformationClient interface
+			container.MarketInformationServer, // Server implements MarketInformationClient interface
 			ecb.WorkerConfig{
 				DatasetCode:   cfg.ECB.DatasetCode,
 				SourceCode:    cfg.ECB.SourceCode,
@@ -324,8 +227,7 @@ func run(logger *slog.Logger) error {
 		return nil
 	})
 
-	// Note: Database pool cleanup is handled via defer dbPool.Close() above
-	// This ensures the pool is closed even if orchestrator.Wait returns early
+	// Note: Database pool and infrastructure cleanup is handled via container.Close() defer
 
 	return orchestrator.Wait(serverErrors)
 }

--- a/services/reconciliation/app/container.go
+++ b/services/reconciliation/app/container.go
@@ -1,0 +1,581 @@
+// Package app provides application configuration and dependency injection for the reconciliation service.
+package app
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/redis/go-redis/v9"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"gorm.io/gorm"
+
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	"github.com/meridianhub/meridian/services/reconciliation/adapters/messaging"
+	"github.com/meridianhub/meridian/services/reconciliation/adapters/persistence"
+	"github.com/meridianhub/meridian/services/reconciliation/config"
+	"github.com/meridianhub/meridian/services/reconciliation/service"
+	"github.com/meridianhub/meridian/services/reconciliation/worker"
+	"github.com/meridianhub/meridian/shared/pkg/valuation"
+	"github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/meridianhub/meridian/shared/platform/bootstrap"
+	"github.com/meridianhub/meridian/shared/platform/env"
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"github.com/meridianhub/meridian/shared/platform/kafka"
+	"github.com/meridianhub/meridian/shared/platform/observability"
+	"github.com/meridianhub/meridian/shared/platform/redislock"
+	"github.com/meridianhub/meridian/shared/platform/scheduler"
+)
+
+// Container holds all application dependencies for the reconciliation service.
+type Container struct {
+	Config *config.Config
+	Logger *slog.Logger
+
+	// Infrastructure
+	Tracer      *observability.Tracer
+	DB          *gorm.DB
+	RedisClient *redis.Client
+
+	// Auth
+	AuthInterceptor *auth.Interceptor
+
+	// Messaging
+	OutboxRepo      *events.PostgresOutboxRepository
+	OutboxPublisher *events.OutboxPublisher
+	OutboxWorker    *events.Worker
+	kafkaProducer   *kafka.ProtoProducer
+
+	// Event publisher (outbox-based)
+	EventPublisher *messaging.OutboxEventPublisher
+
+	// Repositories
+	RunRepo       *persistence.SettlementRunRepository
+	SnapshotRepo  *persistence.SettlementSnapshotRepository
+	VarianceRepo  *persistence.VarianceRepository
+	DisputeRepo   *persistence.DisputeRepository
+	AssertionRepo *persistence.BalanceAssertionRepository
+	TrendRepo     *persistence.ImbalanceTrendRepository
+
+	// Service
+	ReconciliationService *service.AccountReconciliationService
+
+	// Scheduler (may be nil if disabled or Redis unavailable)
+	CronScheduler *scheduler.CronScheduler
+
+	// Cleanup functions for gRPC connections and pgx pools
+	cleanups []func()
+}
+
+// NewContainer creates and initializes a new dependency injection container.
+func NewContainer(ctx context.Context, cfg *config.Config, logger *slog.Logger, version string) (*Container, error) {
+	c := &Container{
+		Config: cfg,
+		Logger: logger,
+	}
+
+	// If initialization fails partway, close already-initialized resources.
+	succeeded := false
+	defer func() { //nolint:contextcheck // Close manages its own shutdown contexts
+		if !succeeded {
+			c.Close()
+		}
+	}()
+
+	if err := c.initTracer(ctx, version); err != nil {
+		return nil, err
+	}
+
+	if err := c.initDatabase(ctx); err != nil {
+		return nil, err
+	}
+
+	if err := c.initKafka(ctx); err != nil {
+		return nil, err
+	}
+
+	c.initRepositories()
+
+	serviceOpts, err := c.initServiceDeps()
+	if err != nil {
+		return nil, err
+	}
+
+	c.initService(serviceOpts)
+
+	if err := c.initRedis(ctx); err != nil {
+		return nil, err
+	}
+
+	c.initScheduler(ctx)
+
+	if err := c.initAuth(ctx); err != nil {
+		return nil, err
+	}
+
+	succeeded = true
+	logger.Info("dependency container initialized successfully")
+	return c, nil
+}
+
+// initTracer initializes the OpenTelemetry tracer.
+func (c *Container) initTracer(ctx context.Context, version string) error {
+	tracer, err := bootstrap.NewTracer(ctx, bootstrap.TracerConfig{
+		ServiceName:    c.Config.Observability.ServiceName,
+		ServiceVersion: version,
+		Logger:         c.Logger,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to initialize tracer: %w", err)
+	}
+	c.Tracer = tracer
+	return nil
+}
+
+// initDatabase initializes the GORM database connection with reconciliation-specific pool settings.
+func (c *Container) initDatabase(ctx context.Context) error {
+	dbConfig := bootstrap.DefaultDatabaseConfig()
+	dbConfig.DSN = c.Config.Database.URL
+	dbConfig.MaxOpenConns = c.Config.Database.MaxOpenConns
+	dbConfig.MaxIdleConns = c.Config.Database.MaxIdleConns
+	dbConfig.ConnMaxLifetime = c.Config.Database.ConnMaxLifetime
+	dbConfig.ConnMaxIdleTime = c.Config.Database.ConnMaxIdleTime
+	dbConfig.Logger = c.Logger
+
+	db, err := bootstrap.NewDatabase(ctx, dbConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize database: %w", err)
+	}
+	c.DB = db
+	c.Logger.Info("database connection established")
+	return nil
+}
+
+// initKafka initializes the outbox publisher, Kafka producer, and outbox worker.
+func (c *Container) initKafka(ctx context.Context) error {
+	c.OutboxRepo = events.NewPostgresOutboxRepository(c.DB)
+	c.OutboxPublisher = events.NewOutboxPublisher("reconciliation")
+
+	bootstrapServers := env.GetEnvOrDefault("KAFKA_BOOTSTRAP_SERVERS", "")
+	if bootstrapServers == "" && c.Config.Kafka.Enabled {
+		bootstrapServers = c.Config.Kafka.Brokers
+	}
+
+	if bootstrapServers != "" {
+		producer, kafkaErr := kafka.NewProtoProducer(kafka.ProducerConfig{
+			BootstrapServers: bootstrapServers,
+			ClientID:         "reconciliation-outbox-worker",
+			Acks:             "all",
+			Retries:          3,
+			Compression:      "snappy",
+		})
+		if kafkaErr != nil {
+			c.Logger.Warn("failed to create Kafka producer for outbox worker",
+				"error", kafkaErr)
+		} else {
+			c.kafkaProducer = producer
+			workerConfig := events.DefaultWorkerConfig("reconciliation")
+			c.OutboxWorker = events.NewWorker(c.OutboxRepo, c.kafkaProducer, workerConfig, c.Logger)
+			c.OutboxWorker.Start(ctx)
+			c.Logger.Info("outbox worker started",
+				"bootstrap_servers", bootstrapServers)
+		}
+	} else {
+		c.Logger.Warn("outbox worker disabled - KAFKA_BOOTSTRAP_SERVERS not set")
+	}
+
+	// Create outbox-based event publisher
+	c.EventPublisher = messaging.NewOutboxEventPublisher(c.DB, c.OutboxPublisher)
+	return nil
+}
+
+// initRepositories creates all persistence repositories.
+func (c *Container) initRepositories() {
+	c.RunRepo = persistence.NewSettlementRunRepository(c.DB)
+	c.SnapshotRepo = persistence.NewSettlementSnapshotRepository(c.DB)
+	c.VarianceRepo = persistence.NewVarianceRepository(c.DB)
+	c.DisputeRepo = persistence.NewDisputeRepository(c.DB)
+	c.AssertionRepo = persistence.NewBalanceAssertionRepository(c.DB)
+	c.TrendRepo = persistence.NewImbalanceTrendRepository(c.DB)
+	c.Logger.Info("repositories initialized")
+}
+
+// initServiceDeps wires the optional service dependencies (snapshot capturer, balance assertor,
+// variance detector, variance valuator, account party resolver) and returns the service options.
+func (c *Container) initServiceDeps() ([]service.Option, error) {
+	serviceOpts := []service.Option{
+		service.WithSettlementRunRepository(c.RunRepo),
+		service.WithDisputeRepository(c.DisputeRepo),
+		service.WithDisputeListRepository(c.DisputeRepo),
+		service.WithAssertionListRepository(c.AssertionRepo),
+		service.WithVarianceRepository(c.VarianceRepo),
+		service.WithVarianceListRepository(c.VarianceRepo),
+		service.WithEventPublisher(c.EventPublisher),
+		service.WithLogger(c.Logger),
+	}
+
+	// Wire SnapshotCapturer and BalanceAssertor if Position Keeping URL is configured
+	if c.Config.Services.PositionKeepingURL != "" {
+		pkConn, connErr := grpc.NewClient(
+			c.Config.Services.PositionKeepingURL,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		if connErr != nil {
+			return nil, fmt.Errorf("failed to create position keeping client at %s: %w",
+				c.Config.Services.PositionKeepingURL, connErr)
+		}
+		c.cleanups = append(c.cleanups, func() {
+			if err := pkConn.Close(); err != nil {
+				c.Logger.Error("failed to close position keeping connection", "error", err)
+			}
+		})
+
+		pkClient := positionkeepingv1.NewPositionKeepingServiceClient(pkConn)
+		provider := service.NewPKPositionProvider(pkClient)
+		capturer := service.NewSnapshotCapturer(provider, c.RunRepo, c.SnapshotRepo)
+		serviceOpts = append(serviceOpts,
+			service.WithSnapshotCapturer(capturer.CaptureSnapshots),
+		)
+		c.Logger.Info("snapshot capturer configured",
+			"position_keeping_url", c.Config.Services.PositionKeepingURL)
+
+		// Wire BalanceAssertor (requires PK client for position summaries)
+		balancePKClient := service.NewGrpcPositionKeepingClient(pkClient)
+		assertor := service.NewBalanceAssertor(c.AssertionRepo, c.TrendRepo, balancePKClient, nil, nil, c.Logger)
+		serviceOpts = append(serviceOpts,
+			service.WithBalanceAssertor(assertor),
+		)
+		c.Logger.Info("balance assertor configured")
+	} else {
+		c.Logger.Warn("snapshot capturer not configured: POSITION_KEEPING_URL not set")
+		c.Logger.Warn("balance assertor not configured: position keeping client unavailable")
+	}
+
+	// Wire VarianceDetector (depends on repos only, always available)
+	detector := service.NewVarianceDetector(c.RunRepo, c.SnapshotRepo, c.VarianceRepo)
+	serviceOpts = append(serviceOpts,
+		service.WithVarianceDetector(detector.DetectVariances),
+	)
+
+	// Wire VarianceValuator with valuation engine and reference data provider
+	valuationEngine, refDataProvider := c.buildValuationComponents()
+
+	// Wire AccountPartyResolver if Current Account URL is configured
+	var partyResolver service.AccountPartyResolver
+	if c.Config.Services.CurrentAccountURL != "" {
+		caConn, caErr := grpc.NewClient(
+			c.Config.Services.CurrentAccountURL,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		if caErr != nil {
+			c.Logger.Warn("failed to create current account gRPC client, party resolution will fall back to account ID",
+				"error", caErr)
+		} else {
+			c.cleanups = append(c.cleanups, func() {
+				if err := caConn.Close(); err != nil {
+					c.Logger.Error("failed to close current account connection", "error", err)
+				}
+			})
+			caClient := currentaccountv1.NewCurrentAccountServiceClient(caConn)
+			partyResolver = service.NewGRPCAccountPartyResolver(caClient)
+			c.Logger.Info("current account party resolver configured",
+				"current_account_url", c.Config.Services.CurrentAccountURL)
+		}
+	}
+
+	valuator := service.NewVarianceValuator(valuationEngine, refDataProvider, partyResolver, c.VarianceRepo, c.RunRepo)
+	serviceOpts = append(serviceOpts,
+		service.WithVarianceValuator(valuator.ValueVariances),
+	)
+
+	return serviceOpts, nil
+}
+
+// buildValuationComponents creates the valuation engine and reference data provider.
+// When the Reference Data gRPC URL is configured, it creates a gRPC client for instrument
+// lookups. Otherwise, it falls back to the identity conversion method with default materiality
+// thresholds.
+func (c *Container) buildValuationComponents() (valuation.Engine, service.ReferenceDataProvider) {
+	// Create valuation engine runtime components
+	policyRT, err := valuation.NewPolicyRuntime()
+	if err != nil {
+		c.Logger.Warn("failed to create CEL policy runtime, using identity method resolver", "error", err)
+	}
+
+	starlarkRT := valuation.NewStarlarkRuntime(valuation.StarlarkRuntimeConfig{
+		PolicyRuntime: policyRT,
+	})
+
+	cache := valuation.NewInMemoryCache(valuation.InMemoryCacheConfig{})
+
+	// Use identity method resolver as the base
+	methodResolver := valuation.NewIdentityMethodResolver()
+
+	engine := valuation.NewEngine(valuation.Config{
+		StarlarkRuntime: starlarkRT,
+		PolicyRuntime:   policyRT,
+		Cache:           cache,
+	}, methodResolver)
+
+	adaptedEngine := service.NewValuationEngineAdapter(engine, c.Logger)
+
+	// Build reference data provider with gRPC clients if available
+	providerCfg := service.GRPCReferenceDataProviderConfig{
+		DefaultMethodID: uuid.MustParse(valuation.IdentityMethodID),
+		Logger:          c.Logger,
+	}
+
+	if c.Config.Services.ReferenceDataURL != "" {
+		refDataConn, connErr := grpc.NewClient(
+			c.Config.Services.ReferenceDataURL,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		if connErr != nil {
+			c.Logger.Warn("failed to create reference data gRPC client", "error", connErr)
+		} else {
+			c.cleanups = append(c.cleanups, func() {
+				if err := refDataConn.Close(); err != nil {
+					c.Logger.Error("failed to close reference data connection", "error", err)
+				}
+			})
+			providerCfg.InstrumentClient = referencedatav1.NewReferenceDataServiceClient(refDataConn)
+			c.Logger.Info("reference data gRPC client configured for instrument lookups",
+				"url", c.Config.Services.ReferenceDataURL)
+		}
+	} else {
+		c.Logger.Info("reference data gRPC not configured, using default valuation method and materiality threshold")
+	}
+
+	refDataProvider := service.NewGRPCReferenceDataProvider(providerCfg)
+
+	c.Logger.Info("variance valuator configured",
+		"engine", "starlark+cel",
+		"method_resolver", "identity (fallback)",
+		"reference_data_url", c.Config.Services.ReferenceDataURL,
+	)
+
+	return adaptedEngine, refDataProvider
+}
+
+// initService creates the AccountReconciliationService from options.
+func (c *Container) initService(opts []service.Option) {
+	c.ReconciliationService = service.NewAccountReconciliationService(opts...)
+	c.Logger.Info("reconciliation service initialized")
+}
+
+// initRedis initializes the Redis client (optional, needed for scheduler leader election).
+func (c *Container) initRedis(ctx context.Context) error {
+	if !c.Config.Redis.Enabled || c.Config.Redis.URL == "" {
+		c.Logger.Info("Redis disabled or not configured")
+		return nil
+	}
+
+	redisCfg := bootstrap.RedisConfig{
+		URL:    c.Config.Redis.URL,
+		Logger: c.Logger,
+	}
+	redisClient, redisErr := bootstrap.NewRedisClient(ctx, redisCfg)
+	if redisErr != nil {
+		c.Logger.Warn("Redis connection failed, scheduler and Redis health check disabled",
+			"error", redisErr)
+		return nil
+	}
+
+	c.RedisClient = redisClient
+	c.Logger.Info("Redis client connected")
+	return nil
+}
+
+// initScheduler creates and configures the CronScheduler with all its dependencies.
+// The scheduler is only created if enabled in config and Redis is available.
+func (c *Container) initScheduler(ctx context.Context) {
+	if !c.Config.Scheduler.Enabled {
+		c.Logger.Info("settlement scheduler disabled")
+		return
+	}
+
+	if c.RedisClient == nil {
+		c.Logger.Warn("scheduler disabled: Redis not configured (required for distributed locking)")
+		return
+	}
+
+	// Create distributed lock
+	distLock := redislock.NewLock(c.RedisClient, redislock.Config{
+		KeyPrefix:  "meridian:reconciliation:scheduler",
+		LockTTL:    c.Config.Scheduler.LeaderLockTTL,
+		RenewEvery: c.Config.Scheduler.LeaderRenewInterval,
+	}, c.Logger)
+
+	// Create execution store (requires pgxpool for direct pgx queries)
+	pool, err := pgxpool.New(ctx, c.Config.Database.URL)
+	if err != nil {
+		c.Logger.Warn("scheduler disabled: failed to create pgx pool for execution store",
+			"error", err)
+		return
+	}
+	c.cleanups = append(c.cleanups, func() {
+		pool.Close()
+	})
+
+	executionStore, err := scheduler.NewPgExecutionStore(pool) //nolint:contextcheck // NewPgExecutionStore creates its own context for schema validation
+	if err != nil {
+		c.Logger.Warn("scheduler disabled: execution store validation failed",
+			"error", err)
+		return
+	}
+
+	// Create Reference Data client (stub until proto available)
+	refDataClient := worker.NewStubReferenceDataClient(c.Logger)
+
+	// Create reconciliation self-client (loopback to this service)
+	reconConn, err := grpc.NewClient(
+		fmt.Sprintf("localhost:%s", c.Config.Server.Port),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		c.Logger.Warn("scheduler disabled: failed to create reconciliation self-client",
+			"error", err)
+		return
+	}
+	c.cleanups = append(c.cleanups, func() {
+		if err := reconConn.Close(); err != nil {
+			c.Logger.Error("failed to close reconciliation self-client connection", "error", err)
+		}
+	})
+
+	reconGrpcClient := reconciliationv1.NewAccountReconciliationServiceClient(reconConn)
+	reconClient := worker.NewGrpcReconciliationClient(reconGrpcClient)
+
+	// Create adapter types
+	provider := worker.NewSettlementScheduleProvider(refDataClient)
+	executor := worker.NewSettlementExecutor(reconClient, nil, c.Logger)
+
+	// Create shared cron scheduler
+	c.CronScheduler = scheduler.NewCronScheduler(
+		provider,
+		executor,
+		distLock,
+		scheduler.CronSchedulerConfig{
+			Name:             "reconciliation",
+			RefreshInterval:  c.Config.Scheduler.PollInterval,
+			ShutdownTimeout:  c.Config.Scheduler.ShutdownTimeout,
+			ExecutionTimeout: 10 * time.Minute,
+			MaxCatchUpAge:    24 * time.Hour,
+		},
+		c.Logger,
+		scheduler.WithCronExecutionStore(executionStore),
+	)
+
+	c.Logger.Info("settlement scheduler configured",
+		"poll_interval", c.Config.Scheduler.PollInterval,
+		"leader_lock_ttl", c.Config.Scheduler.LeaderLockTTL,
+		"shutdown_timeout", c.Config.Scheduler.ShutdownTimeout)
+}
+
+// initAuth initializes the auth interceptor.
+func (c *Container) initAuth(ctx context.Context) error {
+	authConfig := bootstrap.DefaultAuthConfig(c.Logger)
+	interceptor, err := bootstrap.NewAuthInterceptor(ctx, authConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize auth: %w", err)
+	}
+	c.AuthInterceptor = interceptor
+	return nil
+}
+
+// WireScheduler creates and configures a CronScheduler with all its dependencies.
+// This is exported for use in tests. Returns nil if any required dependency is not available.
+func WireScheduler(ctx context.Context, cfg *config.Config, redisClient *redis.Client, logger *slog.Logger) *scheduler.CronScheduler {
+	c := &Container{
+		Config:      cfg,
+		Logger:      logger,
+		RedisClient: redisClient,
+	}
+	c.initScheduler(ctx)
+	return c.CronScheduler
+}
+
+// BuildValuationComponents creates the real valuation engine and reference data provider.
+// This is exported for use in tests.
+func BuildValuationComponents(cfg *config.Config, logger *slog.Logger) (valuation.Engine, service.ReferenceDataProvider, *grpc.ClientConn) {
+	c := &Container{
+		Config: cfg,
+		Logger: logger,
+	}
+	engine, provider := c.buildValuationComponents()
+
+	// Extract connection from cleanups if one was created
+	var conn *grpc.ClientConn
+	if len(c.cleanups) > 0 {
+		// The last cleanup is the reference data connection closer
+		// Return the connection for the caller to manage
+		// We need to re-create it since the cleanup holds a closure
+		if cfg.Services.ReferenceDataURL != "" {
+			var connErr error
+			conn, connErr = grpc.NewClient(
+				cfg.Services.ReferenceDataURL,
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			)
+			if connErr != nil {
+				logger.Warn("failed to create reference data gRPC client for test", "error", connErr)
+			}
+		}
+	}
+	return engine, provider, conn
+}
+
+// Close gracefully shuts down all container resources.
+func (c *Container) Close() {
+	c.Logger.Info("closing container resources...")
+
+	// Stop scheduler first (it makes gRPC calls to self)
+	if c.CronScheduler != nil {
+		c.Logger.Info("stopping settlement scheduler...")
+		c.CronScheduler.Stop()
+		c.Logger.Info("settlement scheduler stopped")
+	}
+
+	// Stop outbox worker
+	if c.OutboxWorker != nil {
+		c.Logger.Info("stopping outbox worker...")
+		c.OutboxWorker.Stop()
+		c.Logger.Info("outbox worker stopped")
+	}
+
+	// Close Kafka producer
+	if c.kafkaProducer != nil {
+		c.Logger.Info("flushing and closing Kafka producer...")
+		if remaining := c.kafkaProducer.FlushWithTimeout(5000); remaining > 0 {
+			c.Logger.Warn("some messages not delivered before close", "remaining", remaining)
+		}
+		c.kafkaProducer.Close()
+		c.Logger.Info("Kafka producer closed")
+	}
+
+	// Run cleanup functions in reverse order (gRPC connections, pgx pools, etc.)
+	for i := len(c.cleanups) - 1; i >= 0; i-- {
+		c.cleanups[i]()
+	}
+
+	// Close Redis client
+	if c.RedisClient != nil {
+		if err := c.RedisClient.Close(); err != nil {
+			c.Logger.Error("failed to close Redis client", "error", err)
+		}
+	}
+
+	// Close database
+	bootstrap.CloseDatabase(c.DB, c.Logger)
+
+	// Shutdown tracer
+	bootstrap.ShutdownTracer(c.Tracer, c.Logger)
+
+	c.Logger.Info("container resources closed")
+}

--- a/services/reconciliation/app/container.go
+++ b/services/reconciliation/app/container.go
@@ -258,11 +258,21 @@ func (c *Container) initServiceDeps() ([]service.Option, error) {
 		c.Logger.Warn("balance assertor not configured: position keeping client unavailable")
 	}
 
+	// Wire variance detection and valuation components
+	varianceOpts := c.wireVarianceComponents()
+	serviceOpts = append(serviceOpts, varianceOpts...)
+
+	return serviceOpts, nil
+}
+
+// wireVarianceComponents creates the variance detector, valuator, and account party resolver,
+// returning the corresponding service options.
+func (c *Container) wireVarianceComponents() []service.Option {
+	var opts []service.Option
+
 	// Wire VarianceDetector (depends on repos only, always available)
 	detector := service.NewVarianceDetector(c.RunRepo, c.SnapshotRepo, c.VarianceRepo)
-	serviceOpts = append(serviceOpts,
-		service.WithVarianceDetector(detector.DetectVariances),
-	)
+	opts = append(opts, service.WithVarianceDetector(detector.DetectVariances))
 
 	// Wire VarianceValuator with valuation engine and reference data provider
 	valuationEngine, refDataProvider := c.buildValuationComponents()
@@ -291,11 +301,9 @@ func (c *Container) initServiceDeps() ([]service.Option, error) {
 	}
 
 	valuator := service.NewVarianceValuator(valuationEngine, refDataProvider, partyResolver, c.VarianceRepo, c.RunRepo)
-	serviceOpts = append(serviceOpts,
-		service.WithVarianceValuator(valuator.ValueVariances),
-	)
+	opts = append(opts, service.WithVarianceValuator(valuator.ValueVariances))
 
-	return serviceOpts, nil
+	return opts
 }
 
 // buildValuationComponents creates the valuation engine and reference data provider.

--- a/services/reconciliation/app/container.go
+++ b/services/reconciliation/app/container.go
@@ -70,6 +70,9 @@ type Container struct {
 	// Scheduler (may be nil if disabled or Redis unavailable)
 	CronScheduler *scheduler.CronScheduler
 
+	// Internal connections (exposed for test helpers)
+	refDataConn *grpc.ClientConn
+
 	// Cleanup functions for gRPC connections and pgx pools
 	cleanups []func()
 }
@@ -348,6 +351,7 @@ func (c *Container) buildValuationComponents() (valuation.Engine, service.Refere
 		if connErr != nil {
 			c.Logger.Warn("failed to create reference data gRPC client", "error", connErr)
 		} else {
+			c.refDataConn = refDataConn
 			c.cleanups = append(c.cleanups, func() {
 				if err := refDataConn.Close(); err != nil {
 					c.Logger.Error("failed to close reference data connection", "error", err)
@@ -499,15 +503,22 @@ func (c *Container) initAuth(ctx context.Context) error {
 }
 
 // WireScheduler creates and configures a CronScheduler with all its dependencies.
-// This is exported for use in tests. Returns nil if any required dependency is not available.
-func WireScheduler(ctx context.Context, cfg *config.Config, redisClient *redis.Client, logger *slog.Logger) *scheduler.CronScheduler {
+// This is exported for use in tests. Returns nil scheduler if any required dependency
+// is not available. The returned cleanup function releases resources (pgx pool, gRPC connections)
+// registered during scheduler wiring.
+func WireScheduler(ctx context.Context, cfg *config.Config, redisClient *redis.Client, logger *slog.Logger) (*scheduler.CronScheduler, func()) {
 	c := &Container{
 		Config:      cfg,
 		Logger:      logger,
 		RedisClient: redisClient,
 	}
 	c.initScheduler(ctx)
-	return c.CronScheduler
+	cleanup := func() {
+		for i := len(c.cleanups) - 1; i >= 0; i-- {
+			c.cleanups[i]()
+		}
+	}
+	return c.CronScheduler, cleanup
 }
 
 // BuildValuationComponents creates the real valuation engine and reference data provider.
@@ -518,25 +529,7 @@ func BuildValuationComponents(cfg *config.Config, logger *slog.Logger) (valuatio
 		Logger: logger,
 	}
 	engine, provider := c.buildValuationComponents()
-
-	// Extract connection from cleanups if one was created
-	var conn *grpc.ClientConn
-	if len(c.cleanups) > 0 {
-		// The last cleanup is the reference data connection closer
-		// Return the connection for the caller to manage
-		// We need to re-create it since the cleanup holds a closure
-		if cfg.Services.ReferenceDataURL != "" {
-			var connErr error
-			conn, connErr = grpc.NewClient(
-				cfg.Services.ReferenceDataURL,
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-			)
-			if connErr != nil {
-				logger.Warn("failed to create reference data gRPC client for test", "error", connErr)
-			}
-		}
-	}
-	return engine, provider, conn
+	return engine, provider, c.refDataConn
 }
 
 // Close gracefully shuts down all container resources.

--- a/services/reconciliation/app/container.go
+++ b/services/reconciliation/app/container.go
@@ -268,7 +268,7 @@ func (c *Container) initServiceDeps() ([]service.Option, error) {
 // wireVarianceComponents creates the variance detector, valuator, and account party resolver,
 // returning the corresponding service options.
 func (c *Container) wireVarianceComponents() []service.Option {
-	var opts []service.Option
+	opts := make([]service.Option, 0, 2) //nolint:mnd // detector + valuator
 
 	// Wire VarianceDetector (depends on repos only, always available)
 	detector := service.NewVarianceDetector(c.RunRepo, c.SnapshotRepo, c.VarianceRepo)

--- a/services/reconciliation/cmd/main.go
+++ b/services/reconciliation/cmd/main.go
@@ -12,30 +12,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgxpool"
-	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
-	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
-	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
-	"github.com/meridianhub/meridian/services/reconciliation/adapters/messaging"
-	"github.com/meridianhub/meridian/services/reconciliation/adapters/persistence"
+	"github.com/meridianhub/meridian/services/reconciliation/app"
 	"github.com/meridianhub/meridian/services/reconciliation/config"
 	"github.com/meridianhub/meridian/services/reconciliation/observability"
-	"github.com/meridianhub/meridian/services/reconciliation/service"
-	"github.com/meridianhub/meridian/services/reconciliation/worker"
 	"github.com/meridianhub/meridian/shared/pkg/health"
-	"github.com/meridianhub/meridian/shared/pkg/valuation"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
-	"github.com/meridianhub/meridian/shared/platform/env"
-	"github.com/meridianhub/meridian/shared/platform/events"
-	"github.com/meridianhub/meridian/shared/platform/kafka"
-	"github.com/meridianhub/meridian/shared/platform/redislock"
-	"github.com/meridianhub/meridian/shared/platform/scheduler"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/redis/go-redis/v9"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 )
@@ -85,240 +68,33 @@ func run(logger *slog.Logger) error {
 		"grpc_port", cfg.Server.Port,
 		"metrics_port", cfg.Observability.MetricsPort)
 
-	// Initialize OpenTelemetry tracer
-	tracer, err := bootstrap.NewTracer(ctx, bootstrap.TracerConfig{
-		ServiceName:    cfg.Observability.ServiceName,
-		ServiceVersion: Version,
-		Logger:         logger,
-	})
+	// Initialize dependency container
+	container, err := app.NewContainer(ctx, cfg, logger, Version)
 	if err != nil {
-		return fmt.Errorf("failed to initialize tracer: %w", err)
+		return err
 	}
-	defer bootstrap.ShutdownTracer(tracer, logger)
-
-	// Initialize database connection
-	dbConfig := bootstrap.DefaultDatabaseConfig()
-	dbConfig.DSN = cfg.Database.URL
-	dbConfig.MaxOpenConns = cfg.Database.MaxOpenConns
-	dbConfig.MaxIdleConns = cfg.Database.MaxIdleConns
-	dbConfig.ConnMaxLifetime = cfg.Database.ConnMaxLifetime
-	dbConfig.ConnMaxIdleTime = cfg.Database.ConnMaxIdleTime
-	dbConfig.Logger = logger
-
-	db, err := bootstrap.NewDatabase(ctx, dbConfig)
-	if err != nil {
-		return fmt.Errorf("failed to initialize database: %w", err)
-	}
-	defer bootstrap.CloseDatabase(db, logger)
-
-	logger.Info("database connection established")
-
-	// Initialize outbox publisher and worker for transactional event publishing
-	outboxRepo := events.NewPostgresOutboxRepository(db)
-	outboxPublisher := events.NewOutboxPublisher("reconciliation")
-
-	var outboxWorker *events.Worker
-	var kafkaProducer *kafka.ProtoProducer
-	bootstrapServers := env.GetEnvOrDefault("KAFKA_BOOTSTRAP_SERVERS", "")
-	if bootstrapServers == "" && cfg.Kafka.Enabled {
-		bootstrapServers = cfg.Kafka.Brokers
-	}
-	if bootstrapServers != "" {
-		producer, kafkaErr := kafka.NewProtoProducer(kafka.ProducerConfig{
-			BootstrapServers: bootstrapServers,
-			ClientID:         "reconciliation-outbox-worker",
-			Acks:             "all",
-			Retries:          3,
-			Compression:      "snappy",
-		})
-		if kafkaErr != nil {
-			logger.Warn("failed to create Kafka producer for outbox worker",
-				"error", kafkaErr)
-		} else {
-			kafkaProducer = producer
-			defer kafkaProducer.Close()
-			workerConfig := events.DefaultWorkerConfig("reconciliation")
-			outboxWorker = events.NewWorker(outboxRepo, kafkaProducer, workerConfig, logger)
-			outboxWorker.Start(ctx)
-			defer outboxWorker.Stop()
-			logger.Info("outbox worker started",
-				"bootstrap_servers", bootstrapServers)
-		}
-	} else {
-		logger.Warn("outbox worker disabled - KAFKA_BOOTSTRAP_SERVERS not set")
-	}
-
-	// Create outbox-based event publisher (replaces KafkaPublisher/NoopPublisher)
-	eventPublisher := messaging.NewOutboxEventPublisher(db, outboxPublisher)
-
-	// Instantiate persistence repositories
-	runRepo := persistence.NewSettlementRunRepository(db)
-	snapshotRepo := persistence.NewSettlementSnapshotRepository(db)
-	varianceRepo := persistence.NewVarianceRepository(db)
-	disputeRepo := persistence.NewDisputeRepository(db)
-	assertionRepo := persistence.NewBalanceAssertionRepository(db)
-	trendRepo := persistence.NewImbalanceTrendRepository(db)
-
-	// Build service options with repositories (always available)
-	serviceOpts := []service.Option{
-		service.WithSettlementRunRepository(runRepo),
-		service.WithDisputeRepository(disputeRepo),
-		service.WithDisputeListRepository(disputeRepo),
-		service.WithAssertionListRepository(assertionRepo),
-		service.WithVarianceRepository(varianceRepo),
-		service.WithVarianceListRepository(varianceRepo),
-		service.WithEventPublisher(eventPublisher),
-		service.WithLogger(logger),
-	}
-
-	// Wire SnapshotCapturer if Position Keeping URL is configured
-	var pkConn *grpc.ClientConn
-	if cfg.Services.PositionKeepingURL != "" {
-		var connErr error
-		pkConn, connErr = grpc.NewClient(
-			cfg.Services.PositionKeepingURL,
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-		)
-		if connErr != nil {
-			return fmt.Errorf("failed to create position keeping client at %s: %w",
-				cfg.Services.PositionKeepingURL, connErr)
-		}
-
-		pkClient := positionkeepingv1.NewPositionKeepingServiceClient(pkConn)
-		provider := service.NewPKPositionProvider(pkClient)
-		capturer := service.NewSnapshotCapturer(provider, runRepo, snapshotRepo)
-		serviceOpts = append(serviceOpts,
-			service.WithSnapshotCapturer(capturer.CaptureSnapshots),
-		)
-
-		logger.Info("snapshot capturer configured",
-			"position_keeping_url", cfg.Services.PositionKeepingURL)
-
-		// Wire BalanceAssertor (requires PK client for position summaries)
-		balancePKClient := service.NewGrpcPositionKeepingClient(pkClient)
-		assertor := service.NewBalanceAssertor(assertionRepo, trendRepo, balancePKClient, nil, nil, logger)
-		serviceOpts = append(serviceOpts,
-			service.WithBalanceAssertor(assertor),
-		)
-		logger.Info("balance assertor configured")
-	} else {
-		logger.Warn("snapshot capturer not configured: POSITION_KEEPING_URL not set")
-		logger.Warn("balance assertor not configured: position keeping client unavailable")
-	}
-	defer func() {
-		if pkConn != nil {
-			if err := pkConn.Close(); err != nil {
-				logger.Error("failed to close position keeping connection", "error", err)
-			}
-		}
-	}()
-
-	// Wire VarianceDetector (depends on repos only, always available)
-	detector := service.NewVarianceDetector(runRepo, snapshotRepo, varianceRepo)
-	serviceOpts = append(serviceOpts,
-		service.WithVarianceDetector(detector.DetectVariances),
-	)
-
-	// Wire VarianceValuator with real valuation engine and reference data provider
-	valuationEngine, refDataProvider, refDataConn := buildValuationComponents(cfg, logger)
-	defer func() {
-		if refDataConn != nil {
-			if err := refDataConn.Close(); err != nil {
-				logger.Error("failed to close reference data connection", "error", err)
-			}
-		}
-	}()
-	// Wire AccountPartyResolver if Current Account URL is configured
-	var partyResolver service.AccountPartyResolver
-	if cfg.Services.CurrentAccountURL != "" {
-		caConn, caErr := grpc.NewClient(
-			cfg.Services.CurrentAccountURL,
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-		)
-		if caErr != nil {
-			logger.Warn("failed to create current account gRPC client, party resolution will fall back to account ID",
-				"error", caErr)
-		} else {
-			defer func() {
-				if err := caConn.Close(); err != nil {
-					logger.Error("failed to close current account connection", "error", err)
-				}
-			}()
-			caClient := currentaccountv1.NewCurrentAccountServiceClient(caConn)
-			partyResolver = service.NewGRPCAccountPartyResolver(caClient)
-			logger.Info("current account party resolver configured",
-				"current_account_url", cfg.Services.CurrentAccountURL)
-		}
-	}
-
-	valuator := service.NewVarianceValuator(valuationEngine, refDataProvider, partyResolver, varianceRepo, runRepo)
-	serviceOpts = append(serviceOpts,
-		service.WithVarianceValuator(valuator.ValueVariances),
-	)
-
-	// Create AccountReconciliationService
-	reconciliationSvc := service.NewAccountReconciliationService(serviceOpts...)
-
-	// Initialize Redis client (optional, needed for scheduler leader election)
-	var redisClient *redis.Client
-	if cfg.Redis.Enabled && cfg.Redis.URL != "" {
-		redisCfg := bootstrap.RedisConfig{
-			URL:    cfg.Redis.URL,
-			Logger: logger,
-		}
-		var redisErr error
-		redisClient, redisErr = bootstrap.NewRedisClient(ctx, redisCfg)
-		if redisErr != nil {
-			logger.Warn("Redis connection failed, scheduler and Redis health check disabled",
-				"error", redisErr)
-		} else {
-			logger.Info("Redis client connected")
-		}
-	}
-	defer func() {
-		if redisClient != nil {
-			if err := redisClient.Close(); err != nil {
-				logger.Error("failed to close Redis client", "error", err)
-			}
-		}
-	}()
-
-	// Wire settlement scheduler (optional, depends on Redis + config)
-	var cronScheduler *scheduler.CronScheduler
-	if cfg.Scheduler.Enabled {
-		cronScheduler = wireScheduler(ctx, cfg, redisClient, logger)
-	} else {
-		logger.Info("settlement scheduler disabled")
-	}
-
-	// Initialize auth interceptor
-	authConfig := bootstrap.DefaultAuthConfig(logger)
-	authInterceptor, err := bootstrap.NewAuthInterceptor(ctx, authConfig)
-	if err != nil {
-		return fmt.Errorf("failed to initialize auth: %w", err)
-	}
+	defer container.Close()
 
 	// Create gRPC server with interceptor chain
-	grpcServer, err := bootstrap.NewGrpcServerBuilder(tracer, logger).
-		WithAuthInterceptor(authInterceptor).
+	grpcServer, err := bootstrap.NewGrpcServerBuilder(container.Tracer, logger).
+		WithAuthInterceptor(container.AuthInterceptor).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to build grpc server: %w", err)
 	}
 
 	// Register AccountReconciliationService
-	reconciliationv1.RegisterAccountReconciliationServiceServer(grpcServer, reconciliationSvc)
+	reconciliationv1.RegisterAccountReconciliationServiceServer(grpcServer, container.ReconciliationService)
 
 	// Register health check service with available checkers
 	healthCheckers := []health.Checker{
-		observability.NewDatabaseChecker(db),
+		observability.NewDatabaseChecker(container.DB),
 	}
-	if redisClient != nil {
-		healthCheckers = append(healthCheckers, observability.NewRedisChecker(redisClient))
+	if container.RedisClient != nil {
+		healthCheckers = append(healthCheckers, observability.NewRedisChecker(container.RedisClient))
 	}
 	healthAggregator := health.NewAggregator(healthCheckers)
-	healthServer := newHealthServer(healthAggregator, logger)
-	grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)
+	grpc_health_v1.RegisterHealthServer(grpcServer, newHealthServer(healthAggregator, logger))
 
 	// Register reflection service for debugging
 	reflection.Register(grpcServer)
@@ -345,9 +121,9 @@ func run(logger *slog.Logger) error {
 	// Start settlement scheduler in background (after gRPC server is listening)
 	schedulerCtx, schedulerCancel := context.WithCancel(context.Background())
 	defer schedulerCancel()
-	if cronScheduler != nil {
+	if container.CronScheduler != nil {
 		go func() {
-			if err := cronScheduler.Start(schedulerCtx); err != nil {
+			if err := container.CronScheduler.Start(schedulerCtx); err != nil {
 				logger.Error("scheduler stopped with error", "error", err)
 			}
 		}()
@@ -401,14 +177,14 @@ func run(logger *slog.Logger) error {
 	logger.Info("shutting down servers...")
 
 	// Stop scheduler first (it makes gRPC calls to self)
-	if cronScheduler != nil {
+	if container.CronScheduler != nil {
 		logger.Info("stopping settlement scheduler...")
 		schedulerCancel()
-		cronScheduler.Stop()
+		container.CronScheduler.Stop()
 		logger.Info("settlement scheduler stopped")
 	}
 
-	// Outbox worker and Kafka producer are cleaned up via defer.
+	// Outbox worker and Kafka producer are cleaned up via container.Close().
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.Server.GracefulShutdownTimeout)
 	defer cancel()
@@ -429,81 +205,6 @@ func run(logger *slog.Logger) error {
 	}
 
 	return runErr
-}
-
-// wireScheduler creates and configures the CronScheduler with all its dependencies.
-// Returns nil if any required dependency is not available.
-func wireScheduler(ctx context.Context, cfg *config.Config, redisClient *redis.Client, logger *slog.Logger) *scheduler.CronScheduler {
-	if redisClient == nil {
-		logger.Warn("scheduler disabled: Redis not configured (required for distributed locking)")
-		return nil
-	}
-
-	// Create distributed lock (replaces custom RedisLeaderElector)
-	distLock := redislock.NewLock(redisClient, redislock.Config{
-		KeyPrefix:  "meridian:reconciliation:scheduler",
-		LockTTL:    cfg.Scheduler.LeaderLockTTL,
-		RenewEvery: cfg.Scheduler.LeaderRenewInterval,
-	}, logger)
-
-	// Create execution store (requires pgxpool for direct pgx queries)
-	pool, err := pgxpool.New(ctx, cfg.Database.URL)
-	if err != nil {
-		logger.Warn("scheduler disabled: failed to create pgx pool for execution store",
-			"error", err)
-		return nil
-	}
-	executionStore, err := scheduler.NewPgExecutionStore(pool) //nolint:contextcheck // NewPgExecutionStore creates its own context for schema validation
-	if err != nil {
-		logger.Warn("scheduler disabled: execution store validation failed",
-			"error", err)
-		pool.Close()
-		return nil
-	}
-
-	// Create Reference Data client (stub until proto available)
-	refDataClient := worker.NewStubReferenceDataClient(logger)
-
-	// Create reconciliation self-client (loopback to this service)
-	reconConn, err := grpc.NewClient(
-		fmt.Sprintf("localhost:%s", cfg.Server.Port),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
-	if err != nil {
-		logger.Warn("scheduler disabled: failed to create reconciliation self-client",
-			"error", err)
-		pool.Close()
-		return nil
-	}
-	reconGrpcClient := reconciliationv1.NewAccountReconciliationServiceClient(reconConn)
-	reconClient := worker.NewGrpcReconciliationClient(reconGrpcClient)
-
-	// Create adapter types
-	provider := worker.NewSettlementScheduleProvider(refDataClient)
-	executor := worker.NewSettlementExecutor(reconClient, nil, logger)
-
-	// Create shared cron scheduler
-	cronScheduler := scheduler.NewCronScheduler(
-		provider,
-		executor,
-		distLock,
-		scheduler.CronSchedulerConfig{
-			Name:             "reconciliation",
-			RefreshInterval:  cfg.Scheduler.PollInterval,
-			ShutdownTimeout:  cfg.Scheduler.ShutdownTimeout,
-			ExecutionTimeout: 10 * time.Minute,
-			MaxCatchUpAge:    24 * time.Hour,
-		},
-		logger,
-		scheduler.WithCronExecutionStore(executionStore),
-	)
-
-	logger.Info("settlement scheduler configured",
-		"poll_interval", cfg.Scheduler.PollInterval,
-		"leader_lock_ttl", cfg.Scheduler.LeaderLockTTL,
-		"shutdown_timeout", cfg.Scheduler.ShutdownTimeout)
-
-	return cronScheduler
 }
 
 // healthServer implements the gRPC health checking protocol.
@@ -536,73 +237,6 @@ func (h *healthServer) Check(ctx context.Context, _ *grpc_health_v1.HealthCheckR
 	return &grpc_health_v1.HealthCheckResponse{
 		Status: grpcStatus,
 	}, nil
-}
-
-// buildValuationComponents creates the real valuation engine and reference data provider.
-// When the Reference Data gRPC URL is configured, it creates a gRPC client for instrument
-// lookups. Otherwise, it falls back to the identity conversion method
-// with default materiality thresholds.
-func buildValuationComponents(cfg *config.Config, logger *slog.Logger) (valuation.Engine, service.ReferenceDataProvider, *grpc.ClientConn) {
-	// Create valuation engine runtime components
-	policyRT, err := valuation.NewPolicyRuntime()
-	if err != nil {
-		logger.Warn("failed to create CEL policy runtime, using identity method resolver", "error", err)
-	}
-
-	starlarkRT := valuation.NewStarlarkRuntime(valuation.StarlarkRuntimeConfig{
-		PolicyRuntime: policyRT,
-	})
-
-	cache := valuation.NewInMemoryCache(valuation.InMemoryCacheConfig{})
-
-	// Use identity method resolver as the base; gRPC method resolution can extend this later
-	methodResolver := valuation.NewIdentityMethodResolver()
-
-	engine := valuation.NewEngine(valuation.Config{
-		StarlarkRuntime: starlarkRT,
-		PolicyRuntime:   policyRT,
-		Cache:           cache,
-	}, methodResolver)
-
-	adaptedEngine := service.NewValuationEngineAdapter(engine, logger)
-
-	// Build reference data provider with gRPC clients if available
-	providerCfg := service.GRPCReferenceDataProviderConfig{
-		DefaultMethodID: uuid.MustParse(valuation.IdentityMethodID),
-		Logger:          logger,
-	}
-
-	var refDataConn *grpc.ClientConn
-	if cfg.Services.ReferenceDataURL != "" {
-		var connErr error
-		refDataConn, connErr = grpc.NewClient(
-			cfg.Services.ReferenceDataURL,
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-		)
-		if connErr != nil {
-			logger.Warn("failed to create reference data gRPC client", "error", connErr)
-			refDataConn = nil
-		} else {
-			providerCfg.InstrumentClient = referencedatav1.NewReferenceDataServiceClient(refDataConn)
-			// AccountTypeClient is not wired here because the identity-only method resolver
-			// cannot resolve non-identity method IDs that account type lookups may return.
-			// Wire AccountTypeClient when a full gRPC method resolver is available.
-			logger.Info("reference data gRPC client configured for instrument lookups",
-				"url", cfg.Services.ReferenceDataURL)
-		}
-	} else {
-		logger.Info("reference data gRPC not configured, using default valuation method and materiality threshold")
-	}
-
-	refDataProvider := service.NewGRPCReferenceDataProvider(providerCfg)
-
-	logger.Info("variance valuator configured",
-		"engine", "starlark+cel",
-		"method_resolver", "identity (fallback)",
-		"reference_data_url", cfg.Services.ReferenceDataURL,
-	)
-
-	return adaptedEngine, refDataProvider, refDataConn
 }
 
 // parseLogLevel converts a string log level to slog.Level.

--- a/services/reconciliation/cmd/main_test.go
+++ b/services/reconciliation/cmd/main_test.go
@@ -13,6 +13,7 @@ import (
 	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
 	"github.com/meridianhub/meridian/services/reconciliation/adapters/messaging"
 	"github.com/meridianhub/meridian/services/reconciliation/adapters/persistence"
+	"github.com/meridianhub/meridian/services/reconciliation/app"
 	"github.com/meridianhub/meridian/services/reconciliation/config"
 	"github.com/meridianhub/meridian/services/reconciliation/observability"
 	"github.com/meridianhub/meridian/services/reconciliation/service"
@@ -474,7 +475,7 @@ func TestWireScheduler_NilRedis_ReturnsNil(t *testing.T) {
 		},
 	}
 
-	scheduler := wireScheduler(context.Background(), cfg, nil, logger)
+	scheduler := app.WireScheduler(context.Background(), cfg, nil, logger)
 	assert.Nil(t, scheduler, "scheduler should be nil when Redis client is nil")
 }
 
@@ -502,7 +503,7 @@ func TestWireScheduler_InvalidDatabaseURL_ReturnsNil(t *testing.T) {
 		},
 	}
 
-	scheduler := wireScheduler(context.Background(), cfg, redisClient, logger)
+	scheduler := app.WireScheduler(context.Background(), cfg, redisClient, logger)
 	assert.Nil(t, scheduler, "scheduler should be nil when database URL is invalid")
 }
 
@@ -546,7 +547,7 @@ func TestWireScheduler_ValidConfig_ReturnsScheduler(t *testing.T) {
 		},
 	}
 
-	scheduler := wireScheduler(context.Background(), cfg, redisClient, logger)
+	scheduler := app.WireScheduler(context.Background(), cfg, redisClient, logger)
 	assert.NotNil(t, scheduler, "scheduler should be created with valid config")
 
 	// Clean up - stop the scheduler before test ends
@@ -638,7 +639,7 @@ func TestBuildValuationComponents_NoRefDataURL(t *testing.T) {
 		},
 	}
 
-	engine, provider, conn := buildValuationComponents(cfg, logger)
+	engine, provider, conn := app.BuildValuationComponents(cfg, logger)
 	assert.NotNil(t, engine, "valuation engine should always be created")
 	assert.NotNil(t, provider, "reference data provider should always be created")
 	assert.Nil(t, conn, "connection should be nil when no URL configured")
@@ -652,7 +653,7 @@ func TestBuildValuationComponents_WithRefDataURL(t *testing.T) {
 		},
 	}
 
-	engine, provider, conn := buildValuationComponents(cfg, logger)
+	engine, provider, conn := app.BuildValuationComponents(cfg, logger)
 	assert.NotNil(t, engine, "valuation engine should always be created")
 	assert.NotNil(t, provider, "reference data provider should always be created")
 	assert.NotNil(t, conn, "connection should be created when URL is configured")

--- a/services/reconciliation/cmd/main_test.go
+++ b/services/reconciliation/cmd/main_test.go
@@ -475,7 +475,8 @@ func TestWireScheduler_NilRedis_ReturnsNil(t *testing.T) {
 		},
 	}
 
-	scheduler := app.WireScheduler(context.Background(), cfg, nil, logger)
+	scheduler, cleanup := app.WireScheduler(context.Background(), cfg, nil, logger)
+	defer cleanup()
 	assert.Nil(t, scheduler, "scheduler should be nil when Redis client is nil")
 }
 
@@ -503,7 +504,8 @@ func TestWireScheduler_InvalidDatabaseURL_ReturnsNil(t *testing.T) {
 		},
 	}
 
-	scheduler := app.WireScheduler(context.Background(), cfg, redisClient, logger)
+	scheduler, wireCleanup := app.WireScheduler(context.Background(), cfg, redisClient, logger)
+	defer wireCleanup()
 	assert.Nil(t, scheduler, "scheduler should be nil when database URL is invalid")
 }
 
@@ -547,7 +549,8 @@ func TestWireScheduler_ValidConfig_ReturnsScheduler(t *testing.T) {
 		},
 	}
 
-	scheduler := app.WireScheduler(context.Background(), cfg, redisClient, logger)
+	scheduler, wireCleanup := app.WireScheduler(context.Background(), cfg, redisClient, logger)
+	defer wireCleanup()
 	assert.NotNil(t, scheduler, "scheduler should be created with valid config")
 
 	// Clean up - stop the scheduler before test ends

--- a/services/tenant/app/container.go
+++ b/services/tenant/app/container.go
@@ -32,7 +32,7 @@ const envValueTrue = "true"
 
 // Sentinel errors for worker configuration validation.
 var (
-	errInvalidPollInterval = errors.New("poll interval must be >= 1s")
+	errInvalidPollInterval    = errors.New("poll interval must be >= 1s")
 	errInvalidMaxRetries      = errors.New("max retries must be >= 0 and <= 20")
 	errInvalidRetryBaseDelay  = errors.New("retry base delay must be > 0")
 	errInvalidRetryMaxDelay   = errors.New("retry max delay must be > 0")

--- a/services/tenant/app/container.go
+++ b/services/tenant/app/container.go
@@ -30,8 +30,16 @@ import (
 // envValueTrue is the string value for enabled environment variables.
 const envValueTrue = "true"
 
-// ErrContainerCloseFailures is returned when one or more resources fail to close during shutdown.
-var ErrContainerCloseFailures = errors.New("one or more container resources failed to close")
+// Sentinel errors for container and worker configuration validation.
+var (
+	ErrContainerCloseFailures = errors.New("one or more container resources failed to close")
+	errInvalidPollInterval    = errors.New("poll interval must be >= 1s")
+	errInvalidMaxRetries      = errors.New("max retries must be >= 0 and <= 20")
+	errInvalidRetryBaseDelay  = errors.New("retry base delay must be > 0")
+	errInvalidRetryMaxDelay   = errors.New("retry max delay must be > 0")
+	errInvalidRetryDelayRange = errors.New("retry base delay must be < retry max delay")
+	errInvalidMaxConcurrent   = errors.New("max concurrent must be >= 1 and <= 100")
+)
 
 // Container holds all application dependencies for the tenant service.
 type Container struct {
@@ -403,22 +411,22 @@ func loadWorkerConfig() (workerConfig, error) {
 	}
 
 	if config.PollInterval < 1*time.Second {
-		return workerConfig{}, fmt.Errorf("poll interval must be >= 1s: got %s", config.PollInterval)
+		return workerConfig{}, fmt.Errorf("%w: got %s", errInvalidPollInterval, config.PollInterval)
 	}
 	if config.MaxRetries < 0 || config.MaxRetries > 20 {
-		return workerConfig{}, fmt.Errorf("max retries must be >= 0 and <= 20: got %d", config.MaxRetries)
+		return workerConfig{}, fmt.Errorf("%w: got %d", errInvalidMaxRetries, config.MaxRetries)
 	}
 	if config.RetryBaseDelay <= 0 {
-		return workerConfig{}, fmt.Errorf("retry base delay must be > 0: got %s", config.RetryBaseDelay)
+		return workerConfig{}, fmt.Errorf("%w: got %s", errInvalidRetryBaseDelay, config.RetryBaseDelay)
 	}
 	if config.RetryMaxDelay <= 0 {
-		return workerConfig{}, fmt.Errorf("retry max delay must be > 0: got %s", config.RetryMaxDelay)
+		return workerConfig{}, fmt.Errorf("%w: got %s", errInvalidRetryMaxDelay, config.RetryMaxDelay)
 	}
 	if config.RetryBaseDelay >= config.RetryMaxDelay {
-		return workerConfig{}, fmt.Errorf("retry base delay must be < retry max delay: base=%s, max=%s", config.RetryBaseDelay, config.RetryMaxDelay)
+		return workerConfig{}, fmt.Errorf("%w: base=%s, max=%s", errInvalidRetryDelayRange, config.RetryBaseDelay, config.RetryMaxDelay)
 	}
 	if config.MaxConcurrent < 1 || config.MaxConcurrent > 100 {
-		return workerConfig{}, fmt.Errorf("max concurrent must be >= 1 and <= 100: got %d", config.MaxConcurrent)
+		return workerConfig{}, fmt.Errorf("%w: got %d", errInvalidMaxConcurrent, config.MaxConcurrent)
 	}
 
 	slog.Info("worker configuration loaded",

--- a/services/tenant/app/container.go
+++ b/services/tenant/app/container.go
@@ -116,13 +116,16 @@ func NewContainer(ctx context.Context, logger *slog.Logger, version string) (*Co
 
 	c.initService(ctx)
 
-	if err := c.initProvisioningWorker(ctx); err != nil {
+	if err := c.initProvisioningWorker(); err != nil {
 		return nil, err
 	}
 
 	if err := c.initAuth(ctx); err != nil {
 		return nil, err
 	}
+
+	// Start background workers only after all initialization succeeds.
+	c.startProvisioningWorker(ctx)
 
 	succeeded = true
 	logger.Info("dependency container initialized successfully")
@@ -320,8 +323,9 @@ func (c *Container) initService(ctx context.Context) {
 		"refresh_interval", "60s")
 }
 
-// initProvisioningWorker creates and starts the provisioning worker if schema provisioning is enabled.
-func (c *Container) initProvisioningWorker(ctx context.Context) error {
+// initProvisioningWorker creates the provisioning worker if schema provisioning is enabled.
+// The worker is not started here - call startProvisioningWorker after all initialization succeeds.
+func (c *Container) initProvisioningWorker() error {
 	if c.SchemaProvisioner == nil {
 		c.Logger.Info("provisioning worker disabled",
 			"hint", "set SCHEMA_PROVISIONING_ENABLED=true to enable background provisioning")
@@ -350,12 +354,16 @@ func (c *Container) initProvisioningWorker(ctx context.Context) error {
 	}
 
 	c.ProvisioningWorker = pw
-
-	// Start worker in background goroutine
-	go pw.Start(ctx)
-
-	c.Logger.Info("provisioning worker started")
 	return nil
+}
+
+// startProvisioningWorker starts the provisioning worker in a background goroutine.
+func (c *Container) startProvisioningWorker(ctx context.Context) {
+	if c.ProvisioningWorker == nil {
+		return
+	}
+	go c.ProvisioningWorker.Start(ctx)
+	c.Logger.Info("provisioning worker started")
 }
 
 // initAuth initializes the auth interceptor.

--- a/services/tenant/app/container.go
+++ b/services/tenant/app/container.go
@@ -1,0 +1,443 @@
+// Package app provides application configuration and dependency injection for the tenant service.
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"gorm.io/gorm"
+
+	"github.com/meridianhub/meridian/services/tenant/adapters/persistence"
+	"github.com/meridianhub/meridian/services/tenant/provisioner"
+	"github.com/meridianhub/meridian/services/tenant/service"
+	"github.com/meridianhub/meridian/services/tenant/worker"
+	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/meridianhub/meridian/shared/platform/bootstrap"
+	"github.com/meridianhub/meridian/shared/platform/defaults"
+	"github.com/meridianhub/meridian/shared/platform/env"
+	"github.com/meridianhub/meridian/shared/platform/observability"
+	"github.com/meridianhub/meridian/shared/platform/ports"
+
+	// Service-owned client (standardized client package from party service)
+	partyclient "github.com/meridianhub/meridian/services/party/client"
+)
+
+// envValueTrue is the string value for enabled environment variables.
+const envValueTrue = "true"
+
+// ErrContainerCloseFailures is returned when one or more resources fail to close during shutdown.
+var ErrContainerCloseFailures = errors.New("one or more container resources failed to close")
+
+// Container holds all application dependencies for the tenant service.
+type Container struct {
+	Logger *slog.Logger
+
+	// Infrastructure
+	Tracer      *observability.Tracer
+	DB          *gorm.DB
+	RedisClient *redis.Client
+
+	// Auth
+	AuthInterceptor  *auth.Interceptor
+	UsePlatformAdmin bool
+
+	// Repositories
+	Repo *persistence.Repository
+
+	// Schema provisioning
+	SchemaProvisioner provisioner.SchemaProvisioner
+
+	// Party client
+	PartyClient service.PartyClient
+
+	// Caching
+	SlugCache *service.SlugCache
+
+	// Service layer
+	TenantService  *service.Service
+	CachedRegistry *service.CachedRegistry
+
+	// Workers
+	ProvisioningWorker *worker.ProvisioningWorker
+
+	// Cleanup functions (executed in reverse order)
+	cleanups []func()
+}
+
+// NewContainer creates and initializes a new dependency injection container.
+func NewContainer(ctx context.Context, logger *slog.Logger, version string) (*Container, error) {
+	c := &Container{
+		Logger:           logger,
+		UsePlatformAdmin: true,
+	}
+
+	// If initialization fails partway, close already-initialized resources.
+	succeeded := false
+	defer func() { //nolint:contextcheck // Close manages its own shutdown contexts
+		if !succeeded {
+			c.Close()
+		}
+	}()
+
+	if err := c.initTracer(ctx, version); err != nil {
+		return nil, err
+	}
+
+	if err := c.initDatabase(ctx); err != nil {
+		return nil, err
+	}
+
+	c.initRepositories()
+
+	if err := c.initSchemaProvisioner(); err != nil {
+		return nil, err
+	}
+
+	if err := c.initPartyClient(ctx); err != nil {
+		return nil, err
+	}
+
+	if err := c.initRedis(ctx); err != nil {
+		return nil, err
+	}
+
+	c.initService(ctx)
+
+	if err := c.initProvisioningWorker(ctx); err != nil {
+		return nil, err
+	}
+
+	if err := c.initAuth(ctx); err != nil {
+		return nil, err
+	}
+
+	succeeded = true
+	logger.Info("dependency container initialized successfully")
+	return c, nil
+}
+
+// initTracer initializes the OpenTelemetry tracer.
+func (c *Container) initTracer(ctx context.Context, version string) error {
+	tracer, err := bootstrap.NewTracer(ctx, bootstrap.TracerConfig{
+		ServiceName:    "tenant-service",
+		ServiceVersion: version,
+		Logger:         c.Logger,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to initialize tracer: %w", err)
+	}
+	c.Tracer = tracer
+	return nil
+}
+
+// initDatabase initializes the GORM database connection.
+func (c *Container) initDatabase(ctx context.Context) error {
+	dbConfig := bootstrap.DefaultDatabaseConfig()
+	dbConfig.Logger = c.Logger
+	db, err := bootstrap.NewDatabase(ctx, dbConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize database: %w", err)
+	}
+	c.DB = db
+	c.Logger.Info("database connection established")
+	return nil
+}
+
+// initRepositories creates persistence repositories.
+func (c *Container) initRepositories() {
+	c.Repo = persistence.NewRepository(c.DB)
+	c.Logger.Info("repositories initialized")
+}
+
+// initSchemaProvisioner initializes the schema provisioner if SCHEMA_PROVISIONING_ENABLED is "true".
+// When disabled, tenant creation will not provision per-tenant schemas.
+func (c *Container) initSchemaProvisioner() error {
+	provisioningEnabled := env.GetEnvOrDefault("SCHEMA_PROVISIONING_ENABLED", "false")
+	if provisioningEnabled != envValueTrue {
+		c.Logger.Warn("schema provisioning not enabled - tenant creation will not provision schemas",
+			"hint", "set SCHEMA_PROVISIONING_ENABLED=true to enable schema provisioning")
+		return nil
+	}
+
+	config := provisioner.DefaultConfig()
+
+	// Pass platform database connection (for tenant_provisioning table).
+	// The provisioner will also connect to each service's database for schema creation.
+	prov, err := provisioner.NewPostgresProvisioner(c.DB, config)
+	if err != nil {
+		return fmt.Errorf("failed to create schema provisioner: %w", err)
+	}
+	c.SchemaProvisioner = prov
+
+	// Register cleanup for service database connections
+	c.cleanups = append(c.cleanups, func() {
+		if err := prov.Close(); err != nil {
+			c.Logger.Error("failed to close provisioner connections", "error", err)
+		}
+	})
+
+	c.Logger.Info("schema provisioner initialized",
+		"services", len(config.Services),
+		"provisioning_timeout", config.ProvisioningTimeout)
+
+	return nil
+}
+
+// initPartyClient initializes the Party gRPC client with resilience patterns.
+// The client is optional - when PARTY_SERVICE_ENABLED is not "true", party registration
+// is skipped during tenant creation.
+func (c *Container) initPartyClient(ctx context.Context) error {
+	namespace := env.GetEnvOrDefault("K8S_NAMESPACE", "default")
+	partyEnabled := env.GetEnvOrDefault("PARTY_SERVICE_ENABLED", envValueTrue) == envValueTrue
+	if !partyEnabled {
+		c.Logger.Warn("party client not configured - tenant creation will not register parties",
+			"hint", "set PARTY_SERVICE_ENABLED=true to enable party registration")
+		return nil
+	}
+
+	c.Logger.Info("connecting to party service",
+		"service", partyclient.ServiceName,
+		"namespace", namespace,
+		"port", ports.Party)
+
+	// Configure resilience settings from environment
+	resilientConfig := &sharedclients.ResilientClientConfig{
+		// Circuit breaker settings
+		CircuitBreakerName:     "party",
+		CircuitBreakerTimeout:  env.GetEnvAsDuration("PARTY_CIRCUIT_BREAKER_TIMEOUT", 30*time.Second),
+		CircuitBreakerInterval: env.GetEnvAsDuration("PARTY_CIRCUIT_BREAKER_INTERVAL", 60*time.Second),
+		MaxRequests:            env.GetEnvAsUint32("PARTY_CIRCUIT_BREAKER_MAX_REQUESTS", 1),
+		FailureThreshold:       env.GetEnvAsUint32("PARTY_CIRCUIT_BREAKER_FAILURE_THRESHOLD", 5),
+
+		// Retry settings
+		MaxRetries:          env.GetEnvAsInt("PARTY_MAX_RETRIES", 3),
+		InitialInterval:     env.GetEnvAsDuration("PARTY_RETRY_INITIAL_INTERVAL", 100*time.Millisecond),
+		MaxInterval:         env.GetEnvAsDuration("PARTY_RETRY_MAX_INTERVAL", 5*time.Second),
+		Multiplier:          env.GetEnvAsFloat("PARTY_RETRY_MULTIPLIER", 2.0),
+		RandomizationFactor: env.GetEnvAsFloat("PARTY_RETRY_RANDOMIZATION", 0.5),
+
+		Logger: c.Logger,
+	}
+
+	c.Logger.Info("party client configured with resilience patterns",
+		"circuit_breaker_timeout", resilientConfig.CircuitBreakerTimeout,
+		"circuit_breaker_failure_threshold", resilientConfig.FailureThreshold,
+		"max_retries", resilientConfig.MaxRetries,
+	)
+
+	// Use the service-owned client package with DNS-based load balancing
+	pc, cleanup, err := partyclient.New(ctx, partyclient.Config{
+		ServiceName: partyclient.ServiceName,
+		Namespace:   namespace,
+		Port:        ports.Party,
+		Timeout:     env.GetEnvAsDuration("PARTY_TIMEOUT", partyclient.DefaultTimeout),
+		Tracer:      c.Tracer,
+		Resilience:  resilientConfig,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create party client: %w", err)
+	}
+
+	// Wrap with adapter to implement tenant-specific PartyClient interface
+	adapter := service.NewPartyClientAdapter(pc, cleanup)
+	c.PartyClient = adapter
+
+	c.cleanups = append(c.cleanups, func() {
+		if err := adapter.Close(); err != nil {
+			c.Logger.Error("failed to close party client", "error", err)
+		}
+	})
+
+	c.Logger.Info("party client initialized",
+		"service_name", partyclient.ServiceName,
+		"namespace", namespace,
+		"port", ports.Party)
+
+	return nil
+}
+
+// initRedis initializes the Redis client and slug cache.
+// Redis is optional - when unavailable, slug caching is disabled until next restart.
+// The slug cache is a performance optimization; the service operates correctly without it.
+func (c *Container) initRedis(ctx context.Context) error {
+	redisEnabled := env.GetEnvOrDefault("REDIS_ENABLED", envValueTrue) == envValueTrue
+	if !redisEnabled {
+		c.Logger.Warn("Redis not enabled - slug caching disabled",
+			"hint", "set REDIS_ENABLED=true to enable slug caching")
+		return nil
+	}
+
+	redisConfig := bootstrap.DefaultRedisConfig()
+	redisConfig.Logger = c.Logger
+	redisClient, err := bootstrap.NewRedisClient(ctx, redisConfig)
+	if err != nil {
+		c.Logger.Warn("Redis not available at startup, slug caching disabled",
+			"error", err,
+			"hint", "slug caching will be available after service restart when Redis is reachable")
+		return nil
+	}
+
+	c.RedisClient = redisClient
+	c.SlugCache = service.NewSlugCache(redisClient)
+
+	c.cleanups = append(c.cleanups, func() {
+		if err := redisClient.Close(); err != nil {
+			c.Logger.Error("failed to close Redis client", "error", err)
+		}
+	})
+
+	c.Logger.Info("slug cache initialized with Redis backend")
+	return nil
+}
+
+// initService creates the tenant gRPC service and cached registry.
+func (c *Container) initService(ctx context.Context) {
+	c.TenantService = service.NewService(c.Repo, c.SchemaProvisioner, c.PartyClient, c.SlugCache, c.Logger)
+
+	c.CachedRegistry = service.NewCachedRegistry(c.Repo, service.CachedRegistryConfig{
+		RefreshInterval: 60 * time.Second,
+		Logger:          c.Logger,
+	})
+	c.CachedRegistry.Start(ctx)
+
+	c.Logger.Info("cached tenant registry started",
+		"refresh_interval", "60s")
+}
+
+// initProvisioningWorker creates and starts the provisioning worker if schema provisioning is enabled.
+func (c *Container) initProvisioningWorker(ctx context.Context) error {
+	if c.SchemaProvisioner == nil {
+		c.Logger.Info("provisioning worker disabled",
+			"hint", "set SCHEMA_PROVISIONING_ENABLED=true to enable background provisioning")
+		return nil
+	}
+
+	config, err := loadWorkerConfig()
+	if err != nil {
+		return bootstrap.Permanent(fmt.Errorf("failed to load worker configuration: %w", err))
+	}
+
+	pw, err := worker.NewProvisioningWorker(
+		c.Repo,
+		c.SchemaProvisioner,
+		worker.Config{
+			PollInterval:   config.PollInterval,
+			MaxRetries:     config.MaxRetries,
+			RetryBaseDelay: config.RetryBaseDelay,
+			RetryMaxDelay:  config.RetryMaxDelay,
+			MaxConcurrent:  config.MaxConcurrent,
+		},
+		c.Logger,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create provisioning worker: %w", err)
+	}
+
+	c.ProvisioningWorker = pw
+
+	// Start worker in background goroutine
+	go pw.Start(ctx)
+
+	c.Logger.Info("provisioning worker started")
+	return nil
+}
+
+// initAuth initializes the auth interceptor.
+// The tenant service uses PlatformAdmin authorization.
+func (c *Container) initAuth(ctx context.Context) error {
+	authConfig := bootstrap.DefaultAuthConfig(c.Logger)
+	interceptor, err := bootstrap.NewAuthInterceptor(ctx, authConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize auth: %w", err)
+	}
+	c.AuthInterceptor = interceptor
+	return nil
+}
+
+// Close gracefully shuts down all container resources in reverse initialization order.
+func (c *Container) Close() {
+	c.Logger.Info("closing container resources...")
+	var errs []error
+
+	// Stop provisioning worker first
+	if c.ProvisioningWorker != nil {
+		c.Logger.Info("stopping provisioning worker...")
+		c.ProvisioningWorker.Stop()
+		c.Logger.Info("provisioning worker stopped")
+	}
+
+	// Run cleanup functions in reverse order (provisioner, party client, Redis)
+	for i := len(c.cleanups) - 1; i >= 0; i-- {
+		c.cleanups[i]()
+	}
+
+	// Close database
+	bootstrap.CloseDatabase(c.DB, c.Logger)
+
+	// Shutdown tracer
+	bootstrap.ShutdownTracer(c.Tracer, c.Logger)
+
+	if len(errs) > 0 {
+		c.Logger.Error("container close completed with errors",
+			"error_count", len(errs),
+			"errors", errors.Join(errs...))
+	} else {
+		c.Logger.Info("container resources closed")
+	}
+}
+
+// loadWorkerConfig loads worker configuration from environment variables with defaults.
+// It validates the configuration and returns an error if any value is invalid.
+func loadWorkerConfig() (workerConfig, error) {
+	config := workerConfig{
+		PollInterval:   env.GetEnvAsDuration("PROVISIONING_WORKER_POLL_INTERVAL", 10*time.Second),
+		MaxRetries:     env.GetEnvAsInt("PROVISIONING_MAX_RETRIES", 5),
+		RetryBaseDelay: env.GetEnvAsDuration("PROVISIONING_RETRY_BASE_DELAY", 2*time.Second),
+		RetryMaxDelay:  env.GetEnvAsDuration("PROVISIONING_RETRY_MAX_DELAY", defaults.DefaultMaxRetryInterval),
+		MaxConcurrent:  env.GetEnvAsInt("PROVISIONING_MAX_CONCURRENT", 5),
+	}
+
+	if config.PollInterval < 1*time.Second {
+		return workerConfig{}, fmt.Errorf("poll interval must be >= 1s: got %s", config.PollInterval)
+	}
+	if config.MaxRetries < 0 || config.MaxRetries > 20 {
+		return workerConfig{}, fmt.Errorf("max retries must be >= 0 and <= 20: got %d", config.MaxRetries)
+	}
+	if config.RetryBaseDelay <= 0 {
+		return workerConfig{}, fmt.Errorf("retry base delay must be > 0: got %s", config.RetryBaseDelay)
+	}
+	if config.RetryMaxDelay <= 0 {
+		return workerConfig{}, fmt.Errorf("retry max delay must be > 0: got %s", config.RetryMaxDelay)
+	}
+	if config.RetryBaseDelay >= config.RetryMaxDelay {
+		return workerConfig{}, fmt.Errorf("retry base delay must be < retry max delay: base=%s, max=%s", config.RetryBaseDelay, config.RetryMaxDelay)
+	}
+	if config.MaxConcurrent < 1 || config.MaxConcurrent > 100 {
+		return workerConfig{}, fmt.Errorf("max concurrent must be >= 1 and <= 100: got %d", config.MaxConcurrent)
+	}
+
+	slog.Info("worker configuration loaded",
+		"poll_interval", config.PollInterval,
+		"max_retries", config.MaxRetries,
+		"retry_base_delay", config.RetryBaseDelay,
+		"retry_max_delay", config.RetryMaxDelay,
+		"max_concurrent", config.MaxConcurrent)
+
+	return config, nil
+}
+
+// workerConfig holds configuration for the provisioning worker behavior.
+// This is internal to the container - the exported WorkerConfig and its validation
+// remain in main.go for backward compatibility.
+type workerConfig struct {
+	PollInterval   time.Duration
+	MaxRetries     int
+	RetryBaseDelay time.Duration
+	RetryMaxDelay  time.Duration
+	MaxConcurrent  int
+}

--- a/services/tenant/app/container.go
+++ b/services/tenant/app/container.go
@@ -30,10 +30,9 @@ import (
 // envValueTrue is the string value for enabled environment variables.
 const envValueTrue = "true"
 
-// Sentinel errors for container and worker configuration validation.
+// Sentinel errors for worker configuration validation.
 var (
-	ErrContainerCloseFailures = errors.New("one or more container resources failed to close")
-	errInvalidPollInterval    = errors.New("poll interval must be >= 1s")
+	errInvalidPollInterval = errors.New("poll interval must be >= 1s")
 	errInvalidMaxRetries      = errors.New("max retries must be >= 0 and <= 20")
 	errInvalidRetryBaseDelay  = errors.New("retry base delay must be > 0")
 	errInvalidRetryMaxDelay   = errors.New("retry max delay must be > 0")
@@ -73,8 +72,9 @@ type Container struct {
 	// Workers
 	ProvisioningWorker *worker.ProvisioningWorker
 
-	// Cleanup functions (executed in reverse order)
-	cleanups []func()
+	// Internal lifecycle
+	cancelRegistry context.CancelFunc
+	cleanups       []func()
 }
 
 // NewContainer creates and initializes a new dependency injection container.
@@ -311,7 +311,10 @@ func (c *Container) initService(ctx context.Context) {
 		RefreshInterval: 60 * time.Second,
 		Logger:          c.Logger,
 	})
-	c.CachedRegistry.Start(ctx)
+
+	registryCtx, cancel := context.WithCancel(ctx)
+	c.cancelRegistry = cancel
+	c.CachedRegistry.Start(registryCtx)
 
 	c.Logger.Info("cached tenant registry started",
 		"refresh_interval", "60s")
@@ -370,9 +373,13 @@ func (c *Container) initAuth(ctx context.Context) error {
 // Close gracefully shuts down all container resources in reverse initialization order.
 func (c *Container) Close() {
 	c.Logger.Info("closing container resources...")
-	var errs []error
 
-	// Stop provisioning worker first
+	// Cancel the cached registry refresh goroutine first
+	if c.cancelRegistry != nil {
+		c.cancelRegistry()
+	}
+
+	// Stop provisioning worker
 	if c.ProvisioningWorker != nil {
 		c.Logger.Info("stopping provisioning worker...")
 		c.ProvisioningWorker.Stop()
@@ -390,13 +397,7 @@ func (c *Container) Close() {
 	// Shutdown tracer
 	bootstrap.ShutdownTracer(c.Tracer, c.Logger)
 
-	if len(errs) > 0 {
-		c.Logger.Error("container close completed with errors",
-			"error_count", len(errs),
-			"errors", errors.Join(errs...))
-	} else {
-		c.Logger.Info("container resources closed")
-	}
+	c.Logger.Info("container resources closed")
 }
 
 // loadWorkerConfig loads worker configuration from environment variables with defaults.

--- a/services/tenant/cmd/main.go
+++ b/services/tenant/cmd/main.go
@@ -13,21 +13,14 @@ import (
 	"time"
 
 	pb "github.com/meridianhub/meridian/api/proto/meridian/tenant/v1"
-	"github.com/meridianhub/meridian/services/tenant/adapters/persistence"
-	"github.com/meridianhub/meridian/services/tenant/provisioner"
+	"github.com/meridianhub/meridian/services/tenant/app"
 	"github.com/meridianhub/meridian/services/tenant/service"
-	"github.com/meridianhub/meridian/services/tenant/worker"
-	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
 	"github.com/meridianhub/meridian/shared/platform/defaults"
 	"github.com/meridianhub/meridian/shared/platform/env"
-	"github.com/meridianhub/meridian/shared/platform/observability"
 	"github.com/meridianhub/meridian/shared/platform/ports"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
-
-	// Service-owned client (standardized client package from party service)
-	partyclient "github.com/meridianhub/meridian/services/party/client"
 )
 
 // Build information set via ldflags during compilation.
@@ -36,9 +29,6 @@ var (
 	Commit    = "unknown"
 	BuildDate = "unknown"
 )
-
-// envValueTrue is the string value for enabled environment variables.
-const envValueTrue = "true"
 
 // Errors returned during configuration and startup.
 var (
@@ -112,165 +102,18 @@ func main() {
 func run(logger *slog.Logger) error {
 	ctx := context.Background()
 
-	// Initialize OpenTelemetry tracer
-	tracer, err := bootstrap.NewTracer(ctx, bootstrap.TracerConfig{
-		ServiceName:    "tenant-service",
-		ServiceVersion: Version,
-		Logger:         logger,
-	})
+	// Initialize dependency container (tracer, database, provisioner, party client, Redis, worker, auth)
+	container, err := app.NewContainer(ctx, logger, Version)
 	if err != nil {
-		return fmt.Errorf("failed to initialize tracer: %w", err)
+		return fmt.Errorf("failed to initialize container: %w", err)
 	}
-	defer bootstrap.ShutdownTracer(tracer, logger)
-
-	// Initialize database connection
-	dbConfig := bootstrap.DefaultDatabaseConfig()
-	dbConfig.Logger = logger
-	db, err := bootstrap.NewDatabase(ctx, dbConfig)
-	if err != nil {
-		return fmt.Errorf("failed to initialize database: %w", err)
-	}
-
-	logger.Info("database connection established")
-
-	// Create repository
-	repo := persistence.NewRepository(db)
-
-	// Initialize schema provisioner (optional - skipped if SCHEMA_PROVISIONING_ENABLED is not "true")
-	var schemaProvisioner provisioner.SchemaProvisioner
-	provisioningEnabled := env.GetEnvOrDefault("SCHEMA_PROVISIONING_ENABLED", "false")
-	if provisioningEnabled == envValueTrue {
-		config := provisioner.DefaultConfig()
-
-		// Pass platform database connection (for tenant_provisioning table).
-		// The provisioner will also connect to each service's database for schema creation.
-		prov, err := provisioner.NewPostgresProvisioner(db, config)
-		if err != nil {
-			return fmt.Errorf("failed to create schema provisioner: %w", err)
-		}
-		schemaProvisioner = prov
-
-		// Clean up service database connections on shutdown
-		defer func() {
-			if err := prov.Close(); err != nil {
-				logger.Error("failed to close provisioner connections", "error", err)
-			}
-		}()
-
-		logger.Info("schema provisioner initialized",
-			"services", len(config.Services),
-			"provisioning_timeout", config.ProvisioningTimeout)
-	} else {
-		logger.Warn("schema provisioning not enabled - tenant creation will not provision schemas",
-			"hint", "set SCHEMA_PROVISIONING_ENABLED=true to enable schema provisioning")
-	}
-
-	// Initialize Party client (optional - skipped if PARTY_SERVICE_ENABLED is not "true")
-	// Uses the service-owned party client package with adapter for tenant-specific interface
-	var partyClient service.PartyClient
-	namespace := env.GetEnvOrDefault("K8S_NAMESPACE", "default")
-	partyEnabled := env.GetEnvOrDefault("PARTY_SERVICE_ENABLED", envValueTrue) == envValueTrue
-	if partyEnabled {
-		pc, cleanup, err := createPartyClient(ctx, namespace, logger, tracer)
-		if err != nil {
-			return fmt.Errorf("failed to create party client: %w", err)
-		}
-		partyClient = pc
-		defer cleanup()
-		logger.Info("party client initialized",
-			"service_name", partyclient.ServiceName,
-			"namespace", namespace,
-			"port", ports.Party)
-	} else {
-		logger.Warn("party client not configured - tenant creation will not register parties",
-			"hint", "set PARTY_SERVICE_ENABLED=true to enable party registration")
-	}
-
-	// Initialize Redis client and slug cache (optional).
-	// If Redis is not available at startup, slug caching is disabled until next restart.
-	// The slug cache is a performance optimization; the service operates correctly without it.
-	var slugCache *service.SlugCache
-	redisEnabled := env.GetEnvOrDefault("REDIS_ENABLED", envValueTrue) == envValueTrue
-	if redisEnabled {
-		redisConfig := bootstrap.DefaultRedisConfig()
-		redisConfig.Logger = logger
-		redisClient, err := bootstrap.NewRedisClient(ctx, redisConfig)
-		if err != nil {
-			logger.Warn("Redis not available at startup, slug caching disabled",
-				"error", err,
-				"hint", "slug caching will be available after service restart when Redis is reachable")
-		} else {
-			defer func() {
-				if err := redisClient.Close(); err != nil {
-					logger.Error("failed to close Redis client", "error", err)
-				}
-			}()
-			slugCache = service.NewSlugCache(redisClient)
-			logger.Info("slug cache initialized with Redis backend")
-		}
-	} else {
-		logger.Warn("Redis not enabled - slug caching disabled",
-			"hint", "set REDIS_ENABLED=true to enable slug caching")
-	}
-
-	// Create gRPC service
-	tenantService := service.NewService(repo, schemaProvisioner, partyClient, slugCache, logger)
-
-	// Create cached registry for validation middleware
-	cachedRegistry := service.NewCachedRegistry(repo, service.CachedRegistryConfig{
-		RefreshInterval: 60 * time.Second,
-		Logger:          logger,
-	})
-	cachedRegistry.Start(ctx)
-
-	logger.Info("cached tenant registry started",
-		"refresh_interval", "60s")
-
-	// Initialize provisioning worker (only if schema provisioning is enabled)
-	var provisioningWorker *worker.ProvisioningWorker
-	if provisioningEnabled == envValueTrue && schemaProvisioner != nil {
-		config, err := loadWorkerConfig()
-		if err != nil {
-			return bootstrap.Permanent(fmt.Errorf("failed to load worker configuration: %w", err))
-		}
-
-		provisioningWorker, err = worker.NewProvisioningWorker(
-			repo,
-			schemaProvisioner,
-			worker.Config{
-				PollInterval:   config.PollInterval,
-				MaxRetries:     config.MaxRetries,
-				RetryBaseDelay: config.RetryBaseDelay,
-				RetryMaxDelay:  config.RetryMaxDelay,
-				MaxConcurrent:  config.MaxConcurrent,
-			},
-			logger,
-		)
-		if err != nil {
-			return fmt.Errorf("failed to create provisioning worker: %w", err)
-		}
-
-		// Start worker in background goroutine
-		go provisioningWorker.Start(ctx)
-
-		logger.Info("provisioning worker started")
-	} else {
-		logger.Info("provisioning worker disabled",
-			"hint", "set SCHEMA_PROVISIONING_ENABLED=true to enable background provisioning")
-	}
-
-	// Initialize auth interceptor (optional - based on AUTH_ENABLED)
-	authConfig := bootstrap.DefaultAuthConfig(logger)
-	authInterceptor, err := bootstrap.NewAuthInterceptor(ctx, authConfig)
-	if err != nil {
-		return fmt.Errorf("failed to initialize auth: %w", err)
-	}
+	defer container.Close()
 
 	// Create gRPC server with interceptor chain
 	// Order is handled by bootstrap: tracing -> platform auth -> platform admin -> recovery
 	// Note: WithPlatformAdmin() adds PlatformAdminInterceptor for platform-layer services
-	grpcServer, err := bootstrap.NewGrpcServerBuilder(tracer, logger).
-		WithAuthInterceptor(authInterceptor).
+	grpcServer, err := bootstrap.NewGrpcServerBuilder(container.Tracer, logger).
+		WithAuthInterceptor(container.AuthInterceptor).
 		WithPlatformAdmin().
 		Build()
 	if err != nil {
@@ -278,11 +121,11 @@ func run(logger *slog.Logger) error {
 	}
 
 	// Register services
-	pb.RegisterTenantServiceServer(grpcServer, tenantService)
+	pb.RegisterTenantServiceServer(grpcServer, container.TenantService)
 
 	// Register health check service
 	healthChecker := service.NewHealthChecker(service.HealthCheckerConfig{
-		Repository:  repo,
+		Repository:  container.Repo,
 		Logger:      logger,
 		ServiceName: "tenant",
 		Timeout:     defaults.DefaultHealthCheckTimeout,
@@ -313,25 +156,10 @@ func run(logger *slog.Logger) error {
 		}
 	}()
 
-	// Wait for shutdown signal and orchestrate graceful shutdown
+	// Wait for shutdown signal and orchestrate graceful shutdown.
+	// container.Close() (deferred above) handles all resource cleanup:
+	// provisioning worker, provisioner connections, party client, Redis, database, tracer.
 	orchestrator := bootstrap.NewShutdownOrchestrator(grpcServer, logger)
-
-	// Add cleanup functions in reverse order of initialization (LIFO)
-	// Stop provisioning worker first
-	if provisioningWorker != nil {
-		orchestrator.AddCleanup(func() error {
-			logger.Info("stopping provisioning worker...")
-			provisioningWorker.Stop()
-			logger.Info("provisioning worker stopped")
-			return nil
-		})
-	}
-
-	// Close database connection
-	orchestrator.AddCleanup(func() error {
-		bootstrap.CloseDatabase(db, logger)
-		return nil
-	})
 
 	return orchestrator.Wait(serverErrors)
 }
@@ -389,62 +217,4 @@ func getConfigSource(key string) string {
 		return "env"
 	}
 	return "default"
-}
-
-// createPartyClient creates the Party gRPC client with resilience patterns.
-// Uses the service-owned client package from services/party/client for standardized
-// client creation with built-in tracing and resilience patterns.
-// Returns a PartyClient interface adapter wrapping the underlying party client.
-func createPartyClient(ctx context.Context, namespace string, logger *slog.Logger, tracer *observability.Tracer) (service.PartyClient, func(), error) {
-	logger.Info("connecting to party service",
-		"service", partyclient.ServiceName,
-		"namespace", namespace,
-		"port", ports.Party)
-
-	// Configure resilience settings from environment
-	resilientConfig := &sharedclients.ResilientClientConfig{
-		// Circuit breaker settings
-		CircuitBreakerName:     "party",
-		CircuitBreakerTimeout:  env.GetEnvAsDuration("PARTY_CIRCUIT_BREAKER_TIMEOUT", 30*time.Second),
-		CircuitBreakerInterval: env.GetEnvAsDuration("PARTY_CIRCUIT_BREAKER_INTERVAL", 60*time.Second),
-		MaxRequests:            env.GetEnvAsUint32("PARTY_CIRCUIT_BREAKER_MAX_REQUESTS", 1),
-		FailureThreshold:       env.GetEnvAsUint32("PARTY_CIRCUIT_BREAKER_FAILURE_THRESHOLD", 5),
-
-		// Retry settings
-		MaxRetries:          env.GetEnvAsInt("PARTY_MAX_RETRIES", 3),
-		InitialInterval:     env.GetEnvAsDuration("PARTY_RETRY_INITIAL_INTERVAL", 100*time.Millisecond),
-		MaxInterval:         env.GetEnvAsDuration("PARTY_RETRY_MAX_INTERVAL", 5*time.Second),
-		Multiplier:          env.GetEnvAsFloat("PARTY_RETRY_MULTIPLIER", 2.0),
-		RandomizationFactor: env.GetEnvAsFloat("PARTY_RETRY_RANDOMIZATION", 0.5),
-
-		Logger: logger,
-	}
-
-	logger.Info("party client configured with resilience patterns",
-		"circuit_breaker_timeout", resilientConfig.CircuitBreakerTimeout,
-		"circuit_breaker_failure_threshold", resilientConfig.FailureThreshold,
-		"max_retries", resilientConfig.MaxRetries,
-	)
-
-	// Use the service-owned client package with DNS-based load balancing
-	pc, cleanup, err := partyclient.New(ctx, partyclient.Config{
-		ServiceName: partyclient.ServiceName,
-		Namespace:   namespace,
-		Port:        ports.Party,
-		Timeout:     env.GetEnvAsDuration("PARTY_TIMEOUT", partyclient.DefaultTimeout),
-		Tracer:      tracer,
-		Resilience:  resilientConfig,
-	})
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create party client: %w", err)
-	}
-
-	// Wrap with adapter to implement tenant-specific PartyClient interface
-	adapter := service.NewPartyClientAdapter(pc, cleanup)
-
-	return adapter, func() {
-		if err := adapter.Close(); err != nil {
-			logger.Error("failed to close party client", "error", err)
-		}
-	}, nil
 }


### PR DESCRIPTION
## Summary
- Extract dependency wiring from run() into Container structs for current-account, tenant, market-information, internal-account, and reconciliation services
- Each service now follows the established container pattern from payment-order, position-keeping, and financial-accounting (PR #2015)
- Container owns all dependency initialization and cleanup; run() handles only server lifecycle

## Changes
- **current-account**: New `app/container.go` - tracer, DB, Redis/idempotency, repos, Starlark handler registry, auth
- **tenant**: New `app/container.go` - tracer, DB, schema provisioner, party client, Redis/slug cache, provisioning worker, auth
- **market-information**: New `app/container.go` - tracer, dual DB (pgxpool + GORM), Kafka/outbox, repos, event publisher, auth
- **internal-account**: New `app/container.go` - tracer, DB, repos, service with outbox publisher, Kafka/outbox, auth
- **reconciliation**: New `app/container.go` - tracer, DB, Kafka/outbox, 6 repos, gRPC clients (PK, CA, RefData), valuation engine, scheduler, Redis, auth

## Test plan
- [x] All services build cleanly (`go build ./...`)
- [x] Architecture test passes (459 oversized functions, below 464 baseline)
- [x] Unit tests pass for all modified service cmd packages
- [ ] CI passes