### PR TITLE
fix: dynamically size saga flow diagram nodes based on content

### DIFF
--- a/frontend/src/features/cookbook/components/saga-flow-sizing.ts
+++ b/frontend/src/features/cookbook/components/saga-flow-sizing.ts
@@ -16,3 +16,27 @@ export function estimateStartNodeWidth(label: string, trigger: string | null): n
   const triggerWidth = trigger ? trigger.length * charWidth + 16 : 0
   return Math.max(160, Math.min(300, Math.max(labelWidth, triggerWidth)))
 }
+
+const DEFAULT_NODE_DIMENSIONS: Record<string, { width: number; height: number }> = {
+  sagaStart: { width: 160, height: 50 },
+  sagaStep: { width: 200, height: 60 },
+  sagaDecision: { width: 120, height: 80 },
+  sagaExit: { width: 120, height: 36 },
+  sagaEnd: { width: 140, height: 44 },
+}
+
+/** Get node dimensions, using dynamic sizing for decision and start nodes. */
+export function getNodeDimensions(
+  type: string | undefined,
+  label: string,
+  trigger: string | null,
+): { width: number; height: number } {
+  if (type === 'sagaDecision') {
+    return estimateDecisionSize(label)
+  }
+  if (type === 'sagaStart') {
+    const width = estimateStartNodeWidth(label, trigger)
+    return { width, height: trigger ? 56 : 44 }
+  }
+  return DEFAULT_NODE_DIMENSIONS[type ?? 'sagaStep'] ?? { width: 200, height: 60 }
+}

--- a/frontend/src/features/cookbook/components/saga-flow-sizing.ts
+++ b/frontend/src/features/cookbook/components/saga-flow-sizing.ts
@@ -1,0 +1,18 @@
+/** Estimate diamond dimensions based on label length. The diamond clip-path
+ *  only exposes ~50% of width/height for text, so we scale up for longer labels. */
+export function estimateDecisionSize(label: string): { width: number; height: number } {
+  const charWidth = 6 // approximate px per character at text-[10px]
+  const textWidth = label.length * charWidth
+  // Diamond usable area is ~50% of dimensions, add padding
+  const width = Math.max(120, Math.min(220, textWidth * 2 + 40))
+  const height = Math.max(80, Math.round(width * 0.7))
+  return { width, height }
+}
+
+/** Estimate start node width based on the longer of name or trigger text. */
+export function estimateStartNodeWidth(label: string, trigger: string | null): number {
+  const charWidth = 6
+  const labelWidth = label.length * charWidth + 32 // px-4 padding
+  const triggerWidth = trigger ? trigger.length * charWidth + 16 : 0
+  return Math.max(160, Math.min(300, Math.max(labelWidth, triggerWidth)))
+}

--- a/frontend/src/features/cookbook/components/saga-flow.test.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { SagaFlowDiagram } from './saga-flow'
+import { SagaFlowDiagram, estimateDecisionSize, estimateStartNodeWidth } from './saga-flow'
 import { parseTriggerService } from '../lib/star-parser'
 import type { SagaFlow } from '../lib/star-parser'
 
@@ -249,6 +249,41 @@ describe('SagaFlowDiagram', () => {
     // Services from both: payments (trigger), reference_data, position_keeping, valuation_engine
     expect(screen.getByRole('button', { name: /valuation_engine/ })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /reference_data/ })).toBeInTheDocument()
+  })
+})
+
+describe('estimateDecisionSize', () => {
+  it('returns minimum size for short labels', () => {
+    const size = estimateDecisionSize('x > 0')
+    expect(size.width).toBeGreaterThanOrEqual(120)
+    expect(size.height).toBeGreaterThanOrEqual(80)
+  })
+
+  it('scales up for longer labels', () => {
+    const short = estimateDecisionSize('x > 0')
+    const long = estimateDecisionSize('not billing_account_id')
+    expect(long.width).toBeGreaterThan(short.width)
+  })
+
+  it('caps at maximum width', () => {
+    const size = estimateDecisionSize('a'.repeat(100))
+    expect(size.width).toBeLessThanOrEqual(220)
+  })
+})
+
+describe('estimateStartNodeWidth', () => {
+  it('returns minimum width for short names', () => {
+    expect(estimateStartNodeWidth('test', null)).toBeGreaterThanOrEqual(160)
+  })
+
+  it('scales up for long trigger text', () => {
+    const short = estimateStartNodeWidth('saga', 'scheduled:topup')
+    const long = estimateStartNodeWidth('saga', 'event:position-keeping.transaction-captured.v1')
+    expect(long).toBeGreaterThan(short)
+  })
+
+  it('caps at maximum width', () => {
+    expect(estimateStartNodeWidth('a'.repeat(100), null)).toBeLessThanOrEqual(300)
   })
 })
 

