### PR TITLE
feat: add visible unsubscribe links to non-transactional email templates

### DIFF
--- a/shared/pkg/email/template_data.go
+++ b/shared/pkg/email/template_data.go
@@ -71,6 +71,7 @@ type WelcomeData struct {
 	TenantName        string
 	LoginURL          string
 	GettingStartedURL string
+	UnsubscribeURL    string // populated by the processor for non-transactional emails
 }
 
 // AccountLockoutData holds the data required to render an account lockout email.

--- a/shared/pkg/email/template_test.go
+++ b/shared/pkg/email/template_test.go
@@ -522,6 +522,71 @@ func TestRender_Welcome_EmptyData_DoesNotPanic(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestRender_Welcome_WithUnsubscribeURL(t *testing.T) {
+	r := newTestRenderer(t)
+	data := WelcomeData{
+		TenantName:        "Acme Platform",
+		LoginURL:          "https://app.example.com/login",
+		GettingStartedURL: "https://docs.example.com/getting-started",
+		UnsubscribeURL:    "https://app.example.com/unsubscribe?token=abc123",
+	}
+
+	html, text, err := r.Render("welcome", data)
+	require.NoError(t, err)
+
+	assert.Contains(t, html, "https://app.example.com/unsubscribe?token=abc123")
+	assert.Contains(t, html, "Unsubscribe from these emails")
+
+	assert.Contains(t, text, "Unsubscribe: https://app.example.com/unsubscribe?token=abc123")
+}
+
+func TestRender_Welcome_WithoutUnsubscribeURL_NoLink(t *testing.T) {
+	r := newTestRenderer(t)
+	data := WelcomeData{
+		TenantName:        "Acme Platform",
+		LoginURL:          "https://app.example.com/login",
+		GettingStartedURL: "https://docs.example.com/getting-started",
+	}
+
+	html, text, err := r.Render("welcome", data)
+	require.NoError(t, err)
+
+	assert.NotContains(t, html, "Unsubscribe")
+	assert.NotContains(t, text, "Unsubscribe")
+}
+
+func TestRender_Welcome_MapData_WithUnsubscribeURL(t *testing.T) {
+	r := newTestRenderer(t)
+	data := map[string]any{
+		"TenantName":        "Acme Platform",
+		"LoginURL":          "https://app.example.com/login",
+		"GettingStartedURL": "https://docs.example.com/getting-started",
+		"UnsubscribeURL":    "https://app.example.com/unsubscribe?token=xyz",
+	}
+
+	html, text, err := r.Render("welcome", data)
+	require.NoError(t, err)
+
+	assert.Contains(t, html, "https://app.example.com/unsubscribe?token=xyz")
+	assert.Contains(t, html, "Unsubscribe from these emails")
+	assert.Contains(t, text, "Unsubscribe: https://app.example.com/unsubscribe?token=xyz")
+}
+
+func TestRender_Welcome_MapData_WithoutUnsubscribeURL(t *testing.T) {
+	r := newTestRenderer(t)
+	data := map[string]any{
+		"TenantName":        "Acme Platform",
+		"LoginURL":          "https://app.example.com/login",
+		"GettingStartedURL": "https://docs.example.com/getting-started",
+	}
+
+	html, text, err := r.Render("welcome", data)
+	require.NoError(t, err)
+
+	assert.NotContains(t, html, "Unsubscribe")
+	assert.NotContains(t, text, "Unsubscribe")
+}
+
 // ---- Account Lockout ----
 
 func TestRender_AccountLockout_ReturnsBothOutputs(t *testing.T) {

--- a/shared/pkg/email/templates/welcome.html
+++ b/shared/pkg/email/templates/welcome.html
@@ -38,6 +38,7 @@
     </div>
   </div>
   <div class="footer">
+    {{if .UnsubscribeURL}}<p style="margin: 0 0 8px;"><a href="{{.UnsubscribeURL}}" style="color: #94a3b8; font-size: 12px; text-decoration: underline;">Unsubscribe from these emails</a></p>{{end}}
     <p>&copy; Meridian &mdash; The Operating System for the Real-World Economy</p>
   </div>
 </div>

--- a/shared/pkg/email/templates/welcome.txt
+++ b/shared/pkg/email/templates/welcome.txt
@@ -8,5 +8,7 @@ Sign in: {{.LoginURL}}
 
 Getting Started Guide: {{.GettingStartedURL}}
 
---
+{{if .UnsubscribeURL}}Unsubscribe: {{.UnsubscribeURL}}
+
+{{end}}--
 Meridian - The Operating System for the Real-World Economy

--- a/shared/pkg/email/unsubscribe.go
+++ b/shared/pkg/email/unsubscribe.go
@@ -80,22 +80,32 @@ func computeHMAC(key []byte, message string) string {
 	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
 }
 
+// BuildUnsubscribeURL returns the unsubscribe URL for OPERATIONAL and MARKETING
+// emails. Returns empty string for TRANSACTIONAL emails, unknown categories, or
+// if config is not set.
+func BuildUnsubscribeURL(cfg *UnsubscribeConfig, params UnsubscribeParams) string {
+	if cfg == nil || len(cfg.HMACKey) == 0 || cfg.BaseURL == "" {
+		return ""
+	}
+	switch params.Category {
+	case CategoryOperational, CategoryMarketing:
+		// These categories get unsubscribe URLs
+	default:
+		return ""
+	}
+
+	token := GenerateUnsubscribeToken(cfg.HMACKey, params)
+	return fmt.Sprintf("%s/unsubscribe?token=%s", cfg.BaseURL, url.QueryEscape(token))
+}
+
 // BuildUnsubscribeHeaders returns RFC 2369 List-Unsubscribe and RFC 8058
 // List-Unsubscribe-Post headers for OPERATIONAL and MARKETING emails only.
 // Returns nil for TRANSACTIONAL emails, unknown categories, or if config is not set.
 func BuildUnsubscribeHeaders(cfg *UnsubscribeConfig, params UnsubscribeParams) map[string]string {
-	if cfg == nil || len(cfg.HMACKey) == 0 || cfg.BaseURL == "" {
+	unsubURL := BuildUnsubscribeURL(cfg, params)
+	if unsubURL == "" {
 		return nil
 	}
-	switch params.Category {
-	case CategoryOperational, CategoryMarketing:
-		// These categories get unsubscribe headers
-	default:
-		return nil
-	}
-
-	token := GenerateUnsubscribeToken(cfg.HMACKey, params)
-	unsubURL := fmt.Sprintf("%s/unsubscribe?token=%s", cfg.BaseURL, url.QueryEscape(token))
 
 	return map[string]string{
 		"List-Unsubscribe":      fmt.Sprintf("<%s>", unsubURL),

--- a/shared/pkg/email/unsubscribe.go
+++ b/shared/pkg/email/unsubscribe.go
@@ -95,7 +95,8 @@ func BuildUnsubscribeURL(cfg *UnsubscribeConfig, params UnsubscribeParams) strin
 	}
 
 	token := GenerateUnsubscribeToken(cfg.HMACKey, params)
-	return fmt.Sprintf("%s/unsubscribe?token=%s", cfg.BaseURL, url.QueryEscape(token))
+	base := strings.TrimRight(cfg.BaseURL, "/")
+	return fmt.Sprintf("%s/unsubscribe?token=%s", base, url.QueryEscape(token))
 }
 
 // BuildUnsubscribeHeaders returns RFC 2369 List-Unsubscribe and RFC 8058

--- a/shared/pkg/email/unsubscribe_test.go
+++ b/shared/pkg/email/unsubscribe_test.go
@@ -141,6 +141,23 @@ func TestBuildUnsubscribeURL_Transactional_ReturnsEmpty(t *testing.T) {
 	assert.Empty(t, url)
 }
 
+func TestBuildUnsubscribeURL_TrailingSlash_Normalized(t *testing.T) {
+	cfg := &UnsubscribeConfig{
+		HMACKey: []byte("test-secret-key-32-bytes-long!!!"),
+		BaseURL: "https://app.meridian.example/",
+	}
+	params := UnsubscribeParams{
+		TenantID: "tenant-1",
+		PartyID:  "party-42",
+		Channel:  "EMAIL",
+		Category: CategoryOperational,
+	}
+
+	url := BuildUnsubscribeURL(cfg, params)
+	assert.Contains(t, url, "https://app.meridian.example/unsubscribe?token=")
+	assert.NotContains(t, url, "//unsubscribe")
+}
+
 func TestBuildUnsubscribeURL_NilConfig_ReturnsEmpty(t *testing.T) {
 	url := BuildUnsubscribeURL(nil, UnsubscribeParams{Category: CategoryOperational})
 	assert.Empty(t, url)

--- a/shared/pkg/email/unsubscribe_test.go
+++ b/shared/pkg/email/unsubscribe_test.go
@@ -90,6 +90,62 @@ func TestVerifyUnsubscribeToken_TamperedPayload(t *testing.T) {
 	assert.Equal(t, "tenant-2", decoded2.TenantID)
 }
 
+func TestBuildUnsubscribeURL_Operational(t *testing.T) {
+	cfg := &UnsubscribeConfig{
+		HMACKey: []byte("test-secret-key-32-bytes-long!!!"),
+		BaseURL: "https://app.meridian.example",
+	}
+	params := UnsubscribeParams{
+		TenantID: "tenant-1",
+		PartyID:  "party-42",
+		Channel:  "EMAIL",
+		Category: CategoryOperational,
+	}
+
+	url := BuildUnsubscribeURL(cfg, params)
+
+	assert.Contains(t, url, "https://app.meridian.example/unsubscribe?token=")
+}
+
+func TestBuildUnsubscribeURL_Marketing(t *testing.T) {
+	cfg := &UnsubscribeConfig{
+		HMACKey: []byte("test-secret-key-32-bytes-long!!!"),
+		BaseURL: "https://app.meridian.example",
+	}
+	params := UnsubscribeParams{
+		TenantID: "tenant-1",
+		PartyID:  "party-42",
+		Channel:  "EMAIL",
+		Category: CategoryMarketing,
+	}
+
+	url := BuildUnsubscribeURL(cfg, params)
+
+	assert.NotEmpty(t, url)
+	assert.Contains(t, url, "https://app.meridian.example/unsubscribe?token=")
+}
+
+func TestBuildUnsubscribeURL_Transactional_ReturnsEmpty(t *testing.T) {
+	cfg := &UnsubscribeConfig{
+		HMACKey: []byte("test-secret-key-32-bytes-long!!!"),
+		BaseURL: "https://app.meridian.example",
+	}
+	params := UnsubscribeParams{
+		TenantID: "tenant-1",
+		PartyID:  "party-42",
+		Channel:  "EMAIL",
+		Category: CategoryTransactional,
+	}
+
+	url := BuildUnsubscribeURL(cfg, params)
+	assert.Empty(t, url)
+}
+
+func TestBuildUnsubscribeURL_NilConfig_ReturnsEmpty(t *testing.T) {
+	url := BuildUnsubscribeURL(nil, UnsubscribeParams{Category: CategoryOperational})
+	assert.Empty(t, url)
+}
+
 func TestBuildUnsubscribeHeaders_Operational(t *testing.T) {
 	cfg := &UnsubscribeConfig{
 		HMACKey: []byte("test-secret-key-32-bytes-long!!!"),

--- a/shared/pkg/email/worker/processor.go
+++ b/shared/pkg/email/worker/processor.go
@@ -104,6 +104,9 @@ func (p *EmailProcessor) processOne(ctx context.Context, instr *OutboxInstructio
 		}
 	}
 
+	// Inject unsubscribe URL into template data for non-transactional emails.
+	p.injectUnsubscribeURL(entry)
+
 	// Render the template. Render errors are deterministic (same template+data will
 	// always fail), so we cancel immediately rather than burning through retries.
 	htmlBody, textBody, err := p.renderer.Render(entry.TemplateName, entry.TemplateData)
@@ -266,15 +269,34 @@ func (p *EmailProcessor) handleRenderFailure(ctx context.Context, entry *email.O
 	return nil
 }
 
-// buildHeaders returns email headers for the given outbox entry.
-// Adds RFC 2369/8058 unsubscribe headers for non-transactional emails.
-func (p *EmailProcessor) buildHeaders(entry *email.OutboxEntry) map[string]string {
-	return email.BuildUnsubscribeHeaders(p.unsubscribeCfg, email.UnsubscribeParams{
+// unsubscribeParams returns the UnsubscribeParams for the given outbox entry.
+func unsubscribeParams(entry *email.OutboxEntry) email.UnsubscribeParams {
+	return email.UnsubscribeParams{
 		TenantID: entry.TenantID,
 		PartyID:  entry.PartyID,
 		Channel:  "EMAIL",
 		Category: entry.Category,
-	})
+	}
+}
+
+// injectUnsubscribeURL adds the UnsubscribeURL key to the entry's TemplateData
+// for non-transactional emails. This makes the URL available to templates for
+// rendering a visible unsubscribe link in the email body.
+func (p *EmailProcessor) injectUnsubscribeURL(entry *email.OutboxEntry) {
+	unsubURL := email.BuildUnsubscribeURL(p.unsubscribeCfg, unsubscribeParams(entry))
+	if unsubURL == "" {
+		return
+	}
+	if entry.TemplateData == nil {
+		entry.TemplateData = make(map[string]any)
+	}
+	entry.TemplateData["UnsubscribeURL"] = unsubURL
+}
+
+// buildHeaders returns email headers for the given outbox entry.
+// Adds RFC 2369/8058 unsubscribe headers for non-transactional emails.
+func (p *EmailProcessor) buildHeaders(entry *email.OutboxEntry) map[string]string {
+	return email.BuildUnsubscribeHeaders(p.unsubscribeCfg, unsubscribeParams(entry))
 }
 
 // handleSendFailure marks the outbox entry as failed, which triggers backoff/dead-letter

--- a/shared/pkg/email/worker/processor_test.go
+++ b/shared/pkg/email/worker/processor_test.go
@@ -25,6 +25,18 @@ func (m *mockRenderer) Render(_ string, _ any) (string, string, error) {
 	return m.html, m.text, m.err
 }
 
+type capturingMockRenderer struct {
+	delegate *mockRenderer
+	calls    int
+	lastData any
+}
+
+func (m *capturingMockRenderer) Render(name string, data any) (string, string, error) {
+	m.calls++
+	m.lastData = data
+	return m.delegate.Render(name, data)
+}
+
 type mockSender struct {
 	result  email.SendResult
 	err     error
@@ -641,6 +653,70 @@ func TestProcessBatch_UnsubscribeHeaders_TransactionalEmail_NoHeaders(t *testing
 
 	require.Equal(t, 1, sender.calls)
 	assert.Nil(t, sender.lastMsg.Headers, "transactional emails should not have unsubscribe headers")
+}
+
+func TestProcessBatch_UnsubscribeURL_InjectedIntoTemplateData(t *testing.T) {
+	ctx := context.Background()
+
+	var capturedData any
+	renderer := &mockRenderer{html: "<h1>Hi</h1>", text: "Hi"}
+	// Use a capturing renderer to inspect template data.
+	capturingRenderer := &capturingMockRenderer{delegate: renderer}
+	sender := &mockSender{result: email.SendResult{ProviderID: "msg-url", SentAt: time.Now()}}
+	outbox := &mockOutboxRepo{}
+	audit := &mockAuditRepo{}
+
+	proc := NewEmailProcessor(capturingRenderer, sender, outbox, audit, nil, nil, nil, nil)
+	proc.SetUnsubscribeConfig(&email.UnsubscribeConfig{
+		HMACKey: []byte("test-secret-key-32-bytes-long!!!"),
+		BaseURL: "https://app.meridian.example",
+	})
+
+	entry := newTestEntry("welcome")
+	entry.Category = email.CategoryOperational
+	entry.PartyID = "party-42"
+	entry.TenantID = "tenant-1"
+	instr := &OutboxInstruction{Entry: entry}
+
+	proc.ProcessBatch(ctx, []*OutboxInstruction{instr})
+
+	require.Equal(t, 1, capturingRenderer.calls)
+	capturedData = capturingRenderer.lastData
+
+	dataMap, ok := capturedData.(map[string]any)
+	require.True(t, ok, "template data should be map[string]any")
+	unsubURL, ok := dataMap["UnsubscribeURL"].(string)
+	require.True(t, ok, "UnsubscribeURL should be a string")
+	assert.Contains(t, unsubURL, "https://app.meridian.example/unsubscribe?token=")
+}
+
+func TestProcessBatch_UnsubscribeURL_NotInjectedForTransactional(t *testing.T) {
+	ctx := context.Background()
+
+	capturingRenderer := &capturingMockRenderer{delegate: &mockRenderer{html: "<h1>Hi</h1>", text: "Hi"}}
+	sender := &mockSender{result: email.SendResult{ProviderID: "msg-txn-url", SentAt: time.Now()}}
+	outbox := &mockOutboxRepo{}
+	audit := &mockAuditRepo{}
+
+	proc := NewEmailProcessor(capturingRenderer, sender, outbox, audit, nil, nil, nil, nil)
+	proc.SetUnsubscribeConfig(&email.UnsubscribeConfig{
+		HMACKey: []byte("test-secret-key-32-bytes-long!!!"),
+		BaseURL: "https://app.meridian.example",
+	})
+
+	entry := newTestEntry("dunning-notice")
+	entry.Category = email.CategoryTransactional
+	entry.PartyID = "party-42"
+	entry.TenantID = "tenant-1"
+	instr := &OutboxInstruction{Entry: entry}
+
+	proc.ProcessBatch(ctx, []*OutboxInstruction{instr})
+
+	require.Equal(t, 1, capturingRenderer.calls)
+	dataMap, ok := capturingRenderer.lastData.(map[string]any)
+	require.True(t, ok)
+	_, hasURL := dataMap["UnsubscribeURL"]
+	assert.False(t, hasURL, "transactional emails should not have UnsubscribeURL in template data")
 }
 
 func TestProcessBatch_UnsubscribeHeaders_NoConfig_NoHeaders(t *testing.T) {


### PR DESCRIPTION
## Summary
- Extract `BuildUnsubscribeURL` from `BuildUnsubscribeHeaders` for reuse by both header generation and template data injection
- Processor injects `UnsubscribeURL` into template data for OPERATIONAL and MARKETING emails before rendering
- Welcome template (the only existing non-transactional template) renders a conditional unsubscribe link in both HTML footer and text footer
- Transactional emails (dunning notices, account frozen, invoices) are unaffected - no URL injected, no link rendered

Complements task 13's RFC 2369/8058 unsubscribe headers with visible in-body links per CAN-SPAM/GDPR requirements.

## Changes Made
- `shared/pkg/email/unsubscribe.go` - Extract `BuildUnsubscribeURL` function, refactor `BuildUnsubscribeHeaders` to use it
- `shared/pkg/email/worker/processor.go` - Add `injectUnsubscribeURL` called before template rendering; extract `unsubscribeParams` helper
- `shared/pkg/email/template_data.go` - Add `UnsubscribeURL` field to `WelcomeData`
- `shared/pkg/email/templates/welcome.html` - Conditional unsubscribe link in footer
- `shared/pkg/email/templates/welcome.txt` - Conditional unsubscribe line in footer

## Test plan
- [x] `BuildUnsubscribeURL` returns URL for operational/marketing, empty for transactional/nil config
- [x] Welcome template renders unsubscribe link when `UnsubscribeURL` is present (struct and map data)
- [x] Welcome template omits unsubscribe link when `UnsubscribeURL` is absent
- [x] Processor injects `UnsubscribeURL` into template data for operational emails
- [x] Processor does not inject `UnsubscribeURL` for transactional emails
- [x] All existing tests pass (golden files, header tests, processor tests)