### PR TITLE
fix: preserve correlation ID in withdrawal events and guard uncompiled eligibility

### DIFF
--- a/services/current-account/service/grpc_withdrawal_execute.go
+++ b/services/current-account/service/grpc_withdrawal_execute.go
@@ -16,6 +16,7 @@ import (
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/platform/events"
 	"github.com/meridianhub/meridian/shared/platform/events/topics"
+	"github.com/meridianhub/meridian/shared/platform/observability"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -315,7 +316,8 @@ func (s *Service) completeWithdrawalWithOutbox(ctx context.Context, withdrawal *
 	}
 
 	// Create and marshal event payload
-	eventPayload, err := buildWithdrawalStatusEvent(withdrawal, accountID)
+	correlationID := observability.GetCorrelationID(ctx)
+	eventPayload, err := buildWithdrawalStatusEvent(withdrawal, accountID, correlationID)
 	if err != nil {
 		return err
 	}
@@ -365,14 +367,14 @@ func (s *Service) completeWithdrawalDirect(ctx context.Context, withdrawal *doma
 }
 
 // buildWithdrawalStatusEvent creates and marshals a WithdrawalStatusUpdatedEvent.
-func buildWithdrawalStatusEvent(withdrawal *domain.Withdrawal, accountID uuid.UUID) ([]byte, error) {
+func buildWithdrawalStatusEvent(withdrawal *domain.Withdrawal, accountID uuid.UUID, correlationID string) ([]byte, error) {
 	now := time.Now().UTC()
 	event := &eventsv1.WithdrawalStatusUpdatedEvent{
 		EventId:       uuid.New().String(),
 		WithdrawalId:  withdrawal.Reference,
 		AccountId:     accountID.String(),
 		Status:        "COMPLETED",
-		CorrelationId: uuid.New().String(),
+		CorrelationId: correlationID,
 		CausationId:   withdrawal.Reference,
 		Timestamp:     timestamppb.New(now),
 		Version:       int64(withdrawal.Version),

--- a/services/current-account/service/grpc_withdrawal_execute.go
+++ b/services/current-account/service/grpc_withdrawal_execute.go
@@ -317,6 +317,9 @@ func (s *Service) completeWithdrawalWithOutbox(ctx context.Context, withdrawal *
 
 	// Create and marshal event payload
 	correlationID := observability.GetCorrelationID(ctx)
+	if correlationID == "" {
+		correlationID = uuid.New().String()
+	}
 	eventPayload, err := buildWithdrawalStatusEvent(withdrawal, accountID, correlationID)
 	if err != nil {
 		return err

--- a/services/current-account/service/grpc_withdrawal_execute.go
+++ b/services/current-account/service/grpc_withdrawal_execute.go
@@ -13,6 +13,7 @@ import (
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	caobservability "github.com/meridianhub/meridian/services/current-account/observability"
+	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/platform/events"
 	"github.com/meridianhub/meridian/shared/platform/events/topics"
@@ -73,6 +74,13 @@ func (s *Service) ExecuteWithdrawal(ctx context.Context, req *pb.ExecuteWithdraw
 			}
 		}()
 	}
+
+	// Extract correlation ID from context/metadata and seed it so all downstream calls share the same trace
+	correlationID := sharedclients.ExtractCorrelationID(ctx)
+	if correlationID == "" {
+		correlationID = uuid.New().String()
+	}
+	ctx = observability.WithCorrelationID(ctx, correlationID)
 
 	// Retrieve and prepare account for withdrawal
 	account, amount, transactionID, opStatus, err := s.prepareAccountForWithdrawal(ctx, accountID, reqAmount)
@@ -315,12 +323,8 @@ func (s *Service) completeWithdrawalWithOutbox(ctx context.Context, withdrawal *
 		return s.completeWithdrawalDirect(ctx, withdrawal)
 	}
 
-	// Create and marshal event payload
-	correlationID := observability.GetCorrelationID(ctx)
-	if correlationID == "" {
-		correlationID = uuid.New().String()
-	}
-	eventPayload, err := buildWithdrawalStatusEvent(withdrawal, accountID, correlationID)
+	// Create and marshal event payload (correlation ID is seeded at handler level)
+	eventPayload, err := buildWithdrawalStatusEvent(withdrawal, accountID, observability.GetCorrelationID(ctx))
 	if err != nil {
 		return err
 	}

--- a/services/current-account/service/validators.go
+++ b/services/current-account/service/validators.go
@@ -151,6 +151,10 @@ func (s *Service) validateProductTypeConstraints(
 	attributes map[string]string,
 	productTypeCode, accountID string,
 ) (string, error) {
+	if cachedType.Definition.EligibilityCEL != "" && cachedType.EligibilityProgram == nil {
+		return "eligibility_not_compiled",
+			status.Errorf(codes.Internal, "eligibility rule is configured but not compiled for product type %s", productTypeCode)
+	}
 	if cachedType.EligibilityProgram != nil {
 		if opStatus, err := s.checkEligibility(ctx, cachedType, partyID, attributes, productTypeCode, accountID); err != nil {
 			return opStatus, err

--- a/services/current-account/service/validators_test.go
+++ b/services/current-account/service/validators_test.go
@@ -12,6 +12,7 @@ import (
 	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	quantitypb "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
 	"github.com/meridianhub/meridian/services/current-account/domain"
+	"github.com/meridianhub/meridian/services/reference-data/accounttype"
 	"github.com/meridianhub/meridian/services/reference-data/cache"
 	"github.com/meridianhub/meridian/services/reference-data/registry"
 	"github.com/stretchr/testify/assert"
@@ -495,3 +496,30 @@ func (m *getPartyErrorClient) GetParty(_ context.Context, _ string) (*partyv1.Pa
 	return nil, m.err
 }
 func (m *getPartyErrorClient) Close() error { return nil }
+
+// ---------------------------------------------------------------------------
+// validateProductTypeConstraints
+// ---------------------------------------------------------------------------
+
+func TestValidateProductTypeConstraints_EligibilityCELWithNilProgram(t *testing.T) {
+	svc := &Service{
+		logger: validatorsTestLogger(),
+	}
+
+	def := &accounttype.Definition{
+		EligibilityCEL: `party.type == "PERSON"`,
+	}
+	cachedType := &CachedAccountType{
+		Definition:         def,
+		EligibilityProgram: nil,
+	}
+
+	opStatus, err := svc.validateProductTypeConstraints(context.Background(), cachedType, "party-1", nil, "SAVINGS", "test-account")
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok, "expected gRPC status error")
+	assert.Equal(t, codes.Internal, st.Code())
+	assert.Contains(t, st.Message(), "eligibility rule is configured but not compiled")
+	assert.Equal(t, "eligibility_not_compiled", opStatus)
+}


### PR DESCRIPTION
## Summary

- Pass existing correlation ID from context into `buildWithdrawalStatusEvent` instead of generating a new UUID, preserving distributed trace continuity across the withdrawal saga
- Guard against silent eligibility bypass in `validateProductTypeConstraints`: return `Internal` error when `EligibilityCEL` is non-empty but `EligibilityProgram` is nil (CEL compiler not configured)

## Changes Made

**`services/current-account/service/grpc_withdrawal_execute.go`**
- Added `"github.com/meridianhub/meridian/shared/platform/observability"` import
- Changed `buildWithdrawalStatusEvent` signature to accept `correlationID string`
- Call site in `completeWithdrawalWithOutbox` now extracts correlation ID via `observability.GetCorrelationID(ctx)`

**`services/current-account/service/validators.go`**
- Added guard before the existing `EligibilityProgram != nil` check: if `Definition.EligibilityCEL != ""` and `EligibilityProgram == nil`, return `codes.Internal` with `"eligibility_not_compiled"` op status

**`services/current-account/service/validators_test.go`**
- Added `TestValidateProductTypeConstraints_EligibilityCELWithNilProgram` covering the new guard path

## Testing

All existing eligibility and withdrawal tests pass. New test verifies the error path.

## Addresses

CodeRabbit review comments on PR #2028 (lines 386 and 158).