### PR TITLE
fix: deduplicate ledger entries before summing totals in stripe reconciliation

### DIFF
--- a/services/control-plane/internal/stripe/reconciliation.go
+++ b/services/control-plane/internal/stripe/reconciliation.go
@@ -159,7 +159,9 @@ func buildChargeIndex(charges []ChargeRecord) (map[string]*ChargeRecord, []strin
 }
 
 // fetchAndIndexLedgerEntries fetches ledger entries matching chargeIDs and builds a lookup map.
-// Returns the map, raw entry count (pre-deduplication), total cents, and any error.
+// Returns the map, deduplicated entry count (len of map), total cents summed from deduplicated
+// entries, and any error. If the ledger source returns multiple entries with the same
+// ExternalReferenceID, only the last is retained and only one amount is counted.
 func (s *ReconciliationService) fetchAndIndexLedgerEntries(ctx context.Context, chargeIDs []string) (map[string]*LedgerRecord, int, int64, error) {
 	if len(chargeIDs) == 0 {
 		return make(map[string]*LedgerRecord), 0, 0, nil
@@ -169,12 +171,14 @@ func (s *ReconciliationService) fetchAndIndexLedgerEntries(ctx context.Context, 
 		return nil, 0, 0, fmt.Errorf("failed to fetch ledger entries: %w", err)
 	}
 	ledgerMap := make(map[string]*LedgerRecord, len(ledgerEntries))
-	var totalCents int64
 	for i := range ledgerEntries {
 		ledgerMap[ledgerEntries[i].ExternalReferenceID] = &ledgerEntries[i]
-		totalCents += ledgerEntries[i].AmountCents
 	}
-	return ledgerMap, len(ledgerEntries), totalCents, nil
+	var totalCents int64
+	for _, entry := range ledgerMap {
+		totalCents += entry.AmountCents
+	}
+	return ledgerMap, len(ledgerMap), totalCents, nil
 }
 
 // findMissingEntries identifies charges missing in ledger and ledger entries missing in Stripe.

--- a/services/control-plane/internal/stripe/reconciliation_test.go
+++ b/services/control-plane/internal/stripe/reconciliation_test.go
@@ -256,6 +256,35 @@ func TestReconciliation_BothThresholdsExceeded(t *testing.T) {
 	assert.Contains(t, report.AlertMessage, "relative variance")
 }
 
+func TestReconciliation_DuplicateLedgerEntries(t *testing.T) {
+	// If ListEntriesByExternalRef returns duplicate ExternalReferenceIDs, the map
+	// deduplicates them. Both LedgerEntryCount and LedgerTotalCents must reflect
+	// the deduplicated view to avoid phantom variance.
+	svc, err := NewReconciliationService(
+		&mockStripeSource{
+			charges: []ChargeRecord{
+				{ChargeID: "ch_1", AmountCents: 10000, Currency: "gbp"},
+			},
+		},
+		&mockLedgerSource{
+			entries: []LedgerRecord{
+				{LogID: "log-1", ExternalReferenceID: "ch_1", AmountCents: 10000, Currency: "gbp"},
+				{LogID: "log-2", ExternalReferenceID: "ch_1", AmountCents: 10000, Currency: "gbp"}, // duplicate ref
+			},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	report, err := svc.RunDailyReconciliation(context.Background(), time.Now())
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, report.LedgerEntryCount, "deduplicated count should be 1")
+	assert.Equal(t, int64(10000), report.LedgerTotalCents, "total must not double-count duplicate entries")
+	assert.Equal(t, int64(0), report.VarianceCents)
+	assert.Empty(t, report.MissingInLedger)
+}
+
 func TestAbs(t *testing.T) {
 	assert.Equal(t, int64(5), abs(5))
 	assert.Equal(t, int64(5), abs(-5))


### PR DESCRIPTION
## Summary

- `fetchAndIndexLedgerEntries` was summing `totalCents` over the raw `ledgerEntries` slice before deduplication into the map
- If `ListEntriesByExternalRef` returns multiple entries with the same `ExternalReferenceID`, the map retains only the last entry, but the total was counting all of them - inflating `LedgerTotalCents` and producing phantom variance
- `LedgerEntryCount` similarly reported the raw slice length rather than the deduplicated map size

## Changes Made

- Moved `totalCents` accumulation to iterate over `ledgerMap` values (post-deduplication) instead of `ledgerEntries`
- Changed the returned count from `len(ledgerEntries)` to `len(ledgerMap)`
- Updated the function comment to document the deduplicated semantics

## Testing

- Added `TestReconciliation_DuplicateLedgerEntries` covering the case where the ledger source returns two entries with the same `ExternalReferenceID` - verifies count is 1 and total is not double-counted
- All existing tests continue to pass