### PR TITLE
feat: add is_system filtering via filterTenantOwned pre-diff step

### DIFF
--- a/services/control-plane/internal/differ/live_state.go
+++ b/services/control-plane/internal/differ/live_state.go
@@ -32,7 +32,7 @@ type LiveState struct {
 }
 
 // filterTenantOwned returns a copy of live with platform default resources removed.
-// Resources present in SystemCodes (is_system=true) are excluded from the resource slices.
+// Resources present in SystemCodes (is_system=true) are excluded from all resource slices.
 // Resources present in PlatformRefs (is_system=false with platform_ref) are tenant overrides
 // and are naturally retained - they are not in SystemCodes and pass through unchanged.
 // This function must be called before DiffAgainstLiveState to ensure system resources
@@ -41,25 +41,28 @@ func filterTenantOwned(live *LiveState) *LiveState {
 	if live == nil {
 		return nil
 	}
-	filtered := &LiveState{
-		SystemCodes:         live.SystemCodes,
-		PlatformRefs:        live.PlatformRefs,
-		MarketDataSources:   live.MarketDataSources,
-		MarketDataSets:      live.MarketDataSets,
-		Organizations:       live.Organizations,
-		InternalAccounts:    live.InternalAccounts,
-		ProviderConnections: live.ProviderConnections,
-		InstructionRoutes:   live.InstructionRoutes,
+	return &LiveState{
+		SystemCodes:  live.SystemCodes,
+		PlatformRefs: live.PlatformRefs,
+		Instruments: filterBySystemCodes(live.Instruments, live.SystemCodes, ResourceInstrument,
+			func(r *controlplanev1.InstrumentDefinition) string { return r.GetCode() }),
+		AccountTypes: filterBySystemCodes(live.AccountTypes, live.SystemCodes, ResourceAccountType,
+			func(r *controlplanev1.AccountTypeDefinition) string { return r.GetCode() }),
+		Sagas: filterBySystemCodes(live.Sagas, live.SystemCodes, ResourceSaga,
+			func(r *controlplanev1.SagaDefinition) string { return r.GetName() }),
+		MarketDataSources: filterBySystemCodes(live.MarketDataSources, live.SystemCodes, ResourceMarketDataSource,
+			func(r *controlplanev1.MarketDataSourceDefinition) string { return r.GetCode() }),
+		MarketDataSets: filterBySystemCodes(live.MarketDataSets, live.SystemCodes, ResourceMarketDataSet,
+			func(r *controlplanev1.MarketDataSetDefinition) string { return r.GetCode() }),
+		Organizations: filterBySystemCodes(live.Organizations, live.SystemCodes, ResourceOrganization,
+			func(r *controlplanev1.OrganizationDefinition) string { return r.GetCode() }),
+		InternalAccounts: filterBySystemCodes(live.InternalAccounts, live.SystemCodes, ResourceInternalAccount,
+			func(r *controlplanev1.InternalAccountDefinition) string { return r.GetCode() }),
+		ProviderConnections: filterBySystemCodes(live.ProviderConnections, live.SystemCodes, ResourceProviderConnection,
+			func(r *controlplanev1.ProviderConnectionConfig) string { return r.GetConnectionId() }),
+		InstructionRoutes: filterBySystemCodes(live.InstructionRoutes, live.SystemCodes, ResourceInstructionRoute,
+			func(r *controlplanev1.InstructionRouteConfig) string { return r.GetInstructionType() }),
 	}
-
-	filtered.Instruments = filterBySystemCodes(live.Instruments, live.SystemCodes, ResourceInstrument,
-		func(r *controlplanev1.InstrumentDefinition) string { return r.GetCode() })
-	filtered.AccountTypes = filterBySystemCodes(live.AccountTypes, live.SystemCodes, ResourceAccountType,
-		func(r *controlplanev1.AccountTypeDefinition) string { return r.GetCode() })
-	filtered.Sagas = filterBySystemCodes(live.Sagas, live.SystemCodes, ResourceSaga,
-		func(r *controlplanev1.SagaDefinition) string { return r.GetName() })
-
-	return filtered
 }
 
 // filterBySystemCodes returns a slice with system-managed resources removed.

--- a/services/control-plane/internal/differ/live_state.go
+++ b/services/control-plane/internal/differ/live_state.go
@@ -21,8 +21,64 @@ type LiveState struct {
 
 	// SystemCodes tracks resources that are system-managed (is_system=true).
 	// Outer key is ResourceType, inner key is the resource code/name.
-	// Resources in this set are excluded from diff planning in DiffAgainstLiveState.
+	// Resources in this set are excluded from diff planning by filterTenantOwned.
 	SystemCodes map[ResourceType]map[string]bool
+
+	// PlatformRefs tracks resources that are tenant overrides of platform defaults
+	// (is_system=false with a non-nil platform_ref in the service layer).
+	// These are tenant-owned resources and must be included in diff planning.
+	// Outer key is ResourceType, inner key is the resource code/name.
+	PlatformRefs map[ResourceType]map[string]bool
+}
+
+// filterTenantOwned returns a copy of live with platform default resources removed.
+// Resources present in SystemCodes (is_system=true) are excluded from the resource slices.
+// Resources present in PlatformRefs (is_system=false with platform_ref) are tenant overrides
+// and are naturally retained - they are not in SystemCodes and pass through unchanged.
+// This function must be called before DiffAgainstLiveState to ensure system resources
+// do not appear as CREATE or UPDATE actions.
+func filterTenantOwned(live *LiveState) *LiveState {
+	if live == nil {
+		return nil
+	}
+	filtered := &LiveState{
+		SystemCodes:         live.SystemCodes,
+		PlatformRefs:        live.PlatformRefs,
+		MarketDataSources:   live.MarketDataSources,
+		MarketDataSets:      live.MarketDataSets,
+		Organizations:       live.Organizations,
+		InternalAccounts:    live.InternalAccounts,
+		ProviderConnections: live.ProviderConnections,
+		InstructionRoutes:   live.InstructionRoutes,
+	}
+
+	filtered.Instruments = filterBySystemCodes(live.Instruments, live.SystemCodes, ResourceInstrument,
+		func(r *controlplanev1.InstrumentDefinition) string { return r.GetCode() })
+	filtered.AccountTypes = filterBySystemCodes(live.AccountTypes, live.SystemCodes, ResourceAccountType,
+		func(r *controlplanev1.AccountTypeDefinition) string { return r.GetCode() })
+	filtered.Sagas = filterBySystemCodes(live.Sagas, live.SystemCodes, ResourceSaga,
+		func(r *controlplanev1.SagaDefinition) string { return r.GetName() })
+
+	return filtered
+}
+
+// filterBySystemCodes returns a slice with system-managed resources removed.
+// Items whose code appears in systemCodes[rt] are excluded.
+func filterBySystemCodes[T any](items []T, systemCodes map[ResourceType]map[string]bool, rt ResourceType, codeOf func(T) string) []T {
+	if len(systemCodes) == 0 {
+		return items
+	}
+	codes := systemCodes[rt]
+	if len(codes) == 0 {
+		return items
+	}
+	result := make([]T, 0, len(items))
+	for _, item := range items {
+		if !codes[codeOf(item)] {
+			result = append(result, item)
+		}
+	}
+	return result
 }
 
 // LiveStateProvider queries downstream services and returns the current live state

--- a/services/control-plane/internal/differ/live_state_filter_test.go
+++ b/services/control-plane/internal/differ/live_state_filter_test.go
@@ -1,0 +1,223 @@
+package differ
+
+import (
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterTenantOwned_NilLiveState(t *testing.T) {
+	result := filterTenantOwned(nil)
+	assert.Nil(t, result)
+}
+
+func TestFilterTenantOwned_NilSystemCodes_NoFiltering(t *testing.T) {
+	live := &LiveState{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP"},
+		},
+	}
+	result := filterTenantOwned(live)
+	require.NotNil(t, result)
+	assert.Len(t, result.Instruments, 1)
+}
+
+func TestFilterTenantOwned_EmptySystemCodes_NoFiltering(t *testing.T) {
+	live := &LiveState{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP"},
+		},
+		SystemCodes: map[ResourceType]map[string]bool{},
+	}
+	result := filterTenantOwned(live)
+	require.NotNil(t, result)
+	assert.Len(t, result.Instruments, 1)
+}
+
+func TestFilterTenantOwned_Instruments_SystemFiltered(t *testing.T) {
+	live := &LiveState{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP", Name: "British Pound"},
+			{Code: "SYS_USD", Name: "System USD"},
+			{Code: "KWH", Name: "Kilowatt Hour"},
+		},
+		SystemCodes: map[ResourceType]map[string]bool{
+			ResourceInstrument: {"SYS_USD": true},
+		},
+	}
+	result := filterTenantOwned(live)
+	require.NotNil(t, result)
+	require.Len(t, result.Instruments, 2)
+	codes := instrumentCodes(result.Instruments)
+	assert.Contains(t, codes, "GBP")
+	assert.Contains(t, codes, "KWH")
+	assert.NotContains(t, codes, "SYS_USD")
+}
+
+func TestFilterTenantOwned_AccountTypes_SystemFiltered(t *testing.T) {
+	live := &LiveState{
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{Code: "CURRENT"},
+			{Code: "SYS_SUSPENSE"},
+		},
+		SystemCodes: map[ResourceType]map[string]bool{
+			ResourceAccountType: {"SYS_SUSPENSE": true},
+		},
+	}
+	result := filterTenantOwned(live)
+	require.NotNil(t, result)
+	require.Len(t, result.AccountTypes, 1)
+	assert.Equal(t, "CURRENT", result.AccountTypes[0].GetCode())
+}
+
+func TestFilterTenantOwned_Sagas_SystemFiltered(t *testing.T) {
+	live := &LiveState{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "platform_payment_saga"},
+			{Name: "tenant_custom_saga"},
+		},
+		SystemCodes: map[ResourceType]map[string]bool{
+			ResourceSaga: {"platform_payment_saga": true},
+		},
+	}
+	result := filterTenantOwned(live)
+	require.NotNil(t, result)
+	require.Len(t, result.Sagas, 1)
+	assert.Equal(t, "tenant_custom_saga", result.Sagas[0].GetName())
+}
+
+// TestFilterTenantOwned_SagaOverride_Retained verifies that a tenant override saga
+// (is_system=false with platform_ref) is retained after filtering.
+// Tenant overrides are not in SystemCodes (they are not platform defaults), so they
+// pass through filterTenantOwned and must be included in diff planning.
+func TestFilterTenantOwned_SagaOverride_Retained(t *testing.T) {
+	live := &LiveState{
+		Sagas: []*controlplanev1.SagaDefinition{
+			// Platform default: is_system=true, filtered out.
+			{Name: "platform_saga"},
+			// Tenant override: is_system=false, has platform_ref (tracked in PlatformRefs).
+			{Name: "override_saga"},
+			// Regular tenant saga: no platform_ref.
+			{Name: "custom_saga"},
+		},
+		SystemCodes: map[ResourceType]map[string]bool{
+			ResourceSaga: {"platform_saga": true},
+		},
+		// PlatformRefs documents which sagas are tenant overrides of platform defaults.
+		PlatformRefs: map[ResourceType]map[string]bool{
+			ResourceSaga: {"override_saga": true},
+		},
+	}
+	result := filterTenantOwned(live)
+	require.NotNil(t, result)
+	require.Len(t, result.Sagas, 2, "both override_saga and custom_saga should be retained")
+	names := sagaNames(result.Sagas)
+	assert.Contains(t, names, "override_saga")
+	assert.Contains(t, names, "custom_saga")
+	assert.NotContains(t, names, "platform_saga")
+}
+
+func TestFilterTenantOwned_MultipleTypes(t *testing.T) {
+	live := &LiveState{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "GBP"},
+			{Code: "SYS_EUR"},
+		},
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{Code: "CURRENT"},
+			{Code: "SYS_FEE"},
+		},
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "tenant_saga"},
+			{Name: "sys_saga"},
+		},
+		SystemCodes: map[ResourceType]map[string]bool{
+			ResourceInstrument:  {"SYS_EUR": true},
+			ResourceAccountType: {"SYS_FEE": true},
+			ResourceSaga:        {"sys_saga": true},
+		},
+	}
+	result := filterTenantOwned(live)
+	require.NotNil(t, result)
+
+	assert.Len(t, result.Instruments, 1)
+	assert.Equal(t, "GBP", result.Instruments[0].GetCode())
+
+	assert.Len(t, result.AccountTypes, 1)
+	assert.Equal(t, "CURRENT", result.AccountTypes[0].GetCode())
+
+	assert.Len(t, result.Sagas, 1)
+	assert.Equal(t, "tenant_saga", result.Sagas[0].GetName())
+}
+
+func TestFilterTenantOwned_NonFilteredResourcesPreserved(t *testing.T) {
+	// MarketDataSources, MarketDataSets, Organizations, etc. are passed through unchanged.
+	live := &LiveState{
+		MarketDataSources: []*controlplanev1.MarketDataSourceDefinition{
+			{Code: "ECB"},
+		},
+		MarketDataSets: []*controlplanev1.MarketDataSetDefinition{
+			{Code: "FX_RATES"},
+		},
+		Organizations: []*controlplanev1.OrganizationDefinition{
+			{Code: "ACME"},
+		},
+		InternalAccounts: []*controlplanev1.InternalAccountDefinition{
+			{Code: "SUSPENSE"},
+		},
+		ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+			{ConnectionId: "stripe-1"},
+		},
+		InstructionRoutes: []*controlplanev1.InstructionRouteConfig{
+			{InstructionType: "payment"},
+		},
+		SystemCodes: map[ResourceType]map[string]bool{
+			ResourceInstrument: {"SYS_GBP": true}, // only instruments filtered
+		},
+	}
+	result := filterTenantOwned(live)
+	require.NotNil(t, result)
+
+	assert.Len(t, result.MarketDataSources, 1)
+	assert.Len(t, result.MarketDataSets, 1)
+	assert.Len(t, result.Organizations, 1)
+	assert.Len(t, result.InternalAccounts, 1)
+	assert.Len(t, result.ProviderConnections, 1)
+	assert.Len(t, result.InstructionRoutes, 1)
+}
+
+func TestFilterTenantOwned_PreservesSystemAndPlatformRefMaps(t *testing.T) {
+	systemCodes := map[ResourceType]map[string]bool{
+		ResourceInstrument: {"SYS_GBP": true},
+	}
+	platformRefs := map[ResourceType]map[string]bool{
+		ResourceSaga: {"override_saga": true},
+	}
+	live := &LiveState{
+		SystemCodes:  systemCodes,
+		PlatformRefs: platformRefs,
+	}
+	result := filterTenantOwned(live)
+	assert.Equal(t, systemCodes, result.SystemCodes)
+	assert.Equal(t, platformRefs, result.PlatformRefs)
+}
+
+// --- helpers ---
+
+func instrumentCodes(instruments []*controlplanev1.InstrumentDefinition) []string {
+	codes := make([]string, len(instruments))
+	for i, inst := range instruments {
+		codes[i] = inst.GetCode()
+	}
+	return codes
+}
+
+func sagaNames(sagas []*controlplanev1.SagaDefinition) []string {
+	names := make([]string, len(sagas))
+	for i, s := range sagas {
+		names[i] = s.GetName()
+	}
+	return names
+}

