### PR TITLE
feat: LiveStateQuery interface for convergent manifest differ

### DIFF
--- a/services/control-plane/internal/differ/live_state.go
+++ b/services/control-plane/internal/differ/live_state.go
@@ -1,0 +1,28 @@
+package differ
+
+import (
+	"context"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+)
+
+// LiveState holds the current state of all resource types queried from downstream services.
+// It is the input to the differ's three-way comparison (last-applied vs desired vs live).
+type LiveState struct {
+	Instruments         []*controlplanev1.InstrumentDefinition
+	AccountTypes        []*controlplanev1.AccountTypeDefinition
+	Sagas               []*controlplanev1.SagaDefinition
+	MarketDataSources   []*controlplanev1.MarketDataSourceDefinition
+	MarketDataSets      []*controlplanev1.MarketDataSetDefinition
+	Organizations       []*controlplanev1.OrganizationDefinition
+	InternalAccounts    []*controlplanev1.InternalAccountDefinition
+	ProviderConnections []*controlplanev1.ProviderConnectionConfig
+	InstructionRoutes   []*controlplanev1.InstructionRouteConfig
+}
+
+// LiveStateProvider queries downstream services and returns the current live state
+// for all resource types. Implementations must return an error if any service query
+// fails - partial state is not acceptable for diff correctness.
+type LiveStateProvider interface {
+	QueryLiveState(ctx context.Context, tenantID string) (*LiveState, error)
+}

--- a/services/control-plane/internal/differ/live_state_provider.go
+++ b/services/control-plane/internal/differ/live_state_provider.go
@@ -111,96 +111,110 @@ func NewGRPCLiveStateProvider(
 // tenantID is propagated via gRPC metadata so downstream services scope queries to the correct tenant.
 // Returns an error if any service query fails.
 func (p *GRPCLiveStateProvider) QueryLiveState(ctx context.Context, tenantID string) (*LiveState, error) {
-	// Enrich context with tenant metadata for outgoing gRPC calls.
 	ctx = metadata.AppendToOutgoingContext(ctx, tenant.TenantIDKey, tenantID)
 
 	state := &LiveState{}
 	g, gctx := errgroup.WithContext(ctx)
 
+	p.scheduleReferenceDataQueries(g, gctx, state)
+	p.scheduleSagaQuery(g, gctx, state)
+	p.scheduleMarketDataQueries(g, gctx, state)
+	p.schedulePartyQuery(g, gctx, state)
+	p.scheduleInternalAccountQuery(g, gctx, state)
+	p.scheduleOperationalGatewayQueries(g, gctx, state)
+
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("query live state: %w", err)
+	}
+	return state, nil
+}
+
+func (p *GRPCLiveStateProvider) scheduleReferenceDataQueries(g *errgroup.Group, ctx context.Context, state *LiveState) {
 	g.Go(func() error {
-		instruments, err := p.referenceData.ListInstruments(gctx)
+		instruments, err := p.referenceData.ListInstruments(ctx)
 		if err != nil {
 			return fmt.Errorf("query instruments: %w", err)
 		}
 		state.Instruments = instruments
 		return nil
 	})
-
 	g.Go(func() error {
-		accountTypes, err := p.referenceData.ListAccountTypes(gctx)
+		accountTypes, err := p.referenceData.ListAccountTypes(ctx)
 		if err != nil {
 			return fmt.Errorf("query account types: %w", err)
 		}
 		state.AccountTypes = accountTypes
 		return nil
 	})
+}
 
+func (p *GRPCLiveStateProvider) scheduleSagaQuery(g *errgroup.Group, ctx context.Context, state *LiveState) {
 	g.Go(func() error {
-		sagas, err := p.sagaRegistry.ListSagas(gctx)
+		sagas, err := p.sagaRegistry.ListSagas(ctx)
 		if err != nil {
 			return fmt.Errorf("query sagas: %w", err)
 		}
 		state.Sagas = sagas
 		return nil
 	})
+}
 
+func (p *GRPCLiveStateProvider) scheduleMarketDataQueries(g *errgroup.Group, ctx context.Context, state *LiveState) {
 	g.Go(func() error {
-		sources, err := p.marketInformation.ListMarketDataSources(gctx)
+		sources, err := p.marketInformation.ListMarketDataSources(ctx)
 		if err != nil {
 			return fmt.Errorf("query market data sources: %w", err)
 		}
 		state.MarketDataSources = sources
 		return nil
 	})
-
 	g.Go(func() error {
-		datasets, err := p.marketInformation.ListMarketDataSets(gctx)
+		datasets, err := p.marketInformation.ListMarketDataSets(ctx)
 		if err != nil {
 			return fmt.Errorf("query market data sets: %w", err)
 		}
 		state.MarketDataSets = datasets
 		return nil
 	})
+}
 
+func (p *GRPCLiveStateProvider) schedulePartyQuery(g *errgroup.Group, ctx context.Context, state *LiveState) {
 	g.Go(func() error {
-		orgs, err := p.party.ListOrganizations(gctx)
+		orgs, err := p.party.ListOrganizations(ctx)
 		if err != nil {
 			return fmt.Errorf("query organizations: %w", err)
 		}
 		state.Organizations = orgs
 		return nil
 	})
+}
 
