### PR TITLE
perf: share testcontainers in reference-data/saga tests (559s -> 27s)

### DIFF
--- a/services/reference-data/saga/grpc_handler_test.go
+++ b/services/reference-data/saga/grpc_handler_test.go
@@ -3,7 +3,9 @@ package saga
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,39 +17,31 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
 
-// setupTestPostgres starts a PostgreSQL container and returns the pool and cleanup function.
+// setupTestPostgres creates a unique tenant schema in the shared PostgreSQL container
+// for test isolation. Each test gets its own schema with fresh tables.
 func setupTestPostgres(t *testing.T) (*pgxpool.Pool, tenant.TenantID, func()) {
 	ctx := context.Background()
+	pool := sharedPgPool
 
-	pgContainer, err := postgres.Run(ctx,
-		"postgres:16-alpine",
-		postgres.WithDatabase("testdb"),
-		postgres.WithUsername("test"),
-		postgres.WithPassword("test"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).
-				WithStartupTimeout(30*time.Second),
-		),
-	)
-	require.NoError(t, err)
-
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
-	require.NoError(t, err)
-
-	pool, err := pgxpool.New(ctx, connStr)
-	require.NoError(t, err)
-
-	// Create tenant schema and saga_definition table
-	tenantID, err := tenant.NewTenantID("test_grpc_handler")
+	// Create a unique tenant ID per test to avoid cross-test interference
+	suffix := strings.ReplaceAll(strings.ToLower(t.Name()), "/", "_")
+	// Replace any non-alphanumeric chars (tenant IDs only allow [a-z0-9_])
+	suffix = strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' {
+			return r
+		}
+		return '_'
+	}, suffix)
+	if len(suffix) > 30 {
+		suffix = suffix[:30]
+	}
+	tenantName := fmt.Sprintf("t_%s_%s", suffix, strings.ReplaceAll(uuid.New().String(), "-", "")[:8])
+	tenantID, err := tenant.NewTenantID(tenantName)
 	require.NoError(t, err)
 
 	schemaName := tenantID.SchemaName()
@@ -105,8 +99,7 @@ func setupTestPostgres(t *testing.T) (*pgxpool.Pool, tenant.TenantID, func()) {
 	require.NoError(t, err)
 
 	cleanup := func() {
-		pool.Close()
-		_ = pgContainer.Terminate(ctx)
+		_, _ = pool.Exec(ctx, "DROP SCHEMA IF EXISTS "+schemaName+" CASCADE")
 	}
 
 	return pool, tenantID, cleanup

--- a/services/reference-data/saga/platform_sync_test.go
+++ b/services/reference-data/saga/platform_sync_test.go
@@ -240,15 +240,16 @@ func setupPlatformTestDB(t *testing.T) (*pgxpool.Pool, func()) {
 	// Connect to shared CockroachDB container to create per-test database
 	adminPool, err := pgxpool.New(ctx, sharedCrdbDSN)
 	require.NoError(t, err)
+	t.Cleanup(func() { adminPool.Close() })
 
 	_, err = adminPool.Exec(ctx, "CREATE DATABASE "+dbName)
 	require.NoError(t, err)
-	adminPool.Close()
 
 	// Build DSN for the per-test database
 	testDSN := replaceDatabaseInDSN(sharedCrdbDSN, dbName)
 	pool, err := pgxpool.New(ctx, testDSN)
 	require.NoError(t, err)
+	t.Cleanup(func() { pool.Close() })
 
 	// Apply migrations in order
 	migrations := []string{
@@ -269,11 +270,7 @@ func setupPlatformTestDB(t *testing.T) (*pgxpool.Pool, func()) {
 		require.NoError(t, err, "failed to apply migration %s", migration)
 	}
 
-	cleanup := func() {
-		pool.Close()
-	}
-
-	return pool, cleanup
+	return pool, func() {}
 }
 
 // replaceDatabaseInDSN swaps the database name in a PostgreSQL DSN.

--- a/services/reference-data/saga/platform_sync_test.go
+++ b/services/reference-data/saga/platform_sync_test.go
@@ -2,8 +2,10 @@ package saga
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,7 +13,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go/modules/cockroachdb"
 )
 
 func TestExtractVersionFromScript(t *testing.T) {
@@ -223,21 +224,30 @@ func setupPlatformTestDB(t *testing.T) (*pgxpool.Pool, func()) {
 
 	ctx := context.Background()
 
-	// Start CockroachDB container in insecure mode to avoid TLS connection issues.
-	// The module's default wait strategy properly waits for database readiness.
-	container, err := cockroachdb.Run(ctx,
-		"cockroachdb/cockroach:v24.3.0",
-		cockroachdb.WithDatabase("test_platform_sync"),
-		cockroachdb.WithInsecure(),
-	)
+	// Create a unique database per test for isolation (tests write to public schema tables).
+	suffix := strings.ReplaceAll(strings.ToLower(t.Name()), "/", "_")
+	suffix = strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' {
+			return r
+		}
+		return '_'
+	}, suffix)
+	if len(suffix) > 30 {
+		suffix = suffix[:30]
+	}
+	dbName := fmt.Sprintf("t_%s_%s", suffix, strings.ReplaceAll(uuid.New().String(), "-", "")[:8])
+
+	// Connect to shared CockroachDB container to create per-test database
+	adminPool, err := pgxpool.New(ctx, sharedCrdbDSN)
 	require.NoError(t, err)
 
