### PR TITLE
feat: migrate notification.send to correspondence.initiate_outbound

### DIFF
--- a/services/current-account/service/saga_handlers.go
+++ b/services/current-account/service/saga_handlers.go
@@ -168,7 +168,10 @@ func currentAccountCoreHandlers(notifHandler saga.Handler) []handlerEntry {
 		{"current_account.execute_lien", stubNotImplemented("current_account.execute_lien"), nil},
 		{"current_account.terminate_lien", stubNotImplemented("current_account.terminate_lien"), nil},
 
-		// Notification
+		// Correspondence (BIAN-aligned, replaces notification)
+		{"correspondence.initiate_outbound", notifHandler, nil},
+
+		// Deprecated alias for backward compatibility
 		{"notification.send", notifHandler, nil},
 	}
 }

--- a/services/current-account/service/saga_handlers_test.go
+++ b/services/current-account/service/saga_handlers_test.go
@@ -34,6 +34,7 @@ func TestRegisterCurrentAccountHandlers_AllHandlersPresent(t *testing.T) {
 		"current_account.create_lien",
 		"current_account.execute_lien",
 		"current_account.terminate_lien",
+		"correspondence.initiate_outbound",
 	}
 
 	for _, name := range coreHandlers {
@@ -44,7 +45,7 @@ func TestRegisterCurrentAccountHandlers_AllHandlersPresent(t *testing.T) {
 
 	// Verify platform-wide stub handlers are also registered
 	platformStubs := []string{
-		"notification.send",
+		"notification.send", // deprecated alias
 		"payment_order.create_lien",
 		"reconciliation.initiate_run",
 		"party.get_default_payment_method",
@@ -107,7 +108,7 @@ func TestRegisterCurrentAccountHandlers_HandlerCount(t *testing.T) {
 	err := RegisterCurrentAccountHandlers(registry)
 	require.NoError(t, err)
 
-	const expectedCount = 47
+	const expectedCount = 48
 	registered := registry.List()
 	assert.Equal(t, expectedCount, len(registered), "expected %d handlers to be registered, got %d: %v", expectedCount, len(registered), registered)
 }

--- a/services/reference-data/saga/defaults/dunning_escalation/v1.0.0.star
+++ b/services/reference-data/saga/defaults/dunning_escalation/v1.0.0.star
@@ -69,14 +69,14 @@ def dunning_escalation():
 
     billing_run_id = ctx["billing_run_id"]
 
-    # Step 1: Send notification based on escalation level
+    # Step 1: Send correspondence based on escalation level
     if new_level == 1:
         step(name="send_first_notice")
-        notification.send(
-            type="EMAIL",
-            recipient=party_id,
-            template="dunning-notice",
-            data={
+        correspondence.initiate_outbound(
+            channel="EMAIL",
+            recipient_party_id=party_id,
+            template_name="dunning-notice",
+            template_data={
                 "severity": 1,
                 "days_overdue": 0,
                 "amount_cents": amount_cents,
@@ -84,16 +84,17 @@ def dunning_escalation():
                 "invoice_number": invoice_number,
             },
             idempotency_key="dunning-1-" + billing_run_id,
+            category="TRANSACTIONAL",
         )
         result["action_taken"] = "first_notice_sent"
 
     elif new_level == 2:
         step(name="send_second_notice")
-        notification.send(
-            type="EMAIL",
-            recipient=party_id,
-            template="dunning-notice",
-            data={
+        correspondence.initiate_outbound(
+            channel="EMAIL",
+            recipient_party_id=party_id,
+            template_name="dunning-notice",
+            template_data={
                 "severity": 2,
                 "days_overdue": 3,
                 "amount_cents": amount_cents,
@@ -101,23 +102,25 @@ def dunning_escalation():
                 "invoice_number": invoice_number,
             },
             idempotency_key="dunning-2-" + billing_run_id,
+            category="TRANSACTIONAL",
         )
         result["action_taken"] = "second_notice_sent"
 
     elif new_level >= 3:
         # At max dunning level: send final warning, freeze the account, notify
         step(name="send_final_warning")
-        notification.send(
-            type="EMAIL",
-            recipient=party_id,
-            template="dunning-notice",
-            data={
+        correspondence.initiate_outbound(
+            channel="EMAIL",
+            recipient_party_id=party_id,
+            template_name="dunning-notice",
+            template_data={
                 "severity": 3,
                 "amount_cents": amount_cents,
                 "currency": currency,
                 "invoice_number": invoice_number,
             },
             idempotency_key="dunning-3-" + billing_run_id,
+            category="TRANSACTIONAL",
         )
 
         # Step 2: Freeze the account at max dunning level
@@ -134,16 +137,17 @@ def dunning_escalation():
 
         # Send freeze notification
         step(name="send_freeze_notice")
-        notification.send(
-            type="EMAIL",
-            recipient=party_id,
-            template="account-frozen",
-            data={
+        correspondence.initiate_outbound(
+            channel="EMAIL",
+            recipient_party_id=party_id,
+            template_name="account-frozen",
+            template_data={
                 "amount_cents": amount_cents,
                 "currency": currency,
                 "invoice_number": invoice_number,
             },
             idempotency_key="dunning-frozen-" + billing_run_id,
+            category="TRANSACTIONAL",
         )
 
     return result

--- a/services/reference-data/saga/defaults/dunning_unfreeze/v1.0.0.star
+++ b/services/reference-data/saga/defaults/dunning_unfreeze/v1.0.0.star
@@ -94,18 +94,19 @@ def dunning_unfreeze():
     result["gateway_reference_id"] = gateway_result.gateway_reference_id
     result["gateway_status"] = gateway_result.gateway_status
 
-    # Step 5: Send confirmation notification
+    # Step 5: Send confirmation correspondence
     step(name="send_confirmation")
-    notification.send(
-        type="EMAIL",
-        recipient=party_id,
-        template="dunning-resolved",
-        data={
+    correspondence.initiate_outbound(
+        channel="EMAIL",
+        recipient_party_id=party_id,
+        template_name="dunning-resolved",
+        template_data={
             "amount_cents": ctx.get("amount_cents"),
             "currency": ctx.get("currency"),
             "billing_run_id": ctx.get("billing_run_id"),
         },
         idempotency_key="dunning-resolved-" + ctx.get("billing_run_id", ""),
+        category="OPERATIONAL",
     )
     result["notification_sent"] = True
 

--- a/shared/pkg/saga/schema/handlers.yaml
+++ b/shared/pkg/saga/schema/handlers.yaml
@@ -269,32 +269,30 @@ handlers:
       proto_rpc: "meridian.market_information.v1.MarketInformationService/ListObservations"
 
   # ---------------------------------------------------------------------------
-  # Notification
+  # Correspondence (BIAN-aligned, replaces notification)
   # ---------------------------------------------------------------------------
-  notification.send:
-    description: "Send a notification (email) to a party"
+  correspondence.initiate_outbound:
+    description: "Initiate outbound correspondence (email) to a party"
     compensation_strategy: none
-    params:
-      type:
-        type: string
-        required: true
-        description: "Notification type: EMAIL"
-      recipient:
-        type: string
-        required: true
-        description: "Party ID (resolved to email server-side)"
-      template:
-        type: string
-        required: false
-        description: "Template name (defaults based on saga context)"
-      data:
-        type: map
-        required: false
-        description: "Template data"
-      idempotency_key:
-        type: string
-        required: false
-        description: "Idempotency key (auto-generated from saga execution ID if omitted)"
+    proto_ref:
+      proto_rpc: "meridian.correspondence.v1.CorrespondenceService/InitiateOutbound"
+      param_aliases:
+        recipient_party_id: recipient
+        channel: type
+        template_name: template
+        template_data: data
+
+  # Deprecated alias - use correspondence.initiate_outbound instead
+  notification.send:
+    description: "[DEPRECATED: Use correspondence.initiate_outbound] Send a notification"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.correspondence.v1.CorrespondenceService/InitiateOutbound"
+      param_aliases:
+        recipient_party_id: recipient
+        channel: type
+        template_name: template
+        template_data: data
 
   # ---------------------------------------------------------------------------
   # Reference Data

--- a/shared/pkg/saga/schema/handlers_yaml_test.go
+++ b/shared/pkg/saga/schema/handlers_yaml_test.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoregistry"
 
 	// Import all service protos to register them in the global registry
+	_ "github.com/meridianhub/meridian/api/proto/meridian/correspondence/v1"
 	_ "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	_ "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
 	_ "github.com/meridianhub/meridian/api/proto/meridian/financial_gateway/v1"
@@ -73,8 +74,8 @@ func TestHandlersYAML_ProtoResolution(t *testing.T) {
 	t.Logf("Proto-referenced: %d, Legacy: %d, Total: %d",
 		protoRefHandlers, legacyHandlers, protoRefHandlers+legacyHandlers)
 
-	assert.GreaterOrEqual(t, protoRefHandlers, 34,
-		"at least 34 handlers should use proto-referenced format")
+	assert.GreaterOrEqual(t, protoRefHandlers, 36,
+		"at least 36 handlers should use proto-referenced format")
 }
 
 func TestHandlersYAML_AllExpectedHandlersPresent(t *testing.T) {
@@ -124,6 +125,8 @@ func TestHandlersYAML_AllExpectedHandlersPresent(t *testing.T) {
 		"internal_account.get_balance",
 		"market_information.get_rate",
 		"reference_data.retrieve_instrument",
+		"correspondence.initiate_outbound",
+		"notification.send",
 	}
 
 	for _, name := range expectedHandlers {


### PR DESCRIPTION
## Summary

- Replace inline-params `notification.send` handler in `handlers.yaml` with proto_ref-based `correspondence.initiate_outbound` pointing to `CorrespondenceService/InitiateOutbound`
- Add `param_aliases` for backward compatibility (`recipient` -> `recipient_party_id`, `type` -> `channel`, `template` -> `template_name`, `data` -> `template_data`)
- Keep `notification.send` as deprecated alias using the same proto_ref
- Update `dunning_escalation` and `dunning_unfreeze` saga scripts to use `correspondence.initiate_outbound` with category assignments:
  - `dunning-notice`: TRANSACTIONAL
  - `account-frozen`: TRANSACTIONAL
  - `dunning-resolved`: OPERATIONAL
- Register `correspondence.initiate_outbound` handler in current-account saga handler registry

## Test plan

- [x] Schema parsing tests pass (`TestHandlersYAML_*`)
- [x] Proto resolution succeeds for both `correspondence.initiate_outbound` and deprecated `notification.send`
- [x] Handler registration tests pass with updated count (48 handlers)
- [x] Service modules tree parsing tests pass
- [x] Starlark syntax valid in updated saga scripts