### PR TITLE
fix: align control-plane platform_saga_definition with reference-data schema

### DIFF
--- a/services/control-plane/migrations/20260330000001_align_platform_saga_definition_columns.sql
+++ b/services/control-plane/migrations/20260330000001_align_platform_saga_definition_columns.sql
@@ -1,0 +1,34 @@
+-- Align platform_saga_definition with reference-data evolved schema.
+--
+-- The reference-data service evolved platform_saga_definition through multiple
+-- migrations (Jan 2026) adding:
+--   - status CHECK constraint (missing from initial migration)
+--   - previous_version: version chain linkage for audit trail
+--   - valid_from / valid_to: bitemporal tracking for historical replay queries
+--
+-- The control-plane copy was created in March 2026 without these columns.
+-- This migration brings the control-plane copy into schema parity so that
+-- both copies of the table have the same structure.
+--
+-- Constraints and indexes on the new columns are added in the next migration
+-- (20260330000002) because CockroachDB cannot create partial indexes on columns
+-- added in the same schema change batch.
+
+-- Add CHECK constraint on existing status column (was missing from initial migration).
+ALTER TABLE public.platform_saga_definition
+  ADD CONSTRAINT chk_platform_saga_definition_status
+    CHECK (status IN ('ACTIVE', 'DEPRECATED'));
+
+-- Add previous_version column for explicit version chain linkage.
+ALTER TABLE public.platform_saga_definition
+  ADD COLUMN IF NOT EXISTS previous_version VARCHAR(16) NULL;
+
+-- Add valid_from: system time when this version became effective.
+-- Default to NOW() so existing rows get a sensible baseline timestamp.
+ALTER TABLE public.platform_saga_definition
+  ADD COLUMN IF NOT EXISTS valid_from TIMESTAMPTZ NOT NULL DEFAULT now();
+
+-- Add valid_to: system time when this version was superseded.
+-- NULL means this is the currently active version.
+ALTER TABLE public.platform_saga_definition
+  ADD COLUMN IF NOT EXISTS valid_to TIMESTAMPTZ NULL;

--- a/services/control-plane/migrations/20260330000002_align_platform_saga_definition_constraints.sql
+++ b/services/control-plane/migrations/20260330000002_align_platform_saga_definition_constraints.sql
@@ -1,0 +1,29 @@
+-- Constraints and indexes for platform_saga_definition schema alignment.
+--
+-- Adds constraints and partial indexes on the columns added in the previous
+-- migration (20260330000001). Separated because CockroachDB cannot create
+-- partial indexes on columns added in the same schema change batch.
+
+-- CHECK constraint: previous_version must be semver format or NULL.
+ALTER TABLE public.platform_saga_definition
+  ADD CONSTRAINT chk_platform_saga_definition_previous_version
+    CHECK (previous_version ~ '^[0-9]+\.[0-9]+\.[0-9]+$' OR previous_version IS NULL);
+
+-- CHECK constraint: valid_to must be strictly after valid_from.
+ALTER TABLE public.platform_saga_definition
+  ADD CONSTRAINT chk_platform_saga_definition_validity_range
+    CHECK (valid_to IS NULL OR valid_to > valid_from);
+
+-- Index for finding active versions efficiently.
+CREATE INDEX IF NOT EXISTS idx_platform_saga_definition_name_status
+  ON public.platform_saga_definition (name, status)
+  WHERE status = 'ACTIVE';
+
+-- Index for version chain queries.
+CREATE INDEX IF NOT EXISTS idx_platform_saga_definition_previous_version
+  ON public.platform_saga_definition (name, previous_version)
+  WHERE previous_version IS NOT NULL;
+
+-- Index for point-in-time temporal lookups: "which version was active at time T?"
+CREATE INDEX IF NOT EXISTS idx_platform_saga_definition_temporal_lookup
+  ON public.platform_saga_definition (name, valid_from, valid_to);

