### PR TITLE
fix: Add docker/docker CVEs to .trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -25,3 +25,15 @@ GHSA-vh7g-p26c-j2cw
 # GO-2024-2476 — Dex TLS config discarding (no upstream fix; not applicable
 # because embedded Dex serves HTTP behind the gateway, Caddy terminates TLS)
 GHSA-gr79-9v6v-gc9r
+
+# docker/docker (Moby) — indirect dependency via testcontainers-go (test only).
+# go mod why confirms main module does not need github.com/docker/docker.
+# No fix available for either CVE.
+
+# CVE-2026-34040 — AuthZ plugin bypass with oversized request bodies
+CVE-2026-34040
+GHSA-x744-4wpc-v9h2
+
+# CVE-2026-33997 — Off-by-one error in plugin privilege validation
+CVE-2026-33997
+GHSA-pxq6-2prw-chj9


### PR DESCRIPTION
## Summary

- Add CVE-2026-34040 (Moby AuthZ plugin bypass) and CVE-2026-33997 (off-by-one in plugin privilege validation) to `.trivyignore`
- Both are indirect dependencies via testcontainers-go (test infrastructure only)
- `go mod why` confirms the main module does not need `github.com/docker/docker`
- No upstream fix available for either CVE

## Context

The Trivy Repository Scan has been failing on all PRs (including develop) because these two docker/docker CVEs were not in `.trivyignore`. The corresponding Dependabot alerts (#31, #32) and code scanning alert (#262) have already been dismissed via the GitHub API with the same justification.

## Test plan

- [ ] Trivy Repository Scan CI check passes on this PR