### PR TITLE
chore: fix import group ordering in api-gateway cmd/main.go

### DIFF
--- a/services/api-gateway/cmd/main.go
+++ b/services/api-gateway/cmd/main.go
@@ -6,10 +6,14 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 	"net/url"
+	"os"
 	"strings"
 	"time"
+
+	"github.com/redis/go-redis/v9"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
 
 	gateway "github.com/meridianhub/meridian/services/api-gateway"
 	"github.com/meridianhub/meridian/services/api-gateway/eventstream"
@@ -22,9 +26,6 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
 	"github.com/meridianhub/meridian/shared/platform/db"
 	"github.com/meridianhub/meridian/shared/platform/env"
-	"github.com/redis/go-redis/v9"
-	"gorm.io/driver/postgres"
-	"gorm.io/gorm"
 )
 
 // ErrRedisURLRequired is returned when Redis fan-out is enabled but no REDIS_URL is configured.


### PR DESCRIPTION
## Summary

- Restores correct import group ordering in `services/api-gateway/cmd/main.go`
- Separates third-party imports (`github.com/redis/go-redis/v9`, `gorm.io/*`) into their own group between stdlib and internal imports
- Fixes alphabetical ordering of stdlib imports (`net/url` before `os`)

## Context

The import ordering was broken during the merge of #2034. The `goimports -local "github.com/meridianhub/meridian"` convention requires three groups: stdlib, third-party, internal. Additionally, `gofmt` requires stdlib imports to be alphabetically ordered.

## Test plan

- CI golangci-lint passes (gofmt + goimports + gofumpt)