### PR TITLE
fix: derive provisioner database URLs from DATABASE_URL and add bootstrap step

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -221,6 +221,15 @@ jobs:
           script: |
             docker exec meridian-meridian-1 /meridian --migrate
 
+      - name: Bootstrap master tenant
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            docker exec meridian-meridian-1 /meridian --bootstrap
+
       - name: Seed demo data
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:

--- a/services/tenant/provisioner/provisioner.go
+++ b/services/tenant/provisioner/provisioner.go
@@ -459,11 +459,14 @@ func getServiceDatabaseURL(serviceName string) string {
 	// the rest of the application (e.g. postgres:5432 on demo, cockroachdb:26257 in prod).
 	if baseURL := os.Getenv("DATABASE_URL"); baseURL != "" {
 		derived, err := deriveServiceURL(baseURL, dbName)
-		if err == nil {
+		if err != nil {
+			// DATABASE_URL is set but malformed - log without leaking credentials
+			// and fall through to hardcoded fallback as a last resort.
+			slog.Error("failed to derive service URL from DATABASE_URL",
+				"service", serviceName, "reason", "malformed DATABASE_URL")
+		} else {
 			return derived
 		}
-		slog.Warn("failed to derive service URL from DATABASE_URL, using hardcoded fallback",
-			"service", serviceName, "error", err)
 	}
 
 	// Hardcoded fallback for local development without DATABASE_URL.

--- a/services/tenant/provisioner/provisioner.go
+++ b/services/tenant/provisioner/provisioner.go
@@ -55,6 +55,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -441,24 +442,45 @@ func DefaultConfig() *Config {
 // Pattern: {SERVICE_NAME}_DATABASE_URL (uppercase with hyphens replaced by underscores)
 // Example: PARTY_DATABASE_URL, CURRENT_ACCOUNT_DATABASE_URL
 //
-// If the environment variable is not set, falls back to a constructed URL:
-// postgres://meridian_{service}_user@cockroachdb:26257/meridian_{service}?sslmode=disable
+// Fallback order:
+//  1. Service-specific env var (e.g. PARTY_DATABASE_URL)
+//  2. DATABASE_URL with the database name replaced to meridian_{service}
+//  3. Hardcoded local dev URL: postgres://meridian_{service}_user@localhost:26257/meridian_{service}
 func getServiceDatabaseURL(serviceName string) string {
 	envKey := strings.ToUpper(strings.ReplaceAll(serviceName, "-", "_")) + "_DATABASE_URL"
-	url := os.Getenv(envKey)
-	if url != "" {
-		return url
+	if envURL := os.Getenv(envKey); envURL != "" {
+		return envURL
 	}
 
-	// Fallback to constructed URL for backward compatibility.
-	// WARNING: Fallback URLs use sslmode=disable which is only suitable for local dev.
-	// In production, always set explicit DATABASE_URL environment variables with
-	// appropriate SSL settings (e.g., sslmode=verify-full).
-	slog.Warn("using fallback database URL (not recommended for production)",
+	dbName := "meridian_" + strings.ReplaceAll(serviceName, "-", "_")
+
+	// Derive from DATABASE_URL by replacing the database name component.
+	// This ensures the provisioner uses the same host/port/credentials as
+	// the rest of the application (e.g. postgres:5432 on demo, cockroachdb:26257 in prod).
+	if baseURL := os.Getenv("DATABASE_URL"); baseURL != "" {
+		derived, err := deriveServiceURL(baseURL, dbName)
+		if err == nil {
+			return derived
+		}
+		slog.Warn("failed to derive service URL from DATABASE_URL, using hardcoded fallback",
+			"service", serviceName, "error", err)
+	}
+
+	// Hardcoded fallback for local development without DATABASE_URL.
+	slog.Warn("using hardcoded fallback database URL (local dev only)",
 		"service", serviceName,
 		"env_var", envKey,
-		"hint", "Set "+envKey+" environment variable with appropriate SSL settings")
-	dbName := "meridian_" + strings.ReplaceAll(serviceName, "-", "_")
+		"hint", "Set DATABASE_URL or "+envKey+" environment variable")
 	user := dbName + "_user"
-	return fmt.Sprintf("postgres://%s@cockroachdb:26257/%s?sslmode=disable", user, dbName)
+	return fmt.Sprintf("postgres://%s@localhost:26257/%s?sslmode=disable", user, dbName)
+}
+
+// deriveServiceURL replaces the database name in a base DSN URL.
+func deriveServiceURL(baseURL, database string) (string, error) {
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("parse base URL: %w", err)
+	}
+	parsed.Path = "/" + database
+	return parsed.String(), nil
 }

--- a/services/tenant/provisioner/provisioner_test.go
+++ b/services/tenant/provisioner/provisioner_test.go
@@ -438,16 +438,24 @@ func TestMockProvisioner_Reset(t *testing.T) {
 }
 
 func TestGetServiceDatabaseURL(t *testing.T) {
-	t.Run("returns env var when set", func(t *testing.T) {
+	t.Run("returns service-specific env var when set", func(t *testing.T) {
 		t.Setenv("PARTY_DATABASE_URL", "postgres://test:test@localhost:5432/party")
 		url := getServiceDatabaseURL("party")
 		assert.Equal(t, "postgres://test:test@localhost:5432/party", url)
 	})
 
-	t.Run("returns fallback URL when env var not set", func(t *testing.T) {
+	t.Run("derives from DATABASE_URL when service env var not set", func(t *testing.T) {
+		t.Setenv("DATABASE_URL", "postgres://user:pass@postgres:5432/meridian?sslmode=disable")
+		url := getServiceDatabaseURL("party")
+		assert.Contains(t, url, "postgres:5432")
+		assert.Contains(t, url, "/meridian_party")
+		assert.Contains(t, url, "user:pass")
+	})
+
+	t.Run("returns hardcoded fallback when no env vars set", func(t *testing.T) {
 		url := getServiceDatabaseURL("party")
 		assert.Contains(t, url, "meridian_party")
-		assert.Contains(t, url, "cockroachdb:26257")
+		assert.Contains(t, url, "localhost:26257")
 	})
 
 	t.Run("handles hyphens in service name", func(t *testing.T) {
@@ -456,9 +464,18 @@ func TestGetServiceDatabaseURL(t *testing.T) {
 		assert.Equal(t, "postgres://test@localhost/ca", url)
 	})
 
-	t.Run("fallback with hyphens replaced", func(t *testing.T) {
+	t.Run("derives with hyphens replaced", func(t *testing.T) {
+		t.Setenv("DATABASE_URL", "postgres://user@myhost:5432/db?sslmode=disable")
 		url := getServiceDatabaseURL("current-account")
 		assert.Contains(t, url, "meridian_current_account")
+		assert.Contains(t, url, "myhost:5432")
+	})
+
+	t.Run("service-specific env var takes priority over DATABASE_URL", func(t *testing.T) {
+		t.Setenv("DATABASE_URL", "postgres://user@postgres:5432/db?sslmode=disable")
+		t.Setenv("PARTY_DATABASE_URL", "postgres://specific@other:9999/party_db")
+		url := getServiceDatabaseURL("party")
+		assert.Equal(t, "postgres://specific@other:9999/party_db", url)
 	})
 }
 

--- a/services/tenant/provisioner/provisioner_test.go
+++ b/services/tenant/provisioner/provisioner_test.go
@@ -447,9 +447,7 @@ func TestGetServiceDatabaseURL(t *testing.T) {
 	t.Run("derives from DATABASE_URL when service env var not set", func(t *testing.T) {
 		t.Setenv("DATABASE_URL", "postgres://user:pass@postgres:5432/meridian?sslmode=disable")
 		url := getServiceDatabaseURL("party")
-		assert.Contains(t, url, "postgres:5432")
-		assert.Contains(t, url, "/meridian_party")
-		assert.Contains(t, url, "user:pass")
+		assert.Equal(t, "postgres://user:pass@postgres:5432/meridian_party?sslmode=disable", url)
 	})
 
 	t.Run("returns hardcoded fallback when no env vars set", func(t *testing.T) {
@@ -467,8 +465,7 @@ func TestGetServiceDatabaseURL(t *testing.T) {
 	t.Run("derives with hyphens replaced", func(t *testing.T) {
 		t.Setenv("DATABASE_URL", "postgres://user@myhost:5432/db?sslmode=disable")
 		url := getServiceDatabaseURL("current-account")
-		assert.Contains(t, url, "meridian_current_account")
-		assert.Contains(t, url, "myhost:5432")
+		assert.Equal(t, "postgres://user@myhost:5432/meridian_current_account?sslmode=disable", url)
 	})
 
 	t.Run("service-specific env var takes priority over DATABASE_URL", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix `getServiceDatabaseURL()` fallback to derive from `DATABASE_URL` env var instead of hardcoding `cockroachdb:26257`. Demo uses `postgres:5432` and the hardcoded fallback prevented the provisioner from connecting to service databases.
- Add `--bootstrap` step to demo deploy workflow between migrations and seed-dev, so master tenant schemas (`org_meridian_master`) are created before seeding.

## Changes

**`services/tenant/provisioner/provisioner.go`**
- `getServiceDatabaseURL()` now has a 3-tier fallback: service-specific env var -> derive from `DATABASE_URL` -> hardcoded localhost (local dev only)
- Added `deriveServiceURL()` helper to parse and replace database name in a base DSN

**`.github/workflows/deploy-demo.yml`**
- Added "Bootstrap master tenant" step after migrations and before seed-dev

**`services/tenant/provisioner/provisioner_test.go`**
- Updated tests to cover DATABASE_URL derivation and priority order

## Test plan

- [x] Unit tests for `getServiceDatabaseURL()` pass with all fallback tiers
- [x] `DeriveProvisionerConfig` tests pass (connections_test.go)
- [ ] CI passes
- [ ] After deploy to demo: `SELECT nspname FROM pg_namespace WHERE nspname LIKE 'org_%'` returns tenant schemas