### PR TITLE
fix: adapt CockroachDB DDL for Postgres in migration runner

### DIFF
--- a/internal/migrations/adapt_test.go
+++ b/internal/migrations/adapt_test.go
@@ -1,0 +1,26 @@
+package migrations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdaptCockroachDDLForPostgres_NoChanges(t *testing.T) {
+	input := `CREATE TABLE foo (id UUID PRIMARY KEY);`
+	assert.Equal(t, input, adaptCockroachDDLForPostgres(input))
+}
+
+func TestAdaptCockroachDDLForPostgres_ManifestVersionUniqueConstraint(t *testing.T) {
+	input := `DROP INDEX IF EXISTS uq_manifest_version_version CASCADE;`
+	result := adaptCockroachDDLForPostgres(input)
+	assert.Contains(t, result, "ALTER TABLE manifest_version DROP CONSTRAINT IF EXISTS uq_manifest_version_version")
+	assert.NotContains(t, result, "DROP INDEX")
+}
+
+func TestAdaptCockroachDDLForPostgres_SagaDefinitionUniqueConstraint(t *testing.T) {
+	input := `DROP INDEX IF EXISTS "public"."uq_platform_saga_definition_name" CASCADE;`
+	result := adaptCockroachDDLForPostgres(input)
+	assert.Contains(t, result, `ALTER TABLE "public"."platform_saga_definition" DROP CONSTRAINT IF EXISTS "uq_platform_saga_definition_name"`)
+	assert.NotContains(t, result, "DROP INDEX")
+}

--- a/internal/migrations/adapt_test.go
+++ b/internal/migrations/adapt_test.go
@@ -24,3 +24,21 @@ func TestAdaptCockroachDDLForPostgres_SagaDefinitionUniqueConstraint(t *testing.
 	assert.Contains(t, result, `ALTER TABLE "public"."platform_saga_definition" DROP CONSTRAINT IF EXISTS "uq_platform_saga_definition_name"`)
 	assert.NotContains(t, result, "DROP INDEX")
 }
+
+func TestAdaptCockroachDDLForPostgres_MultiStatementMigration(t *testing.T) {
+	input := `UPDATE manifest_version SET version_new = version::TEXT WHERE version_new IS NULL;
+ALTER TABLE manifest_version ALTER COLUMN version_new SET NOT NULL;
+DROP INDEX IF EXISTS uq_manifest_version_version CASCADE;
+DROP INDEX IF EXISTS idx_manifest_version_version;
+ALTER TABLE manifest_version DROP COLUMN version;`
+
+	result := adaptCockroachDDLForPostgres(input)
+
+	// The DROP INDEX CASCADE for the unique constraint should be rewritten
+	assert.Contains(t, result, "ALTER TABLE manifest_version DROP CONSTRAINT IF EXISTS uq_manifest_version_version")
+	// The regular DROP INDEX (non-unique) should be left unchanged
+	assert.Contains(t, result, "DROP INDEX IF EXISTS idx_manifest_version_version")
+	// Other statements should be untouched
+	assert.Contains(t, result, "UPDATE manifest_version SET version_new")
+	assert.Contains(t, result, "ALTER TABLE manifest_version DROP COLUMN version")
+}

--- a/internal/migrations/adapt_test.go
+++ b/internal/migrations/adapt_test.go
@@ -25,6 +25,22 @@ func TestAdaptCockroachDDLForPostgres_SagaDefinitionUniqueConstraint(t *testing.
 	assert.NotContains(t, result, "DROP INDEX")
 }
 