--- a/services/control-plane/internal/differ/live_state_filter_test.go
+++ b/services/control-plane/internal/differ/live_state_filter_test.go
@@ -152,40 +152,78 @@ func TestFilterTenantOwned_MultipleTypes(t *testing.T) {
 	assert.Equal(t, "tenant_saga", result.Sagas[0].GetName())
 }
 
-func TestFilterTenantOwned_NonFilteredResourcesPreserved(t *testing.T) {
-	// MarketDataSources, MarketDataSets, Organizations, etc. are passed through unchanged.
+func TestFilterTenantOwned_AllResourceTypesFiltered(t *testing.T) {
+	// SystemCodes can filter any resource type. Verify all 9 types are filtered.
 	live := &LiveState{
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{Code: "TENANT_GBP"},
+			{Code: "SYS_GBP"},
+		},
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{Code: "TENANT_AT"},
+			{Code: "SYS_AT"},
+		},
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "tenant_saga"},
+			{Name: "sys_saga"},
+		},
 		MarketDataSources: []*controlplanev1.MarketDataSourceDefinition{
-			{Code: "ECB"},
+			{Code: "TENANT_SRC"},
+			{Code: "SYS_SRC"},
 		},
 		MarketDataSets: []*controlplanev1.MarketDataSetDefinition{
-			{Code: "FX_RATES"},
+			{Code: "TENANT_SET"},
+			{Code: "SYS_SET"},
 		},
 		Organizations: []*controlplanev1.OrganizationDefinition{
-			{Code: "ACME"},
+			{Code: "TENANT_ORG"},
+			{Code: "SYS_ORG"},
 		},
 		InternalAccounts: []*controlplanev1.InternalAccountDefinition{
-			{Code: "SUSPENSE"},
+			{Code: "TENANT_ACCT"},
+			{Code: "SYS_ACCT"},
 		},
 		ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
