### PR TITLE
fix: payment order saga handler and config validation fixes

### DIFF
--- a/services/payment-order/service/grpc_service_test.go
+++ b/services/payment-order/service/grpc_service_test.go
@@ -632,6 +632,20 @@ func TestNewServiceWithConfig(t *testing.T) {
 			},
 			wantErr: ErrIdempotencyServiceNil,
 		},
+		{
+			name: "saga orchestration enabled with nil reference data client returns error",
+			config: Config{
+				Repository:                NewMockRepository(),
+				CurrentAccountClient:      &MockCurrentAccountClient{},
+				FinancialAccountingClient: &MockFinancialAccountingClient{},
+				PaymentGateway:            &MockPaymentGateway{},
+				GatewayAccountConfig:      testGatewayAccountConfig(),
+				IdempotencyService:        NewMockIdempotencyService(),
+				SagaOrchestrationEnabled:  true,
+				ReferenceDataClient:       nil,
+			},
+			wantErr: ErrReferenceDataClientNil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/services/payment-order/service/saga_handler_lien.go
+++ b/services/payment-order/service/saga_handler_lien.go
@@ -127,15 +127,16 @@ func buildInitiateLienRequest(p createLienParams, bucketID string, logger *slog.
 
 // buildCreateLienResult constructs the handler result map from a successful lien response.
 func buildCreateLienResult(resp *currentaccountv1.InitiateLienResponse, bucketID string) map[string]any {
-	result := map[string]any{
-		"lien_id":   resp.Lien.LienId,
-		"bucket_id": bucketID,
-		"status":    "ACTIVE",
-	}
+	var valuationAnalysis any
 	if basis := resp.GetBasis(); basis != nil {
-		result["valuation_analysis"] = currentaccountclient.ConvertValuationAnalysisToMap(basis)
+		valuationAnalysis = currentaccountclient.ConvertValuationAnalysisToMap(basis)
 	}
-	return result
+	return map[string]any{
+		"lien_id":            resp.Lien.LienId,
+		"bucket_id":          bucketID,
+		"status":             "ACTIVE",
+		"valuation_analysis": valuationAnalysis,
+	}
 }
 
 // executeLienHandler creates a handler for the payment_order.execute_lien step.

--- a/services/payment-order/service/saga_handler_lien_test.go
+++ b/services/payment-order/service/saga_handler_lien_test.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"testing"
+
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCreateLienResult_ValuationAnalysisKeyAlwaysPresent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil basis includes valuation_analysis key with nil value", func(t *testing.T) {
+		resp := &currentaccountv1.InitiateLienResponse{
+			Lien: &currentaccountv1.Lien{LienId: "lien-123"},
+		}
+
+		result := buildCreateLienResult(resp, "bucket-1")
+
+		require.Contains(t, result, "valuation_analysis", "valuation_analysis key must always be present")
+		assert.Nil(t, result["valuation_analysis"])
+		assert.Equal(t, "lien-123", result["lien_id"])
+		assert.Equal(t, "bucket-1", result["bucket_id"])
+		assert.Equal(t, "ACTIVE", result["status"])
+	})
+
+	t.Run("non-nil basis populates valuation_analysis", func(t *testing.T) {
+		resp := &currentaccountv1.InitiateLienResponse{
+			Lien: &currentaccountv1.Lien{LienId: "lien-456"},
+			Basis: &currentaccountv1.ValuationAnalysis{
+				MethodId: "spot-rate",
+			},
+		}
+
+		result := buildCreateLienResult(resp, "")
+
+		require.Contains(t, result, "valuation_analysis", "valuation_analysis key must always be present")
+		assert.NotNil(t, result["valuation_analysis"])
+		analysis, ok := result["valuation_analysis"].(map[string]any)
+		require.True(t, ok, "valuation_analysis should be a map[string]any when basis is set")
+		assert.Equal(t, "spot-rate", analysis["method_id"])
+	})
+}

--- a/services/payment-order/service/server.go
+++ b/services/payment-order/service/server.go
@@ -32,6 +32,7 @@ var (
 	ErrCurrentAccountClientNil      = errors.New("current account client cannot be nil")
 	ErrFinancialAccountingClientNil = errors.New("financial accounting client cannot be nil")
 	ErrInternalAccountClientNil     = errors.New("internal account client cannot be nil when internal clearing is enabled")
+	ErrReferenceDataClientNil       = errors.New("reference data client cannot be nil when saga orchestration is enabled")
 	ErrPaymentGatewayNil            = errors.New("payment gateway cannot be nil")
 	ErrGatewayAccountConfigNil      = errors.New("gateway account config cannot be nil")
 	ErrIdempotencyServiceNil        = errors.New("idempotency service cannot be nil")
@@ -383,6 +384,9 @@ func validateServiceConfig(cfg Config) error {
 	}
 	if cfg.InternalClearingEnabled && cfg.InternalAccountClient == nil {
 		return ErrInternalAccountClientNil
+	}
+	if cfg.SagaOrchestrationEnabled && cfg.ReferenceDataClient == nil {
+		return ErrReferenceDataClientNil
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- **Task 6**: `buildCreateLienResult` now always includes the `valuation_analysis` key in the result map. Previously the key was conditionally present only when a `Basis` was returned by the lien response; callers accessing it unconditionally would fail. Now uses `nil` when no analysis is available.
- **Task 7**: `validateServiceConfig` now rejects a `nil` `ReferenceDataClient` when `SagaOrchestrationEnabled` is `true`. The client is required for bucket-aware solvency evaluation in saga handlers; failing fast at construction is safer than a runtime nil-dereference.

## Changes

- `services/payment-order/service/saga_handler_lien.go` - unconditional `valuation_analysis` key
- `services/payment-order/service/saga_handler_lien_test.go` - new unit tests for nil and non-nil basis
- `services/payment-order/service/server.go` - `ErrReferenceDataClientNil` error + validation guard
- `services/payment-order/service/grpc_service_test.go` - new test case for the new validation

## Test plan

- [ ] `TestBuildCreateLienResult_ValuationAnalysisKeyAlwaysPresent` covers nil and non-nil basis
- [ ] `TestNewServiceWithConfig/saga_orchestration_enabled_with_nil_reference_data_client_returns_error` covers config validation
- [ ] Existing `TestNewServiceWithConfig` table tests remain green