+func TestAdaptCockroachDDLForPostgres_AddConstraintCheck(t *testing.T) {
+	input := `ALTER TABLE public.my_table ADD CONSTRAINT chk_status CHECK (status IN ('a','b'));`
+	result := adaptCockroachDDLForPostgres(input)
+	assert.Contains(t, result, "DO $compat$ BEGIN")
+	assert.Contains(t, result, "EXCEPTION WHEN duplicate_object THEN NULL")
+	assert.Contains(t, result, "ADD CONSTRAINT chk_status CHECK")
+}
+
+func TestAdaptCockroachDDLForPostgres_AddConstraintIfNotExists(t *testing.T) {
+	input := `ALTER TABLE public.my_table ADD CONSTRAINT IF NOT EXISTS chk_val CHECK (val > 0);`
+	result := adaptCockroachDDLForPostgres(input)
+	assert.Contains(t, result, "DO $compat$ BEGIN")
+	assert.NotContains(t, result, "IF NOT EXISTS")
+	assert.Contains(t, result, "ADD CONSTRAINT chk_val CHECK")
+}
+
 func TestAdaptCockroachDDLForPostgres_MultiStatementMigration(t *testing.T) {
 	input := `UPDATE manifest_version SET version_new = version::TEXT WHERE version_new IS NULL;
 ALTER TABLE manifest_version ALTER COLUMN version_new SET NOT NULL;

--- a/internal/migrations/runner.go
+++ b/internal/migrations/runner.go
@@ -17,6 +17,7 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -601,6 +602,9 @@ func runPostgresPreMigrationFixups(ctx context.Context, superuserDSN string, dri
 // Migrations are written for CockroachDB (production). When running against
 // PostgreSQL (demo, local dev), this function translates known incompatibilities:
 //   - DROP INDEX CASCADE for unique constraints -> ALTER TABLE DROP CONSTRAINT
+//   - ADD CONSTRAINT [IF NOT EXISTS] CHECK on public-schema tables -> idempotent DO block
+//
+// This mirrors shared/platform/testdb/pgx.go:adaptCockroachDDLForPostgres.
 func adaptCockroachDDLForPostgres(sql string) string {
 	// CockroachDB uses DROP INDEX CASCADE for unique constraints;
 	// PostgreSQL requires ALTER TABLE DROP CONSTRAINT.
@@ -612,5 +616,16 @@ func adaptCockroachDDLForPostgres(sql string) string {
 		`DROP INDEX IF EXISTS uq_manifest_version_version CASCADE`,
 		`ALTER TABLE manifest_version DROP CONSTRAINT IF EXISTS uq_manifest_version_version`,
 	)
+
+	// Wrap ADD CONSTRAINT ... CHECK statements targeting public-schema tables in a
+	// DO block that ignores duplicate_object errors. In multi-tenant tests, multiple
+	// schemas apply the same migration against the shared public schema.
+	re := regexp.MustCompile(`(?s)(ALTER TABLE\s+public\.\S+\s+)ADD CONSTRAINT(?:\s+IF NOT EXISTS)?\s+(\S+\s+CHECK\s*\([^;]+?\));`)
+	sql = re.ReplaceAllStringFunc(sql, func(match string) string {
+		inner := strings.Replace(match, "ADD CONSTRAINT IF NOT EXISTS", "ADD CONSTRAINT", 1)
+		inner = strings.TrimSuffix(strings.TrimSpace(inner), ";")
+		return "DO $compat$ BEGIN " + inner + "; EXCEPTION WHEN duplicate_object THEN NULL; END $compat$;"
+	})
+
 	return sql
 }

--- a/internal/migrations/runner.go
+++ b/internal/migrations/runner.go
@@ -400,7 +400,12 @@ func applyDatabaseMigrations(ctx context.Context, dsn, dbName string, migrations
 
 		logger.Info("applying migration", "database", dbName, "service", m.service, "file", m.filename)
 
-		if _, err := conn.Exec(ctx, m.sql); err != nil {
+		sql := m.sql
+		if driver == DriverPostgres {
+			sql = adaptCockroachDDLForPostgres(sql)
+		}
+
+		if _, err := conn.Exec(ctx, sql); err != nil {
 			return fmt.Errorf("execute %s/%s: %w", m.service, m.filename, err)
 		}
 
@@ -589,4 +594,23 @@ func runPostgresPreMigrationFixups(ctx context.Context, superuserDSN string, dri
 	}
 
 	return nil
+}
+
+// adaptCockroachDDLForPostgres rewrites CockroachDB-specific DDL to work on PostgreSQL.
+//
+// Migrations are written for CockroachDB (production). When running against
+// PostgreSQL (demo, local dev), this function translates known incompatibilities:
+//   - DROP INDEX CASCADE for unique constraints -> ALTER TABLE DROP CONSTRAINT
+func adaptCockroachDDLForPostgres(sql string) string {
+	// CockroachDB uses DROP INDEX CASCADE for unique constraints;
+	// PostgreSQL requires ALTER TABLE DROP CONSTRAINT.
+	sql = strings.ReplaceAll(sql,
+		`DROP INDEX IF EXISTS "public"."uq_platform_saga_definition_name" CASCADE`,
+		`ALTER TABLE "public"."platform_saga_definition" DROP CONSTRAINT IF EXISTS "uq_platform_saga_definition_name"`,
+	)
+	sql = strings.ReplaceAll(sql,
+		`DROP INDEX IF EXISTS uq_manifest_version_version CASCADE`,
+		`ALTER TABLE manifest_version DROP CONSTRAINT IF EXISTS uq_manifest_version_version`,
+	)
+	return sql
 }


### PR DESCRIPTION
## Summary

- Adds `adaptCockroachDDLForPostgres` to the production migration runner, mirroring the existing adapter in `shared/platform/testdb`
- When `DB_DRIVER=postgres`, rewrites CockroachDB-specific `DROP INDEX CASCADE` for unique constraints to Postgres-compatible `ALTER TABLE DROP CONSTRAINT`
- Fixes demo deployment failure at the "Run migrations" step

## Context

Migrations are written for CockroachDB (production). The test infrastructure already has `adaptCockroachDDLForPostgres` in `shared/platform/testdb/pgx.go`, but the production runner in `internal/migrations/runner.go` executed SQL as-is. This caused the demo droplet (Postgres) to fail on the version column migration from #2085.

## Test Plan

- [ ] `TestAdaptCockroachDDLForPostgres_*` unit tests pass
- [ ] E2E tests pass (CockroachDB - adapter not invoked)
- [ ] Demo deployment passes the migration step