### PR TITLE
refactor: mop-up pass for remaining function size violations

### DIFF
--- a/services/control-plane/internal/applier/executor.go
+++ b/services/control-plane/internal/applier/executor.go
@@ -430,13 +430,25 @@ func (e *ManifestExecutor) resolveSagaScript(ctx context.Context) (string, error
 // format expected by the Starlark saga runner.
 func (e *ManifestExecutor) buildSagaInput(input *ApplyManifestInput) map[string]interface{} {
 	sagaInput := map[string]interface{}{
-		"manifest_version": input.ManifestVersion,
+		"manifest_version":    input.ManifestVersion,
+		"instruments":         convertInstruments(input.Instruments),
+		"account_types":       convertAccountTypes(input.AccountTypes),
+		"market_data_sources": convertMarketDataSources(input.MarketDataSources),
+		"market_data_sets":    convertMarketDataSets(input.MarketDataSets),
+		"valuation_rules":     convertValuationRules(input.ValuationRules),
+		"organizations":       convertOrganizations(input.Organizations),
+		"internal_accounts":   convertInternalAccounts(input.InternalAccounts),
+		"saga_definitions":    convertSagaDefinitions(input.SagaDefinitions),
+		"provider_connections": convertProviderConnections(input.ProviderConnections),
+		"instruction_routes":  convertInstructionRoutes(input.InstructionRoutes),
 	}
+	return sagaInput
+}
 
-	// Convert instruments
-	instruments := make([]interface{}, len(input.Instruments))
-	for i, inst := range input.Instruments {
-		instruments[i] = map[string]interface{}{
+func convertInstruments(instruments []InstrumentInput) []interface{} {
+	result := make([]interface{}, len(instruments))
+	for i, inst := range instruments {
+		result[i] = map[string]interface{}{
 			"code":           inst.Code,
 			"display_name":   inst.DisplayName,
 			"dimension":      inst.Dimension,
@@ -444,11 +456,12 @@ func (e *ManifestExecutor) buildSagaInput(input *ApplyManifestInput) map[string]
 			"description":    inst.Description,
 		}
 	}
-	sagaInput["instruments"] = instruments
+	return result
+}
 
-	// Convert account types
-	accountTypes := make([]interface{}, len(input.AccountTypes))
-	for i, at := range input.AccountTypes {
+func convertAccountTypes(accountTypes []AccountTypeInput) []interface{} {
+	result := make([]interface{}, len(accountTypes))
+	for i, at := range accountTypes {
 		vmethods := make([]interface{}, len(at.ValuationMethods))
 		for j, vm := range at.ValuationMethods {
 			vmethods[j] = map[string]interface{}{
@@ -456,7 +469,7 @@ func (e *ManifestExecutor) buildSagaInput(input *ApplyManifestInput) map[string]
 				"method_name":      vm.MethodName,
 			}
 		}
-		accountTypes[i] = map[string]interface{}{
+		result[i] = map[string]interface{}{
 			"code":                      at.Code,
 			"display_name":              at.DisplayName,
 			"description":               at.Description,
@@ -472,24 +485,26 @@ func (e *ManifestExecutor) buildSagaInput(input *ApplyManifestInput) map[string]
 			"valuation_methods":         vmethods,
 		}
 	}
-	sagaInput["account_types"] = accountTypes
+	return result
+}
 
-	// Convert market data sources
-	marketSources := make([]interface{}, len(input.MarketDataSources))
-	for i, src := range input.MarketDataSources {
-		marketSources[i] = map[string]interface{}{
+func convertMarketDataSources(sources []MarketDataSourceInput) []interface{} {
+	result := make([]interface{}, len(sources))
+	for i, src := range sources {
+		result[i] = map[string]interface{}{
 			"code":        src.Code,
 			"name":        src.Name,
 			"description": src.Description,
 			"trust_level": src.TrustLevel,
 		}
 	}
-	sagaInput["market_data_sources"] = marketSources
+	return result
+}
 
-	// Convert market data sets
-	marketDataSets := make([]interface{}, len(input.MarketDataSets))
-	for i, ds := range input.MarketDataSets {
-		marketDataSets[i] = map[string]interface{}{
+func convertMarketDataSets(dataSets []MarketDataSetInput) []interface{} {
+	result := make([]interface{}, len(dataSets))
+	for i, ds := range dataSets {
+		result[i] = map[string]interface{}{
 			"code":                      ds.Code,
 			"category":                  ds.Category,
 			"unit":                      ds.Unit,
@@ -500,12 +515,13 @@ func (e *ManifestExecutor) buildSagaInput(input *ApplyManifestInput) map[string]
 			"resolution_key_expression": ds.ResolutionKeyExpression,
 		}
 	}
-	sagaInput["market_data_sets"] = marketDataSets
+	return result
+}
 
-	// Convert valuation rules
-	valuationRules := make([]interface{}, len(input.ValuationRules))
-	for i, vr := range input.ValuationRules {
-		valuationRules[i] = map[string]interface{}{
+func convertValuationRules(rules []ValuationRuleInput) []interface{} {
+	result := make([]interface{}, len(rules))
+	for i, vr := range rules {
+		result[i] = map[string]interface{}{
 			"from_instrument": vr.FromInstrument,
 			"to_instrument":   vr.ToInstrument,
 			"rule_type":       vr.RuleType,
@@ -513,16 +529,17 @@ func (e *ManifestExecutor) buildSagaInput(input *ApplyManifestInput) map[string]
 			"description":     vr.Description,
 		}
 	}
-	sagaInput["valuation_rules"] = valuationRules
+	return result
+}
 
-	// Convert organizations
-	organizations := make([]interface{}, len(input.Organizations))
-	for i, org := range input.Organizations {
+func convertOrganizations(organizations []OrganizationInput) []interface{} {
+	result := make([]interface{}, len(organizations))
+	for i, org := range organizations {
 		attrs := make(map[string]interface{}, len(org.Attributes))
 		for k, v := range org.Attributes {
 			attrs[k] = v
 		}
-		organizations[i] = map[string]interface{}{
+		result[i] = map[string]interface{}{
 			"code":                    org.Code,
 			"name":                    org.Name,
 			"legal_name":              org.LegalName,
@@ -533,12 +550,13 @@ func (e *ManifestExecutor) buildSagaInput(input *ApplyManifestInput) map[string]
 			"attributes":              attrs,
 		}
 	}
-	sagaInput["organizations"] = organizations
+	return result
+}
 
-	// Convert internal accounts
-	internalAccounts := make([]interface{}, len(input.InternalAccounts))
-	for i, ia := range input.InternalAccounts {
-		internalAccounts[i] = map[string]interface{}{
+func convertInternalAccounts(accounts []InternalAccountInput) []interface{} {
+	result := make([]interface{}, len(accounts))
+	for i, ia := range accounts {
+		result[i] = map[string]interface{}{
 			"code":               ia.Code,
 			"account_type":       ia.AccountType,
 			"instrument_code":    ia.InstrumentCode,
@@ -546,12 +564,13 @@ func (e *ManifestExecutor) buildSagaInput(input *ApplyManifestInput) map[string]
 			"description":        ia.Description,
 		}
 	}
-	sagaInput["internal_accounts"] = internalAccounts
+	return result
+}
 
-	// Convert saga definitions
-	sagaDefs := make([]interface{}, len(input.SagaDefinitions))
-	for i, sd := range input.SagaDefinitions {
-		sagaDefs[i] = map[string]interface{}{
+func convertSagaDefinitions(defs []SagaDefinitionInput) []interface{} {
+	result := make([]interface{}, len(defs))
+	for i, sd := range defs {
+		result[i] = map[string]interface{}{
 			"name":         sd.Name,
 			"display_name": sd.DisplayName,
 			"description":  sd.Description,
@@ -559,12 +578,13 @@ func (e *ManifestExecutor) buildSagaInput(input *ApplyManifestInput) map[string]
 			"version":      sd.Version,
 		}
 	}
-	sagaInput["saga_definitions"] = sagaDefs
+	return result
+}
 
-	// Convert provider connections
-	providerConns := make([]interface{}, len(input.ProviderConnections))
-	for i, pc := range input.ProviderConnections {
-		providerConns[i] = map[string]interface{}{
+func convertProviderConnections(conns []ProviderConnectionInput) []interface{} {
+	result := make([]interface{}, len(conns))
+	for i, pc := range conns {
+		result[i] = map[string]interface{}{
 			"connection_id":     pc.ConnectionID,
 			"provider_name":     pc.ProviderName,
 			"provider_type":     pc.ProviderType,
@@ -576,12 +596,13 @@ func (e *ManifestExecutor) buildSagaInput(input *ApplyManifestInput) map[string]
 			"rate_limit_config": pc.RateLimitConfig,
 		}
 	}
-	sagaInput["provider_connections"] = providerConns
+	return result
+}
 
-	// Convert instruction routes
-	routes := make([]interface{}, len(input.InstructionRoutes))
-	for i, r := range input.InstructionRoutes {
-		routes[i] = map[string]interface{}{
+func convertInstructionRoutes(routes []InstructionRouteInput) []interface{} {
+	result := make([]interface{}, len(routes))
+	for i, r := range routes {
+		result[i] = map[string]interface{}{
 			"instruction_type":       r.InstructionType,
 			"connection_id":          r.ConnectionID,
 			"fallback_connection_id": r.FallbackConnectionID,
@@ -591,9 +612,7 @@ func (e *ManifestExecutor) buildSagaInput(input *ApplyManifestInput) map[string]
 			"path_template":          r.PathTemplate,
 		}
 	}
-	sagaInput["instruction_routes"] = routes
-
-	return sagaInput
+	return result
 }
 
 // parseManifestVersion extracts the leading numeric portion of a version string.

--- a/services/control-plane/internal/applier/executor.go
+++ b/services/control-plane/internal/applier/executor.go
@@ -430,17 +430,17 @@ func (e *ManifestExecutor) resolveSagaScript(ctx context.Context) (string, error
 // format expected by the Starlark saga runner.
 func (e *ManifestExecutor) buildSagaInput(input *ApplyManifestInput) map[string]interface{} {
 	sagaInput := map[string]interface{}{
-		"manifest_version":    input.ManifestVersion,
-		"instruments":         convertInstruments(input.Instruments),
-		"account_types":       convertAccountTypes(input.AccountTypes),
-		"market_data_sources": convertMarketDataSources(input.MarketDataSources),
-		"market_data_sets":    convertMarketDataSets(input.MarketDataSets),
-		"valuation_rules":     convertValuationRules(input.ValuationRules),
-		"organizations":       convertOrganizations(input.Organizations),
-		"internal_accounts":   convertInternalAccounts(input.InternalAccounts),
-		"saga_definitions":    convertSagaDefinitions(input.SagaDefinitions),
+		"manifest_version":     input.ManifestVersion,
+		"instruments":          convertInstruments(input.Instruments),
+		"account_types":        convertAccountTypes(input.AccountTypes),
+		"market_data_sources":  convertMarketDataSources(input.MarketDataSources),
+		"market_data_sets":     convertMarketDataSets(input.MarketDataSets),
+		"valuation_rules":      convertValuationRules(input.ValuationRules),
+		"organizations":        convertOrganizations(input.Organizations),
+		"internal_accounts":    convertInternalAccounts(input.InternalAccounts),
+		"saga_definitions":     convertSagaDefinitions(input.SagaDefinitions),
 		"provider_connections": convertProviderConnections(input.ProviderConnections),
-		"instruction_routes":  convertInstructionRoutes(input.InstructionRoutes),
+		"instruction_routes":   convertInstructionRoutes(input.InstructionRoutes),
 	}
 	return sagaInput
 }

--- a/services/control-plane/internal/applier/handlers.go
+++ b/services/control-plane/internal/applier/handlers.go
@@ -34,11 +34,44 @@ var ErrPartyNotConfigured = errors.New("party service not configured")
 //
 // Each handler is registered with metadata for compensation support.
 func RegisterManifestHandlers(registry *saga.HandlerRegistry, deps *HandlerDependencies) error {
-	handlers := map[string]struct {
-		handler  saga.Handler
-		metadata saga.HandlerMetadata
-	}{
-		// Reference Data - Instrument registration
+	registrators := []func(*saga.HandlerRegistry, *HandlerDependencies) error{
+		registerReferenceDataHandlers,
+		registerInternalAccountHandlers,
+		registerOperationalGatewayHandlers,
+		registerMarketInformationHandlers,
+		registerPartyHandlers,
+	}
+	for _, reg := range registrators {
+		if err := reg(registry, deps); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type handlerEntry struct {
+	handler  saga.Handler
+	metadata saga.HandlerMetadata
+}
+
+func registerAll(registry *saga.HandlerRegistry, handlers map[string]handlerEntry) error {
+	for name, h := range handlers {
+		if err := registry.RegisterWithMetadata(name, h.handler, &h.metadata); err != nil {
+			return fmt.Errorf("failed to register %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func registerReferenceDataHandlers(registry *saga.HandlerRegistry, deps *HandlerDependencies) error {
+	if err := registerReferenceDataCoreHandlers(registry, deps); err != nil {
+		return err
+	}
+	return registerReferenceDataCompensationHandlers(registry, deps)
+}
+
+func registerReferenceDataCoreHandlers(registry *saga.HandlerRegistry, deps *HandlerDependencies) error {
+	return registerAll(registry, map[string]handlerEntry{
 		"reference_data.register_instrument": {
 			handler: registerInstrumentHandler(deps),
 			metadata: saga.HandlerMetadata{
@@ -52,12 +85,11 @@ func RegisterManifestHandlers(registry *saga.HandlerRegistry, deps *HandlerDepen
 				Version:             1,
 			},
 		},
-		// Reference Data - Instrument activation (DRAFT → ACTIVE)
 		"reference_data.activate_instrument": {
 			handler: activateInstrumentHandler(deps),
 			metadata: saga.HandlerMetadata{
 				Category:             saga.HandlerCategorySettlement,
-				Description:          "Activate an instrument definition (DRAFT → ACTIVE)",
+				Description:          "Activate an instrument definition (DRAFT -> ACTIVE)",
 				CompensationStrategy: "none",
 				ProducesInstruments:  []string{},
 				ProtoRequestType:     (*referencedatav1.ActivateInstrumentRequest)(nil),
@@ -65,7 +97,6 @@ func RegisterManifestHandlers(registry *saga.HandlerRegistry, deps *HandlerDepen
 				Version:              1,
 			},
 		},
-		// Reference Data - Account type registration (idempotent: CreateDraft + Activate)
 		"reference_data.register_account_type": {
 			handler: registerAccountTypeHandler(deps),
 			metadata: saga.HandlerMetadata{
@@ -79,7 +110,6 @@ func RegisterManifestHandlers(registry *saga.HandlerRegistry, deps *HandlerDepen
 				Version:             1,
 			},
 		},
-		// Reference Data - Valuation rule registration
 		"reference_data.register_valuation_rule": {
 			handler: registerValuationRuleHandler(deps),
 			metadata: saga.HandlerMetadata{
@@ -90,7 +120,6 @@ func RegisterManifestHandlers(registry *saga.HandlerRegistry, deps *HandlerDepen
 				Version:              1,
 			},
 		},
-		// Reference Data - Saga definition registration
 		"reference_data.register_saga_definition": {
 			handler: registerSagaDefinitionHandler(deps),
 			metadata: saga.HandlerMetadata{
@@ -101,20 +130,11 @@ func RegisterManifestHandlers(registry *saga.HandlerRegistry, deps *HandlerDepen
 				Version:              1,
 			},
 		},
-		// Internal Account - Account initiation
-		"internal_account.initiate": {
-			handler: initiateAccountHandler(deps),
-			metadata: saga.HandlerMetadata{
-				Category:             saga.HandlerCategorySettlement,
-				Description:          "Initiate a new internal account",
-				CompensationStrategy: "none",
-				ProducesInstruments:  []string{},
-				ProtoRequestType:     (*internalaccountv1.InitiateInternalAccountRequest)(nil),
-				ProtoResponseType:    (*internalaccountv1.InitiateInternalAccountResponse)(nil),
-				Version:              1,
-			},
-		},
-		// Compensation handlers
+	})
+}
+
+func registerReferenceDataCompensationHandlers(registry *saga.HandlerRegistry, deps *HandlerDependencies) error {
+	return registerAll(registry, map[string]handlerEntry{
 		"reference_data.delete_instrument": {
 			handler: deleteInstrumentHandler(deps),
 			metadata: saga.HandlerMetadata{
@@ -135,7 +155,28 @@ func RegisterManifestHandlers(registry *saga.HandlerRegistry, deps *HandlerDepen
 				Version:              1,
 			},
 		},
-		// Operational Gateway - Provider Connection Management
+	})
+}
+
+func registerInternalAccountHandlers(registry *saga.HandlerRegistry, deps *HandlerDependencies) error {
+	return registerAll(registry, map[string]handlerEntry{
+		"internal_account.initiate": {
+			handler: initiateAccountHandler(deps),
+			metadata: saga.HandlerMetadata{
+				Category:             saga.HandlerCategorySettlement,
+				Description:          "Initiate a new internal account",
+				CompensationStrategy: "none",
+				ProducesInstruments:  []string{},
+				ProtoRequestType:     (*internalaccountv1.InitiateInternalAccountRequest)(nil),
+				ProtoResponseType:    (*internalaccountv1.InitiateInternalAccountResponse)(nil),
+				Version:              1,
+			},
+		},
+	})
+}
+
+func registerOperationalGatewayHandlers(registry *saga.HandlerRegistry, deps *HandlerDependencies) error {
+	return registerAll(registry, map[string]handlerEntry{
 		"operational_gateway.upsert_connection": {
 			handler: upsertConnectionHandler(deps),
 			metadata: saga.HandlerMetadata{
@@ -148,7 +189,6 @@ func RegisterManifestHandlers(registry *saga.HandlerRegistry, deps *HandlerDepen
 				Version:              1,
 			},
 		},
-		// Operational Gateway - Instruction Route Management
 		"operational_gateway.upsert_route": {
 			handler: upsertRouteHandler(deps),
 			metadata: saga.HandlerMetadata{
@@ -161,7 +201,11 @@ func RegisterManifestHandlers(registry *saga.HandlerRegistry, deps *HandlerDepen
 				Version:              1,
 			},
 		},
-		// Market Information - Data source registration
+	})
+}
+
+func registerMarketInformationHandlers(registry *saga.HandlerRegistry, deps *HandlerDependencies) error {
+	return registerAll(registry, map[string]handlerEntry{
 		"market_information.register_data_source": {
 			handler: registerDataSourceHandler(deps),
 			metadata: saga.HandlerMetadata{
@@ -174,7 +218,6 @@ func RegisterManifestHandlers(registry *saga.HandlerRegistry, deps *HandlerDepen
 				Version:              1,
 			},
 		},
-		// Market Information - Data set registration (creates in DRAFT status)
 		"market_information.register_data_set": {
 			handler: registerDataSetHandler(deps),
 			metadata: saga.HandlerMetadata{
@@ -187,12 +230,11 @@ func RegisterManifestHandlers(registry *saga.HandlerRegistry, deps *HandlerDepen
 				Version:              1,
 			},
 		},
-		// Market Information - Data set activation (DRAFT → ACTIVE)
 		"market_information.activate_data_set": {
 			handler: activateDataSetHandler(deps),
 			metadata: saga.HandlerMetadata{
 				Category:             saga.HandlerCategorySettlement,
-				Description:          "Activate a market data set definition (DRAFT → ACTIVE)",
+				Description:          "Activate a market data set definition (DRAFT -> ACTIVE)",
 				CompensationStrategy: "none",
 				ProducesInstruments:  []string{},
 				ProtoRequestType:     (*marketinformationv1.ActivateDataSetRequest)(nil),
@@ -200,7 +242,11 @@ func RegisterManifestHandlers(registry *saga.HandlerRegistry, deps *HandlerDepen
 				Version:              1,
 			},
 		},
-		// Party - Organization registration
+	})
+}
+
+func registerPartyHandlers(registry *saga.HandlerRegistry, deps *HandlerDependencies) error {
+	return registerAll(registry, map[string]handlerEntry{
 		"party.register_organization": {
 			handler: registerOrganizationHandler(deps),
 			metadata: saga.HandlerMetadata{
@@ -213,7 +259,6 @@ func RegisterManifestHandlers(registry *saga.HandlerRegistry, deps *HandlerDepen
 				Version:              1,
 			},
 		},
-		// Party - Organization lifecycle control (deactivation via TERMINATE)
 		"party.control_organization": {
 			handler: controlOrganizationHandler(deps),
 			metadata: saga.HandlerMetadata{
@@ -226,14 +271,7 @@ func RegisterManifestHandlers(registry *saga.HandlerRegistry, deps *HandlerDepen
 				Version:              1,
 			},
 		},
-	}
-
-	for name, h := range handlers {
-		if err := registry.RegisterWithMetadata(name, h.handler, &h.metadata); err != nil {
-			return fmt.Errorf("failed to register %s: %w", name, err)
-		}
-	}
-	return nil
+	})
 }
 
 // HandlerDependencies holds the service clients needed by manifest handlers.

--- a/services/current-account/service/lien_lifecycle.go
+++ b/services/current-account/service/lien_lifecycle.go
@@ -4,24 +4,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/google/uuid"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
-	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	caobservability "github.com/meridianhub/meridian/services/current-account/observability"
-	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/platform/db"
-	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/shopspring/decimal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 	"gorm.io/gorm"
 )
 
@@ -70,87 +65,16 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 	var valuationResult *valuateInternalResult
 
 	if useValuation {
-		// Multi-asset mode: parse input and run atomic valuation
-		inputAmount, err := decimal.NewFromString(req.Input.Amount)
+		var err error
+		lienAmount, valuationResult, operationStatus, err = s.computeMultiAssetLienAmount(ctx, req, prefetchedAccount)
 		if err != nil {
-			operationStatus = opStatusInvalidInputAmount
-			return nil, status.Errorf(codes.InvalidArgument, "invalid input amount: %v", err)
-		}
-		if !inputAmount.IsPositive() {
-			operationStatus = opStatusInputAmountNonPositive
-			return nil, status.Error(codes.InvalidArgument, "input amount must be positive")
-		}
-
-		knowledgeAt := time.Now()
-		if req.KnowledgeAt != nil {
-			knowledgeAt = req.KnowledgeAt.AsTime()
-		}
-
-		// Run shared valuation function (same logic as EvaluateAssetValuation - Ghost Pricing prevention)
-		valuationResult, err = s.valuateInternal(ctx, req.AccountId, inputAmount, req.Input.InstrumentCode, knowledgeAt)
-		if err != nil {
-			switch {
-			case errors.Is(err, ErrValuationAccountNotFound):
-				operationStatus = opStatusAccountNotFound
-				return nil, status.Errorf(codes.NotFound, "%v", err)
-			case errors.Is(err, ErrNoActiveValuationFeature):
-				operationStatus = opStatusNoValuationFeature
-				return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
-			case errors.Is(err, ErrValuationFeatureNotActive):
-				operationStatus = opStatusFeatureNotActive
-				return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
-			case errors.Is(err, ErrValuationRepoNotConfigured):
-				operationStatus = opStatusValuationFeatureRepoNil
-				return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
-			case errors.Is(err, ErrValuationEngineFailed):
-				operationStatus = opStatusValuationFailed
-				return nil, status.Errorf(codes.Internal, "%v", err)
-			default:
-				operationStatus = opStatusValuationFailed
-				return nil, status.Errorf(codes.Internal, "valuation failed: %v", err)
-			}
-		}
-
-		// Convert valued output to domain Amount for lien amount (the actual reservation).
-		// Use the account's instrument precision so non-2-decimal instruments work correctly.
-		precision := prefetchedAccount.Balance().Instrument().Precision
-		// #nosec G115 - precision is bounded by instrument definition (0-9 in practice)
-		scale := decimal.NewFromInt(1).Shift(int32(precision))
-		valuedMinor := valuationResult.OutputAmount.Mul(scale).RoundBank(0)
-		maxInt64 := decimal.NewFromInt(math.MaxInt64)
-		minInt64 := decimal.NewFromInt(math.MinInt64)
-		if valuedMinor.GreaterThan(maxInt64) || valuedMinor.LessThan(minInt64) {
-			operationStatus = opStatusInvalidAmount
-			return nil, status.Error(codes.InvalidArgument, ErrAmountOverflow.Error())
-		}
-		lienAmount, err = domain.NewAmountFromInstrument(
-			valuationResult.OutputCode,
-			prefetchedAccount.Dimension(),
-			precision,
-			valuedMinor.IntPart(),
-		)
-		if err != nil {
-			operationStatus = opStatusInvalidAmount
-			return nil, status.Errorf(codes.Internal, "failed to create valued amount: %v", err)
+			return nil, err
 		}
 	} else {
-		// Legacy mode: validate instrument match and convert MoneyAmount using the account's
-		// instrument for dimension-agnostic support.
-		if req.Amount == nil || req.Amount.Amount == nil {
-			operationStatus = opStatusInvalidAmount
-			return nil, status.Error(codes.InvalidArgument, "amount is required")
-		}
-		if req.Amount.Amount.CurrencyCode != prefetchedAccount.InstrumentCode() {
-			operationStatus = opStatusCurrencyMismatch
-			return nil, status.Errorf(codes.InvalidArgument,
-				"currency mismatch: lien currency %s does not match account currency %s",
-				req.Amount.Amount.CurrencyCode, prefetchedAccount.InstrumentCode())
-		}
 		var err error
-		lienAmount, err = protoMoneyToAmount(req.Amount, prefetchedAccount)
+		lienAmount, operationStatus, err = computeLegacyLienAmount(req, prefetchedAccount)
 		if err != nil {
-			operationStatus = opStatusInvalidAmount
-			return nil, status.Errorf(codes.InvalidArgument, "invalid amount: %v", err)
+			return nil, err
 		}
 	}
 
@@ -245,29 +169,8 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 	})
 
 	if txErr != nil {
-		switch {
-		case errors.Is(txErr, persistence.ErrAccountNotFound):
-			operationStatus = opStatusAccountNotFound
-			return nil, status.Errorf(codes.NotFound, "account not found: %s", req.AccountId)
-		case errors.Is(txErr, errTxAccountNotActive):
-			operationStatus = opStatusAccountNotActive
-			return nil, status.Errorf(codes.FailedPrecondition, "account is not active")
-		case errors.Is(txErr, errTxCurrencyMismatch):
-			operationStatus = opStatusCurrencyMismatch
-			return nil, status.Errorf(codes.InvalidArgument, "lien currency must match account currency")
-		case errors.Is(txErr, errTxInsufficientFunds):
-			operationStatus = opStatusInsufficientFunds
-			return nil, status.Errorf(codes.FailedPrecondition, "insufficient available balance")
-		case errors.Is(txErr, errTxDomainError):
-			operationStatus = opStatusDomainError
-			return nil, status.Errorf(codes.InvalidArgument, "failed to create lien: %v", txErr)
-		case errors.Is(txErr, errTxSaveLien):
-			operationStatus = opStatusSaveFailed
-			return nil, status.Errorf(codes.Internal, "failed to save lien: %v", txErr)
-		default:
-			operationStatus = opStatusRetrieveFailed
-			return nil, status.Errorf(codes.Internal, "failed to create lien: %v", txErr)
-		}
+		operationStatus, err = mapInitiateLienTxError(txErr, req.AccountId)
+		return nil, err
 	}
 
 	s.logger.Info("lien created",
@@ -277,36 +180,7 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 		"has_valuation", lien.HasValuation(),
 		"payment_order_ref", req.PaymentOrderReference)
 
-	// Calculate new available balance after this lien
-	newAvailableBalance := availableBalance - lienAmount.ToMinorUnitsUnchecked()
-	availableMoney, err := domain.NewAmountFromInstrument(
-		account.Balance().InstrumentCode(),
-		account.Balance().Dimension(),
-		account.Balance().Instrument().Precision,
-		newAvailableBalance,
-	)
-	if err != nil {
-		s.logger.Error("failed to create available balance amount", "error", err)
-		// Fall back to the pre-lien available balance so the response is not zero.
-		availableMoney = account.AvailableBalance()
-	}
-
-	resp := &pb.InitiateLienResponse{
-		Lien:             toLienProto(lien),
-		AvailableBalance: toMoneyAmount(availableMoney),
-	}
-
-	// Add valuation fields to response when atomic valuation was performed
-	if useValuation && valuationResult != nil {
-		resp.ValuedAmount = &quantityv1.InstrumentAmount{
-			Amount:         valuationResult.OutputAmount.String(),
-			InstrumentCode: valuationResult.OutputCode,
-			Version:        1,
-		}
-		resp.Basis = valuationResult.Analysis
-	}
-
-	return resp, nil
+	return s.buildInitiateLienResponse(account, lien, lienAmount, availableBalance, useValuation, valuationResult), nil
 }
 
 // ExecuteLien converts a reservation to an actual debit atomically with Redis idempotency
@@ -330,73 +204,27 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 		return nil, status.Errorf(codes.InvalidArgument, "invalid lien ID: %v", err)
 	}
 
-	// Get idempotency key if provided
-	var idempotencyKeyStr string
-	if req.IdempotencyKey != nil && req.IdempotencyKey.Key != "" {
-		idempotencyKeyStr = req.IdempotencyKey.Key
+	// Idempotency: check Redis cache, acquire distributed lock
+	idempotencyKeyStr, idempKey, idempotencyLockAcquired, cachedResp, err := s.acquireExecuteLienIdempotency(ctx, req)
+	if err != nil {
+		operationStatus = opStatusRetrieveFailed
+		return nil, err
+	}
+	if cachedResp != nil {
+		operationStatus = opStatusIdempotent
+		return cachedResp, nil
 	}
 
-	// Build idempotency key structure for Redis
-	var idempKey idempotency.Key
-	var idempotencyLockAcquired bool
-	if idempotencyKeyStr != "" && s.idempotencyService != nil {
-		tenantID, ok := tenant.FromContext(ctx)
-		if !ok {
-			s.logger.Debug("tenant not found in context for idempotency key",
-				"lien_id", req.LienId)
-		}
-		idempKey = idempotency.Key{
-			TenantID:  string(tenantID),
-			Namespace: idempotencyNamespace,
-			Operation: "execute_lien",
-			EntityID:  req.LienId,
-			RequestID: idempotencyKeyStr,
-		}
-
-		// Check Redis for existing result
-		result, err := s.idempotencyService.Check(ctx, idempKey)
-		if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) && result != nil && result.Data != nil {
-			var cachedResp pb.ExecuteLienResponse
-			unmarshalErr := proto.Unmarshal(result.Data, &cachedResp)
-			if unmarshalErr == nil {
-				s.logger.Info("returning cached execute lien response from Redis",
-					"lien_id", req.LienId,
-					"transaction_id", cachedResp.TransactionId,
+	// Cleanup pending state on failure - ensures retries aren't blocked for 5 minutes
+	defer func() {
+		if idempotencyLockAcquired && operationStatus != operationStatusSuccess {
+			if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
+				s.logger.Warn("failed to cleanup pending idempotency state",
+					"error", delErr,
 					"idempotency_key", idempotencyKeyStr)
-				operationStatus = opStatusIdempotent
-				return &cachedResp, nil
 			}
-			s.logger.Warn("failed to unmarshal cached idempotency result",
-				"error", unmarshalErr)
-		} else if err != nil && !errors.Is(err, idempotency.ErrResultNotFound) {
-			s.logger.Error("idempotency check failed", "error", err)
-			return nil, status.Error(codes.Internal, "failed to check idempotency")
 		}
-
-		// Mark operation as pending (distributed lock)
-		if err := s.idempotencyService.MarkPending(ctx, idempKey, idempotencyPendingTTL); err != nil {
-			// Check if another request is already processing this operation
-			if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) {
-				s.logger.Info("operation already in progress, please retry",
-					"idempotency_key", idempotencyKeyStr)
-				return nil, status.Error(codes.Aborted, "operation already in progress, please retry")
-			}
-			s.logger.Error("failed to mark operation pending", "error", err)
-			return nil, status.Error(codes.Aborted, "failed to acquire idempotency lock, please retry")
-		}
-		idempotencyLockAcquired = true
-
-		// Cleanup pending state on failure - ensures retries aren't blocked for 5 minutes
-		defer func() {
-			if idempotencyLockAcquired && operationStatus != operationStatusSuccess {
-				if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
-					s.logger.Warn("failed to cleanup pending idempotency state",
-						"error", delErr,
-						"idempotency_key", idempotencyKeyStr)
-				}
-			}
-		}()
-	}
+	}()
 
 	// First, check for idempotency without locking (read-only check)
 	// Note: Context is passed to enable organization scoping in multi-org mode
@@ -510,36 +338,8 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 	})
 
 	if txErr != nil {
-		// Determine which operation failed for proper error reporting
-		switch {
-		case errors.Is(txErr, persistence.ErrLienNotFound):
-			operationStatus = opStatusLienNotFound
-			return nil, status.Errorf(codes.NotFound, "lien not found: %s", req.LienId)
-		case errors.Is(txErr, persistence.ErrLienVersionConflict):
-			operationStatus = opStatusVersionConflict
-			return nil, status.Error(codes.Aborted, "concurrent modification detected, please retry")
-		case errors.Is(txErr, persistence.ErrVersionConflict):
-			operationStatus = opStatusVersionConflict
-			return nil, status.Error(codes.Aborted, "concurrent modification detected, please retry")
-		case errors.Is(txErr, errTxInvalidLienStatus):
-			operationStatus = opStatusInvalidLienStatus
-			return nil, status.Errorf(codes.FailedPrecondition, "lien cannot be executed: status=%s, expired=%v", lien.Status, lien.IsExpired())
-		case errors.Is(txErr, errTxSaveAccount):
-			operationStatus = opStatusSaveAccountFailed
-			return nil, status.Errorf(codes.Internal, "failed to execute lien transaction: %v", txErr)
-		case errors.Is(txErr, errTxUpdateLien):
-			operationStatus = opStatusUpdateLienFailed
-			return nil, status.Errorf(codes.Internal, "failed to execute lien transaction: %v", txErr)
-		case errors.Is(txErr, errTxExecuteFailed):
-			operationStatus = opStatusExecuteFailed
-			return nil, status.Errorf(codes.FailedPrecondition, "failed to execute lien: %v", txErr)
-		case errors.Is(txErr, errTxWithdrawFailed):
-			operationStatus = opStatusWithdrawFailed
-			return nil, status.Errorf(codes.FailedPrecondition, "failed to debit account: %v", txErr)
-		default:
-			operationStatus = opStatusRetrieveAccountFailed
-			return nil, status.Errorf(codes.Internal, "failed to execute lien transaction: %v", txErr)
-		}
+		operationStatus, err = mapExecuteLienTxError(txErr, req.LienId, lien)
+		return nil, err
 	}
 
 	// Handle case where lien was already executed by concurrent request
@@ -580,25 +380,7 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 		TransactionId:    transactionID,
 	}
 
-	// Store successful result in Redis for future idempotency checks
-	if idempotencyKeyStr != "" && s.idempotencyService != nil {
-		responseData, marshalErr := proto.Marshal(resp)
-		if marshalErr == nil {
-			storeErr := s.idempotencyService.StoreResult(ctx, idempotency.Result{
-				Key:         idempKey,
-				Status:      idempotency.StatusCompleted,
-				Data:        responseData,
-				CompletedAt: time.Now(),
-				TTL:         idempotencyResultTTL,
-			})
-			if storeErr != nil {
-				s.logger.Error("failed to store idempotency result", "error", storeErr)
-				// Continue - operation succeeded, caching is optimization
-			}
-		} else {
-			s.logger.Error("failed to marshal response for idempotency cache", "error", marshalErr)
-		}
-	}
+	s.storeIdempotencyResult(ctx, idempotencyKeyStr, idempKey, resp)
 
 	return resp, nil
 }
@@ -702,26 +484,8 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 	})
 
 	if txErr != nil {
-		switch {
-		case errors.Is(txErr, persistence.ErrLienNotFound):
-			operationStatus = opStatusLienNotFound
-			return nil, status.Errorf(codes.NotFound, "lien not found: %s", req.LienId)
-		case errors.Is(txErr, persistence.ErrLienVersionConflict):
-			operationStatus = opStatusVersionConflict
-			return nil, status.Error(codes.Aborted, "concurrent modification detected, please retry")
-		case errors.Is(txErr, errTxInvalidLienStatus):
-			operationStatus = opStatusInvalidLienStatus
-			return nil, status.Errorf(codes.FailedPrecondition, "lien cannot be terminated: status=%s", lien.Status)
-		case errors.Is(txErr, errTxTerminateFailed):
-			operationStatus = opStatusTerminateFailed
-			return nil, status.Errorf(codes.FailedPrecondition, "failed to terminate lien: %v", txErr)
-		case errors.Is(txErr, errTxUpdateLien):
-			operationStatus = opStatusUpdateFailed
-			return nil, status.Errorf(codes.Internal, "failed to update lien: %v", txErr)
-		default:
-			operationStatus = opStatusRetrieveFailed
-			return nil, status.Errorf(codes.Internal, "failed to terminate lien: %v", txErr)
-		}
+		operationStatus, err = mapTerminateLienTxError(txErr, req.LienId, lien)
+		return nil, err
 	}
 
 	// Handle case where lien was already terminated by concurrent request

--- a/services/current-account/service/lien_lifecycle_helpers.go
+++ b/services/current-account/service/lien_lifecycle_helpers.go
@@ -224,7 +224,7 @@ func (s *Service) checkIdempotencyCache(
 		s.logger.Error("idempotency check failed", "error", err)
 		return nil, status.Error(codes.Internal, "failed to check idempotency")
 	}
-	return nil, nil
+	return nil, nil //nolint:nilnil // nil,nil means no cache hit and no error
 }
 
 // mapExecuteLienTxError converts an ExecuteLien transaction error to operation status and gRPC error.

--- a/services/current-account/service/lien_lifecycle_helpers.go
+++ b/services/current-account/service/lien_lifecycle_helpers.go
@@ -1,0 +1,292 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"math"
+	"time"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
+	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
+	"github.com/meridianhub/meridian/services/current-account/domain"
+	"github.com/meridianhub/meridian/shared/pkg/idempotency"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/shopspring/decimal"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+// computeMultiAssetLienAmount runs atomic valuation and converts the result to a domain Amount.
+func (s *Service) computeMultiAssetLienAmount(
+	ctx context.Context, req *pb.InitiateLienRequest, prefetchedAccount domain.CurrentAccount,
+) (domain.Amount, *valuateInternalResult, string, error) {
+	inputAmount, err := decimal.NewFromString(req.Input.Amount)
+	if err != nil {
+		return domain.Amount{}, nil, opStatusInvalidInputAmount,
+			status.Errorf(codes.InvalidArgument, "invalid input amount: %v", err)
+	}
+	if !inputAmount.IsPositive() {
+		return domain.Amount{}, nil, opStatusInputAmountNonPositive,
+			status.Error(codes.InvalidArgument, "input amount must be positive")
+	}
+
+	knowledgeAt := time.Now()
+	if req.KnowledgeAt != nil {
+		knowledgeAt = req.KnowledgeAt.AsTime()
+	}
+
+	valuationResult, err := s.valuateInternal(ctx, req.AccountId, inputAmount, req.Input.InstrumentCode, knowledgeAt)
+	if err != nil {
+		opStatus, grpcErr := mapValuationError(err)
+		return domain.Amount{}, nil, opStatus, grpcErr
+	}
+
+	// Convert valued output to domain Amount for lien amount (the actual reservation).
+	// Use the account's instrument precision so non-2-decimal instruments work correctly.
+	precision := prefetchedAccount.Balance().Instrument().Precision
+	// #nosec G115 - precision is bounded by instrument definition (0-9 in practice)
+	scale := decimal.NewFromInt(1).Shift(int32(precision))
+	valuedMinor := valuationResult.OutputAmount.Mul(scale).RoundBank(0)
+	maxInt64 := decimal.NewFromInt(math.MaxInt64)
+	minInt64 := decimal.NewFromInt(math.MinInt64)
+	if valuedMinor.GreaterThan(maxInt64) || valuedMinor.LessThan(minInt64) {
+		return domain.Amount{}, nil, opStatusInvalidAmount,
+			status.Error(codes.InvalidArgument, ErrAmountOverflow.Error())
+	}
+	lienAmount, err := domain.NewAmountFromInstrument(
+		valuationResult.OutputCode,
+		prefetchedAccount.Dimension(),
+		precision,
+		valuedMinor.IntPart(),
+	)
+	if err != nil {
+		return domain.Amount{}, nil, opStatusInvalidAmount,
+			status.Errorf(codes.Internal, "failed to create valued amount: %v", err)
+	}
+	return lienAmount, valuationResult, "", nil
+}
+
+// mapValuationError converts a valuation error to an operation status and gRPC error.
+func mapValuationError(err error) (string, error) {
+	switch {
+	case errors.Is(err, ErrValuationAccountNotFound):
+		return opStatusAccountNotFound, status.Errorf(codes.NotFound, "%v", err)
+	case errors.Is(err, ErrNoActiveValuationFeature):
+		return opStatusNoValuationFeature, status.Errorf(codes.FailedPrecondition, "%v", err)
+	case errors.Is(err, ErrValuationFeatureNotActive):
+		return opStatusFeatureNotActive, status.Errorf(codes.FailedPrecondition, "%v", err)
+	case errors.Is(err, ErrValuationRepoNotConfigured):
+		return opStatusValuationFeatureRepoNil, status.Errorf(codes.FailedPrecondition, "%v", err)
+	case errors.Is(err, ErrValuationEngineFailed):
+		return opStatusValuationFailed, status.Errorf(codes.Internal, "%v", err)
+	default:
+		return opStatusValuationFailed, status.Errorf(codes.Internal, "valuation failed: %v", err)
+	}
+}
+
+// computeLegacyLienAmount validates instrument match and converts MoneyAmount to a domain Amount.
+func computeLegacyLienAmount(req *pb.InitiateLienRequest, prefetchedAccount domain.CurrentAccount) (domain.Amount, string, error) {
+	if req.Amount == nil || req.Amount.Amount == nil {
+		return domain.Amount{}, opStatusInvalidAmount,
+			status.Error(codes.InvalidArgument, "amount is required")
+	}
+	if req.Amount.Amount.CurrencyCode != prefetchedAccount.InstrumentCode() {
+		return domain.Amount{}, opStatusCurrencyMismatch,
+			status.Errorf(codes.InvalidArgument,
+				"currency mismatch: lien currency %s does not match account currency %s",
+				req.Amount.Amount.CurrencyCode, prefetchedAccount.InstrumentCode())
+	}
+	lienAmount, err := protoMoneyToAmount(req.Amount, prefetchedAccount)
+	if err != nil {
+		return domain.Amount{}, opStatusInvalidAmount,
+			status.Errorf(codes.InvalidArgument, "invalid amount: %v", err)
+	}
+	return lienAmount, "", nil
+}
+
+// mapInitiateLienTxError converts an InitiateLien transaction error to operation status and gRPC error.
+func mapInitiateLienTxError(txErr error, accountID string) (string, error) {
+	switch {
+	case errors.Is(txErr, persistence.ErrAccountNotFound):
+		return opStatusAccountNotFound, status.Errorf(codes.NotFound, "account not found: %s", accountID)
+	case errors.Is(txErr, errTxAccountNotActive):
+		return opStatusAccountNotActive, status.Errorf(codes.FailedPrecondition, "account is not active")
+	case errors.Is(txErr, errTxCurrencyMismatch):
+		return opStatusCurrencyMismatch, status.Errorf(codes.InvalidArgument, "lien currency must match account currency")
+	case errors.Is(txErr, errTxInsufficientFunds):
+		return opStatusInsufficientFunds, status.Errorf(codes.FailedPrecondition, "insufficient available balance")
+	case errors.Is(txErr, errTxDomainError):
+		return opStatusDomainError, status.Errorf(codes.InvalidArgument, "failed to create lien: %v", txErr)
+	case errors.Is(txErr, errTxSaveLien):
+		return opStatusSaveFailed, status.Errorf(codes.Internal, "failed to save lien: %v", txErr)
+	default:
+		return opStatusRetrieveFailed, status.Errorf(codes.Internal, "failed to create lien: %v", txErr)
+	}
+}
+
+// buildInitiateLienResponse constructs the response for a successful InitiateLien operation.
+func (s *Service) buildInitiateLienResponse(
+	account *domain.CurrentAccount, lien *domain.Lien, lienAmount domain.Amount,
+	availableBalance int64, useValuation bool, valuationResult *valuateInternalResult,
+) *pb.InitiateLienResponse {
+	newAvailableBalance := availableBalance - lienAmount.ToMinorUnitsUnchecked()
+	availableMoney, err := domain.NewAmountFromInstrument(
+		account.Balance().InstrumentCode(),
+		account.Balance().Dimension(),
+		account.Balance().Instrument().Precision,
+		newAvailableBalance,
+	)
+	if err != nil {
+		s.logger.Error("failed to create available balance amount", "error", err)
+		availableMoney = account.AvailableBalance()
+	}
+
+	resp := &pb.InitiateLienResponse{
+		Lien:             toLienProto(lien),
+		AvailableBalance: toMoneyAmount(availableMoney),
+	}
+
+	if useValuation && valuationResult != nil {
+		resp.ValuedAmount = &quantityv1.InstrumentAmount{
+			Amount:         valuationResult.OutputAmount.String(),
+			InstrumentCode: valuationResult.OutputCode,
+			Version:        1,
+		}
+		resp.Basis = valuationResult.Analysis
+	}
+
+	return resp
+}
+
+// acquireExecuteLienIdempotency checks Redis cache and acquires a distributed lock for ExecuteLien.
+// Returns the idempotency key string, key struct, lock status, and optionally a cached response.
+func (s *Service) acquireExecuteLienIdempotency(
+	ctx context.Context, req *pb.ExecuteLienRequest,
+) (string, idempotency.Key, bool, *pb.ExecuteLienResponse, error) {
+	var idempotencyKeyStr string
+	if req.IdempotencyKey != nil && req.IdempotencyKey.Key != "" {
+		idempotencyKeyStr = req.IdempotencyKey.Key
+	}
+
+	var idempKey idempotency.Key
+	if idempotencyKeyStr == "" || s.idempotencyService == nil {
+		return idempotencyKeyStr, idempKey, false, nil, nil
+	}
+
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		s.logger.Debug("tenant not found in context for idempotency key", "lien_id", req.LienId)
+	}
+	idempKey = idempotency.Key{
+		TenantID: string(tenantID), Namespace: idempotencyNamespace,
+		Operation: "execute_lien", EntityID: req.LienId, RequestID: idempotencyKeyStr,
+	}
+
+	// Check Redis for existing result
+	if cachedResp, err := s.checkIdempotencyCache(ctx, idempKey, req.LienId, idempotencyKeyStr); err != nil {
+		return idempotencyKeyStr, idempKey, false, nil, err
+	} else if cachedResp != nil {
+		return idempotencyKeyStr, idempKey, false, cachedResp, nil
+	}
+
+	// Mark operation as pending (distributed lock)
+	if err := s.idempotencyService.MarkPending(ctx, idempKey, idempotencyPendingTTL); err != nil {
+		if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) {
+			s.logger.Info("operation already in progress, please retry", "idempotency_key", idempotencyKeyStr)
+			return idempotencyKeyStr, idempKey, false, nil,
+				status.Error(codes.Aborted, "operation already in progress, please retry")
+		}
+		s.logger.Error("failed to mark operation pending", "error", err)
+		return idempotencyKeyStr, idempKey, false, nil,
+			status.Error(codes.Aborted, "failed to acquire idempotency lock, please retry")
+	}
+
+	return idempotencyKeyStr, idempKey, true, nil, nil
+}
+
+// checkIdempotencyCache checks Redis for an existing ExecuteLien result.
+func (s *Service) checkIdempotencyCache(
+	ctx context.Context, idempKey idempotency.Key, lienID, idempotencyKeyStr string,
+) (*pb.ExecuteLienResponse, error) {
+	result, err := s.idempotencyService.Check(ctx, idempKey)
+	if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) && result != nil && result.Data != nil {
+		var cachedResp pb.ExecuteLienResponse
+		if unmarshalErr := proto.Unmarshal(result.Data, &cachedResp); unmarshalErr == nil {
+			s.logger.Info("returning cached execute lien response from Redis",
+				"lien_id", lienID, "transaction_id", cachedResp.TransactionId,
+				"idempotency_key", idempotencyKeyStr)
+			return &cachedResp, nil
+		}
+		s.logger.Warn("failed to unmarshal cached idempotency result", "error", err)
+	} else if err != nil && !errors.Is(err, idempotency.ErrResultNotFound) {
+		s.logger.Error("idempotency check failed", "error", err)
+		return nil, status.Error(codes.Internal, "failed to check idempotency")
+	}
+	return nil, nil
+}
+
+// mapExecuteLienTxError converts an ExecuteLien transaction error to operation status and gRPC error.
+func mapExecuteLienTxError(txErr error, lienID string, lien *domain.Lien) (string, error) {
+	switch {
+	case errors.Is(txErr, persistence.ErrLienNotFound):
+		return opStatusLienNotFound, status.Errorf(codes.NotFound, "lien not found: %s", lienID)
+	case errors.Is(txErr, persistence.ErrLienVersionConflict):
+		return opStatusVersionConflict, status.Error(codes.Aborted, "concurrent modification detected, please retry")
+	case errors.Is(txErr, persistence.ErrVersionConflict):
+		return opStatusVersionConflict, status.Error(codes.Aborted, "concurrent modification detected, please retry")
+	case errors.Is(txErr, errTxInvalidLienStatus):
+		return opStatusInvalidLienStatus, status.Errorf(codes.FailedPrecondition, "lien cannot be executed: status=%s, expired=%v", lien.Status, lien.IsExpired())
+	case errors.Is(txErr, errTxSaveAccount):
+		return opStatusSaveAccountFailed, status.Errorf(codes.Internal, "failed to execute lien transaction: %v", txErr)
+	case errors.Is(txErr, errTxUpdateLien):
+		return opStatusUpdateLienFailed, status.Errorf(codes.Internal, "failed to execute lien transaction: %v", txErr)
+	case errors.Is(txErr, errTxExecuteFailed):
+		return opStatusExecuteFailed, status.Errorf(codes.FailedPrecondition, "failed to execute lien: %v", txErr)
+	case errors.Is(txErr, errTxWithdrawFailed):
+		return opStatusWithdrawFailed, status.Errorf(codes.FailedPrecondition, "failed to debit account: %v", txErr)
+	default:
+		return opStatusRetrieveAccountFailed, status.Errorf(codes.Internal, "failed to execute lien transaction: %v", txErr)
+	}
+}
+
+// storeIdempotencyResult stores a successful ExecuteLien response in Redis for future idempotency checks.
+func (s *Service) storeIdempotencyResult(ctx context.Context, idempotencyKeyStr string, idempKey idempotency.Key, resp *pb.ExecuteLienResponse) {
+	if idempotencyKeyStr == "" || s.idempotencyService == nil {
+		return
+	}
+	responseData, marshalErr := proto.Marshal(resp)
+	if marshalErr != nil {
+		s.logger.Error("failed to marshal response for idempotency cache", "error", marshalErr)
+		return
+	}
+	storeErr := s.idempotencyService.StoreResult(ctx, idempotency.Result{
+		Key:         idempKey,
+		Status:      idempotency.StatusCompleted,
+		Data:        responseData,
+		CompletedAt: time.Now(),
+		TTL:         idempotencyResultTTL,
+	})
+	if storeErr != nil {
+		s.logger.Error("failed to store idempotency result", "error", storeErr)
+	}
+}
+
+// mapTerminateLienTxError converts a TerminateLien transaction error to operation status and gRPC error.
+func mapTerminateLienTxError(txErr error, lienID string, lien *domain.Lien) (string, error) {
+	switch {
+	case errors.Is(txErr, persistence.ErrLienNotFound):
+		return opStatusLienNotFound, status.Errorf(codes.NotFound, "lien not found: %s", lienID)
+	case errors.Is(txErr, persistence.ErrLienVersionConflict):
+		return opStatusVersionConflict, status.Error(codes.Aborted, "concurrent modification detected, please retry")
+	case errors.Is(txErr, errTxInvalidLienStatus):
+		return opStatusInvalidLienStatus, status.Errorf(codes.FailedPrecondition, "lien cannot be terminated: status=%s", lien.Status)
+	case errors.Is(txErr, errTxTerminateFailed):
+		return opStatusTerminateFailed, status.Errorf(codes.FailedPrecondition, "failed to terminate lien: %v", txErr)
+	case errors.Is(txErr, errTxUpdateLien):
+		return opStatusUpdateFailed, status.Errorf(codes.Internal, "failed to update lien: %v", txErr)
+	default:
+		return opStatusRetrieveFailed, status.Errorf(codes.Internal, "failed to terminate lien: %v", txErr)
+	}
+}

--- a/services/current-account/service/lien_lifecycle_helpers.go
+++ b/services/current-account/service/lien_lifecycle_helpers.go
@@ -213,13 +213,14 @@ func (s *Service) checkIdempotencyCache(
 	result, err := s.idempotencyService.Check(ctx, idempKey)
 	if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) && result != nil && result.Data != nil {
 		var cachedResp pb.ExecuteLienResponse
-		if unmarshalErr := proto.Unmarshal(result.Data, &cachedResp); unmarshalErr == nil {
+		unmarshalErr := proto.Unmarshal(result.Data, &cachedResp)
+		if unmarshalErr == nil {
 			s.logger.Info("returning cached execute lien response from Redis",
 				"lien_id", lienID, "transaction_id", cachedResp.TransactionId,
 				"idempotency_key", idempotencyKeyStr)
 			return &cachedResp, nil
 		}
-		s.logger.Warn("failed to unmarshal cached idempotency result", "error", err)
+		s.logger.Warn("failed to unmarshal cached idempotency result", "error", unmarshalErr)
 	} else if err != nil && !errors.Is(err, idempotency.ErrResultNotFound) {
 		s.logger.Error("idempotency check failed", "error", err)
 		return nil, status.Error(codes.Internal, "failed to check idempotency")

--- a/services/current-account/service/saga_handlers.go
+++ b/services/current-account/service/saga_handlers.go
@@ -101,12 +101,28 @@ func RegisterCurrentAccountHandlers(registry *saga.HandlerRegistry, opts ...Regi
 		notifHandler = options.notificationHandler
 	}
 
-	handlers := []struct {
-		name     string
-		handler  saga.Handler
-		metadata *saga.HandlerMetadata
-	}{
-		// Position Keeping handlers (global namespace)
+	handlers := currentAccountCoreHandlers(notifHandler)
+	handlers = append(handlers, currentAccountStubHandlers()...)
+
+	for _, h := range handlers {
+		if err := registry.RegisterWithMetadata(h.name, h.handler, h.metadata); err != nil {
+			return fmt.Errorf("failed to register handler %s: %w", h.name, err)
+		}
+	}
+	return nil
+}
+
+type handlerEntry struct {
+	name     string
+	handler  saga.Handler
+	metadata *saga.HandlerMetadata
+}
+
+// currentAccountCoreHandlers returns the implemented handlers for position keeping,
+// financial accounting, and current account domain operations.
+func currentAccountCoreHandlers(notifHandler saga.Handler) []handlerEntry {
+	return []handlerEntry{
+		// Position Keeping handlers
 		{"position_keeping.initiate_log", currentAccountPositionKeepingInitiateLog, &saga.HandlerMetadata{
 			Category:             saga.HandlerCategoryIngestion,
 			CompensationStrategy: "auto",
@@ -122,7 +138,7 @@ func RegisterCurrentAccountHandlers(registry *saga.HandlerRegistry, opts ...Regi
 			CompensationStrategy: "none",
 		}},
 
-		// Financial Accounting handlers (global namespace)
+		// Financial Accounting handlers
 		{"financial_accounting.post_entries", stubNotImplemented("financial_accounting.post_entries"), nil},
 		{"financial_accounting.reverse_entries", stubNotImplemented("financial_accounting.reverse_entries"), nil},
 		{"financial_accounting.create_booking", stubNotImplemented("financial_accounting.create_booking"), nil},
@@ -147,17 +163,20 @@ func RegisterCurrentAccountHandlers(registry *saga.HandlerRegistry, opts ...Regi
 
 		// Current Account domain handlers
 		{"current_account.save", currentAccountRepositorySave, nil},
-
-		// Control handler (stub - implemented in client package for cross-service use)
 		{"current_account.control", stubNotImplemented("current_account.control"), nil},
-
-		// Lien handlers (stubs - not yet implemented but required by schema)
 		{"current_account.create_lien", stubNotImplemented("current_account.create_lien"), nil},
 		{"current_account.execute_lien", stubNotImplemented("current_account.execute_lien"), nil},
 		{"current_account.terminate_lien", stubNotImplemented("current_account.terminate_lien"), nil},
 
-		// Platform-wide handlers (stubs - defined in schema for other services)
+		// Notification
 		{"notification.send", notifHandler, nil},
+	}
+}
+
+// currentAccountStubHandlers returns stub handlers for cross-service operations
+// that are defined in the schema but implemented by other services.
+func currentAccountStubHandlers() []handlerEntry {
+	return []handlerEntry{
 		{"payment_order.create_lien", stubNotImplemented("payment_order.create_lien"), nil},
 		{"payment_order.execute_lien", stubNotImplemented("payment_order.execute_lien"), nil},
 		{"payment_order.post_ledger_entries", stubNotImplemented("payment_order.post_ledger_entries"), nil},
@@ -165,55 +184,31 @@ func RegisterCurrentAccountHandlers(registry *saga.HandlerRegistry, opts ...Regi
 		{"payment_order.terminate_lien", stubNotImplemented("payment_order.terminate_lien"), nil},
 		{"repository.save", stubNotImplemented("repository.save"), nil},
 		{"valuation_engine.valuate", stubNotImplemented("valuation_engine.valuate"), nil},
-
-		// Reconciliation handlers (stubs - defined in schema for reconciliation service)
 		{"reconciliation.initiate_run", stubNotImplemented("reconciliation.initiate_run"), nil},
 		{"reconciliation.execute_run", stubNotImplemented("reconciliation.execute_run"), nil},
 		{"reconciliation.retrieve_run", stubNotImplemented("reconciliation.retrieve_run"), nil},
 		{"reconciliation.cancel_run", stubNotImplemented("reconciliation.cancel_run"), nil},
 		{"reconciliation.assert_balance", stubNotImplemented("reconciliation.assert_balance"), nil},
 		{"reconciliation.initiate_dispute", stubNotImplemented("reconciliation.initiate_dispute"), nil},
-
-		// Party handlers (stubs - defined in schema for party service)
 		{"party.get_default_payment_method", stubNotImplemented("party.get_default_payment_method"), nil},
-
-		// Operational Gateway handlers (stubs - defined in schema for operational gateway service)
 		{"operational_gateway.dispatch_instruction", stubNotImplemented("operational_gateway.dispatch_instruction"), nil},
 		{"operational_gateway.cancel_instruction", stubNotImplemented("operational_gateway.cancel_instruction"), nil},
 		{"operational_gateway.get_instruction", stubNotImplemented("operational_gateway.get_instruction"), nil},
-
-		// Financial Gateway handlers (stubs - defined in schema for financial gateway service)
 		{"financial_gateway.dispatch_payment", stubNotImplemented("financial_gateway.dispatch_payment"), nil},
 		{"financial_gateway.cancel_payment", stubNotImplemented("financial_gateway.cancel_payment"), nil},
 		{"financial_gateway.dispatch_refund", stubNotImplemented("financial_gateway.dispatch_refund"), nil},
-
-		// Forecasting handlers (stubs - defined in schema for forecasting service)
 		{"forecasting.compute_forward_curve", stubNotImplemented("forecasting.compute_forward_curve"), nil},
-
-		// Market Information handlers (stubs - defined in schema for market information service)
 		{"market_information.publish_observation", stubNotImplemented("market_information.publish_observation"), nil},
 		{"market_information.query_latest", stubNotImplemented("market_information.query_latest"), nil},
 		{"market_information.manage_dataset", stubNotImplemented("market_information.manage_dataset"), nil},
-
-		// Reference Data handlers (stubs - defined in schema for reference data service)
 		{"reference_data.register_instrument", stubNotImplemented("reference_data.register_instrument"), nil},
 		{"reference_data.delete_instrument", stubNotImplemented("reference_data.delete_instrument"), nil},
 		{"reference_data.register_account_type", stubNotImplemented("reference_data.register_account_type"), nil},
 		{"reference_data.delete_account_type", stubNotImplemented("reference_data.delete_account_type"), nil},
 		{"reference_data.register_valuation_rule", stubNotImplemented("reference_data.register_valuation_rule"), nil},
 		{"reference_data.register_saga_definition", stubNotImplemented("reference_data.register_saga_definition"), nil},
-
-		// Internal Account handlers (stubs - defined in schema for internal account service)
 		{"internal_account.initiate", stubNotImplemented("internal_account.initiate"), nil},
 	}
-
-	for _, h := range handlers {
-		if err := registry.RegisterWithMetadata(h.name, h.handler, h.metadata); err != nil {
-			return fmt.Errorf("failed to register handler %s: %w", h.name, err)
-		}
-	}
-
-	return nil
 }
 
 // getDeps extracts handler dependencies from the StarlarkContext.

--- a/services/financial-accounting/client/starlark.go
+++ b/services/financial-accounting/client/starlark.go
@@ -68,21 +68,38 @@ var (
 //	defer cleanup()
 //	err := RegisterStarlarkHandlers(registry, client)
 func RegisterStarlarkHandlers(registry *saga.HandlerRegistry, client *Client) error {
-	handlers := map[string]struct {
-		handler  saga.Handler
-		metadata saga.HandlerMetadata
-	}{
+	if err := registerBookingLogHandlers(registry, client); err != nil {
+		return err
+	}
+	return registerPostingHandlers(registry, client)
+}
+
+type starlarkHandlerEntry struct {
+	handler  saga.Handler
+	metadata saga.HandlerMetadata
+}
+
+func registerHandlerMap(registry *saga.HandlerRegistry, handlers map[string]starlarkHandlerEntry) error {
+	for name, h := range handlers {
+		if err := registry.RegisterWithMetadata(name, h.handler, &h.metadata); err != nil {
+			return fmt.Errorf("failed to register %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func registerBookingLogHandlers(registry *saga.HandlerRegistry, client *Client) error {
+	return registerHandlerMap(registry, map[string]starlarkHandlerEntry{
 		"financial_accounting.initiate_booking_log": {
 			handler: initiateBookingLogHandler(client),
 			metadata: saga.HandlerMetadata{
 				Category:             saga.HandlerCategorySettlement,
 				Description:          "Initiate a booking log for a deposit or withdrawal transaction",
 				CompensationStrategy: "none",
-				// Financial Accounting produces Money instruments through bookkeeping
-				ProducesInstruments: []string{"USD", "EUR", "GBP", "NZD"},
-				ProtoRequestType:    (*financialaccountingv1.InitiateFinancialBookingLogRequest)(nil),
-				ProtoResponseType:   (*financialaccountingv1.InitiateFinancialBookingLogResponse)(nil),
-				Version:             1,
+				ProducesInstruments:  []string{"USD", "EUR", "GBP", "NZD"},
+				ProtoRequestType:     (*financialaccountingv1.InitiateFinancialBookingLogRequest)(nil),
+				ProtoResponseType:    (*financialaccountingv1.InitiateFinancialBookingLogResponse)(nil),
+				Version:              1,
 			},
 		},
 		"financial_accounting.update_booking_log": {
@@ -91,13 +108,29 @@ func RegisterStarlarkHandlers(registry *saga.HandlerRegistry, client *Client) er
 				Category:             saga.HandlerCategorySettlement,
 				Description:          "Update the status of an existing booking log",
 				CompensationStrategy: "none",
-				// Updates don't produce new instruments, just modify existing logs
-				ProducesInstruments: []string{},
-				ProtoRequestType:    (*financialaccountingv1.UpdateFinancialBookingLogRequest)(nil),
-				ProtoResponseType:   (*financialaccountingv1.UpdateFinancialBookingLogResponse)(nil),
-				Version:             1,
+				ProducesInstruments:  []string{},
+				ProtoRequestType:     (*financialaccountingv1.UpdateFinancialBookingLogRequest)(nil),
+				ProtoResponseType:    (*financialaccountingv1.UpdateFinancialBookingLogResponse)(nil),
+				Version:              1,
 			},
 		},
+		"financial_accounting.create_booking": {
+			handler: createBookingHandler(client),
+			metadata: saga.HandlerMetadata{
+				Category:             saga.HandlerCategorySettlement,
+				Description:          "Create a booking log entry for audit purposes",
+				CompensationStrategy: "none",
+				ProducesInstruments:  []string{"USD", "EUR", "GBP", "NZD"},
+				ProtoRequestType:     (*financialaccountingv1.InitiateFinancialBookingLogRequest)(nil),
+				ProtoResponseType:    (*financialaccountingv1.InitiateFinancialBookingLogResponse)(nil),
+				Version:              1,
+			},
+		},
+	})
+}
+
+func registerPostingHandlers(registry *saga.HandlerRegistry, client *Client) error {
+	return registerHandlerMap(registry, map[string]starlarkHandlerEntry{
 		"financial_accounting.capture_posting": {
 			handler: capturePostingHandler(client),
 			metadata: saga.HandlerMetadata{
@@ -105,7 +138,6 @@ func RegisterStarlarkHandlers(registry *saga.HandlerRegistry, client *Client) er
 				Description:         "Capture a single-sided posting entry within a booking log",
 				Compensate:          "financial_accounting.compensate_posting",
 				HasAutoCompensation: true,
-				// Capturing a posting creates a Money instrument entry
 				ProducesInstruments: []string{"USD", "EUR", "GBP", "NZD"},
 				ProtoRequestType:    (*financialaccountingv1.CaptureLedgerPostingRequest)(nil),
 				ProtoResponseType:   (*financialaccountingv1.CaptureLedgerPostingResponse)(nil),
@@ -122,24 +154,10 @@ func RegisterStarlarkHandlers(registry *saga.HandlerRegistry, client *Client) er
 				Category:             saga.HandlerCategorySettlement,
 				Description:          "Compensate (reverse) a captured posting entry",
 				CompensationStrategy: "none",
-				// Compensation doesn't produce instruments, it reverses them
-				ProducesInstruments: []string{},
-				ProtoRequestType:    (*financialaccountingv1.UpdateLedgerPostingRequest)(nil),
-				ProtoResponseType:   (*financialaccountingv1.UpdateLedgerPostingResponse)(nil),
-				Version:             1,
-			},
-		},
-		"financial_accounting.create_booking": {
-			handler: createBookingHandler(client),
-			metadata: saga.HandlerMetadata{
-				Category:             saga.HandlerCategorySettlement,
-				Description:          "Create a booking log entry for audit purposes",
-				CompensationStrategy: "none",
-				// Creating a booking log produces Money instruments
-				ProducesInstruments: []string{"USD", "EUR", "GBP", "NZD"},
-				ProtoRequestType:    (*financialaccountingv1.InitiateFinancialBookingLogRequest)(nil),
-				ProtoResponseType:   (*financialaccountingv1.InitiateFinancialBookingLogResponse)(nil),
-				Version:             1,
+				ProducesInstruments:  []string{},
+				ProtoRequestType:     (*financialaccountingv1.UpdateLedgerPostingRequest)(nil),
+				ProtoResponseType:    (*financialaccountingv1.UpdateLedgerPostingResponse)(nil),
+				Version:              1,
 			},
 		},
 		"financial_accounting.post_entries": {
@@ -149,10 +167,8 @@ func RegisterStarlarkHandlers(registry *saga.HandlerRegistry, client *Client) er
 				Description:         "Post double-entry accounting entries to the ledger",
 				Compensate:          "financial_accounting.reverse_entries",
 				HasAutoCompensation: true,
-				// Posting entries creates Money instrument movements
 				ProducesInstruments: []string{"USD", "EUR", "GBP", "NZD"},
-				// No single proto type: this handler iterates over entries calling CaptureLedgerPosting per entry
-				Version: 1,
+				Version:             1,
 			},
 		},
 		"financial_accounting.reverse_entries": {
@@ -161,21 +177,13 @@ func RegisterStarlarkHandlers(registry *saga.HandlerRegistry, client *Client) er
 				Category:             saga.HandlerCategorySettlement,
 				Description:          "Reverse previously posted accounting entries (compensation handler)",
 				CompensationStrategy: "none",
-				// Reversal cancels the booking log; no new instruments are produced
-				ProducesInstruments: []string{},
-				ProtoRequestType:    (*financialaccountingv1.UpdateFinancialBookingLogRequest)(nil),
-				ProtoResponseType:   (*financialaccountingv1.UpdateFinancialBookingLogResponse)(nil),
-				Version:             1,
+				ProducesInstruments:  []string{},
+				ProtoRequestType:     (*financialaccountingv1.UpdateFinancialBookingLogRequest)(nil),
+				ProtoResponseType:    (*financialaccountingv1.UpdateFinancialBookingLogResponse)(nil),
+				Version:              1,
 			},
 		},
-	}
-
-	for name, h := range handlers {
-		if err := registry.RegisterWithMetadata(name, h.handler, &h.metadata); err != nil {
-			return fmt.Errorf("failed to register %s: %w", name, err)
-		}
-	}
-	return nil
+	})
 }
 
 // initiateBookingLogHandler creates a new financial booking log via gRPC.

--- a/services/internal-account/service/grpc_account_endpoints.go
+++ b/services/internal-account/service/grpc_account_endpoints.go
@@ -2,24 +2,19 @@ package service
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	eventsv1 "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/internal_account/v1"
-	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
 	"github.com/meridianhub/meridian/services/internal-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/internal-account/domain"
 	ibaobservability "github.com/meridianhub/meridian/services/internal-account/observability"
-	"github.com/meridianhub/meridian/services/reference-data/accounttype"
 	vf "github.com/meridianhub/meridian/shared/pkg/valuationfeature"
 	"github.com/meridianhub/meridian/shared/platform/events"
 	"github.com/meridianhub/meridian/shared/platform/events/topics"
-	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -34,172 +29,27 @@ func (s *Service) InitiateInternalAccount(ctx context.Context, req *pb.InitiateI
 		ibaobservability.RecordOperationDuration("initiate_internal_account", operationStatus, time.Since(start))
 	}()
 
-	// 1. Determine product_type_code (required for new accounts).
+	// 1. Resolve product type, validate eligibility, and validate attributes.
 	productTypeCode := req.ProductTypeCode
-
-	var accountType domain.AccountType
-	var clearingPurpose domain.ClearingPurpose
-	var dimension string
-	var productTypeVersion int
-	var productTypeDef *accounttype.Definition
-
-	// 2. Product type resolution via cache (if cache is configured and code is available)
-	if s.accountTypeCache != nil && productTypeCode != "" {
-		tenantID, ok := tenant.FromContext(ctx)
-		if !ok {
-			operationStatus = operationStatusFailed
-			return nil, status.Error(codes.InvalidArgument, "tenant context required")
-		}
-
-		cached, err := s.accountTypeCache.GetOrLoad(ctx, tenantID, productTypeCode)
-		if err != nil {
-			operationStatus = operationStatusFailed
-			s.logger.Warn("product type resolution failed",
-				"product_type_code", productTypeCode,
-				"error", err)
-			return nil, status.Errorf(codes.InvalidArgument, "product type not found: %s", productTypeCode)
-		}
-
-		if cached.Definition == nil {
-			operationStatus = operationStatusFailed
-			return nil, status.Errorf(codes.Internal, "product type %s has no definition", productTypeCode)
-		}
-
-		def := cached.Definition
-
-		// 3. BehaviorClass gating: must NOT be CUSTOMER
-		if !internalBehaviorClasses[def.BehaviorClass] {
-			operationStatus = operationStatusFailed
-			return nil, status.Errorf(codes.InvalidArgument,
-				"product type %s has behavior class %s which is not an internal account type",
-				productTypeCode, def.BehaviorClass)
-		}
-
-		// 4. EligibilityCEL evaluation (skip if empty or "true")
-		if cached.EligibilityProgram != nil && def.EligibilityCEL != "" && def.EligibilityCEL != "true" {
-			// For internal accounts, eligibility checks evaluate without a party.
-			// The CEL environment receives account-level context only.
-			activation := map[string]interface{}{
-				"instrument_code": req.InstrumentCode,
-				"account_code":    req.AccountCode,
-			}
-			out, _, evalErr := cached.EligibilityProgram.Eval(activation)
-			if evalErr != nil {
-				operationStatus = operationStatusFailed
-				return nil, status.Errorf(codes.Internal, "eligibility evaluation failed: %v", evalErr)
-			}
-			eligible, isBool := out.Value().(bool)
-			if !isBool || !eligible {
-				operationStatus = operationStatusFailed
-				return nil, status.Errorf(codes.FailedPrecondition,
-					"account not eligible per product type %s eligibility rules", productTypeCode)
-			}
-		}
-
-		// 5. Attribute validation against AttributeSchema (if defined)
-		if cached.CompiledSchema != nil {
-			attrsMap := map[string]interface{}{}
-			if req.Attributes != nil {
-				attrsMap = req.Attributes.AsMap()
-			}
-			attrsJSON, err := json.Marshal(attrsMap)
-			if err != nil {
-				operationStatus = operationStatusFailed
-				return nil, status.Errorf(codes.InvalidArgument, "invalid attributes: %v", err)
-			}
-			var attrs interface{}
-			if err := json.Unmarshal(attrsJSON, &attrs); err != nil {
-				operationStatus = operationStatusFailed
-				return nil, status.Errorf(codes.InvalidArgument, "invalid attributes JSON: %v", err)
-			}
-			if err := cached.CompiledSchema.Validate(attrs); err != nil {
-				operationStatus = operationStatusFailed
-				return nil, status.Errorf(codes.InvalidArgument, "attributes validation failed: %v", err)
-			}
-		}
-
-		// Derive account type from BehaviorClass via mapping
-		accountType = behaviorClassToAccountType[def.BehaviorClass]
-		productTypeVersion = def.Version
-		productTypeDef = def
-
-		// Derive dimension from instrument via Reference Data (if available)
-	} else if s.accountTypeCache == nil && req.ProductTypeCode != "" {
-		// product_type_code was explicitly provided but cache is not configured
+	accountType, productTypeVersion, productTypeDef, err := s.resolveProductType(ctx, req)
+	if err != nil {
 		operationStatus = operationStatusFailed
-		return nil, status.Error(codes.FailedPrecondition,
-			"product type resolution not available; configure account type cache")
-	} else if productTypeCode == "" {
-		// product_type_code is required - the deprecated account_type enum has been removed
-		operationStatus = opStatusInvalidAccountType
-		return nil, status.Error(codes.InvalidArgument,
-			"product_type_code is required; the deprecated account_type enum has been removed")
+		return nil, err
 	}
 
 	// Convert clearing purpose from proto to domain
-	var err error
+	var clearingPurpose domain.ClearingPurpose
 	clearingPurpose, err = protoToClearingPurpose(req.ClearingPurpose)
 	if err != nil {
 		operationStatus = operationStatusFailed
 		return nil, status.Errorf(codes.InvalidArgument, "invalid clearing purpose: %v", err)
 	}
 
-	// Validate instrument exists and is ACTIVE via Reference Data service (if client is configured)
-	if s.referenceDataClient != nil {
-		validationStart := time.Now()
-		refDataCtx, refDataCancel := context.WithTimeout(ctx, 5*time.Second)
-		defer refDataCancel()
-
-		refDataResp, err := s.referenceDataClient.RetrieveInstrument(refDataCtx, &referencedatav1.RetrieveInstrumentRequest{
-			Code: req.InstrumentCode,
-		})
-		if err != nil {
-			validationDuration := time.Since(validationStart)
-			errCode := status.Code(err)
-			s.logger.Warn("instrument validation failed",
-				"instrument_code", req.InstrumentCode,
-				"error", err)
-
-			if errCode == codes.NotFound {
-				operationStatus = opStatusInstrumentNotFound
-				ibaobservability.RecordInstrumentValidation("not_found", validationDuration)
-				return nil, status.Errorf(codes.InvalidArgument, "instrument not found: %s", req.InstrumentCode)
-			}
-			if errCode == codes.DeadlineExceeded || errCode == codes.Canceled {
-				operationStatus = opStatusInstrumentValidationErr
-				ibaobservability.RecordInstrumentValidation("timeout", validationDuration)
-				return nil, status.Errorf(codes.DeadlineExceeded, "instrument validation timed out for: %s", req.InstrumentCode)
-			}
-			operationStatus = opStatusInstrumentValidationErr
-			ibaobservability.RecordInstrumentValidation("error", validationDuration)
-			return nil, status.Errorf(codes.Internal, "failed to validate instrument: %v", err)
-		}
-
-		// Guard against nil instrument in response (defensive programming)
-		if refDataResp.Instrument == nil {
-			validationDuration := time.Since(validationStart)
-			operationStatus = opStatusInstrumentValidationErr
-			s.logger.Error("reference data service returned nil instrument",
-				"instrument_code", req.InstrumentCode)
-			ibaobservability.RecordInstrumentValidation("error", validationDuration)
-			return nil, status.Errorf(codes.Internal, "reference data service returned invalid response for instrument: %s", req.InstrumentCode)
-		}
-
-		// Validate instrument status is ACTIVE
-		if refDataResp.Instrument.Status != referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE {
-			validationDuration := time.Since(validationStart)
-			operationStatus = opStatusInstrumentNotActive
-			s.logger.Warn("instrument not active",
-				"instrument_code", req.InstrumentCode,
-				"status", refDataResp.Instrument.Status.String())
-			ibaobservability.RecordInstrumentValidation("not_active", validationDuration)
-			return nil, status.Errorf(codes.InvalidArgument, "instrument %s is not active (status: %s)",
-				req.InstrumentCode, refDataResp.Instrument.Status.String())
-		}
-
-		// Extract dimension from validated instrument (strip DIMENSION_ prefix for domain consistency)
-		dimension = strings.TrimPrefix(refDataResp.Instrument.Dimension.String(), "DIMENSION_")
-		ibaobservability.RecordInstrumentValidation("success", time.Since(validationStart))
+	// 2. Validate instrument exists and is ACTIVE via Reference Data service.
+	dimension, opStatus, err := s.validateInstrument(ctx, req.InstrumentCode)
+	if err != nil {
+		operationStatus = opStatus
+		return nil, err
 	}
 
 	// Generate account ID using full UUID for uniqueness

--- a/services/internal-account/service/grpc_account_helpers.go
+++ b/services/internal-account/service/grpc_account_helpers.go
@@ -1,0 +1,173 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/internal_account/v1"
+	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	"github.com/meridianhub/meridian/services/internal-account/domain"
+	ibaobservability "github.com/meridianhub/meridian/services/internal-account/observability"
+	"github.com/meridianhub/meridian/services/reference-data/accounttype"
+	"github.com/meridianhub/meridian/services/reference-data/cache"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// resolveProductType resolves the product type from cache, validates behavior class,
+// evaluates eligibility CEL, and validates attributes against the schema.
+func (s *Service) resolveProductType(ctx context.Context, req *pb.InitiateInternalAccountRequest) (domain.AccountType, int, *accounttype.Definition, error) {
+	productTypeCode := req.ProductTypeCode
+
+	if productTypeCode == "" {
+		return "", 0, nil, status.Error(codes.InvalidArgument,
+			"product_type_code is required; the deprecated account_type enum has been removed")
+	}
+
+	if s.accountTypeCache == nil {
+		return "", 0, nil, status.Error(codes.FailedPrecondition,
+			"product type resolution not available; configure account type cache")
+	}
+
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return "", 0, nil, status.Error(codes.InvalidArgument, "tenant context required")
+	}
+
+	cached, err := s.accountTypeCache.GetOrLoad(ctx, tenantID, productTypeCode)
+	if err != nil {
+		s.logger.Warn("product type resolution failed",
+			"product_type_code", productTypeCode, "error", err)
+		return "", 0, nil, status.Errorf(codes.InvalidArgument, "product type not found: %s", productTypeCode)
+	}
+
+	if cached.Definition == nil {
+		return "", 0, nil, status.Errorf(codes.Internal, "product type %s has no definition", productTypeCode)
+	}
+
+	def := cached.Definition
+
+	if !internalBehaviorClasses[def.BehaviorClass] {
+		return "", 0, nil, status.Errorf(codes.InvalidArgument,
+			"product type %s has behavior class %s which is not an internal account type",
+			productTypeCode, def.BehaviorClass)
+	}
+
+	if err := evaluateEligibility(cached, def, req); err != nil {
+		return "", 0, nil, err
+	}
+
+	if err := validateProductTypeAttributes(cached, req); err != nil {
+		return "", 0, nil, err
+	}
+
+	accountType := behaviorClassToAccountType[def.BehaviorClass]
+	return accountType, def.Version, def, nil
+}
+
+// evaluateEligibility runs the CEL eligibility program if configured.
+func evaluateEligibility(cached *cache.CachedAccountType, def *accounttype.Definition, req *pb.InitiateInternalAccountRequest) error {
+	if cached.EligibilityProgram == nil || def.EligibilityCEL == "" || def.EligibilityCEL == "true" {
+		return nil
+	}
+	activation := map[string]interface{}{
+		"instrument_code": req.InstrumentCode,
+		"account_code":    req.AccountCode,
+	}
+	out, _, evalErr := cached.EligibilityProgram.Eval(activation)
+	if evalErr != nil {
+		return status.Errorf(codes.Internal, "eligibility evaluation failed: %v", evalErr)
+	}
+	eligible, isBool := out.Value().(bool)
+	if !isBool || !eligible {
+		return status.Errorf(codes.FailedPrecondition,
+			"account not eligible per product type %s eligibility rules", req.ProductTypeCode)
+	}
+	return nil
+}
+
+// validateProductTypeAttributes validates request attributes against the product type's JSON schema.
+func validateProductTypeAttributes(cached *cache.CachedAccountType, req *pb.InitiateInternalAccountRequest) error {
+	if cached.CompiledSchema == nil {
+		return nil
+	}
+	attrsMap := map[string]interface{}{}
+	if req.Attributes != nil {
+		attrsMap = req.Attributes.AsMap()
+	}
+	attrsJSON, err := json.Marshal(attrsMap)
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "invalid attributes: %v", err)
+	}
+	var attrs interface{}
+	if err := json.Unmarshal(attrsJSON, &attrs); err != nil {
+		return status.Errorf(codes.InvalidArgument, "invalid attributes JSON: %v", err)
+	}
+	if err := cached.CompiledSchema.Validate(attrs); err != nil {
+		return status.Errorf(codes.InvalidArgument, "attributes validation failed: %v", err)
+	}
+	return nil
+}
+
+// validateInstrument checks that an instrument exists and is ACTIVE via Reference Data service.
+// Returns the instrument dimension, operation status on error, and any error.
+func (s *Service) validateInstrument(ctx context.Context, instrumentCode string) (string, string, error) {
+	if s.referenceDataClient == nil {
+		return "", "", nil
+	}
+
+	validationStart := time.Now()
+	refDataCtx, refDataCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer refDataCancel()
+
+	refDataResp, err := s.referenceDataClient.RetrieveInstrument(refDataCtx, &referencedatav1.RetrieveInstrumentRequest{
+		Code: instrumentCode,
+	})
+	if err != nil {
+		return "", "", s.mapInstrumentValidationError(err, instrumentCode, validationStart)
+	}
+
+	if refDataResp.Instrument == nil {
+		validationDuration := time.Since(validationStart)
+		s.logger.Error("reference data service returned nil instrument", "instrument_code", instrumentCode)
+		ibaobservability.RecordInstrumentValidation("error", validationDuration)
+		return "", opStatusInstrumentValidationErr,
+			status.Errorf(codes.Internal, "reference data service returned invalid response for instrument: %s", instrumentCode)
+	}
+
+	if refDataResp.Instrument.Status != referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE {
+		validationDuration := time.Since(validationStart)
+		s.logger.Warn("instrument not active",
+			"instrument_code", instrumentCode, "status", refDataResp.Instrument.Status.String())
+		ibaobservability.RecordInstrumentValidation("not_active", validationDuration)
+		return "", opStatusInstrumentNotActive,
+			status.Errorf(codes.InvalidArgument, "instrument %s is not active (status: %s)",
+				instrumentCode, refDataResp.Instrument.Status.String())
+	}
+
+	dimension := strings.TrimPrefix(refDataResp.Instrument.Dimension.String(), "DIMENSION_")
+	ibaobservability.RecordInstrumentValidation("success", time.Since(validationStart))
+	return dimension, "", nil
+}
+
+// mapInstrumentValidationError maps a Reference Data retrieval error to a gRPC status error.
+func (s *Service) mapInstrumentValidationError(err error, instrumentCode string, validationStart time.Time) error {
+	validationDuration := time.Since(validationStart)
+	errCode := status.Code(err)
+	s.logger.Warn("instrument validation failed", "instrument_code", instrumentCode, "error", err)
+
+	switch errCode {
+	case codes.NotFound:
+		ibaobservability.RecordInstrumentValidation("not_found", validationDuration)
+		return status.Errorf(codes.InvalidArgument, "instrument not found: %s", instrumentCode)
+	case codes.DeadlineExceeded, codes.Canceled:
+		ibaobservability.RecordInstrumentValidation("timeout", validationDuration)
+		return status.Errorf(codes.DeadlineExceeded, "instrument validation timed out for: %s", instrumentCode)
+	default:
+		ibaobservability.RecordInstrumentValidation("error", validationDuration)
+		return status.Errorf(codes.Internal, "failed to validate instrument: %v", err)
+	}
+}

--- a/services/internal-account/service/grpc_account_helpers.go
+++ b/services/internal-account/service/grpc_account_helpers.go
@@ -159,7 +159,7 @@ func (s *Service) mapInstrumentValidationError(err error, instrumentCode string,
 	errCode := status.Code(err)
 	s.logger.Warn("instrument validation failed", "instrument_code", instrumentCode, "error", err)
 
-	switch errCode {
+	switch errCode { //nolint:exhaustive // only handling specific gRPC codes
 	case codes.NotFound:
 		ibaobservability.RecordInstrumentValidation("not_found", validationDuration)
 		return status.Errorf(codes.InvalidArgument, "instrument not found: %s", instrumentCode)

--- a/services/internal-account/service/grpc_account_helpers.go
+++ b/services/internal-account/service/grpc_account_helpers.go
@@ -127,7 +127,8 @@ func (s *Service) validateInstrument(ctx context.Context, instrumentCode string)
 		Code: instrumentCode,
 	})
 	if err != nil {
-		return "", "", s.mapInstrumentValidationError(err, instrumentCode, validationStart)
+		opStatus, grpcErr := s.mapInstrumentValidationError(err, instrumentCode, validationStart)
+		return "", opStatus, grpcErr
 	}
 
 	if refDataResp.Instrument == nil {
@@ -153,8 +154,8 @@ func (s *Service) validateInstrument(ctx context.Context, instrumentCode string)
 	return dimension, "", nil
 }
 
-// mapInstrumentValidationError maps a Reference Data retrieval error to a gRPC status error.
-func (s *Service) mapInstrumentValidationError(err error, instrumentCode string, validationStart time.Time) error {
+// mapInstrumentValidationError maps a Reference Data retrieval error to an operation status and gRPC status error.
+func (s *Service) mapInstrumentValidationError(err error, instrumentCode string, validationStart time.Time) (string, error) {
 	validationDuration := time.Since(validationStart)
 	errCode := status.Code(err)
 	s.logger.Warn("instrument validation failed", "instrument_code", instrumentCode, "error", err)
@@ -162,12 +163,12 @@ func (s *Service) mapInstrumentValidationError(err error, instrumentCode string,
 	switch errCode { //nolint:exhaustive // only handling specific gRPC codes
 	case codes.NotFound:
 		ibaobservability.RecordInstrumentValidation("not_found", validationDuration)
-		return status.Errorf(codes.InvalidArgument, "instrument not found: %s", instrumentCode)
+		return opStatusInstrumentNotFound, status.Errorf(codes.InvalidArgument, "instrument not found: %s", instrumentCode)
 	case codes.DeadlineExceeded, codes.Canceled:
 		ibaobservability.RecordInstrumentValidation("timeout", validationDuration)
-		return status.Errorf(codes.DeadlineExceeded, "instrument validation timed out for: %s", instrumentCode)
+		return opStatusInstrumentValidationErr, status.Errorf(codes.DeadlineExceeded, "instrument validation timed out for: %s", instrumentCode)
 	default:
 		ibaobservability.RecordInstrumentValidation("error", validationDuration)
-		return status.Errorf(codes.Internal, "failed to validate instrument: %v", err)
+		return opStatusInstrumentValidationErr, status.Errorf(codes.Internal, "failed to validate instrument: %v", err)
 	}
 }

--- a/services/market-information/service/observation_batch.go
+++ b/services/market-information/service/observation_batch.go
@@ -23,279 +23,30 @@ import (
 
 // RecordObservationBatch records multiple observations with parallel validation.
 // Returns partial success with details for each observation.
+// RecordObservationBatch records multiple observations with parallel validation.
+// Returns partial success with details for each observation.
 func (s *Server) RecordObservationBatch(ctx context.Context, req *pb.RecordObservationBatchRequest) (*pb.RecordObservationBatchResponse, error) {
 	if len(req.Observations) == 0 {
 		return nil, status.Errorf(codes.InvalidArgument, "at least one observation is required")
 	}
 
-	// Generate batch ID if not provided
 	batchID := req.BatchId
 	if batchID == "" {
 		batchID = uuid.New().String()
 	}
 
-	// Pre-fetch datasets and sources to avoid repeated lookups
-	datasets := make(map[string]domain.DataSetDefinition)
-	sources := make(map[string]domain.DataSource)
-	var fetchMu sync.Mutex
-
-	// Use sync.Map for concurrent error collection
-	validationErrors := &sync.Map{}
-
-	// Parallel CEL validation using errgroup
-	g, gCtx := errgroup.WithContext(ctx)
-
-	// Limit concurrency to avoid overwhelming the system
-	g.SetLimit(50)
-
-	for i, entry := range req.Observations {
-		i, entry := i, entry // Capture loop variables
-
-		g.Go(func() error {
-			// Check context cancellation
-			if gCtx.Err() != nil {
-				return gCtx.Err()
-			}
-
-			// validateEntry handles validation and stores errors in validationErrors.
-			// We always return nil from the goroutine to allow other entries to continue processing.
-			// The actual errors are collected in validationErrors sync.Map.
-			validateEntry := func() {
-				// Fetch or get cached dataset
-				fetchMu.Lock()
-				dataset, exists := datasets[entry.DatasetCode]
-				fetchMu.Unlock()
-
-				if !exists {
-					ds, err := s.dataSetRepo.FindByCode(gCtx, entry.DatasetCode)
-					if err != nil {
-						validationErrors.Store(i, fmt.Sprintf("dataset not found: %s", entry.DatasetCode))
-						return
-					}
-					fetchMu.Lock()
-					datasets[entry.DatasetCode] = ds
-					dataset = ds
-					fetchMu.Unlock()
-				}
-
-				// Verify dataset is active
-				if dataset.Status() != domain.DataSetStatusActive {
-					validationErrors.Store(i, fmt.Sprintf("dataset %s is not active", entry.DatasetCode))
-					return
-				}
-
-				// Fetch or get cached source
-				fetchMu.Lock()
-				source, exists := sources[entry.SourceCode]
-				fetchMu.Unlock()
-
-				if !exists {
-					src, err := s.sourceRepo.FindByCode(gCtx, entry.SourceCode)
-					if err != nil {
-						validationErrors.Store(i, fmt.Sprintf("source not found: %s", entry.SourceCode))
-						return
-					}
-					fetchMu.Lock()
-					sources[entry.SourceCode] = src
-					source = src
-					fetchMu.Unlock()
-				}
-
-				// Verify source is active
-				if !source.IsActive() {
-					validationErrors.Store(i, fmt.Sprintf("source %s is not active", entry.SourceCode))
-					return
-				}
-
-				// Validate required timestamps (guard against nil dereference)
-				if entry.ObservedAt == nil {
-					validationErrors.Store(i, "observed_at timestamp is required")
-					return
-				}
-				if entry.ValidFrom == nil {
-					validationErrors.Store(i, "valid_from timestamp is required")
-					return
-				}
-
-				// Convert observation context
-				observationContext := ToContextMap(entry.Attributes)
-
-				// Validate using CEL expression
-				if s.celValidator != nil && dataset.ValidationExpression() != "" {
-					validTo := time.Now().Add(100 * 365 * 24 * time.Hour)
-					if entry.ValidTo != nil {
-						validTo = entry.ValidTo.AsTime()
-					}
-
-					validationInput := ValidationInput{
-						Value:              entry.Value,
-						ObservationContext: observationContext,
-						ObservedAt:         entry.ObservedAt.AsTime(),
-						ValidFrom:          entry.ValidFrom.AsTime(),
-						ValidTo:            validTo,
-						SourceID:           source.ID().String(),
-						Quality:            int(entry.Quality),
-					}
-
-					prg, err := s.celValidator.CompileValidation(dataset.ValidationExpression())
-					if err != nil {
-						validationErrors.Store(i, fmt.Sprintf("validation expression error: %v", err))
-						return
-					}
-
-					valid, err := s.celValidator.EvaluateValidation(prg, validationInput)
-					if err != nil {
-						validationErrors.Store(i, fmt.Sprintf("validation evaluation error: %v", err))
-						return
-					}
-
-					if !valid {
-						errMsg := s.generateValidationErrorMessage(dataset, entry.Value, observationContext)
-						validationErrors.Store(i, errMsg)
-						return
-					}
-				}
-
-				// Validate decimal value
-				if _, err := decimal.NewFromString(entry.Value); err != nil {
-					validationErrors.Store(i, fmt.Sprintf("invalid decimal value: %s", entry.Value))
-					return
-				}
-			}
-
-			validateEntry()
-			return nil
-		})
+	bc := &batchContext{
+		server:   s,
+		datasets: make(map[string]domain.DataSetDefinition),
+		sources:  make(map[string]domain.DataSource),
 	}
 
-	// Wait for all validations to complete
-	if err := g.Wait(); err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			return nil, status.Errorf(codes.DeadlineExceeded, "batch validation timed out")
-		}
-		if errors.Is(err, context.Canceled) {
-			return nil, status.Errorf(codes.Canceled, "batch validation was canceled")
-		}
-		return nil, status.Errorf(codes.Internal, "batch validation failed: %v", err)
+	validationErrors, err := bc.validateBatchEntries(ctx, req.Observations)
+	if err != nil {
+		return nil, err
 	}
 
-	// Process valid observations and build results
-	results := make([]*pb.BatchObservationResult, len(req.Observations))
-	var successCount, failureCount int32
-
-	for i, entry := range req.Observations {
-		// Check if this entry had a validation error
-		if errMsgVal, hasError := validationErrors.Load(i); hasError {
-			errMsg, ok := errMsgVal.(string)
-			if !ok {
-				errMsg = "unknown validation error"
-			}
-			results[i] = &pb.BatchObservationResult{
-				Success:         false,
-				ErrorMessage:    errMsg,
-				ClientReference: entry.ClientReference,
-				Index:           int32(i),
-			}
-			failureCount++
-			continue
-		}
-
-		// Get cached dataset and source
-		fetchMu.Lock()
-		dataset := datasets[entry.DatasetCode]
-		source := sources[entry.SourceCode]
-		fetchMu.Unlock()
-
-		// Compute resolution key
-		observationContext := ToContextMap(entry.Attributes)
-		resolutionKey, err := s.computeResolutionKey(dataset, observationContext)
-		if err != nil {
-			results[i] = &pb.BatchObservationResult{
-				Success:         false,
-				ErrorMessage:    fmt.Sprintf("resolution key error: %v", err),
-				ClientReference: entry.ClientReference,
-				Index:           int32(i),
-			}
-			failureCount++
-			continue
-		}
-
-		// Parse value
-		value, _ := decimal.NewFromString(entry.Value) // Already validated
-
-		// Convert quality level
-		qualityLevel := protoQualityLevelToDomain(entry.Quality)
-
-		// Determine valid_to
-		validTo := time.Now().Add(100 * 365 * 24 * time.Hour)
-		if entry.ValidTo != nil {
-			validTo = entry.ValidTo.AsTime()
-		}
-
-		// Create domain observation
-		observation, err := domain.NewMarketPriceObservation(
-			entry.DatasetCode,
-			source.ID(),
-			resolutionKey,
-			value,
-			dataset.Name(),
-			entry.ObservedAt.AsTime(),
-			entry.ValidFrom.AsTime(),
-			validTo,
-			uuid.New(),
-			qualityLevel,
-			source.TrustLevel(),
-			domain.NewObservationContext(observationContext),
-		)
-		if err != nil {
-			results[i] = &pb.BatchObservationResult{
-				Success:         false,
-				ErrorMessage:    fmt.Sprintf("observation creation error: %v", err),
-				ClientReference: entry.ClientReference,
-				Index:           int32(i),
-			}
-			failureCount++
-			continue
-		}
-
-		// Record the observation
-		if err := s.observationRepo.Record(ctx, observation); err != nil {
-			results[i] = &pb.BatchObservationResult{
-				Success:         false,
-				ErrorMessage:    fmt.Sprintf("persistence error: %v", err),
-				ClientReference: entry.ClientReference,
-				Index:           int32(i),
-			}
-			failureCount++
-			continue
-		}
-
-		// Publish event for ACTUAL and VERIFIED quality levels
-		if s.eventPublisher != nil && shouldPublishObservationEvent(qualityLevel) {
-			if obsPublisher, ok := s.eventPublisher.(ObservationEventPublisher); ok {
-				if err := obsPublisher.PublishObservationRecorded(ctx, observation); err != nil {
-					s.logger.Error("failed to publish batch observation event",
-						"observation_id", observation.ID().String(),
-						"error", err)
-				}
-			} else {
-				event := mapObservationToProtoEvent(observation)
-				if err := s.eventPublisher.Publish(ctx, event); err != nil {
-					s.logger.Error("failed to publish batch observation event",
-						"observation_id", observation.ID().String(),
-						"error", err)
-				}
-			}
-		}
-
-		results[i] = &pb.BatchObservationResult{
-			Success:         true,
-			Observation:     domainObservationToProto(observation, entry.Attributes, dataset.Version()),
-			ClientReference: entry.ClientReference,
-			Index:           int32(i),
-		}
-		successCount++
-	}
+	results, successCount, failureCount := bc.processValidObservations(ctx, req.Observations, validationErrors)
 
 	s.logger.Info("batch observation recorded",
 		"batch_id", batchID,
@@ -310,4 +61,255 @@ func (s *Server) RecordObservationBatch(ctx context.Context, req *pb.RecordObser
 		SuccessCount: successCount,
 		FailureCount: failureCount,
 	}, nil
+}
+
+// batchContext holds shared state for batch observation processing.
+type batchContext struct {
+	server   *Server
+	datasets map[string]domain.DataSetDefinition
+	sources  map[string]domain.DataSource
+	fetchMu  sync.Mutex
+}
+
+// validateBatchEntries runs parallel CEL validation on all entries.
+// Returns a sync.Map of index -> error message for failed entries.
+func (bc *batchContext) validateBatchEntries(ctx context.Context, entries []*pb.BatchObservationEntry) (*sync.Map, error) {
+	validationErrors := &sync.Map{}
+	g, gCtx := errgroup.WithContext(ctx)
+	g.SetLimit(50)
+
+	for i, entry := range entries {
+		i, entry := i, entry
+		g.Go(func() error {
+			if gCtx.Err() != nil {
+				return gCtx.Err()
+			}
+			bc.validateSingleEntry(gCtx, i, entry, validationErrors)
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, status.Errorf(codes.DeadlineExceeded, "batch validation timed out")
+		}
+		if errors.Is(err, context.Canceled) {
+			return nil, status.Errorf(codes.Canceled, "batch validation was canceled")
+		}
+		return nil, status.Errorf(codes.Internal, "batch validation failed: %v", err)
+	}
+	return validationErrors, nil
+}
+
+// validateSingleEntry validates one observation entry, storing any error in validationErrors.
+func (bc *batchContext) validateSingleEntry(ctx context.Context, idx int, entry *pb.BatchObservationEntry, validationErrors *sync.Map) {
+	dataset, err := bc.fetchDataset(ctx, entry.DatasetCode)
+	if err != nil {
+		validationErrors.Store(idx, fmt.Sprintf("dataset not found: %s", entry.DatasetCode))
+		return
+	}
+	if dataset.Status() != domain.DataSetStatusActive {
+		validationErrors.Store(idx, fmt.Sprintf("dataset %s is not active", entry.DatasetCode))
+		return
+	}
+
+	source, err := bc.fetchSource(ctx, entry.SourceCode)
+	if err != nil {
+		validationErrors.Store(idx, fmt.Sprintf("source not found: %s", entry.SourceCode))
+		return
+	}
+	if !source.IsActive() {
+		validationErrors.Store(idx, fmt.Sprintf("source %s is not active", entry.SourceCode))
+		return
+	}
+
+	if entry.ObservedAt == nil {
+		validationErrors.Store(idx, "observed_at timestamp is required")
+		return
+	}
+	if entry.ValidFrom == nil {
+		validationErrors.Store(idx, "valid_from timestamp is required")
+		return
+	}
+
+	if errMsg := bc.validateCEL(dataset, source, entry); errMsg != "" {
+		validationErrors.Store(idx, errMsg)
+		return
+	}
+
+	if _, err := decimal.NewFromString(entry.Value); err != nil {
+		validationErrors.Store(idx, fmt.Sprintf("invalid decimal value: %s", entry.Value))
+	}
+}
+
+// validateCEL runs CEL validation if configured for the dataset.
+func (bc *batchContext) validateCEL(dataset domain.DataSetDefinition, source domain.DataSource, entry *pb.BatchObservationEntry) string {
+	if bc.server.celValidator == nil || dataset.ValidationExpression() == "" {
+		return ""
+	}
+
+	validTo := time.Now().Add(100 * 365 * 24 * time.Hour)
+	if entry.ValidTo != nil {
+		validTo = entry.ValidTo.AsTime()
+	}
+
+	observationContext := ToContextMap(entry.Attributes)
+	validationInput := ValidationInput{
+		Value:              entry.Value,
+		ObservationContext: observationContext,
+		ObservedAt:         entry.ObservedAt.AsTime(),
+		ValidFrom:          entry.ValidFrom.AsTime(),
+		ValidTo:            validTo,
+		SourceID:           source.ID().String(),
+		Quality:            int(entry.Quality),
+	}
+
+	prg, err := bc.server.celValidator.CompileValidation(dataset.ValidationExpression())
+	if err != nil {
+		return fmt.Sprintf("validation expression error: %v", err)
+	}
+	valid, err := bc.server.celValidator.EvaluateValidation(prg, validationInput)
+	if err != nil {
+		return fmt.Sprintf("validation evaluation error: %v", err)
+	}
+	if !valid {
+		return bc.server.generateValidationErrorMessage(dataset, entry.Value, observationContext)
+	}
+	return ""
+}
+
+func (bc *batchContext) fetchDataset(ctx context.Context, code string) (domain.DataSetDefinition, error) {
+	bc.fetchMu.Lock()
+	ds, exists := bc.datasets[code]
+	bc.fetchMu.Unlock()
+	if exists {
+		return ds, nil
+	}
+
+	ds, err := bc.server.dataSetRepo.FindByCode(ctx, code)
+	if err != nil {
+		return ds, err
+	}
+	bc.fetchMu.Lock()
+	bc.datasets[code] = ds
+	bc.fetchMu.Unlock()
+	return ds, nil
+}
+
+func (bc *batchContext) fetchSource(ctx context.Context, code string) (domain.DataSource, error) {
+	bc.fetchMu.Lock()
+	src, exists := bc.sources[code]
+	bc.fetchMu.Unlock()
+	if exists {
+		return src, nil
+	}
+
+	src, err := bc.server.sourceRepo.FindByCode(ctx, code)
+	if err != nil {
+		return src, err
+	}
+	bc.fetchMu.Lock()
+	bc.sources[code] = src
+	bc.fetchMu.Unlock()
+	return src, nil
+}
+
+// processValidObservations processes entries that passed validation and persists them.
+func (bc *batchContext) processValidObservations(ctx context.Context, entries []*pb.BatchObservationEntry, validationErrors *sync.Map) ([]*pb.BatchObservationResult, int32, int32) {
+	results := make([]*pb.BatchObservationResult, len(entries))
+	var successCount, failureCount int32
+
+	for i, entry := range entries {
+		if errMsgVal, hasError := validationErrors.Load(i); hasError {
+			errMsg, _ := errMsgVal.(string)
+			if errMsg == "" {
+				errMsg = "unknown validation error"
+			}
+			results[i] = &pb.BatchObservationResult{
+				Success: false, ErrorMessage: errMsg,
+				ClientReference: entry.ClientReference, Index: int32(i),
+			}
+			failureCount++
+			continue
+		}
+
+		result := bc.processSingleObservation(ctx, entry, i)
+		results[i] = result
+		if result.Success {
+			successCount++
+		} else {
+			failureCount++
+		}
+	}
+	return results, successCount, failureCount
+}
+
+func (bc *batchContext) processSingleObservation(ctx context.Context, entry *pb.BatchObservationEntry, idx int) *pb.BatchObservationResult {
+	bc.fetchMu.Lock()
+	dataset := bc.datasets[entry.DatasetCode]
+	source := bc.sources[entry.SourceCode]
+	bc.fetchMu.Unlock()
+
+	observationContext := ToContextMap(entry.Attributes)
+	resolutionKey, err := bc.server.computeResolutionKey(dataset, observationContext)
+	if err != nil {
+		return &pb.BatchObservationResult{
+			Success: false, ErrorMessage: fmt.Sprintf("resolution key error: %v", err),
+			ClientReference: entry.ClientReference, Index: int32(idx),
+		}
+	}
+
+	value, _ := decimal.NewFromString(entry.Value)
+	qualityLevel := protoQualityLevelToDomain(entry.Quality)
+	validTo := time.Now().Add(100 * 365 * 24 * time.Hour)
+	if entry.ValidTo != nil {
+		validTo = entry.ValidTo.AsTime()
+	}
+
+	observation, err := domain.NewMarketPriceObservation(
+		entry.DatasetCode, source.ID(), resolutionKey, value, dataset.Name(),
+		entry.ObservedAt.AsTime(), entry.ValidFrom.AsTime(), validTo,
+		uuid.New(), qualityLevel, source.TrustLevel(),
+		domain.NewObservationContext(observationContext),
+	)
+	if err != nil {
+		return &pb.BatchObservationResult{
+			Success: false, ErrorMessage: fmt.Sprintf("observation creation error: %v", err),
+			ClientReference: entry.ClientReference, Index: int32(idx),
+		}
+	}
+
+	if err := bc.server.observationRepo.Record(ctx, observation); err != nil {
+		return &pb.BatchObservationResult{
+			Success: false, ErrorMessage: fmt.Sprintf("persistence error: %v", err),
+			ClientReference: entry.ClientReference, Index: int32(idx),
+		}
+	}
+
+	bc.publishObservationEvent(ctx, observation, qualityLevel)
+
+	return &pb.BatchObservationResult{
+		Success:         true,
+		Observation:     domainObservationToProto(observation, entry.Attributes, dataset.Version()),
+		ClientReference: entry.ClientReference,
+		Index:           int32(idx),
+	}
+}
+
+func (bc *batchContext) publishObservationEvent(ctx context.Context, observation domain.MarketPriceObservation, qualityLevel domain.QualityLevel) {
+	if bc.server.eventPublisher == nil || !shouldPublishObservationEvent(qualityLevel) {
+		return
+	}
+	if obsPublisher, ok := bc.server.eventPublisher.(ObservationEventPublisher); ok {
+		if err := obsPublisher.PublishObservationRecorded(ctx, observation); err != nil {
+			bc.server.logger.Error("failed to publish batch observation event",
+				"observation_id", observation.ID().String(), "error", err)
+		}
+	} else {
+		event := mapObservationToProtoEvent(observation)
+		if err := bc.server.eventPublisher.Publish(ctx, event); err != nil {
+			bc.server.logger.Error("failed to publish batch observation event",
+				"observation_id", observation.ID().String(), "error", err)
+		}
+	}
 }

--- a/services/market-information/service/observation_batch.go
+++ b/services/market-information/service/observation_batch.go
@@ -23,8 +23,6 @@ import (
 
 // RecordObservationBatch records multiple observations with parallel validation.
 // Returns partial success with details for each observation.
-// RecordObservationBatch records multiple observations with parallel validation.
-// Returns partial success with details for each observation.
 func (s *Server) RecordObservationBatch(ctx context.Context, req *pb.RecordObservationBatchRequest) (*pb.RecordObservationBatchResponse, error) {
 	if len(req.Observations) == 0 {
 		return nil, status.Errorf(codes.InvalidArgument, "at least one observation is required")

--- a/shared/pkg/saga/builtins.go
+++ b/shared/pkg/saga/builtins.go
@@ -60,37 +60,29 @@ func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 	}
 
 	builtins := make(starlark.StringDict)
+	addSafeUniverseBuiltins(builtins, logger)
+	addDSLCoreBuiltins(builtins, logger)
+	addCELBuiltin(builtins)
+	addResolverBuiltins(builtins)
+	addCompositionBuiltins(builtins)
 
-	// Copy safe builtins from Starlark Universe
+	// BLOCKED functions are simply not added to the builtins dict
+	// load(), time.now(), random(), exec(), compile(), open(), http are all absent
+
+	return builtins
+}
+
+// addSafeUniverseBuiltins copies whitelisted builtins from starlark.Universe
+// and overrides print to route to the audit logger.
+func addSafeUniverseBuiltins(builtins starlark.StringDict, logger *slog.Logger) {
 	safeFunctions := []string{
-		"True",
-		"False",
-		"None",
-		"len",
-		"str",
-		"int",
-		"float", // Safe for computation, but Decimal preferred for financial
-		"bool",
-		"list",
-		"dict",
-		"tuple",
-		"range",
-		"enumerate",
-		"zip",
-		"sorted",
-		"reversed",
-		"min",
-		"max",
-		"abs",
-		"any",
-		"all",
-		"hasattr",
-		"getattr",
-		"dir",
-		"type",
-		"repr",
-		"hash",
-		"print", // Will be overridden with audit-logging version
+		"True", "False", "None",
+		"len", "str", "int", "float", "bool",
+		"list", "dict", "tuple", "range",
+		"enumerate", "zip", "sorted", "reversed",
+		"min", "max", "abs", "any", "all",
+		"hasattr", "getattr", "dir", "type", "repr", "hash",
+		"print", // Will be overridden below
 	}
 
 	for _, name := range safeFunctions {
@@ -99,7 +91,6 @@ func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 		}
 	}
 
-	// Override print to route to audit logger
 	builtins["print"] = starlark.NewBuiltin("print", func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 		var msg string
 		for i, arg := range args {
@@ -111,43 +102,56 @@ func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 		logger.Info("saga script print", "message", msg, "thread", thread.Name)
 		return starlark.None, nil
 	})
+}
 
-	// Add DSL functions
-
-	// Decimal - arbitrary precision decimal type
+// addDSLCoreBuiltins registers the saga DSL primitives: Decimal, saga, step, posting, fail, log.
+func addDSLCoreBuiltins(builtins starlark.StringDict, logger *slog.Logger) {
 	builtins["Decimal"] = DecimalBuiltin()
 
-	// saga - define a saga
 	builtins["saga"] = starlark.NewBuiltin("saga", func(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var name string
 		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "name", &name); err != nil {
 			return nil, err
 		}
-		// Return a saga definition object (placeholder implementation)
 		return &sagaDefinitionValue{name: name}, nil
 	})
 
-	// step - define a saga step
 	builtins["step"] = starlark.NewBuiltin("step", func(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var name string
 		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "name", &name); err != nil {
 			return nil, err
 		}
-		// Return a step definition object (placeholder implementation)
 		return &stepDefinitionValue{name: name}, nil
 	})
 
-	// posting - create a ledger posting
 	builtins["posting"] = starlark.NewBuiltin("posting", func(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var debit, credit, amount string
 		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "debit", &debit, "credit", &credit, "amount", &amount); err != nil {
 			return nil, err
 		}
-		// Return a posting object (placeholder implementation)
 		return &postingValue{debit: debit, credit: credit, amount: amount}, nil
 	})
 
-	// cel_eval - evaluate a CEL expression
+	builtins["fail"] = starlark.NewBuiltin("fail", func(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var message string
+		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "message", &message); err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("%w: %s", ErrSagaFailed, message)
+	})
+
+	builtins["log"] = starlark.NewBuiltin("log", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var message string
+		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "message", &message); err != nil {
+			return nil, err
+		}
+		logger.Info("saga log", "message", message, "thread", thread.Name)
+		return starlark.None, nil
+	})
+}
+
+// addCELBuiltin registers the cel_eval function for evaluating CEL expressions within sagas.
+func addCELBuiltin(builtins starlark.StringDict) {
 	builtins["cel_eval"] = starlark.NewBuiltin("cel_eval", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var expression string
 		var inputDict *starlark.Dict
@@ -155,23 +159,16 @@ func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 			return nil, err
 		}
 
-		// Get StarlarkContext from thread local storage
-		ctxVal := thread.Local("saga.StarlarkContext")
-		if ctxVal == nil {
-			return nil, fmt.Errorf("cel_eval: %w", ErrMissingStarlarkContext)
-		}
-		starlarkCtx, ok := ctxVal.(*StarlarkContext)
-		if !ok {
-			return nil, fmt.Errorf("cel_eval: %w", ErrInvalidStarlarkContext)
+		starlarkCtx, err := getStarlarkContext(thread, "cel_eval")
+		if err != nil {
+			return nil, err
 		}
 
-		// Create CEL evaluator
 		evaluator, err := NewCELEvaluator()
 		if err != nil {
 			return nil, fmt.Errorf("cel_eval: %w", err)
 		}
 
-		// Build evaluation context with saga metadata
 		variables := map[string]interface{}{
 			"ctx": map[string]interface{}{
 				"saga_execution_id": starlarkCtx.SagaExecutionID.String(),
@@ -179,7 +176,6 @@ func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 			},
 		}
 
-		// Add optional input variables if provided
 		if inputDict != nil {
 			inputMap := make(map[string]interface{})
 			for _, item := range inputDict.Items() {
@@ -192,7 +188,6 @@ func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 			variables["input"] = inputMap
 		}
 
-		// Evaluate expression
 		result, err := evaluator.Eval(expression, variables)
 		if err != nil {
 			return nil, fmt.Errorf("cel_eval: %w", err)
@@ -200,124 +195,85 @@ func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 
 		return goToStarlark(result), nil
 	})
+}
 
-	// resolve_account - resolve account ID from reference
-	// Supports both simple references (e.g., "ACC-001") and composite references
-	// (e.g., "party:<party_id>:org:<org_id>:currency:<code>") for org-scoped account resolution.
-	// Composite references are validated before being passed to the ReferenceDataClient.
-	builtins["resolve_account"] = starlark.NewBuiltin("resolve_account", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+// addResolverBuiltins registers resolve_account, resolve_instrument, and build_org_account_ref.
+func addResolverBuiltins(builtins starlark.StringDict) {
+	builtins["resolve_account"] = resolveAccountBuiltin()
+	builtins["resolve_instrument"] = resolveInstrumentBuiltin()
+	builtins["build_org_account_ref"] = buildOrgAccountRefBuiltin()
+}
+
+func resolveAccountBuiltin() *starlark.Builtin {
+	return starlark.NewBuiltin("resolve_account", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var reference string
 		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "reference", &reference); err != nil {
 			return nil, err
 		}
 
-		// Validate composite reference format if it contains colons
 		if strings.Contains(reference, ":") {
 			if _, err := ParseCompositeAccountRef(reference); err != nil {
 				return nil, fmt.Errorf("resolve_account: %w", err)
 			}
 		}
 
-		// Get StarlarkContext from thread
-		ctxVal := thread.Local("saga.StarlarkContext")
-		if ctxVal == nil {
-			return nil, fmt.Errorf("resolve_account: %w", ErrMissingStarlarkContext)
-		}
-		starlarkCtx, ok := ctxVal.(*StarlarkContext)
-		if !ok {
-			return nil, fmt.Errorf("resolve_account: %w", ErrInvalidStarlarkContext)
+		starlarkCtx, err := getStarlarkContext(thread, "resolve_account")
+		if err != nil {
+			return nil, err
 		}
 
-		// Check lookup cache for deterministic replay (FR-34)
-		cacheKey := "account:" + reference
-		if starlarkCtx.LookupCache != nil {
-			if cached, found := starlarkCtx.LookupCache.Get(cacheKey); found {
-				if accountID, ok := cached.(string); ok {
-					return starlark.String(accountID), nil
-				}
-			}
+		if val, ok := cachedLookup(starlarkCtx, "account:"+reference); ok {
+			return starlark.String(val), nil
 		}
 
-		// Get reference-data client from thread
-		clientVal := thread.Local("saga.ReferenceDataClient")
-		if clientVal == nil {
-			return nil, fmt.Errorf("resolve_account: %w", ErrMissingClient)
-		}
-		refDataClient, ok := clientVal.(ReferenceDataClient)
-		if !ok {
-			return nil, fmt.Errorf("resolve_account: %w", ErrInvalidClientType)
+		refDataClient, err := getRefDataClient(thread, "resolve_account")
+		if err != nil {
+			return nil, err
 		}
 
-		// Query reference-data service with bi-temporal KnowledgeAt
 		accountID, err := refDataClient.ResolveAccount(starlarkCtx.Context, reference, starlarkCtx.KnowledgeAt)
 		if err != nil {
 			return nil, fmt.Errorf("resolve_account(%q): %w", reference, err)
 		}
 
-		// Cache result for replay
-		if starlarkCtx.LookupCache != nil {
-			starlarkCtx.LookupCache.Set(cacheKey, accountID)
-		}
-
+		cacheLookup(starlarkCtx, "account:"+reference, accountID)
 		return starlark.String(accountID), nil
 	})
+}
 
-	// resolve_instrument - resolve instrument ID from reference
-	builtins["resolve_instrument"] = starlark.NewBuiltin("resolve_instrument", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func resolveInstrumentBuiltin() *starlark.Builtin {
+	return starlark.NewBuiltin("resolve_instrument", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var reference string
 		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "reference", &reference); err != nil {
 			return nil, err
 		}
 
-		// Get StarlarkContext from thread
-		ctxVal := thread.Local("saga.StarlarkContext")
-		if ctxVal == nil {
-			return nil, fmt.Errorf("resolve_instrument: %w", ErrMissingStarlarkContext)
-		}
-		starlarkCtx, ok := ctxVal.(*StarlarkContext)
-		if !ok {
-			return nil, fmt.Errorf("resolve_instrument: %w", ErrInvalidStarlarkContext)
+		starlarkCtx, err := getStarlarkContext(thread, "resolve_instrument")
+		if err != nil {
+			return nil, err
 		}
 
-		// Check cache
-		cacheKey := "instrument:" + reference
-		if starlarkCtx.LookupCache != nil {
-			if cached, found := starlarkCtx.LookupCache.Get(cacheKey); found {
-				if instrumentID, ok := cached.(string); ok {
-					return starlark.String(instrumentID), nil
-				}
-			}
+		if val, ok := cachedLookup(starlarkCtx, "instrument:"+reference); ok {
+			return starlark.String(val), nil
 		}
 
-		// Get reference-data client from thread
-		clientVal := thread.Local("saga.ReferenceDataClient")
-		if clientVal == nil {
-			return nil, fmt.Errorf("resolve_instrument: %w", ErrMissingClient)
-		}
-		refDataClient, ok := clientVal.(ReferenceDataClient)
-		if !ok {
-			return nil, fmt.Errorf("resolve_instrument: %w", ErrInvalidClientType)
+		refDataClient, err := getRefDataClient(thread, "resolve_instrument")
+		if err != nil {
+			return nil, err
 		}
 
-		// Query with KnowledgeAt for bi-temporal lookup
 		instrumentID, err := refDataClient.ResolveInstrument(starlarkCtx.Context, reference, starlarkCtx.KnowledgeAt)
 		if err != nil {
 			return nil, fmt.Errorf("resolve_instrument(%q): %w", reference, err)
 		}
 
-		// Cache result
-		if starlarkCtx.LookupCache != nil {
-			starlarkCtx.LookupCache.Set(cacheKey, instrumentID)
-		}
-
+		cacheLookup(starlarkCtx, "instrument:"+reference, instrumentID)
 		return starlark.String(instrumentID), nil
 	})
+}
 
-	// build_org_account_ref - build a composite account reference for org-scoped resolution
-	// Returns a properly formatted composite reference string:
-	//   party:<party_id>:org:<org_id>:currency:<currency_code>
-	// This prevents manual string concatenation errors in saga scripts.
-	builtins["build_org_account_ref"] = starlark.NewBuiltin("build_org_account_ref", func(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func buildOrgAccountRefBuiltin() *starlark.Builtin {
+	return starlark.NewBuiltin("build_org_account_ref", func(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var partyID, orgID, currency string
 		if err := starlark.UnpackArgs(b.Name(), args, kwargs,
 			"party_id", &partyID,
@@ -340,73 +296,60 @@ func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 		ref := BuildCompositeAccountRef(partyID, orgID, currency)
 		return starlark.String(ref), nil
 	})
+}
 
-	// invoke_saga - invoke a child saga
+// cachedLookup checks the StarlarkContext lookup cache for a previously resolved value.
+func cachedLookup(ctx *StarlarkContext, cacheKey string) (string, bool) {
+	if ctx.LookupCache == nil {
+		return "", false
+	}
+	cached, found := ctx.LookupCache.Get(cacheKey)
+	if !found {
+		return "", false
+	}
+	val, ok := cached.(string)
+	return val, ok
+}
+
+// cacheLookup stores a resolved value in the StarlarkContext lookup cache.
+func cacheLookup(ctx *StarlarkContext, cacheKey, value string) {
+	if ctx.LookupCache != nil {
+		ctx.LookupCache.Set(cacheKey, value)
+	}
+}
+
+// addCompositionBuiltins registers invoke_saga for child saga invocation.
+func addCompositionBuiltins(builtins starlark.StringDict) {
 	builtins["invoke_saga"] = starlark.NewBuiltin("invoke_saga", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var sagaName string
 		inputDict := starlark.NewDict(0)
-
-		if err := starlark.UnpackArgs(b.Name(), args, kwargs,
-			"saga_name", &sagaName,
-			"input?", &inputDict,
-		); err != nil {
+		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "saga_name", &sagaName, "input?", &inputDict); err != nil {
 			return nil, err
 		}
 
-		// Get StarlarkContext
-		ctxVal := thread.Local("saga.StarlarkContext")
-		if ctxVal == nil {
-			return nil, fmt.Errorf("invoke_saga: %w", ErrMissingStarlarkContext)
+		starlarkCtx, err := getStarlarkContext(thread, "invoke_saga")
+		if err != nil {
+			return nil, err
 		}
-		starlarkCtx, ok := ctxVal.(*StarlarkContext)
-		if !ok {
-			return nil, fmt.Errorf("invoke_saga: %w", ErrInvalidStarlarkContext)
+		composer, err := getThreadLocal[*Composer](thread, "saga.Composer", "invoke_saga")
+		if err != nil {
+			return nil, err
 		}
-
-		// Get Composer from thread
-		composerVal := thread.Local("saga.Composer")
-		if composerVal == nil {
-			return nil, fmt.Errorf("invoke_saga: %w", ErrMissingClient)
-		}
-		composer, ok := composerVal.(*Composer)
-		if !ok {
-			return nil, fmt.Errorf("invoke_saga: %w", ErrInvalidClientType)
+		stack, err := getThreadLocal[*CallStack](thread, "saga.CallStack", "invoke_saga")
+		if err != nil {
+			return nil, err
 		}
 
-		// Get CallStack for nesting tracking
-		stackVal := thread.Local("saga.CallStack")
-		if stackVal == nil {
-			return nil, fmt.Errorf("invoke_saga: %w", ErrMissingClient)
-		}
-		stack, ok := stackVal.(*CallStack)
-		if !ok {
-			return nil, fmt.Errorf("invoke_saga: %w", ErrInvalidClientType)
+		input, err := starlarkDictToGoMap(inputDict, "invoke_saga")
+		if err != nil {
+			return nil, err
 		}
 
-		// Convert Starlark dict to Go map
-		input := make(map[string]interface{})
-		for _, item := range inputDict.Items() {
-			key, ok := item[0].(starlark.String)
-			if !ok {
-				return nil, fmt.Errorf("invoke_saga: %w: input keys must be strings, got %s", ErrInvalidParameterType, item[0].Type())
-			}
-			input[string(key)] = convertStarlarkToGo(item[1])
-		}
-
-		// Invoke child saga with scope inheritance and circular detection
-		result, err := composer.InvokeSaga(
-			starlarkCtx.Context,
-			sagaName,
-			input,
-			starlarkCtx.PartyScope, // Inherit parent scope - child cannot escalate
-			stack,
-		)
+		result, err := composer.InvokeSaga(starlarkCtx.Context, sagaName, input, starlarkCtx.PartyScope, stack)
 		if err != nil {
 			return nil, fmt.Errorf("invoke_saga(%q): %w", sagaName, err)
 		}
 
-		// Return sagaResultValue from composition.go
-		// goToStarlark handles map[string]interface{} -> *starlark.Dict conversion
 		outputDict, ok := goToStarlark(result.Output).(*starlark.Dict)
 		if !ok {
 			outputDict = starlark.NewDict(0)
@@ -418,30 +361,59 @@ func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 			stepsCompleted: result.StepsCompleted,
 		}, nil
 	})
+}
 
-	// fail - explicitly fail the saga
-	builtins["fail"] = starlark.NewBuiltin("fail", func(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-		var message string
-		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "message", &message); err != nil {
-			return nil, err
+// getThreadLocal extracts a typed value from thread local storage.
+func getThreadLocal[T any](thread *starlark.Thread, key, caller string) (T, error) {
+	var zero T
+	val := thread.Local(key)
+	if val == nil {
+		return zero, fmt.Errorf("%s: %w", caller, ErrMissingClient)
+	}
+	typed, ok := val.(T)
+	if !ok {
+		return zero, fmt.Errorf("%s: %w", caller, ErrInvalidClientType)
+	}
+	return typed, nil
+}
+
+// starlarkDictToGoMap converts a Starlark dict to a Go map[string]interface{}.
+func starlarkDictToGoMap(dict *starlark.Dict, caller string) (map[string]interface{}, error) {
+	result := make(map[string]interface{})
+	for _, item := range dict.Items() {
+		key, ok := item[0].(starlark.String)
+		if !ok {
+			return nil, fmt.Errorf("%s: %w: input keys must be strings, got %s", caller, ErrInvalidParameterType, item[0].Type())
 		}
-		return nil, fmt.Errorf("%w: %s", ErrSagaFailed, message)
-	})
+		result[string(key)] = convertStarlarkToGo(item[1])
+	}
+	return result, nil
+}
 
-	// log - log a message to audit logger
-	builtins["log"] = starlark.NewBuiltin("log", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-		var message string
-		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "message", &message); err != nil {
-			return nil, err
-		}
-		logger.Info("saga log", "message", message, "thread", thread.Name)
-		return starlark.None, nil
-	})
+// getStarlarkContext extracts the StarlarkContext from thread local storage.
+func getStarlarkContext(thread *starlark.Thread, caller string) (*StarlarkContext, error) {
+	ctxVal := thread.Local("saga.StarlarkContext")
+	if ctxVal == nil {
+		return nil, fmt.Errorf("%s: %w", caller, ErrMissingStarlarkContext)
+	}
+	starlarkCtx, ok := ctxVal.(*StarlarkContext)
+	if !ok {
+		return nil, fmt.Errorf("%s: %w", caller, ErrInvalidStarlarkContext)
+	}
+	return starlarkCtx, nil
+}
 
-	// BLOCKED functions are simply not added to the builtins dict
-	// load(), time.now(), random(), exec(), compile(), open(), http are all absent
-
-	return builtins
+// getRefDataClient extracts the ReferenceDataClient from thread local storage.
+func getRefDataClient(thread *starlark.Thread, caller string) (ReferenceDataClient, error) {
+	clientVal := thread.Local("saga.ReferenceDataClient")
+	if clientVal == nil {
+		return nil, fmt.Errorf("%s: %w", caller, ErrMissingClient)
+	}
+	refDataClient, ok := clientVal.(ReferenceDataClient)
+	if !ok {
+		return nil, fmt.Errorf("%s: %w", caller, ErrInvalidClientType)
+	}
+	return refDataClient, nil
 }
 
 // sagaDefinitionValue represents a saga definition in Starlark.

--- a/shared/pkg/saga/schema/service_modules.go
+++ b/shared/pkg/saga/schema/service_modules.go
@@ -267,125 +267,116 @@ func buildServiceStruct(name string, node *handlerTree, registry *saga.HandlerRe
 // It handles parameter validation against the schema and type conversion.
 func wrapHandler(fullName string, handler saga.Handler, handlerDef *HandlerDef) *starlark.Builtin {
 	return starlark.NewBuiltin(fullName, func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-		// Handle positional args (should be empty for handlers) - check first for fast fail
 		if len(args) > 0 {
 			return nil, fmt.Errorf("%w: handler %s", ErrPositionalArgsNotAllowed, fullName)
 		}
 
-		// Get StarlarkContext from thread-local storage
 		ctx := getStarlarkContext(thread)
 		if ctx == nil {
 			return nil, ErrMissingStarlarkContext
 		}
 
-		// Authorization check: enforce RBAC when handler declares a ResourceType
 		if err := authorizeHandlerInvocation(ctx, handlerDef, fullName); err != nil {
 			return nil, err
 		}
 
-		// Convert kwargs to Go map
 		params, err := convertKwargsToParams(kwargs)
 		if err != nil {
 			return nil, err
 		}
 
-		// Coerce all parameters to their schema-defined types
 		if err := CoerceParams(params, handlerDef); err != nil {
 			return nil, fmt.Errorf("handler %s: %w", fullName, err)
 		}
-
-		// Validate parameters against schema
 		if err := handlerDef.ValidateParams(params); err != nil {
 			return nil, fmt.Errorf("handler %s: %w", fullName, err)
 		}
 
-		// Generate idempotency key for this step
 		ctx.IdempotencyKey = ctx.NextIdempotencyKey()
 
-		// Call the handler
 		result, err := handler(ctx, params)
-
-		// Always track step results (for both success and failure cases)
-		// Get stepResults slice from thread-local storage
-		if stepResultsVal := thread.Local("saga.StepResults"); stepResultsVal != nil {
-			if stepResults, ok := stepResultsVal.(*[]saga.StepResult); ok {
-				// Build step result
-				stepResult := saga.StepResult{
-					StepName: fullName,
-					Success:  err == nil,
-					Output:   result,
-				}
-
-				if err != nil {
-					stepResult.Error = err.Error()
-				} else if handlerDef.Compensate != "" {
-					// If successful and has compensation handler, capture compensation metadata
-					stepResult.CompensateHandler = handlerDef.Compensate
-
-					// Derive compensation params from BOTH forward step output AND input
-					compensateParams := make(map[string]any)
-
-					// 1. Copy ALL fields from output (not just _id fields)
-					//    Compensation handlers need output fields like version, status, etc.
-					if output, ok := result.(map[string]interface{}); ok {
-						for key, value := range output {
-							compensateParams[key] = value
-						}
-					}
-
-					// 2. Copy commonly-needed input fields to compensation params
-					//    Compensation handlers often need context from the forward step input
-					inputFieldsForCompensation := []string{
-						"transaction_id", "account_id", "position_id", "direction",
-						"amount", "instrument_code", "currency", "booking_log_id", "posting_id", "posting_type",
-					}
-					for _, field := range inputFieldsForCompensation {
-						if value, ok := params[field]; ok {
-							compensateParams[field] = value
-						}
-					}
-
-					// 3. Handle field aliases: position_id and account_id are often interchangeable
-					//    If position_id exists but account_id doesn't, copy it as account_id
-					if posID, ok := compensateParams["position_id"]; ok {
-						if _, hasAcctID := compensateParams["account_id"]; !hasAcctID {
-							compensateParams["account_id"] = posID
-						}
-					}
-					// And vice versa
-					if acctID, ok := compensateParams["account_id"]; ok {
-						if _, hasPosID := compensateParams["position_id"]; !hasPosID {
-							compensateParams["position_id"] = acctID
-						}
-					}
-
-					// 4. Invert direction for financial posting compensations
-					//    Compensation postings must use the opposite direction to reverse the original
-					if handlerDef.Compensate == "financial_accounting.compensate_posting" {
-						if direction, ok := compensateParams["direction"].(string); ok {
-							switch direction {
-							case "DEBIT":
-								compensateParams["direction"] = "CREDIT"
-							case "CREDIT":
-								compensateParams["direction"] = "DEBIT"
-							}
-						}
-					}
-
-					stepResult.CompensateParams = compensateParams
-				}
-
-				*stepResults = append(*stepResults, stepResult)
-			}
-		}
+		trackStepResult(thread, fullName, result, err, params, handlerDef)
 
 		if err != nil {
 			return nil, err
 		}
-
-		// Convert result to Starlark value
 		return goToStarlarkResult(fullName, result)
 	})
+}
+
+// trackStepResult records the step result (success or failure) for saga compensation tracking.
+func trackStepResult(thread *starlark.Thread, fullName string, result any, err error, params map[string]any, handlerDef *HandlerDef) {
+	stepResultsVal := thread.Local("saga.StepResults")
+	if stepResultsVal == nil {
+		return
+	}
+	stepResults, ok := stepResultsVal.(*[]saga.StepResult)
+	if !ok {
+		return
+	}
+
+	stepResult := saga.StepResult{
+		StepName: fullName,
+		Success:  err == nil,
+		Output:   result,
+	}
+
+	if err != nil {
+		stepResult.Error = err.Error()
+	} else if handlerDef.Compensate != "" {
+		stepResult.CompensateHandler = handlerDef.Compensate
+		stepResult.CompensateParams = buildCompensateParams(result, params, handlerDef.Compensate)
+	}
+
+	*stepResults = append(*stepResults, stepResult)
+}
+
+// buildCompensateParams derives compensation parameters from the forward step's output and input.
+func buildCompensateParams(result any, params map[string]any, compensateHandler string) map[string]any {
+	compensateParams := make(map[string]any)
+
+	// Copy ALL fields from output (compensation handlers need version, status, etc.)
+	if output, ok := result.(map[string]interface{}); ok {
+		for key, value := range output {
+			compensateParams[key] = value
+		}
+	}
+
+	// Copy commonly-needed input fields for compensation context
+	for _, field := range []string{
+		"transaction_id", "account_id", "position_id", "direction",
+		"amount", "instrument_code", "currency", "booking_log_id", "posting_id", "posting_type",
+	} {
+		if value, ok := params[field]; ok {
+			compensateParams[field] = value
+		}
+	}
+
+	// Handle field aliases: position_id and account_id are often interchangeable
+	if posID, ok := compensateParams["position_id"]; ok {
+		if _, hasAcctID := compensateParams["account_id"]; !hasAcctID {
+			compensateParams["account_id"] = posID
+		}
+	}
+	if acctID, ok := compensateParams["account_id"]; ok {
+		if _, hasPosID := compensateParams["position_id"]; !hasPosID {
+			compensateParams["position_id"] = acctID
+		}
+	}
+
+	// Invert direction for financial posting compensations
+	if compensateHandler == "financial_accounting.compensate_posting" {
+		if direction, ok := compensateParams["direction"].(string); ok {
+			switch direction {
+			case "DEBIT":
+				compensateParams["direction"] = "CREDIT"
+			case "CREDIT":
+				compensateParams["direction"] = "DEBIT"
+			}
+		}
+	}
+
+	return compensateParams
 }
 
 // authorizeHandlerInvocation checks RBAC authorization before handler invocation.

--- a/tests/architecture/layers_test.go
+++ b/tests/architecture/layers_test.go
@@ -57,6 +57,7 @@ var knownCrossServiceDomainImports = map[string]bool{
 	"services/event-router/internal/correlation/extractor.go":               true,
 	"services/financial-accounting/app/container.go":                        true,
 	"services/internal-account/service/grpc_account_endpoints.go":           true,
+	"services/internal-account/service/grpc_account_helpers.go":            true,
 	"services/internal-account/service/server.go":                           true,
 }
 

--- a/tests/architecture/layers_test.go
+++ b/tests/architecture/layers_test.go
@@ -57,7 +57,7 @@ var knownCrossServiceDomainImports = map[string]bool{
 	"services/event-router/internal/correlation/extractor.go":               true,
 	"services/financial-accounting/app/container.go":                        true,
 	"services/internal-account/service/grpc_account_endpoints.go":           true,
-	"services/internal-account/service/grpc_account_helpers.go":            true,
+	"services/internal-account/service/grpc_account_helpers.go":             true,
 	"services/internal-account/service/server.go":                           true,
 }
 


### PR DESCRIPTION
## Summary

- Extract and split oversized functions across 5 services to reduce function size violations from 464 baseline to 443 (net -21)
- Pure code motion refactoring - no behavioral changes
- Focus on mechanically extractable patterns: error mapping switches, validation blocks, handler registration splits, batch processing helpers

## Changes Made

**shared/pkg/saga/builtins.go** - Split `NewRestrictedBuiltins` (389 lines) into 5 category-based helpers with shared generic `getThreadLocal[T]` extraction

**services/control-plane/internal/applier/executor.go** - Split `buildSagaInput` (167 lines) into per-entity-type converter functions

**services/control-plane/internal/applier/handlers.go** - Split `RegisterManifestHandlers` (202 lines) into per-service registrators

**shared/pkg/saga/schema/service_modules.go** - Split `wrapHandler` (122 lines) by extracting `trackStepResult` and `buildCompensateParams`

**services/current-account/service/saga_handlers.go** - Split `RegisterCurrentAccountHandlers` (125 lines) into core + stub handler lists

**services/financial-accounting/client/starlark.go** - Split `RegisterStarlarkHandlers` (110 lines) into booking log + posting handler groups

**services/market-information/service/observation_batch.go** - Split `RecordObservationBatch` (288 lines) into `batchContext` struct with focused methods

**services/current-account/service/lien_lifecycle.go** - Extract error mapping, amount computation, idempotency, and response building from lien lifecycle handlers (278->157, 292->200, 156->138)

**services/internal-account/service/grpc_account_endpoints.go** - Extract product type resolution and instrument validation from `InitiateInternalAccount` (274->129)

## Test plan

- [ ] `go test ./tests/architecture/ -run TestFunctionSize -v` passes (443 violations, baseline 464)
- [ ] `go build ./...` compiles clean
- [ ] CI passes all existing tests
- [ ] No behavioral changes - pure code motion