+func (p *GRPCLiveStateProvider) scheduleInternalAccountQuery(g *errgroup.Group, ctx context.Context, state *LiveState) {
 	g.Go(func() error {
-		accounts, err := p.internalAccount.ListInternalAccounts(gctx)
+		accounts, err := p.internalAccount.ListInternalAccounts(ctx)
 		if err != nil {
 			return fmt.Errorf("query internal accounts: %w", err)
 		}
 		state.InternalAccounts = accounts
 		return nil
 	})
+}
 
+func (p *GRPCLiveStateProvider) scheduleOperationalGatewayQueries(g *errgroup.Group, ctx context.Context, state *LiveState) {
 	g.Go(func() error {
-		connections, err := p.operationalGateway.ListProviderConnections(gctx)
+		connections, err := p.operationalGateway.ListProviderConnections(ctx)
 		if err != nil {
 			return fmt.Errorf("query provider connections: %w", err)
 		}
 		state.ProviderConnections = connections
 		return nil
 	})
-
 	g.Go(func() error {
-		routes, err := p.operationalGateway.ListInstructionRoutes(gctx)
+		routes, err := p.operationalGateway.ListInstructionRoutes(ctx)
 		if err != nil {
 			return fmt.Errorf("query instruction routes: %w", err)
 		}
 		state.InstructionRoutes = routes
 		return nil
 	})
-
-	if err := g.Wait(); err != nil {
-		return nil, fmt.Errorf("query live state: %w", err)
-	}
-
-	return state, nil
 }

