### PR TITLE
feat: executor receives planned actions from diff

### DIFF
--- a/services/control-plane/internal/applier/executor.go
+++ b/services/control-plane/internal/applier/executor.go
@@ -10,9 +10,19 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/services/control-plane/internal/differ"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
 )
+
+// PlannedResourceAction pairs a resource identifier with the diff action
+// computed by the manifest differ. It is used to communicate which resources
+// need to be acted upon and what kind of change is required.
+type PlannedResourceAction struct {
+	ResourceType differ.ResourceType
+	ResourceCode string
+	Action       differ.ActionType
+}
 
 // ManifestExecutor orchestrates the ApplyManifest saga for a tenant.
 // It loads the saga definition (with platform default fallback per ADR-0028),
@@ -144,6 +154,7 @@ type InstrumentInput struct {
 	Dimension     string
 	DecimalPlaces int
 	Description   string
+	Action        string // Diff action: CREATE, UPDATE, DEPRECATE (empty for legacy path)
 }
 
 // AccountTypeInput represents an account type to register and provision.
@@ -161,6 +172,7 @@ type AccountTypeInput struct {
 	EligibilityCEL          string
 	AttributeSchema         string
 	ValuationMethods        []ValuationMethodInput
+	Action                  string
 }
 
 // ValuationMethodInput represents a valuation method template for an account type.
@@ -176,6 +188,7 @@ type ValuationRuleInput struct {
 	RuleType       string
 	Expression     string
 	Description    string
+	Action         string
 }
 
 // SagaDefinitionInput represents a saga definition to register.
@@ -185,6 +198,7 @@ type SagaDefinitionInput struct {
 	Description string
 	Script      string
 	Version     string
+	Action      string
 }
 
 // ProviderConnectionInput represents a provider connection to upsert.
@@ -198,6 +212,7 @@ type ProviderConnectionInput struct {
 	AuthConfig      map[string]any
 	RetryPolicy     map[string]any
 	RateLimitConfig map[string]any
+	Action          string
 }
 
 // InstructionRouteInput represents an instruction route to upsert.
@@ -209,6 +224,7 @@ type InstructionRouteInput struct {
 	InboundMapping       string
 	HTTPMethod           string
 	PathTemplate         string
+	Action               string
 }
 
 // MarketDataSourceInput represents a market data source to register.
@@ -217,6 +233,7 @@ type MarketDataSourceInput struct {
 	Name        string
 	Description string
 	TrustLevel  int
+	Action      string
 }
 
 // MarketDataSetInput represents a market data set to register and activate.
@@ -229,6 +246,7 @@ type MarketDataSetInput struct {
 	Description             string
 	ValidationExpression    string
 	ResolutionKeyExpression string
+	Action                  string
 }
 
 // OrganizationInput represents an organization to register.
@@ -241,6 +259,7 @@ type OrganizationInput struct {
 	ExternalReferenceType string
 	PartyType             string
 	Attributes            map[string]string
+	Action                string
 }
 
 // InternalAccountInput represents an internal account to initiate.
@@ -250,6 +269,7 @@ type InternalAccountInput struct {
 	InstrumentCode    string
 	OwnerOrganization string
 	Description       string
+	Action            string
 }
 
 // ApplyManifestResult contains the result of a manifest application.
@@ -461,6 +481,7 @@ func convertInstruments(instruments []InstrumentInput) []interface{} {
 			"dimension":      inst.Dimension,
 			"decimal_places": inst.DecimalPlaces,
 			"description":    inst.Description,
+			"action":         inst.Action,
 		}
 	}
 	return result
@@ -490,6 +511,7 @@ func convertAccountTypes(accountTypes []AccountTypeInput) []interface{} {
 			"eligibility_cel":           at.EligibilityCEL,
 			"attribute_schema":          at.AttributeSchema,
 			"valuation_methods":         vmethods,
+			"action":                    at.Action,
 		}
 	}
 	return result
@@ -503,6 +525,7 @@ func convertMarketDataSources(sources []MarketDataSourceInput) []interface{} {
 			"name":        src.Name,
 			"description": src.Description,
 			"trust_level": src.TrustLevel,
+			"action":      src.Action,
 		}
 	}
 	return result
@@ -520,6 +543,7 @@ func convertMarketDataSets(dataSets []MarketDataSetInput) []interface{} {
 			"description":               ds.Description,
 			"validation_expression":     ds.ValidationExpression,
 			"resolution_key_expression": ds.ResolutionKeyExpression,
+			"action":                    ds.Action,
 		}
 	}
 	return result
@@ -534,6 +558,7 @@ func convertValuationRules(rules []ValuationRuleInput) []interface{} {
 			"rule_type":       vr.RuleType,
 			"expression":      vr.Expression,
 			"description":     vr.Description,
+			"action":          vr.Action,
 		}
 	}
 	return result
@@ -555,6 +580,7 @@ func convertOrganizations(organizations []OrganizationInput) []interface{} {
 			"external_reference_type": org.ExternalReferenceType,
 			"party_type":              org.PartyType,
 			"attributes":              attrs,
+			"action":                  org.Action,
 		}
 	}
 	return result
@@ -569,6 +595,7 @@ func convertInternalAccounts(accounts []InternalAccountInput) []interface{} {
 			"instrument_code":    ia.InstrumentCode,
 			"owner_organization": ia.OwnerOrganization,
 			"description":        ia.Description,
+			"action":             ia.Action,
 		}
 	}
 	return result
@@ -583,6 +610,7 @@ func convertSagaDefinitions(defs []SagaDefinitionInput) []interface{} {
 			"description":  sd.Description,
 			"script":       sd.Script,
 			"version":      sd.Version,
+			"action":       sd.Action,
 		}
 	}
 	return result
@@ -601,6 +629,7 @@ func convertProviderConnections(conns []ProviderConnectionInput) []interface{} {
 			"auth_config":       pc.AuthConfig,
 			"retry_policy":      pc.RetryPolicy,
 			"rate_limit_config": pc.RateLimitConfig,
+			"action":            pc.Action,
 		}
 	}
 	return result
@@ -617,6 +646,7 @@ func convertInstructionRoutes(routes []InstructionRouteInput) []interface{} {
 			"inbound_mapping":        r.InboundMapping,
 			"http_method":            r.HTTPMethod,
 			"path_template":          r.PathTemplate,
+			"action":                 r.Action,
 		}
 	}
 	return result

