### PR TITLE
fix: use docker inspect for container readiness check in deploy workflows

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -237,13 +237,15 @@ jobs:
               echo "New databases created - restarting app to pick up connections"
               docker compose restart meridian
             fi
-            # Wait for the container to be running before attempting migrations
+            # Wait for the container to be running (not restarting) before migrations.
+            # The app image is distroless - no shell utilities - so use docker inspect.
             for i in $(seq 1 30); do
-              if docker exec meridian-meridian-1 echo ok 2>/dev/null; then
+              status=$(docker inspect --format='{{.State.Status}}' meridian-meridian-1 2>/dev/null || echo "missing")
+              if [ "$status" = "running" ]; then
                 echo "Container is running"
                 exit 0
               fi
-              echo "Waiting for container... ($i/30)"
+              echo "Waiting for container (status: $status)... ($i/30)"
               sleep 2
             done
             echo "Container failed to start after 60s"

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -249,13 +249,15 @@ jobs:
               echo "New databases created - restarting app to pick up connections"
               docker compose -f docker-compose.develop.yml restart meridian-develop
             fi
-            # Wait for the container to be running before attempting migrations
+            # Wait for the container to be running (not restarting) before migrations.
+            # The app image is distroless - no shell utilities - so use docker inspect.
             for i in $(seq 1 30); do
-              if docker exec meridian-develop echo ok 2>/dev/null; then
+              status=$(docker inspect --format='{{.State.Status}}' meridian-develop 2>/dev/null || echo "missing")
+              if [ "$status" = "running" ]; then
                 echo "Container is running"
                 exit 0
               fi
-              echo "Waiting for container... ($i/30)"
+              echo "Waiting for container (status: $status)... ($i/30)"
               sleep 2
             done
             echo "Container failed to start after 60s"


### PR DESCRIPTION
## Summary

- Follow-up to #2063 - the container readiness check used `docker exec echo ok` which fails because the meridian container is distroless (no shell utilities)
- Replace with `docker inspect --format='{{.State.Status}}'` which works on any container image
- This was the remaining cause of develop deploy failures after #2063 fixed the missing database issue

## Test plan

- [ ] Merge and verify develop deploy succeeds end-to-end
- [ ] Fast-forward demo to develop and verify demo deploy succeeds