### PR TITLE
feat: add live-state diff to ManifestDiffer

### DIFF
--- a/services/control-plane/internal/applier/grpc_handler_test.go
+++ b/services/control-plane/internal/applier/grpc_handler_test.go
@@ -55,7 +55,7 @@ func newTestHandler(t *testing.T) *ApplyManifestHandler {
 	v, err := validator.New()
 	require.NoError(t, err)
 
-	d := differ.New(nil, nil)
+	d := differ.New(nil, nil, nil)
 	p := planner.NewManifestPlanner()
 
 	handler, err := NewApplyManifestHandler(ApplyManifestHandlerConfig{
@@ -71,7 +71,7 @@ func TestNewApplyManifestHandler_RequiredDependencies(t *testing.T) {
 	v, err := validator.New()
 	require.NoError(t, err)
 
-	d := differ.New(nil, nil)
+	d := differ.New(nil, nil, nil)
 	p := planner.NewManifestPlanner()
 
 	tests := []struct {
@@ -116,7 +116,7 @@ func TestNewApplyManifestHandler_PostApplyHooksStored(t *testing.T) {
 	v, err := validator.New()
 	require.NoError(t, err)
 
-	d := differ.New(nil, nil)
+	d := differ.New(nil, nil, nil)
 	p := planner.NewManifestPlanner()
 
 	called := false
@@ -463,7 +463,7 @@ func newTestHandlerWithVersionStore(t *testing.T, prev *controlplanev1.Manifest)
 	v, err := validator.New()
 	require.NoError(t, err)
 
-	d := differ.New(nil, nil)
+	d := differ.New(nil, nil, nil)
 	p := planner.NewManifestPlanner()
 
 	handler, err := NewApplyManifestHandler(ApplyManifestHandlerConfig{
@@ -730,7 +730,7 @@ func TestRunPostApplyHooks_MultipleHooks(t *testing.T) {
 
 	handler, err := NewApplyManifestHandler(ApplyManifestHandlerConfig{
 		Validator:      v,
-		Differ:         differ.New(nil, nil),
+		Differ:         differ.New(nil, nil, nil),
 		Planner:        planner.NewManifestPlanner(),
 		PostApplyHooks: []PostApplyHook{hook1, hook2},
 	})
@@ -754,7 +754,7 @@ func TestRunPostApplyHooks_PanicRecovery(t *testing.T) {
 
 	handler, err := NewApplyManifestHandler(ApplyManifestHandlerConfig{
 		Validator:      v,
-		Differ:         differ.New(nil, nil),
+		Differ:         differ.New(nil, nil, nil),
 		Planner:        planner.NewManifestPlanner(),
 		PostApplyHooks: []PostApplyHook{panicHook, normalHook},
 	})

--- a/services/control-plane/internal/differ/drift_test.go
+++ b/services/control-plane/internal/differ/drift_test.go
@@ -36,7 +36,7 @@ func TestDriftWarning_Fields(t *testing.T) {
 
 func TestManifestDiffer_WithNoOpDriftDetector(t *testing.T) {
 	drift := &NoOpDriftDetector{}
-	d := New(nil, drift)
+	d := New(nil, drift, nil)
 	require.NotNil(t, d)
 
 	plan, err := d.Diff(context.Background(), nil, &controlplanev1.Manifest{})

--- a/services/control-plane/internal/differ/live_state.go
+++ b/services/control-plane/internal/differ/live_state.go
@@ -18,6 +18,11 @@ type LiveState struct {
 	InternalAccounts    []*controlplanev1.InternalAccountDefinition
 	ProviderConnections []*controlplanev1.ProviderConnectionConfig
 	InstructionRoutes   []*controlplanev1.InstructionRouteConfig
+
+	// SystemCodes tracks resources that are system-managed (is_system=true).
+	// Outer key is ResourceType, inner key is the resource code/name.
+	// Resources in this set are excluded from diff planning in DiffAgainstLiveState.
+	SystemCodes map[ResourceType]map[string]bool
 }
 
 // LiveStateProvider queries downstream services and returns the current live state

--- a/services/control-plane/internal/differ/manifest_differ.go
+++ b/services/control-plane/internal/differ/manifest_differ.go
@@ -18,12 +18,14 @@ import (
 //   - Resources present in last-applied but not in new -> DELETE (with safety checks)
 //   - Resources identical in both -> NO_CHANGE
 type ManifestDiffer struct {
-	safety SafetyChecker
-	drift  DriftDetector
+	safety    SafetyChecker
+	drift     DriftDetector
+	liveState LiveStateProvider
 }
 
-// New creates a ManifestDiffer with the given safety checker and drift detector.
-func New(safety SafetyChecker, drift DriftDetector) *ManifestDiffer {
+// New creates a ManifestDiffer with the given safety checker, drift detector,
+// and optional live state provider. Pass nil for any parameter to use no-op defaults.
+func New(safety SafetyChecker, drift DriftDetector, liveState LiveStateProvider) *ManifestDiffer {
 	if safety == nil {
 		safety = &NoOpSafetyChecker{}
 	}
@@ -31,8 +33,9 @@ func New(safety SafetyChecker, drift DriftDetector) *ManifestDiffer {
 		drift = &NoOpDriftDetector{}
 	}
 	return &ManifestDiffer{
-		safety: safety,
-		drift:  drift,
+		safety:    safety,
+		drift:     drift,
+		liveState: liveState,
 	}
 }
 

--- a/services/control-plane/internal/differ/manifest_differ_live.go
+++ b/services/control-plane/internal/differ/manifest_differ_live.go
@@ -1,0 +1,515 @@
+package differ
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+// ErrNoLiveStateProvider is returned when DiffAgainstLiveState is called without a LiveStateProvider.
+var ErrNoLiveStateProvider = errors.New("live state provider is required for DiffAgainstLiveState")
+
+// DiffAgainstLiveState queries live state from downstream services and computes a diff plan
+// by comparing live state against the desired manifest. Resources with is_system=true in the
+// live state are excluded from the diff entirely. Resources in live but not in the manifest
+// receive a DEPRECATE action instead of DELETE.
+func (d *ManifestDiffer) DiffAgainstLiveState(ctx context.Context, tenantID string, manifest *controlplanev1.Manifest) (*DiffPlan, error) {
+	if manifest == nil {
+		return nil, ErrNilManifest
+	}
+	if d.liveState == nil {
+		return nil, ErrNoLiveStateProvider
+	}
+
+	live, err := d.liveState.QueryLiveState(ctx, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("query live state: %w", err)
+	}
+
+	plan := &DiffPlan{}
+
+	d.diffInstrumentsAgainstLive(live, manifest, plan)
+	d.diffAccountTypesAgainstLive(live, manifest, plan)
+	d.diffSagasAgainstLive(live, manifest, plan)
+	d.diffMarketDataSourcesAgainstLive(live, manifest, plan)
+	d.diffMarketDataSetsAgainstLive(live, manifest, plan)
+	d.diffOrganizationsAgainstLive(live, manifest, plan)
+	d.diffInternalAccountsAgainstLive(live, manifest, plan)
+	d.diffProviderConnectionsAgainstLive(live, manifest, plan)
+	d.diffInstructionRoutesAgainstLive(live, manifest, plan)
+
+	sort.Slice(plan.Actions, func(i, j int) bool {
+		if plan.Actions[i].ResourceType != plan.Actions[j].ResourceType {
+			return plan.Actions[i].ResourceType < plan.Actions[j].ResourceType
+		}
+		return plan.Actions[i].ResourceCode < plan.Actions[j].ResourceCode
+	})
+
+	return plan, nil
+}
+
+// isSystemResource checks whether a resource code is marked as system-managed in the live state.
+func isSystemResource(live *LiveState, rt ResourceType, code string) bool {
+	if live.SystemCodes == nil {
+		return false
+	}
+	codes, ok := live.SystemCodes[rt]
+	if !ok {
+		return false
+	}
+	return codes[code]
+}
+
+func (d *ManifestDiffer) diffInstrumentsAgainstLive(live *LiveState, manifest *controlplanev1.Manifest, plan *DiffPlan) {
+	liveMap := make(map[string]*controlplanev1.InstrumentDefinition)
+	for _, inst := range live.Instruments {
+		if isSystemResource(live, ResourceInstrument, inst.GetCode()) {
+			continue
+		}
+		liveMap[inst.GetCode()] = inst
+	}
+	desiredMap := instrumentMap(manifest.GetInstruments())
+
+	for code, desired := range desiredMap {
+		existing, exists := liveMap[code]
+		if !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceInstrument,
+				ResourceCode: code,
+				Action:       ActionCreate,
+				Description:  fmt.Sprintf("Create instrument %s (%s)", code, desired.GetName()),
+			})
+			continue
+		}
+		if !proto.Equal(existing, desired) {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceInstrument,
+				ResourceCode: code,
+				Action:       ActionUpdate,
+				Description:  describeInstrumentChanges(code, existing, desired),
+			})
+		} else {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceInstrument,
+				ResourceCode: code,
+				Action:       ActionNoChange,
+				Description:  fmt.Sprintf("Instrument %s unchanged", code),
+			})
+		}
+	}
+
+	for code := range liveMap {
+		if _, exists := desiredMap[code]; !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceInstrument,
+				ResourceCode: code,
+				Action:       ActionDeprecate,
+				Description:  fmt.Sprintf("Deprecate instrument %s", code),
+			})
+		}
+	}
+}
+
+func (d *ManifestDiffer) diffAccountTypesAgainstLive(live *LiveState, manifest *controlplanev1.Manifest, plan *DiffPlan) {
+	liveMap := make(map[string]*controlplanev1.AccountTypeDefinition)
+	for _, at := range live.AccountTypes {
+		if isSystemResource(live, ResourceAccountType, at.GetCode()) {
+			continue
+		}
+		liveMap[at.GetCode()] = at
+	}
+	desiredMap := accountTypeMap(manifest.GetAccountTypes())
+
+	for code, desired := range desiredMap {
+		existing, exists := liveMap[code]
+		if !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceAccountType,
+				ResourceCode: code,
+				Action:       ActionCreate,
+				Description:  fmt.Sprintf("Create account type %s (%s)", code, desired.GetName()),
+			})
+			continue
+		}
+		if !proto.Equal(existing, desired) {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceAccountType,
+				ResourceCode: code,
+				Action:       ActionUpdate,
+				Description:  describeAccountTypeChanges(code, existing, desired),
+			})
+		} else {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceAccountType,
+				ResourceCode: code,
+				Action:       ActionNoChange,
+				Description:  fmt.Sprintf("Account type %s unchanged", code),
+			})
+		}
+	}
+
+	for code := range liveMap {
+		if _, exists := desiredMap[code]; !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceAccountType,
+				ResourceCode: code,
+				Action:       ActionDeprecate,
+				Description:  fmt.Sprintf("Deprecate account type %s", code),
+			})
+		}
+	}
+}
+
+func (d *ManifestDiffer) diffSagasAgainstLive(live *LiveState, manifest *controlplanev1.Manifest, plan *DiffPlan) {
+	liveMap := make(map[string]*controlplanev1.SagaDefinition)
+	for _, s := range live.Sagas {
+		if isSystemResource(live, ResourceSaga, s.GetName()) {
+			continue
+		}
+		liveMap[s.GetName()] = s
+	}
+	desiredMap := sagaMap(manifest.GetSagas())
+
+	for name, desired := range desiredMap {
+		existing, exists := liveMap[name]
+		if !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceSaga,
+				ResourceCode: name,
+				Action:       ActionCreate,
+				Description:  fmt.Sprintf("Create saga %s (trigger: %s)", name, desired.GetTrigger()),
+			})
+			continue
+		}
+		if !proto.Equal(existing, desired) {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceSaga,
+				ResourceCode: name,
+				Action:       ActionUpdate,
+				Description:  describeSagaChanges(name, existing, desired),
+			})
+		} else {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceSaga,
+				ResourceCode: name,
+				Action:       ActionNoChange,
+				Description:  fmt.Sprintf("Saga %s unchanged", name),
+			})
+		}
+	}
+
+	for name := range liveMap {
+		if _, exists := desiredMap[name]; !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceSaga,
+				ResourceCode: name,
+				Action:       ActionDeprecate,
+				Description:  fmt.Sprintf("Deprecate saga %s", name),
+			})
+		}
+	}
+}
+
+func (d *ManifestDiffer) diffMarketDataSourcesAgainstLive(live *LiveState, manifest *controlplanev1.Manifest, plan *DiffPlan) {
+	liveMap := make(map[string]*controlplanev1.MarketDataSourceDefinition)
+	for _, s := range live.MarketDataSources {
+		if isSystemResource(live, ResourceMarketDataSource, s.GetCode()) {
+			continue
+		}
+		liveMap[s.GetCode()] = s
+	}
+	desiredMap := marketDataSourceMap(manifest.GetMarketData().GetSources())
+
+	for code, desired := range desiredMap {
+		existing, exists := liveMap[code]
+		if !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceMarketDataSource,
+				ResourceCode: code,
+				Action:       ActionCreate,
+				Description:  fmt.Sprintf("Create market data source %s (%s)", code, desired.GetName()),
+			})
+			continue
+		}
+		if !proto.Equal(existing, desired) {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceMarketDataSource,
+				ResourceCode: code,
+				Action:       ActionUpdate,
+				Description:  describeMarketDataSourceChanges(code, existing, desired),
+			})
+		} else {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceMarketDataSource,
+				ResourceCode: code,
+				Action:       ActionNoChange,
+				Description:  fmt.Sprintf("Market data source %s unchanged", code),
+			})
+		}
+	}
+
+	for code := range liveMap {
+		if _, exists := desiredMap[code]; !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceMarketDataSource,
+				ResourceCode: code,
+				Action:       ActionDeprecate,
+				Description:  fmt.Sprintf("Deprecate market data source %s", code),
+			})
+		}
+	}
+}
+
+func (d *ManifestDiffer) diffMarketDataSetsAgainstLive(live *LiveState, manifest *controlplanev1.Manifest, plan *DiffPlan) {
+	liveMap := make(map[string]*controlplanev1.MarketDataSetDefinition)
+	for _, ds := range live.MarketDataSets {
+		if isSystemResource(live, ResourceMarketDataSet, ds.GetCode()) {
+			continue
+		}
+		liveMap[ds.GetCode()] = ds
+	}
+	desiredMap := marketDataSetMap(manifest.GetMarketData().GetDatasets())
+
+	for code, desired := range desiredMap {
+		existing, exists := liveMap[code]
+		if !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceMarketDataSet,
+				ResourceCode: code,
+				Action:       ActionCreate,
+				Description:  fmt.Sprintf("Create market data set %s (%s)", code, desired.GetUnit()),
+			})
+			continue
+		}
+		if !proto.Equal(existing, desired) {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceMarketDataSet,
+				ResourceCode: code,
+				Action:       ActionUpdate,
+				Description:  describeMarketDataSetChanges(code, existing, desired),
+			})
+		} else {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceMarketDataSet,
+				ResourceCode: code,
+				Action:       ActionNoChange,
+				Description:  fmt.Sprintf("Market data set %s unchanged", code),
+			})
+		}
+	}
+
+	for code := range liveMap {
+		if _, exists := desiredMap[code]; !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceMarketDataSet,
+				ResourceCode: code,
+				Action:       ActionDeprecate,
+				Description:  fmt.Sprintf("Deprecate market data set %s", code),
+			})
+		}
+	}
+}
+
+func (d *ManifestDiffer) diffOrganizationsAgainstLive(live *LiveState, manifest *controlplanev1.Manifest, plan *DiffPlan) {
+	liveMap := make(map[string]*controlplanev1.OrganizationDefinition)
+	for _, o := range live.Organizations {
+		if isSystemResource(live, ResourceOrganization, o.GetCode()) {
+			continue
+		}
+		liveMap[o.GetCode()] = o
+	}
+	desiredMap := organizationMap(manifest.GetOrganizations())
+
+	for code, desired := range desiredMap {
+		existing, exists := liveMap[code]
+		if !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceOrganization,
+				ResourceCode: code,
+				Action:       ActionCreate,
+				Description:  fmt.Sprintf("Create organization %s (%s)", code, desired.GetName()),
+			})
+			continue
+		}
+		if !proto.Equal(existing, desired) {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceOrganization,
+				ResourceCode: code,
+				Action:       ActionUpdate,
+				Description:  describeOrganizationChanges(code, existing, desired),
+			})
+		} else {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceOrganization,
+				ResourceCode: code,
+				Action:       ActionNoChange,
+				Description:  fmt.Sprintf("Organization %s unchanged", code),
+			})
+		}
+	}
+
+	for code := range liveMap {
+		if _, exists := desiredMap[code]; !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceOrganization,
+				ResourceCode: code,
+				Action:       ActionDeprecate,
+				Description:  fmt.Sprintf("Deprecate organization %s", code),
+			})
+		}
+	}
+}
+
+func (d *ManifestDiffer) diffInternalAccountsAgainstLive(live *LiveState, manifest *controlplanev1.Manifest, plan *DiffPlan) {
+	liveMap := make(map[string]*controlplanev1.InternalAccountDefinition)
+	for _, a := range live.InternalAccounts {
+		if isSystemResource(live, ResourceInternalAccount, a.GetCode()) {
+			continue
+		}
+		liveMap[a.GetCode()] = a
+	}
+	desiredMap := internalAccountMap(manifest.GetInternalAccounts())
+
+	for code, desired := range desiredMap {
+		existing, exists := liveMap[code]
+		if !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceInternalAccount,
+				ResourceCode: code,
+				Action:       ActionCreate,
+				Description:  fmt.Sprintf("Create internal account %s (type: %s, instrument: %s)", code, desired.GetAccountType(), desired.GetInstrument()),
+			})
+			continue
+		}
+		if !proto.Equal(existing, desired) {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceInternalAccount,
+				ResourceCode: code,
+				Action:       ActionUpdate,
+				Description:  describeInternalAccountChanges(code, existing, desired),
+			})
+		} else {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceInternalAccount,
+				ResourceCode: code,
+				Action:       ActionNoChange,
+				Description:  fmt.Sprintf("Internal account %s unchanged", code),
+			})
+		}
+	}
+
+	for code := range liveMap {
+		if _, exists := desiredMap[code]; !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceInternalAccount,
+				ResourceCode: code,
+				Action:       ActionDeprecate,
+				Description:  fmt.Sprintf("Deprecate internal account %s", code),
+			})
+		}
+	}
+}
+
+func (d *ManifestDiffer) diffProviderConnectionsAgainstLive(live *LiveState, manifest *controlplanev1.Manifest, plan *DiffPlan) {
+	liveMap := make(map[string]*controlplanev1.ProviderConnectionConfig)
+	for _, c := range live.ProviderConnections {
+		if isSystemResource(live, ResourceProviderConnection, c.GetConnectionId()) {
+			continue
+		}
+		liveMap[c.GetConnectionId()] = c
+	}
+	desiredMap := providerConnectionMap(manifest.GetOperationalGateway().GetProviderConnections())
+
+	for id, desired := range desiredMap {
+		existing, exists := liveMap[id]
+		if !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceProviderConnection,
+				ResourceCode: id,
+				Action:       ActionCreate,
+				Description:  fmt.Sprintf("Create provider connection %s (%s)", id, desired.GetProviderName()),
+			})
+			continue
+		}
+		if !proto.Equal(existing, desired) {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceProviderConnection,
+				ResourceCode: id,
+				Action:       ActionUpdate,
+				Description:  fmt.Sprintf("Update provider connection %s", id),
+			})
+		} else {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceProviderConnection,
+				ResourceCode: id,
+				Action:       ActionNoChange,
+				Description:  fmt.Sprintf("Provider connection %s unchanged", id),
+			})
+		}
+	}
+
+	for id := range liveMap {
+		if _, exists := desiredMap[id]; !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceProviderConnection,
+				ResourceCode: id,
+				Action:       ActionDeprecate,
+				Description:  fmt.Sprintf("Deprecate provider connection %s", id),
+			})
+		}
+	}
+}
+
+func (d *ManifestDiffer) diffInstructionRoutesAgainstLive(live *LiveState, manifest *controlplanev1.Manifest, plan *DiffPlan) {
+	liveMap := make(map[string]*controlplanev1.InstructionRouteConfig)
+	for _, r := range live.InstructionRoutes {
+		if isSystemResource(live, ResourceInstructionRoute, r.GetInstructionType()) {
+			continue
+		}
+		liveMap[r.GetInstructionType()] = r
+	}
+	desiredMap := instructionRouteMap(manifest.GetOperationalGateway().GetInstructionRoutes())
+
+	for key, desired := range desiredMap {
+		existing, exists := liveMap[key]
+		if !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceInstructionRoute,
+				ResourceCode: key,
+				Action:       ActionCreate,
+				Description:  fmt.Sprintf("Create instruction route %s → %s", key, desired.GetConnectionId()),
+			})
+			continue
+		}
+		if !proto.Equal(existing, desired) {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceInstructionRoute,
+				ResourceCode: key,
+				Action:       ActionUpdate,
+				Description:  fmt.Sprintf("Update instruction route %s", key),
+			})
+		} else {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceInstructionRoute,
+				ResourceCode: key,
+				Action:       ActionNoChange,
+				Description:  fmt.Sprintf("Instruction route %s unchanged", key),
+			})
+		}
+	}
+
+	for key := range liveMap {
+		if _, exists := desiredMap[key]; !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceInstructionRoute,
+				ResourceCode: key,
+				Action:       ActionDeprecate,
+				Description:  fmt.Sprintf("Deprecate instruction route %s", key),
+			})
+		}
+	}
+}