--- a/services/control-plane/internal/applier/grpc_handler_mappers.go
+++ b/services/control-plane/internal/applier/grpc_handler_mappers.go
@@ -5,6 +5,7 @@ import (
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
 	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	"github.com/meridianhub/meridian/services/control-plane/internal/differ"
 )
 
 // buildExecutorInput converts a Manifest proto into the ApplyManifestInput
@@ -72,6 +73,261 @@ func buildExecutorInput(mf *controlplanev1.Manifest) *ApplyManifestInput {
 	extractOperationalGateway(mf, input)
 
 	return input
+}
+
+// buildExecutorInputFromPlan converts a Manifest proto into ApplyManifestInput using
+// a DiffPlan to filter resources. Only resources with actionable changes (CREATE,
+// UPDATE, DEPRECATE) are included. NO_CHANGE and DELETE resources are excluded.
+// Each included resource carries its Action field so handlers can behave differently.
+func buildExecutorInputFromPlan(mf *controlplanev1.Manifest, plan *differ.DiffPlan) *ApplyManifestInput {
+	// Build a lookup of actionable resources: resourceType+code -> action
+	actionable := make(map[string]differ.ActionType, len(plan.Actions))
+	for _, a := range plan.Actions {
+		if a.Action == differ.ActionNoChange || a.Action == differ.ActionDelete {
+			continue
+		}
+		actionable[resourceKey(a.ResourceType, a.ResourceCode)] = a.Action
+	}
+
+	input := &ApplyManifestInput{
+		ManifestVersion: mf.GetVersion(),
+	}
+
+	// Instruments
+	for _, inst := range mf.GetInstruments() {
+		action, ok := actionable[resourceKey(differ.ResourceInstrument, inst.GetCode())]
+		if !ok {
+			continue
+		}
+		dim := instrumentTypeToDimension(inst.GetType(), inst.GetDimensions().GetUnit())
+		if dim == "" {
+			dim = "CURRENCY"
+		}
+		input.Instruments = append(input.Instruments, InstrumentInput{
+			Code:          inst.GetCode(),
+			DisplayName:   inst.GetName(),
+			Dimension:     dim,
+			DecimalPlaces: int(inst.GetDimensions().GetPrecision()),
+			Action:        string(action),
+		})
+	}
+
+	// Account Types
+	for _, acct := range mf.GetAccountTypes() {
+		action, ok := actionable[resourceKey(differ.ResourceAccountType, acct.GetCode())]
+		if !ok {
+			continue
+		}
+		nb := stripEnumPrefix(acct.GetNormalBalance().String(), "NORMAL_BALANCE_")
+		if nb == "UNSPECIFIED" {
+			nb = "DEBIT"
+		}
+		var instrumentCode string
+		if instruments := acct.GetAllowedInstruments(); len(instruments) > 0 {
+			instrumentCode = instruments[0]
+		}
+		input.AccountTypes = append(input.AccountTypes, AccountTypeInput{
+			Code:           acct.GetCode(),
+			DisplayName:    acct.GetName(),
+			NormalBalance:  nb,
+			BehaviorClass:  "HOLDING",
+			InstrumentCode: instrumentCode,
+			AccountType:    acct.GetCode(),
+			Action:         string(action),
+		})
+	}
+
+	// Valuation Rules
+	for _, vr := range mf.GetValuationRules() {
+		key := valRuleKeyForMapper(vr.GetFromInstrument(), vr.GetToInstrument())
+		action, ok := actionable[resourceKey(differ.ResourceValuationRule, key)]
+		if !ok {
+			continue
+		}
+		input.ValuationRules = append(input.ValuationRules, ValuationRuleInput{
+			FromInstrument: vr.GetFromInstrument(),
+			ToInstrument:   vr.GetToInstrument(),
+			RuleType:       vr.GetMethod().String(),
+			Action:         string(action),
+		})
+	}
+
+	// Market Data
+	extractMarketDataFromPlan(mf, input, actionable)
+
+	// Organizations and Internal Accounts
+	extractPartyAndAccountsFromPlan(mf, input, actionable)
+
+	// Saga Definitions
+	for _, saga := range mf.GetSagas() {
+		action, ok := actionable[resourceKey(differ.ResourceSaga, saga.GetName())]
+		if !ok {
+			continue
+		}
+		input.SagaDefinitions = append(input.SagaDefinitions, SagaDefinitionInput{
+			Name:   saga.GetName(),
+			Script: saga.GetScript(),
+			Action: string(action),
+		})
+	}
+
+	// Operational Gateway
+	extractOperationalGatewayFromPlan(mf, input, actionable)
+
+	return input
+}
+
+// resourceKey builds a lookup key for matching diff actions to manifest resources.
+func resourceKey(rt differ.ResourceType, code string) string {
+	return string(rt) + ":" + code
+}
+
+// extractMarketDataFromPlan converts market data resources filtered by the action map.
+func extractMarketDataFromPlan(mf *controlplanev1.Manifest, input *ApplyManifestInput, actionable map[string]differ.ActionType) {
+	md := mf.GetMarketData()
+	if md == nil {
+		return
+	}
+	for _, src := range md.GetSources() {
+		action, ok := actionable[resourceKey(differ.ResourceMarketDataSource, src.GetCode())]
+		if !ok {
+			continue
+		}
+		input.MarketDataSources = append(input.MarketDataSources, MarketDataSourceInput{
+			Code:        src.GetCode(),
+			Name:        src.GetName(),
+			Description: src.GetDescription(),
+			TrustLevel:  int(src.GetTrustLevel()),
+			Action:      string(action),
+		})
+	}
+	for _, ds := range md.GetDatasets() {
+		action, ok := actionable[resourceKey(differ.ResourceMarketDataSet, ds.GetCode())]
+		if !ok {
+			continue
+		}
+		input.MarketDataSets = append(input.MarketDataSets, MarketDataSetInput{
+			Code:                    ds.GetCode(),
+			Category:                stripEnumPrefix(ds.GetCategory().String(), "DATA_CATEGORY_"),
+			Unit:                    ds.GetUnit(),
+			SourceCode:              ds.GetSourceCode(),
+			DisplayName:             ds.GetDisplayName(),
+			Description:             ds.GetDescription(),
+			ValidationExpression:    ds.GetValidationExpression(),
+			ResolutionKeyExpression: ds.GetResolutionKeyExpression(),
+			Action:                  string(action),
+		})
+	}
+}
+
+// extractPartyAndAccountsFromPlan converts organizations and internal accounts filtered by the action map.
+func extractPartyAndAccountsFromPlan(mf *controlplanev1.Manifest, input *ApplyManifestInput, actionable map[string]differ.ActionType) {
+	for _, org := range mf.GetOrganizations() {
+		action, ok := actionable[resourceKey(differ.ResourceOrganization, org.GetCode())]
+		if !ok {
+			continue
+		}
+		legalName := org.GetLegalName()
+		if legalName == "" {
+			legalName = org.GetName()
+		}
+		if legalName == "" {
+			legalName = org.GetCode()
+		}
+		displayName := org.GetDisplayName()
+		if displayName == "" {
+			displayName = legalName
+		}
+		extRef := org.GetExternalReference()
+		if extRef == "" {
+			extRef = org.GetCode()
+		}
+		input.Organizations = append(input.Organizations, OrganizationInput{
+			Code:                  org.GetCode(),
+			Name:                  org.GetName(),
+			LegalName:             legalName,
+			DisplayName:           displayName,
+			ExternalReference:     extRef,
+			ExternalReferenceType: org.GetExternalReferenceType(),
+			PartyType:             org.GetPartyType(),
+			Attributes:            org.GetAttributes(),
+			Action:                string(action),
+		})
+	}
+	for _, ia := range mf.GetInternalAccounts() {
+		action, ok := actionable[resourceKey(differ.ResourceInternalAccount, ia.GetCode())]
+		if !ok {
+			continue
+		}
+		input.InternalAccounts = append(input.InternalAccounts, InternalAccountInput{
+			Code:              ia.GetCode(),
+			AccountType:       ia.GetAccountType(),
+			InstrumentCode:    ia.GetInstrument(),
+			OwnerOrganization: ia.GetOwnerOrganization(),
+			Description:       ia.GetDescription(),
+			Action:            string(action),
+		})
+	}
+}
+
+// extractOperationalGatewayFromPlan converts operational gateway resources filtered by the action map.
+func extractOperationalGatewayFromPlan(mf *controlplanev1.Manifest, input *ApplyManifestInput, actionable map[string]differ.ActionType) {
+	gw := mf.GetOperationalGateway()
+	if gw == nil {
+		return
+	}
+	for _, conn := range gw.GetProviderConnections() {
+		action, ok := actionable[resourceKey(differ.ResourceProviderConnection, conn.GetConnectionId())]
+		if !ok {
+			continue
+		}
+		pc := ProviderConnectionInput{
+			ConnectionID: conn.GetConnectionId(),
+			ProviderName: conn.GetProviderName(),
+			ProviderType: conn.GetProviderType(),
+			Protocol:     conn.GetProtocol().String(),
+			BaseURL:      conn.GetBaseUrl(),
+			Action:       string(action),
+		}
+		pc.AuthType, pc.AuthConfig = extractAuthConfig(conn.GetAuth())
+		if rp := conn.GetRetryPolicy(); rp != nil {
+			pc.RetryPolicy = map[string]any{
+				"max_attempts":            rp.GetMaxAttempts(),
+				"initial_backoff_seconds": rp.GetInitialBackoffSeconds(),
+				"max_backoff_seconds":     rp.GetMaxBackoffSeconds(),
+				"backoff_multiplier":      rp.GetBackoffMultiplier(),
+			}
+		}
+		if rl := conn.GetRateLimit(); rl != nil {
+			pc.RateLimitConfig = map[string]any{
+				"requests_per_second": rl.GetRequestsPerSecond(),
+				"burst_size":          rl.GetBurstSize(),
+			}
+		}
+		input.ProviderConnections = append(input.ProviderConnections, pc)
+	}
+	for _, route := range gw.GetInstructionRoutes() {
+		action, ok := actionable[resourceKey(differ.ResourceInstructionRoute, route.GetInstructionType())]
+		if !ok {
+			continue
+		}
+		input.InstructionRoutes = append(input.InstructionRoutes, InstructionRouteInput{
+			InstructionType:      route.GetInstructionType(),
+			ConnectionID:         route.GetConnectionId(),
+			FallbackConnectionID: route.GetFallbackConnectionId(),
+			OutboundMapping:      route.GetOutboundMappingId(),
+			InboundMapping:       route.GetInboundMappingId(),
+			HTTPMethod:           route.GetHttpMethod(),
+			PathTemplate:         route.GetPathTemplate(),
+			Action:               string(action),
+		})
+	}
+}
+
+// valRuleKey is imported from differ but we need a local version for the mapper.
+// It produces a stable identifier for a valuation rule (FROM->TO pair).
+func valRuleKeyForMapper(from, to string) string {
+	return strings.ToUpper(from) + "->" + strings.ToUpper(to)
 }
 
 // extractMarketData converts market data sources and data sets from the manifest proto.