--- a/services/control-plane/migrations/atlas.sum
+++ b/services/control-plane/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:5CL8b9ue00jnzxuSge0B/LwnAWVv86o7JJ3HGJTEOq8=
+h1:EOQY2WAL2i9RxoVpQTrJ8w445CgQlY1TbpUEA1xqCWM=
 20260209000001_staff_identity.sql h1:OR9Cq4l2MfrW7It8jLDt0Kzg/z1th9KJdSlZEVpOhqA=
 20260209000002_create_manifest_versions.sql h1:+HzLzVoK1e/nPNN9wb56hb1yxxC9K2I53CpwAks6nCE=
 20260209000004_manifest_apply_jobs.sql h1:nq4MOflgbXAfdltITMKqKWHg9RuUXVs0mrIa2CDkIig=
@@ -8,3 +8,5 @@ h1:5CL8b9ue00jnzxuSge0B/LwnAWVv86o7JJ3HGJTEOq8=
 20260316000003_add_partial_apply_status.sql h1:t3WSSdJv5UCG5ll9lguVXHuhcSKEwvDFJwklDm8b/ZE=
 20260316000004_add_partial_apply_status_constraint.sql h1:R/xxq3z7LkebGaJRw6/02dOANeMW/YlwbLlhAhh9i8g=
 20260317000001_platform_saga_definition.sql h1:f+CQuqVahzjjbNzUsDaYcYpBz5MvUHUOF4qwrrXtbJE=
+20260330000001_align_platform_saga_definition_columns.sql h1:LRJ0XLwdUYXTKWsAXvvQiXWnUMb7QUcvlrKdKG3q5Kk=
+20260330000002_align_platform_saga_definition_constraints.sql h1:Pv0/g8x8AVQYqu+5WmPOQvH1tQjdlnSm/TSEnm5K1mE=


### PR DESCRIPTION
## Summary

- The `platform_saga_definition` table exists in two databases: `meridian_reference_data` (reference-data service) and `meridian_platform` (control-plane service)
- The reference-data copy was evolved through 6 migrations in January 2026, adding `previous_version`, `valid_from`, `valid_to` columns and a `CHECK` constraint on `status`
- The control-plane migration (created March 2026) was based on the original schema and missed these columns - accidental drift

## Changes Made

Two Atlas migrations for the control-plane service following the CockroachDB split-file pattern:

**`20260330000001_align_platform_saga_definition_columns.sql`**
- Adds missing `CHECK (status IN ('ACTIVE', 'DEPRECATED'))` constraint on existing `status` column
- Adds `previous_version VARCHAR(16) NULL` for version chain linkage
- Adds `valid_from TIMESTAMPTZ NOT NULL DEFAULT now()` for bitemporal tracking
- Adds `valid_to TIMESTAMPTZ NULL` for bitemporal tracking

**`20260330000002_align_platform_saga_definition_constraints.sql`**
- `CHECK (previous_version ~ semver format OR NULL)`
- `CHECK (valid_to IS NULL OR valid_to > valid_from)`
- Indexes: `idx_platform_saga_definition_name_status` (partial), `idx_platform_saga_definition_previous_version` (partial), `idx_platform_saga_definition_temporal_lookup`

Separated per CockroachDB requirement: partial indexes cannot be created on columns added in the same migration batch.

## Technical Details

The control-plane's existing code (`Bootstrap.EnsurePlatformSaga`, `ManifestExecutor.resolveSagaScript`) only reads/writes `id`, `name`, `version`, `script`, `status`, `display_name`, `description`. Adding the new nullable columns with defaults does not require any Go code changes - the INSERT statements will use column defaults.

## Risk Assessment

- No Go code changes required
- All new columns have defaults or are nullable - no existing row impact
- `valid_from DEFAULT now()` will assign a timestamp to the existing `apply_manifest` row on migration
- The `status` CHECK constraint validates against existing data (all rows have `status = 'ACTIVE'`)