--- a/frontend/src/features/cookbook/components/saga-flow.test.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { SagaFlowDiagram } from './saga-flow'
-import { estimateDecisionSize, estimateStartNodeWidth } from './saga-flow-sizing'
+import { estimateDecisionSize, estimateStartNodeWidth, getNodeDimensions } from './saga-flow-sizing'
 import { parseTriggerService } from '../lib/star-parser'
 import type { SagaFlow } from '../lib/star-parser'
 
@@ -12,14 +12,23 @@ vi.mock('@xyflow/react', () => {
 
   function Handle() { return null }
 
-  function ReactFlow({ nodes, edges, children }: { nodes: unknown[]; edges: unknown[]; children?: React.ReactNode }) {
+  // Render actual custom node components so their rendering logic gets coverage
+  function ReactFlow({ nodes, edges, nodeTypes, children }: {
+    nodes: { id: string; type?: string; data: Record<string, unknown> }[];
+    edges: unknown[];
+    nodeTypes?: Record<string, React.ComponentType<{ data: Record<string, unknown> }>>;
+    children?: React.ReactNode;
+  }) {
     return (
       <div data-testid="react-flow" data-node-count={nodes.length} data-edge-count={edges.length}>
-        {(nodes as { id: string; data: { label?: string } }[]).map((n) => (
-          <div key={n.id} data-testid={`node-${n.id}`}>
-            {n.data?.label ?? n.id}
-          </div>
-        ))}
+        {nodes.map((n) => {
+          const NodeComponent = nodeTypes?.[n.type ?? '']
+          return (
+            <div key={n.id} data-testid={`node-${n.id}`}>
+              {NodeComponent ? <NodeComponent data={n.data} /> : (n.data?.label as string) ?? n.id}
+            </div>
+          )
+        })}
         {children}
       </div>
     )
@@ -251,6 +260,32 @@ describe('SagaFlowDiagram', () => {
     expect(screen.getByRole('button', { name: /valuation_engine/ })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /reference_data/ })).toBeInTheDocument()
   })
+
+  it('renders decision node with condition label visible', () => {
+    render(<SagaFlowDiagram flows={[flowWithEarlyExit]} />)
+    expect(screen.getByText('existing.count > 0')).toBeInTheDocument()
+  })
+
+  it('renders exit node with return status visible', () => {
+    render(<SagaFlowDiagram flows={[flowWithEarlyExit]} />)
+    expect(screen.getByText('ALREADY_PROCESSED')).toBeInTheDocument()
+  })
+
+  it('renders trigger badge in start node', () => {
+    render(<SagaFlowDiagram flows={[simpleFlow]} />)
+    expect(screen.getByText('event:payments.received.v1')).toBeInTheDocument()
+  })
+
+  it('renders COMPLETED label in end node', () => {
+    render(<SagaFlowDiagram flows={[simpleFlow]} />)
+    expect(screen.getByText('COMPLETED')).toBeInTheDocument()
+  })
+
+  it('renders service call badges in step nodes', () => {
+    render(<SagaFlowDiagram flows={[simpleFlow]} />)
+    expect(screen.getByText('reference_data.get_account')).toBeInTheDocument()
+    expect(screen.getByText('position_keeping.initiate_log')).toBeInTheDocument()
+  })
 })
 
 describe('estimateDecisionSize', () => {
@@ -285,6 +320,46 @@ describe('estimateStartNodeWidth', () => {
 
   it('caps at maximum width', () => {
     expect(estimateStartNodeWidth('a'.repeat(100), null)).toBeLessThanOrEqual(300)
+  })
+})
+
+describe('getNodeDimensions', () => {
+  it('uses dynamic sizing for decision nodes', () => {
+    const short = getNodeDimensions('sagaDecision', 'x > 0', null)
+    const long = getNodeDimensions('sagaDecision', 'not billing_account_id', null)
+    expect(long.width).toBeGreaterThan(short.width)
+  })
+
+  it('uses dynamic sizing for start nodes', () => {
+    const short = getNodeDimensions('sagaStart', 'saga', null)
+    const long = getNodeDimensions('sagaStart', 'saga', 'event:position-keeping.transaction-captured.v1')
+    expect(long.width).toBeGreaterThan(short.width)
+  })
+
+  it('adjusts start node height based on trigger presence', () => {
+    const withTrigger = getNodeDimensions('sagaStart', 'saga', 'scheduled:topup')
+    const noTrigger = getNodeDimensions('sagaStart', 'saga', null)
+    expect(withTrigger.height).toBeGreaterThan(noTrigger.height)
+  })
+
+  it('returns default dimensions for step nodes', () => {
+    const dims = getNodeDimensions('sagaStep', 'step', null)
+    expect(dims).toEqual({ width: 200, height: 60 })
+  })
+
+  it('returns default dimensions for exit nodes', () => {
+    const dims = getNodeDimensions('sagaExit', 'exit', null)
+    expect(dims).toEqual({ width: 120, height: 36 })
+  })
+
+  it('returns default dimensions for end nodes', () => {
+    const dims = getNodeDimensions('sagaEnd', '', null)
+    expect(dims).toEqual({ width: 140, height: 44 })
+  })
+
+  it('falls back to step dimensions for unknown types', () => {
+    const dims = getNodeDimensions('unknown', '', null)
+    expect(dims).toEqual({ width: 200, height: 60 })
   })
 })
 

--- a/frontend/src/features/cookbook/components/saga-flow.test.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { SagaFlowDiagram, estimateDecisionSize, estimateStartNodeWidth } from './saga-flow'
+import { SagaFlowDiagram } from './saga-flow'
+import { estimateDecisionSize, estimateStartNodeWidth } from './saga-flow-sizing'
 import { parseTriggerService } from '../lib/star-parser'
 import type { SagaFlow } from '../lib/star-parser'
 

--- a/frontend/src/features/cookbook/components/saga-flow.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.tsx
@@ -13,7 +13,7 @@ import '@xyflow/react/dist/style.css'
 import Dagre from '@dagrejs/dagre'
 import type { SagaFlow } from '../lib/star-parser'
 import { parseTriggerService } from '../lib/star-parser'
-import { estimateDecisionSize, estimateStartNodeWidth } from './saga-flow-sizing'
+import { estimateDecisionSize, getNodeDimensions } from './saga-flow-sizing'
 
 // Curated palette of visually distinct service colors using CSS custom properties
 const SERVICE_PALETTE = [
@@ -276,29 +276,6 @@ const nodeTypes = {
 
 // --- Layout ---
 
-const DEFAULT_NODE_DIMENSIONS: Record<string, { width: number; height: number }> = {
-  sagaStart: { width: 160, height: 50 },
-  sagaStep: { width: 200, height: 60 },
-  sagaDecision: { width: 120, height: 80 },
-  sagaExit: { width: 120, height: 36 },
-  sagaEnd: { width: 140, height: 44 },
-}
-
-/** Get node dimensions, using dynamic sizing for decision and start nodes. */
-function getNodeDimensions(node: Node): { width: number; height: number } {
-  if (node.type === 'sagaDecision') {
-    return estimateDecisionSize(String(node.data?.label ?? ''))
-  }
-  if (node.type === 'sagaStart') {
-    const width = estimateStartNodeWidth(
-      String(node.data?.label ?? ''),
-      (node.data?.trigger as string | null) ?? null,
-    )
-    return { width, height: node.data?.trigger ? 56 : 44 }
-  }
-  return DEFAULT_NODE_DIMENSIONS[node.type ?? 'sagaStep'] ?? { width: 200, height: 60 }
-}
-
 export type FlowDirection = 'LR' | 'TB'
 
 function layoutNodes(nodes: Node[], edges: Edge[], direction: FlowDirection = 'LR'): Node[] {
@@ -306,7 +283,7 @@ function layoutNodes(nodes: Node[], edges: Edge[], direction: FlowDirection = 'L
   g.setGraph({ rankdir: direction, nodesep: 60, ranksep: 100 })
 
   for (const n of nodes) {
-    const dims = getNodeDimensions(n)
+    const dims = getNodeDimensions(n.type, String(n.data?.label ?? ''), (n.data?.trigger as string | null) ?? null)
     g.setNode(n.id, { width: dims.width, height: dims.height })
   }
 
@@ -318,7 +295,7 @@ function layoutNodes(nodes: Node[], edges: Edge[], direction: FlowDirection = 'L
 
   return nodes.map((n) => {
     const nodeWithPos = g.node(n.id)
-    const dims = getNodeDimensions(n)
+    const dims = getNodeDimensions(n.type, String(n.data?.label ?? ''), (n.data?.trigger as string | null) ?? null)
     return {
       ...n,
       position: {

--- a/frontend/src/features/cookbook/components/saga-flow.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.tsx
@@ -13,6 +13,7 @@ import '@xyflow/react/dist/style.css'
 import Dagre from '@dagrejs/dagre'
 import type { SagaFlow } from '../lib/star-parser'
 import { parseTriggerService } from '../lib/star-parser'
+import { estimateDecisionSize, estimateStartNodeWidth } from './saga-flow-sizing'
 
 // Curated palette of visually distinct service colors using CSS custom properties
 const SERVICE_PALETTE = [
@@ -197,17 +198,6 @@ interface DecisionNodeData {
   [key: string]: unknown
 }
 
-/** Estimate diamond dimensions based on label length. The diamond clip-path
- *  only exposes ~50% of width/height for text, so we scale up for longer labels. */
-export function estimateDecisionSize(label: string): { width: number; height: number } {
-  const charWidth = 6 // approximate px per character at text-[10px]
-  const textWidth = label.length * charWidth
-  // Diamond usable area is ~50% of dimensions, add padding
-  const width = Math.max(120, Math.min(220, textWidth * 2 + 40))
-  const height = Math.max(80, Math.round(width * 0.7))
-  return { width, height }
-}
-
 const DecisionNode = memo(function DecisionNode({ data }: { data: DecisionNodeData }) {
   const dimmed = data.highlightedSaga && data.highlightedSaga !== data.sagaName
   const size = useMemo(() => estimateDecisionSize(data.label), [data.label])
@@ -292,14 +282,6 @@ const DEFAULT_NODE_DIMENSIONS: Record<string, { width: number; height: number }>
   sagaDecision: { width: 120, height: 80 },
   sagaExit: { width: 120, height: 36 },
   sagaEnd: { width: 140, height: 44 },
-}
-
-/** Estimate start node width based on the longer of name or trigger text. */
-export function estimateStartNodeWidth(label: string, trigger: string | null): number {
-  const charWidth = 6
-  const labelWidth = label.length * charWidth + 32 // px-4 padding
-  const triggerWidth = trigger ? trigger.length * charWidth + 16 : 0
-  return Math.max(160, Math.min(300, Math.max(labelWidth, triggerWidth)))
 }
 
 /** Get node dimensions, using dynamic sizing for decision and start nodes. */

--- a/frontend/src/features/cookbook/components/saga-flow.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.tsx
@@ -106,10 +106,10 @@ const StartNode = memo(function StartNode({ data }: { data: StartNodeData }) {
         className={`flex flex-col items-center justify-center rounded-full border-2 border-success bg-success-muted px-4 py-2 transition-opacity ${dimmed ? 'opacity-30' : 'opacity-100'}`}
         style={containerStyle}
       >
-        <span className="text-xs font-semibold text-success-foreground">{data.label}</span>
+        <span className="text-xs font-semibold text-success-foreground whitespace-nowrap">{data.label}</span>
         {data.trigger && (
           <span
-            className="inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium mt-0.5"
+            className="inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium mt-0.5 whitespace-nowrap"
             style={triggerBadgeStyle}
           >
             {data.trigger}
@@ -197,22 +197,37 @@ interface DecisionNodeData {
   [key: string]: unknown
 }
 
-const DECISION_NODE_STYLE = {
-  width: 120,
-  height: 80,
-  clipPath: 'polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%)',
-} as const
+/** Estimate diamond dimensions based on label length. The diamond clip-path
+ *  only exposes ~50% of width/height for text, so we scale up for longer labels. */
+export function estimateDecisionSize(label: string): { width: number; height: number } {
+  const charWidth = 6 // approximate px per character at text-[10px]
+  const textWidth = label.length * charWidth
+  // Diamond usable area is ~50% of dimensions, add padding
+  const width = Math.max(120, Math.min(220, textWidth * 2 + 40))
+  const height = Math.max(80, Math.round(width * 0.7))
+  return { width, height }
+}
 
 const DecisionNode = memo(function DecisionNode({ data }: { data: DecisionNodeData }) {
   const dimmed = data.highlightedSaga && data.highlightedSaga !== data.sagaName
+  const size = useMemo(() => estimateDecisionSize(data.label), [data.label])
+  const style = useMemo(() => ({
+    width: size.width,
+    height: size.height,
+    clipPath: 'polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%)',
+  }), [size])
+
   return (
     <>
       <Handle type="target" position={data.direction === 'TB' ? Position.Top : Position.Left} className="bg-transparent! border-0! w-0! h-0!" />
       <div
         className={`flex items-center justify-center border-2 border-warning bg-warning-muted transition-opacity ${dimmed ? 'opacity-30' : 'opacity-100'}`}
-        style={DECISION_NODE_STYLE}
+        style={style}
       >
-        <span className="inline-block text-[10px] font-medium text-warning-foreground text-center leading-tight px-4 max-w-[120px]">
+        <span
+          className="inline-block text-[10px] font-medium text-warning-foreground text-center leading-tight"
+          style={{ maxWidth: Math.round(size.width * 0.5), padding: '0 4px' }}
+        >
           {data.label}
         </span>
       </div>
@@ -271,12 +286,35 @@ const nodeTypes = {
 
 // --- Layout ---
 
-const NODE_DIMENSIONS: Record<string, { width: number; height: number }> = {
+const DEFAULT_NODE_DIMENSIONS: Record<string, { width: number; height: number }> = {
   sagaStart: { width: 160, height: 50 },
   sagaStep: { width: 200, height: 60 },
   sagaDecision: { width: 120, height: 80 },
   sagaExit: { width: 120, height: 36 },
   sagaEnd: { width: 140, height: 44 },
+}
+
+/** Estimate start node width based on the longer of name or trigger text. */
+export function estimateStartNodeWidth(label: string, trigger: string | null): number {
+  const charWidth = 6
+  const labelWidth = label.length * charWidth + 32 // px-4 padding
+  const triggerWidth = trigger ? trigger.length * charWidth + 16 : 0
+  return Math.max(160, Math.min(300, Math.max(labelWidth, triggerWidth)))
+}
+
+/** Get node dimensions, using dynamic sizing for decision and start nodes. */
+function getNodeDimensions(node: Node): { width: number; height: number } {
+  if (node.type === 'sagaDecision') {
+    return estimateDecisionSize(String(node.data?.label ?? ''))
+  }
+  if (node.type === 'sagaStart') {
+    const width = estimateStartNodeWidth(
+      String(node.data?.label ?? ''),
+      (node.data?.trigger as string | null) ?? null,
+    )
+    return { width, height: node.data?.trigger ? 56 : 44 }
+  }
+  return DEFAULT_NODE_DIMENSIONS[node.type ?? 'sagaStep'] ?? { width: 200, height: 60 }
 }
 
 export type FlowDirection = 'LR' | 'TB'
@@ -286,7 +324,7 @@ function layoutNodes(nodes: Node[], edges: Edge[], direction: FlowDirection = 'L
   g.setGraph({ rankdir: direction, nodesep: 60, ranksep: 100 })
 
   for (const n of nodes) {
-    const dims = NODE_DIMENSIONS[n.type ?? 'sagaStep'] ?? { width: 200, height: 60 }
+    const dims = getNodeDimensions(n)
     g.setNode(n.id, { width: dims.width, height: dims.height })
   }
 
@@ -298,7 +336,7 @@ function layoutNodes(nodes: Node[], edges: Edge[], direction: FlowDirection = 'L
 
   return nodes.map((n) => {
     const nodeWithPos = g.node(n.id)
-    const dims = NODE_DIMENSIONS[n.type ?? 'sagaStep'] ?? { width: 200, height: 60 }
+    const dims = getNodeDimensions(n)
     return {
       ...n,
       position: {

--- a/frontend/src/test/architecture/size.test.ts
+++ b/frontend/src/test/architecture/size.test.ts
@@ -31,7 +31,7 @@ const knownOversizedFiles: Record<string, number> = {
   'src/features/manifests/components/manifest-graph.tsx': 1090,
   'src/features/manifests/components/manifest-diff-graph.tsx': 657,
   'src/features/reconciliation/pages/detail.tsx': 638,
-  'src/features/cookbook/components/saga-flow.tsx': 614,
+  'src/features/cookbook/components/saga-flow.tsx': 611,
   'src/App.tsx': 390,
   'src/features/reference-data/pages/account-types/create-account-type-dialog.tsx': 516,
   'src/features/accounts/pages/[accountId].tsx': 497,


### PR DESCRIPTION
## Summary

- Diamond decision nodes and start/trigger nodes in the saga flow diagram used fixed pixel dimensions, causing text clipping on diamonds (e.g., "not billing_account_id" truncated) and spacing issues when trigger strings are long (e.g., "event:position-keeping.transaction-captured.v1")
- Both node types now dynamically estimate their dagre layout dimensions from actual label/trigger text length, with min/max bounds (diamonds: 120-220px wide, start nodes: 160-300px wide)
- Added `whitespace-nowrap` to start node text to prevent awkward line wrapping inside the pill shape

## Test plan

- [x] All 24 existing saga-flow tests pass
- [x] Added 6 new tests for `estimateDecisionSize` and `estimateStartNodeWidth` sizing functions
- [ ] Visual verification on /cookbook/payg-energy page