--- a/services/control-plane/internal/applier/grpc_handler_mappers.go
+++ b/services/control-plane/internal/applier/grpc_handler_mappers.go
@@ -8,6 +8,9 @@ import (
 	"github.com/meridianhub/meridian/services/control-plane/internal/differ"
 )
 
+// defaultDimension is the fallback dimension for instruments when the type cannot be derived.
+const defaultDimension = "CURRENCY"
+
 // buildExecutorInput converts a Manifest proto into the ApplyManifestInput
 // consumed by the saga-based ManifestExecutor.
 func buildExecutorInput(mf *controlplanev1.Manifest) *ApplyManifestInput {
@@ -22,7 +25,7 @@ func buildExecutorInput(mf *controlplanev1.Manifest) *ApplyManifestInput {
 			// kicks in when the key is absent, not when it's empty. Use CURRENCY
 			// as a safe default so the saga can proceed. A future manifest proto
 			// change should add an explicit dimension field.
-			dim = "CURRENCY"
+			dim = defaultDimension
 		}
 		input.Instruments = append(input.Instruments, InstrumentInput{
 			Code:          inst.GetCode(),
@@ -80,7 +83,26 @@ func buildExecutorInput(mf *controlplanev1.Manifest) *ApplyManifestInput {
 // UPDATE, DEPRECATE) are included. NO_CHANGE and DELETE resources are excluded.
 // Each included resource carries its Action field so handlers can behave differently.
 func buildExecutorInputFromPlan(mf *controlplanev1.Manifest, plan *differ.DiffPlan) *ApplyManifestInput {
-	// Build a lookup of actionable resources: resourceType+code -> action
+	actionable := buildActionableMap(plan)
+
+	input := &ApplyManifestInput{
+		ManifestVersion: mf.GetVersion(),
+	}
+
+	extractInstrumentsFromPlan(mf, input, actionable)
+	extractAccountTypesFromPlan(mf, input, actionable)
+	extractValuationRulesFromPlan(mf, input, actionable)
+	extractMarketDataFromPlan(mf, input, actionable)
+	extractPartyAndAccountsFromPlan(mf, input, actionable)
+	extractSagasFromPlan(mf, input, actionable)
+	extractOperationalGatewayFromPlan(mf, input, actionable)
+
+	return input
+}
+
+// buildActionableMap builds a lookup of resources with actionable changes from a DiffPlan.
+// Only CREATE, UPDATE, and DEPRECATE actions are included; NO_CHANGE and DELETE are excluded.
+func buildActionableMap(plan *differ.DiffPlan) map[string]differ.ActionType {
 	actionable := make(map[string]differ.ActionType, len(plan.Actions))
 	for _, a := range plan.Actions {
 		if a.Action == differ.ActionNoChange || a.Action == differ.ActionDelete {
@@ -88,12 +110,11 @@ func buildExecutorInputFromPlan(mf *controlplanev1.Manifest, plan *differ.DiffPl
 		}
 		actionable[resourceKey(a.ResourceType, a.ResourceCode)] = a.Action
 	}
+	return actionable
+}
 
-	input := &ApplyManifestInput{
-		ManifestVersion: mf.GetVersion(),
-	}
-
-	// Instruments
+// extractInstrumentsFromPlan adds instruments with actionable changes to the input.
+func extractInstrumentsFromPlan(mf *controlplanev1.Manifest, input *ApplyManifestInput, actionable map[string]differ.ActionType) {
 	for _, inst := range mf.GetInstruments() {
 		action, ok := actionable[resourceKey(differ.ResourceInstrument, inst.GetCode())]
 		if !ok {
@@ -101,7 +122,7 @@ func buildExecutorInputFromPlan(mf *controlplanev1.Manifest, plan *differ.DiffPl
 		}
 		dim := instrumentTypeToDimension(inst.GetType(), inst.GetDimensions().GetUnit())
 		if dim == "" {
-			dim = "CURRENCY"
+			dim = defaultDimension
 		}
 		input.Instruments = append(input.Instruments, InstrumentInput{
 			Code:          inst.GetCode(),
@@ -111,8 +132,10 @@ func buildExecutorInputFromPlan(mf *controlplanev1.Manifest, plan *differ.DiffPl
 			Action:        string(action),
 		})
 	}
+}
 
-	// Account Types
+// extractAccountTypesFromPlan adds account types with actionable changes to the input.
+func extractAccountTypesFromPlan(mf *controlplanev1.Manifest, input *ApplyManifestInput, actionable map[string]differ.ActionType) {
 	for _, acct := range mf.GetAccountTypes() {
 		action, ok := actionable[resourceKey(differ.ResourceAccountType, acct.GetCode())]
 		if !ok {
@@ -136,8 +159,10 @@ func buildExecutorInputFromPlan(mf *controlplanev1.Manifest, plan *differ.DiffPl
 			Action:         string(action),
 		})
 	}
+}
 
-	// Valuation Rules
+// extractValuationRulesFromPlan adds valuation rules with actionable changes to the input.
+func extractValuationRulesFromPlan(mf *controlplanev1.Manifest, input *ApplyManifestInput, actionable map[string]differ.ActionType) {
 	for _, vr := range mf.GetValuationRules() {
 		key := valRuleKeyForMapper(vr.GetFromInstrument(), vr.GetToInstrument())
 		action, ok := actionable[resourceKey(differ.ResourceValuationRule, key)]
@@ -151,14 +176,10 @@ func buildExecutorInputFromPlan(mf *controlplanev1.Manifest, plan *differ.DiffPl
 			Action:         string(action),
 		})
 	}
+}
 
-	// Market Data
-	extractMarketDataFromPlan(mf, input, actionable)
-
-	// Organizations and Internal Accounts
-	extractPartyAndAccountsFromPlan(mf, input, actionable)
-
-	// Saga Definitions
+// extractSagasFromPlan adds saga definitions with actionable changes to the input.
+func extractSagasFromPlan(mf *controlplanev1.Manifest, input *ApplyManifestInput, actionable map[string]differ.ActionType) {
 	for _, saga := range mf.GetSagas() {
 		action, ok := actionable[resourceKey(differ.ResourceSaga, saga.GetName())]
 		if !ok {
@@ -170,11 +191,6 @@ func buildExecutorInputFromPlan(mf *controlplanev1.Manifest, plan *differ.DiffPl
 			Action: string(action),
 		})
 	}
-
-	// Operational Gateway
-	extractOperationalGatewayFromPlan(mf, input, actionable)
-
-	return input
 }
 
 // resourceKey builds a lookup key for matching diff actions to manifest resources.
@@ -480,7 +496,7 @@ var unitToDimension = map[string]string{
 func instrumentTypeToDimension(instType controlplanev1.InstrumentType, unit string) string {
 	switch instType {
 	case controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT:
-		return "CURRENCY"
+		return defaultDimension
 	case controlplanev1.InstrumentType_INSTRUMENT_TYPE_VOUCHER:
 		return "COUNT"
 	case controlplanev1.InstrumentType_INSTRUMENT_TYPE_COMMODITY,

--- a/services/control-plane/internal/applier/grpc_handler_mappers_plan_test.go
+++ b/services/control-plane/internal/applier/grpc_handler_mappers_plan_test.go
@@ -398,6 +398,303 @@ func TestPlannedResourceAction_Fields(t *testing.T) {
 	assert.Equal(t, differ.ActionCreate, pra.Action)
 }
 
+func TestBuildExecutorInputFromPlan_OrganizationFallbacks(t *testing.T) {
+	tests := []struct {
+		name                string
+		org                 *controlplanev1.OrganizationDefinition
+		expectedLegalName   string
+		expectedDisplayName string
+		expectedExtRef      string
+	}{
+		{
+			name: "all fields populated",
+			org: &controlplanev1.OrganizationDefinition{
+				Code:              "ACME",
+				Name:              "Acme Corp",
+				LegalName:         strPtr("Acme Corporation"),
+				DisplayName:       strPtr("Acme"),
+				ExternalReference: strPtr("LEI-001"),
+			},
+			expectedLegalName:   "Acme Corporation",
+			expectedDisplayName: "Acme",
+			expectedExtRef:      "LEI-001",
+		},
+		{
+			name: "legal_name falls back to name",
+			org: &controlplanev1.OrganizationDefinition{
+				Code: "ACME",
+				Name: "Acme Corp",
+			},
+			expectedLegalName:   "Acme Corp",
+			expectedDisplayName: "Acme Corp",
+			expectedExtRef:      "ACME",
+		},
+		{
+			name: "legal_name falls back to code when name empty",
+			org: &controlplanev1.OrganizationDefinition{
+				Code: "ACME",
+			},
+			expectedLegalName:   "ACME",
+			expectedDisplayName: "ACME",
+			expectedExtRef:      "ACME",
+		},
+		{
+			name: "display_name falls back to legal_name",
+			org: &controlplanev1.OrganizationDefinition{
+				Code:      "ACME",
+				LegalName: strPtr("Acme Corporation"),
+			},
+			expectedLegalName:   "Acme Corporation",
+			expectedDisplayName: "Acme Corporation",
+			expectedExtRef:      "ACME",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mf := &controlplanev1.Manifest{
+				Version:       "1.0",
+				Organizations: []*controlplanev1.OrganizationDefinition{tt.org},
+			}
+			plan := &differ.DiffPlan{
+				Actions: []differ.PlannedAction{
+					{ResourceType: differ.ResourceOrganization, ResourceCode: "ACME", Action: differ.ActionCreate},
+				},
+			}
+
+			input := buildExecutorInputFromPlan(mf, plan)
+
+			require.Len(t, input.Organizations, 1)
+			assert.Equal(t, tt.expectedLegalName, input.Organizations[0].LegalName)
+			assert.Equal(t, tt.expectedDisplayName, input.Organizations[0].DisplayName)
+			assert.Equal(t, tt.expectedExtRef, input.Organizations[0].ExternalReference)
+			assert.Equal(t, "CREATE", input.Organizations[0].Action)
+		})
+	}
+}
+
+func strPtr(s string) *string { return &s }
+
+func TestBuildExecutorInputFromPlan_InternalAccounts(t *testing.T) {
+	mf := &controlplanev1.Manifest{
+		Version: "1.0",
+		InternalAccounts: []*controlplanev1.InternalAccountDefinition{
+			{
+				Code:              "REVENUE_GBP",
+				AccountType:       "REVENUE",
+				Instrument:        "GBP",
+				OwnerOrganization: "ACME",
+				Description:       "Revenue account",
+			},
+			{
+				Code:        "CLEARING_USD",
+				AccountType: "CLEARING",
+				Instrument:  "USD",
+			},
+		},
+	}
+
+	plan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInternalAccount, ResourceCode: "REVENUE_GBP", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceInternalAccount, ResourceCode: "CLEARING_USD", Action: differ.ActionNoChange},
+		},
+	}
+
+	input := buildExecutorInputFromPlan(mf, plan)
+
+	require.Len(t, input.InternalAccounts, 1)
+	assert.Equal(t, "REVENUE_GBP", input.InternalAccounts[0].Code)
+	assert.Equal(t, "REVENUE", input.InternalAccounts[0].AccountType)
+	assert.Equal(t, "GBP", input.InternalAccounts[0].InstrumentCode)
+	assert.Equal(t, "ACME", input.InternalAccounts[0].OwnerOrganization)
+	assert.Equal(t, "Revenue account", input.InternalAccounts[0].Description)
+	assert.Equal(t, "CREATE", input.InternalAccounts[0].Action)
+}
+
+func TestBuildExecutorInputFromPlan_SagaDefinitions(t *testing.T) {
+	mf := &controlplanev1.Manifest{
+		Version: "1.0",
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "deposit", Script: "def exec(): pass"},
+			{Name: "withdraw", Script: "def exec(): pass"},
+		},
+	}
+
+	plan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceSaga, ResourceCode: "deposit", Action: differ.ActionUpdate},
+			{ResourceType: differ.ResourceSaga, ResourceCode: "withdraw", Action: differ.ActionNoChange},
+		},
+	}
+
+	input := buildExecutorInputFromPlan(mf, plan)
+
+	require.Len(t, input.SagaDefinitions, 1)
+	assert.Equal(t, "deposit", input.SagaDefinitions[0].Name)
+	assert.Equal(t, "def exec(): pass", input.SagaDefinitions[0].Script)
+	assert.Equal(t, "UPDATE", input.SagaDefinitions[0].Action)
+}
+
+func TestBuildExecutorInputFromPlan_InstrumentDimensionFallback(t *testing.T) {
+	// Test the defaultDimension fallback when instrument type is unspecified
+	mf := &controlplanev1.Manifest{
+		Version: "1.0",
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{
+				Code: "UNKNOWN",
+				Name: "Unknown Instrument",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_UNSPECIFIED,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "",
+					Precision: 2,
+				},
+			},
+		},
+	}
+
+	plan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "UNKNOWN", Action: differ.ActionCreate},
+		},
+	}
+
+	input := buildExecutorInputFromPlan(mf, plan)
+
+	require.Len(t, input.Instruments, 1)
+	assert.Equal(t, "CURRENCY", input.Instruments[0].Dimension)
+}
+
+func TestBuildExecutorInputFromPlan_AccountTypeUnspecifiedBalance(t *testing.T) {
+	mf := &controlplanev1.Manifest{
+		Version: "1.0",
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{
+				Code:          "MISC",
+				Name:          "Miscellaneous",
+				NormalBalance: controlplanev1.NormalBalance_NORMAL_BALANCE_UNSPECIFIED,
+			},
+		},
+	}
+
+	plan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceAccountType, ResourceCode: "MISC", Action: differ.ActionCreate},
+		},
+	}
+
+	input := buildExecutorInputFromPlan(mf, plan)
+
+	require.Len(t, input.AccountTypes, 1)
+	assert.Equal(t, "DEBIT", input.AccountTypes[0].NormalBalance)
+}
+
+func TestBuildExecutorInputFromPlan_OperationalGatewayWithAuth(t *testing.T) {
+	mf := &controlplanev1.Manifest{
+		Version: "1.0",
+		OperationalGateway: &controlplanev1.OperationalGatewayConfig{
+			ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+				{
+					ConnectionId: "api-conn",
+					ProviderName: "API Provider",
+					Protocol:     controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_HTTPS,
+					BaseUrl:      "https://api.example.com",
+					Auth: &controlplanev1.AuthConfigManifest{
+						AuthConfig: &controlplanev1.AuthConfigManifest_ApiKey{
+							ApiKey: &controlplanev1.ApiKeyAuthConfig{
+								HeaderName:      "Authorization",
+								ApiKeySecretRef: "secret-ref",
+							},
+						},
+					},
+					RetryPolicy: &controlplanev1.RetryPolicyConfig{
+						MaxAttempts: 3,
+					},
+					RateLimit: &controlplanev1.RateLimitConfig{
+						RequestsPerSecond: 100,
+						BurstSize:         10,
+					},
+				},
+			},
+		},
+	}
+
+	plan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceProviderConnection, ResourceCode: "api-conn", Action: differ.ActionCreate},
+		},
+	}
+
+	input := buildExecutorInputFromPlan(mf, plan)
+
+	require.Len(t, input.ProviderConnections, 1)
+	pc := input.ProviderConnections[0]
+	assert.Equal(t, "api-conn", pc.ConnectionID)
+	assert.Equal(t, "api_key", pc.AuthType)
+	assert.Equal(t, "Authorization", pc.AuthConfig["header_name"])
+	assert.Equal(t, int32(3), pc.RetryPolicy["max_attempts"])
+	assert.Equal(t, float64(100), pc.RateLimitConfig["requests_per_second"])
+	assert.Equal(t, "CREATE", pc.Action)
+}
+
+func TestBuildExecutorInputFromPlan_ValuationRulesIncluded(t *testing.T) {
+	mf := &controlplanev1.Manifest{
+		Version: "1.0",
+		ValuationRules: []*controlplanev1.ValuationRule{
+			{
+				FromInstrument: "KWH",
+				ToInstrument:   "GBP",
+				Method:         controlplanev1.ValuationMethod_VALUATION_METHOD_SPOT_RATE,
+			},
+			{
+				FromInstrument: "USD",
+				ToInstrument:   "EUR",
+				Method:         controlplanev1.ValuationMethod_VALUATION_METHOD_FIXED,
+			},
+		},
+	}
+
+	plan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceValuationRule, ResourceCode: "KWH->GBP", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceValuationRule, ResourceCode: "USD->EUR", Action: differ.ActionNoChange},
+		},
+	}
+
+	input := buildExecutorInputFromPlan(mf, plan)
+
+	require.Len(t, input.ValuationRules, 1)
+	assert.Equal(t, "KWH", input.ValuationRules[0].FromInstrument)
+	assert.Equal(t, "GBP", input.ValuationRules[0].ToInstrument)
+	assert.Equal(t, "CREATE", input.ValuationRules[0].Action)
+}
+
+func TestBuildExecutorInputFromPlan_MarketDataNoConfig(t *testing.T) {
+	// Manifest with no MarketData section
+	mf := &controlplanev1.Manifest{
+		Version: "1.0",
+	}
+	plan := &differ.DiffPlan{}
+
+	input := buildExecutorInputFromPlan(mf, plan)
+
+	assert.Empty(t, input.MarketDataSources)
+	assert.Empty(t, input.MarketDataSets)
+}
+
+func TestBuildExecutorInputFromPlan_OperationalGatewayNoConfig(t *testing.T) {
+	// Manifest with no OperationalGateway section
+	mf := &controlplanev1.Manifest{
+		Version: "1.0",
+	}
+	plan := &differ.DiffPlan{}
+
+	input := buildExecutorInputFromPlan(mf, plan)
+
+	assert.Empty(t, input.ProviderConnections)
+	assert.Empty(t, input.InstructionRoutes)
+}
+
 func TestBuildExecutorInputFromPlan_DeleteActionsExcluded(t *testing.T) {
 	// DELETE actions should NOT appear in the executor input.
 	// Deletions are handled separately (e.g., blocked deletion safety checks).

--- a/services/control-plane/internal/applier/grpc_handler_mappers_plan_test.go
+++ b/services/control-plane/internal/applier/grpc_handler_mappers_plan_test.go
@@ -1,0 +1,430 @@
+package applier
+
+import (
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/services/control-plane/internal/differ"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildExecutorInputFromPlan_FiltersNoChangeActions(t *testing.T) {
+	mf := &controlplanev1.Manifest{
+		Version: "2.0",
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{
+				Code: "GBP",
+				Name: "British Pound",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "GBP",
+					Precision: 2,
+				},
+			},
+			{
+				Code: "USD",
+				Name: "US Dollar",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "USD",
+					Precision: 2,
+				},
+			},
+			{
+				Code: "KWH",
+				Name: "Kilowatt Hour",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_COMMODITY,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "kWh",
+					Precision: 4,
+				},
+			},
+		},
+	}
+
+	plan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "GBP", Action: differ.ActionNoChange},
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "USD", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "KWH", Action: differ.ActionUpdate},
+		},
+	}
+
+	input := buildExecutorInputFromPlan(mf, plan)
+
+	require.NotNil(t, input)
+	assert.Equal(t, "2.0", input.ManifestVersion)
+
+	// GBP is NO_CHANGE and should be excluded
+	assert.Len(t, input.Instruments, 2)
+	assert.Equal(t, "USD", input.Instruments[0].Code)
+	assert.Equal(t, "CREATE", input.Instruments[0].Action)
+	assert.Equal(t, "KWH", input.Instruments[1].Code)
+	assert.Equal(t, "UPDATE", input.Instruments[1].Action)
+}
+
+func TestBuildExecutorInputFromPlan_IncludesDeprecateActions(t *testing.T) {
+	mf := &controlplanev1.Manifest{
+		Version: "3.0",
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{
+				Code: "EUR",
+				Name: "Euro",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "EUR",
+					Precision: 2,
+				},
+			},
+		},
+	}
+
+	plan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "EUR", Action: differ.ActionDeprecate},
+		},
+	}
+
+	input := buildExecutorInputFromPlan(mf, plan)
+
+	require.Len(t, input.Instruments, 1)
+	assert.Equal(t, "EUR", input.Instruments[0].Code)
+	assert.Equal(t, "DEPRECATE", input.Instruments[0].Action)
+}
+
+func TestBuildExecutorInputFromPlan_AccountTypes(t *testing.T) {
+	mf := &controlplanev1.Manifest{
+		Version: "1.0",
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{
+				Code:               "CURRENT",
+				Name:               "Current Account",
+				NormalBalance:      controlplanev1.NormalBalance_NORMAL_BALANCE_DEBIT,
+				AllowedInstruments: []string{"GBP"},
+			},
+			{
+				Code:               "SAVINGS",
+				Name:               "Savings Account",
+				NormalBalance:      controlplanev1.NormalBalance_NORMAL_BALANCE_CREDIT,
+				AllowedInstruments: []string{"GBP"},
+			},
+		},
+	}
+
+	plan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceAccountType, ResourceCode: "CURRENT", Action: differ.ActionNoChange},
+			{ResourceType: differ.ResourceAccountType, ResourceCode: "SAVINGS", Action: differ.ActionCreate},
+		},
+	}
+
+	input := buildExecutorInputFromPlan(mf, plan)
+
+	require.Len(t, input.AccountTypes, 1)
+	assert.Equal(t, "SAVINGS", input.AccountTypes[0].Code)
+	assert.Equal(t, "CREATE", input.AccountTypes[0].Action)
+}
+
+func TestBuildExecutorInputFromPlan_MultipleResourceTypes(t *testing.T) {
+	mf := &controlplanev1.Manifest{
+		Version: "4.0",
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{
+				Code: "GBP",
+				Name: "British Pound",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "GBP",
+					Precision: 2,
+				},
+			},
+		},
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{
+				Code:               "CURRENT",
+				Name:               "Current Account",
+				NormalBalance:      controlplanev1.NormalBalance_NORMAL_BALANCE_DEBIT,
+				AllowedInstruments: []string{"GBP"},
+			},
+		},
+		ValuationRules: []*controlplanev1.ValuationRule{
+			{
+				FromInstrument: "KWH",
+				ToInstrument:   "GBP",
+				Method:         controlplanev1.ValuationMethod_VALUATION_METHOD_FIXED,
+			},
+		},
+		Organizations: []*controlplanev1.OrganizationDefinition{
+			{
+				Code: "ACME",
+				Name: "Acme Corp",
+			},
+		},
+		InternalAccounts: []*controlplanev1.InternalAccountDefinition{
+			{
+				Code:        "REVENUE_GBP",
+				AccountType: "CURRENT",
+				Instrument:  "GBP",
+			},
+		},
+		Sagas: []*controlplanev1.SagaDefinition{
+			{
+				Name:   "deposit",
+				Script: "def execute(): pass",
+			},
+		},
+	}
+
+	plan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "GBP", Action: differ.ActionNoChange},
+			{ResourceType: differ.ResourceAccountType, ResourceCode: "CURRENT", Action: differ.ActionUpdate},
+			{ResourceType: differ.ResourceValuationRule, ResourceCode: "KWH->GBP", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceOrganization, ResourceCode: "ACME", Action: differ.ActionNoChange},
+			{ResourceType: differ.ResourceInternalAccount, ResourceCode: "REVENUE_GBP", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceSaga, ResourceCode: "deposit", Action: differ.ActionNoChange},
+		},
+	}
+
+	input := buildExecutorInputFromPlan(mf, plan)
+
+	// GBP instrument: NO_CHANGE -> excluded
+	assert.Empty(t, input.Instruments)
+
+	// CURRENT account type: UPDATE -> included
+	require.Len(t, input.AccountTypes, 1)
+	assert.Equal(t, "CURRENT", input.AccountTypes[0].Code)
+	assert.Equal(t, "UPDATE", input.AccountTypes[0].Action)
+
+	// Valuation rule: CREATE -> included
+	require.Len(t, input.ValuationRules, 1)
+	assert.Equal(t, "KWH", input.ValuationRules[0].FromInstrument)
+	assert.Equal(t, "CREATE", input.ValuationRules[0].Action)
+
+	// ACME org: NO_CHANGE -> excluded
+	assert.Empty(t, input.Organizations)
+
+	// REVENUE_GBP internal account: CREATE -> included
+	require.Len(t, input.InternalAccounts, 1)
+	assert.Equal(t, "REVENUE_GBP", input.InternalAccounts[0].Code)
+	assert.Equal(t, "CREATE", input.InternalAccounts[0].Action)
+
+	// deposit saga: NO_CHANGE -> excluded
+	assert.Empty(t, input.SagaDefinitions)
+}
+
+func TestBuildExecutorInputFromPlan_EmptyPlan(t *testing.T) {
+	mf := &controlplanev1.Manifest{
+		Version: "1.0",
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{
+				Code: "GBP",
+				Name: "British Pound",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "GBP",
+					Precision: 2,
+				},
+			},
+		},
+	}
+
+	plan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "GBP", Action: differ.ActionNoChange},
+		},
+	}
+
+	input := buildExecutorInputFromPlan(mf, plan)
+
+	assert.Equal(t, "1.0", input.ManifestVersion)
+	assert.Empty(t, input.Instruments)
+	assert.Empty(t, input.AccountTypes)
+}
+
+func TestBuildExecutorInputFromPlan_MarketData(t *testing.T) {
+	mf := &controlplanev1.Manifest{
+		Version: "1.0",
+		MarketData: &controlplanev1.MarketDataConfig{
+			Sources: []*controlplanev1.MarketDataSourceDefinition{
+				{Code: "BLOOMBERG", Name: "Bloomberg", TrustLevel: 90},
+				{Code: "REUTERS", Name: "Reuters", TrustLevel: 85},
+			},
+			Datasets: []*controlplanev1.MarketDataSetDefinition{
+				{
+					Code:       "USD_EUR_FX",
+					SourceCode: "BLOOMBERG",
+				},
+			},
+		},
+	}
+
+	plan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceMarketDataSource, ResourceCode: "BLOOMBERG", Action: differ.ActionNoChange},
+			{ResourceType: differ.ResourceMarketDataSource, ResourceCode: "REUTERS", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceMarketDataSet, ResourceCode: "USD_EUR_FX", Action: differ.ActionUpdate},
+		},
+	}
+
+	input := buildExecutorInputFromPlan(mf, plan)
+
+	require.Len(t, input.MarketDataSources, 1)
+	assert.Equal(t, "REUTERS", input.MarketDataSources[0].Code)
+	assert.Equal(t, "CREATE", input.MarketDataSources[0].Action)
+
+	require.Len(t, input.MarketDataSets, 1)
+	assert.Equal(t, "USD_EUR_FX", input.MarketDataSets[0].Code)
+	assert.Equal(t, "UPDATE", input.MarketDataSets[0].Action)
+}
+
+func TestBuildExecutorInputFromPlan_OperationalGateway(t *testing.T) {
+	mf := &controlplanev1.Manifest{
+		Version: "1.0",
+		OperationalGateway: &controlplanev1.OperationalGatewayConfig{
+			ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+				{
+					ConnectionId: "stripe-conn",
+					ProviderName: "Stripe",
+					Protocol:     controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_HTTPS,
+					BaseUrl:      "https://api.stripe.com",
+				},
+				{
+					ConnectionId: "backup-conn",
+					ProviderName: "Backup",
+					Protocol:     controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_HTTPS,
+					BaseUrl:      "https://backup.example.com",
+				},
+			},
+			InstructionRoutes: []*controlplanev1.InstructionRouteConfig{
+				{
+					InstructionType: "payment.initiate",
+					ConnectionId:    "stripe-conn",
+				},
+			},
+		},
+	}
+
+	plan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceProviderConnection, ResourceCode: "stripe-conn", Action: differ.ActionNoChange},
+			{ResourceType: differ.ResourceProviderConnection, ResourceCode: "backup-conn", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceInstructionRoute, ResourceCode: "payment.initiate", Action: differ.ActionUpdate},
+		},
+	}
+
+	input := buildExecutorInputFromPlan(mf, plan)
+
+	require.Len(t, input.ProviderConnections, 1)
+	assert.Equal(t, "backup-conn", input.ProviderConnections[0].ConnectionID)
+	assert.Equal(t, "CREATE", input.ProviderConnections[0].Action)
+
+	require.Len(t, input.InstructionRoutes, 1)
+	assert.Equal(t, "payment.initiate", input.InstructionRoutes[0].InstructionType)
+	assert.Equal(t, "UPDATE", input.InstructionRoutes[0].Action)
+}
+
+func TestBuildExecutorInputFromPlan_ActionPassedToSagaInput(t *testing.T) {
+	mf := &controlplanev1.Manifest{
+		Version: "1.0",
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{
+				Code: "USD",
+				Name: "US Dollar",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "USD",
+					Precision: 2,
+				},
+			},
+		},
+	}
+
+	plan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "USD", Action: differ.ActionUpdate},
+		},
+	}
+
+	input := buildExecutorInputFromPlan(mf, plan)
+	require.Len(t, input.Instruments, 1)
+
+	// Verify action propagates through to saga input
+	executor := &ManifestExecutor{}
+	sagaInput := executor.buildSagaInput(input)
+
+	instruments, ok := sagaInput["instruments"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, instruments, 1)
+
+	inst, ok := instruments[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "UPDATE", inst["action"])
+}
+
+func TestBuildSagaInput_ActionFieldOmittedWhenEmpty(t *testing.T) {
+	executor := &ManifestExecutor{}
+
+	// Legacy path: no action set (from buildExecutorInput)
+	input := &ApplyManifestInput{
+		ManifestVersion: "1",
+		Instruments: []InstrumentInput{
+			{Code: "GBP", DisplayName: "Pound", Dimension: "CURRENCY", DecimalPlaces: 2},
+		},
+	}
+
+	sagaInput := executor.buildSagaInput(input)
+	instruments, ok := sagaInput["instruments"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, instruments, 1)
+
+	inst, ok := instruments[0].(map[string]interface{})
+	require.True(t, ok)
+
+	// When Action is empty, the "action" key should be empty string (legacy behavior)
+	assert.Equal(t, "", inst["action"])
+}
+
+func TestPlannedResourceAction_Fields(t *testing.T) {
+	pra := PlannedResourceAction{
+		ResourceType: differ.ResourceInstrument,
+		ResourceCode: "GBP",
+		Action:       differ.ActionCreate,
+	}
+
+	assert.Equal(t, differ.ResourceInstrument, pra.ResourceType)
+	assert.Equal(t, "GBP", pra.ResourceCode)
+	assert.Equal(t, differ.ActionCreate, pra.Action)
+}
+
+func TestBuildExecutorInputFromPlan_DeleteActionsExcluded(t *testing.T) {
+	// DELETE actions should NOT appear in the executor input.
+	// Deletions are handled separately (e.g., blocked deletion safety checks).
+	mf := &controlplanev1.Manifest{
+		Version: "1.0",
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{
+				Code: "OBSOLETE",
+				Name: "Obsolete Currency",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "OBSOLETE",
+					Precision: 2,
+				},
+			},
+		},
+	}
+
+	plan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "OBSOLETE", Action: differ.ActionDelete},
+		},
+	}
+
+	input := buildExecutorInputFromPlan(mf, plan)
+
+	// DELETE actions are not included - the existing manifest won't contain
+	// deleted resources (they were removed from the new manifest).
+	assert.Empty(t, input.Instruments)
+}


