### PR TITLE
feat: category enforcement with templateCategoryMap

### DIFF
--- a/cmd/meridian/wire_grpc.go
+++ b/cmd/meridian/wire_grpc.go
@@ -330,10 +330,13 @@ func wireCurrentAccount(
 	// Uses the current-account database for the email outbox (each service owns its outbox).
 	caEmailOutboxRepo := email.NewPostgresOutboxRepository(db)
 	emailResolver := newGRPCPartyEmailResolver(partyLoopback.Conn())
+	prefRepo := email.NewPostgresPreferenceRepository(db)
+	prefEnforcer := email.NewPreferenceEnforcer(prefRepo, email.DefaultTemplateCategoryMap, logger.With("component", "preference-enforcer"))
 	notifHandler := email.NewNotificationSendHandler(email.NotificationHandlerDeps{
-		Outbox:        caEmailOutboxRepo,
-		EmailResolver: emailResolver,
-		Logger:        logger.With("component", "notification-handler"),
+		Outbox:             caEmailOutboxRepo,
+		EmailResolver:      emailResolver,
+		PreferenceEnforcer: prefEnforcer,
+		Logger:             logger.With("component", "notification-handler"),
 	})
 	caOpts = append(caOpts, currentaccountservice.WithNotificationSagaHandler(notifHandler))
 

--- a/cmd/meridian/wire_grpc.go
+++ b/cmd/meridian/wire_grpc.go
@@ -331,7 +331,7 @@ func wireCurrentAccount(
 	caEmailOutboxRepo := email.NewPostgresOutboxRepository(db)
 	emailResolver := newGRPCPartyEmailResolver(partyLoopback.Conn())
 	prefRepo := email.NewPostgresPreferenceRepository(db)
-	prefEnforcer := email.NewPreferenceEnforcer(prefRepo, email.DefaultTemplateCategoryMap, logger.With("component", "preference-enforcer"))
+	prefEnforcer := email.NewPreferenceEnforcer(prefRepo, email.DefaultTemplateCategoryMap(), logger.With("component", "preference-enforcer"))
 	notifHandler := email.NewNotificationSendHandler(email.NotificationHandlerDeps{
 		Outbox:             caEmailOutboxRepo,
 		EmailResolver:      emailResolver,

--- a/shared/pkg/email/category_map.go
+++ b/shared/pkg/email/category_map.go
@@ -1,0 +1,20 @@
+package email
+
+// DefaultTemplateCategoryMap maps template names to their allowed category.
+// This prevents callers from self-declaring a category to bypass consent checks
+// (e.g., declaring a marketing template as TRANSACTIONAL).
+var DefaultTemplateCategoryMap = map[string]string{
+	// Transactional - legally required, cannot be suppressed.
+	"dunning-notice":       CategoryTransactional,
+	"account-frozen":       CategoryTransactional,
+	"payment-confirmation": CategoryTransactional,
+	"invoice-delivery":     CategoryTransactional,
+
+	// Operational - service-related, opt-out model.
+	"dunning-resolved": CategoryOperational,
+	"welcome":          CategoryOperational,
+	"service-update":   CategoryOperational,
+
+	// Marketing - promotional, opt-in model.
+	"promotional-offer": CategoryMarketing,
+}

--- a/shared/pkg/email/category_map.go
+++ b/shared/pkg/email/category_map.go
@@ -1,9 +1,9 @@
 package email
 
-// DefaultTemplateCategoryMap maps template names to their allowed category.
+// defaultTemplateCategoryMap maps template names to their allowed category.
 // This prevents callers from self-declaring a category to bypass consent checks
 // (e.g., declaring a marketing template as TRANSACTIONAL).
-var DefaultTemplateCategoryMap = map[string]string{
+var defaultTemplateCategoryMap = map[string]string{
 	// Transactional - legally required, cannot be suppressed.
 	"dunning-notice":       CategoryTransactional,
 	"account-frozen":       CategoryTransactional,
@@ -17,4 +17,15 @@ var DefaultTemplateCategoryMap = map[string]string{
 
 	// Marketing - promotional, opt-in model.
 	"promotional-offer": CategoryMarketing,
+}
+
+// DefaultTemplateCategoryMap returns a copy of the default template-to-category
+// mapping. Each call returns a fresh map, so callers cannot mutate the canonical
+// enforcement rules.
+func DefaultTemplateCategoryMap() map[string]string {
+	cp := make(map[string]string, len(defaultTemplateCategoryMap))
+	for k, v := range defaultTemplateCategoryMap {
+		cp[k] = v
+	}
+	return cp
 }

--- a/shared/pkg/email/category_map_test.go
+++ b/shared/pkg/email/category_map_test.go
@@ -1,0 +1,127 @@
+package email_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/pkg/email"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultTemplateCategoryMap_AllEntriesHaveValidCategories(t *testing.T) {
+	validCategories := map[string]bool{
+		email.CategoryTransactional: true,
+		email.CategoryOperational:   true,
+		email.CategoryMarketing:     true,
+	}
+
+	for template, category := range email.DefaultTemplateCategoryMap {
+		assert.True(t, validCategories[category],
+			"template %q has invalid category %q", template, category)
+	}
+}
+
+func TestDefaultTemplateCategoryMap_TransactionalTemplates(t *testing.T) {
+	transactional := []string{
+		"dunning-notice",
+		"account-frozen",
+		"payment-confirmation",
+		"invoice-delivery",
+	}
+	for _, tmpl := range transactional {
+		assert.Equal(t, email.CategoryTransactional, email.DefaultTemplateCategoryMap[tmpl],
+			"template %q should be TRANSACTIONAL", tmpl)
+	}
+}
+
+func TestDefaultTemplateCategoryMap_OperationalTemplates(t *testing.T) {
+	operational := []string{
+		"dunning-resolved",
+		"welcome",
+		"service-update",
+	}
+	for _, tmpl := range operational {
+		assert.Equal(t, email.CategoryOperational, email.DefaultTemplateCategoryMap[tmpl],
+			"template %q should be OPERATIONAL", tmpl)
+	}
+}
+
+func TestDefaultTemplateCategoryMap_MarketingTemplates(t *testing.T) {
+	marketing := []string{
+		"promotional-offer",
+	}
+	for _, tmpl := range marketing {
+		assert.Equal(t, email.CategoryMarketing, email.DefaultTemplateCategoryMap[tmpl],
+			"template %q should be MARKETING", tmpl)
+	}
+}
+
+func TestCategoryEnforcement_MismatchRejectedForAllMapEntries(t *testing.T) {
+	enforcer := email.NewPreferenceEnforcer(
+		&mockPreferenceRepository{},
+		email.DefaultTemplateCategoryMap,
+		slog.Default(),
+	)
+
+	// For each template in the map, try declaring a wrong category and verify rejection.
+	for tmpl, correctCategory := range email.DefaultTemplateCategoryMap {
+		wrongCategory := email.CategoryMarketing
+		if correctCategory == email.CategoryMarketing {
+			wrongCategory = email.CategoryTransactional
+		}
+
+		allowed, reason, err := enforcer.ShouldSend(testCtx(), "t1", "p1", "EMAIL", tmpl, wrongCategory)
+		require.ErrorIs(t, err, email.ErrCategoryMismatch, "template %q should reject mismatched category", tmpl)
+		assert.False(t, allowed, "template %q should not be allowed with wrong category", tmpl)
+		assert.Contains(t, reason, "category mismatch", "template %q reason should mention mismatch", tmpl)
+	}
+}
+
+func TestCategoryEnforcement_CorrectCategoryAllowed(t *testing.T) {
+	enforcer := email.NewPreferenceEnforcer(
+		&mockPreferenceRepository{},
+		email.DefaultTemplateCategoryMap,
+		slog.Default(),
+	)
+
+	// Transactional templates should always be allowed.
+	for _, tmpl := range []string{"dunning-notice", "account-frozen", "payment-confirmation", "invoice-delivery"} {
+		allowed, _, err := enforcer.ShouldSend(testCtx(), "t1", "p1", "EMAIL", tmpl, email.CategoryTransactional)
+		require.NoError(t, err, "template %q with correct category should not error", tmpl)
+		assert.True(t, allowed, "template %q with correct TRANSACTIONAL category should be allowed", tmpl)
+	}
+
+	// Operational templates should be allowed by default (no explicit opt-out).
+	for _, tmpl := range []string{"dunning-resolved", "welcome", "service-update"} {
+		allowed, _, err := enforcer.ShouldSend(testCtx(), "t1", "p1", "EMAIL", tmpl, email.CategoryOperational)
+		require.NoError(t, err, "template %q with correct category should not error", tmpl)
+		assert.True(t, allowed, "template %q with correct OPERATIONAL category should be allowed", tmpl)
+	}
+}
+
+func TestCategoryEnforcement_MarketingCorrectCategorySuppressedWithoutOptIn(t *testing.T) {
+	enforcer := email.NewPreferenceEnforcer(
+		&mockPreferenceRepository{}, // no explicit opt-in
+		email.DefaultTemplateCategoryMap,
+		slog.Default(),
+	)
+
+	allowed, reason, err := enforcer.ShouldSend(testCtx(), "t1", "p1", "EMAIL", "promotional-offer", email.CategoryMarketing)
+	require.NoError(t, err)
+	assert.False(t, allowed, "marketing should be suppressed without opt-in")
+	assert.Contains(t, reason, "no explicit opt-in")
+}
+
+func TestCategoryEnforcement_UnknownTemplatePassesThrough(t *testing.T) {
+	enforcer := email.NewPreferenceEnforcer(
+		&mockPreferenceRepository{},
+		email.DefaultTemplateCategoryMap,
+		slog.Default(),
+	)
+
+	// A template not in the map should skip the map check.
+	allowed, _, err := enforcer.ShouldSend(testCtx(), "t1", "p1", "EMAIL", "custom-template", email.CategoryOperational)
+	require.NoError(t, err)
+	assert.True(t, allowed)
+}

--- a/shared/pkg/email/category_map_test.go
+++ b/shared/pkg/email/category_map_test.go
@@ -16,7 +16,7 @@ func TestDefaultTemplateCategoryMap_AllEntriesHaveValidCategories(t *testing.T) 
 		email.CategoryMarketing:     true,
 	}
 
-	for template, category := range email.DefaultTemplateCategoryMap {
+	for template, category := range email.DefaultTemplateCategoryMap() {
 		assert.True(t, validCategories[category],
 			"template %q has invalid category %q", template, category)
 	}
@@ -30,7 +30,7 @@ func TestDefaultTemplateCategoryMap_TransactionalTemplates(t *testing.T) {
 		"invoice-delivery",
 	}
 	for _, tmpl := range transactional {
-		assert.Equal(t, email.CategoryTransactional, email.DefaultTemplateCategoryMap[tmpl],
+		assert.Equal(t, email.CategoryTransactional, email.DefaultTemplateCategoryMap()[tmpl],
 			"template %q should be TRANSACTIONAL", tmpl)
 	}
 }
@@ -42,7 +42,7 @@ func TestDefaultTemplateCategoryMap_OperationalTemplates(t *testing.T) {
 		"service-update",
 	}
 	for _, tmpl := range operational {
-		assert.Equal(t, email.CategoryOperational, email.DefaultTemplateCategoryMap[tmpl],
+		assert.Equal(t, email.CategoryOperational, email.DefaultTemplateCategoryMap()[tmpl],
 			"template %q should be OPERATIONAL", tmpl)
 	}
 }
@@ -52,7 +52,7 @@ func TestDefaultTemplateCategoryMap_MarketingTemplates(t *testing.T) {
 		"promotional-offer",
 	}
 	for _, tmpl := range marketing {
-		assert.Equal(t, email.CategoryMarketing, email.DefaultTemplateCategoryMap[tmpl],
+		assert.Equal(t, email.CategoryMarketing, email.DefaultTemplateCategoryMap()[tmpl],
 			"template %q should be MARKETING", tmpl)
 	}
 }
@@ -60,12 +60,12 @@ func TestDefaultTemplateCategoryMap_MarketingTemplates(t *testing.T) {
 func TestCategoryEnforcement_MismatchRejectedForAllMapEntries(t *testing.T) {
 	enforcer := email.NewPreferenceEnforcer(
 		&mockPreferenceRepository{},
-		email.DefaultTemplateCategoryMap,
+		email.DefaultTemplateCategoryMap(),
 		slog.Default(),
 	)
 
 	// For each template in the map, try declaring a wrong category and verify rejection.
-	for tmpl, correctCategory := range email.DefaultTemplateCategoryMap {
+	for tmpl, correctCategory := range email.DefaultTemplateCategoryMap() {
 		wrongCategory := email.CategoryMarketing
 		if correctCategory == email.CategoryMarketing {
 			wrongCategory = email.CategoryTransactional
@@ -81,7 +81,7 @@ func TestCategoryEnforcement_MismatchRejectedForAllMapEntries(t *testing.T) {
 func TestCategoryEnforcement_CorrectCategoryAllowed(t *testing.T) {
 	enforcer := email.NewPreferenceEnforcer(
 		&mockPreferenceRepository{},
-		email.DefaultTemplateCategoryMap,
+		email.DefaultTemplateCategoryMap(),
 		slog.Default(),
 	)
 
@@ -103,7 +103,7 @@ func TestCategoryEnforcement_CorrectCategoryAllowed(t *testing.T) {
 func TestCategoryEnforcement_MarketingCorrectCategorySuppressedWithoutOptIn(t *testing.T) {
 	enforcer := email.NewPreferenceEnforcer(
 		&mockPreferenceRepository{}, // no explicit opt-in
-		email.DefaultTemplateCategoryMap,
+		email.DefaultTemplateCategoryMap(),
 		slog.Default(),
 	)
 
@@ -116,7 +116,7 @@ func TestCategoryEnforcement_MarketingCorrectCategorySuppressedWithoutOptIn(t *t
 func TestCategoryEnforcement_UnknownTemplatePassesThrough(t *testing.T) {
 	enforcer := email.NewPreferenceEnforcer(
 		&mockPreferenceRepository{},
-		email.DefaultTemplateCategoryMap,
+		email.DefaultTemplateCategoryMap(),
 		slog.Default(),
 	)
 

--- a/shared/pkg/email/preference_enforcer.go
+++ b/shared/pkg/email/preference_enforcer.go
@@ -36,9 +36,13 @@ func NewPreferenceEnforcer(prefRepo PreferenceRepository, templateCategoryMap ma
 	if logger == nil {
 		logger = slog.Default()
 	}
+	cp := make(map[string]string, len(templateCategoryMap))
+	for k, v := range templateCategoryMap {
+		cp[k] = v
+	}
 	return &PreferenceEnforcer{
 		prefRepo:            prefRepo,
-		templateCategoryMap: templateCategoryMap,
+		templateCategoryMap: cp,
 		logger:              logger,
 	}
 }


### PR DESCRIPTION
## Summary

- Add `DefaultTemplateCategoryMap` mapping template names to their allowed `CorrespondenceCategory` (TRANSACTIONAL, OPERATIONAL, MARKETING)
- Wire `PreferenceEnforcer` with the category map into the notification handler in `wire_grpc.go`, enabling server-side enforcement that prevents callers from self-declaring a category to bypass consent checks
- Add unit tests verifying mismatch rejection for all mapped templates, correct category passthrough, and unknown template passthrough

## Test plan

- [x] All 8 new category map tests pass
- [x] All 32 existing email package unit tests pass
- [x] `cmd/meridian` builds successfully with wired PreferenceEnforcer
- [ ] CI passes