### PR TITLE
feat: proactive idempotency for reference data handlers

### DIFF
--- a/services/control-plane/internal/applier/reference_data_client.go
+++ b/services/control-plane/internal/applier/reference_data_client.go
@@ -92,28 +92,44 @@ func (c *ReferenceDataClient) RegisterInstrument(ctx *saga.StarlarkContext, para
 
 // ActivateInstrument implements ReferenceDataService.
 // Converts Starlark params to an ActivateInstrumentRequest and calls the gRPC service.
+// Uses proactive idempotency: checks current state before attempting activation.
 func (c *ReferenceDataClient) ActivateInstrument(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
-	req := &referencedatav1.ActivateInstrumentRequest{}
-	req.Code, _ = params["instrument_code"].(string)
+	code, _ := params["instrument_code"].(string)
+	var version int32 = 1
 	if v, ok := toInt32(params["version"]); ok {
-		req.Version = v
-	} else {
-		// Default to version 1 — the saga registers then immediately activates,
-		// and RegisterInstrument always creates version 1.
-		req.Version = 1
+		version = v
 	}
 
 	callCtx := prepareCallContext(ctx)
-	resp, err := c.instruments.ActivateInstrument(callCtx, req)
+
+	// Proactive check: if already ACTIVE, return success immediately.
+	existing, lookupErr := c.instruments.RetrieveInstrument(callCtx, &referencedatav1.RetrieveInstrumentRequest{
+		Code:    code,
+		Version: version,
+	})
+	if lookupErr == nil && existing.GetInstrument().GetStatus() == referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE {
+		inst := existing.GetInstrument()
+		return map[string]any{
+			"instrument_code": inst.GetCode(),
+			"version":         inst.GetVersion(),
+			"status":          inst.GetStatus().String(),
+		}, nil
+	}
+
+	// Proceed with activation.
+	resp, err := c.instruments.ActivateInstrument(callCtx, &referencedatav1.ActivateInstrumentRequest{
+		Code:    code,
+		Version: version,
+	})
 	if err != nil {
-		// Idempotency: if the instrument is already ACTIVE, treat as success.
+		// Reactive fallback: if FailedPrecondition and instrument is ACTIVE, treat as success.
 		if status.Code(err) == codes.FailedPrecondition {
-			existing, lookupErr := c.instruments.RetrieveInstrument(callCtx, &referencedatav1.RetrieveInstrumentRequest{
-				Code:    req.Code,
-				Version: req.Version,
+			retryLookup, retryErr := c.instruments.RetrieveInstrument(callCtx, &referencedatav1.RetrieveInstrumentRequest{
+				Code:    code,
+				Version: version,
 			})
-			if lookupErr == nil && existing.GetInstrument().GetStatus() == referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE {
-				inst := existing.GetInstrument()
+			if retryErr == nil && retryLookup.GetInstrument().GetStatus() == referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE {
+				inst := retryLookup.GetInstrument()
 				return map[string]any{
 					"instrument_code": inst.GetCode(),
 					"version":         inst.GetVersion(),
@@ -157,10 +173,32 @@ func (c *ReferenceDataClient) DeleteInstrument(ctx *saga.StarlarkContext, params
 }
 
 // RegisterAccountType implements ReferenceDataService.
-// Creates a draft account type and immediately activates it (idempotent).
+// Creates a draft account type and immediately activates it.
+// Uses proactive idempotency: checks if already ACTIVE before creating a draft.
 func (c *ReferenceDataClient) RegisterAccountType(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+	code, _ := params["code"].(string)
+
+	callCtx := prepareCallContext(ctx)
+
+	// Proactive check: if already ACTIVE, return success immediately.
+	existing, lookupErr := c.accountTypes.GetActiveDefinition(callCtx, &referencedatav1.GetActiveDefinitionRequest{
+		Code: code,
+	})
+	if lookupErr == nil {
+		def := existing.GetDefinition()
+		if def.GetStatus() == referencedatav1.AccountTypeStatus_ACCOUNT_TYPE_STATUS_ACTIVE {
+			return map[string]any{
+				"id":      def.GetId(),
+				"code":    def.GetCode(),
+				"version": def.GetVersion(),
+				"status":  def.GetStatus().String(),
+			}, nil
+		}
+	}
+
+	// Proceed with create + activate flow.
 	draftReq := &referencedatav1.CreateDraftRequest{}
-	draftReq.Code, _ = params["code"].(string)
+	draftReq.Code = code
 	draftReq.DisplayName, _ = params["display_name"].(string)
 	draftReq.Description, _ = params["description"].(string)
 	draftReq.InstrumentCode, _ = params["instrument_code"].(string)
@@ -183,7 +221,6 @@ func (c *ReferenceDataClient) RegisterAccountType(ctx *saga.StarlarkContext, par
 		draftReq.DefaultConversionMethodVersion = v
 	}
 
-	callCtx := prepareCallContext(ctx)
 	draftResp, err := c.accountTypes.CreateDraft(callCtx, draftReq)
 	if err != nil {
 		return nil, fmt.Errorf("create account type draft: %w", err)
@@ -192,10 +229,9 @@ func (c *ReferenceDataClient) RegisterAccountType(ctx *saga.StarlarkContext, par
 	def := draftResp.GetDefinition()
 
 	// Activate the draft
-	activateReq := &referencedatav1.ActivateAccountTypeRequest{
+	activateResp, err := c.accountTypes.ActivateAccountType(callCtx, &referencedatav1.ActivateAccountTypeRequest{
 		Id: def.GetId(),
-	}
-	activateResp, err := c.accountTypes.ActivateAccountType(callCtx, activateReq)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("activate account type: %w", err)
 	}
@@ -243,20 +279,39 @@ func (c *ReferenceDataClient) RegisterValuationRule(_ *saga.StarlarkContext, par
 
 // RegisterSagaDefinition implements ReferenceDataService.
 // Creates a saga draft and activates it via the SagaRegistryService.
+// Uses proactive idempotency: checks if already ACTIVE before creating a draft.
 func (c *ReferenceDataClient) RegisterSagaDefinition(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+	sagaName, _ := params["saga_name"].(string)
+
+	callCtx := prepareCallContext(ctx)
+
+	// Proactive check: if already ACTIVE, return success immediately.
+	existing, lookupErr := c.sagas.GetActiveSaga(callCtx, &sagav1.GetActiveSagaRequest{
+		Name: sagaName,
+	})
+	if lookupErr == nil {
+		s := existing.GetSaga()
+		if s.GetStatus() == sagav1.SagaStatus_SAGA_STATUS_ACTIVE {
+			return map[string]any{
+				"saga_name": s.GetName(),
+				"saga_id":   s.GetId(),
+				"status":    s.GetStatus().String(),
+			}, nil
+		}
+	}
+
+	// Proceed with create + activate flow.
 	draftReq := &sagav1.CreateSagaDraftRequest{}
-	draftReq.Name, _ = params["saga_name"].(string)
+	draftReq.Name = sagaName
 	draftReq.DisplayName, _ = params["display_name"].(string)
 	draftReq.Description, _ = params["description"].(string)
 	draftReq.Script, _ = params["script"].(string)
 
-	callCtx := prepareCallContext(ctx)
 	draftResp, err := c.sagas.CreateSagaDraft(callCtx, draftReq)
 	if err != nil {
-		// Idempotency: treat AlreadyExists as success for manifest re-apply scenarios.
-		// Look up the existing active saga by name to return its details.
+		// Reactive fallback: treat AlreadyExists as success (belt and suspenders).
 		if status.Code(err) == codes.AlreadyExists {
-			return c.handleSagaAlreadyExists(callCtx, draftReq.Name)
+			return c.handleSagaAlreadyExists(callCtx, sagaName)
 		}
 		return nil, fmt.Errorf("create saga draft: %w", err)
 	}

--- a/services/control-plane/internal/applier/reference_data_client.go
+++ b/services/control-plane/internal/applier/reference_data_client.go
@@ -177,51 +177,18 @@ func (c *ReferenceDataClient) DeleteInstrument(ctx *saga.StarlarkContext, params
 // Uses proactive idempotency: checks if already ACTIVE before creating a draft.
 func (c *ReferenceDataClient) RegisterAccountType(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
 	code, _ := params["code"].(string)
-
 	callCtx := prepareCallContext(ctx)
 
 	// Proactive check: if already ACTIVE, return success immediately.
 	existing, lookupErr := c.accountTypes.GetActiveDefinition(callCtx, &referencedatav1.GetActiveDefinitionRequest{
 		Code: code,
 	})
-	if lookupErr == nil {
-		def := existing.GetDefinition()
-		if def.GetStatus() == referencedatav1.AccountTypeStatus_ACCOUNT_TYPE_STATUS_ACTIVE {
-			return map[string]any{
-				"id":      def.GetId(),
-				"code":    def.GetCode(),
-				"version": def.GetVersion(),
-				"status":  def.GetStatus().String(),
-			}, nil
-		}
+	if lookupErr == nil && existing.GetDefinition().GetStatus() == referencedatav1.AccountTypeStatus_ACCOUNT_TYPE_STATUS_ACTIVE {
+		return accountTypeResult(existing.GetDefinition()), nil
 	}
 
 	// Proceed with create + activate flow.
-	draftReq := &referencedatav1.CreateDraftRequest{}
-	draftReq.Code = code
-	draftReq.DisplayName, _ = params["display_name"].(string)
-	draftReq.Description, _ = params["description"].(string)
-	draftReq.InstrumentCode, _ = params["instrument_code"].(string)
-	draftReq.DefaultSagaPrefix, _ = params["default_saga_prefix"].(string)
-	draftReq.ValidationCel, _ = params["validation_cel"].(string)
-	draftReq.EligibilityCel, _ = params["eligibility_cel"].(string)
-
-	if bcStr, ok := params["behavior_class"].(string); ok {
-		draftReq.BehaviorClass = parseBehaviorClass(bcStr)
-	}
-	if nbStr, ok := params["normal_balance"].(string); ok {
-		draftReq.NormalBalance = parseNormalBalance(nbStr)
-	}
-
-	// Resolved conversion method (UUID + version from ValuationMethodService)
-	if id, ok := params["default_conversion_method_id"].(string); ok {
-		draftReq.DefaultConversionMethodId = id
-	}
-	if v, ok := toInt32(params["default_conversion_method_version"]); ok {
-		draftReq.DefaultConversionMethodVersion = v
-	}
-
-	draftResp, err := c.accountTypes.CreateDraft(callCtx, draftReq)
+	draftResp, err := c.accountTypes.CreateDraft(callCtx, buildCreateDraftRequest(params))
 	if err != nil {
 		// Reactive fallback: if AlreadyExists (race condition), look up the active definition.
 		if status.Code(err) == codes.AlreadyExists {
@@ -230,23 +197,50 @@ func (c *ReferenceDataClient) RegisterAccountType(ctx *saga.StarlarkContext, par
 		return nil, fmt.Errorf("create account type draft: %w", err)
 	}
 
-	def := draftResp.GetDefinition()
-
 	// Activate the draft
 	activateResp, err := c.accountTypes.ActivateAccountType(callCtx, &referencedatav1.ActivateAccountTypeRequest{
-		Id: def.GetId(),
+		Id: draftResp.GetDefinition().GetId(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("activate account type: %w", err)
 	}
+	return accountTypeResult(activateResp.GetDefinition()), nil
+}
 
-	activeDef := activateResp.GetDefinition()
+// buildCreateDraftRequest converts Starlark params to a CreateDraftRequest.
+func buildCreateDraftRequest(params map[string]any) *referencedatav1.CreateDraftRequest {
+	req := &referencedatav1.CreateDraftRequest{}
+	req.Code, _ = params["code"].(string)
+	req.DisplayName, _ = params["display_name"].(string)
+	req.Description, _ = params["description"].(string)
+	req.InstrumentCode, _ = params["instrument_code"].(string)
+	req.DefaultSagaPrefix, _ = params["default_saga_prefix"].(string)
+	req.ValidationCel, _ = params["validation_cel"].(string)
+	req.EligibilityCel, _ = params["eligibility_cel"].(string)
+
+	if bcStr, ok := params["behavior_class"].(string); ok {
+		req.BehaviorClass = parseBehaviorClass(bcStr)
+	}
+	if nbStr, ok := params["normal_balance"].(string); ok {
+		req.NormalBalance = parseNormalBalance(nbStr)
+	}
+	if id, ok := params["default_conversion_method_id"].(string); ok {
+		req.DefaultConversionMethodId = id
+	}
+	if v, ok := toInt32(params["default_conversion_method_version"]); ok {
+		req.DefaultConversionMethodVersion = v
+	}
+	return req
+}
+
+// accountTypeResult converts an AccountTypeDefinition to a saga result map.
+func accountTypeResult(def *referencedatav1.AccountTypeDefinition) map[string]any {
 	return map[string]any{
-		"id":      activeDef.GetId(),
-		"code":    activeDef.GetCode(),
-		"version": activeDef.GetVersion(),
-		"status":  activeDef.GetStatus().String(),
-	}, nil
+		"id":      def.GetId(),
+		"code":    def.GetCode(),
+		"version": def.GetVersion(),
+		"status":  def.GetStatus().String(),
+	}
 }
 
 // DeleteAccountType implements ReferenceDataService.
@@ -277,13 +271,7 @@ func (c *ReferenceDataClient) handleAccountTypeAlreadyExists(ctx context.Context
 	if err != nil {
 		return nil, fmt.Errorf("create account type draft: account type already exists but lookup failed: %w", err)
 	}
-	def := resp.GetDefinition()
-	return map[string]any{
-		"id":      def.GetId(),
-		"code":    def.GetCode(),
-		"version": def.GetVersion(),
-		"status":  def.GetStatus().String(),
-	}, nil
+	return accountTypeResult(resp.GetDefinition()), nil
 }
 
 // RegisterValuationRule implements ReferenceDataService.

--- a/services/control-plane/internal/applier/reference_data_client.go
+++ b/services/control-plane/internal/applier/reference_data_client.go
@@ -223,6 +223,10 @@ func (c *ReferenceDataClient) RegisterAccountType(ctx *saga.StarlarkContext, par
 
 	draftResp, err := c.accountTypes.CreateDraft(callCtx, draftReq)
 	if err != nil {
+		// Reactive fallback: if AlreadyExists (race condition), look up the active definition.
+		if status.Code(err) == codes.AlreadyExists {
+			return c.handleAccountTypeAlreadyExists(callCtx, code)
+		}
 		return nil, fmt.Errorf("create account type draft: %w", err)
 	}
 
@@ -261,6 +265,24 @@ func (c *ReferenceDataClient) DeleteAccountType(ctx *saga.StarlarkContext, param
 	return map[string]any{
 		"code":   def.GetCode(),
 		"status": def.GetStatus().String(),
+	}, nil
+}
+
+// handleAccountTypeAlreadyExists resolves the existing active account type by code
+// so that downstream saga steps receive the id. Returns an error if the lookup fails.
+func (c *ReferenceDataClient) handleAccountTypeAlreadyExists(ctx context.Context, code string) (any, error) {
+	resp, err := c.accountTypes.GetActiveDefinition(ctx, &referencedatav1.GetActiveDefinitionRequest{
+		Code: code,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create account type draft: account type already exists but lookup failed: %w", err)
+	}
+	def := resp.GetDefinition()
+	return map[string]any{
+		"id":      def.GetId(),
+		"code":    def.GetCode(),
+		"version": def.GetVersion(),
+		"status":  def.GetStatus().String(),
 	}, nil
 }
 

--- a/services/control-plane/internal/applier/reference_data_client_test.go
+++ b/services/control-plane/internal/applier/reference_data_client_test.go
@@ -699,6 +699,66 @@ func TestReferenceDataClient_RegisterAccountType_LookupError_ProceedsToCreate(t 
 	assert.Contains(t, m["status"], "ACTIVE")
 }
 
+func TestReferenceDataClient_RegisterAccountType_ReactiveFallback_AlreadyExists(t *testing.T) {
+	// Proactive check returns NotFound, CreateDraft returns AlreadyExists (race condition).
+	// Reactive fallback calls GetActiveDefinition again and finds the account type.
+	callCount := 0
+	atSrv := &fakeAccountTypeServer{
+		getActiveDefinitionFn: func(_ context.Context, req *referencedatav1.GetActiveDefinitionRequest) (*referencedatav1.GetActiveDefinitionResponse, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, status.Error(codes.NotFound, "no active definition found")
+			}
+			return &referencedatav1.GetActiveDefinitionResponse{
+				Definition: &referencedatav1.AccountTypeDefinition{
+					Id:      "at-uuid-race",
+					Code:    req.Code,
+					Version: 1,
+					Status:  referencedatav1.AccountTypeStatus_ACCOUNT_TYPE_STATUS_ACTIVE,
+				},
+			}, nil
+		},
+		createDraftFn: func(_ context.Context, _ *referencedatav1.CreateDraftRequest) (*referencedatav1.CreateDraftResponse, error) {
+			return nil, status.Error(codes.AlreadyExists, "account type already exists")
+		},
+	}
+	conn := newRefDataTestServerWithAccountType(t, atSrv)
+	client := NewReferenceDataClient(conn, conn)
+
+	result, err := client.RegisterAccountType(testStarlarkCtx(), map[string]any{
+		"code":            "RACE_TYPE",
+		"display_name":    "Race Condition Type",
+		"instrument_code": "GBP",
+	})
+	require.NoError(t, err, "reactive AlreadyExists fallback should handle race condition")
+
+	m := result.(map[string]any)
+	assert.Equal(t, "at-uuid-race", m["id"])
+	assert.Equal(t, "RACE_TYPE", m["code"])
+	assert.Contains(t, m["status"], "ACTIVE")
+}
+
+func TestReferenceDataClient_RegisterAccountType_AlreadyExists_LookupFails(t *testing.T) {
+	// Both proactive and reactive GetActiveDefinition calls return NotFound.
+	// CreateDraft returns AlreadyExists. The reactive fallback lookup also fails.
+	atSrv := &fakeAccountTypeServer{
+		getActiveDefinitionFn: func(_ context.Context, _ *referencedatav1.GetActiveDefinitionRequest) (*referencedatav1.GetActiveDefinitionResponse, error) {
+			return nil, status.Error(codes.NotFound, "no active definition found")
+		},
+		createDraftFn: func(_ context.Context, _ *referencedatav1.CreateDraftRequest) (*referencedatav1.CreateDraftResponse, error) {
+			return nil, status.Error(codes.AlreadyExists, "account type already exists")
+		},
+	}
+	conn := newRefDataTestServerWithAccountType(t, atSrv)
+	client := NewReferenceDataClient(conn, conn)
+
+	_, err := client.RegisterAccountType(testStarlarkCtx(), map[string]any{
+		"code": "ORPHAN_TYPE",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lookup failed")
+}
+
 // ─── Task 3: Proactive RegisterSagaDefinition idempotency ─────────────────
 
 func TestReferenceDataClient_RegisterSagaDefinition_ProactiveCheck_AlreadyActive(t *testing.T) {

--- a/services/control-plane/internal/applier/reference_data_client_test.go
+++ b/services/control-plane/internal/applier/reference_data_client_test.go
@@ -80,9 +80,21 @@ func (f *fakeReferenceDataServer) DeprecateInstrument(_ context.Context, req *re
 
 type fakeAccountTypeServer struct {
 	referencedatav1.UnimplementedAccountTypeRegistryServiceServer
+	getActiveDefinitionFn func(context.Context, *referencedatav1.GetActiveDefinitionRequest) (*referencedatav1.GetActiveDefinitionResponse, error)
+	createDraftFn         func(context.Context, *referencedatav1.CreateDraftRequest) (*referencedatav1.CreateDraftResponse, error)
 }
 
-func (f *fakeAccountTypeServer) CreateDraft(_ context.Context, req *referencedatav1.CreateDraftRequest) (*referencedatav1.CreateDraftResponse, error) {
+func (f *fakeAccountTypeServer) GetActiveDefinition(ctx context.Context, req *referencedatav1.GetActiveDefinitionRequest) (*referencedatav1.GetActiveDefinitionResponse, error) {
+	if f.getActiveDefinitionFn != nil {
+		return f.getActiveDefinitionFn(ctx, req)
+	}
+	return nil, status.Error(codes.NotFound, "no active definition found")
+}
+
+func (f *fakeAccountTypeServer) CreateDraft(ctx context.Context, req *referencedatav1.CreateDraftRequest) (*referencedatav1.CreateDraftResponse, error) {
+	if f.createDraftFn != nil {
+		return f.createDraftFn(ctx, req)
+	}
 	return &referencedatav1.CreateDraftResponse{
 		Definition: &referencedatav1.AccountTypeDefinition{
 			Id:      "at-uuid-1",
@@ -148,13 +160,8 @@ func (f *fakeSagaRegistryServer) GetActiveSaga(ctx context.Context, req *sagav1.
 	if f.getActiveFn != nil {
 		return f.getActiveFn(ctx, req)
 	}
-	return &sagav1.GetActiveSagaResponse{
-		Saga: &sagav1.SagaDefinition{
-			Id:     "existing-saga-uuid",
-			Name:   req.Name,
-			Status: sagav1.SagaStatus_SAGA_STATUS_ACTIVE,
-		},
-	}, nil
+	// Default: no active saga found (proactive check falls through to create).
+	return nil, status.Error(codes.NotFound, "no active saga found")
 }
 
 // ─── Test setup ────────────────────────────────────────────────────────────
@@ -193,6 +200,28 @@ func newRefDataTestServerWith(t *testing.T, sagaSrv *fakeSagaRegistryServer) *gr
 	referencedatav1.RegisterReferenceDataServiceServer(srv, &fakeReferenceDataServer{})
 	referencedatav1.RegisterAccountTypeRegistryServiceServer(srv, &fakeAccountTypeServer{})
 	sagav1.RegisterSagaRegistryServiceServer(srv, sagaSrv)
+
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.GracefulStop)
+
+	conn, err := grpc.NewClient("passthrough:///bufconn",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return conn
+}
+
+func newRefDataTestServerWithAccountType(t *testing.T, atSrv *fakeAccountTypeServer) *grpc.ClientConn {
+	t.Helper()
+
+	lis := bufconn.Listen(1024 * 1024)
+	srv := grpc.NewServer()
+	referencedatav1.RegisterReferenceDataServiceServer(srv, &fakeReferenceDataServer{})
+	referencedatav1.RegisterAccountTypeRegistryServiceServer(srv, atSrv)
+	sagav1.RegisterSagaRegistryServiceServer(srv, &fakeSagaRegistryServer{})
 
 	go func() { _ = srv.Serve(lis) }()
 	t.Cleanup(srv.GracefulStop)
@@ -383,7 +412,23 @@ func TestParseNormalBalance(t *testing.T) {
 // ─── Idempotency tests ──────────────────────────────────────────────────────
 
 func TestReferenceDataClient_RegisterSagaDefinition_AlreadyExists_TreatedAsSuccess(t *testing.T) {
+	// Proactive check returns NotFound (first call), but CreateSagaDraft returns AlreadyExists.
+	// The reactive fallback calls GetActiveSaga again (second call) and finds the saga.
+	callCount := 0
 	sagaSrv := &fakeSagaRegistryServer{
+		getActiveFn: func(_ context.Context, req *sagav1.GetActiveSagaRequest) (*sagav1.GetActiveSagaResponse, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, status.Error(codes.NotFound, "no active saga found")
+			}
+			return &sagav1.GetActiveSagaResponse{
+				Saga: &sagav1.SagaDefinition{
+					Id:     "existing-saga-uuid",
+					Name:   req.Name,
+					Status: sagav1.SagaStatus_SAGA_STATUS_ACTIVE,
+				},
+			}, nil
+		},
 		createDraftFn: func(_ context.Context, _ *sagav1.CreateSagaDraftRequest) (*sagav1.CreateSagaDraftResponse, error) {
 			return nil, status.Error(codes.AlreadyExists, "saga already exists: test-saga")
 		},
@@ -404,11 +449,14 @@ func TestReferenceDataClient_RegisterSagaDefinition_AlreadyExists_TreatedAsSucce
 }
 
 func TestReferenceDataClient_RegisterSagaDefinition_AlreadyExists_LookupFails(t *testing.T) {
+	// Both proactive and reactive GetActiveSaga calls return NotFound.
+	// CreateSagaDraft returns AlreadyExists. The reactive fallback lookup also fails.
 	sagaSrv := &fakeSagaRegistryServer{
 		createDraftFn: func(_ context.Context, _ *sagav1.CreateSagaDraftRequest) (*sagav1.CreateSagaDraftResponse, error) {
 			return nil, status.Error(codes.AlreadyExists, "saga already exists")
 		},
 		getActiveFn: func(_ context.Context, _ *sagav1.GetActiveSagaRequest) (*sagav1.GetActiveSagaResponse, error) {
+			// Both calls (proactive + reactive fallback) return NotFound.
 			return nil, status.Error(codes.NotFound, "no active saga found")
 		},
 	}
@@ -424,6 +472,10 @@ func TestReferenceDataClient_RegisterSagaDefinition_AlreadyExists_LookupFails(t 
 
 func TestReferenceDataClient_RegisterSagaDefinition_OtherError_Propagated(t *testing.T) {
 	sagaSrv := &fakeSagaRegistryServer{
+		// Proactive check returns NotFound, so we proceed to CreateSagaDraft.
+		getActiveFn: func(_ context.Context, _ *sagav1.GetActiveSagaRequest) (*sagav1.GetActiveSagaResponse, error) {
+			return nil, status.Error(codes.NotFound, "no active saga found")
+		},
 		createDraftFn: func(_ context.Context, _ *sagav1.CreateSagaDraftRequest) (*sagav1.CreateSagaDraftResponse, error) {
 			return nil, status.Error(codes.Internal, "database unavailable")
 		},
@@ -490,4 +542,255 @@ func TestReferenceDataClient_ActivateInstrument_NotActive_ErrorPropagated(t *tes
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "activate instrument")
+}
+
+// ─── Task 1: Proactive ActivateInstrument idempotency ─────────────────────
+
+func TestReferenceDataClient_ActivateInstrument_ProactiveCheck_AlreadyActive(t *testing.T) {
+	// RetrieveInstrument returns ACTIVE on the proactive check,
+	// so ActivateInstrument should never be called.
+	activateCalled := false
+	refDataSrv := &fakeReferenceDataServer{
+		retrieveInstrumentFn: func(_ context.Context, req *referencedatav1.RetrieveInstrumentRequest) (*referencedatav1.RetrieveInstrumentResponse, error) {
+			return &referencedatav1.RetrieveInstrumentResponse{
+				Instrument: &referencedatav1.InstrumentDefinition{
+					Id:      "inst-uuid-1",
+					Code:    req.Code,
+					Version: req.Version,
+					Status:  referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE,
+				},
+			}, nil
+		},
+		activateInstrumentFn: func(_ context.Context, _ *referencedatav1.ActivateInstrumentRequest) (*referencedatav1.ActivateInstrumentResponse, error) {
+			activateCalled = true
+			return nil, status.Error(codes.FailedPrecondition, "should not be called")
+		},
+	}
+	conn := newRefDataTestServerWithRefData(t, refDataSrv)
+	client := NewReferenceDataClient(conn, conn)
+
+	result, err := client.ActivateInstrument(testStarlarkCtx(), map[string]any{
+		"instrument_code": "GBP",
+		"version":         int32(1),
+	})
+	require.NoError(t, err, "proactive check should return success for already-ACTIVE instrument")
+	assert.False(t, activateCalled, "ActivateInstrument gRPC should not be called when proactive check finds ACTIVE")
+
+	m := result.(map[string]any)
+	assert.Equal(t, "GBP", m["instrument_code"])
+	assert.Contains(t, m["status"], "ACTIVE")
+}
+
+func TestReferenceDataClient_ActivateInstrument_ProactiveCheck_LookupFails_ProceedsToActivate(t *testing.T) {
+	// RetrieveInstrument fails (e.g., NotFound), so the handler proceeds to activate normally.
+	refDataSrv := &fakeReferenceDataServer{
+		retrieveInstrumentFn: func(_ context.Context, _ *referencedatav1.RetrieveInstrumentRequest) (*referencedatav1.RetrieveInstrumentResponse, error) {
+			return nil, status.Error(codes.NotFound, "instrument not found")
+		},
+	}
+	conn := newRefDataTestServerWithRefData(t, refDataSrv)
+	client := NewReferenceDataClient(conn, conn)
+
+	result, err := client.ActivateInstrument(testStarlarkCtx(), map[string]any{
+		"instrument_code": "GBP",
+	})
+	require.NoError(t, err, "should proceed to activate when proactive lookup fails")
+
+	m := result.(map[string]any)
+	assert.Equal(t, "GBP", m["instrument_code"])
+	assert.Contains(t, m["status"], "ACTIVE")
+}
+
+func TestReferenceDataClient_ActivateInstrument_ProactiveCheck_DraftState_ProceedsToActivate(t *testing.T) {
+	// RetrieveInstrument returns DRAFT, so the handler proceeds to activate.
+	refDataSrv := &fakeReferenceDataServer{
+		retrieveInstrumentFn: func(_ context.Context, req *referencedatav1.RetrieveInstrumentRequest) (*referencedatav1.RetrieveInstrumentResponse, error) {
+			return &referencedatav1.RetrieveInstrumentResponse{
+				Instrument: &referencedatav1.InstrumentDefinition{
+					Id:      "inst-uuid-1",
+					Code:    req.Code,
+					Version: req.Version,
+					Status:  referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_DRAFT,
+				},
+			}, nil
+		},
+	}
+	conn := newRefDataTestServerWithRefData(t, refDataSrv)
+	client := NewReferenceDataClient(conn, conn)
+
+	result, err := client.ActivateInstrument(testStarlarkCtx(), map[string]any{
+		"instrument_code": "GBP",
+	})
+	require.NoError(t, err, "should proceed to activate when instrument is DRAFT")
+
+	m := result.(map[string]any)
+	assert.Contains(t, m["status"], "ACTIVE")
+}
+
+// ─── Task 2: Proactive RegisterAccountType idempotency ────────────────────
+
+func TestReferenceDataClient_RegisterAccountType_AlreadyActive_TreatedAsSuccess(t *testing.T) {
+	atSrv := &fakeAccountTypeServer{
+		getActiveDefinitionFn: func(_ context.Context, req *referencedatav1.GetActiveDefinitionRequest) (*referencedatav1.GetActiveDefinitionResponse, error) {
+			return &referencedatav1.GetActiveDefinitionResponse{
+				Definition: &referencedatav1.AccountTypeDefinition{
+					Id:      "at-uuid-existing",
+					Code:    req.Code,
+					Version: 1,
+					Status:  referencedatav1.AccountTypeStatus_ACCOUNT_TYPE_STATUS_ACTIVE,
+				},
+			}, nil
+		},
+		createDraftFn: func(_ context.Context, _ *referencedatav1.CreateDraftRequest) (*referencedatav1.CreateDraftResponse, error) {
+			return nil, status.Error(codes.AlreadyExists, "should not be called")
+		},
+	}
+	conn := newRefDataTestServerWithAccountType(t, atSrv)
+	client := NewReferenceDataClient(conn, conn)
+
+	result, err := client.RegisterAccountType(testStarlarkCtx(), map[string]any{
+		"code":            "ENERGY_TRADING",
+		"display_name":    "Energy Trading Account",
+		"instrument_code": "GBP",
+	})
+	require.NoError(t, err, "already-ACTIVE account type should be treated as idempotent success")
+
+	m := result.(map[string]any)
+	assert.Equal(t, "at-uuid-existing", m["id"])
+	assert.Equal(t, "ENERGY_TRADING", m["code"])
+	assert.Contains(t, m["status"], "ACTIVE")
+}
+
+func TestReferenceDataClient_RegisterAccountType_LookupNotFound_ProceedsToCreate(t *testing.T) {
+	// GetActiveDefinition returns NotFound, so the handler proceeds to create + activate.
+	conn := newRefDataTestServerWithAccountType(t, &fakeAccountTypeServer{})
+	client := NewReferenceDataClient(conn, conn)
+
+	result, err := client.RegisterAccountType(testStarlarkCtx(), map[string]any{
+		"code":            "NEW_TYPE",
+		"display_name":    "New Account Type",
+		"instrument_code": "GBP",
+	})
+	require.NoError(t, err, "should proceed to create when GetActiveDefinition returns NotFound")
+
+	m := result.(map[string]any)
+	assert.Equal(t, "at-uuid-1", m["id"])
+	assert.Contains(t, m["status"], "ACTIVE")
+}
+
+func TestReferenceDataClient_RegisterAccountType_LookupError_ProceedsToCreate(t *testing.T) {
+	// GetActiveDefinition returns an unexpected error, handler should still proceed.
+	atSrv := &fakeAccountTypeServer{
+		getActiveDefinitionFn: func(_ context.Context, _ *referencedatav1.GetActiveDefinitionRequest) (*referencedatav1.GetActiveDefinitionResponse, error) {
+			return nil, status.Error(codes.Internal, "database unavailable")
+		},
+	}
+	conn := newRefDataTestServerWithAccountType(t, atSrv)
+	client := NewReferenceDataClient(conn, conn)
+
+	result, err := client.RegisterAccountType(testStarlarkCtx(), map[string]any{
+		"code":            "NEW_TYPE",
+		"display_name":    "New Account Type",
+		"instrument_code": "GBP",
+	})
+	require.NoError(t, err, "should proceed to create when GetActiveDefinition returns error")
+
+	m := result.(map[string]any)
+	assert.Contains(t, m["status"], "ACTIVE")
+}
+
+// ─── Task 3: Proactive RegisterSagaDefinition idempotency ─────────────────
+
+func TestReferenceDataClient_RegisterSagaDefinition_ProactiveCheck_AlreadyActive(t *testing.T) {
+	createDraftCalled := false
+	sagaSrv := &fakeSagaRegistryServer{
+		getActiveFn: func(_ context.Context, req *sagav1.GetActiveSagaRequest) (*sagav1.GetActiveSagaResponse, error) {
+			return &sagav1.GetActiveSagaResponse{
+				Saga: &sagav1.SagaDefinition{
+					Id:     "existing-saga-uuid",
+					Name:   req.Name,
+					Status: sagav1.SagaStatus_SAGA_STATUS_ACTIVE,
+				},
+			}, nil
+		},
+		createDraftFn: func(_ context.Context, _ *sagav1.CreateSagaDraftRequest) (*sagav1.CreateSagaDraftResponse, error) {
+			createDraftCalled = true
+			return nil, status.Error(codes.AlreadyExists, "should not be called")
+		},
+	}
+	conn := newRefDataTestServerWith(t, sagaSrv)
+	client := NewReferenceDataClient(conn, conn)
+
+	result, err := client.RegisterSagaDefinition(testStarlarkCtx(), map[string]any{
+		"saga_name":    "test-saga",
+		"display_name": "Test Saga",
+		"script":       "def execute(): pass",
+	})
+	require.NoError(t, err, "proactive check should return success for already-ACTIVE saga")
+	assert.False(t, createDraftCalled, "CreateSagaDraft should not be called when proactive check finds ACTIVE")
+
+	m := result.(map[string]any)
+	assert.Equal(t, "existing-saga-uuid", m["saga_id"])
+	assert.Equal(t, "test-saga", m["saga_name"])
+	assert.Contains(t, m["status"], "ACTIVE")
+}
+
+func TestReferenceDataClient_RegisterSagaDefinition_ProactiveCheck_NotFound_ProceedsToCreate(t *testing.T) {
+	sagaSrv := &fakeSagaRegistryServer{
+		getActiveFn: func(_ context.Context, _ *sagav1.GetActiveSagaRequest) (*sagav1.GetActiveSagaResponse, error) {
+			return nil, status.Error(codes.NotFound, "no active saga found")
+		},
+	}
+	conn := newRefDataTestServerWith(t, sagaSrv)
+	client := NewReferenceDataClient(conn, conn)
+
+	result, err := client.RegisterSagaDefinition(testStarlarkCtx(), map[string]any{
+		"saga_name":    "new-saga",
+		"display_name": "New Saga",
+		"script":       "def execute(): pass",
+	})
+	require.NoError(t, err, "should proceed to create when proactive check returns NotFound")
+
+	m := result.(map[string]any)
+	assert.Equal(t, "saga-uuid-1", m["saga_id"])
+	assert.Contains(t, m["status"], "ACTIVE")
+}
+
+func TestReferenceDataClient_RegisterSagaDefinition_ReactiveFallback_AlreadyExists(t *testing.T) {
+	// Proactive check returns NotFound, but CreateSagaDraft returns AlreadyExists (race condition).
+	// The reactive fallback should handle this.
+	callCount := 0
+	sagaSrv := &fakeSagaRegistryServer{
+		getActiveFn: func(_ context.Context, req *sagav1.GetActiveSagaRequest) (*sagav1.GetActiveSagaResponse, error) {
+			callCount++
+			if callCount == 1 {
+				// First call (proactive check): not found
+				return nil, status.Error(codes.NotFound, "no active saga found")
+			}
+			// Second call (reactive fallback): return the saga
+			return &sagav1.GetActiveSagaResponse{
+				Saga: &sagav1.SagaDefinition{
+					Id:     "race-condition-saga-uuid",
+					Name:   req.Name,
+					Status: sagav1.SagaStatus_SAGA_STATUS_ACTIVE,
+				},
+			}, nil
+		},
+		createDraftFn: func(_ context.Context, _ *sagav1.CreateSagaDraftRequest) (*sagav1.CreateSagaDraftResponse, error) {
+			return nil, status.Error(codes.AlreadyExists, "saga already exists")
+		},
+	}
+	conn := newRefDataTestServerWith(t, sagaSrv)
+	client := NewReferenceDataClient(conn, conn)
+
+	result, err := client.RegisterSagaDefinition(testStarlarkCtx(), map[string]any{
+		"saga_name":    "race-saga",
+		"display_name": "Race Condition Saga",
+		"script":       "def execute(): pass",
+	})
+	require.NoError(t, err, "reactive AlreadyExists fallback should handle race condition")
+
+	m := result.(map[string]any)
+	assert.Equal(t, "race-condition-saga-uuid", m["saga_id"])
+	assert.Contains(t, m["status"], "ACTIVE")
 }


### PR DESCRIPTION
## Summary

- Refactor `ActivateInstrument`, `RegisterAccountType`, and `RegisterSagaDefinition` handlers to use proactive check-then-act idempotency pattern
- Each handler now queries current state (via `RetrieveInstrument`, `GetActiveDefinition`, `GetActiveSaga`) before attempting mutations
- If the resource is already in its target state (ACTIVE), return success immediately without calling create/activate
- Existing reactive error handling (catching `FailedPrecondition`, `AlreadyExists`) retained as secondary safety net for race conditions

## Test plan

- [x] `ActivateInstrument`: proactive check finds ACTIVE - returns success without calling activate
- [x] `ActivateInstrument`: proactive lookup fails (NotFound) - proceeds to activate normally
- [x] `ActivateInstrument`: proactive check finds DRAFT - proceeds to activate normally
- [x] `ActivateInstrument`: reactive fallback still works for FailedPrecondition + ACTIVE
- [x] `RegisterAccountType`: already ACTIVE - returns success without creating draft
- [x] `RegisterAccountType`: NotFound on lookup - proceeds to create + activate normally
- [x] `RegisterAccountType`: Internal error on lookup - proceeds to create + activate normally
- [x] `RegisterSagaDefinition`: proactive check finds ACTIVE - returns success without creating draft
- [x] `RegisterSagaDefinition`: NotFound on proactive check - proceeds to create + activate normally
- [x] `RegisterSagaDefinition`: race condition (NotFound then AlreadyExists) - reactive fallback handles it
- [x] All existing tests continue to pass (21 reference data client tests total)