### PR TITLE
refactor: tighten function size baseline from 464 to 443

### DIFF
--- a/tests/architecture/size_test.go
+++ b/tests/architecture/size_test.go
@@ -17,8 +17,8 @@ const (
 	// baselineOversizedFunctions is the number of functions exceeding maxFunctionLines
 	// at the time this test was introduced. The test fails if this count increases,
 	// preventing new violations while allowing gradual cleanup.
-	// Last measured: 2026-03-27 (develop branch at 05ad45f9)
-	baselineOversizedFunctions = 464
+	// Last measured: 2026-03-28 (develop branch at be7b91a7)
+	baselineOversizedFunctions = 443
 )
 
 // knownOversizedFiles tracks files that currently exceed the size limit.


### PR DESCRIPTION
## Summary
- Tighten `baselineOversizedFunctions` from 464 to 443, reflecting 21 fewer violations after 18 PRs of function-size refactoring
- No stale entries in `knownOversizedFiles` - all allowlisted files still exceed 800 lines
- All architecture tests pass

## Test plan
- [x] `TestFunctionSize` passes with new baseline of 443
- [x] `TestFileSizeAllowlistAccuracy` confirms no stale allowlist entries
- [x] All architecture tests green