### PR TITLE
feat: Complaint suppression + DeliveryStatusRecorder

### DIFF
--- a/cmd/meridian/gateway.go
+++ b/cmd/meridian/gateway.go
@@ -255,7 +255,9 @@ func wireResendWebhook(paymentOrderDB *gorm.DB, logger *slog.Logger) gateway.Ser
 	}
 
 	auditRepo := email.NewPostgresAuditRepository(paymentOrderDB)
-	handler := gateway.NewResendWebhookHandler(auditRepo, secret, logger)
+	suppressionRepo := email.NewPostgresSuppressionRepository(paymentOrderDB)
+	recorder := email.NewDeliveryStatusRecorder(auditRepo, suppressionRepo, logger)
+	handler := gateway.NewResendWebhookHandler(recorder, secret, logger)
 	logger.Info("resend webhook handler initialized")
 	return gateway.WithResendWebhookHandler(handler)
 }

--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -431,6 +431,7 @@ func startEmailWorker(ctx context.Context, paymentOrderDB *gorm.DB, logger *slog
 
 	outboxRepo := email.NewPostgresOutboxRepository(paymentOrderDB)
 	auditRepo := email.NewPostgresAuditRepository(paymentOrderDB)
+	suppressionRepo := email.NewPostgresSuppressionRepository(paymentOrderDB)
 	metrics := email.NewMetrics()
 
 	w := emailworker.NewEmailWorker(
@@ -438,6 +439,7 @@ func startEmailWorker(ctx context.Context, paymentOrderDB *gorm.DB, logger *slog
 		auditRepo,
 		renderer,
 		sender,
+		suppressionRepo,
 		nil, // invoiceChecker - not wired yet (dunning validation)
 		metrics,
 		dispatch.WorkerConfig{

--- a/services/api-gateway/resend_webhook_handler.go
+++ b/services/api-gateway/resend_webhook_handler.go
@@ -39,18 +39,21 @@ type resendWebhookPayload struct {
 // Resend uses Svix for webhook delivery. Each request carries three headers:
 // Svix-Id, Svix-Timestamp, and Svix-Signature. The handler verifies the
 // HMAC-SHA256 signature before processing the payload. No auth middleware
-// is applied to this route — the signature IS the authentication.
+// is applied to this route - the signature IS the authentication.
+//
+// HTTP/signature concerns live here; business logic (audit recording,
+// suppression) is delegated to email.DeliveryStatusRecorder.
 type ResendWebhookHandler struct {
-	auditRepo  email.AuditRepository
+	recorder   *email.DeliveryStatusRecorder
 	webhookKey string
 	logger     *slog.Logger
 }
 
 // NewResendWebhookHandler creates a webhook handler.
 // webhookKey must be the raw secret from Resend (format: "whsec_<base64>").
-func NewResendWebhookHandler(auditRepo email.AuditRepository, webhookKey string, logger *slog.Logger) *ResendWebhookHandler {
+func NewResendWebhookHandler(recorder *email.DeliveryStatusRecorder, webhookKey string, logger *slog.Logger) *ResendWebhookHandler {
 	return &ResendWebhookHandler{
-		auditRepo:  auditRepo,
+		recorder:   recorder,
 		webhookKey: webhookKey,
 		logger:     logger,
 	}
@@ -115,7 +118,7 @@ func (h *ResendWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if err := h.auditRepo.RecordByProviderID(r.Context(), providerID, auditStatus, payload.Data); err != nil {
+	if err := h.recorder.RecordDeliveryStatus(r.Context(), providerID, auditStatus, payload.Data); err != nil {
 		if errors.Is(err, email.ErrAuditEntryNotFound) {
 			// Not found: may be a replay of an old event or a race with cleanup.
 			h.logger.WarnContext(r.Context(), "resend webhook: no audit entry for provider ID",
@@ -123,7 +126,7 @@ func (h *ResendWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			w.WriteHeader(http.StatusOK)
 			return
 		}
-		h.logger.ErrorContext(r.Context(), "resend webhook: failed to record audit entry",
+		h.logger.ErrorContext(r.Context(), "resend webhook: failed to record delivery status",
 			"provider_id", providerID, "type", payload.Type, "error", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/services/api-gateway/resend_webhook_handler_test.go
+++ b/services/api-gateway/resend_webhook_handler_test.go
@@ -43,6 +43,10 @@ func (f *fakeAuditRepo) FindByOutboxID(_ context.Context, _ uuid.UUID) ([]email.
 	return nil, nil
 }
 
+func (f *fakeAuditRepo) FindByProviderID(_ context.Context, _ string) ([]email.AuditEntry, error) {
+	return nil, nil
+}
+
 func (f *fakeAuditRepo) RecordByProviderID(_ context.Context, providerID string, status email.AuditStatus, payload map[string]any) error {
 	if f.notFoundOnIDs[providerID] {
 		return email.ErrAuditEntryNotFound
@@ -114,7 +118,7 @@ func buildPayload(t *testing.T, eventType, emailID string) []byte {
 
 func TestResendWebhookHandler_ValidSignature(t *testing.T) {
 	repo := &fakeAuditRepo{}
-	handler := gateway.NewResendWebhookHandler(repo, testSecret, slog.Default())
+	handler := gateway.NewResendWebhookHandler(email.NewDeliveryStatusRecorder(repo, nil, nil), testSecret, slog.Default())
 
 	body := buildPayload(t, "email.delivered", "resend-id-001")
 	r := buildWebhookRequest(t, body, testSecret)
@@ -138,7 +142,7 @@ func TestResendWebhookHandler_ValidSignature(t *testing.T) {
 
 func TestResendWebhookHandler_InvalidSignature(t *testing.T) {
 	repo := &fakeAuditRepo{}
-	handler := gateway.NewResendWebhookHandler(repo, testSecret, slog.Default())
+	handler := gateway.NewResendWebhookHandler(email.NewDeliveryStatusRecorder(repo, nil, nil), testSecret, slog.Default())
 
 	body := buildPayload(t, "email.delivered", "resend-id-001")
 	r := buildWebhookRequest(t, body, testSecret, func(h http.Header) {
@@ -158,7 +162,7 @@ func TestResendWebhookHandler_InvalidSignature(t *testing.T) {
 
 func TestResendWebhookHandler_MissingHeaders(t *testing.T) {
 	repo := &fakeAuditRepo{}
-	handler := gateway.NewResendWebhookHandler(repo, testSecret, slog.Default())
+	handler := gateway.NewResendWebhookHandler(email.NewDeliveryStatusRecorder(repo, nil, nil), testSecret, slog.Default())
 
 	body := buildPayload(t, "email.delivered", "resend-id-001")
 	r := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/resend", bytes.NewReader(body))
@@ -184,7 +188,7 @@ func TestResendWebhookHandler_EventTypesRouteCorrectly(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.eventType, func(t *testing.T) {
 			repo := &fakeAuditRepo{}
-			handler := gateway.NewResendWebhookHandler(repo, testSecret, slog.Default())
+			handler := gateway.NewResendWebhookHandler(email.NewDeliveryStatusRecorder(repo, nil, nil), testSecret, slog.Default())
 
 			body := buildPayload(t, tc.eventType, "resend-id-test")
 			r := buildWebhookRequest(t, body, testSecret)
@@ -207,7 +211,7 @@ func TestResendWebhookHandler_EventTypesRouteCorrectly(t *testing.T) {
 
 func TestResendWebhookHandler_UnknownEventType_Returns200(t *testing.T) {
 	repo := &fakeAuditRepo{}
-	handler := gateway.NewResendWebhookHandler(repo, testSecret, slog.Default())
+	handler := gateway.NewResendWebhookHandler(email.NewDeliveryStatusRecorder(repo, nil, nil), testSecret, slog.Default())
 
 	body := buildPayload(t, "email.opened", "resend-id-001") // unknown type
 	r := buildWebhookRequest(t, body, testSecret)
@@ -225,7 +229,7 @@ func TestResendWebhookHandler_UnknownEventType_Returns200(t *testing.T) {
 
 func TestResendWebhookHandler_AuditEntryNotFound_Returns200(t *testing.T) {
 	repo := &fakeAuditRepo{notFoundOnIDs: map[string]bool{"missing-id": true}}
-	handler := gateway.NewResendWebhookHandler(repo, testSecret, slog.Default())
+	handler := gateway.NewResendWebhookHandler(email.NewDeliveryStatusRecorder(repo, nil, nil), testSecret, slog.Default())
 
 	body := buildPayload(t, "email.delivered", "missing-id")
 	r := buildWebhookRequest(t, body, testSecret)
@@ -241,7 +245,7 @@ func TestResendWebhookHandler_AuditEntryNotFound_Returns200(t *testing.T) {
 
 func TestResendWebhookHandler_RepoError_Returns500(t *testing.T) {
 	repo := &fakeAuditRepo{returnErr: errors.New("db connection lost")}
-	handler := gateway.NewResendWebhookHandler(repo, testSecret, slog.Default())
+	handler := gateway.NewResendWebhookHandler(email.NewDeliveryStatusRecorder(repo, nil, nil), testSecret, slog.Default())
 
 	body := buildPayload(t, "email.delivered", "resend-id-err")
 	r := buildWebhookRequest(t, body, testSecret)
@@ -256,7 +260,7 @@ func TestResendWebhookHandler_RepoError_Returns500(t *testing.T) {
 
 func TestResendWebhookHandler_WrongMethod(t *testing.T) {
 	repo := &fakeAuditRepo{}
-	handler := gateway.NewResendWebhookHandler(repo, testSecret, slog.Default())
+	handler := gateway.NewResendWebhookHandler(email.NewDeliveryStatusRecorder(repo, nil, nil), testSecret, slog.Default())
 
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/webhooks/resend", nil)
 	w := httptest.NewRecorder()
@@ -270,7 +274,7 @@ func TestResendWebhookHandler_WrongMethod(t *testing.T) {
 
 func TestResendWebhookHandler_InvalidBody_Returns400(t *testing.T) {
 	repo := &fakeAuditRepo{}
-	handler := gateway.NewResendWebhookHandler(repo, testSecret, slog.Default())
+	handler := gateway.NewResendWebhookHandler(email.NewDeliveryStatusRecorder(repo, nil, nil), testSecret, slog.Default())
 
 	body := []byte("not valid json")
 	r := buildWebhookRequest(t, body, testSecret)
@@ -287,7 +291,7 @@ func TestResendWebhookHandler_MultipleSignatures_FirstInvalid(t *testing.T) {
 	// Svix may send multiple signatures (key rotation). Verification should pass
 	// if any of them match.
 	repo := &fakeAuditRepo{}
-	handler := gateway.NewResendWebhookHandler(repo, testSecret, slog.Default())
+	handler := gateway.NewResendWebhookHandler(email.NewDeliveryStatusRecorder(repo, nil, nil), testSecret, slog.Default())
 
 	body := buildPayload(t, "email.delivered", "resend-id-multi")
 	msgID, ts, validSig := signPayload(t, body, "msg_multi", testSecret)

--- a/shared/pkg/email/audit_postgres.go
+++ b/shared/pkg/email/audit_postgres.go
@@ -90,6 +90,24 @@ func (r *PostgresAuditRepository) FindByOutboxID(ctx context.Context, outboxID u
 	return entries, nil
 }
 
+// FindByProviderID returns all audit entries for a given provider ID (cross-tenant).
+func (r *PostgresAuditRepository) FindByProviderID(ctx context.Context, providerID string) ([]AuditEntry, error) {
+	var entities []AuditLogEntity
+
+	if err := r.db.WithContext(ctx).
+		Where("provider_id = ?", providerID).
+		Order("created_at DESC").
+		Find(&entities).Error; err != nil {
+		return nil, fmt.Errorf("email: failed to find audit entries by provider ID: %w", err)
+	}
+
+	entries := make([]AuditEntry, len(entities))
+	for i, e := range entities {
+		entries[i] = entityToAuditEntry(e)
+	}
+	return entries, nil
+}
+
 // RecordByProviderID looks up existing audit entries by providerID (without tenant scope),
 // resolves the tenant from the first match, then records a new status update entry.
 func (r *PostgresAuditRepository) RecordByProviderID(ctx context.Context, providerID string, status AuditStatus, payload map[string]any) error {

--- a/shared/pkg/email/delivery_status.go
+++ b/shared/pkg/email/delivery_status.go
@@ -1,0 +1,85 @@
+package email
+
+import (
+	"context"
+	"log/slog"
+)
+
+// DeliveryStatusRecorder encapsulates the business logic for recording email
+// delivery status updates from webhook callbacks. It updates the audit log and
+// adds addresses to the suppression list on bounces/complaints.
+type DeliveryStatusRecorder struct {
+	auditRepo       AuditRepository
+	suppressionRepo SuppressionRepository
+	logger          *slog.Logger
+}
+
+// NewDeliveryStatusRecorder creates a new recorder. suppressionRepo may be nil
+// to skip suppression recording.
+func NewDeliveryStatusRecorder(auditRepo AuditRepository, suppressionRepo SuppressionRepository, logger *slog.Logger) *DeliveryStatusRecorder {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &DeliveryStatusRecorder{
+		auditRepo:       auditRepo,
+		suppressionRepo: suppressionRepo,
+		logger:          logger.With("component", "delivery-status-recorder"),
+	}
+}
+
+// RecordDeliveryStatus records a delivery status update for an email identified
+// by providerID. If the status is BOUNCED or COMPLAINED and a suppression
+// repository is configured, the recipient addresses are added to the
+// suppression list using data from the audit trail.
+//
+// Returns ErrAuditEntryNotFound if no audit entry exists for the providerID.
+func (r *DeliveryStatusRecorder) RecordDeliveryStatus(ctx context.Context, providerID string, status AuditStatus, metadata map[string]any) error {
+	// Record audit entry first - this is the primary concern.
+	if err := r.auditRepo.RecordByProviderID(ctx, providerID, status, metadata); err != nil {
+		return err
+	}
+
+	// Add suppression on bounce/complaint.
+	if r.suppressionRepo != nil && (status == AuditStatusBounced || status == AuditStatusComplained) {
+		r.recordSuppressions(ctx, providerID, status)
+	}
+
+	return nil
+}
+
+// recordSuppressions looks up audit entries by provider ID to get tenant and
+// recipients, then writes suppression records. Errors are logged but not
+// propagated - the audit record is the primary concern.
+func (r *DeliveryStatusRecorder) recordSuppressions(ctx context.Context, providerID string, status AuditStatus) {
+	entries, err := r.auditRepo.FindByProviderID(ctx, providerID)
+	if err != nil || len(entries) == 0 {
+		r.logger.WarnContext(ctx, "cannot resolve recipients for suppression",
+			"provider_id", providerID,
+			"error", err,
+		)
+		return
+	}
+
+	// Use the oldest entry (original SENT record) for tenant/recipient info.
+	original := entries[len(entries)-1]
+
+	suppType := SuppressionBounce
+	if status == AuditStatusComplained {
+		suppType = SuppressionComplaint
+	}
+
+	for _, addr := range original.ToAddresses {
+		if err := r.suppressionRepo.AddSuppression(ctx, &SuppressionEntry{
+			EmailAddress:    addr,
+			SuppressionType: suppType,
+			ProviderID:      providerID,
+			TenantID:        original.TenantID,
+		}); err != nil {
+			r.logger.WarnContext(ctx, "failed to add suppression",
+				"address", addr,
+				"provider_id", providerID,
+				"error", err,
+			)
+		}
+	}
+}

--- a/shared/pkg/email/delivery_status_test.go
+++ b/shared/pkg/email/delivery_status_test.go
@@ -14,11 +14,11 @@ import (
 // --- Test doubles for DeliveryStatusRecorder ---
 
 type stubAuditRepo struct {
-	recordByProviderIDErr   error
-	recordCalls             int
-	findByProviderIDResult  []email.AuditEntry
-	findByProviderIDErr     error
-	findByProviderIDCalls   int
+	recordByProviderIDErr  error
+	recordCalls            int
+	findByProviderIDResult []email.AuditEntry
+	findByProviderIDErr    error
+	findByProviderIDCalls  int
 }
 
 func (s *stubAuditRepo) Record(_ context.Context, _ *email.AuditEntry) error { return nil }

--- a/shared/pkg/email/delivery_status_test.go
+++ b/shared/pkg/email/delivery_status_test.go
@@ -25,10 +25,12 @@ func (s *stubAuditRepo) Record(_ context.Context, _ *email.AuditEntry) error { r
 func (s *stubAuditRepo) FindByOutboxID(_ context.Context, _ uuid.UUID) ([]email.AuditEntry, error) {
 	return nil, nil
 }
+
 func (s *stubAuditRepo) FindByProviderID(_ context.Context, _ string) ([]email.AuditEntry, error) {
 	s.findByProviderIDCalls++
 	return s.findByProviderIDResult, s.findByProviderIDErr
 }
+
 func (s *stubAuditRepo) RecordByProviderID(_ context.Context, _ string, _ email.AuditStatus, _ map[string]any) error {
 	s.recordCalls++
 	return s.recordByProviderIDErr
@@ -44,6 +46,7 @@ type stubSuppressionRepo struct {
 func (s *stubSuppressionRepo) IsSuppressed(_ context.Context, _ string) (bool, error) {
 	return false, nil
 }
+
 func (s *stubSuppressionRepo) AddSuppression(_ context.Context, entry *email.SuppressionEntry) error {
 	s.addCalls++
 	s.lastEntry = entry

--- a/shared/pkg/email/delivery_status_test.go
+++ b/shared/pkg/email/delivery_status_test.go
@@ -1,0 +1,181 @@
+package email_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/pkg/email"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Test doubles for DeliveryStatusRecorder ---
+
+type stubAuditRepo struct {
+	recordByProviderIDErr   error
+	recordCalls             int
+	findByProviderIDResult  []email.AuditEntry
+	findByProviderIDErr     error
+	findByProviderIDCalls   int
+}
+
+func (s *stubAuditRepo) Record(_ context.Context, _ *email.AuditEntry) error { return nil }
+func (s *stubAuditRepo) FindByOutboxID(_ context.Context, _ uuid.UUID) ([]email.AuditEntry, error) {
+	return nil, nil
+}
+func (s *stubAuditRepo) FindByProviderID(_ context.Context, _ string) ([]email.AuditEntry, error) {
+	s.findByProviderIDCalls++
+	return s.findByProviderIDResult, s.findByProviderIDErr
+}
+func (s *stubAuditRepo) RecordByProviderID(_ context.Context, _ string, _ email.AuditStatus, _ map[string]any) error {
+	s.recordCalls++
+	return s.recordByProviderIDErr
+}
+
+type stubSuppressionRepo struct {
+	addCalls   int
+	addErr     error
+	lastEntry  *email.SuppressionEntry
+	allEntries []*email.SuppressionEntry
+}
+
+func (s *stubSuppressionRepo) IsSuppressed(_ context.Context, _ string) (bool, error) {
+	return false, nil
+}
+func (s *stubSuppressionRepo) AddSuppression(_ context.Context, entry *email.SuppressionEntry) error {
+	s.addCalls++
+	s.lastEntry = entry
+	s.allEntries = append(s.allEntries, entry)
+	return s.addErr
+}
+
+// --- Tests ---
+
+func TestDeliveryStatusRecorder_RecordDelivered_NoSuppression(t *testing.T) {
+	audit := &stubAuditRepo{}
+	supp := &stubSuppressionRepo{}
+	recorder := email.NewDeliveryStatusRecorder(audit, supp, nil)
+
+	err := recorder.RecordDeliveryStatus(context.Background(), "msg-1", email.AuditStatusDelivered, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, audit.recordCalls)
+	assert.Equal(t, 0, supp.addCalls, "delivered status should not suppress")
+	assert.Equal(t, 0, audit.findByProviderIDCalls, "should not look up entries for non-bounce status")
+}
+
+func TestDeliveryStatusRecorder_RecordBounced_AddsSuppression(t *testing.T) {
+	audit := &stubAuditRepo{
+		findByProviderIDResult: []email.AuditEntry{
+			{TenantID: "tenant-1", ToAddresses: []string{"bounced@example.com"}},
+		},
+	}
+	supp := &stubSuppressionRepo{}
+	recorder := email.NewDeliveryStatusRecorder(audit, supp, nil)
+
+	err := recorder.RecordDeliveryStatus(context.Background(), "msg-2", email.AuditStatusBounced, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, audit.recordCalls)
+	assert.Equal(t, 1, supp.addCalls)
+	assert.Equal(t, "bounced@example.com", supp.lastEntry.EmailAddress)
+	assert.Equal(t, email.SuppressionBounce, supp.lastEntry.SuppressionType)
+	assert.Equal(t, "msg-2", supp.lastEntry.ProviderID)
+	assert.Equal(t, "tenant-1", supp.lastEntry.TenantID)
+}
+
+func TestDeliveryStatusRecorder_RecordComplained_AddsSuppression(t *testing.T) {
+	audit := &stubAuditRepo{
+		findByProviderIDResult: []email.AuditEntry{
+			{TenantID: "tenant-1", ToAddresses: []string{"complainer@example.com"}},
+		},
+	}
+	supp := &stubSuppressionRepo{}
+	recorder := email.NewDeliveryStatusRecorder(audit, supp, nil)
+
+	err := recorder.RecordDeliveryStatus(context.Background(), "msg-3", email.AuditStatusComplained, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, supp.addCalls)
+	assert.Equal(t, email.SuppressionComplaint, supp.lastEntry.SuppressionType)
+}
+
+func TestDeliveryStatusRecorder_MultipleRecipients(t *testing.T) {
+	audit := &stubAuditRepo{
+		findByProviderIDResult: []email.AuditEntry{
+			{TenantID: "tenant-1", ToAddresses: []string{"a@example.com", "b@example.com"}},
+		},
+	}
+	supp := &stubSuppressionRepo{}
+	recorder := email.NewDeliveryStatusRecorder(audit, supp, nil)
+
+	err := recorder.RecordDeliveryStatus(context.Background(), "msg-4", email.AuditStatusBounced, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, supp.addCalls)
+}
+
+func TestDeliveryStatusRecorder_AuditError_PropagatesImmediately(t *testing.T) {
+	audit := &stubAuditRepo{recordByProviderIDErr: email.ErrAuditEntryNotFound}
+	supp := &stubSuppressionRepo{}
+	recorder := email.NewDeliveryStatusRecorder(audit, supp, nil)
+
+	err := recorder.RecordDeliveryStatus(context.Background(), "msg-5", email.AuditStatusBounced, nil)
+
+	require.True(t, errors.Is(err, email.ErrAuditEntryNotFound))
+	assert.Equal(t, 0, supp.addCalls, "should not attempt suppression when audit fails")
+}
+
+func TestDeliveryStatusRecorder_NilSuppressionRepo_SkipsSuppression(t *testing.T) {
+	audit := &stubAuditRepo{}
+	recorder := email.NewDeliveryStatusRecorder(audit, nil, nil)
+
+	err := recorder.RecordDeliveryStatus(context.Background(), "msg-6", email.AuditStatusBounced, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, audit.recordCalls)
+	assert.Equal(t, 0, audit.findByProviderIDCalls, "should not look up entries when no suppression repo")
+}
+
+func TestDeliveryStatusRecorder_SuppressionError_DoesNotFail(t *testing.T) {
+	audit := &stubAuditRepo{
+		findByProviderIDResult: []email.AuditEntry{
+			{TenantID: "tenant-1", ToAddresses: []string{"user@example.com"}},
+		},
+	}
+	supp := &stubSuppressionRepo{addErr: errors.New("db error")}
+	recorder := email.NewDeliveryStatusRecorder(audit, supp, nil)
+
+	err := recorder.RecordDeliveryStatus(context.Background(), "msg-7", email.AuditStatusBounced, nil)
+
+	require.NoError(t, err, "suppression error should not propagate")
+	assert.Equal(t, 1, supp.addCalls, "suppression was attempted")
+}
+
+func TestDeliveryStatusRecorder_FindByProviderIDFails_LogsWarning(t *testing.T) {
+	audit := &stubAuditRepo{
+		findByProviderIDErr: errors.New("db error"),
+	}
+	supp := &stubSuppressionRepo{}
+	recorder := email.NewDeliveryStatusRecorder(audit, supp, nil)
+
+	err := recorder.RecordDeliveryStatus(context.Background(), "msg-8", email.AuditStatusBounced, nil)
+
+	require.NoError(t, err, "suppression lookup failure should not propagate")
+	assert.Equal(t, 0, supp.addCalls, "should not attempt suppression when lookup fails")
+}
+
+func TestDeliveryStatusRecorder_NoAuditEntries_SkipsSuppression(t *testing.T) {
+	audit := &stubAuditRepo{
+		findByProviderIDResult: []email.AuditEntry{},
+	}
+	supp := &stubSuppressionRepo{}
+	recorder := email.NewDeliveryStatusRecorder(audit, supp, nil)
+
+	err := recorder.RecordDeliveryStatus(context.Background(), "msg-9", email.AuditStatusBounced, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, supp.addCalls)
+}

--- a/shared/pkg/email/repository.go
+++ b/shared/pkg/email/repository.go
@@ -39,6 +39,10 @@ type AuditRepository interface {
 	// FindByOutboxID returns all audit entries for a given outbox entry.
 	FindByOutboxID(ctx context.Context, outboxID uuid.UUID) ([]AuditEntry, error)
 
+	// FindByProviderID returns all audit entries for a given provider-assigned
+	// email ID (cross-tenant lookup). Returns entries ordered newest-first.
+	FindByProviderID(ctx context.Context, providerID string) ([]AuditEntry, error)
+
 	// RecordByProviderID records a webhook delivery status update for the email
 	// identified by providerID. It looks up the tenant from existing audit entries
 	// and records a new status entry with the supplied payload. Returns

--- a/shared/pkg/email/suppression.go
+++ b/shared/pkg/email/suppression.go
@@ -14,6 +14,7 @@ import (
 // SuppressionType indicates why an address was suppressed.
 type SuppressionType string
 
+// Suppression type constants.
 const (
 	SuppressionBounce    SuppressionType = "BOUNCE"
 	SuppressionComplaint SuppressionType = "COMPLAINT"
@@ -21,11 +22,11 @@ const (
 
 // SuppressionEntry represents a suppressed email address.
 type SuppressionEntry struct {
-	EmailAddress   string
+	EmailAddress    string
 	SuppressionType SuppressionType
-	ProviderID     string
-	Reason         string
-	TenantID       string
+	ProviderID      string
+	Reason          string
+	TenantID        string
 }
 
 // SuppressionRepository checks and records email address suppressions.
@@ -53,6 +54,9 @@ type SuppressedAddressEntity struct {
 func (SuppressedAddressEntity) TableName() string {
 	return "suppressed_addresses"
 }
+
+// ErrNilSuppressionEntry is returned when a nil entry is passed to AddSuppression.
+var ErrNilSuppressionEntry = errors.New("email: suppression entry must not be nil")
 
 var _ SuppressionRepository = (*PostgresSuppressionRepository)(nil)
 
@@ -83,7 +87,7 @@ func (r *PostgresSuppressionRepository) IsSuppressed(ctx context.Context, emailA
 // already exists, the row is updated with the latest suppression details.
 func (r *PostgresSuppressionRepository) AddSuppression(ctx context.Context, entry *SuppressionEntry) error {
 	if entry == nil {
-		return errors.New("email: suppression entry must not be nil")
+		return ErrNilSuppressionEntry
 	}
 
 	now := time.Now().UTC()

--- a/shared/pkg/email/suppression.go
+++ b/shared/pkg/email/suppression.go
@@ -60,7 +60,14 @@ var (
 	ErrNilSuppressionEntry      = errors.New("email: suppression entry must not be nil")
 	ErrEmptySuppressionEmail    = errors.New("email: suppression entry must have an email address")
 	ErrEmptySuppressionTenantID = errors.New("email: suppression entry must have a tenant ID")
+	ErrInvalidSuppressionType   = errors.New("email: suppression entry must have a valid suppression type")
 )
+
+// validSuppressionTypes enumerates accepted SuppressionType values.
+var validSuppressionTypes = map[SuppressionType]bool{
+	SuppressionBounce:    true,
+	SuppressionComplaint: true,
+}
 
 var _ SuppressionRepository = (*PostgresSuppressionRepository)(nil)
 
@@ -100,6 +107,9 @@ func (r *PostgresSuppressionRepository) AddSuppression(ctx context.Context, entr
 	}
 	if strings.TrimSpace(entry.TenantID) == "" {
 		return ErrEmptySuppressionTenantID
+	}
+	if !validSuppressionTypes[entry.SuppressionType] {
+		return ErrInvalidSuppressionType
 	}
 
 	now := time.Now().UTC()

--- a/shared/pkg/email/suppression.go
+++ b/shared/pkg/email/suppression.go
@@ -42,7 +42,7 @@ type SuppressionRepository interface {
 type SuppressedAddressEntity struct {
 	ID              uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
 	TenantID        string    `gorm:"not null;uniqueIndex:uq_suppressed_addresses_tenant_email,priority:1"`
-	EmailAddress    string    `gorm:"not null;size:255;uniqueIndex:uq_suppressed_addresses_tenant_email,priority:2"`
+	EmailAddress    string    `gorm:"not null;size:255;uniqueIndex:uq_suppressed_addresses_tenant_email,priority:2;index:idx_suppressed_addresses_email"`
 	SuppressionType string    `gorm:"not null;size:20"`
 	ProviderID      *string   `gorm:"size:255"`
 	Reason          *string   `gorm:"type:text"`
@@ -55,8 +55,12 @@ func (SuppressedAddressEntity) TableName() string {
 	return "suppressed_addresses"
 }
 
-// ErrNilSuppressionEntry is returned when a nil entry is passed to AddSuppression.
-var ErrNilSuppressionEntry = errors.New("email: suppression entry must not be nil")
+// Suppression validation errors.
+var (
+	ErrNilSuppressionEntry      = errors.New("email: suppression entry must not be nil")
+	ErrEmptySuppressionEmail    = errors.New("email: suppression entry must have an email address")
+	ErrEmptySuppressionTenantID = errors.New("email: suppression entry must have a tenant ID")
+)
 
 var _ SuppressionRepository = (*PostgresSuppressionRepository)(nil)
 
@@ -90,8 +94,15 @@ func (r *PostgresSuppressionRepository) AddSuppression(ctx context.Context, entr
 		return ErrNilSuppressionEntry
 	}
 
-	now := time.Now().UTC()
 	normalised := strings.ToLower(strings.TrimSpace(entry.EmailAddress))
+	if normalised == "" {
+		return ErrEmptySuppressionEmail
+	}
+	if strings.TrimSpace(entry.TenantID) == "" {
+		return ErrEmptySuppressionTenantID
+	}
+
+	now := time.Now().UTC()
 
 	var providerID *string
 	if entry.ProviderID != "" {

--- a/shared/pkg/email/suppression.go
+++ b/shared/pkg/email/suppression.go
@@ -1,0 +1,128 @@
+package email
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// SuppressionType indicates why an address was suppressed.
+type SuppressionType string
+
+const (
+	SuppressionBounce    SuppressionType = "BOUNCE"
+	SuppressionComplaint SuppressionType = "COMPLAINT"
+)
+
+// SuppressionEntry represents a suppressed email address.
+type SuppressionEntry struct {
+	EmailAddress   string
+	SuppressionType SuppressionType
+	ProviderID     string
+	Reason         string
+	TenantID       string
+}
+
+// SuppressionRepository checks and records email address suppressions.
+type SuppressionRepository interface {
+	// IsSuppressed returns true if the email address is suppressed for any tenant.
+	IsSuppressed(ctx context.Context, emailAddress string) (bool, error)
+
+	// AddSuppression records a suppression entry. Uses ON CONFLICT to avoid duplicates.
+	AddSuppression(ctx context.Context, entry *SuppressionEntry) error
+}
+
+// SuppressedAddressEntity is the GORM model for the suppressed_addresses table.
+type SuppressedAddressEntity struct {
+	ID              uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	TenantID        string    `gorm:"not null;uniqueIndex:uq_suppressed_addresses_tenant_email,priority:1"`
+	EmailAddress    string    `gorm:"not null;size:255;uniqueIndex:uq_suppressed_addresses_tenant_email,priority:2"`
+	SuppressionType string    `gorm:"not null;size:20"`
+	ProviderID      *string   `gorm:"size:255"`
+	Reason          *string   `gorm:"type:text"`
+	SuppressedAt    time.Time `gorm:"not null"`
+	CreatedAt       time.Time `gorm:"not null"`
+}
+
+// TableName returns the database table name.
+func (SuppressedAddressEntity) TableName() string {
+	return "suppressed_addresses"
+}
+
+var _ SuppressionRepository = (*PostgresSuppressionRepository)(nil)
+
+// PostgresSuppressionRepository implements SuppressionRepository using GORM.
+type PostgresSuppressionRepository struct {
+	db *gorm.DB
+}
+
+// NewPostgresSuppressionRepository creates a new suppression repository.
+func NewPostgresSuppressionRepository(gormDB *gorm.DB) *PostgresSuppressionRepository {
+	return &PostgresSuppressionRepository{db: gormDB}
+}
+
+// IsSuppressed checks whether the given email address is suppressed (cross-tenant).
+func (r *PostgresSuppressionRepository) IsSuppressed(ctx context.Context, emailAddress string) (bool, error) {
+	normalised := strings.ToLower(strings.TrimSpace(emailAddress))
+	var count int64
+	if err := r.db.WithContext(ctx).
+		Model(&SuppressedAddressEntity{}).
+		Where("email_address = ?", normalised).
+		Count(&count).Error; err != nil {
+		return false, fmt.Errorf("email: checking suppression: %w", err)
+	}
+	return count > 0, nil
+}
+
+// AddSuppression records a suppressed address. If the tenant+email combination
+// already exists, the row is updated with the latest suppression details.
+func (r *PostgresSuppressionRepository) AddSuppression(ctx context.Context, entry *SuppressionEntry) error {
+	if entry == nil {
+		return errors.New("email: suppression entry must not be nil")
+	}
+
+	now := time.Now().UTC()
+	normalised := strings.ToLower(strings.TrimSpace(entry.EmailAddress))
+
+	var providerID *string
+	if entry.ProviderID != "" {
+		providerID = &entry.ProviderID
+	}
+	var reason *string
+	if entry.Reason != "" {
+		reason = &entry.Reason
+	}
+
+	entity := SuppressedAddressEntity{
+		ID:              uuid.New(),
+		TenantID:        entry.TenantID,
+		EmailAddress:    normalised,
+		SuppressionType: string(entry.SuppressionType),
+		ProviderID:      providerID,
+		Reason:          reason,
+		SuppressedAt:    now,
+		CreatedAt:       now,
+	}
+
+	// ON CONFLICT update with latest suppression info.
+	result := r.db.WithContext(ctx).Exec(`
+		INSERT INTO suppressed_addresses (id, tenant_id, email_address, suppression_type, provider_id, reason, suppressed_at, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT (tenant_id, email_address)
+		DO UPDATE SET suppression_type = EXCLUDED.suppression_type,
+		             provider_id = EXCLUDED.provider_id,
+		             reason = EXCLUDED.reason,
+		             suppressed_at = EXCLUDED.suppressed_at
+	`, entity.ID, entity.TenantID, entity.EmailAddress, entity.SuppressionType,
+		entity.ProviderID, entity.Reason, entity.SuppressedAt, entity.CreatedAt)
+
+	if result.Error != nil {
+		return fmt.Errorf("email: adding suppression: %w", result.Error)
+	}
+	return nil
+}

--- a/shared/pkg/email/suppression_test.go
+++ b/shared/pkg/email/suppression_test.go
@@ -1,0 +1,130 @@
+package email_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/pkg/email"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func setupSuppressionTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
+	t.Helper()
+	return testdb.SetupTestDB(t,
+		testdb.WithModels(&email.SuppressedAddressEntity{}),
+		testdb.WithTenant(testTenantID),
+	)
+}
+
+func TestPostgresSuppressionRepository_IsSuppressed_NotFound(t *testing.T) {
+	db, _, cleanup := setupSuppressionTestDB(t)
+	defer cleanup()
+
+	repo := email.NewPostgresSuppressionRepository(db)
+
+	suppressed, err := repo.IsSuppressed(context.Background(), "unknown@example.com")
+	require.NoError(t, err)
+	assert.False(t, suppressed)
+}
+
+func TestPostgresSuppressionRepository_AddAndCheck(t *testing.T) {
+	db, _, cleanup := setupSuppressionTestDB(t)
+	defer cleanup()
+
+	repo := email.NewPostgresSuppressionRepository(db)
+
+	entry := &email.SuppressionEntry{
+		EmailAddress:    "bounced@example.com",
+		SuppressionType: email.SuppressionBounce,
+		ProviderID:      "resend-123",
+		Reason:          "hard bounce",
+		TenantID:        testTenantID,
+	}
+	err := repo.AddSuppression(context.Background(), entry)
+	require.NoError(t, err)
+
+	suppressed, err := repo.IsSuppressed(context.Background(), "bounced@example.com")
+	require.NoError(t, err)
+	assert.True(t, suppressed)
+}
+
+func TestPostgresSuppressionRepository_CaseInsensitive(t *testing.T) {
+	db, _, cleanup := setupSuppressionTestDB(t)
+	defer cleanup()
+
+	repo := email.NewPostgresSuppressionRepository(db)
+
+	err := repo.AddSuppression(context.Background(), &email.SuppressionEntry{
+		EmailAddress:    "User@Example.COM",
+		SuppressionType: email.SuppressionComplaint,
+		TenantID:        testTenantID,
+	})
+	require.NoError(t, err)
+
+	suppressed, err := repo.IsSuppressed(context.Background(), "user@example.com")
+	require.NoError(t, err)
+	assert.True(t, suppressed)
+}
+
+func TestPostgresSuppressionRepository_UpsertOnConflict(t *testing.T) {
+	db, _, cleanup := setupSuppressionTestDB(t)
+	defer cleanup()
+
+	repo := email.NewPostgresSuppressionRepository(db)
+
+	// First insert: bounce
+	err := repo.AddSuppression(context.Background(), &email.SuppressionEntry{
+		EmailAddress:    "user@example.com",
+		SuppressionType: email.SuppressionBounce,
+		ProviderID:      "id-1",
+		TenantID:        testTenantID,
+	})
+	require.NoError(t, err)
+
+	// Second insert: complaint (same tenant+email) - should upsert, not error
+	err = repo.AddSuppression(context.Background(), &email.SuppressionEntry{
+		EmailAddress:    "user@example.com",
+		SuppressionType: email.SuppressionComplaint,
+		ProviderID:      "id-2",
+		TenantID:        testTenantID,
+	})
+	require.NoError(t, err)
+
+	// Should still be suppressed
+	suppressed, err := repo.IsSuppressed(context.Background(), "user@example.com")
+	require.NoError(t, err)
+	assert.True(t, suppressed)
+}
+
+func TestPostgresSuppressionRepository_CrossTenantCheck(t *testing.T) {
+	db, _, cleanup := setupSuppressionTestDB(t)
+	defer cleanup()
+
+	repo := email.NewPostgresSuppressionRepository(db)
+
+	// Suppress in one tenant
+	err := repo.AddSuppression(context.Background(), &email.SuppressionEntry{
+		EmailAddress:    "shared@example.com",
+		SuppressionType: email.SuppressionBounce,
+		TenantID:        "tenant-A",
+	})
+	require.NoError(t, err)
+
+	// IsSuppressed is cross-tenant - should find it regardless of tenant context
+	suppressed, err := repo.IsSuppressed(context.Background(), "shared@example.com")
+	require.NoError(t, err)
+	assert.True(t, suppressed)
+}
+
+func TestPostgresSuppressionRepository_NilEntry(t *testing.T) {
+	db, _, cleanup := setupSuppressionTestDB(t)
+	defer cleanup()
+
+	repo := email.NewPostgresSuppressionRepository(db)
+
+	err := repo.AddSuppression(context.Background(), nil)
+	require.Error(t, err)
+}

--- a/shared/pkg/email/suppression_test.go
+++ b/shared/pkg/email/suppression_test.go
@@ -128,3 +128,30 @@ func TestPostgresSuppressionRepository_NilEntry(t *testing.T) {
 	err := repo.AddSuppression(context.Background(), nil)
 	require.Error(t, err)
 }
+
+func TestPostgresSuppressionRepository_InvalidSuppressionType(t *testing.T) {
+	db, _, cleanup := setupSuppressionTestDB(t)
+	defer cleanup()
+
+	repo := email.NewPostgresSuppressionRepository(db)
+
+	err := repo.AddSuppression(context.Background(), &email.SuppressionEntry{
+		EmailAddress:    "user@example.com",
+		SuppressionType: "INVALID",
+		TenantID:        testTenantID,
+	})
+	require.ErrorIs(t, err, email.ErrInvalidSuppressionType)
+}
+
+func TestPostgresSuppressionRepository_EmptySuppressionType(t *testing.T) {
+	db, _, cleanup := setupSuppressionTestDB(t)
+	defer cleanup()
+
+	repo := email.NewPostgresSuppressionRepository(db)
+
+	err := repo.AddSuppression(context.Background(), &email.SuppressionEntry{
+		EmailAddress: "user@example.com",
+		TenantID:     testTenantID,
+	})
+	require.ErrorIs(t, err, email.ErrInvalidSuppressionType)
+}

--- a/shared/pkg/email/worker/processor.go
+++ b/shared/pkg/email/worker/processor.go
@@ -48,8 +48,8 @@ func NewEmailProcessor(
 		auditRepo:       auditRepo,
 		suppressionRepo: suppressionRepo,
 		invoiceChecker:  invoiceChecker,
-		metrics:        metrics,
-		logger:         logger.With("component", "email-processor"),
+		metrics:         metrics,
+		logger:          logger.With("component", "email-processor"),
 	}
 }
 
@@ -104,7 +104,11 @@ func (p *EmailProcessor) processOne(ctx context.Context, instr *OutboxInstructio
 		return p.handleRenderFailure(ctx, entry, fmt.Sprintf("template render failed: %v", err))
 	}
 
-	// Build and send message.
+	return p.sendAndRecord(ctx, entry, htmlBody, textBody)
+}
+
+// sendAndRecord sends the email and records the result in outbox and audit log.
+func (p *EmailProcessor) sendAndRecord(ctx context.Context, entry *email.OutboxEntry, htmlBody, textBody string) error {
 	msg := email.Message{
 		To:             entry.ToAddresses,
 		From:           entry.FromAddress,
@@ -129,12 +133,10 @@ func (p *EmailProcessor) processOne(ctx context.Context, instr *OutboxInstructio
 		return p.handleSendFailure(ctx, entry, fmt.Sprintf("send failed: %v", err))
 	}
 
-	// Mark sent in outbox.
 	if err := p.outboxRepo.MarkSent(ctx, entry.ID); err != nil {
 		return fmt.Errorf("marking outbox entry sent: %w", err)
 	}
 
-	// Create audit entry.
 	sentAt := result.SentAt
 	providerID := result.ProviderID
 	auditEntry := &email.AuditEntry{
@@ -149,7 +151,6 @@ func (p *EmailProcessor) processOne(ctx context.Context, instr *OutboxInstructio
 		SentAt:       &sentAt,
 	}
 	if err := p.auditRepo.Record(ctx, auditEntry); err != nil {
-		// Log but don't fail - the email was sent successfully.
 		p.logger.WarnContext(ctx, "failed to record audit entry",
 			"outbox_id", entry.ID,
 			"error", err,

--- a/shared/pkg/email/worker/processor.go
+++ b/shared/pkg/email/worker/processor.go
@@ -214,9 +214,11 @@ func (p *EmailProcessor) checkSuppression(ctx context.Context, entry *email.Outb
 	for _, addr := range entry.ToAddresses {
 		suppressed, err := p.suppressionRepo.IsSuppressed(ctx, addr)
 		if err != nil {
+			if ctx.Err() != nil {
+				return false, ctx.Err()
+			}
 			p.logger.WarnContext(ctx, "failed to check suppression, continuing",
 				"outbox_id", entry.ID,
-				"address", addr,
 				"error", err,
 			)
 			continue
@@ -230,7 +232,6 @@ func (p *EmailProcessor) checkSuppression(ctx context.Context, entry *email.Outb
 			}
 			p.logger.InfoContext(ctx, "cancelled email - recipient suppressed",
 				"outbox_id", entry.ID,
-				"address", addr,
 			)
 			return true, nil
 		}

--- a/shared/pkg/email/worker/processor.go
+++ b/shared/pkg/email/worker/processor.go
@@ -17,13 +17,14 @@ type InvoiceStatusChecker interface {
 // EmailProcessor handles the per-entry processing logic for the email dispatch worker.
 // It renders templates, sends emails, and updates outbox/audit state.
 type EmailProcessor struct {
-	renderer       email.TemplateRenderer
-	sender         email.Sender
-	outboxRepo     email.OutboxRepository
-	auditRepo      email.AuditRepository
-	invoiceChecker InvoiceStatusChecker
-	metrics        *EmailMetrics
-	logger         *slog.Logger
+	renderer        email.TemplateRenderer
+	sender          email.Sender
+	outboxRepo      email.OutboxRepository
+	auditRepo       email.AuditRepository
+	suppressionRepo email.SuppressionRepository
+	invoiceChecker  InvoiceStatusChecker
+	metrics         *EmailMetrics
+	logger          *slog.Logger
 }
 
 // NewEmailProcessor creates an EmailProcessor with the given dependencies.
@@ -32,6 +33,7 @@ func NewEmailProcessor(
 	sender email.Sender,
 	outboxRepo email.OutboxRepository,
 	auditRepo email.AuditRepository,
+	suppressionRepo email.SuppressionRepository,
 	invoiceChecker InvoiceStatusChecker,
 	metrics *EmailMetrics,
 	logger *slog.Logger,
@@ -40,11 +42,12 @@ func NewEmailProcessor(
 		logger = slog.Default()
 	}
 	return &EmailProcessor{
-		renderer:       renderer,
-		sender:         sender,
-		outboxRepo:     outboxRepo,
-		auditRepo:      auditRepo,
-		invoiceChecker: invoiceChecker,
+		renderer:        renderer,
+		sender:          sender,
+		outboxRepo:      outboxRepo,
+		auditRepo:       auditRepo,
+		suppressionRepo: suppressionRepo,
+		invoiceChecker:  invoiceChecker,
 		metrics:        metrics,
 		logger:         logger.With("component", "email-processor"),
 	}
@@ -77,6 +80,17 @@ func (p *EmailProcessor) processOne(ctx context.Context, instr *OutboxInstructio
 		cancelled, err := p.checkDunningCancellation(ctx, entry)
 		if err != nil {
 			return fmt.Errorf("checking dunning cancellation: %w", err)
+		}
+		if cancelled {
+			return nil
+		}
+	}
+
+	// Check if any recipient is suppressed (bounced/complained).
+	if p.suppressionRepo != nil {
+		cancelled, err := p.checkSuppression(ctx, entry)
+		if err != nil {
+			return fmt.Errorf("checking suppression: %w", err)
 		}
 		if cancelled {
 			return nil
@@ -188,6 +202,36 @@ func (p *EmailProcessor) checkDunningCancellation(ctx context.Context, entry *em
 		return true, nil
 	}
 
+	return false, nil
+}
+
+// checkSuppression checks if any recipient address is suppressed. If all recipients
+// are suppressed, the entry is cancelled. Returns true if the entry was cancelled.
+func (p *EmailProcessor) checkSuppression(ctx context.Context, entry *email.OutboxEntry) (bool, error) {
+	for _, addr := range entry.ToAddresses {
+		suppressed, err := p.suppressionRepo.IsSuppressed(ctx, addr)
+		if err != nil {
+			p.logger.WarnContext(ctx, "failed to check suppression, proceeding with send",
+				"outbox_id", entry.ID,
+				"address", addr,
+				"error", err,
+			)
+			return false, nil
+		}
+		if suppressed {
+			if err := p.outboxRepo.Cancel(ctx, entry.ID); err != nil {
+				return false, fmt.Errorf("cancelling suppressed email: %w", err)
+			}
+			if p.metrics != nil {
+				p.metrics.RecordCancelled()
+			}
+			p.logger.InfoContext(ctx, "cancelled email - recipient suppressed",
+				"outbox_id", entry.ID,
+				"address", addr,
+			)
+			return true, nil
+		}
+	}
 	return false, nil
 }
 

--- a/shared/pkg/email/worker/processor.go
+++ b/shared/pkg/email/worker/processor.go
@@ -206,8 +206,8 @@ func (p *EmailProcessor) checkDunningCancellation(ctx context.Context, entry *em
 	return false, nil
 }
 
-// checkSuppression checks if any recipient address is suppressed. If all recipients
-// are suppressed, the entry is cancelled. Returns true if the entry was cancelled.
+// checkSuppression checks if any recipient address is suppressed. Cancels the
+// entry as soon as the first suppressed address is found. Returns true if cancelled.
 func (p *EmailProcessor) checkSuppression(ctx context.Context, entry *email.OutboxEntry) (bool, error) {
 	for _, addr := range entry.ToAddresses {
 		suppressed, err := p.suppressionRepo.IsSuppressed(ctx, addr)

--- a/shared/pkg/email/worker/processor.go
+++ b/shared/pkg/email/worker/processor.go
@@ -207,17 +207,19 @@ func (p *EmailProcessor) checkDunningCancellation(ctx context.Context, entry *em
 }
 
 // checkSuppression checks if any recipient address is suppressed. Cancels the
-// entry as soon as the first suppressed address is found. Returns true if cancelled.
+// entry as soon as the first suppressed address is found. On lookup errors,
+// logs and continues checking remaining recipients (fail-open per address).
+// Returns true if cancelled.
 func (p *EmailProcessor) checkSuppression(ctx context.Context, entry *email.OutboxEntry) (bool, error) {
 	for _, addr := range entry.ToAddresses {
 		suppressed, err := p.suppressionRepo.IsSuppressed(ctx, addr)
 		if err != nil {
-			p.logger.WarnContext(ctx, "failed to check suppression, proceeding with send",
+			p.logger.WarnContext(ctx, "failed to check suppression, continuing",
 				"outbox_id", entry.ID,
 				"address", addr,
 				"error", err,
 			)
-			return false, nil
+			continue
 		}
 		if suppressed {
 			if err := p.outboxRepo.Cancel(ctx, entry.ID); err != nil {

--- a/shared/pkg/email/worker/processor_test.go
+++ b/shared/pkg/email/worker/processor_test.go
@@ -87,6 +87,10 @@ func (m *mockAuditRepo) FindByOutboxID(_ context.Context, _ uuid.UUID) ([]email.
 	return nil, nil
 }
 
+func (m *mockAuditRepo) FindByProviderID(_ context.Context, _ string) ([]email.AuditEntry, error) {
+	return nil, nil
+}
+
 func (m *mockAuditRepo) RecordByProviderID(_ context.Context, _ string, _ email.AuditStatus, _ map[string]any) error {
 	return nil
 }

--- a/shared/pkg/email/worker/processor_test.go
+++ b/shared/pkg/email/worker/processor_test.go
@@ -521,6 +521,27 @@ func TestProcessBatch_SuppressionCheckError_ProceedsWithSend(t *testing.T) {
 	assert.Equal(t, []string{"user@example.com"}, suppression.checkedAddrs, "should have attempted the check")
 }
 
+func TestProcessBatch_SuppressionCheckContextCancelled_DoesNotSend(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	renderer := &mockRenderer{html: "<h1>Hi</h1>", text: "Hi"}
+	sender := &mockSender{result: email.SendResult{ProviderID: "msg-ctx", SentAt: time.Now()}}
+	outbox := &mockOutboxRepo{}
+	audit := &mockAuditRepo{}
+	suppression := &mockSuppressionRepo{isSuppErr: context.Canceled}
+
+	proc := NewEmailProcessor(renderer, sender, outbox, audit, suppression, nil, nil, nil)
+
+	entry := newTestEntry("invoice")
+	instr := &OutboxInstruction{Entry: entry}
+
+	proc.ProcessBatch(ctx, []*OutboxInstruction{instr})
+
+	assert.Equal(t, 0, sender.calls, "should not send when context is cancelled")
+	assert.Equal(t, 0, outbox.markSentCalls)
+}
+
 func TestProcessBatch_NilSuppressionRepo_SkipsCheck(t *testing.T) {
 	ctx := context.Background()
 

--- a/shared/pkg/email/worker/processor_test.go
+++ b/shared/pkg/email/worker/processor_test.go
@@ -100,6 +100,25 @@ func (m *mockInvoiceChecker) IsInvoicePaid(_ context.Context, _, _ string) (bool
 	return m.paid, m.err
 }
 
+type mockSuppressionRepo struct {
+	suppressed    bool
+	isSuppErr     error
+	addCalls      int
+	lastAddEntry  *email.SuppressionEntry
+	checkedAddrs  []string
+}
+
+func (m *mockSuppressionRepo) IsSuppressed(_ context.Context, addr string) (bool, error) {
+	m.checkedAddrs = append(m.checkedAddrs, addr)
+	return m.suppressed, m.isSuppErr
+}
+
+func (m *mockSuppressionRepo) AddSuppression(_ context.Context, entry *email.SuppressionEntry) error {
+	m.addCalls++
+	m.lastAddEntry = entry
+	return nil
+}
+
 // --- Helpers ---
 
 func newTestEntry(templateName string) email.OutboxEntry {
@@ -159,7 +178,7 @@ func TestProcessBatch_HappyPath(t *testing.T) {
 	outbox := &mockOutboxRepo{}
 	audit := &mockAuditRepo{}
 
-	proc := NewEmailProcessor(renderer, sender, outbox, audit, nil, NewEmailMetrics(m), nil)
+	proc := NewEmailProcessor(renderer, sender, outbox, audit, nil, nil, NewEmailMetrics(m), nil)
 
 	entry := newTestEntry("invoice")
 	instr := &OutboxInstruction{Entry: entry}
@@ -184,7 +203,7 @@ func TestProcessBatch_TemplateRenderFailure_DeadLettersImmediately(t *testing.T)
 	outbox := &mockOutboxRepo{}
 	audit := &mockAuditRepo{}
 
-	proc := NewEmailProcessor(renderer, sender, outbox, audit, nil, NewEmailMetrics(m), nil)
+	proc := NewEmailProcessor(renderer, sender, outbox, audit, nil, nil, NewEmailMetrics(m), nil)
 
 	entry := newTestEntry("invoice")
 	entry.Attempts = 0
@@ -211,7 +230,7 @@ func TestProcessBatch_SendFailure_WithRetry(t *testing.T) {
 	outbox := &mockOutboxRepo{}
 	audit := &mockAuditRepo{}
 
-	proc := NewEmailProcessor(renderer, sender, outbox, audit, nil, NewEmailMetrics(m), nil)
+	proc := NewEmailProcessor(renderer, sender, outbox, audit, nil, nil, NewEmailMetrics(m), nil)
 
 	entry := newTestEntry("invoice")
 	entry.Attempts = 1
@@ -238,7 +257,7 @@ func TestProcessBatch_SendFailure_DeadLetter(t *testing.T) {
 	outbox := &mockOutboxRepo{}
 	audit := &mockAuditRepo{}
 
-	proc := NewEmailProcessor(renderer, sender, outbox, audit, nil, NewEmailMetrics(m), nil)
+	proc := NewEmailProcessor(renderer, sender, outbox, audit, nil, nil, NewEmailMetrics(m), nil)
 
 	entry := newTestEntry("invoice")
 	entry.Attempts = 4
@@ -263,7 +282,7 @@ func TestProcessBatch_DunningCancellation_InvoicePaid(t *testing.T) {
 	audit := &mockAuditRepo{}
 	checker := &mockInvoiceChecker{paid: true}
 
-	proc := NewEmailProcessor(renderer, sender, outbox, audit, checker, NewEmailMetrics(m), nil)
+	proc := NewEmailProcessor(renderer, sender, outbox, audit, nil, checker, NewEmailMetrics(m), nil)
 
 	entry := newTestEntry("dunning-notice")
 	entry.TemplateData = map[string]any{
@@ -290,7 +309,7 @@ func TestProcessBatch_DunningNotCancelled_InvoiceUnpaid(t *testing.T) {
 	audit := &mockAuditRepo{}
 	checker := &mockInvoiceChecker{paid: false}
 
-	proc := NewEmailProcessor(renderer, sender, outbox, audit, checker, nil, nil)
+	proc := NewEmailProcessor(renderer, sender, outbox, audit, nil, checker, nil, nil)
 
 	entry := newTestEntry("dunning-notice")
 	entry.TemplateData = map[string]any{
@@ -315,7 +334,7 @@ func TestProcessBatch_DunningCancellation_CheckerError(t *testing.T) {
 	audit := &mockAuditRepo{}
 	checker := &mockInvoiceChecker{err: errors.New("db error")}
 
-	proc := NewEmailProcessor(renderer, sender, outbox, audit, checker, nil, nil)
+	proc := NewEmailProcessor(renderer, sender, outbox, audit, nil, checker, nil, nil)
 
 	entry := newTestEntry("dunning-notice")
 	entry.TemplateData = map[string]any{
@@ -340,7 +359,7 @@ func TestProcessBatch_ContextCancelled(t *testing.T) {
 	outbox := &mockOutboxRepo{}
 	audit := &mockAuditRepo{}
 
-	proc := NewEmailProcessor(renderer, sender, outbox, audit, nil, nil, nil)
+	proc := NewEmailProcessor(renderer, sender, outbox, audit, nil, nil, nil, nil)
 
 	entry := newTestEntry("invoice")
 	instr := &OutboxInstruction{Entry: entry}
@@ -358,7 +377,7 @@ func TestProcessBatch_AuditFailureDoesNotBlockSend(t *testing.T) {
 	outbox := &mockOutboxRepo{}
 	audit := &mockAuditRepo{recordErr: errors.New("audit db error")}
 
-	proc := NewEmailProcessor(renderer, sender, outbox, audit, nil, nil, nil)
+	proc := NewEmailProcessor(renderer, sender, outbox, audit, nil, nil, nil, nil)
 
 	entry := newTestEntry("invoice")
 	instr := &OutboxInstruction{Entry: entry}
@@ -377,7 +396,7 @@ func TestProcessBatch_NilInvoiceChecker_DunningProceedsNormally(t *testing.T) {
 	outbox := &mockOutboxRepo{}
 	audit := &mockAuditRepo{}
 
-	proc := NewEmailProcessor(renderer, sender, outbox, audit, nil, nil, nil)
+	proc := NewEmailProcessor(renderer, sender, outbox, audit, nil, nil, nil, nil)
 
 	entry := newTestEntry("dunning-notice")
 	entry.TemplateData = map[string]any{
@@ -401,7 +420,7 @@ func TestProcessBatch_SendErrorMetricsRecorded(t *testing.T) {
 	outbox := &mockOutboxRepo{}
 	audit := &mockAuditRepo{}
 
-	proc := NewEmailProcessor(renderer, sender, outbox, audit, nil, NewEmailMetrics(m), nil)
+	proc := NewEmailProcessor(renderer, sender, outbox, audit, nil, nil, NewEmailMetrics(m), nil)
 
 	entry := newTestEntry("invoice")
 	instr := &OutboxInstruction{Entry: entry}
@@ -430,4 +449,87 @@ func TestProcessBatch_SendErrorMetricsRecorded(t *testing.T) {
 		}
 	}
 	assert.True(t, foundError, "send_errors_total metric should exist")
+}
+
+func TestProcessBatch_SuppressedRecipient_CancelsEntry(t *testing.T) {
+	ctx := context.Background()
+	m, reg := newTestMetrics(t)
+
+	renderer := &mockRenderer{html: "<h1>Hi</h1>", text: "Hi"}
+	sender := &mockSender{}
+	outbox := &mockOutboxRepo{}
+	audit := &mockAuditRepo{}
+	suppression := &mockSuppressionRepo{suppressed: true}
+
+	proc := NewEmailProcessor(renderer, sender, outbox, audit, suppression, nil, NewEmailMetrics(m), nil)
+
+	entry := newTestEntry("invoice")
+	instr := &OutboxInstruction{Entry: entry}
+
+	proc.ProcessBatch(ctx, []*OutboxInstruction{instr})
+
+	assert.Equal(t, 0, sender.calls, "should not send to suppressed recipient")
+	assert.Equal(t, 1, outbox.cancelCalls, "should cancel the entry")
+	assert.Equal(t, 0, outbox.markSentCalls)
+	assert.Equal(t, float64(1), getMetricValue(t, reg, "meridian_email_outbox_cancelled_total"))
+}
+
+func TestProcessBatch_NotSuppressed_SendsNormally(t *testing.T) {
+	ctx := context.Background()
+
+	renderer := &mockRenderer{html: "<h1>Hi</h1>", text: "Hi"}
+	sender := &mockSender{result: email.SendResult{ProviderID: "msg-ok", SentAt: time.Now()}}
+	outbox := &mockOutboxRepo{}
+	audit := &mockAuditRepo{}
+	suppression := &mockSuppressionRepo{suppressed: false}
+
+	proc := NewEmailProcessor(renderer, sender, outbox, audit, suppression, nil, nil, nil)
+
+	entry := newTestEntry("invoice")
+	instr := &OutboxInstruction{Entry: entry}
+
+	proc.ProcessBatch(ctx, []*OutboxInstruction{instr})
+
+	assert.Equal(t, 1, sender.calls, "should send when not suppressed")
+	assert.Equal(t, 1, outbox.markSentCalls)
+	assert.Equal(t, 0, outbox.cancelCalls)
+}
+
+func TestProcessBatch_SuppressionCheckError_ProceedsWithSend(t *testing.T) {
+	ctx := context.Background()
+
+	renderer := &mockRenderer{html: "<h1>Hi</h1>", text: "Hi"}
+	sender := &mockSender{result: email.SendResult{ProviderID: "msg-err", SentAt: time.Now()}}
+	outbox := &mockOutboxRepo{}
+	audit := &mockAuditRepo{}
+	suppression := &mockSuppressionRepo{isSuppErr: errors.New("db error")}
+
+	proc := NewEmailProcessor(renderer, sender, outbox, audit, suppression, nil, nil, nil)
+
+	entry := newTestEntry("invoice")
+	instr := &OutboxInstruction{Entry: entry}
+
+	proc.ProcessBatch(ctx, []*OutboxInstruction{instr})
+
+	assert.Equal(t, 1, sender.calls, "should send when suppression check fails")
+	assert.Equal(t, 1, outbox.markSentCalls)
+}
+
+func TestProcessBatch_NilSuppressionRepo_SkipsCheck(t *testing.T) {
+	ctx := context.Background()
+
+	renderer := &mockRenderer{html: "<h1>Hi</h1>", text: "Hi"}
+	sender := &mockSender{result: email.SendResult{ProviderID: "msg-nil-supp", SentAt: time.Now()}}
+	outbox := &mockOutboxRepo{}
+	audit := &mockAuditRepo{}
+
+	proc := NewEmailProcessor(renderer, sender, outbox, audit, nil, nil, nil, nil)
+
+	entry := newTestEntry("invoice")
+	instr := &OutboxInstruction{Entry: entry}
+
+	proc.ProcessBatch(ctx, []*OutboxInstruction{instr})
+
+	assert.Equal(t, 1, sender.calls, "should send when no suppression repo configured")
+	assert.Equal(t, 1, outbox.markSentCalls)
 }

--- a/shared/pkg/email/worker/processor_test.go
+++ b/shared/pkg/email/worker/processor_test.go
@@ -497,6 +497,7 @@ func TestProcessBatch_NotSuppressed_SendsNormally(t *testing.T) {
 	assert.Equal(t, 1, sender.calls, "should send when not suppressed")
 	assert.Equal(t, 1, outbox.markSentCalls)
 	assert.Equal(t, 0, outbox.cancelCalls)
+	assert.Equal(t, []string{"user@example.com"}, suppression.checkedAddrs, "should have checked the recipient")
 }
 
 func TestProcessBatch_SuppressionCheckError_ProceedsWithSend(t *testing.T) {
@@ -517,6 +518,7 @@ func TestProcessBatch_SuppressionCheckError_ProceedsWithSend(t *testing.T) {
 
 	assert.Equal(t, 1, sender.calls, "should send when suppression check fails")
 	assert.Equal(t, 1, outbox.markSentCalls)
+	assert.Equal(t, []string{"user@example.com"}, suppression.checkedAddrs, "should have attempted the check")
 }
 
 func TestProcessBatch_NilSuppressionRepo_SkipsCheck(t *testing.T) {

--- a/shared/pkg/email/worker/processor_test.go
+++ b/shared/pkg/email/worker/processor_test.go
@@ -105,11 +105,11 @@ func (m *mockInvoiceChecker) IsInvoicePaid(_ context.Context, _, _ string) (bool
 }
 
 type mockSuppressionRepo struct {
-	suppressed    bool
-	isSuppErr     error
-	addCalls      int
-	lastAddEntry  *email.SuppressionEntry
-	checkedAddrs  []string
+	suppressed   bool
+	isSuppErr    error
+	addCalls     int
+	lastAddEntry *email.SuppressionEntry
+	checkedAddrs []string
 }
 
 func (m *mockSuppressionRepo) IsSuppressed(_ context.Context, addr string) (bool, error) {

--- a/shared/pkg/email/worker/worker.go
+++ b/shared/pkg/email/worker/worker.go
@@ -43,6 +43,7 @@ func NewEmailWorker(
 	auditRepo email.AuditRepository,
 	renderer email.TemplateRenderer,
 	sender email.Sender,
+	suppressionRepo email.SuppressionRepository,
 	invoiceChecker InvoiceStatusChecker,
 	metrics *email.Metrics,
 	config dispatch.WorkerConfig,
@@ -50,7 +51,7 @@ func NewEmailWorker(
 ) *dispatch.Worker[*OutboxInstruction] {
 	fetcher := NewOutboxFetcher(outboxRepo)
 	emailMetrics := NewEmailMetrics(metrics)
-	processor := NewEmailProcessor(renderer, sender, outboxRepo, auditRepo, invoiceChecker, emailMetrics, logger)
+	processor := NewEmailProcessor(renderer, sender, outboxRepo, auditRepo, suppressionRepo, invoiceChecker, emailMetrics, logger)
 
 	return dispatch.NewWorker[*OutboxInstruction](
 		fetcher,


### PR DESCRIPTION
## Summary

- Add `SuppressionRepository` for tracking bounced/complained email addresses with cross-tenant lookup
- Integrate suppression checks into `EmailProcessor` - suppressed recipients are cancelled before sending
- Create `DeliveryStatusRecorder` to encapsulate audit recording + suppression logic (Phase 1 of correspondence domain extraction)
- Refactor `ResendWebhookHandler` to delegate business logic to `DeliveryStatusRecorder`, keeping only HTTP/signature verification in api-gateway
- Add `FindByProviderID` to `AuditRepository` for cross-tenant recipient resolution

## Changes Made

### Task 4: Complaint suppression in email worker
- `shared/pkg/email/suppression.go` - `SuppressionRepository` interface, `PostgresSuppressionRepository` with GORM, ON CONFLICT upsert
- `shared/pkg/email/worker/processor.go` - `checkSuppression()` before send, nil-safe (skips when no repo)
- `cmd/meridian/main.go` - Wire suppression repo into email worker
- `cmd/meridian/gateway.go` - Wire suppression repo into webhook handler via DeliveryStatusRecorder

### Task 5: Relocate webhook handler to correspondence domain
- `shared/pkg/email/delivery_status.go` - `DeliveryStatusRecorder` encapsulating audit + suppression
- `shared/pkg/email/repository.go` - Add `FindByProviderID` to `AuditRepository` interface
- `shared/pkg/email/audit_postgres.go` - Implement `FindByProviderID` (cross-tenant)
- `services/api-gateway/resend_webhook_handler.go` - Delegate to `DeliveryStatusRecorder`

## Test plan

- [x] `TestPostgresSuppressionRepository_*` - CRUD, case insensitivity, upsert, cross-tenant
- [x] `TestProcessBatch_SuppressedRecipient_*` - cancellation, skip-when-nil, error-proceeds
- [x] `TestDeliveryStatusRecorder_*` - bounce/complaint suppression, error propagation, nil-safety
- [x] `TestResendWebhookHandler_*` - existing webhook tests passing with refactored handler
- [x] `go vet ./...` passes