### PR TITLE
fix: ensure databases exist before app startup in deploy workflows

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -223,25 +223,21 @@ jobs:
             # databases are added to init-databases.sql, existing volumes
             # won't have them. Create any missing databases so the app can start.
             cd /opt/meridian
+            created=0
             for db in $(grep -oP 'CREATE DATABASE \K\w+' init-databases.sql); do
               exists=$(docker exec meridian-postgres-1 psql -U meridian -tAc \
                 "SELECT 1 FROM pg_database WHERE datname = '${db}'")
               if [ "$exists" != "1" ]; then
                 docker exec meridian-postgres-1 createdb -U meridian "${db}"
                 echo "Created missing database: ${db}"
+                created=1
               fi
             done
-
-      - name: Restart app after database provisioning
-        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
-        with:
-          host: ${{ secrets.DROPLET_IP }}
-          username: deploy
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
-          script: |
-            # Restart to pick up any newly-created databases
-            cd /opt/meridian
-            docker compose restart meridian
+            if [ "$created" = "1" ]; then
+              echo "New databases created - restarting app to pick up connections"
+              docker compose restart meridian
+            fi
+            # Wait for the container to be running before attempting migrations
             for i in $(seq 1 30); do
               if docker exec meridian-meridian-1 echo ok 2>/dev/null; then
                 echo "Container is running"

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -241,11 +241,13 @@ jobs:
             for i in $(seq 1 30); do
               if docker exec meridian-meridian-1 echo ok 2>/dev/null; then
                 echo "Container is running"
-                break
+                exit 0
               fi
               echo "Waiting for container... ($i/30)"
               sleep 2
             done
+            echo "Container failed to start after 60s"
+            exit 1
 
       - name: Run migrations
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -212,6 +212,45 @@ jobs:
             docker compose exec -T caddy caddy reload --config /etc/caddy/Caddyfile
             docker image prune -f
 
+      - name: Ensure databases exist
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            # Docker init scripts only run on first volume creation. When new
+            # databases are added to init-databases.sql, existing volumes
+            # won't have them. Create any missing databases so the app can start.
+            cd /opt/meridian
+            for db in $(grep -oP 'CREATE DATABASE \K\w+' init-databases.sql); do
+              exists=$(docker exec meridian-postgres-1 psql -U meridian -tAc \
+                "SELECT 1 FROM pg_database WHERE datname = '${db}'")
+              if [ "$exists" != "1" ]; then
+                docker exec meridian-postgres-1 createdb -U meridian "${db}"
+                echo "Created missing database: ${db}"
+              fi
+            done
+
+      - name: Restart app after database provisioning
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            # Restart to pick up any newly-created databases
+            cd /opt/meridian
+            docker compose restart meridian
+            for i in $(seq 1 30); do
+              if docker exec meridian-meridian-1 echo ok 2>/dev/null; then
+                echo "Container is running"
+                break
+              fi
+              echo "Waiting for container... ($i/30)"
+              sleep 2
+            done
+
       - name: Run migrations
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -235,26 +235,20 @@ jobs:
             # databases are added to init-databases-develop.sql, existing volumes
             # won't have them. Create any missing databases so the app can start.
             cd /opt/meridian-develop
+            created=0
             for db in $(grep -oP 'CREATE DATABASE \K\w+' init-databases-develop.sql); do
               exists=$(docker exec postgres-develop psql -U meridian -tAc \
                 "SELECT 1 FROM pg_database WHERE datname = '${db}'")
               if [ "$exists" != "1" ]; then
                 docker exec postgres-develop createdb -U meridian "${db}"
                 echo "Created missing database: ${db}"
+                created=1
               fi
             done
-
-      - name: Restart app after database provisioning
-        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
-        with:
-          host: ${{ secrets.DROPLET_IP }}
-          username: deploy
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
-          script: |
-            # Restart to pick up any newly-created databases. The app connects to
-            # all databases at startup; missing ones cause a crash loop.
-            cd /opt/meridian-develop
-            docker compose -f docker-compose.develop.yml restart meridian-develop
+            if [ "$created" = "1" ]; then
+              echo "New databases created - restarting app to pick up connections"
+              docker compose -f docker-compose.develop.yml restart meridian-develop
+            fi
             # Wait for the container to be running before attempting migrations
             for i in $(seq 1 30); do
               if docker exec meridian-develop echo ok 2>/dev/null; then

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -224,6 +224,47 @@ jobs:
             docker compose -f /opt/meridian/docker-compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile
             docker image prune -f
 
+      - name: Ensure databases exist
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            # Docker init scripts only run on first volume creation. When new
+            # databases are added to init-databases-develop.sql, existing volumes
+            # won't have them. Create any missing databases so the app can start.
+            cd /opt/meridian-develop
+            for db in $(grep -oP 'CREATE DATABASE \K\w+' init-databases-develop.sql); do
+              exists=$(docker exec postgres-develop psql -U meridian -tAc \
+                "SELECT 1 FROM pg_database WHERE datname = '${db}'")
+              if [ "$exists" != "1" ]; then
+                docker exec postgres-develop createdb -U meridian "${db}"
+                echo "Created missing database: ${db}"
+              fi
+            done
+
+      - name: Restart app after database provisioning
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            # Restart to pick up any newly-created databases. The app connects to
+            # all databases at startup; missing ones cause a crash loop.
+            cd /opt/meridian-develop
+            docker compose -f docker-compose.develop.yml restart meridian-develop
+            # Wait for the container to be running before attempting migrations
+            for i in $(seq 1 30); do
+              if docker exec meridian-develop echo ok 2>/dev/null; then
+                echo "Container is running"
+                break
+              fi
+              echo "Waiting for container... ($i/30)"
+              sleep 2
+            done
+
       - name: Run migrations
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -253,11 +253,13 @@ jobs:
             for i in $(seq 1 30); do
               if docker exec meridian-develop echo ok 2>/dev/null; then
                 echo "Container is running"
-                break
+                exit 0
               fi
               echo "Waiting for container... ($i/30)"
               sleep 2
             done
+            echo "Container failed to start after 60s"
+            exit 1
 
       - name: Run migrations
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5


### PR DESCRIPTION
## Summary

- Both develop and demo deploy workflows fail when new databases are added to the init SQL files because Docker only runs init scripts on first volume creation
- Develop has been failing since #2050 (control-plane DB separation) - the app crash-loops because `meridian_control_plane` doesn't exist on the existing postgres volume, so `docker exec --migrate` can never run
- Demo's seed step fails because the same missing database prevents proper tenant schema provisioning

## Changes Made

- Add "Ensure databases exist" step to both `deploy-develop.yml` and `deploy-demo.yml`
- Parses the init SQL file for `CREATE DATABASE` statements and idempotently creates any missing databases via `createdb`
- Adds a restart + readiness wait after database provisioning so the app picks up newly-created databases before migrations run

## Test plan

- [ ] Merge and verify develop deploy succeeds (has been broken since March 30)
- [ ] Fast-forward demo to develop and verify demo deploy succeeds
- [ ] Confirm the ensure step is a no-op when all databases already exist (no unnecessary restarts on subsequent deploys)