### PR TITLE
refactor: tighten function size baseline from 443 to 179

### DIFF
--- a/tests/architecture/size_test.go
+++ b/tests/architecture/size_test.go
@@ -17,8 +17,8 @@ const (
 	// baselineOversizedFunctions is the number of functions exceeding maxFunctionLines
 	// at the time this test was introduced. The test fails if this count increases,
 	// preventing new violations while allowing gradual cleanup.
-	// Last measured: 2026-03-28 (develop branch at be7b91a7)
-	baselineOversizedFunctions = 443
+	// Last measured: 2026-03-28 (develop branch at 6dc95916)
+	baselineOversizedFunctions = 179
 )
 
 // knownOversizedFiles tracks files that currently exceed the size limit.


### PR DESCRIPTION
## Summary

- Tighten `baselineOversizedFunctions` from 443 to 179 in architecture tests
- Locks in gains from recent extraction PRs (#2026, #2027, #2028)
- No stale `knownOversizedFiles` entries found

## Test plan

- [x] `TestFunctionSize` confirms 179 current violations matching new baseline
- [x] `TestFileSizeAllowlistAccuracy` passes (no stale entries)
- [x] All architecture tests pass