### PR TITLE
fix: add migration files and control-plane DB to unified Dockerfile

### DIFF
--- a/cmd/meridian/Dockerfile
+++ b/cmd/meridian/Dockerfile
@@ -59,6 +59,19 @@ COPY --from=builder /build/mcp-server /mcp-server
 # Copy manifest files for seed-dev
 COPY --from=builder /build/examples/manifests/ /app/examples/manifests/
 
+# Copy service migrations for tenant provisioning (read from /migrations/ by provisioner)
+COPY --from=builder /build/services/party/migrations /migrations/party
+COPY --from=builder /build/services/current-account/migrations /migrations/current-account
+COPY --from=builder /build/services/position-keeping/migrations /migrations/position-keeping
+COPY --from=builder /build/services/financial-accounting/migrations /migrations/financial-accounting
+COPY --from=builder /build/services/payment-order/migrations /migrations/payment-order
+COPY --from=builder /build/services/market-information/migrations /migrations/market-information
+COPY --from=builder /build/services/reference-data/migrations /migrations/reference-data
+COPY --from=builder /build/services/internal-account/migrations /migrations/internal-account
+COPY --from=builder /build/services/reconciliation/migrations /migrations/reconciliation
+COPY --from=builder /build/services/identity/migrations /migrations/identity
+COPY --from=builder /build/services/control-plane/migrations /migrations/control-plane
+
 # Copy saga assets for Starlark saga execution (deposit, withdrawal scripts + handlers schema)
 COPY --from=builder /build/services/reference-data/saga/defaults/ /app/services/reference-data/saga/defaults/
 COPY --from=builder /build/shared/pkg/saga/schema/handlers.yaml /app/shared/pkg/saga/schema/handlers.yaml

--- a/deploy/demo/init-databases.sql
+++ b/deploy/demo/init-databases.sql
@@ -16,3 +16,4 @@ CREATE DATABASE meridian_reference_data;
 CREATE DATABASE meridian_identity;
 CREATE DATABASE meridian_operational_gateway;
 CREATE DATABASE meridian_financial_gateway;
+CREATE DATABASE meridian_control_plane;

--- a/deploy/develop/init-databases-develop.sql
+++ b/deploy/develop/init-databases-develop.sql
@@ -19,3 +19,4 @@ CREATE DATABASE meridian_reference_data;
 CREATE DATABASE meridian_identity;
 CREATE DATABASE meridian_operational_gateway;
 CREATE DATABASE meridian_financial_gateway;
+CREATE DATABASE meridian_control_plane;


### PR DESCRIPTION
## Summary

- The unified binary Dockerfile (`cmd/meridian/Dockerfile`) was missing COPY lines for service migration SQL files. The tenant provisioner reads these from `/migrations/` at runtime to apply per-tenant schema migrations during tenant provisioning, but only the standalone tenant service Dockerfile (`services/tenant/cmd/Dockerfile`) had them.
- Also adds `meridian_control_plane` to `init-databases.sql` for demo and develop environments (was missing since PR #2001 added control-plane to the provisioner service list)

## Changes Made

- Copy all 11 service migration directories to `/migrations/` in the runtime image
- Add `CREATE DATABASE meridian_control_plane` to both init-databases scripts

## Test plan

- [ ] Deploy Demo workflow succeeds (bootstrap + seed steps pass)
- [ ] Tenant schemas created with manifest_version table