### PR TITLE
fix: reset tenant provisioning when new databases are created during deploy

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -234,10 +234,7 @@ jobs:
               fi
             done
             if [ "$created" = "1" ]; then
-              echo "New databases created - resetting tenant provisioning status"
-              docker exec meridian-postgres-1 psql -U meridian -d meridian_platform -c \
-                "UPDATE tenant_provisioning SET state = 'pending' WHERE state = 'active'"
-              echo "Restarting app to pick up new database connections"
+              echo "New databases created - restarting app to pick up connections"
               docker compose restart meridian
             fi
             # Wait for the container to be running (not restarting) before migrations.
@@ -262,6 +259,20 @@ jobs:
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           script: |
             docker exec meridian-meridian-1 /meridian --migrate
+
+      - name: Reset tenant provisioning
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            # If any tenant has stale "active" status but missing schemas (e.g. after
+            # new databases were created), reset to "pending" so the provisioner
+            # re-creates schemas. Must run AFTER migrations so the provisioner has
+            # up-to-date DDL. Safe when schemas already exist (CREATE SCHEMA IF NOT EXISTS).
+            docker exec meridian-postgres-1 psql -U meridian -d meridian_platform -c \
+              "UPDATE tenant_provisioning SET state = 'pending' WHERE state IN ('active', 'failed')"
 
       - name: Bootstrap master tenant
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -234,7 +234,10 @@ jobs:
               fi
             done
             if [ "$created" = "1" ]; then
-              echo "New databases created - restarting app to pick up connections"
+              echo "New databases created - resetting tenant provisioning status"
+              docker exec meridian-postgres-1 psql -U meridian -d meridian_platform -c \
+                "UPDATE tenant_provisioning SET state = 'pending' WHERE state = 'active'"
+              echo "Restarting app to pick up new database connections"
               docker compose restart meridian
             fi
             # Wait for the container to be running (not restarting) before migrations.

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -246,13 +246,7 @@ jobs:
               fi
             done
             if [ "$created" = "1" ]; then
-              echo "New databases created - resetting tenant provisioning status"
-              # The provisioner skips tenants with "active" status, but the new
-              # databases have no tenant schemas yet. Reset all tenants to "pending"
-              # so the provisioner re-creates schemas in the new empty databases.
-              docker exec postgres-develop psql -U meridian -d meridian_platform -c \
-                "UPDATE tenant_provisioning SET state = 'pending' WHERE state = 'active'"
-              echo "Restarting app to pick up new database connections"
+              echo "New databases created - restarting app to pick up connections"
               docker compose -f docker-compose.develop.yml restart meridian-develop
             fi
             # Wait for the container to be running (not restarting) before migrations.
@@ -285,10 +279,16 @@ jobs:
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           script: |
+            cd /opt/meridian-develop
+            # If any tenant has stale "active" status but missing schemas (e.g. after
+            # new databases were created), reset to "pending" so the provisioner
+            # re-creates schemas. Must run AFTER migrations so the provisioner has
+            # up-to-date DDL. Safe when schemas already exist (CREATE SCHEMA IF NOT EXISTS).
+            docker exec postgres-develop psql -U meridian -d meridian_platform -c \
+              "UPDATE tenant_provisioning SET state = 'pending' WHERE state IN ('active', 'failed')"
             # Restart so the app picks up migrated schemas and provisions tenant
             # schemas (SCHEMA_PROVISIONING_ENABLED=true). Without this, seed-dev
             # fails on fresh databases because tenant schemas don't exist yet.
-            cd /opt/meridian-develop
             docker compose -f docker-compose.develop.yml restart meridian-develop
 
       - name: Seed develop data

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -246,7 +246,13 @@ jobs:
               fi
             done
             if [ "$created" = "1" ]; then
-              echo "New databases created - restarting app to pick up connections"
+              echo "New databases created - resetting tenant provisioning status"
+              # The provisioner skips tenants with "active" status, but the new
+              # databases have no tenant schemas yet. Reset all tenants to "pending"
+              # so the provisioner re-creates schemas in the new empty databases.
+              docker exec postgres-develop psql -U meridian -d meridian_platform -c \
+                "UPDATE tenant_provisioning SET state = 'pending' WHERE state = 'active'"
+              echo "Restarting app to pick up new database connections"
               docker compose -f docker-compose.develop.yml restart meridian-develop
             fi
             # Wait for the container to be running (not restarting) before migrations.


### PR DESCRIPTION
## Summary

- Follow-up to #2063 and #2068 - the ensure-databases step now successfully creates missing databases, but existing tenants have stale "active" provisioning status
- The provisioner skips "active" tenants, so tenant schemas (e.g. `org_volterra_energy`) are never created in newly-empty databases
- Reset all tenant provisioning to "pending" when new databases are created, triggering the provisioner to re-run schema creation

## Context

The develop deploy now gets through: databases created, app restarted, migrations run. But seed-dev fails because:
```
schema does not exist in database: org_volterra_energy
```

The provisioner checks `tenant_provisioning.state` - if "active", it skips. But the new database has no schemas. This reset makes the provisioner re-create them.

## Test plan

- [ ] Merge and verify develop deploy succeeds end-to-end including seed
- [ ] Verify the reset is a no-op on subsequent deploys (no new databases = no reset)