--- a/services/control-plane/internal/differ/live_state_provider.go
+++ b/services/control-plane/internal/differ/live_state_provider.go
@@ -111,7 +111,10 @@ func NewGRPCLiveStateProvider(
 // tenantID is propagated via gRPC metadata so downstream services scope queries to the correct tenant.
 // Returns an error if any service query fails.
 func (p *GRPCLiveStateProvider) QueryLiveState(ctx context.Context, tenantID string) (*LiveState, error) {
-	ctx = metadata.AppendToOutgoingContext(ctx, tenant.TenantIDKey, tenantID)
+	md, _ := metadata.FromOutgoingContext(ctx)
+	md = md.Copy()
+	md.Set(tenant.TenantIDKey, tenantID)
+	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	state := &LiveState{}
 	g, gctx := errgroup.WithContext(ctx)

--- a/services/control-plane/internal/differ/live_state_provider.go
+++ b/services/control-plane/internal/differ/live_state_provider.go
@@ -119,12 +119,12 @@ func (p *GRPCLiveStateProvider) QueryLiveState(ctx context.Context, tenantID str
 	state := &LiveState{}
 	g, gctx := errgroup.WithContext(ctx)
 
-	p.scheduleReferenceDataQueries(g, gctx, state)
-	p.scheduleSagaQuery(g, gctx, state)
-	p.scheduleMarketDataQueries(g, gctx, state)
-	p.schedulePartyQuery(g, gctx, state)
-	p.scheduleInternalAccountQuery(g, gctx, state)
-	p.scheduleOperationalGatewayQueries(g, gctx, state)
+	p.scheduleReferenceDataQueries(gctx, g, state)
+	p.scheduleSagaQuery(gctx, g, state)
+	p.scheduleMarketDataQueries(gctx, g, state)
+	p.schedulePartyQuery(gctx, g, state)
+	p.scheduleInternalAccountQuery(gctx, g, state)
+	p.scheduleOperationalGatewayQueries(gctx, g, state)
 
 	if err := g.Wait(); err != nil {
 		return nil, fmt.Errorf("query live state: %w", err)
@@ -132,7 +132,7 @@ func (p *GRPCLiveStateProvider) QueryLiveState(ctx context.Context, tenantID str
 	return state, nil
 }
 
-func (p *GRPCLiveStateProvider) scheduleReferenceDataQueries(g *errgroup.Group, ctx context.Context, state *LiveState) {
+func (p *GRPCLiveStateProvider) scheduleReferenceDataQueries(ctx context.Context, g *errgroup.Group, state *LiveState) {
 	g.Go(func() error {
 		instruments, err := p.referenceData.ListInstruments(ctx)
 		if err != nil {
@@ -151,7 +151,7 @@ func (p *GRPCLiveStateProvider) scheduleReferenceDataQueries(g *errgroup.Group, 
 	})
 }
 
-func (p *GRPCLiveStateProvider) scheduleSagaQuery(g *errgroup.Group, ctx context.Context, state *LiveState) {
+func (p *GRPCLiveStateProvider) scheduleSagaQuery(ctx context.Context, g *errgroup.Group, state *LiveState) {
 	g.Go(func() error {
 		sagas, err := p.sagaRegistry.ListSagas(ctx)
 		if err != nil {
@@ -162,7 +162,7 @@ func (p *GRPCLiveStateProvider) scheduleSagaQuery(g *errgroup.Group, ctx context
 	})
 }
 
-func (p *GRPCLiveStateProvider) scheduleMarketDataQueries(g *errgroup.Group, ctx context.Context, state *LiveState) {
+func (p *GRPCLiveStateProvider) scheduleMarketDataQueries(ctx context.Context, g *errgroup.Group, state *LiveState) {
 	g.Go(func() error {
 		sources, err := p.marketInformation.ListMarketDataSources(ctx)
 		if err != nil {
@@ -181,7 +181,7 @@ func (p *GRPCLiveStateProvider) scheduleMarketDataQueries(g *errgroup.Group, ctx
 	})
 }
 
-func (p *GRPCLiveStateProvider) schedulePartyQuery(g *errgroup.Group, ctx context.Context, state *LiveState) {
+func (p *GRPCLiveStateProvider) schedulePartyQuery(ctx context.Context, g *errgroup.Group, state *LiveState) {
 	g.Go(func() error {
 		orgs, err := p.party.ListOrganizations(ctx)
 		if err != nil {
@@ -192,7 +192,7 @@ func (p *GRPCLiveStateProvider) schedulePartyQuery(g *errgroup.Group, ctx contex
 	})
 }
 
-func (p *GRPCLiveStateProvider) scheduleInternalAccountQuery(g *errgroup.Group, ctx context.Context, state *LiveState) {
+func (p *GRPCLiveStateProvider) scheduleInternalAccountQuery(ctx context.Context, g *errgroup.Group, state *LiveState) {
 	g.Go(func() error {
 		accounts, err := p.internalAccount.ListInternalAccounts(ctx)
 		if err != nil {
@@ -203,7 +203,7 @@ func (p *GRPCLiveStateProvider) scheduleInternalAccountQuery(g *errgroup.Group, 
 	})
 }
 
-func (p *GRPCLiveStateProvider) scheduleOperationalGatewayQueries(g *errgroup.Group, ctx context.Context, state *LiveState) {
+func (p *GRPCLiveStateProvider) scheduleOperationalGatewayQueries(ctx context.Context, g *errgroup.Group, state *LiveState) {
 	g.Go(func() error {
 		connections, err := p.operationalGateway.ListProviderConnections(ctx)
 		if err != nil {

--- a/services/control-plane/internal/differ/live_state_provider.go
+++ b/services/control-plane/internal/differ/live_state_provider.go
@@ -2,12 +2,23 @@ package differ
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/metadata"
+)
+
+// Sentinel errors for nil client parameters.
+var (
+	ErrNilReferenceDataClient      = errors.New("referenceData client is required")
+	ErrNilSagaRegistryClient       = errors.New("sagaRegistry client is required")
+	ErrNilMarketInformationClient  = errors.New("marketInformation client is required")
+	ErrNilPartyClient              = errors.New("party client is required")
+	ErrNilInternalAccountClient    = errors.New("internalAccount client is required")
+	ErrNilOperationalGatewayClient = errors.New("operationalGateway client is required")
 )
 
 // Service-specific client interfaces, decoupled from generated gRPC stubs.
@@ -69,22 +80,22 @@ func NewGRPCLiveStateProvider(
 	operationalGateway OperationalGatewayClient,
 ) (*GRPCLiveStateProvider, error) {
 	if referenceData == nil {
-		return nil, fmt.Errorf("referenceData client is required")
+		return nil, ErrNilReferenceDataClient
 	}
 	if sagaRegistry == nil {
-		return nil, fmt.Errorf("sagaRegistry client is required")
+		return nil, ErrNilSagaRegistryClient
 	}
 	if marketInformation == nil {
-		return nil, fmt.Errorf("marketInformation client is required")
+		return nil, ErrNilMarketInformationClient
 	}
 	if party == nil {
-		return nil, fmt.Errorf("party client is required")
+		return nil, ErrNilPartyClient
 	}
 	if internalAccount == nil {
-		return nil, fmt.Errorf("internalAccount client is required")
+		return nil, ErrNilInternalAccountClient
 	}
 	if operationalGateway == nil {
-		return nil, fmt.Errorf("operationalGateway client is required")
+		return nil, ErrNilOperationalGatewayClient
 	}
 	return &GRPCLiveStateProvider{
 		referenceData:      referenceData,

--- a/services/control-plane/internal/differ/live_state_provider.go
+++ b/services/control-plane/internal/differ/live_state_provider.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/metadata"
 )
 
 // Service-specific client interfaces, decoupled from generated gRPC stubs.
@@ -95,9 +97,12 @@ func NewGRPCLiveStateProvider(
 }
 
 // QueryLiveState queries all downstream services concurrently and returns the aggregated live state.
-// The tenantID parameter is passed through context by the caller (tenant middleware).
+// tenantID is propagated via gRPC metadata so downstream services scope queries to the correct tenant.
 // Returns an error if any service query fails.
-func (p *GRPCLiveStateProvider) QueryLiveState(ctx context.Context, _ string) (*LiveState, error) {
+func (p *GRPCLiveStateProvider) QueryLiveState(ctx context.Context, tenantID string) (*LiveState, error) {
+	// Enrich context with tenant metadata for outgoing gRPC calls.
+	ctx = metadata.AppendToOutgoingContext(ctx, tenant.TenantIDKey, tenantID)
+
 	state := &LiveState{}
 	g, gctx := errgroup.WithContext(ctx)
 

--- a/services/control-plane/internal/differ/live_state_provider.go
+++ b/services/control-plane/internal/differ/live_state_provider.go
@@ -1,0 +1,190 @@
+package differ
+
+import (
+	"context"
+	"fmt"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"golang.org/x/sync/errgroup"
+)
+
+// Service-specific client interfaces, decoupled from generated gRPC stubs.
+// Each returns manifest-compatible control-plane proto types.
+
+// ReferenceDataClient queries the reference-data service for instruments and account types.
+type ReferenceDataClient interface {
+	ListInstruments(ctx context.Context) ([]*controlplanev1.InstrumentDefinition, error)
+	ListAccountTypes(ctx context.Context) ([]*controlplanev1.AccountTypeDefinition, error)
+}
+
+// SagaRegistryClient queries the saga-registry service for saga definitions.
+type SagaRegistryClient interface {
+	ListSagas(ctx context.Context) ([]*controlplanev1.SagaDefinition, error)
+}
+
+// MarketInformationClient queries the market-information service for data sources and data sets.
+type MarketInformationClient interface {
+	ListMarketDataSources(ctx context.Context) ([]*controlplanev1.MarketDataSourceDefinition, error)
+	ListMarketDataSets(ctx context.Context) ([]*controlplanev1.MarketDataSetDefinition, error)
+}
+
+// PartyClient queries the party service for organizations.
+type PartyClient interface {
+	ListOrganizations(ctx context.Context) ([]*controlplanev1.OrganizationDefinition, error)
+}
+
+// InternalAccountClient queries the internal-account service for internal accounts.
+type InternalAccountClient interface {
+	ListInternalAccounts(ctx context.Context) ([]*controlplanev1.InternalAccountDefinition, error)
+}
+
+// OperationalGatewayClient queries the operational-gateway service for provider connections and instruction routes.
+type OperationalGatewayClient interface {
+	ListProviderConnections(ctx context.Context) ([]*controlplanev1.ProviderConnectionConfig, error)
+	ListInstructionRoutes(ctx context.Context) ([]*controlplanev1.InstructionRouteConfig, error)
+}
+
+// GRPCLiveStateProvider queries all downstream services via gRPC to build a LiveState snapshot.
+// All service queries run concurrently via errgroup. If any query fails, the entire
+// operation fails - partial state is not acceptable for diff correctness.
+type GRPCLiveStateProvider struct {
+	referenceData      ReferenceDataClient
+	sagaRegistry       SagaRegistryClient
+	marketInformation  MarketInformationClient
+	party              PartyClient
+	internalAccount    InternalAccountClient
+	operationalGateway OperationalGatewayClient
+}
+
+// NewGRPCLiveStateProvider creates a new GRPCLiveStateProvider with all required service clients.
+// All client parameters are required and must not be nil.
+func NewGRPCLiveStateProvider(
+	referenceData ReferenceDataClient,
+	sagaRegistry SagaRegistryClient,
+	marketInformation MarketInformationClient,
+	party PartyClient,
+	internalAccount InternalAccountClient,
+	operationalGateway OperationalGatewayClient,
+) (*GRPCLiveStateProvider, error) {
+	if referenceData == nil {
+		return nil, fmt.Errorf("referenceData client is required")
+	}
+	if sagaRegistry == nil {
+		return nil, fmt.Errorf("sagaRegistry client is required")
+	}
+	if marketInformation == nil {
+		return nil, fmt.Errorf("marketInformation client is required")
+	}
+	if party == nil {
+		return nil, fmt.Errorf("party client is required")
+	}
+	if internalAccount == nil {
+		return nil, fmt.Errorf("internalAccount client is required")
+	}
+	if operationalGateway == nil {
+		return nil, fmt.Errorf("operationalGateway client is required")
+	}
+	return &GRPCLiveStateProvider{
+		referenceData:      referenceData,
+		sagaRegistry:       sagaRegistry,
+		marketInformation:  marketInformation,
+		party:              party,
+		internalAccount:    internalAccount,
+		operationalGateway: operationalGateway,
+	}, nil
+}
+
+// QueryLiveState queries all downstream services concurrently and returns the aggregated live state.
+// The tenantID parameter is passed through context by the caller (tenant middleware).
+// Returns an error if any service query fails.
+func (p *GRPCLiveStateProvider) QueryLiveState(ctx context.Context, _ string) (*LiveState, error) {
+	state := &LiveState{}
+	g, gctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		instruments, err := p.referenceData.ListInstruments(gctx)
+		if err != nil {
+			return fmt.Errorf("query instruments: %w", err)
+		}
+		state.Instruments = instruments
+		return nil
+	})
+
+	g.Go(func() error {
+		accountTypes, err := p.referenceData.ListAccountTypes(gctx)
+		if err != nil {
+			return fmt.Errorf("query account types: %w", err)
+		}
+		state.AccountTypes = accountTypes
+		return nil
+	})
+
+	g.Go(func() error {
+		sagas, err := p.sagaRegistry.ListSagas(gctx)
+		if err != nil {
+			return fmt.Errorf("query sagas: %w", err)
+		}
+		state.Sagas = sagas
+		return nil
+	})
+
+	g.Go(func() error {
+		sources, err := p.marketInformation.ListMarketDataSources(gctx)
+		if err != nil {
+			return fmt.Errorf("query market data sources: %w", err)
+		}
+		state.MarketDataSources = sources
+		return nil
+	})
+
+	g.Go(func() error {
+		datasets, err := p.marketInformation.ListMarketDataSets(gctx)
+		if err != nil {
+			return fmt.Errorf("query market data sets: %w", err)
+		}
+		state.MarketDataSets = datasets
+		return nil
+	})
+
+	g.Go(func() error {
+		orgs, err := p.party.ListOrganizations(gctx)
+		if err != nil {
+			return fmt.Errorf("query organizations: %w", err)
+		}
+		state.Organizations = orgs
+		return nil
+	})
+
+	g.Go(func() error {
+		accounts, err := p.internalAccount.ListInternalAccounts(gctx)
+		if err != nil {
+			return fmt.Errorf("query internal accounts: %w", err)
+		}
+		state.InternalAccounts = accounts
+		return nil
+	})
+
+	g.Go(func() error {
+		connections, err := p.operationalGateway.ListProviderConnections(gctx)
+		if err != nil {
+			return fmt.Errorf("query provider connections: %w", err)
+		}
+		state.ProviderConnections = connections
+		return nil
+	})
+
+	g.Go(func() error {
+		routes, err := p.operationalGateway.ListInstructionRoutes(gctx)
+		if err != nil {
+			return fmt.Errorf("query instruction routes: %w", err)
+		}
+		state.InstructionRoutes = routes
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("query live state: %w", err)
+	}
+
+	return state, nil
+}

--- a/services/control-plane/internal/differ/live_state_provider_test.go
+++ b/services/control-plane/internal/differ/live_state_provider_test.go
@@ -158,29 +158,28 @@ func TestNewGRPCLiveStateProvider_AllClientsRequired(t *testing.T) {
 	refData, saga, market, party, intAcct, opGw := newTestMocks()
 
 	tests := []struct {
-		name           string
-		refData        ReferenceDataClient
-		saga           SagaRegistryClient
-		market         MarketInformationClient
-		party          PartyClient
-		intAcct        InternalAccountClient
-		opGw           OperationalGatewayClient
-		expectContains string
+		name      string
+		refData   ReferenceDataClient
+		saga      SagaRegistryClient
+		market    MarketInformationClient
+		party     PartyClient
+		intAcct   InternalAccountClient
+		opGw      OperationalGatewayClient
+		expectErr error
 	}{
-		{"nil referenceData", nil, saga, market, party, intAcct, opGw, "referenceData"},
-		{"nil sagaRegistry", refData, nil, market, party, intAcct, opGw, "sagaRegistry"},
-		{"nil marketInformation", refData, saga, nil, party, intAcct, opGw, "marketInformation"},
-		{"nil party", refData, saga, market, nil, intAcct, opGw, "party"},
-		{"nil internalAccount", refData, saga, market, party, nil, opGw, "internalAccount"},
-		{"nil operationalGateway", refData, saga, market, party, intAcct, nil, "operationalGateway"},
+		{"nil referenceData", nil, saga, market, party, intAcct, opGw, ErrNilReferenceDataClient},
+		{"nil sagaRegistry", refData, nil, market, party, intAcct, opGw, ErrNilSagaRegistryClient},
+		{"nil marketInformation", refData, saga, nil, party, intAcct, opGw, ErrNilMarketInformationClient},
+		{"nil party", refData, saga, market, nil, intAcct, opGw, ErrNilPartyClient},
+		{"nil internalAccount", refData, saga, market, party, nil, opGw, ErrNilInternalAccountClient},
+		{"nil operationalGateway", refData, saga, market, party, intAcct, nil, ErrNilOperationalGatewayClient},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			provider, err := NewGRPCLiveStateProvider(tt.refData, tt.saga, tt.market, tt.party, tt.intAcct, tt.opGw)
 			assert.Nil(t, provider)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tt.expectContains)
+			require.ErrorIs(t, err, tt.expectErr)
 		})
 	}
 }

--- a/services/control-plane/internal/differ/live_state_provider_test.go
+++ b/services/control-plane/internal/differ/live_state_provider_test.go
@@ -1,0 +1,396 @@
+package differ
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Mock clients ---
+
+type mockReferenceDataClient struct {
+	instruments  []*controlplanev1.InstrumentDefinition
+	accountTypes []*controlplanev1.AccountTypeDefinition
+	instrErr     error
+	acctErr      error
+}
+
+func (m *mockReferenceDataClient) ListInstruments(_ context.Context) ([]*controlplanev1.InstrumentDefinition, error) {
+	return m.instruments, m.instrErr
+}
+
+func (m *mockReferenceDataClient) ListAccountTypes(_ context.Context) ([]*controlplanev1.AccountTypeDefinition, error) {
+	return m.accountTypes, m.acctErr
+}
+
+type mockSagaRegistryClient struct {
+	sagas []*controlplanev1.SagaDefinition
+	err   error
+}
+
+func (m *mockSagaRegistryClient) ListSagas(_ context.Context) ([]*controlplanev1.SagaDefinition, error) {
+	return m.sagas, m.err
+}
+
+type mockMarketInformationClient struct {
+	sources  []*controlplanev1.MarketDataSourceDefinition
+	datasets []*controlplanev1.MarketDataSetDefinition
+	srcErr   error
+	dsErr    error
+}
+
+func (m *mockMarketInformationClient) ListMarketDataSources(_ context.Context) ([]*controlplanev1.MarketDataSourceDefinition, error) {
+	return m.sources, m.srcErr
+}
+
+func (m *mockMarketInformationClient) ListMarketDataSets(_ context.Context) ([]*controlplanev1.MarketDataSetDefinition, error) {
+	return m.datasets, m.dsErr
+}
+
+type mockPartyClient struct {
+	organizations []*controlplanev1.OrganizationDefinition
+	err           error
+}
+
+func (m *mockPartyClient) ListOrganizations(_ context.Context) ([]*controlplanev1.OrganizationDefinition, error) {
+	return m.organizations, m.err
+}
+
+type mockInternalAccountClient struct {
+	accounts []*controlplanev1.InternalAccountDefinition
+	err      error
+}
+
+func (m *mockInternalAccountClient) ListInternalAccounts(_ context.Context) ([]*controlplanev1.InternalAccountDefinition, error) {
+	return m.accounts, m.err
+}
+
+type mockOperationalGatewayClient struct {
+	connections []*controlplanev1.ProviderConnectionConfig
+	routes      []*controlplanev1.InstructionRouteConfig
+	connErr     error
+	routeErr    error
+}
+
+func (m *mockOperationalGatewayClient) ListProviderConnections(_ context.Context) ([]*controlplanev1.ProviderConnectionConfig, error) {
+	return m.connections, m.connErr
+}
+
+func (m *mockOperationalGatewayClient) ListInstructionRoutes(_ context.Context) ([]*controlplanev1.InstructionRouteConfig, error) {
+	return m.routes, m.routeErr
+}
+
+// --- Helper to build a provider with all healthy mocks ---
+
+func newTestMocks() (
+	*mockReferenceDataClient,
+	*mockSagaRegistryClient,
+	*mockMarketInformationClient,
+	*mockPartyClient,
+	*mockInternalAccountClient,
+	*mockOperationalGatewayClient,
+) {
+	return &mockReferenceDataClient{
+			instruments: []*controlplanev1.InstrumentDefinition{
+				{Code: "GBP", Name: "British Pound"},
+				{Code: "KWH", Name: "Kilowatt Hour"},
+			},
+			accountTypes: []*controlplanev1.AccountTypeDefinition{
+				{Code: "CURRENT", Name: "Current Account"},
+			},
+		},
+		&mockSagaRegistryClient{
+			sagas: []*controlplanev1.SagaDefinition{
+				{Name: "process_payment"},
+			},
+		},
+		&mockMarketInformationClient{
+			sources: []*controlplanev1.MarketDataSourceDefinition{
+				{Code: "ECB"},
+			},
+			datasets: []*controlplanev1.MarketDataSetDefinition{
+				{Code: "FX_RATES"},
+			},
+		},
+		&mockPartyClient{
+			organizations: []*controlplanev1.OrganizationDefinition{
+				{Code: "ACME"},
+			},
+		},
+		&mockInternalAccountClient{
+			accounts: []*controlplanev1.InternalAccountDefinition{
+				{Code: "SUSPENSE_GBP"},
+			},
+		},
+		&mockOperationalGatewayClient{
+			connections: []*controlplanev1.ProviderConnectionConfig{
+				{ConnectionId: "stripe-prod", ProviderName: "Stripe Production"},
+			},
+			routes: []*controlplanev1.InstructionRouteConfig{
+				{InstructionType: "PAYMENT", ConnectionId: "stripe-prod"},
+			},
+		}
+}
+
+func newTestProvider(t *testing.T) (
+	*GRPCLiveStateProvider,
+	*mockReferenceDataClient,
+	*mockSagaRegistryClient,
+	*mockMarketInformationClient,
+	*mockPartyClient,
+	*mockInternalAccountClient,
+	*mockOperationalGatewayClient,
+) {
+	t.Helper()
+	refData, saga, market, party, intAcct, opGw := newTestMocks()
+	provider, err := NewGRPCLiveStateProvider(refData, saga, market, party, intAcct, opGw)
+	require.NoError(t, err)
+	return provider, refData, saga, market, party, intAcct, opGw
+}
+
+// --- Constructor tests ---
+
+func TestNewGRPCLiveStateProvider_AllClientsRequired(t *testing.T) {
+	refData, saga, market, party, intAcct, opGw := newTestMocks()
+
+	tests := []struct {
+		name           string
+		refData        ReferenceDataClient
+		saga           SagaRegistryClient
+		market         MarketInformationClient
+		party          PartyClient
+		intAcct        InternalAccountClient
+		opGw           OperationalGatewayClient
+		expectContains string
+	}{
+		{"nil referenceData", nil, saga, market, party, intAcct, opGw, "referenceData"},
+		{"nil sagaRegistry", refData, nil, market, party, intAcct, opGw, "sagaRegistry"},
+		{"nil marketInformation", refData, saga, nil, party, intAcct, opGw, "marketInformation"},
+		{"nil party", refData, saga, market, nil, intAcct, opGw, "party"},
+		{"nil internalAccount", refData, saga, market, party, nil, opGw, "internalAccount"},
+		{"nil operationalGateway", refData, saga, market, party, intAcct, nil, "operationalGateway"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, err := NewGRPCLiveStateProvider(tt.refData, tt.saga, tt.market, tt.party, tt.intAcct, tt.opGw)
+			assert.Nil(t, provider)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectContains)
+		})
+	}
+}
+
+func TestNewGRPCLiveStateProvider_Success(t *testing.T) {
+	refData, saga, market, party, intAcct, opGw := newTestMocks()
+	provider, err := NewGRPCLiveStateProvider(refData, saga, market, party, intAcct, opGw)
+	require.NoError(t, err)
+	assert.NotNil(t, provider)
+}
+
+// --- QueryLiveState tests ---
+
+func TestQueryLiveState_AllServicesSucceed(t *testing.T) {
+	provider, _, _, _, _, _, _ := newTestProvider(t)
+
+	state, err := provider.QueryLiveState(context.Background(), "tenant-1")
+	require.NoError(t, err)
+	require.NotNil(t, state)
+
+	assert.Len(t, state.Instruments, 2)
+	assert.Equal(t, "GBP", state.Instruments[0].Code)
+	assert.Equal(t, "KWH", state.Instruments[1].Code)
+
+	assert.Len(t, state.AccountTypes, 1)
+	assert.Equal(t, "CURRENT", state.AccountTypes[0].Code)
+
+	assert.Len(t, state.Sagas, 1)
+	assert.Equal(t, "process_payment", state.Sagas[0].Name)
+
+	assert.Len(t, state.MarketDataSources, 1)
+	assert.Equal(t, "ECB", state.MarketDataSources[0].Code)
+
+	assert.Len(t, state.MarketDataSets, 1)
+	assert.Equal(t, "FX_RATES", state.MarketDataSets[0].Code)
+
+	assert.Len(t, state.Organizations, 1)
+	assert.Equal(t, "ACME", state.Organizations[0].Code)
+
+	assert.Len(t, state.InternalAccounts, 1)
+	assert.Equal(t, "SUSPENSE_GBP", state.InternalAccounts[0].Code)
+
+	assert.Len(t, state.ProviderConnections, 1)
+	assert.Equal(t, "stripe-prod", state.ProviderConnections[0].ConnectionId)
+
+	assert.Len(t, state.InstructionRoutes, 1)
+	assert.Equal(t, "PAYMENT", state.InstructionRoutes[0].InstructionType)
+}
+
+func TestQueryLiveState_EmptyResults(t *testing.T) {
+	refData, saga, market, party, intAcct, opGw := newTestMocks()
+	// Override all with empty slices
+	refData.instruments = nil
+	refData.accountTypes = nil
+	saga.sagas = nil
+	market.sources = nil
+	market.datasets = nil
+	party.organizations = nil
+	intAcct.accounts = nil
+	opGw.connections = nil
+	opGw.routes = nil
+
+	provider, err := NewGRPCLiveStateProvider(refData, saga, market, party, intAcct, opGw)
+	require.NoError(t, err)
+
+	state, err := provider.QueryLiveState(context.Background(), "tenant-1")
+	require.NoError(t, err)
+	require.NotNil(t, state)
+
+	assert.Empty(t, state.Instruments)
+	assert.Empty(t, state.AccountTypes)
+	assert.Empty(t, state.Sagas)
+	assert.Empty(t, state.MarketDataSources)
+	assert.Empty(t, state.MarketDataSets)
+	assert.Empty(t, state.Organizations)
+	assert.Empty(t, state.InternalAccounts)
+	assert.Empty(t, state.ProviderConnections)
+	assert.Empty(t, state.InstructionRoutes)
+}
+
+func TestQueryLiveState_InstrumentQueryFails(t *testing.T) {
+	provider, refData, _, _, _, _, _ := newTestProvider(t)
+	refData.instrErr = errors.New("connection refused")
+
+	state, err := provider.QueryLiveState(context.Background(), "tenant-1")
+	assert.Nil(t, state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "query instruments")
+	assert.Contains(t, err.Error(), "connection refused")
+}
+
+func TestQueryLiveState_AccountTypeQueryFails(t *testing.T) {
+	provider, refData, _, _, _, _, _ := newTestProvider(t)
+	refData.acctErr = errors.New("timeout")
+
+	state, err := provider.QueryLiveState(context.Background(), "tenant-1")
+	assert.Nil(t, state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "query account types")
+}
+
+func TestQueryLiveState_SagaQueryFails(t *testing.T) {
+	provider, _, saga, _, _, _, _ := newTestProvider(t)
+	saga.err = errors.New("unavailable")
+
+	state, err := provider.QueryLiveState(context.Background(), "tenant-1")
+	assert.Nil(t, state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "query sagas")
+}
+
+func TestQueryLiveState_MarketDataSourceQueryFails(t *testing.T) {
+	provider, _, _, market, _, _, _ := newTestProvider(t)
+	market.srcErr = errors.New("not found")
+
+	state, err := provider.QueryLiveState(context.Background(), "tenant-1")
+	assert.Nil(t, state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "query market data sources")
+}
+
+func TestQueryLiveState_MarketDataSetQueryFails(t *testing.T) {
+	provider, _, _, market, _, _, _ := newTestProvider(t)
+	market.dsErr = errors.New("internal error")
+
+	state, err := provider.QueryLiveState(context.Background(), "tenant-1")
+	assert.Nil(t, state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "query market data sets")
+}
+
+func TestQueryLiveState_OrganizationQueryFails(t *testing.T) {
+	provider, _, _, _, party, _, _ := newTestProvider(t)
+	party.err = errors.New("permission denied")
+
+	state, err := provider.QueryLiveState(context.Background(), "tenant-1")
+	assert.Nil(t, state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "query organizations")
+}
+
+func TestQueryLiveState_InternalAccountQueryFails(t *testing.T) {
+	provider, _, _, _, _, intAcct, _ := newTestProvider(t)
+	intAcct.err = errors.New("deadline exceeded")
+
+	state, err := provider.QueryLiveState(context.Background(), "tenant-1")
+	assert.Nil(t, state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "query internal accounts")
+}
+
+func TestQueryLiveState_ProviderConnectionQueryFails(t *testing.T) {
+	provider, _, _, _, _, _, opGw := newTestProvider(t)
+	opGw.connErr = errors.New("connection reset")
+
+	state, err := provider.QueryLiveState(context.Background(), "tenant-1")
+	assert.Nil(t, state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "query provider connections")
+}
+
+func TestQueryLiveState_InstructionRouteQueryFails(t *testing.T) {
+	provider, _, _, _, _, _, opGw := newTestProvider(t)
+	opGw.routeErr = errors.New("service unavailable")
+
+	state, err := provider.QueryLiveState(context.Background(), "tenant-1")
+	assert.Nil(t, state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "query instruction routes")
+}
+
+func TestQueryLiveState_ContextCancelled(t *testing.T) {
+	// Use a client that respects context cancellation to verify errgroup propagation.
+	refData := &contextAwareRefDataClient{}
+	saga := &mockSagaRegistryClient{sagas: []*controlplanev1.SagaDefinition{{Name: "s"}}}
+	market := &mockMarketInformationClient{}
+	party := &mockPartyClient{}
+	intAcct := &mockInternalAccountClient{}
+	opGw := &mockOperationalGatewayClient{}
+
+	provider, err := NewGRPCLiveStateProvider(refData, saga, market, party, intAcct, opGw)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	state, err := provider.QueryLiveState(ctx, "tenant-1")
+	assert.Nil(t, state)
+	require.Error(t, err)
+}
+
+// contextAwareRefDataClient checks context before returning.
+type contextAwareRefDataClient struct{}
+
+func (c *contextAwareRefDataClient) ListInstruments(ctx context.Context) ([]*controlplanev1.InstrumentDefinition, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (c *contextAwareRefDataClient) ListAccountTypes(ctx context.Context) ([]*controlplanev1.AccountTypeDefinition, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func TestQueryLiveState_ImplementsLiveStateProvider(t *testing.T) {
+	provider, _, _, _, _, _, _ := newTestProvider(t)
+	// Compile-time check that GRPCLiveStateProvider implements LiveStateProvider.
+	var _ LiveStateProvider = provider
+}


### PR DESCRIPTION
## Summary

- Adds `LiveStateProvider` interface and `LiveState` struct in the differ package for querying current state from all downstream services
- Implements `GRPCLiveStateProvider` that queries all 6 services concurrently via errgroup (reference-data, saga-registry, market-information, party, internal-account, operational-gateway)
- Defines decoupled client interfaces per service (`ReferenceDataClient`, `SagaRegistryClient`, `MarketInformationClient`, `PartyClient`, `InternalAccountClient`, `OperationalGatewayClient`) returning manifest-compatible control-plane proto types
- Partial state is rejected - any single service failure causes the entire query to fail, ensuring diff correctness

## Technical Details

- Uses `golang.org/x/sync/errgroup` for concurrent queries with context propagation
- Client interfaces are narrowly scoped to the differ package, decoupled from generated gRPC stubs
- Follows the same pattern as the existing `ExportCollectors` in the manifest package but adapted for the differ's stricter requirements (no fallback to stored manifest)
- `LiveState` struct includes `IsSystem`-capable fields on all resource types for later filtering by task 8

## Test Plan

- [x] Constructor validation: all 6 client parameters required (nil rejection)
- [x] Happy path: all services return data, LiveState fully populated
- [x] Empty results: all services return empty slices, no errors
- [x] Individual service failures: 9 separate tests (one per query) verifying error propagation with descriptive wrapping
- [x] Context cancellation: verifies errgroup cancels sibling goroutines
- [x] Interface compliance: compile-time check that GRPCLiveStateProvider implements LiveStateProvider