--- a/services/control-plane/internal/differ/manifest_differ_live_test.go
+++ b/services/control-plane/internal/differ/manifest_differ_live_test.go
@@ -212,7 +212,7 @@ func TestDiffAgainstLiveState_AccountTypes_AllActions(t *testing.T) {
 
 	manifest := &controlplanev1.Manifest{
 		AccountTypes: []*controlplanev1.AccountTypeDefinition{
-			{Code: "CURRENT", Name: "Current Account", NormalBalance: controlplanev1.NormalBalance_NORMAL_BALANCE_DEBIT}, // NO_CHANGE
+			{Code: "CURRENT", Name: "Current Account", NormalBalance: controlplanev1.NormalBalance_NORMAL_BALANCE_DEBIT},  // NO_CHANGE
 			{Code: "SAVINGS", Name: "Updated Savings", NormalBalance: controlplanev1.NormalBalance_NORMAL_BALANCE_CREDIT}, // UPDATE
 			{Code: "NEW_TYPE", Name: "New Type"}, // CREATE
 		},
@@ -263,8 +263,8 @@ func TestDiffAgainstLiveState_Sagas_AllActions(t *testing.T) {
 	manifest := &controlplanev1.Manifest{
 		Sagas: []*controlplanev1.SagaDefinition{
 			{Name: "existing_saga", Trigger: "api:/v1/settle", Script: "new_script"}, // UPDATE
-			{Name: "unchanged_saga", Trigger: "event:foo", Script: "script"},          // NO_CHANGE
-			{Name: "new_saga", Trigger: "webhook:stripe", Script: "new"},              // CREATE
+			{Name: "unchanged_saga", Trigger: "event:foo", Script: "script"},         // NO_CHANGE
+			{Name: "new_saga", Trigger: "webhook:stripe", Script: "new"},             // CREATE
 		},
 	}
 
@@ -390,7 +390,7 @@ func TestDiffAgainstLiveState_InternalAccounts(t *testing.T) {
 
 	manifest := &controlplanev1.Manifest{
 		InternalAccounts: []*controlplanev1.InternalAccountDefinition{
-			{Code: "SUSPENSE", AccountType: "CURRENT", Instrument: "GBP"},      // NO_CHANGE
+			{Code: "SUSPENSE", AccountType: "CURRENT", Instrument: "GBP"}, // NO_CHANGE
 			{Code: "NEW_ACCT", AccountType: "CURRENT", Instrument: "EUR"}, // CREATE
 		},
 	}
@@ -416,7 +416,7 @@ func TestDiffAgainstLiveState_ProviderConnections(t *testing.T) {
 	manifest := &controlplanev1.Manifest{
 		OperationalGateway: &controlplanev1.OperationalGatewayConfig{
 			ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
-				{ConnectionId: "stripe-1", ProviderName: "stripe"},         // NO_CHANGE
+				{ConnectionId: "stripe-1", ProviderName: "stripe"},       // NO_CHANGE
 				{ConnectionId: "new-conn", ProviderName: "new-provider"}, // CREATE
 			},
 		},
@@ -443,7 +443,7 @@ func TestDiffAgainstLiveState_InstructionRoutes(t *testing.T) {
 	manifest := &controlplanev1.Manifest{
 		OperationalGateway: &controlplanev1.OperationalGatewayConfig{
 			InstructionRoutes: []*controlplanev1.InstructionRouteConfig{
-				{InstructionType: "payment", ConnectionId: "stripe-1"},       // NO_CHANGE
+				{InstructionType: "payment", ConnectionId: "stripe-1"},   // NO_CHANGE
 				{InstructionType: "new-route", ConnectionId: "new-conn"}, // CREATE
 			},
 		},
@@ -555,9 +555,9 @@ func TestDiffAgainstLiveState_FullMixedScenario(t *testing.T) {
 
 	manifest := &controlplanev1.Manifest{
 		Instruments: []*controlplanev1.InstrumentDefinition{
-			{Code: "GBP", Name: "British Pound", Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT},          // NO_CHANGE
+			{Code: "GBP", Name: "British Pound", Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT},              // NO_CHANGE
 			{Code: "KWH", Name: "Kilowatt-Hour Updated", Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_COMMODITY}, // UPDATE
-			{Code: "CO2", Name: "Carbon Credit", Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_VOUCHER}, // CREATE
+			{Code: "CO2", Name: "Carbon Credit", Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_VOUCHER},           // CREATE
 		},
 	}
 

--- a/services/control-plane/internal/differ/manifest_differ_live_test.go
+++ b/services/control-plane/internal/differ/manifest_differ_live_test.go
@@ -1,0 +1,597 @@
+package differ
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockLiveStateProvider implements LiveStateProvider for tests.
+type mockLiveStateProvider struct {
+	state *LiveState
+	err   error
+}
+
+func (m *mockLiveStateProvider) QueryLiveState(_ context.Context, _ string) (*LiveState, error) {
+	return m.state, m.err
+}
+
+func TestDiffAgainstLiveState_NilManifest(t *testing.T) {
+	provider := &mockLiveStateProvider{state: &LiveState{}}
+	d := New(nil, nil, provider)
+
+	_, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", nil)
+	assert.ErrorIs(t, err, ErrNilManifest)
+}
+
+func TestDiffAgainstLiveState_NoProvider(t *testing.T) {
+	d := New(nil, nil, nil)
+
+	_, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", &controlplanev1.Manifest{})
+	assert.ErrorIs(t, err, ErrNoLiveStateProvider)
+}
+
+func TestDiffAgainstLiveState_QueryFailure(t *testing.T) {
+	provider := &mockLiveStateProvider{err: fmt.Errorf("connection refused")}
+	d := New(nil, nil, provider)
+
+	_, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", &controlplanev1.Manifest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "query live state")
+	assert.Contains(t, err.Error(), "connection refused")
+}
+
+func TestDiffAgainstLiveState_EmptyLiveState_AllCreate(t *testing.T) {
+	provider := &mockLiveStateProvider{state: &LiveState{}}
+	d := New(nil, nil, provider)
+
+	manifest := &controlplanev1.Manifest{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "British Pound"},
+		},
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{Code: "CURRENT", Name: "Current Account"},
+		},
+	}
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", manifest)
+	require.NoError(t, err)
+
+	creates := filterActions(plan.Actions, ActionCreate)
+	assert.Len(t, creates, 2)
+	assertActionExists(t, creates, ResourceInstrument, "GBP", ActionCreate)
+	assertActionExists(t, creates, ResourceAccountType, "CURRENT", ActionCreate)
+}
+
+func TestDiffAgainstLiveState_Instruments_Create(t *testing.T) {
+	provider := &mockLiveStateProvider{state: &LiveState{}}
+	d := New(nil, nil, provider)
+
+	manifest := &controlplanev1.Manifest{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "British Pound", Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT},
+		},
+	}
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", manifest)
+	require.NoError(t, err)
+
+	require.Len(t, plan.Actions, 1)
+	assert.Equal(t, ActionCreate, plan.Actions[0].Action)
+	assert.Equal(t, ResourceInstrument, plan.Actions[0].ResourceType)
+	assert.Equal(t, "GBP", plan.Actions[0].ResourceCode)
+}
+
+func TestDiffAgainstLiveState_Instruments_Update(t *testing.T) {
+	provider := &mockLiveStateProvider{state: &LiveState{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "British Pound", Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT},
+		},
+	}}
+	d := New(nil, nil, provider)
+
+	manifest := &controlplanev1.Manifest{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "Pound Sterling", Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT},
+		},
+	}
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", manifest)
+	require.NoError(t, err)
+
+	require.Len(t, plan.Actions, 1)
+	assert.Equal(t, ActionUpdate, plan.Actions[0].Action)
+	assert.Equal(t, "GBP", plan.Actions[0].ResourceCode)
+}
+
+func TestDiffAgainstLiveState_Instruments_NoChange(t *testing.T) {
+	inst := &controlplanev1.InstrumentDefinition{
+		Code: "GBP", Name: "British Pound", Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+	}
+	provider := &mockLiveStateProvider{state: &LiveState{
+		Instruments: []*controlplanev1.InstrumentDefinition{inst},
+	}}
+	d := New(nil, nil, provider)
+
+	manifest := &controlplanev1.Manifest{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "British Pound", Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT},
+		},
+	}
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", manifest)
+	require.NoError(t, err)
+
+	require.Len(t, plan.Actions, 1)
+	assert.Equal(t, ActionNoChange, plan.Actions[0].Action)
+}
+
+func TestDiffAgainstLiveState_Instruments_Deprecate(t *testing.T) {
+	provider := &mockLiveStateProvider{state: &LiveState{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "OLD_INST", Name: "Old Instrument"},
+		},
+	}}
+	d := New(nil, nil, provider)
+
+	manifest := &controlplanev1.Manifest{}
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", manifest)
+	require.NoError(t, err)
+
+	require.Len(t, plan.Actions, 1)
+	assert.Equal(t, ActionDeprecate, plan.Actions[0].Action)
+	assert.Equal(t, ResourceInstrument, plan.Actions[0].ResourceType)
+	assert.Equal(t, "OLD_INST", plan.Actions[0].ResourceCode)
+	assert.Contains(t, plan.Actions[0].Description, "Deprecate")
+}
+
+func TestDiffAgainstLiveState_SystemInstruments_Filtered(t *testing.T) {
+	provider := &mockLiveStateProvider{state: &LiveState{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "SYS_INST", Name: "System Instrument"},
+			{Code: "TENANT_INST", Name: "Tenant Instrument"},
+		},
+		SystemCodes: map[ResourceType]map[string]bool{
+			ResourceInstrument: {"SYS_INST": true},
+		},
+	}}
+	d := New(nil, nil, provider)
+
+	// Manifest doesn't include either - SYS_INST should be filtered, TENANT_INST should be DEPRECATE
+	manifest := &controlplanev1.Manifest{}
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", manifest)
+	require.NoError(t, err)
+
+	require.Len(t, plan.Actions, 1)
+	assert.Equal(t, ActionDeprecate, plan.Actions[0].Action)
+	assert.Equal(t, "TENANT_INST", plan.Actions[0].ResourceCode)
+}
+
+func TestDiffAgainstLiveState_SystemInstruments_NotMatchedForUpdate(t *testing.T) {
+	// System instrument in live state should not match manifest instrument for NO_CHANGE
+	provider := &mockLiveStateProvider{state: &LiveState{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "British Pound", Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT},
+		},
+		SystemCodes: map[ResourceType]map[string]bool{
+			ResourceInstrument: {"GBP": true},
+		},
+	}}
+	d := New(nil, nil, provider)
+
+	manifest := &controlplanev1.Manifest{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "British Pound", Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT},
+		},
+	}
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", manifest)
+	require.NoError(t, err)
+
+	// GBP in live is system, so it's filtered - manifest GBP should be CREATE
+	require.Len(t, plan.Actions, 1)
+	assert.Equal(t, ActionCreate, plan.Actions[0].Action)
+	assert.Equal(t, "GBP", plan.Actions[0].ResourceCode)
+}
+
+func TestDiffAgainstLiveState_AccountTypes_AllActions(t *testing.T) {
+	provider := &mockLiveStateProvider{state: &LiveState{
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{Code: "CURRENT", Name: "Current Account", NormalBalance: controlplanev1.NormalBalance_NORMAL_BALANCE_DEBIT},
+			{Code: "SAVINGS", Name: "Savings Account", NormalBalance: controlplanev1.NormalBalance_NORMAL_BALANCE_CREDIT},
+			{Code: "OLD_TYPE", Name: "Old Type"},
+		},
+	}}
+	d := New(nil, nil, provider)
+
+	manifest := &controlplanev1.Manifest{
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{Code: "CURRENT", Name: "Current Account", NormalBalance: controlplanev1.NormalBalance_NORMAL_BALANCE_DEBIT}, // NO_CHANGE
+			{Code: "SAVINGS", Name: "Updated Savings", NormalBalance: controlplanev1.NormalBalance_NORMAL_BALANCE_CREDIT}, // UPDATE
+			{Code: "NEW_TYPE", Name: "New Type"}, // CREATE
+		},
+	}
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", manifest)
+	require.NoError(t, err)
+
+	assert.Len(t, plan.Actions, 4)
+	assertActionExists(t, plan.Actions, ResourceAccountType, "CURRENT", ActionNoChange)
+	assertActionExists(t, plan.Actions, ResourceAccountType, "SAVINGS", ActionUpdate)
+	assertActionExists(t, plan.Actions, ResourceAccountType, "NEW_TYPE", ActionCreate)
+	assertActionExists(t, plan.Actions, ResourceAccountType, "OLD_TYPE", ActionDeprecate)
+}
+
+func TestDiffAgainstLiveState_SystemAccountTypes_Filtered(t *testing.T) {
+	provider := &mockLiveStateProvider{state: &LiveState{
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{Code: "SYSTEM_AT", Name: "System Account Type"},
+			{Code: "TENANT_AT", Name: "Tenant Account Type"},
+		},
+		SystemCodes: map[ResourceType]map[string]bool{
+			ResourceAccountType: {"SYSTEM_AT": true},
+		},
+	}}
+	d := New(nil, nil, provider)
+
+	manifest := &controlplanev1.Manifest{}
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", manifest)
+	require.NoError(t, err)
+
+	require.Len(t, plan.Actions, 1)
+	assert.Equal(t, "TENANT_AT", plan.Actions[0].ResourceCode)
+	assert.Equal(t, ActionDeprecate, plan.Actions[0].Action)
+}
+
+func TestDiffAgainstLiveState_Sagas_AllActions(t *testing.T) {
+	provider := &mockLiveStateProvider{state: &LiveState{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "existing_saga", Trigger: "api:/v1/settle", Script: "old_script"},
+			{Name: "unchanged_saga", Trigger: "event:foo", Script: "script"},
+			{Name: "removed_saga", Trigger: "scheduled:daily", Script: "old"},
+		},
+	}}
+	d := New(nil, nil, provider)
+
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "existing_saga", Trigger: "api:/v1/settle", Script: "new_script"}, // UPDATE
+			{Name: "unchanged_saga", Trigger: "event:foo", Script: "script"},          // NO_CHANGE
+			{Name: "new_saga", Trigger: "webhook:stripe", Script: "new"},              // CREATE
+		},
+	}
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", manifest)
+	require.NoError(t, err)
+
+	assert.Len(t, plan.Actions, 4)
+	assertActionExists(t, plan.Actions, ResourceSaga, "existing_saga", ActionUpdate)
+	assertActionExists(t, plan.Actions, ResourceSaga, "unchanged_saga", ActionNoChange)
+	assertActionExists(t, plan.Actions, ResourceSaga, "new_saga", ActionCreate)
+	assertActionExists(t, plan.Actions, ResourceSaga, "removed_saga", ActionDeprecate)
+}
+
+func TestDiffAgainstLiveState_SystemSagas_Filtered(t *testing.T) {
+	provider := &mockLiveStateProvider{state: &LiveState{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "system_saga", Trigger: "event:sys", Script: "sys_script"},
+			{Name: "tenant_saga", Trigger: "api:/v1/pay", Script: "pay_script"},
+		},
+		SystemCodes: map[ResourceType]map[string]bool{
+			ResourceSaga: {"system_saga": true},
+		},
+	}}
+	d := New(nil, nil, provider)
+
+	manifest := &controlplanev1.Manifest{}
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", manifest)
+	require.NoError(t, err)
+
+	require.Len(t, plan.Actions, 1)
+	assert.Equal(t, "tenant_saga", plan.Actions[0].ResourceCode)
+	assert.Equal(t, ActionDeprecate, plan.Actions[0].Action)
+}
+
+func TestDiffAgainstLiveState_MarketDataSources(t *testing.T) {
+	provider := &mockLiveStateProvider{state: &LiveState{
+		MarketDataSources: []*controlplanev1.MarketDataSourceDefinition{
+			{Code: "ECB", Name: "European Central Bank", TrustLevel: 10},
+			{Code: "OLD_SRC", Name: "Old Source"},
+		},
+	}}
+	d := New(nil, nil, provider)
+
+	manifest := &controlplanev1.Manifest{
+		MarketData: &controlplanev1.MarketDataConfig{
+			Sources: []*controlplanev1.MarketDataSourceDefinition{
+				{Code: "ECB", Name: "ECB Updated", TrustLevel: 10},
+				{Code: "NEW_SRC", Name: "New Source"},
+			},
+		},
+	}
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", manifest)
+	require.NoError(t, err)
+
+	assert.Len(t, plan.Actions, 3)
+	assertActionExists(t, plan.Actions, ResourceMarketDataSource, "ECB", ActionUpdate)
+	assertActionExists(t, plan.Actions, ResourceMarketDataSource, "NEW_SRC", ActionCreate)
+	assertActionExists(t, plan.Actions, ResourceMarketDataSource, "OLD_SRC", ActionDeprecate)
+}
+
+func TestDiffAgainstLiveState_MarketDataSets(t *testing.T) {
+	provider := &mockLiveStateProvider{state: &LiveState{
+		MarketDataSets: []*controlplanev1.MarketDataSetDefinition{
+			{Code: "GBP_USD", Unit: "rate"},
+			{Code: "OLD_SET", Unit: "price"},
+		},
+	}}
+	d := New(nil, nil, provider)
+
+	manifest := &controlplanev1.Manifest{
+		MarketData: &controlplanev1.MarketDataConfig{
+			Datasets: []*controlplanev1.MarketDataSetDefinition{
+				{Code: "GBP_USD", Unit: "rate"},
+				{Code: "NEW_SET", Unit: "price"},
+			},
+		},
+	}
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", manifest)
+	require.NoError(t, err)
+
+	assert.Len(t, plan.Actions, 3)
+	assertActionExists(t, plan.Actions, ResourceMarketDataSet, "GBP_USD", ActionNoChange)
+	assertActionExists(t, plan.Actions, ResourceMarketDataSet, "NEW_SET", ActionCreate)
+	assertActionExists(t, plan.Actions, ResourceMarketDataSet, "OLD_SET", ActionDeprecate)
+}
+
+func TestDiffAgainstLiveState_Organizations(t *testing.T) {
+	provider := &mockLiveStateProvider{state: &LiveState{
+		Organizations: []*controlplanev1.OrganizationDefinition{
+			{Code: "ORG_A", Name: "Organization A"},
+			{Code: "ORG_OLD", Name: "Old Org"},
+		},
+	}}
+	d := New(nil, nil, provider)
+
+	manifest := &controlplanev1.Manifest{
+		Organizations: []*controlplanev1.OrganizationDefinition{
+			{Code: "ORG_A", Name: "Organization A"},     // NO_CHANGE
+			{Code: "ORG_NEW", Name: "New Organization"}, // CREATE
+		},
+	}
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", manifest)
+	require.NoError(t, err)
+
+	assert.Len(t, plan.Actions, 3)
+	assertActionExists(t, plan.Actions, ResourceOrganization, "ORG_A", ActionNoChange)
+	assertActionExists(t, plan.Actions, ResourceOrganization, "ORG_NEW", ActionCreate)
+	assertActionExists(t, plan.Actions, ResourceOrganization, "ORG_OLD", ActionDeprecate)
+}
+
+func TestDiffAgainstLiveState_InternalAccounts(t *testing.T) {
+	provider := &mockLiveStateProvider{state: &LiveState{
+		InternalAccounts: []*controlplanev1.InternalAccountDefinition{
+			{Code: "SUSPENSE", AccountType: "CURRENT", Instrument: "GBP"},
+			{Code: "OLD_ACCT", AccountType: "SAVINGS", Instrument: "USD"},
+		},
+	}}
+	d := New(nil, nil, provider)
+
+	manifest := &controlplanev1.Manifest{
+		InternalAccounts: []*controlplanev1.InternalAccountDefinition{
+			{Code: "SUSPENSE", AccountType: "CURRENT", Instrument: "GBP"},      // NO_CHANGE
+			{Code: "NEW_ACCT", AccountType: "CURRENT", Instrument: "EUR"}, // CREATE
+		},
+	}
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", manifest)
+	require.NoError(t, err)
+
+	assert.Len(t, plan.Actions, 3)
+	assertActionExists(t, plan.Actions, ResourceInternalAccount, "SUSPENSE", ActionNoChange)
+	assertActionExists(t, plan.Actions, ResourceInternalAccount, "NEW_ACCT", ActionCreate)
+	assertActionExists(t, plan.Actions, ResourceInternalAccount, "OLD_ACCT", ActionDeprecate)
+}
+
+func TestDiffAgainstLiveState_ProviderConnections(t *testing.T) {
+	provider := &mockLiveStateProvider{state: &LiveState{
+		ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+			{ConnectionId: "stripe-1", ProviderName: "stripe"},
+			{ConnectionId: "old-conn", ProviderName: "legacy"},
+		},
+	}}
+	d := New(nil, nil, provider)
+
+	manifest := &controlplanev1.Manifest{
+		OperationalGateway: &controlplanev1.OperationalGatewayConfig{
+			ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+				{ConnectionId: "stripe-1", ProviderName: "stripe"},         // NO_CHANGE
+				{ConnectionId: "new-conn", ProviderName: "new-provider"}, // CREATE
+			},
+		},
+	}
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", manifest)
+	require.NoError(t, err)
+
+	assert.Len(t, plan.Actions, 3)
+	assertActionExists(t, plan.Actions, ResourceProviderConnection, "stripe-1", ActionNoChange)
+	assertActionExists(t, plan.Actions, ResourceProviderConnection, "new-conn", ActionCreate)
+	assertActionExists(t, plan.Actions, ResourceProviderConnection, "old-conn", ActionDeprecate)
+}
+
+func TestDiffAgainstLiveState_InstructionRoutes(t *testing.T) {
+	provider := &mockLiveStateProvider{state: &LiveState{
+		InstructionRoutes: []*controlplanev1.InstructionRouteConfig{
+			{InstructionType: "payment", ConnectionId: "stripe-1"},
+			{InstructionType: "old-route", ConnectionId: "legacy"},
+		},
+	}}
+	d := New(nil, nil, provider)
+
+	manifest := &controlplanev1.Manifest{
+		OperationalGateway: &controlplanev1.OperationalGatewayConfig{
+			InstructionRoutes: []*controlplanev1.InstructionRouteConfig{
+				{InstructionType: "payment", ConnectionId: "stripe-1"},       // NO_CHANGE
+				{InstructionType: "new-route", ConnectionId: "new-conn"}, // CREATE
+			},
+		},
+	}
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", manifest)
+	require.NoError(t, err)
+
+	assert.Len(t, plan.Actions, 3)
+	assertActionExists(t, plan.Actions, ResourceInstructionRoute, "payment", ActionNoChange)
+	assertActionExists(t, plan.Actions, ResourceInstructionRoute, "new-route", ActionCreate)
+	assertActionExists(t, plan.Actions, ResourceInstructionRoute, "old-route", ActionDeprecate)
+}
+
+func TestDiffAgainstLiveState_MultipleSystemCodeTypes(t *testing.T) {
+	provider := &mockLiveStateProvider{state: &LiveState{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "SYS_GBP", Name: "System GBP"},
+			{Code: "TENANT_KWH", Name: "Tenant kWh"},
+		},
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{Code: "SYS_CURRENT", Name: "System Current"},
+			{Code: "TENANT_SAVINGS", Name: "Tenant Savings"},
+		},
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "sys_saga", Trigger: "event:sys", Script: "s"},
+			{Name: "tenant_saga", Trigger: "api:/pay", Script: "p"},
+		},
+		SystemCodes: map[ResourceType]map[string]bool{
+			ResourceInstrument:  {"SYS_GBP": true},
+			ResourceAccountType: {"SYS_CURRENT": true},
+			ResourceSaga:        {"sys_saga": true},
+		},
+	}}
+	d := New(nil, nil, provider)
+
+	manifest := &controlplanev1.Manifest{}
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", manifest)
+	require.NoError(t, err)
+
+	// Only tenant resources should appear as DEPRECATE - 3 total
+	assert.Len(t, plan.Actions, 3)
+	for _, a := range plan.Actions {
+		assert.Equal(t, ActionDeprecate, a.Action)
+		assert.NotContains(t, a.ResourceCode, "SYS")
+	}
+}
+
+func TestDiffAgainstLiveState_NilSystemCodes(t *testing.T) {
+	// When SystemCodes is nil, no filtering should happen
+	provider := &mockLiveStateProvider{state: &LiveState{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "British Pound"},
+		},
+	}}
+	d := New(nil, nil, provider)
+
+	manifest := &controlplanev1.Manifest{}
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", manifest)
+	require.NoError(t, err)
+
+	require.Len(t, plan.Actions, 1)
+	assert.Equal(t, ActionDeprecate, plan.Actions[0].Action)
+	assert.Equal(t, "GBP", plan.Actions[0].ResourceCode)
+}
+
+func TestDiffAgainstLiveState_ResultsSorted(t *testing.T) {
+	provider := &mockLiveStateProvider{state: &LiveState{}}
+	d := New(nil, nil, provider)
+
+	manifest := &controlplanev1.Manifest{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "ZZZ", Name: "Z Instrument"},
+			{Code: "AAA", Name: "A Instrument"},
+		},
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{Code: "BBB", Name: "B Type"},
+		},
+	}
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", manifest)
+	require.NoError(t, err)
+
+	require.Len(t, plan.Actions, 3)
+	// Should be sorted by resource type then code
+	assert.Equal(t, ResourceAccountType, plan.Actions[0].ResourceType)
+	assert.Equal(t, "BBB", plan.Actions[0].ResourceCode)
+	assert.Equal(t, ResourceInstrument, plan.Actions[1].ResourceType)
+	assert.Equal(t, "AAA", plan.Actions[1].ResourceCode)
+	assert.Equal(t, ResourceInstrument, plan.Actions[2].ResourceType)
+	assert.Equal(t, "ZZZ", plan.Actions[2].ResourceCode)
+}
+
+func TestDiffAgainstLiveState_FullMixedScenario(t *testing.T) {
+	provider := &mockLiveStateProvider{state: &LiveState{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "British Pound", Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT},
+			{Code: "KWH", Name: "Kilowatt Hour", Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_COMMODITY},
+			{Code: "SYS_FIAT", Name: "System Fiat"},
+			{Code: "LEGACY", Name: "Legacy Instrument"},
+		},
+		SystemCodes: map[ResourceType]map[string]bool{
+			ResourceInstrument: {"SYS_FIAT": true},
+		},
+	}}
+	d := New(nil, nil, provider)
+
+	manifest := &controlplanev1.Manifest{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "British Pound", Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT},          // NO_CHANGE
+			{Code: "KWH", Name: "Kilowatt-Hour Updated", Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_COMMODITY}, // UPDATE
+			{Code: "CO2", Name: "Carbon Credit", Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_VOUCHER}, // CREATE
+		},
+	}
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", manifest)
+	require.NoError(t, err)
+
+	assert.Len(t, plan.Actions, 4)
+	assertActionExists(t, plan.Actions, ResourceInstrument, "GBP", ActionNoChange)
+	assertActionExists(t, plan.Actions, ResourceInstrument, "KWH", ActionUpdate)
+	assertActionExists(t, plan.Actions, ResourceInstrument, "CO2", ActionCreate)
+	assertActionExists(t, plan.Actions, ResourceInstrument, "LEGACY", ActionDeprecate)
+	// SYS_FIAT should NOT appear at all
+	for _, a := range plan.Actions {
+		assert.NotEqual(t, "SYS_FIAT", a.ResourceCode)
+	}
+}
+
+func TestDiffAgainstLiveState_EmptyManifestAndLive(t *testing.T) {
+	provider := &mockLiveStateProvider{state: &LiveState{}}
+	d := New(nil, nil, provider)
+
+	plan, err := d.DiffAgainstLiveState(context.Background(), "tenant-1", &controlplanev1.Manifest{})
+	require.NoError(t, err)
+	assert.Empty(t, plan.Actions)
+}
+
+// --- helpers ---
+
+func assertActionExists(t *testing.T, actions []PlannedAction, rt ResourceType, code string, action ActionType) {
+	t.Helper()
+	for _, a := range actions {
+		if a.ResourceType == rt && a.ResourceCode == code && a.Action == action {
+			return
+		}
+	}
+	t.Errorf("expected action %s for %s %s, not found in %d actions", action, rt, code, len(actions))
+}

