### PR TITLE
fix: market-information dataset pagination validation and status error mapping

### DIFF
--- a/services/market-information/service/dataset_service.go
+++ b/services/market-information/service/dataset_service.go
@@ -380,6 +380,9 @@ func (s *Server) buildDataSetFilters(req *pb.ListDataSetsRequest) (domain.DataSe
 	}
 
 	pageSize := int(req.PageSize)
+	if pageSize < 0 {
+		return filters, status.Errorf(codes.InvalidArgument, "page_size must not be negative")
+	}
 	if pageSize == 0 {
 		pageSize = 50
 	}
@@ -494,6 +497,8 @@ func mapDataSetValidationError(err error) error {
 		return status.Errorf(codes.InvalidArgument, "resolution_key_expression is required")
 	case errors.Is(err, domain.ErrInvalidDataCategory):
 		return status.Errorf(codes.InvalidArgument, "invalid data category")
+	case errors.Is(err, domain.ErrInvalidDataSetStatus):
+		return status.Errorf(codes.InvalidArgument, "invalid dataset status")
 	default:
 		return nil
 	}

--- a/services/market-information/service/dataset_service_unhappy_test.go
+++ b/services/market-information/service/dataset_service_unhappy_test.go
@@ -311,6 +311,20 @@ func TestListDataSets_Pagination(t *testing.T) {
 
 	ctx := context.Background()
 
+	t.Run("rejects negative page size", func(t *testing.T) {
+		listReq := &pb.ListDataSetsRequest{
+			PageSize: -1,
+		}
+
+		_, err := server.ListDataSets(ctx, listReq)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "page_size")
+	})
+
 	t.Run("caps page size at maximum", func(t *testing.T) {
 		listReq := &pb.ListDataSetsRequest{
 			PageSize: 500, // Exceeds max of 100
@@ -366,6 +380,7 @@ func TestMapDataSetDomainError(t *testing.T) {
 		{"validation expr required", domain.ErrValidationExpressionRequired, codes.InvalidArgument},
 		{"resolution key expr required", domain.ErrResolutionKeyExpressionRequired, codes.InvalidArgument},
 		{"invalid category", domain.ErrInvalidDataCategory, codes.InvalidArgument},
+		{"invalid status", domain.ErrInvalidDataSetStatus, codes.InvalidArgument},
 		{"unknown error", errors.New("some unknown error"), codes.Internal},
 	}
 


### PR DESCRIPTION
## Summary

- Reject negative `PageSize` values in `ListDataSets` with `codes.InvalidArgument` (previously accepted, causing undefined behavior)
- Add missing `ErrInvalidDataSetStatus` case to `mapDataSetValidationError` — was falling through to `codes.Internal` instead of `codes.InvalidArgument`

## Changes Made

**`services/market-information/service/dataset_service.go`**
- Added `pageSize < 0` guard before the default/cap logic in `buildDataSetFilters`
- Added `case errors.Is(err, domain.ErrInvalidDataSetStatus)` to `mapDataSetValidationError`

**`services/market-information/service/dataset_service_unhappy_test.go`**
- Added `rejects negative page size` subtest to `TestListDataSets_Pagination`
- Added `invalid status` test case to `TestMapDataSetDomainError`

## Testing

All new and existing tests pass:
- `TestListDataSets_Pagination/rejects_negative_page_size` ✓
- `TestMapDataSetDomainError/invalid_status` ✓