### PR TITLE
fix: remove duplicate pool.Close, dead constant, and log severity mismatch

### DIFF
--- a/services/control-plane/cmd/main.go
+++ b/services/control-plane/cmd/main.go
@@ -77,7 +77,6 @@ func run(logger *slog.Logger) error {
 	if err != nil {
 		return err
 	}
-	defer pool.Close()
 
 	// Build gRPC server with auth and RBAC interceptors
 	grpcServer, err := buildGRPCServer(ctx, tracer, logger)

--- a/services/current-account/service/valuation_engine.go
+++ b/services/current-account/service/valuation_engine.go
@@ -81,7 +81,6 @@ var (
 
 // Valuation operation status constants for metrics
 const (
-	opStatusValuationEngineNil     = "valuation_engine_nil"
 	opStatusNoValuationFeature     = "no_valuation_feature"
 	opStatusValuationFailed        = "valuation_failed"
 	opStatusInvalidInputAmount     = "invalid_input_amount"

--- a/services/event-router/internal/handlers/saga_dispatch_handler.go
+++ b/services/event-router/internal/handlers/saga_dispatch_handler.go
@@ -210,7 +210,7 @@ func (h *SagaDispatchHandler) evaluateFilter(
 
 	if evalErr != nil {
 		observability.RecordFilterEvaluationError(sagaName)
-		h.logger.ErrorContext(ctx, "CEL filter evaluation error, skipping saga",
+		h.logger.WarnContext(ctx, "CEL filter evaluation error, skipping saga",
 			"saga_name", sagaName,
 			"channel", channel,
 			"correlation_id", correlationID,


### PR DESCRIPTION
## Summary

Three minor code quality fixes across separate services:

- **control-plane**: Remove duplicate `defer pool.Close()` in `run()`. The pool lifecycle is already managed by `startAndServe` via the shutdown orchestrator cleanup callback — the deferred call in `run()` would close the pool a second time on return.
- **current-account**: Remove unused constant `opStatusValuationEngineNil` from `valuation_engine.go`. No references found outside the definition.
- **event-router**: Downgrade CEL filter evaluation error log from `logger.ErrorContext` to `logger.WarnContext`. Skipping a saga due to a CEL evaluation error is graceful degradation — the system handles it without impact to other sagas — making Warn the appropriate severity.

## Changes Made

- `services/control-plane/cmd/main.go`: Remove `defer pool.Close()` (line 80)
- `services/current-account/service/valuation_engine.go`: Remove `opStatusValuationEngineNil` constant
- `services/event-router/internal/handlers/saga_dispatch_handler.go`: `ErrorContext` → `WarnContext` for CEL filter evaluation error

## Testing

All three services build cleanly. No new tests required — these are pure cleanup changes with no behavioral impact.