--- a/services/control-plane/internal/differ/manifest_differ_mappings_test.go
+++ b/services/control-plane/internal/differ/manifest_differ_mappings_test.go
@@ -31,7 +31,7 @@ func testManifestWithMappings() *controlplanev1.Manifest {
 }
 
 func TestDiff_MappingAdded_Create(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 	newManifest := testManifestWithMappings()
 
@@ -46,7 +46,7 @@ func TestDiff_MappingAdded_Create(t *testing.T) {
 }
 
 func TestDiff_MappingRemoved_Delete(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifestWithMappings()
 	newManifest := testManifest()
 	newManifest.Mappings = nil
@@ -62,7 +62,7 @@ func TestDiff_MappingRemoved_Delete(t *testing.T) {
 }
 
 func TestDiff_MappingUnchanged_NoChange(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	manifest := testManifestWithMappings()
 
 	plan, err := d.Diff(context.Background(), manifest, manifest)
@@ -74,7 +74,7 @@ func TestDiff_MappingUnchanged_NoChange(t *testing.T) {
 }
 
 func TestDiff_MappingModified_Update(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifestWithMappings()
 
 	newManifest := testManifestWithMappings()
@@ -90,7 +90,7 @@ func TestDiff_MappingModified_Update(t *testing.T) {
 }
 
 func TestDiff_MappingModifiedTargetService_DescribesChange(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifestWithMappings()
 
 	newManifest := testManifestWithMappings()
@@ -105,7 +105,7 @@ func TestDiff_MappingModifiedTargetService_DescribesChange(t *testing.T) {
 }
 
 func TestDiff_MappingModifiedStatus_DescribesChange(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifestWithMappings()
 
 	newManifest := testManifestWithMappings()
@@ -121,7 +121,7 @@ func TestDiff_MappingModifiedStatus_DescribesChange(t *testing.T) {
 
 func TestDiff_MappingKey_NameVersionComposite(t *testing.T) {
 	// Two mappings with same name but different versions are distinct resources
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 	oldManifest.Mappings = []*mappingv1.MappingDefinition{
 		testMapping("stripe_webhook", 1),
@@ -146,7 +146,7 @@ func TestDiff_MappingKey_NameVersionComposite(t *testing.T) {
 }
 
 func TestDiff_NilLastApplied_MappingCreated(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	manifest := testManifestWithMappings()
 
 	plan, err := d.Diff(context.Background(), nil, manifest)

--- a/services/control-plane/internal/differ/manifest_differ_resources_test.go
+++ b/services/control-plane/internal/differ/manifest_differ_resources_test.go
@@ -13,7 +13,7 @@ import (
 // ─── diffInstruments ─────────────────────────────────────────────────────────
 
 func TestDiffInstruments_Create(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	manifest := &controlplanev1.Manifest{
 		Instruments: []*controlplanev1.InstrumentDefinition{
 			{Code: "GBP", Name: "British Pound", Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT},
@@ -29,7 +29,7 @@ func TestDiffInstruments_Create(t *testing.T) {
 }
 
 func TestDiffInstruments_Delete(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	last := &controlplanev1.Manifest{
 		Instruments: []*controlplanev1.InstrumentDefinition{
 			{Code: "GBP", Name: "British Pound"},
@@ -51,7 +51,7 @@ func TestDiffInstruments_Delete(t *testing.T) {
 }
 
 func TestDiffInstruments_Update(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	last := &controlplanev1.Manifest{
 		Instruments: []*controlplanev1.InstrumentDefinition{
 			{Code: "GBP", Name: "Pound"},
@@ -72,7 +72,7 @@ func TestDiffInstruments_Update(t *testing.T) {
 }
 
 func TestDiffInstruments_NoChange(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	manifest := &controlplanev1.Manifest{
 		Instruments: []*controlplanev1.InstrumentDefinition{
 			{Code: "GBP", Name: "British Pound"},
@@ -89,7 +89,7 @@ func TestDiffInstruments_NoChange(t *testing.T) {
 // ─── diffAccountTypes ────────────────────────────────────────────────────────
 
 func TestDiffAccountTypes_Create(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	manifest := &controlplanev1.Manifest{
 		AccountTypes: []*controlplanev1.AccountTypeDefinition{
 			{Code: "SETTLEMENT", Name: "Settlement"},
@@ -105,7 +105,7 @@ func TestDiffAccountTypes_Create(t *testing.T) {
 }
 
 func TestDiffAccountTypes_Delete(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	last := &controlplanev1.Manifest{
 		AccountTypes: []*controlplanev1.AccountTypeDefinition{
 			{Code: "SETTLEMENT", Name: "Settlement"},
@@ -129,7 +129,7 @@ func TestDiffAccountTypes_Delete(t *testing.T) {
 // ─── diffValuationRules ──────────────────────────────────────────────────────
 
 func TestDiffValuationRules_Create(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	manifest := &controlplanev1.Manifest{
 		ValuationRules: []*controlplanev1.ValuationRule{
 			{
@@ -149,7 +149,7 @@ func TestDiffValuationRules_Create(t *testing.T) {
 }
 
 func TestDiffValuationRules_Delete(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	last := &controlplanev1.Manifest{
 		ValuationRules: []*controlplanev1.ValuationRule{
 			{FromInstrument: "KWH", ToInstrument: "GBP"},
@@ -173,7 +173,7 @@ func TestDiffValuationRules_Delete(t *testing.T) {
 // ─── diffSagas ───────────────────────────────────────────────────────────────
 
 func TestDiffSagas_Create(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	manifest := &controlplanev1.Manifest{
 		Sagas: []*controlplanev1.SagaDefinition{
 			{Name: "process_order", Trigger: "api:/v1/orders", Script: "def execute(ctx): pass"},
@@ -189,7 +189,7 @@ func TestDiffSagas_Create(t *testing.T) {
 }
 
 func TestDiffSagas_Update_ScriptChange(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	last := &controlplanev1.Manifest{
 		Sagas: []*controlplanev1.SagaDefinition{
 			{Name: "process_order", Trigger: "api:/v1/orders", Script: "old script"},
@@ -212,7 +212,7 @@ func TestDiffSagas_Update_ScriptChange(t *testing.T) {
 // ─── diffPartyTypes ──────────────────────────────────────────────────────────
 
 func TestDiffPartyTypes_Create(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	manifest := &controlplanev1.Manifest{
 		PartyTypes: []*partyv1.PartyTypeDefinition{
 			{TenantId: "t1", PartyType: "CUSTOMER"},
@@ -230,7 +230,7 @@ func TestDiffPartyTypes_Create(t *testing.T) {
 // ─── diffOrganizations ───────────────────────────────────────────────────────
 
 func TestDiffOrganizations_Create(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	manifest := &controlplanev1.Manifest{
 		Organizations: []*controlplanev1.OrganizationDefinition{
 			{Code: "PLATFORM", Name: "Platform", PartyType: "OPERATOR"},
@@ -246,7 +246,7 @@ func TestDiffOrganizations_Create(t *testing.T) {
 }
 
 func TestDiffOrganizations_Update_AttributeChange(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	last := &controlplanev1.Manifest{
 		Organizations: []*controlplanev1.OrganizationDefinition{
 			{Code: "PLATFORM", Name: "Platform", Attributes: map[string]string{"region": "EU"}},
@@ -268,7 +268,7 @@ func TestDiffOrganizations_Update_AttributeChange(t *testing.T) {
 // ─── diffMarketDataSources ───────────────────────────────────────────────────
 
 func TestDiffMarketDataSources_Create(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	manifest := &controlplanev1.Manifest{
 		MarketData: &controlplanev1.MarketDataConfig{
 			Sources: []*controlplanev1.MarketDataSourceDefinition{
@@ -292,7 +292,7 @@ func TestDiffMarketDataSources_Create(t *testing.T) {
 // ─── diffInternalAccounts ────────────────────────────────────────────────────
 
 func TestDiffInternalAccounts_Create(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	manifest := &controlplanev1.Manifest{
 		InternalAccounts: []*controlplanev1.InternalAccountDefinition{
 			{Code: "PLATFORM_REVENUE", AccountType: "REVENUE", Instrument: "GBP"},
@@ -310,7 +310,7 @@ func TestDiffInternalAccounts_Create(t *testing.T) {
 // ─── WithSkipSafetyChecks ────────────────────────────────────────────────────
 
 func TestDiffWithSkipSafetyChecks_AllowsDeletion(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	last := &controlplanev1.Manifest{
 		Instruments: []*controlplanev1.InstrumentDefinition{
 			{Code: "OLD"},
@@ -329,7 +329,7 @@ func TestDiffWithSkipSafetyChecks_AllowsDeletion(t *testing.T) {
 // ─── DiffPlan.HasBreakingChanges ─────────────────────────────────────────────
 
 func TestDiffPlan_BreakingChangesFlaggedOnDelete(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	last := &controlplanev1.Manifest{
 		Instruments: []*controlplanev1.InstrumentDefinition{
 			{Code: "GBP", Name: "British Pound"},

--- a/services/control-plane/internal/differ/manifest_differ_test.go
+++ b/services/control-plane/internal/differ/manifest_differ_test.go
@@ -70,7 +70,7 @@ func testManifest() *controlplanev1.Manifest {
 }
 
 func TestDiff_NilLastApplied_AllCreates(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	manifest := testManifest()
 
 	plan, err := d.Diff(context.Background(), nil, manifest)
@@ -87,14 +87,14 @@ func TestDiff_NilLastApplied_AllCreates(t *testing.T) {
 }
 
 func TestDiff_NilNewManifest_ReturnsError(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	_, err := d.Diff(context.Background(), testManifest(), nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "new manifest cannot be nil")
 }
 
 func TestDiff_IdenticalManifests_AllNoChange(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	manifest := testManifest()
 
 	plan, err := d.Diff(context.Background(), manifest, manifest)
@@ -110,7 +110,7 @@ func TestDiff_IdenticalManifests_AllNoChange(t *testing.T) {
 }
 
 func TestDiff_AddedInstrument_Create(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -134,7 +134,7 @@ func TestDiff_AddedInstrument_Create(t *testing.T) {
 }
 
 func TestDiff_RemovedInstrument_Delete(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -151,7 +151,7 @@ func TestDiff_RemovedInstrument_Delete(t *testing.T) {
 }
 
 func TestDiff_ModifiedInstrument_Update(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -167,7 +167,7 @@ func TestDiff_ModifiedInstrument_Update(t *testing.T) {
 }
 
 func TestDiff_ModifiedInstrumentType_DescribesChange(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -183,7 +183,7 @@ func TestDiff_ModifiedInstrumentType_DescribesChange(t *testing.T) {
 }
 
 func TestDiff_ModifiedAccountType_Update(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -199,7 +199,7 @@ func TestDiff_ModifiedAccountType_Update(t *testing.T) {
 }
 
 func TestDiff_ModifiedAccountTypeName_DescribesChange(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -214,7 +214,7 @@ func TestDiff_ModifiedAccountTypeName_DescribesChange(t *testing.T) {
 }
 
 func TestDiff_ModifiedSaga_Update(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -230,7 +230,7 @@ func TestDiff_ModifiedSaga_Update(t *testing.T) {
 }
 
 func TestDiff_ModifiedSagaTrigger_DescribesChange(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -245,7 +245,7 @@ func TestDiff_ModifiedSagaTrigger_DescribesChange(t *testing.T) {
 }
 
 func TestDiff_AddedSaga_Create(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -265,7 +265,7 @@ func TestDiff_AddedSaga_Create(t *testing.T) {
 }
 
 func TestDiff_RemovedSaga_Delete(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -281,7 +281,7 @@ func TestDiff_RemovedSaga_Delete(t *testing.T) {
 }
 
 func TestDiff_RemovedAccountType_Delete(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -296,7 +296,7 @@ func TestDiff_RemovedAccountType_Delete(t *testing.T) {
 }
 
 func TestDiff_ValuationRuleAdded(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -316,7 +316,7 @@ func TestDiff_ValuationRuleAdded(t *testing.T) {
 }
 
 func TestDiff_ValuationRuleModified(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -331,7 +331,7 @@ func TestDiff_ValuationRuleModified(t *testing.T) {
 }
 
 func TestDiff_ValuationRuleRemoved(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -346,7 +346,7 @@ func TestDiff_ValuationRuleRemoved(t *testing.T) {
 }
 
 func TestDiff_MultipleChanges_MixedActions(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -388,7 +388,7 @@ func TestDiff_MultipleChanges_MixedActions(t *testing.T) {
 }
 
 func TestDiff_EmptyManifests_NoActions(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	empty := &controlplanev1.Manifest{
 		Version:  "1.0",
 		Metadata: &controlplanev1.ManifestMetadata{Name: "Empty"},
@@ -410,7 +410,7 @@ func TestDiff_SafetyChecker_BlocksDeletion(t *testing.T) {
 			},
 		},
 	}
-	d := New(checker, nil)
+	d := New(checker, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -435,7 +435,7 @@ func TestDiff_SafetyChecker_BlocksInstrumentDeletion(t *testing.T) {
 			},
 		},
 	}
-	d := New(checker, nil)
+	d := New(checker, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -459,7 +459,7 @@ func TestDiff_SafetyChecker_BlocksSagaDeletion(t *testing.T) {
 			},
 		},
 	}
-	d := New(checker, nil)
+	d := New(checker, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -475,7 +475,7 @@ func TestDiff_SafetyChecker_BlocksSagaDeletion(t *testing.T) {
 
 func TestDiff_SafetyChecker_AllowsDeletionWhenNothingBlocked(t *testing.T) {
 	checker := &mockSafetyChecker{} // no blocked resources
-	d := New(checker, nil)
+	d := New(checker, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -492,7 +492,7 @@ func TestDiff_SafetyChecker_ErrorPropagates(t *testing.T) {
 	checker := &mockSafetyChecker{
 		err: fmt.Errorf("connection refused"),
 	}
-	d := New(checker, nil)
+	d := New(checker, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -513,7 +513,7 @@ func TestDiff_DriftDetector_WarningsIncluded(t *testing.T) {
 			},
 		},
 	}
-	d := New(nil, detector)
+	d := New(nil, detector, nil)
 	manifest := testManifest()
 
 	plan, err := d.Diff(context.Background(), manifest, manifest)
@@ -528,7 +528,7 @@ func TestDiff_DriftDetector_NotCalledWhenNoLastApplied(t *testing.T) {
 	detector := &mockDriftDetector{
 		called: false,
 	}
-	d := New(nil, detector)
+	d := New(nil, detector, nil)
 
 	plan, err := d.Diff(context.Background(), nil, testManifest())
 	require.NoError(t, err)
@@ -541,7 +541,7 @@ func TestDiff_DriftDetector_ErrorPropagates(t *testing.T) {
 	detector := &mockDriftDetector{
 		err: fmt.Errorf("database unreachable"),
 	}
-	d := New(nil, detector)
+	d := New(nil, detector, nil)
 	manifest := testManifest()
 
 	_, err := d.Diff(context.Background(), manifest, manifest)
@@ -550,7 +550,7 @@ func TestDiff_DriftDetector_ErrorPropagates(t *testing.T) {
 }
 
 func TestDiff_DeterministicOrdering(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 
 	plan, err := d.Diff(context.Background(), nil, testManifest())
 	require.NoError(t, err)
@@ -605,7 +605,7 @@ func TestDiffPlan_BlockedDeletionErrors(t *testing.T) {
 }
 
 func TestDiff_BreakingChangeFlagging(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -718,7 +718,7 @@ func testPartyTypeDefinition(tenantID, partyType, schema string) *partyv1.PartyT
 }
 
 func TestDiff_PartyTypeAdded_Create(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -736,7 +736,7 @@ func TestDiff_PartyTypeAdded_Create(t *testing.T) {
 }
 
 func TestDiff_PartyTypeRemoved_Delete(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 	oldManifest.PartyTypes = []*partyv1.PartyTypeDefinition{
 		testPartyTypeDefinition("tenant-1", "PERSON", `{"type":"object"}`),
@@ -756,7 +756,7 @@ func TestDiff_PartyTypeRemoved_Delete(t *testing.T) {
 }
 
 func TestDiff_PartyTypeUnchanged_NoChange(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	partyType := testPartyTypeDefinition("tenant-1", "ORGANIZATION", `{"type":"object","properties":{}}`)
 	manifest := testManifest()
 	manifest.PartyTypes = []*partyv1.PartyTypeDefinition{partyType}
@@ -770,7 +770,7 @@ func TestDiff_PartyTypeUnchanged_NoChange(t *testing.T) {
 }
 
 func TestDiff_PartyTypeModifiedSchema_Update(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 	oldManifest.PartyTypes = []*partyv1.PartyTypeDefinition{
 		testPartyTypeDefinition("tenant-1", "PERSON", `{"type":"object"}`),
@@ -791,7 +791,7 @@ func TestDiff_PartyTypeModifiedSchema_Update(t *testing.T) {
 }
 
 func TestDiff_PartyTypeModifiedCEL_DescribesChange(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 	oldManifest.PartyTypes = []*partyv1.PartyTypeDefinition{
 		{
@@ -821,7 +821,7 @@ func TestDiff_PartyTypeModifiedCEL_DescribesChange(t *testing.T) {
 }
 
 func TestDiff_MultiplePartyTypes_DifferentTenants(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -848,7 +848,7 @@ func TestDiff_PartyTypeKey_IsCompositeOfTenantAndType(t *testing.T) {
 }
 
 func TestDiff_NilLastApplied_WithPartyTypes_AllCreates(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	manifest := testManifest()
 	manifest.PartyTypes = []*partyv1.PartyTypeDefinition{
 		testPartyTypeDefinition("tenant-1", "PERSON", `{"type":"object"}`),
@@ -863,7 +863,7 @@ func TestDiff_NilLastApplied_WithPartyTypes_AllCreates(t *testing.T) {
 }
 
 func TestDiff_AddedEventSaga_Create(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	filter := `event.amount > 0 && event.currency == "GBP"`
@@ -885,7 +885,7 @@ func TestDiff_AddedEventSaga_Create(t *testing.T) {
 }
 
 func TestDiff_ModifiedSagaFilter_DescribesChange(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 
 	filter := `event.amount > 0`
 	oldManifest := testManifest()
@@ -915,7 +915,7 @@ func TestDiff_WithSkipSafetyChecks_SkipsSafetyChecksAndBreakingFlags(t *testing.
 			},
 		},
 	}
-	d := New(checker, nil)
+	d := New(checker, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -942,7 +942,7 @@ func TestDiff_WithSkipSafetyChecks_SafetyCheckerErrorNotReturned(t *testing.T) {
 	checker := &mockSafetyChecker{
 		err: fmt.Errorf("connection refused"),
 	}
-	d := New(checker, nil)
+	d := New(checker, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -964,7 +964,7 @@ func TestDiff_WithoutSkipSafetyChecks_SafetyChecksStillRun(t *testing.T) {
 			},
 		},
 	}
-	d := New(checker, nil)
+	d := New(checker, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -981,7 +981,7 @@ func TestDiff_WithoutSkipSafetyChecks_SafetyChecksStillRun(t *testing.T) {
 // --- Market Data Source differ tests ---
 
 func TestDiff_MarketDataSourceAdded_Create(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -1001,7 +1001,7 @@ func TestDiff_MarketDataSourceAdded_Create(t *testing.T) {
 }
 
 func TestDiff_MarketDataSourceRemoved_Delete(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 	oldManifest.MarketData = &controlplanev1.MarketDataConfig{
 		Sources: []*controlplanev1.MarketDataSourceDefinition{
@@ -1020,7 +1020,7 @@ func TestDiff_MarketDataSourceRemoved_Delete(t *testing.T) {
 }
 
 func TestDiff_MarketDataSourceModified_Update(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 	oldManifest.MarketData = &controlplanev1.MarketDataConfig{
 		Sources: []*controlplanev1.MarketDataSourceDefinition{
@@ -1046,7 +1046,7 @@ func TestDiff_MarketDataSourceModified_Update(t *testing.T) {
 }
 
 func TestDiff_MarketDataSourceUnchanged_NoChange(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	manifest := testManifest()
 	manifest.MarketData = &controlplanev1.MarketDataConfig{
 		Sources: []*controlplanev1.MarketDataSourceDefinition{
@@ -1065,7 +1065,7 @@ func TestDiff_MarketDataSourceUnchanged_NoChange(t *testing.T) {
 // --- Market Data Set differ tests ---
 
 func TestDiff_MarketDataSetAdded_Create(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -1090,7 +1090,7 @@ func TestDiff_MarketDataSetAdded_Create(t *testing.T) {
 }
 
 func TestDiff_MarketDataSetRemoved_Delete(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 	oldManifest.MarketData = &controlplanev1.MarketDataConfig{
 		Datasets: []*controlplanev1.MarketDataSetDefinition{
@@ -1114,7 +1114,7 @@ func TestDiff_MarketDataSetRemoved_Delete(t *testing.T) {
 }
 
 func TestDiff_MarketDataSetModified_Update(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 	oldManifest.MarketData = &controlplanev1.MarketDataConfig{
 		Datasets: []*controlplanev1.MarketDataSetDefinition{
@@ -1152,7 +1152,7 @@ func TestDiff_MarketDataSetModified_Update(t *testing.T) {
 // --- Organization differ tests ---
 
 func TestDiff_OrganizationAdded_Create(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -1170,7 +1170,7 @@ func TestDiff_OrganizationAdded_Create(t *testing.T) {
 }
 
 func TestDiff_OrganizationRemoved_Delete(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 	oldManifest.Organizations = []*controlplanev1.OrganizationDefinition{
 		{Code: "GRID_OPS", Name: "Grid Operations", PartyType: "ORGANIZATION"},
@@ -1187,7 +1187,7 @@ func TestDiff_OrganizationRemoved_Delete(t *testing.T) {
 }
 
 func TestDiff_OrganizationModified_Update(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 	oldManifest.Organizations = []*controlplanev1.OrganizationDefinition{
 		{Code: "ACME_ENERGY", Name: "Acme Energy Ltd", PartyType: "ORGANIZATION"},
@@ -1209,7 +1209,7 @@ func TestDiff_OrganizationModified_Update(t *testing.T) {
 }
 
 func TestDiff_OrganizationUnchanged_NoChange(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	manifest := testManifest()
 	manifest.Organizations = []*controlplanev1.OrganizationDefinition{
 		{Code: "ACME_ENERGY", Name: "Acme Energy Ltd", PartyType: "ORGANIZATION"},
@@ -1226,7 +1226,7 @@ func TestDiff_OrganizationUnchanged_NoChange(t *testing.T) {
 // --- Internal Account differ tests ---
 
 func TestDiff_InternalAccountAdded_Create(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 
 	newManifest := testManifest()
@@ -1245,7 +1245,7 @@ func TestDiff_InternalAccountAdded_Create(t *testing.T) {
 }
 
 func TestDiff_InternalAccountRemoved_Delete(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 	oldManifest.InternalAccounts = []*controlplanev1.InternalAccountDefinition{
 		{Code: "SETTLEMENT_KWH", AccountType: "SETTLEMENT", Instrument: "KWH"},
@@ -1262,7 +1262,7 @@ func TestDiff_InternalAccountRemoved_Delete(t *testing.T) {
 }
 
 func TestDiff_InternalAccountModified_Update(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	oldManifest := testManifest()
 	oldManifest.InternalAccounts = []*controlplanev1.InternalAccountDefinition{
 		{Code: "REVENUE_GBP", AccountType: "REVENUE", Instrument: "GBP"},
@@ -1284,7 +1284,7 @@ func TestDiff_InternalAccountModified_Update(t *testing.T) {
 }
 
 func TestDiff_InternalAccountUnchanged_NoChange(t *testing.T) {
-	d := New(nil, nil)
+	d := New(nil, nil, nil)
 	manifest := testManifest()
 	manifest.InternalAccounts = []*controlplanev1.InternalAccountDefinition{
 		{Code: "REVENUE_GBP", AccountType: "REVENUE", Instrument: "GBP"},

--- a/services/control-plane/internal/differ/types.go
+++ b/services/control-plane/internal/differ/types.go
@@ -17,10 +17,11 @@ type ActionType string
 
 // Action type constants for diff plan entries.
 const (
-	ActionCreate   ActionType = "CREATE"
-	ActionUpdate   ActionType = "UPDATE"
-	ActionDelete   ActionType = "DELETE"
-	ActionNoChange ActionType = "NO_CHANGE"
+	ActionCreate    ActionType = "CREATE"
+	ActionUpdate    ActionType = "UPDATE"
+	ActionDelete    ActionType = "DELETE"
+	ActionNoChange  ActionType = "NO_CHANGE"
+	ActionDeprecate ActionType = "DEPRECATE"
 )
 
 // ResourceType identifies the category of resource being planned.

--- a/services/control-plane/internal/differ/types.go
+++ b/services/control-plane/internal/differ/types.go
@@ -81,6 +81,16 @@ func (p *DiffPlan) Summary() string {
 	for _, a := range p.Actions {
 		counts[a.Action]++
 	}
+	if counts[ActionDeprecate] > 0 {
+		return fmt.Sprintf(
+			"%d to create, %d to update, %d to delete, %d to deprecate, %d no-change",
+			counts[ActionCreate],
+			counts[ActionUpdate],
+			counts[ActionDelete],
+			counts[ActionDeprecate],
+			counts[ActionNoChange],
+		)
+	}
 	return fmt.Sprintf(
 		"%d to create, %d to update, %d to delete, %d no-change",
 		counts[ActionCreate],

--- a/services/control-plane/internal/manifest/grpc_handler.go
+++ b/services/control-plane/internal/manifest/grpc_handler.go
@@ -219,6 +219,8 @@ func diffPlanToProtoSummary(plan *differ.DiffPlan) *controlplanev1.DiffSummary {
 			summary.Deletes++
 		case differ.ActionNoChange:
 			summary.NoChanges++
+		case differ.ActionDeprecate:
+			summary.Deletes++
 		}
 	}
 	return summary

--- a/services/control-plane/internal/manifest/history.go
+++ b/services/control-plane/internal/manifest/history.go
@@ -40,7 +40,7 @@ func NewHistoryService(repo *Repository) (*HistoryService, error) {
 	}
 	return &HistoryService{
 		repo:   repo,
-		differ: differ.New(nil, nil),
+		differ: differ.New(nil, nil, nil),
 	}, nil
 }
 
@@ -51,7 +51,7 @@ func NewHistoryServiceWithDiffer(repo *Repository, d *differ.ManifestDiffer) (*H
 		return nil, ErrNilRepository
 	}
 	if d == nil {
-		d = differ.New(nil, nil)
+		d = differ.New(nil, nil, nil)
 	}
 	return &HistoryService{
 		repo:   repo,

--- a/services/control-plane/internal/manifest/history_test.go
+++ b/services/control-plane/internal/manifest/history_test.go
@@ -19,7 +19,7 @@ func TestNewHistoryService_NilRepository(t *testing.T) {
 }
 
 func TestNewHistoryServiceWithDiffer_NilRepository(t *testing.T) {
-	_, err := NewHistoryServiceWithDiffer(nil, differ.New(nil, nil))
+	_, err := NewHistoryServiceWithDiffer(nil, differ.New(nil, nil, nil))
 	assert.ErrorIs(t, err, ErrNilRepository)
 }
 

--- a/services/control-plane/internal/manifest/reconcile.go
+++ b/services/control-plane/internal/manifest/reconcile.go
@@ -170,6 +170,15 @@ func diffPlanToReconcileResult(plan *differ.DiffPlan, version string) *Reconcile
 			result.Summary.TotalDrifted++
 		case differ.ActionNoChange:
 			// No drift for this resource.
+		case differ.ActionDeprecate:
+			result.DriftItems = append(result.DriftItems, DriftItem{
+				ResourceType: string(action.ResourceType),
+				ResourceCode: action.ResourceCode,
+				DriftType:    DriftTypeExtra,
+				Description:  fmt.Sprintf("Resource %s %s exists in live state but not in manifest (deprecated)", action.ResourceType, action.ResourceCode),
+			})
+			result.Summary.Extra++
+			result.Summary.TotalDrifted++
 		}
 		result.Summary.TotalChecked++
 	}

--- a/services/control-plane/internal/manifest/reconcile.go
+++ b/services/control-plane/internal/manifest/reconcile.go
@@ -78,7 +78,7 @@ func NewReconcileService(history *HistoryService, exporter *ExportService, d *di
 		return nil, ErrNilExporter
 	}
 	if d == nil {
-		d = differ.New(nil, nil)
+		d = differ.New(nil, nil, nil)
 	}
 	return &ReconcileService{
 		history:  history,

--- a/services/control-plane/internal/manifest/reconcile_test.go
+++ b/services/control-plane/internal/manifest/reconcile_test.go
@@ -308,7 +308,7 @@ func TestReconcile_EndToEnd_NoDrift(t *testing.T) {
 	stored := testManifest("1.0")
 	live := testManifest("1.0")
 
-	d := differ.New(nil, nil)
+	d := differ.New(nil, nil, nil)
 	plan, err := d.Diff(context.Background(), stored, live, differ.WithSkipSafetyChecks())
 	require.NoError(t, err)
 
@@ -325,7 +325,7 @@ func TestReconcile_EndToEnd_MissingInstrument(t *testing.T) {
 	live := testManifest("1.0")
 	live.Instruments = live.Instruments[:1] // Remove KWH
 
-	d := differ.New(nil, nil)
+	d := differ.New(nil, nil, nil)
 	plan, err := d.Diff(context.Background(), stored, live, differ.WithSkipSafetyChecks())
 	require.NoError(t, err)
 
@@ -351,7 +351,7 @@ func TestReconcile_EndToEnd_ExtraInstrument(t *testing.T) {
 		Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
 	})
 
-	d := differ.New(nil, nil)
+	d := differ.New(nil, nil, nil)
 	plan, err := d.Diff(context.Background(), stored, live, differ.WithSkipSafetyChecks())
 	require.NoError(t, err)
 
@@ -381,7 +381,7 @@ func TestReconcile_EndToEnd_ModifiedInstrument(t *testing.T) {
 		},
 	}
 
-	d := differ.New(nil, nil)
+	d := differ.New(nil, nil, nil)
 	plan, err := d.Diff(context.Background(), stored, live, differ.WithSkipSafetyChecks())
 	require.NoError(t, err)
 

--- a/services/control-plane/internal/planner/types.go
+++ b/services/control-plane/internal/planner/types.go
@@ -275,6 +275,8 @@ func actionSymbol(action differ.ActionType) string {
 		return "-"
 	case differ.ActionNoChange:
 		return "="
+	case differ.ActionDeprecate:
+		return "!"
 	}
 	return "?"
 }

--- a/services/control-plane/service/apply_manifest.go
+++ b/services/control-plane/service/apply_manifest.go
@@ -51,7 +51,7 @@ func RegisterApplyManifestService(server *grpc.Server, cfg ApplyManifestServiceC
 	}
 
 	versionStore := persistence.NewPostgresManifestVersionStore(cfg.Pool)
-	d := differ.New(nil, nil) // NoOp safety checker and drift detector
+	d := differ.New(nil, nil, nil) // NoOp safety checker, drift detector, and live state provider
 	p := planner.NewManifestPlanner()
 
 	var executor *applier.ManifestExecutor


### PR DESCRIPTION
## Summary

- Add `DiffAgainstLiveState` method to `ManifestDiffer` that queries live state from downstream services and computes a three-way diff (live vs desired manifest)
- Add `ActionDeprecate` constant - resources in live state but not in manifest receive DEPRECATE instead of DELETE
- Add `LiveStateProvider` dependency to `ManifestDiffer` constructor (nil-safe, all existing call sites updated)
- Add `SystemCodes` map to `LiveState` struct for pre-plan filtering of `is_system=true` resources
- Implement per-resource-type live diff methods for all 9 resource types: instruments, account types, sagas, market data sources/sets, organizations, internal accounts, provider connections, instruction routes

## Test plan

- [x] 25 unit tests covering CREATE, UPDATE, NO_CHANGE, DEPRECATE for each resource type
- [x] System resource filtering tests (single type, multiple types, nil SystemCodes)
- [x] Error handling tests (nil manifest, nil provider, query failure)
- [x] Sorting verification test
- [x] Full mixed scenario test combining all action types
- [x] Existing differ tests pass (constructor signature updated)