-			{ConnectionId: "stripe-1"},
+			{ConnectionId: "tenant-conn"},
+			{ConnectionId: "sys-conn"},
 		},
 		InstructionRoutes: []*controlplanev1.InstructionRouteConfig{
-			{InstructionType: "payment"},
+			{InstructionType: "tenant-route"},
+			{InstructionType: "sys-route"},
 		},
 		SystemCodes: map[ResourceType]map[string]bool{
-			ResourceInstrument: {"SYS_GBP": true}, // only instruments filtered
+			ResourceInstrument:         {"SYS_GBP": true},
+			ResourceAccountType:        {"SYS_AT": true},
+			ResourceSaga:               {"sys_saga": true},
+			ResourceMarketDataSource:   {"SYS_SRC": true},
+			ResourceMarketDataSet:      {"SYS_SET": true},
+			ResourceOrganization:       {"SYS_ORG": true},
+			ResourceInternalAccount:    {"SYS_ACCT": true},
+			ResourceProviderConnection: {"sys-conn": true},
+			ResourceInstructionRoute:   {"sys-route": true},
 		},
 	}
 	result := filterTenantOwned(live)
 	require.NotNil(t, result)
 
+	assert.Len(t, result.Instruments, 1)
+	assert.Equal(t, "TENANT_GBP", result.Instruments[0].GetCode())
+	assert.Len(t, result.AccountTypes, 1)
+	assert.Equal(t, "TENANT_AT", result.AccountTypes[0].GetCode())
+	assert.Len(t, result.Sagas, 1)
+	assert.Equal(t, "tenant_saga", result.Sagas[0].GetName())
 	assert.Len(t, result.MarketDataSources, 1)
