### PR TITLE
fix: Stabilize flaky FetchDispatchable nightly test

### DIFF
--- a/services/operational-gateway/adapters/persistence/instruction_repository_test.go
+++ b/services/operational-gateway/adapters/persistence/instruction_repository_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/services/operational-gateway/domain"
 	"github.com/meridianhub/meridian/services/operational-gateway/ports"
+	"github.com/meridianhub/meridian/shared/platform/await"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
@@ -212,12 +213,22 @@ func TestInstructionRepository_FetchDispatchable_RespectsScheduledAt(t *testing.
 	ready := makeInstruction(t, tenantID, connID.String(), domain.PriorityNormal)
 	require.NoError(t, repo.Save(ctx, ready, fmt.Sprintf("idem-%s", ready.ID)))
 
-	results, err := repo.FetchDispatchable(ctx, ports.FetchDispatchableParams{
-		Limit: 10,
-		AsOf:  time.Now(),
-	})
-	require.NoError(t, err)
-	require.Len(t, results, 1)
+	// CockroachDB's FOR UPDATE SKIP LOCKED under READ COMMITTED may skip rows
+	// with unresolved write intents from recently-committed transactions.
+	// Retry until the intent is resolved and the row becomes visible.
+	var results []*domain.Instruction
+	err = await.New().
+		AtMost(5 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			var fetchErr error
+			results, fetchErr = repo.FetchDispatchable(ctx, ports.FetchDispatchableParams{
+				Limit: 10,
+				AsOf:  time.Now(),
+			})
+			return fetchErr == nil && len(results) == 1
+		})
+	require.NoError(t, err, "expected 1 dispatchable instruction within timeout")
 	assert.Equal(t, ready.ID, results[0].ID)
 }
 


### PR DESCRIPTION
## Summary
- `TestInstructionRepository_FetchDispatchable_RespectsScheduledAt` failed in the 03/30 nightly
- Root cause: CockroachDB's `FOR UPDATE SKIP LOCKED` under `READ COMMITTED` can skip rows with unresolved write intents from recently-committed transactions
- Fix: wrap the FetchDispatchable assertion in `await.Until` (project standard for async DB operations)

## Evidence
- Failing nightly run: https://github.com/meridianhub/meridian/actions/runs/23728416500
- Error: `"[]" should have 1 item(s), but has 0` at `instruction_repository_test.go:220`

## Technical Detail
The test inserts two instructions (one future-scheduled, one ready) then immediately calls `FetchDispatchable`. Under CockroachDB's `SKIP LOCKED`, rows with unresolved write intents from the just-committed `Save()` transactions may be skipped. The `await.Until` retries with 50ms intervals (5s timeout) until CockroachDB resolves the intent and the row becomes visible to the lock query.