### PR TITLE
fix: return 503 with Retry-After when OIDC state store is full

### DIFF
--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -363,6 +363,20 @@ func (h *OIDCHandler) validateAuthorizeClient(clientID, redirectURI string) (str
 	return registered, ""
 }
 
+// writeDexRedirectError writes the appropriate HTTP error for a buildDexRedirect failure.
+// errOIDCStateFull is transient backpressure and returns 503 with Retry-After: 30;
+// all other errors return 500.
+func (h *OIDCHandler) writeDexRedirectError(w http.ResponseWriter, err error) {
+	if errors.Is(err, errOIDCStateFull) {
+		h.logger.Warn("oidc: state store at capacity, rejecting new authorization request")
+		w.Header().Set("Retry-After", "30")
+		http.Error(w, "service temporarily unavailable, retry later", http.StatusServiceUnavailable)
+		return
+	}
+	h.logger.Error("oidc: failed to build Dex redirect", "error", err)
+	http.Error(w, "internal server error", http.StatusInternalServerError)
+}
+
 // HandleAuthorize handles GET /oauth/authorize from the MCP client.
 // It stores the MCP client's PKCE state and redirects to Dex for authentication.
 func (h *OIDCHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
@@ -414,14 +428,7 @@ func (h *OIDCHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 	// Store OIDC flow state and redirect to Dex for authentication.
 	redirectURL, err := h.buildDexRedirect(challenge, clientID, redirectURI, q.Get("state"), tenantSlug)
 	if err != nil {
-		if errors.Is(err, errOIDCStateFull) {
-			h.logger.Warn("oidc: state store at capacity, rejecting new authorization request")
-			w.Header().Set("Retry-After", "30")
-			http.Error(w, "service temporarily unavailable, retry later", http.StatusServiceUnavailable)
-			return
-		}
-		h.logger.Error("oidc: failed to build Dex redirect", "error", err)
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		h.writeDexRedirectError(w, err)
 		return
 	}
 

--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -414,6 +414,12 @@ func (h *OIDCHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 	// Store OIDC flow state and redirect to Dex for authentication.
 	redirectURL, err := h.buildDexRedirect(challenge, clientID, redirectURI, q.Get("state"), tenantSlug)
 	if err != nil {
+		if errors.Is(err, errOIDCStateFull) {
+			h.logger.Warn("oidc: state store at capacity, rejecting new authorization request")
+			w.Header().Set("Retry-After", "30")
+			http.Error(w, "service temporarily unavailable, retry later", http.StatusServiceUnavailable)
+			return
+		}
 		h.logger.Error("oidc: failed to build Dex redirect", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return

--- a/services/mcp-server/internal/auth/oidc_state_full_test.go
+++ b/services/mcp-server/internal/auth/oidc_state_full_test.go
@@ -1,0 +1,71 @@
+package auth_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/auth"
+	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleAuthorize_StateStoreFull verifies that when the in-flight OIDC
+// state store is at capacity, HandleAuthorize returns 503 Service Unavailable
+// with a Retry-After: 30 header instead of a generic 500.
+//
+// Backpressure from a full store is a transient condition — clients should
+// retry, not treat it as a permanent failure.
+func TestHandleAuthorize_StateStoreFull(t *testing.T) {
+	dexSrv := fakeDexServer(t, "user@example.com")
+	signer, err := platformauth.NewJWTSigner(platformauth.JWTSignerConfig{})
+	require.NoError(t, err)
+
+	stateStore := auth.NewOIDCStateStore()
+	t.Cleanup(stateStore.Close)
+
+	handler, err := auth.NewOIDCHandler(auth.OIDCHandlerConfig{
+		OIDC: auth.OIDCConfig{
+			DexIssuerURL: dexSrv.URL + "/dex",
+			ClientID:     "meridian-service",
+			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
+		},
+		OAuth: auth.OAuthConfig{
+			ClientID:    "meridian-mcp",
+			RedirectURI: "https://claude.ai/callback",
+		},
+		DefaultTenantSlug: "acme",
+		StateStore:        stateStore,
+		CodeStore:         newTestStore(t),
+		Signer:            signer,
+		Logger:            slog.Default(),
+	})
+	require.NoError(t, err)
+
+	// Fill the state store to capacity via the public API.
+	for i := 0; i < 10_000; i++ {
+		_, err := stateStore.Store(auth.OIDCFlowState{IssuedAt: time.Now()})
+		require.NoError(t, err, "expected store to accept entry %d", i)
+	}
+	// One more should fail — but we rely on the handler returning 503.
+
+	_, challenge := generatePKCEPair(t)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?"+url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"meridian-mcp"},
+		"redirect_uri":          {"https://claude.ai/callback"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+	}.Encode(), nil)
+	w := httptest.NewRecorder()
+	handler.HandleAuthorize(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Equal(t, "30", w.Header().Get("Retry-After"))
+}


### PR DESCRIPTION
## Summary
- `errOIDCStateFull` in `HandleAuthorize` was caught by the generic error handler and returned 500
- A full state store is transient backpressure, not an internal server error
- Now returns 503 Service Unavailable with `Retry-After: 30` so clients know to retry

## Changes Made
- `services/mcp-server/internal/auth/oidc.go`: Added specific `errors.Is(err, errOIDCStateFull)` check before the generic error fallback in `HandleAuthorize`, returning 503 with `Retry-After: 30` header
- `services/mcp-server/internal/auth/oidc_state_full_test.go`: New test that fills the state store to capacity (10,000 entries) and asserts 503 + `Retry-After: 30`

## Test plan
- [ ] `TestHandleAuthorize_StateStoreFull` passes (fills store to 10,000 entries, asserts 503 + Retry-After: 30)
- [ ] All existing `mcp-server` tests continue to pass