-	// Use ConnectionConfig to get a proper connection string.
-	// ConnectionString() returns a registered pgx config reference that pgxpool cannot parse.
-	connConfig, err := container.ConnectionConfig(ctx)
+	_, err = adminPool.Exec(ctx, "CREATE DATABASE "+dbName)
 	require.NoError(t, err)
+	adminPool.Close()
 
-	pool, err := pgxpool.New(ctx, connConfig.ConnString())
+	// Build DSN for the per-test database
+	testDSN := replaceDatabaseInDSN(sharedCrdbDSN, dbName)
+	pool, err := pgxpool.New(ctx, testDSN)
 	require.NoError(t, err)
 
 	// Apply migrations in order
@@ -261,10 +271,27 @@ func setupPlatformTestDB(t *testing.T) (*pgxpool.Pool, func()) {
 
 	cleanup := func() {
 		pool.Close()
-		_ = container.Terminate(ctx)
 	}
 
 	return pool, cleanup
+}
+
+// replaceDatabaseInDSN swaps the database name in a PostgreSQL DSN.
+func replaceDatabaseInDSN(dsn, newDB string) string {
+	// DSN format: postgres://user@host:port/database?params
+	// Find the last / before ? and replace the database name
+	qIdx := strings.Index(dsn, "?")
+	base := dsn
+	query := ""
+	if qIdx >= 0 {
+		base = dsn[:qIdx]
+		query = dsn[qIdx:]
+	}
+	lastSlash := strings.LastIndex(base, "/")
+	if lastSlash >= 0 {
+		return base[:lastSlash+1] + newDB + query
+	}
+	return dsn
 }
 
 func TestPlatformSync_SyncPlatformDefaults(t *testing.T) {

--- a/services/reference-data/saga/postgres_registry_test.go
+++ b/services/reference-data/saga/postgres_registry_test.go
@@ -18,7 +18,12 @@ import (
 func setupTestRegistry(t *testing.T) (*saga.PostgresRegistry, *pgxpool.Pool) {
 	t.Helper()
 
-	pool := testdb.NewTestPool(t)
+	// Use the shared PostgreSQL container started in TestMain (testmain_test.go).
+	// Create a fresh pool from the shared connection string so each test
+	// gets its own pool lifecycle while reusing the same container.
+	pool, err := pgxpool.New(context.Background(), saga.SharedPgConnStr)
+	require.NoError(t, err)
+	t.Cleanup(func() { pool.Close() })
 
 	reg := saga.NewPostgresRegistry(pool, nil)
 

--- a/services/reference-data/saga/testmain_test.go
+++ b/services/reference-data/saga/testmain_test.go
@@ -1,0 +1,48 @@
+package saga
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+)
+
+// sharedPgPool is a shared PostgreSQL connection pool for integration tests.
+// Started once in TestMain, reused across all tests via per-test schema isolation.
+var sharedPgPool *pgxpool.Pool
+
+// SharedPgConnStr is the connection string for the shared PostgreSQL container.
+// Exported so that saga_test (external test package) can access it.
+var SharedPgConnStr string
+
+// sharedCrdbDSN is a shared CockroachDB DSN for platform sync integration tests.
+// Started once in TestMain, tests create per-test databases for isolation.
+var sharedCrdbDSN string
+
+func TestMain(m *testing.M) {
+	// Start shared PostgreSQL container (used by grpc_handler_test.go)
+	pgConnStr, pgCleanup := testdb.StartSharedPostgres()
+
+	pool, err := pgxpool.New(context.Background(), pgConnStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "testdb: failed to create shared pgx pool: %v\n", err)
+		pgCleanup()
+		os.Exit(1)
+	}
+	sharedPgPool = pool
+	SharedPgConnStr = pgConnStr
+
+	// Start shared CockroachDB container (used by platform_sync, seeder, e2e tests)
+	crdbDSN, crdbCleanup := testdb.StartSharedCockroachDB()
+	sharedCrdbDSN = crdbDSN
+
+	code := m.Run()
+
+	pool.Close()
+	pgCleanup()
+	crdbCleanup()
+	os.Exit(code)
+}

--- a/shared/platform/testdb/shared.go
+++ b/shared/platform/testdb/shared.go
@@ -83,18 +83,43 @@ func StartSharedPostgres() (string, func()) {
 //	dbName := "test_" + strings.ReplaceAll(t.Name(), "/", "_")
 //	pool.Exec(ctx, "CREATE DATABASE "+dbName)
 func StartSharedCockroachDB() (string, func()) {
-	ctx, cancel := context.WithTimeout(context.Background(), cockroachStartupTimeout)
-	defer cancel()
-
-	container, err := cockroachdb.Run(ctx,
-		CockroachDBImage,
+	opts := []testcontainers.ContainerCustomizer{
 		cockroachdb.WithDatabase("defaultdb"),
 		cockroachdb.WithUser("root"),
 		cockroachdb.WithInsecure(),
-	)
-	if err != nil {
-		panic(fmt.Sprintf("testdb: failed to start shared CockroachDB container: %v", err))
 	}
+
+	var container *cockroachdb.CockroachDBContainer
+	var lastErr error
+
+	for attempt := 1; attempt <= cockroachMaxRetries; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), cockroachStartupTimeout)
+
+		var err error
+		container, err = cockroachdb.Run(ctx, CockroachDBImage, opts...)
+		cancel()
+
+		if err == nil {
+			break
+		}
+
+		lastErr = err
+		fmt.Printf("testdb: CockroachDB container start attempt %d/%d failed: %v\n", attempt, cockroachMaxRetries, err)
+
+		if container != nil {
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			_ = container.Terminate(cleanupCtx)
+			cleanupCancel()
+			container = nil
+		}
+	}
+
+	if container == nil {
+		panic(fmt.Sprintf("testdb: failed to start shared CockroachDB container after %d attempts: %v", cockroachMaxRetries, lastErr))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
 	connConfig, err := container.ConnectionConfig(ctx)
 	if err != nil {

--- a/shared/platform/testdb/shared.go
+++ b/shared/platform/testdb/shared.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/cockroachdb"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
@@ -59,4 +60,54 @@ func StartSharedPostgres() (string, func()) {
 	}
 
 	return connStr, cleanup
+}
+
+// StartSharedCockroachDB starts a single CockroachDB testcontainer for sharing
+// across all tests in a package via TestMain. Returns the connection string
+// and a cleanup function that terminates the container.
+//
+// Usage in TestMain:
+//
+//	var sharedCockroachDSN string
+//
+//	func TestMain(m *testing.M) {
+//	    dsn, cleanup := testdb.StartSharedCockroachDB()
+//	    sharedCockroachDSN = dsn
+//	    code := m.Run()
+//	    cleanup()
+//	    os.Exit(code)
+//	}
+//
+// Then in each test, create a unique database for isolation:
+//
+//	dbName := "test_" + strings.ReplaceAll(t.Name(), "/", "_")
+//	pool.Exec(ctx, "CREATE DATABASE "+dbName)
+func StartSharedCockroachDB() (string, func()) {
+	ctx, cancel := context.WithTimeout(context.Background(), cockroachStartupTimeout)
+	defer cancel()
+
+	container, err := cockroachdb.Run(ctx,
+		CockroachDBImage,
+		cockroachdb.WithDatabase("defaultdb"),
+		cockroachdb.WithUser("root"),
+		cockroachdb.WithInsecure(),
+	)
+	if err != nil {
+		panic(fmt.Sprintf("testdb: failed to start shared CockroachDB container: %v", err))
+	}
+
+	connConfig, err := container.ConnectionConfig(ctx)
+	if err != nil {
+		panic(fmt.Sprintf("testdb: failed to get CockroachDB connection config: %v", err))
+	}
+
+	dsn := connConfig.ConnString()
+
+	cleanup := func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		_ = container.Terminate(cleanupCtx)
+	}
+
+	return dsn, cleanup
 }


### PR DESCRIPTION
## Summary

- The `reference-data/saga` test package was creating **38 separate database containers** (20 Postgres + 17 CockroachDB + 1 via testdb), each taking ~15s to start. Total package runtime: **559s**
- Introduces a `TestMain` pattern that starts **2 shared containers** (1 Postgres, 1 CockroachDB) and uses per-test schema/database isolation
- Adds `StartSharedCockroachDB` to `shared/platform/testdb` (mirrors existing `StartSharedPostgres`)
- Package runtime drops from **559s to 27s** (95% reduction), saving ~8-9 minutes of nightly CI wall time

## Changes

| File | Change |
|------|--------|
| `shared/platform/testdb/shared.go` | Add `StartSharedCockroachDB()` for TestMain patterns |
| `saga/testmain_test.go` | New - starts shared PG + CRDB containers once |
| `saga/grpc_handler_test.go` | Reuse shared PG pool with per-test tenant schemas |
| `saga/platform_sync_test.go` | Reuse shared CRDB with per-test databases |
| `saga/postgres_registry_test.go` | Reuse shared PG connection string |

## Test plan

- [x] All saga tests pass locally (`go test -race ./services/reference-data/saga/`)
- [x] Verified 95% runtime reduction (559s -> 27s, 34s with race detector)
- [ ] CI passes on this PR