+	assert.Equal(t, "TENANT_SRC", result.MarketDataSources[0].GetCode())
 	assert.Len(t, result.MarketDataSets, 1)
+	assert.Equal(t, "TENANT_SET", result.MarketDataSets[0].GetCode())
 	assert.Len(t, result.Organizations, 1)
+	assert.Equal(t, "TENANT_ORG", result.Organizations[0].GetCode())
 	assert.Len(t, result.InternalAccounts, 1)
+	assert.Equal(t, "TENANT_ACCT", result.InternalAccounts[0].GetCode())
 	assert.Len(t, result.ProviderConnections, 1)
+	assert.Equal(t, "tenant-conn", result.ProviderConnections[0].GetConnectionId())
 	assert.Len(t, result.InstructionRoutes, 1)
+	assert.Equal(t, "tenant-route", result.InstructionRoutes[0].GetInstructionType())
 }
 
 func TestFilterTenantOwned_PreservesSystemAndPlatformRefMaps(t *testing.T) {

--- a/services/control-plane/internal/differ/manifest_differ_live.go
+++ b/services/control-plane/internal/differ/manifest_differ_live.go
@@ -54,7 +54,6 @@ func (d *ManifestDiffer) DiffAgainstLiveState(ctx context.Context, tenantID stri
 	return plan, nil
 }
 
-
 func (d *ManifestDiffer) diffInstrumentsAgainstLive(live *LiveState, manifest *controlplanev1.Manifest, plan *DiffPlan) {
 	liveMap := make(map[string]*controlplanev1.InstrumentDefinition)
 	for _, inst := range live.Instruments {

--- a/services/control-plane/internal/differ/manifest_differ_live.go
+++ b/services/control-plane/internal/differ/manifest_differ_live.go
@@ -30,6 +30,8 @@ func (d *ManifestDiffer) DiffAgainstLiveState(ctx context.Context, tenantID stri
 		return nil, fmt.Errorf("query live state: %w", err)
 	}
 
+	live = filterTenantOwned(live)
+
 	plan := &DiffPlan{}
 
 	d.diffInstrumentsAgainstLive(live, manifest, plan)
@@ -52,24 +54,10 @@ func (d *ManifestDiffer) DiffAgainstLiveState(ctx context.Context, tenantID stri
 	return plan, nil
 }
 
-// isSystemResource checks whether a resource code is marked as system-managed in the live state.
-func isSystemResource(live *LiveState, rt ResourceType, code string) bool {
-	if live.SystemCodes == nil {
-		return false
-	}
-	codes, ok := live.SystemCodes[rt]
-	if !ok {
-		return false
-	}
-	return codes[code]
-}
 
 func (d *ManifestDiffer) diffInstrumentsAgainstLive(live *LiveState, manifest *controlplanev1.Manifest, plan *DiffPlan) {
 	liveMap := make(map[string]*controlplanev1.InstrumentDefinition)
 	for _, inst := range live.Instruments {
-		if isSystemResource(live, ResourceInstrument, inst.GetCode()) {
-			continue
-		}
 		liveMap[inst.GetCode()] = inst
 	}
 	desiredMap := instrumentMap(manifest.GetInstruments())
@@ -117,9 +105,6 @@ func (d *ManifestDiffer) diffInstrumentsAgainstLive(live *LiveState, manifest *c
 func (d *ManifestDiffer) diffAccountTypesAgainstLive(live *LiveState, manifest *controlplanev1.Manifest, plan *DiffPlan) {
 	liveMap := make(map[string]*controlplanev1.AccountTypeDefinition)
 	for _, at := range live.AccountTypes {
-		if isSystemResource(live, ResourceAccountType, at.GetCode()) {
-			continue
-		}
 		liveMap[at.GetCode()] = at
 	}
 	desiredMap := accountTypeMap(manifest.GetAccountTypes())
@@ -167,9 +152,6 @@ func (d *ManifestDiffer) diffAccountTypesAgainstLive(live *LiveState, manifest *
 func (d *ManifestDiffer) diffSagasAgainstLive(live *LiveState, manifest *controlplanev1.Manifest, plan *DiffPlan) {
 	liveMap := make(map[string]*controlplanev1.SagaDefinition)
 	for _, s := range live.Sagas {
-		if isSystemResource(live, ResourceSaga, s.GetName()) {
-			continue
-		}
 		liveMap[s.GetName()] = s
 	}
 	desiredMap := sagaMap(manifest.GetSagas())
@@ -217,9 +199,6 @@ func (d *ManifestDiffer) diffSagasAgainstLive(live *LiveState, manifest *control
 func (d *ManifestDiffer) diffMarketDataSourcesAgainstLive(live *LiveState, manifest *controlplanev1.Manifest, plan *DiffPlan) {
 	liveMap := make(map[string]*controlplanev1.MarketDataSourceDefinition)
 	for _, s := range live.MarketDataSources {
-		if isSystemResource(live, ResourceMarketDataSource, s.GetCode()) {
-			continue
-		}
 		liveMap[s.GetCode()] = s
 	}
 	desiredMap := marketDataSourceMap(manifest.GetMarketData().GetSources())
@@ -267,9 +246,6 @@ func (d *ManifestDiffer) diffMarketDataSourcesAgainstLive(live *LiveState, manif
 func (d *ManifestDiffer) diffMarketDataSetsAgainstLive(live *LiveState, manifest *controlplanev1.Manifest, plan *DiffPlan) {
 	liveMap := make(map[string]*controlplanev1.MarketDataSetDefinition)
 	for _, ds := range live.MarketDataSets {
-		if isSystemResource(live, ResourceMarketDataSet, ds.GetCode()) {
-			continue
-		}
 		liveMap[ds.GetCode()] = ds
 	}
 	desiredMap := marketDataSetMap(manifest.GetMarketData().GetDatasets())
@@ -317,9 +293,6 @@ func (d *ManifestDiffer) diffMarketDataSetsAgainstLive(live *LiveState, manifest
 func (d *ManifestDiffer) diffOrganizationsAgainstLive(live *LiveState, manifest *controlplanev1.Manifest, plan *DiffPlan) {
 	liveMap := make(map[string]*controlplanev1.OrganizationDefinition)
 	for _, o := range live.Organizations {
-		if isSystemResource(live, ResourceOrganization, o.GetCode()) {
-			continue
-		}
 		liveMap[o.GetCode()] = o
 	}
 	desiredMap := organizationMap(manifest.GetOrganizations())
@@ -367,9 +340,6 @@ func (d *ManifestDiffer) diffOrganizationsAgainstLive(live *LiveState, manifest 
 func (d *ManifestDiffer) diffInternalAccountsAgainstLive(live *LiveState, manifest *controlplanev1.Manifest, plan *DiffPlan) {
 	liveMap := make(map[string]*controlplanev1.InternalAccountDefinition)
 	for _, a := range live.InternalAccounts {
-		if isSystemResource(live, ResourceInternalAccount, a.GetCode()) {
-			continue
-		}
 		liveMap[a.GetCode()] = a
 	}
 	desiredMap := internalAccountMap(manifest.GetInternalAccounts())
@@ -417,9 +387,6 @@ func (d *ManifestDiffer) diffInternalAccountsAgainstLive(live *LiveState, manife
 func (d *ManifestDiffer) diffProviderConnectionsAgainstLive(live *LiveState, manifest *controlplanev1.Manifest, plan *DiffPlan) {
 	liveMap := make(map[string]*controlplanev1.ProviderConnectionConfig)
 	for _, c := range live.ProviderConnections {
-		if isSystemResource(live, ResourceProviderConnection, c.GetConnectionId()) {
-			continue
-		}
 		liveMap[c.GetConnectionId()] = c
 	}
 	desiredMap := providerConnectionMap(manifest.GetOperationalGateway().GetProviderConnections())
@@ -467,9 +434,6 @@ func (d *ManifestDiffer) diffProviderConnectionsAgainstLive(live *LiveState, man
 func (d *ManifestDiffer) diffInstructionRoutesAgainstLive(live *LiveState, manifest *controlplanev1.Manifest, plan *DiffPlan) {
 	liveMap := make(map[string]*controlplanev1.InstructionRouteConfig)
 	for _, r := range live.InstructionRoutes {
-		if isSystemResource(live, ResourceInstructionRoute, r.GetInstructionType()) {
-			continue
-		}
 		liveMap[r.GetInstructionType()] = r
 	}
 	desiredMap := instructionRouteMap(manifest.GetOperationalGateway().GetInstructionRoutes())


### PR DESCRIPTION
## Summary

- Add `PlatformRefs map[ResourceType]map[string]bool` to `LiveState` to track tenant overrides of platform defaults (is_system=false with platform_ref in the service layer)
- Implement `filterTenantOwned` in `live_state.go` that removes system-managed resources (SystemCodes entries) from resource slices before diff planning runs
- Move filtering from per-function `isSystemResource` checks to a single pre-diff `filterTenantOwned` call at the start of `DiffAgainstLiveState`
- Remove now-redundant `isSystemResource` function

## Key behavior

- `is_system=true` resources (in SystemCodes) are removed from LiveState slices before any diff computation
- Saga overrides (`is_system=false` with `platform_ref`) are naturally retained - they are not in SystemCodes and pass through `filterTenantOwned` unchanged
- Regular tenant resources (neither in SystemCodes nor PlatformRefs) pass through unchanged

## Test plan

- [x] `TestFilterTenantOwned_*` - 9 new unit tests directly exercising `filterTenantOwned`
  - nil/empty SystemCodes (no filtering)
  - instruments, account types, sagas filtered independently
  - saga override scenario: platform_saga filtered, override_saga retained
  - multiple resource types filtered simultaneously
  - non-filtered resource types (MarketData, Organizations, etc.) preserved unchanged
- [x] All existing `TestDiffAgainstLiveState_System*` tests continue to pass via the pre-diff filter path