### PR TITLE
feat: proactive idempotency for remaining manifest handlers

### DIFF
--- a/services/control-plane/internal/applier/internal_account_client.go
+++ b/services/control-plane/internal/applier/internal_account_client.go
@@ -29,6 +29,7 @@ func NewInternalAccountClient(conn *grpc.ClientConn) *InternalAccountClient {
 
 // InitiateAccount implements InternalAccountService.
 // Converts Starlark params to an InitiateInternalAccountRequest and calls the gRPC service.
+// Uses proactive idempotency: checks if account already exists before creating.
 func (c *InternalAccountClient) InitiateAccount(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
 	req := &internalaccountv1.InitiateInternalAccountRequest{}
 	req.AccountCode, _ = params["account_code"].(string)
@@ -39,11 +40,20 @@ func (c *InternalAccountClient) InitiateAccount(ctx *saga.StarlarkContext, param
 	req.OrgPartyId, _ = params["owner_organization"].(string)
 
 	callCtx := prepareCallContext(ctx)
+
+	// Proactive check: if account already exists, return success immediately.
+	existing, lookupErr := c.client.RetrieveInternalAccount(callCtx, &internalaccountv1.RetrieveInternalAccountRequest{
+		AccountId: req.AccountCode,
+	})
+	if lookupErr == nil {
+		facility := existing.GetFacility()
+		return accountResult(facility), nil
+	}
+
+	// Proceed with account creation.
 	resp, err := c.client.InitiateInternalAccount(callCtx, req)
 	if err != nil {
-		// Idempotency: treat AlreadyExists as success for manifest re-apply scenarios
-		// where the account was already created by a previous apply.
-		// Look up the existing account to return account_id (required by the saga script).
+		// Reactive fallback: treat AlreadyExists as success for manifest re-apply scenarios.
 		if status.Code(err) == codes.AlreadyExists {
 			return c.handleAlreadyExists(callCtx, req.AccountCode)
 		}
@@ -57,6 +67,15 @@ func (c *InternalAccountClient) InitiateAccount(ctx *saga.StarlarkContext, param
 	}, nil
 }
 
+// accountResult converts an InternalAccountFacility to a saga result map.
+func accountResult(facility *internalaccountv1.InternalAccountFacility) map[string]any {
+	return map[string]any{
+		"account_id":   facility.GetAccountId(),
+		"account_code": facility.GetAccountCode(),
+		"status":       facility.GetAccountStatus().String(),
+	}
+}
+
 // handleAlreadyExists resolves the existing account by code so that
 // downstream saga steps receive account_id. The RetrieveInternalAccount
 // RPC accepts account_code as well as UUID.
@@ -68,12 +87,7 @@ func (c *InternalAccountClient) handleAlreadyExists(ctx context.Context, account
 		return nil, fmt.Errorf("initiate internal account: account already exists but lookup failed: %w", err)
 	}
 
-	facility := resp.GetFacility()
-	return map[string]any{
-		"account_id":   facility.GetAccountId(),
-		"account_code": facility.GetAccountCode(),
-		"status":       facility.GetAccountStatus().String(),
-	}, nil
+	return accountResult(resp.GetFacility()), nil
 }
 
 // Ensure InternalAccountClient implements InternalAccountService at compile time.

--- a/services/control-plane/internal/applier/internal_account_client_test.go
+++ b/services/control-plane/internal/applier/internal_account_client_test.go
@@ -44,13 +44,8 @@ func (f *fakeInternalAccountServer) RetrieveInternalAccount(ctx context.Context,
 	if f.retrieveFn != nil {
 		return f.retrieveFn(ctx, req)
 	}
-	return &internalaccountv1.RetrieveInternalAccountResponse{
-		Facility: &internalaccountv1.InternalAccountFacility{
-			AccountId:     "existing-ia-uuid",
-			AccountCode:   req.AccountId, // The service accepts code as account_id
-			AccountStatus: internalaccountv1.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_ACTIVE,
-		},
-	}, nil
+	// Default: not found (proactive check falls through to create).
+	return nil, status.Error(codes.NotFound, "account not found")
 }
 
 // ─── Test setup ────────────────────────────────────────────────────────────
@@ -119,9 +114,25 @@ func TestInternalAccountClient_InitiateAccount_MinimalParams(t *testing.T) {
 // ─── Idempotency tests ──────────────────────────────────────────────────────
 
 func TestInternalAccountClient_InitiateAccount_AlreadyExists_TreatedAsSuccess(t *testing.T) {
+	// Proactive check returns NotFound, InitiateInternalAccount returns AlreadyExists,
+	// reactive fallback calls RetrieveInternalAccount again and finds the account.
+	callCount := 0
 	srv := &fakeInternalAccountServer{
 		initiateFn: func(_ context.Context, _ *internalaccountv1.InitiateInternalAccountRequest) (*internalaccountv1.InitiateInternalAccountResponse, error) {
 			return nil, status.Error(codes.AlreadyExists, "account code already exists: CLEARING_GBP")
+		},
+		retrieveFn: func(_ context.Context, req *internalaccountv1.RetrieveInternalAccountRequest) (*internalaccountv1.RetrieveInternalAccountResponse, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, status.Error(codes.NotFound, "account not found")
+			}
+			return &internalaccountv1.RetrieveInternalAccountResponse{
+				Facility: &internalaccountv1.InternalAccountFacility{
+					AccountId:     "existing-ia-uuid",
+					AccountCode:   req.AccountId,
+					AccountStatus: internalaccountv1.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_ACTIVE,
+				},
+			}, nil
 		},
 	}
 	conn := newInternalAccountTestServerWith(t, srv)
@@ -173,4 +184,78 @@ func TestInternalAccountClient_InitiateAccount_OtherError_Propagated(t *testing.
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "database unavailable")
+}
+
+// ─── Proactive idempotency tests ──────────────────────────────────────────
+
+func TestInternalAccountClient_InitiateAccount_ProactiveCheck_AlreadyExists(t *testing.T) {
+	// RetrieveInternalAccount returns the account, so InitiateInternalAccount should never be called.
+	initiateCalled := false
+	srv := &fakeInternalAccountServer{
+		retrieveFn: func(_ context.Context, req *internalaccountv1.RetrieveInternalAccountRequest) (*internalaccountv1.RetrieveInternalAccountResponse, error) {
+			return &internalaccountv1.RetrieveInternalAccountResponse{
+				Facility: &internalaccountv1.InternalAccountFacility{
+					AccountId:     "existing-ia-uuid",
+					AccountCode:   req.AccountId,
+					AccountStatus: internalaccountv1.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_ACTIVE,
+				},
+			}, nil
+		},
+		initiateFn: func(_ context.Context, _ *internalaccountv1.InitiateInternalAccountRequest) (*internalaccountv1.InitiateInternalAccountResponse, error) {
+			initiateCalled = true
+			return nil, status.Error(codes.AlreadyExists, "should not be called")
+		},
+	}
+	conn := newInternalAccountTestServerWith(t, srv)
+	client := NewInternalAccountClient(conn)
+
+	result, err := client.InitiateAccount(testStarlarkCtx(), map[string]any{
+		"account_code": "CLEARING_GBP",
+	})
+	require.NoError(t, err, "proactive check should return success for existing account")
+	assert.False(t, initiateCalled, "InitiateInternalAccount gRPC should not be called when proactive check finds account")
+
+	m := result.(map[string]any)
+	assert.Equal(t, "existing-ia-uuid", m["account_id"])
+	assert.Equal(t, "CLEARING_GBP", m["account_code"])
+	assert.Contains(t, m["status"], "ACTIVE")
+}
+
+func TestInternalAccountClient_InitiateAccount_ProactiveCheck_NotFound_ProceedsToCreate(t *testing.T) {
+	// RetrieveInternalAccount returns NotFound, so handler proceeds to InitiateInternalAccount.
+	srv := &fakeInternalAccountServer{
+		retrieveFn: func(_ context.Context, _ *internalaccountv1.RetrieveInternalAccountRequest) (*internalaccountv1.RetrieveInternalAccountResponse, error) {
+			return nil, status.Error(codes.NotFound, "account not found")
+		},
+	}
+	conn := newInternalAccountTestServerWith(t, srv)
+	client := NewInternalAccountClient(conn)
+
+	result, err := client.InitiateAccount(testStarlarkCtx(), map[string]any{
+		"account_code": "NEW_ACCOUNT",
+	})
+	require.NoError(t, err, "should proceed to create when proactive check returns NotFound")
+
+	m := result.(map[string]any)
+	assert.Equal(t, "ia-uuid-1", m["account_id"])
+	assert.Equal(t, "NEW_ACCOUNT", m["account_code"])
+}
+
+func TestInternalAccountClient_InitiateAccount_ProactiveCheck_Error_ProceedsToCreate(t *testing.T) {
+	// RetrieveInternalAccount returns an unexpected error, handler should still proceed.
+	srv := &fakeInternalAccountServer{
+		retrieveFn: func(_ context.Context, _ *internalaccountv1.RetrieveInternalAccountRequest) (*internalaccountv1.RetrieveInternalAccountResponse, error) {
+			return nil, status.Error(codes.Internal, "database unavailable")
+		},
+	}
+	conn := newInternalAccountTestServerWith(t, srv)
+	client := NewInternalAccountClient(conn)
+
+	result, err := client.InitiateAccount(testStarlarkCtx(), map[string]any{
+		"account_code": "FALLTHROUGH",
+	})
+	require.NoError(t, err, "should proceed to create when proactive check fails")
+
+	m := result.(map[string]any)
+	assert.Equal(t, "ia-uuid-1", m["account_id"])
 }

--- a/services/control-plane/internal/applier/market_information_client.go
+++ b/services/control-plane/internal/applier/market_information_client.go
@@ -17,6 +17,9 @@ import (
 // ErrUnknownDataCategory is returned when an unrecognized data category string is provided.
 var ErrUnknownDataCategory = errors.New("unknown data category")
 
+// errDataSourceNotFound is returned when a data source lookup finds no matching source.
+var errDataSourceNotFound = errors.New("data source not found")
+
 // MarketInformationClient wraps the market-information gRPC client to implement
 // MarketInformationService for use as a saga handler dependency.
 //
@@ -87,7 +90,7 @@ func (c *MarketInformationClient) RegisterDataSource(ctx *saga.StarlarkContext, 
 }
 
 // findDataSourceByCode pages through ListDataSources to locate a data source by code.
-// Returns nil, nil if not found. Returns nil, error on RPC failure.
+// Returns errDataSourceNotFound if no matching source is found.
 func (c *MarketInformationClient) findDataSourceByCode(ctx context.Context, code string) (*marketinformationv1.DataSource, error) {
 	pageToken := ""
 	for {
@@ -105,7 +108,7 @@ func (c *MarketInformationClient) findDataSourceByCode(ctx context.Context, code
 		}
 		pageToken = resp.GetNextPageToken()
 		if pageToken == "" {
-			return nil, nil
+			return nil, errDataSourceNotFound
 		}
 	}
 }

--- a/services/control-plane/internal/applier/market_information_client.go
+++ b/services/control-plane/internal/applier/market_information_client.go
@@ -35,6 +35,7 @@ func NewMarketInformationClient(conn *grpc.ClientConn) *MarketInformationClient 
 
 // RegisterDataSource implements MarketInformationService.
 // Converts Starlark params to a RegisterDataSourceRequest and calls the gRPC service.
+// Uses proactive idempotency: checks if data source already exists before creating.
 func (c *MarketInformationClient) RegisterDataSource(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
 	req := &marketinformationv1.RegisterDataSourceRequest{}
 	req.Code, _ = params["code"].(string)
@@ -45,10 +46,30 @@ func (c *MarketInformationClient) RegisterDataSource(ctx *saga.StarlarkContext, 
 	}
 
 	callCtx := prepareCallContext(ctx)
+
+	// Proactive check: if a data source with this code already exists, return success immediately.
+	existing, lookupErr := c.findDataSourceByCode(callCtx, req.Code)
+	if lookupErr == nil && existing != nil {
+		return map[string]any{
+			"source_id": existing.GetId(),
+			"code":      existing.GetCode(),
+			"status":    "REGISTERED",
+		}, nil
+	}
+
+	// Proceed with registration.
 	resp, err := c.client.RegisterDataSource(callCtx, req)
 	if err != nil {
-		// Idempotency: treat AlreadyExists as success for manifest re-apply scenarios.
+		// Reactive fallback: treat AlreadyExists as success for manifest re-apply scenarios.
 		if status.Code(err) == codes.AlreadyExists {
+			fallback, fallbackErr := c.findDataSourceByCode(callCtx, req.Code)
+			if fallbackErr == nil && fallback != nil {
+				return map[string]any{
+					"source_id": fallback.GetId(),
+					"code":      fallback.GetCode(),
+					"status":    "REGISTERED",
+				}, nil
+			}
 			return map[string]any{
 				"code":   req.Code,
 				"status": "REGISTERED",
@@ -65,9 +86,34 @@ func (c *MarketInformationClient) RegisterDataSource(ctx *saga.StarlarkContext, 
 	}, nil
 }
 
+// findDataSourceByCode pages through ListDataSources to locate a data source by code.
+// Returns nil, nil if not found. Returns nil, error on RPC failure.
+func (c *MarketInformationClient) findDataSourceByCode(ctx context.Context, code string) (*marketinformationv1.DataSource, error) {
+	pageToken := ""
+	for {
+		resp, err := c.client.ListDataSources(ctx, &marketinformationv1.ListDataSourcesRequest{
+			PageSize:  100,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list data sources for lookup: %w", err)
+		}
+		for _, src := range resp.GetSources() {
+			if src.GetCode() == code {
+				return src, nil
+			}
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			return nil, nil
+		}
+	}
+}
+
 // RegisterDataSet implements MarketInformationService.
 // Converts Starlark params to a RegisterDataSetRequest and calls the gRPC service.
 // The created data set is in DRAFT status and must be activated separately.
+// Uses proactive idempotency: checks if data set already exists before creating.
 func (c *MarketInformationClient) RegisterDataSet(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
 	req := &marketinformationv1.RegisterDataSetRequest{}
 	req.Code, _ = params["code"].(string)
@@ -94,10 +140,17 @@ func (c *MarketInformationClient) RegisterDataSet(ctx *saga.StarlarkContext, par
 	}
 
 	callCtx := prepareCallContext(ctx)
+
+	// Proactive check: if data set already exists (DRAFT or ACTIVE), return success immediately.
+	existing, lookupErr := c.retrieveDataSet(callCtx, req.Code)
+	if lookupErr == nil && existing != nil {
+		return dataSetResult(existing), nil
+	}
+
+	// Proceed with registration.
 	resp, err := c.client.RegisterDataSet(callCtx, req)
 	if err != nil {
-		// Idempotency: treat AlreadyExists as success for manifest re-apply scenarios.
-		// Attempt to retrieve the existing data set to return its details.
+		// Reactive fallback: treat AlreadyExists as success for manifest re-apply scenarios.
 		if status.Code(err) == codes.AlreadyExists {
 			return c.handleDataSetAlreadyExists(callCtx, req.Code)
 		}
@@ -105,16 +158,12 @@ func (c *MarketInformationClient) RegisterDataSet(ctx *saga.StarlarkContext, par
 	}
 
 	ds := resp.GetDataset()
-	return map[string]any{
-		"dataset_id": ds.GetId(),
-		"code":       ds.GetCode(),
-		"version":    ds.GetVersion(),
-		"status":     ds.GetStatus().String(),
-	}, nil
+	return dataSetResult(ds), nil
 }
 
 // ActivateDataSet implements MarketInformationService.
 // Converts Starlark params to an ActivateDataSetRequest and calls the gRPC service.
+// Uses proactive idempotency: checks if already ACTIVE before attempting activation.
 func (c *MarketInformationClient) ActivateDataSet(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
 	req := &marketinformationv1.ActivateDataSetRequest{}
 	req.Code, _ = params["code"].(string)
@@ -123,31 +172,38 @@ func (c *MarketInformationClient) ActivateDataSet(ctx *saga.StarlarkContext, par
 	}
 
 	callCtx := prepareCallContext(ctx)
+
+	// Proactive check: if already ACTIVE, return success immediately.
+	existing, lookupErr := c.retrieveDataSet(callCtx, req.Code)
+	if lookupErr == nil && existing.GetStatus() == marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE {
+		return dataSetResult(existing), nil
+	}
+
+	// Proceed with activation.
 	resp, err := c.client.ActivateDataSet(callCtx, req)
 	if err != nil {
-		// Idempotency: on FailedPrecondition, check if the data set is already ACTIVE.
-		// Only treat as success if the dataset has reached the desired state.
+		// Reactive fallback: on FailedPrecondition, check if the data set is already ACTIVE.
 		if status.Code(err) == codes.FailedPrecondition {
-			existing, lookupErr := c.retrieveDataSet(callCtx, req.Code)
-			if lookupErr == nil && existing.GetStatus() == marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE {
-				return map[string]any{
-					"dataset_id": existing.GetId(),
-					"code":       existing.GetCode(),
-					"version":    existing.GetVersion(),
-					"status":     existing.GetStatus().String(),
-				}, nil
+			retryLookup, retryErr := c.retrieveDataSet(callCtx, req.Code)
+			if retryErr == nil && retryLookup.GetStatus() == marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE {
+				return dataSetResult(retryLookup), nil
 			}
 		}
 		return nil, fmt.Errorf("activate data set: %w", err)
 	}
 
 	ds := resp.GetDataset()
+	return dataSetResult(ds), nil
+}
+
+// dataSetResult converts a DataSetDefinition to a saga result map.
+func dataSetResult(ds *marketinformationv1.DataSetDefinition) map[string]any {
 	return map[string]any{
 		"dataset_id": ds.GetId(),
 		"code":       ds.GetCode(),
 		"version":    ds.GetVersion(),
 		"status":     ds.GetStatus().String(),
-	}, nil
+	}
 }
 
 // handleDataSetAlreadyExists retrieves an existing data set by code so that
@@ -157,12 +213,7 @@ func (c *MarketInformationClient) handleDataSetAlreadyExists(ctx context.Context
 	if err != nil {
 		return nil, fmt.Errorf("register data set: dataset already exists but lookup failed: %w", err)
 	}
-	return map[string]any{
-		"dataset_id": ds.GetId(),
-		"code":       ds.GetCode(),
-		"version":    ds.GetVersion(),
-		"status":     ds.GetStatus().String(),
-	}, nil
+	return dataSetResult(ds), nil
 }
 
 // retrieveDataSet looks up a data set by code. Returns the proto definition or an error.

--- a/services/control-plane/internal/applier/market_information_client_test.go
+++ b/services/control-plane/internal/applier/market_information_client_test.go
@@ -23,12 +23,19 @@ var _ MarketInformationService = (*MarketInformationClient)(nil)
 type fakeMarketInformationServer struct {
 	marketinformationv1.UnimplementedMarketInformationServiceServer
 	registerDataSourceErr error
+	registerDataSourceFn  func(context.Context, *marketinformationv1.RegisterDataSourceRequest) (*marketinformationv1.RegisterDataSourceResponse, error)
 	registerDataSetErr    error
+	registerDataSetFn     func(context.Context, *marketinformationv1.RegisterDataSetRequest) (*marketinformationv1.RegisterDataSetResponse, error)
 	activateDataSetErr    error
+	activateDataSetFn     func(context.Context, *marketinformationv1.ActivateDataSetRequest) (*marketinformationv1.ActivateDataSetResponse, error)
 	retrieveDataSetFn     func(context.Context, *marketinformationv1.RetrieveDataSetRequest) (*marketinformationv1.RetrieveDataSetResponse, error)
+	listDataSourcesFn     func(context.Context, *marketinformationv1.ListDataSourcesRequest) (*marketinformationv1.ListDataSourcesResponse, error)
 }
 
-func (f *fakeMarketInformationServer) RegisterDataSource(_ context.Context, req *marketinformationv1.RegisterDataSourceRequest) (*marketinformationv1.RegisterDataSourceResponse, error) {
+func (f *fakeMarketInformationServer) RegisterDataSource(ctx context.Context, req *marketinformationv1.RegisterDataSourceRequest) (*marketinformationv1.RegisterDataSourceResponse, error) {
+	if f.registerDataSourceFn != nil {
+		return f.registerDataSourceFn(ctx, req)
+	}
 	if f.registerDataSourceErr != nil {
 		return nil, f.registerDataSourceErr
 	}
@@ -40,7 +47,18 @@ func (f *fakeMarketInformationServer) RegisterDataSource(_ context.Context, req 
 	}, nil
 }
 
-func (f *fakeMarketInformationServer) RegisterDataSet(_ context.Context, req *marketinformationv1.RegisterDataSetRequest) (*marketinformationv1.RegisterDataSetResponse, error) {
+func (f *fakeMarketInformationServer) ListDataSources(ctx context.Context, req *marketinformationv1.ListDataSourcesRequest) (*marketinformationv1.ListDataSourcesResponse, error) {
+	if f.listDataSourcesFn != nil {
+		return f.listDataSourcesFn(ctx, req)
+	}
+	// Default: no data sources found (proactive check falls through to create).
+	return &marketinformationv1.ListDataSourcesResponse{}, nil
+}
+
+func (f *fakeMarketInformationServer) RegisterDataSet(ctx context.Context, req *marketinformationv1.RegisterDataSetRequest) (*marketinformationv1.RegisterDataSetResponse, error) {
+	if f.registerDataSetFn != nil {
+		return f.registerDataSetFn(ctx, req)
+	}
 	if f.registerDataSetErr != nil {
 		return nil, f.registerDataSetErr
 	}
@@ -54,7 +72,10 @@ func (f *fakeMarketInformationServer) RegisterDataSet(_ context.Context, req *ma
 	}, nil
 }
 
-func (f *fakeMarketInformationServer) ActivateDataSet(_ context.Context, req *marketinformationv1.ActivateDataSetRequest) (*marketinformationv1.ActivateDataSetResponse, error) {
+func (f *fakeMarketInformationServer) ActivateDataSet(ctx context.Context, req *marketinformationv1.ActivateDataSetRequest) (*marketinformationv1.ActivateDataSetResponse, error) {
+	if f.activateDataSetFn != nil {
+		return f.activateDataSetFn(ctx, req)
+	}
 	if f.activateDataSetErr != nil {
 		return nil, f.activateDataSetErr
 	}
@@ -72,14 +93,8 @@ func (f *fakeMarketInformationServer) RetrieveDataSet(ctx context.Context, req *
 	if f.retrieveDataSetFn != nil {
 		return f.retrieveDataSetFn(ctx, req)
 	}
-	return &marketinformationv1.RetrieveDataSetResponse{
-		Dataset: &marketinformationv1.DataSetDefinition{
-			Id:      "ds-existing-uuid",
-			Code:    req.Code,
-			Version: 1,
-			Status:  marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
-		},
-	}, nil
+	// Default: not found (proactive check falls through to create/activate).
+	return nil, status.Error(codes.NotFound, "dataset not found")
 }
 
 // ─── Test setup ────────────────────────────────────────────────────────────
@@ -339,8 +354,25 @@ func TestMarketInformationClient_ActivateDataSet_GRPCError(t *testing.T) {
 // ─── Idempotency tests ──────────────────────────────────────────────────────
 
 func TestMarketInformationClient_RegisterDataSet_AlreadyExists_TreatedAsSuccess(t *testing.T) {
+	// Proactive check returns NotFound, RegisterDataSet returns AlreadyExists,
+	// reactive fallback calls RetrieveDataSet again and finds the dataset.
+	callCount := 0
 	srv := &fakeMarketInformationServer{
 		registerDataSetErr: status.Error(codes.AlreadyExists, "dataset already exists"),
+		retrieveDataSetFn: func(_ context.Context, req *marketinformationv1.RetrieveDataSetRequest) (*marketinformationv1.RetrieveDataSetResponse, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, status.Error(codes.NotFound, "dataset not found")
+			}
+			return &marketinformationv1.RetrieveDataSetResponse{
+				Dataset: &marketinformationv1.DataSetDefinition{
+					Id:      "ds-existing-uuid",
+					Code:    req.Code,
+					Version: 1,
+					Status:  marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
+				},
+			}, nil
+		},
 	}
 	conn := newMarketInformationTestServer(t, srv)
 	client := NewMarketInformationClient(conn)
@@ -373,9 +405,25 @@ func TestMarketInformationClient_RegisterDataSet_AlreadyExists_LookupFails(t *te
 }
 
 func TestMarketInformationClient_ActivateDataSet_AlreadyActive_TreatedAsSuccess(t *testing.T) {
+	// Proactive check returns NotFound, ActivateDataSet returns FailedPrecondition,
+	// reactive fallback calls RetrieveDataSet again and finds ACTIVE.
+	callCount := 0
 	srv := &fakeMarketInformationServer{
 		activateDataSetErr: status.Error(codes.FailedPrecondition, "invalid status transition: ACTIVE to ACTIVE"),
-		// RetrieveDataSet returns ACTIVE status, confirming idempotent completion
+		retrieveDataSetFn: func(_ context.Context, req *marketinformationv1.RetrieveDataSetRequest) (*marketinformationv1.RetrieveDataSetResponse, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, status.Error(codes.NotFound, "dataset not found")
+			}
+			return &marketinformationv1.RetrieveDataSetResponse{
+				Dataset: &marketinformationv1.DataSetDefinition{
+					Id:      "ds-existing-uuid",
+					Code:    req.Code,
+					Version: 1,
+					Status:  marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
+				},
+			}, nil
+		},
 	}
 	conn := newMarketInformationTestServer(t, srv)
 	client := NewMarketInformationClient(conn)
@@ -413,4 +461,211 @@ func TestMarketInformationClient_ActivateDataSet_NotActive_ErrorPropagated(t *te
 	})
 	require.Error(t, err, "FailedPrecondition for non-ACTIVE should propagate")
 	assert.Contains(t, err.Error(), "activate data set")
+}
+
+// ─── Proactive idempotency tests ──────────────────────────────────────────
+
+func TestMarketInformationClient_RegisterDataSource_ProactiveCheck_AlreadyExists(t *testing.T) {
+	// ListDataSources returns the source, so RegisterDataSource should never be called.
+	registerCalled := false
+	srv := &fakeMarketInformationServer{
+		listDataSourcesFn: func(_ context.Context, _ *marketinformationv1.ListDataSourcesRequest) (*marketinformationv1.ListDataSourcesResponse, error) {
+			return &marketinformationv1.ListDataSourcesResponse{
+				Sources: []*marketinformationv1.DataSource{
+					{Id: "existing-src-uuid", Code: "BLOOMBERG"},
+				},
+			}, nil
+		},
+		registerDataSourceFn: func(_ context.Context, _ *marketinformationv1.RegisterDataSourceRequest) (*marketinformationv1.RegisterDataSourceResponse, error) {
+			registerCalled = true
+			return nil, status.Error(codes.AlreadyExists, "should not be called")
+		},
+	}
+	conn := newMarketInformationTestServer(t, srv)
+	client := NewMarketInformationClient(conn)
+
+	result, err := client.RegisterDataSource(testStarlarkCtx(), map[string]any{
+		"code": "BLOOMBERG",
+	})
+	require.NoError(t, err, "proactive check should return success for existing data source")
+	assert.False(t, registerCalled, "RegisterDataSource gRPC should not be called when proactive check finds source")
+
+	m := result.(map[string]any)
+	assert.Equal(t, "existing-src-uuid", m["source_id"])
+	assert.Equal(t, "BLOOMBERG", m["code"])
+	assert.Equal(t, "REGISTERED", m["status"])
+}
+
+func TestMarketInformationClient_RegisterDataSource_ProactiveCheck_NotFound_ProceedsToCreate(t *testing.T) {
+	// ListDataSources returns empty, so handler proceeds to RegisterDataSource.
+	srv := &fakeMarketInformationServer{
+		listDataSourcesFn: func(_ context.Context, _ *marketinformationv1.ListDataSourcesRequest) (*marketinformationv1.ListDataSourcesResponse, error) {
+			return &marketinformationv1.ListDataSourcesResponse{}, nil
+		},
+	}
+	conn := newMarketInformationTestServer(t, srv)
+	client := NewMarketInformationClient(conn)
+
+	result, err := client.RegisterDataSource(testStarlarkCtx(), map[string]any{
+		"code": "NEW_SOURCE",
+	})
+	require.NoError(t, err, "should proceed to create when proactive check finds no source")
+
+	m := result.(map[string]any)
+	assert.Equal(t, "src-uuid-1", m["source_id"])
+	assert.Equal(t, "NEW_SOURCE", m["code"])
+}
+
+func TestMarketInformationClient_RegisterDataSource_ProactiveCheck_ListFails_ProceedsToCreate(t *testing.T) {
+	// ListDataSources returns an error, so handler proceeds to RegisterDataSource.
+	srv := &fakeMarketInformationServer{
+		listDataSourcesFn: func(_ context.Context, _ *marketinformationv1.ListDataSourcesRequest) (*marketinformationv1.ListDataSourcesResponse, error) {
+			return nil, status.Error(codes.Internal, "database unavailable")
+		},
+	}
+	conn := newMarketInformationTestServer(t, srv)
+	client := NewMarketInformationClient(conn)
+
+	result, err := client.RegisterDataSource(testStarlarkCtx(), map[string]any{
+		"code": "FALLTHROUGH",
+	})
+	require.NoError(t, err, "should proceed to create when proactive check fails")
+
+	m := result.(map[string]any)
+	assert.Equal(t, "src-uuid-1", m["source_id"])
+}
+
+func TestMarketInformationClient_RegisterDataSet_ProactiveCheck_AlreadyExists(t *testing.T) {
+	// RetrieveDataSet returns the existing dataset, so RegisterDataSet should never be called.
+	registerCalled := false
+	srv := &fakeMarketInformationServer{
+		retrieveDataSetFn: func(_ context.Context, req *marketinformationv1.RetrieveDataSetRequest) (*marketinformationv1.RetrieveDataSetResponse, error) {
+			return &marketinformationv1.RetrieveDataSetResponse{
+				Dataset: &marketinformationv1.DataSetDefinition{
+					Id:      "ds-existing-uuid",
+					Code:    req.Code,
+					Version: 1,
+					Status:  marketinformationv1.DataSetStatus_DATA_SET_STATUS_DRAFT,
+				},
+			}, nil
+		},
+		registerDataSetFn: func(_ context.Context, _ *marketinformationv1.RegisterDataSetRequest) (*marketinformationv1.RegisterDataSetResponse, error) {
+			registerCalled = true
+			return nil, status.Error(codes.AlreadyExists, "should not be called")
+		},
+	}
+	conn := newMarketInformationTestServer(t, srv)
+	client := NewMarketInformationClient(conn)
+
+	result, err := client.RegisterDataSet(testStarlarkCtx(), map[string]any{
+		"code": "EXISTING_DS",
+	})
+	require.NoError(t, err, "proactive check should return success for existing data set")
+	assert.False(t, registerCalled, "RegisterDataSet gRPC should not be called when proactive check finds dataset")
+
+	m := result.(map[string]any)
+	assert.Equal(t, "ds-existing-uuid", m["dataset_id"])
+	assert.Equal(t, "EXISTING_DS", m["code"])
+}
+
+func TestMarketInformationClient_RegisterDataSet_ProactiveCheck_NotFound_ProceedsToCreate(t *testing.T) {
+	// RetrieveDataSet returns NotFound, so handler proceeds to RegisterDataSet.
+	srv := &fakeMarketInformationServer{
+		retrieveDataSetFn: func(_ context.Context, _ *marketinformationv1.RetrieveDataSetRequest) (*marketinformationv1.RetrieveDataSetResponse, error) {
+			return nil, status.Error(codes.NotFound, "dataset not found")
+		},
+	}
+	conn := newMarketInformationTestServer(t, srv)
+	client := NewMarketInformationClient(conn)
+
+	result, err := client.RegisterDataSet(testStarlarkCtx(), map[string]any{
+		"code": "NEW_DS",
+	})
+	require.NoError(t, err, "should proceed to create when proactive check returns NotFound")
+
+	m := result.(map[string]any)
+	assert.Equal(t, "ds-uuid-1", m["dataset_id"])
+	assert.Equal(t, "NEW_DS", m["code"])
+}
+
+func TestMarketInformationClient_ActivateDataSet_ProactiveCheck_AlreadyActive(t *testing.T) {
+	// RetrieveDataSet returns ACTIVE, so ActivateDataSet should never be called.
+	activateCalled := false
+	srv := &fakeMarketInformationServer{
+		retrieveDataSetFn: func(_ context.Context, req *marketinformationv1.RetrieveDataSetRequest) (*marketinformationv1.RetrieveDataSetResponse, error) {
+			return &marketinformationv1.RetrieveDataSetResponse{
+				Dataset: &marketinformationv1.DataSetDefinition{
+					Id:      "ds-existing-uuid",
+					Code:    req.Code,
+					Version: 1,
+					Status:  marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
+				},
+			}, nil
+		},
+		activateDataSetFn: func(_ context.Context, _ *marketinformationv1.ActivateDataSetRequest) (*marketinformationv1.ActivateDataSetResponse, error) {
+			activateCalled = true
+			return nil, status.Error(codes.FailedPrecondition, "should not be called")
+		},
+	}
+	conn := newMarketInformationTestServer(t, srv)
+	client := NewMarketInformationClient(conn)
+
+	result, err := client.ActivateDataSet(testStarlarkCtx(), map[string]any{
+		"code":    "ALREADY_ACTIVE",
+		"version": int32(1),
+	})
+	require.NoError(t, err, "proactive check should return success for already-ACTIVE data set")
+	assert.False(t, activateCalled, "ActivateDataSet gRPC should not be called when proactive check finds ACTIVE")
+
+	m := result.(map[string]any)
+	assert.Equal(t, "ds-existing-uuid", m["dataset_id"])
+	assert.Equal(t, "ALREADY_ACTIVE", m["code"])
+	assert.Contains(t, m["status"].(string), "ACTIVE")
+}
+
+func TestMarketInformationClient_ActivateDataSet_ProactiveCheck_Draft_ProceedsToActivate(t *testing.T) {
+	// RetrieveDataSet returns DRAFT, so handler proceeds to ActivateDataSet.
+	srv := &fakeMarketInformationServer{
+		retrieveDataSetFn: func(_ context.Context, req *marketinformationv1.RetrieveDataSetRequest) (*marketinformationv1.RetrieveDataSetResponse, error) {
+			return &marketinformationv1.RetrieveDataSetResponse{
+				Dataset: &marketinformationv1.DataSetDefinition{
+					Id:      "ds-uuid-1",
+					Code:    req.Code,
+					Version: 1,
+					Status:  marketinformationv1.DataSetStatus_DATA_SET_STATUS_DRAFT,
+				},
+			}, nil
+		},
+	}
+	conn := newMarketInformationTestServer(t, srv)
+	client := NewMarketInformationClient(conn)
+
+	result, err := client.ActivateDataSet(testStarlarkCtx(), map[string]any{
+		"code":    "DRAFT_DS",
+		"version": int32(1),
+	})
+	require.NoError(t, err, "should proceed to activate when data set is DRAFT")
+
+	m := result.(map[string]any)
+	assert.Contains(t, m["status"].(string), "ACTIVE")
+}
+
+func TestMarketInformationClient_ActivateDataSet_ProactiveCheck_LookupFails_ProceedsToActivate(t *testing.T) {
+	// RetrieveDataSet fails, so handler proceeds to ActivateDataSet.
+	srv := &fakeMarketInformationServer{
+		retrieveDataSetFn: func(_ context.Context, _ *marketinformationv1.RetrieveDataSetRequest) (*marketinformationv1.RetrieveDataSetResponse, error) {
+			return nil, status.Error(codes.NotFound, "dataset not found")
+		},
+	}
+	conn := newMarketInformationTestServer(t, srv)
+	client := NewMarketInformationClient(conn)
+
+	result, err := client.ActivateDataSet(testStarlarkCtx(), map[string]any{
+		"code":    "MISSING_DS",
+		"version": int32(1),
+	})
+	require.NoError(t, err, "should proceed to activate when proactive lookup fails")
+
+	m := result.(map[string]any)
+	assert.Contains(t, m["status"].(string), "ACTIVE")
 }

--- a/services/control-plane/internal/applier/party_client.go
+++ b/services/control-plane/internal/applier/party_client.go
@@ -37,6 +37,7 @@ func NewPartyClient(conn *grpc.ClientConn) *PartyClient {
 // RegisterOrganization implements PartyService.
 // Converts Starlark params to a RegisterPartyRequest with PARTY_TYPE_ORGANIZATION
 // and calls the gRPC service.
+// Uses proactive idempotency: checks if organization already exists before creating.
 func (c *PartyClient) RegisterOrganization(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
 	req := &partyv1.RegisterPartyRequest{
 		PartyType: partyv1.PartyType_PARTY_TYPE_ORGANIZATION,
@@ -53,10 +54,19 @@ func (c *PartyClient) RegisterOrganization(ctx *saga.StarlarkContext, params map
 	req.ExternalReferenceType = externalRefType
 
 	callCtx := prepareCallContext(ctx)
+
+	// Proactive check: if organization with this external reference already exists, return success.
+	if req.ExternalReference != "" {
+		existing, lookupErr := c.findPartyByExternalRef(callCtx, req.ExternalReference, req.ExternalReferenceType)
+		if lookupErr == nil && existing != nil {
+			return partyResult(existing), nil
+		}
+	}
+
+	// Proceed with registration.
 	resp, err := c.client.RegisterParty(callCtx, req)
 	if err != nil {
-		// Idempotency: treat AlreadyExists as success for manifest re-apply scenarios
-		// where the underlying party was already created by a previous apply.
+		// Reactive fallback: treat AlreadyExists as success for manifest re-apply scenarios.
 		if status.Code(err) == codes.AlreadyExists {
 			return c.handleAlreadyExists(callCtx, req)
 		}
@@ -64,11 +74,16 @@ func (c *PartyClient) RegisterOrganization(ctx *saga.StarlarkContext, params map
 	}
 
 	party := resp.GetParty()
+	return partyResult(party), nil
+}
+
+// partyResult converts a Party to a saga result map.
+func partyResult(p *partyv1.Party) map[string]any {
 	return map[string]any{
-		"party_id":   party.GetPartyId(),
-		"legal_name": party.GetLegalName(),
-		"status":     party.GetStatus().String(),
-	}, nil
+		"party_id":   p.GetPartyId(),
+		"legal_name": p.GetLegalName(),
+		"status":     p.GetStatus().String(),
+	}
 }
 
 // handleAlreadyExists resolves the existing party on AlreadyExists so that
@@ -77,11 +92,7 @@ func (c *PartyClient) RegisterOrganization(ctx *saga.StarlarkContext, params map
 func (c *PartyClient) handleAlreadyExists(ctx context.Context, req *partyv1.RegisterPartyRequest) (any, error) {
 	existing, _ := c.findPartyByExternalRef(ctx, req.GetExternalReference(), req.GetExternalReferenceType())
 	if existing != nil {
-		return map[string]any{
-			"party_id":   existing.GetPartyId(),
-			"legal_name": existing.GetLegalName(),
-			"status":     existing.GetStatus().String(),
-		}, nil
+		return partyResult(existing), nil
 	}
 	return map[string]any{
 		"legal_name": req.GetLegalName(),

--- a/services/control-plane/internal/applier/party_client_test.go
+++ b/services/control-plane/internal/applier/party_client_test.go
@@ -164,3 +164,101 @@ func TestRegisterOrganization_OtherError_Propagated(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "database unavailable")
 }
+
+// ─── Proactive idempotency tests ──────────────────────────────────────────
+
+func TestRegisterOrganization_ProactiveCheck_AlreadyExists(t *testing.T) {
+	// ListParties returns the organization, so RegisterParty should never be called.
+	registerCalled := false
+	srv := &fakePartyServer{
+		listFn: func(_ context.Context, _ *partyv1.ListPartiesRequest) (*partyv1.ListPartiesResponse, error) {
+			return &partyv1.ListPartiesResponse{
+				Parties: []*partyv1.Party{
+					{
+						PartyId:               "existing-party-uuid",
+						LegalName:             "Acme Corp",
+						Status:                partyv1.PartyStatus_PARTY_STATUS_ACTIVE,
+						ExternalReference:     "123456",
+						ExternalReferenceType: partyv1.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_LEI,
+					},
+				},
+			}, nil
+		},
+		registerFn: func(_ context.Context, _ *partyv1.RegisterPartyRequest) (*partyv1.RegisterPartyResponse, error) {
+			registerCalled = true
+			return nil, status.Error(codes.AlreadyExists, "should not be called")
+		},
+	}
+	conn := newPartyTestServer(t, srv)
+	client := NewPartyClient(conn)
+
+	result, err := client.RegisterOrganization(testStarlarkCtx(), map[string]any{
+		"legal_name":              "Acme Corp",
+		"external_reference":      "123456",
+		"external_reference_type": "LEI",
+	})
+	require.NoError(t, err, "proactive check should return success for existing organization")
+	assert.False(t, registerCalled, "RegisterParty gRPC should not be called when proactive check finds party")
+
+	m := result.(map[string]any)
+	assert.Equal(t, "existing-party-uuid", m["party_id"])
+	assert.Equal(t, "Acme Corp", m["legal_name"])
+}
+
+func TestRegisterOrganization_ProactiveCheck_NotFound_ProceedsToCreate(t *testing.T) {
+	// ListParties returns empty, so handler proceeds to RegisterParty.
+	srv := &fakePartyServer{
+		listFn: func(_ context.Context, _ *partyv1.ListPartiesRequest) (*partyv1.ListPartiesResponse, error) {
+			return &partyv1.ListPartiesResponse{}, nil
+		},
+	}
+	conn := newPartyTestServer(t, srv)
+	client := NewPartyClient(conn)
+
+	result, err := client.RegisterOrganization(testStarlarkCtx(), map[string]any{
+		"legal_name":              "New Corp",
+		"external_reference":      "789",
+		"external_reference_type": "LEI",
+	})
+	require.NoError(t, err, "should proceed to create when proactive check finds no party")
+
+	m := result.(map[string]any)
+	assert.Equal(t, "party-uuid-1", m["party_id"])
+	assert.Equal(t, "New Corp", m["legal_name"])
+}
+
+func TestRegisterOrganization_ProactiveCheck_NoExternalRef_SkipsCheck(t *testing.T) {
+	// No external_reference, so proactive check is skipped.
+	srv := &fakePartyServer{}
+	conn := newPartyTestServer(t, srv)
+	client := NewPartyClient(conn)
+
+	result, err := client.RegisterOrganization(testStarlarkCtx(), map[string]any{
+		"legal_name": "No Ref Corp",
+	})
+	require.NoError(t, err, "should proceed directly when no external_reference")
+
+	m := result.(map[string]any)
+	assert.Equal(t, "party-uuid-1", m["party_id"])
+}
+
+func TestRegisterOrganization_ProactiveCheck_ListFails_ProceedsToCreate(t *testing.T) {
+	// ListParties returns an error, so handler proceeds to RegisterParty.
+	srv := &fakePartyServer{
+		listFn: func(_ context.Context, _ *partyv1.ListPartiesRequest) (*partyv1.ListPartiesResponse, error) {
+			return nil, status.Error(codes.Internal, "database unavailable")
+		},
+	}
+	conn := newPartyTestServer(t, srv)
+	client := NewPartyClient(conn)
+
+	result, err := client.RegisterOrganization(testStarlarkCtx(), map[string]any{
+		"legal_name":              "Fallthrough Corp",
+		"external_reference":      "999",
+		"external_reference_type": "LEI",
+	})
+	require.NoError(t, err, "should proceed to create when proactive check fails")
+
+	m := result.(map[string]any)
+	assert.Equal(t, "party-uuid-1", m["party_id"])
+}


### PR DESCRIPTION
## Summary

- Adds proactive check-then-act idempotency to all remaining manifest handlers: `RegisterDataSource`, `RegisterDataSet`, `ActivateDataSet`, `RegisterOrganization`, and `InitiateAccount`
- Each handler now looks up the resource before attempting create/activate - if already in target state, returns success immediately without calling the mutating RPC
- Preserves reactive fallbacks (AlreadyExists/FailedPrecondition handling) as belt-and-suspenders safety nets
- Extracts `dataSetResult`, `partyResult`, and `accountResult` helpers to reduce duplication

This completes the proactive idempotency pattern established in PR #2078 for instruments, account types, and sagas, extending it to cover all manifest resource types.

## Test plan

- [x] Proactive check tests for each handler (finds existing resource, skips mutating RPC)
- [x] Proactive check not-found tests (falls through to normal create path)
- [x] Proactive check failure tests (lookup error falls through gracefully)
- [x] Existing reactive fallback tests updated to work with proactive checks
- [x] Full applier test suite passes