### PR DESCRIPTION
## Summary

- Define `PlannedResourceAction` struct pairing resource type/code with a diff action (CREATE/UPDATE/DEPRECATE)
- Add `Action` field to all resource input structs (`InstrumentInput`, `AccountTypeInput`, etc.) so handlers can distinguish action context
- Create `buildExecutorInputFromPlan` alongside existing `buildExecutorInput` - filters manifest resources using the DiffPlan, only including resources with actionable changes (CREATE/UPDATE/DEPRECATE), excluding NO_CHANGE and DELETE
- Action propagates through `buildSagaInput` converters into the Starlark saga input maps

## Changes Made

**`executor.go`**:
- Added `PlannedResourceAction` struct
- Added `Action string` field to all 10 resource input structs
- Updated all `convert*` functions to pass `action` through to saga input maps

**`grpc_handler_mappers.go`**:
- Added `buildExecutorInputFromPlan(manifest, diffPlan)` - the plan-aware alternative to `buildExecutorInput`
- Added helper extractors (`extractMarketDataFromPlan`, `extractPartyAndAccountsFromPlan`, `extractOperationalGatewayFromPlan`) that filter by action map
- Existing `buildExecutorInput` preserved for backward compatibility (Task 12 will wire the new function)

**`grpc_handler_mappers_plan_test.go`** (new):
- 11 unit tests covering: NO_CHANGE filtering, DEPRECATE inclusion, DELETE exclusion, multi-resource-type filtering, empty plans, market data, operational gateway, action propagation to saga input, legacy path compatibility

## Test plan

- [x] All 11 new tests pass
- [x] Full applier test suite passes (14s, no regressions)
- [x] Differ and planner tests pass
- [ ] CI green