### PR TITLE
feat: update economy overview empty state and add platform capabilities line

### DIFF
--- a/frontend/src/features/economy/pages/economy-overview-page.test.tsx
+++ b/frontend/src/features/economy/pages/economy-overview-page.test.tsx
@@ -223,7 +223,7 @@ describe('EconomyOverviewPage', () => {
     await waitFor(() => {
       expect(screen.getByTestId('overview-empty')).toBeInTheDocument()
     })
-    expect(screen.getByText('No economy configured')).toBeInTheDocument()
+    expect(screen.getByText('No custom economy configured')).toBeInTheDocument()
   })
 
   it('renders compact stat cards inside a stats-bar container', async () => {
@@ -260,6 +260,86 @@ describe('EconomyOverviewPage', () => {
     const instruments = screen.getByTestId('stat-instruments')
     const clickableCard = instruments.closest('button')
     expect(clickableCard).toBeInTheDocument()
+  })
+
+  it('renders empty state with updated copy and navigation links', async () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      manifestHistory: {
+        getCurrentManifest: vi.fn().mockResolvedValue({ version: undefined }),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('overview-empty')).toBeInTheDocument()
+    })
+    expect(screen.getByText('No custom economy configured')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /view sagas/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /view account types/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /view valuation rules/i })).toBeInTheDocument()
+  })
+
+  it('empty state View Sagas button navigates to /starlark-config', async () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      manifestHistory: {
+        getCurrentManifest: vi.fn().mockResolvedValue({ version: undefined }),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /view sagas/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /view sagas/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/starlark-config')
+  })
+
+  it('empty state View Account Types button navigates to /reference-data/account-types', async () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      manifestHistory: {
+        getCurrentManifest: vi.fn().mockResolvedValue({ version: undefined }),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /view account types/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /view account types/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/reference-data/account-types')
+  })
+
+  it('empty state View Valuation Rules button navigates to /reference-data/valuation-rules', async () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      manifestHistory: {
+        getCurrentManifest: vi.fn().mockResolvedValue({ version: undefined }),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /view valuation rules/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /view valuation rules/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/reference-data/valuation-rules')
+  })
+
+  it('renders platform capabilities line when manifest is present', async () => {
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('platform-capabilities-line')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('platform-capabilities-line')).toHaveTextContent(
+      'Running on 28 platform capabilities (8 sagas, 12 account types, 5 valuation methods, 3 policies)',
+    )
   })
 
   it('renders breadcrumbs navigation', async () => {

--- a/frontend/src/features/economy/pages/economy-overview-page.tsx
+++ b/frontend/src/features/economy/pages/economy-overview-page.tsx
@@ -41,10 +41,22 @@ function EmptyState() {
   const navigate = useNavigate()
   return (
     <div data-testid="overview-empty" className="p-6 flex flex-col items-center gap-4 py-16 text-muted-foreground">
-      <span className="text-lg font-medium">No economy configured</span>
+      <span className="text-lg font-medium">No custom economy configured</span>
       <span className="text-sm text-center max-w-md">
-        Apply a manifest to configure instruments, account types, sagas, and more.
+        Your tenant includes 28 platform capabilities out of the box - 8 sagas, 12 account types,
+        5 valuation methods, and 3 policies. Apply a manifest to customize or extend them.
       </span>
+      <div className="flex flex-wrap gap-2 mt-2">
+        <Button variant="outline" size="sm" onClick={() => navigate('/starlark-config')}>
+          View Sagas
+        </Button>
+        <Button variant="outline" size="sm" onClick={() => navigate('/reference-data/account-types')}>
+          View Account Types
+        </Button>
+        <Button variant="outline" size="sm" onClick={() => navigate('/reference-data/valuation-rules')}>
+          View Valuation Rules
+        </Button>
+      </div>
       <Button onClick={() => navigate('/economy/edit')}>Configure Economy</Button>
     </div>
   )
@@ -149,6 +161,11 @@ export function EconomyOverviewPage() {
         <StatChip label="Account Types" value={accountTypes.length} testId="stat-account-types" onClick={() => navigate('/reference-data/account-types')} />
         <StatChip label="Sagas" value={sagas.length} testId="stat-sagas" onClick={() => navigate('/starlark-config')} />
         <StatChip label="Valuation Rules" value={valuationRules.length} testId="stat-valuation-rules" onClick={() => navigate('/reference-data/valuation-rules')} />
+      </div>
+
+      {/* Platform capabilities indicator */}
+      <div className="text-sm text-muted-foreground" data-testid="platform-capabilities-line">
+        Running on 28 platform capabilities (8 sagas, 12 account types, 5 valuation methods, 3 policies)
       </div>
 
       {/* Relationship graph */}


### PR DESCRIPTION
## Summary

- Updates empty state copy from "No economy configured" to "No custom economy configured" with messaging about 28 built-in platform capabilities (tasks 1 + 7 from PRD-058)
- Adds navigation links in empty state to View Sagas, View Account Types, and View Valuation Rules
- Adds a platform capabilities indicator line below the stats bar when a manifest is present

## Changes Made

- `frontend/src/features/economy/pages/economy-overview-page.tsx`: Updated `EmptyState` component with new copy and navigation buttons; added `platform-capabilities-line` div after the stats bar
- `frontend/src/features/economy/pages/economy-overview-page.test.tsx`: Updated stale assertion for old copy; added 5 new tests covering empty state copy, navigation links, and capabilities line

## Testing

- 22 tests pass (17 existing + 5 new)
- New tests cover: updated empty state copy, View Sagas/Account Types/Valuation Rules navigation, and platform capabilities line rendering