### PR TITLE
feat: add composite handler marker for post_entries

### DIFF
--- a/docs/spec/saga-contract.md
+++ b/docs/spec/saga-contract.md
@@ -175,6 +175,36 @@ Every handler invocation returns a `map[string]any` to the saga script. The keys
 
 **This is a formal contract.** Saga scripts depend on specific return keys (e.g., `lien_id`, `log_id`, `booking_log_id`). Removing or renaming a return field is a breaking change to all sagas that consume it.
 
+### 2.7 Composite Handlers
+
+Some handlers orchestrate multiple underlying operations rather than mapping to a single proto RPC. These **composite handlers** process variable-length inputs (e.g., arrays of entries), call other handlers iteratively, and aggregate results. They have no single request/response proto message.
+
+Composite handlers are marked explicitly in the schema:
+
+```yaml
+financial_accounting.post_entries:
+  description: "Post double-entry accounting entries to the ledger"
+  compensate: financial_accounting.reverse_entries
+  composite: true
+  params: {}
+```
+
+**Key properties:**
+
+- `composite: true` signals that empty `params: {}` is intentional, not a gap
+- No `proto_ref` - the handler's parameter shape is defined by its implementation, not a proto message
+- Proto type resolution skips composite handlers without error
+- Compensation still applies - composite handlers declare `compensate` or `compensation_strategy` like any other handler
+- The runtime provides composite handlers as DSL builtins (e.g., `posting()`) rather than auto-generated service module methods
+
+**When to use `composite: true`:**
+
+A handler should be marked composite when it iterates over a collection of sub-operations and no single proto message represents its input. The canonical example is `post_entries`, which processes a variable-length array of ledger entries, calling `CaptureLedgerPosting` for each one and aggregating the results.
+
+**When NOT to use `composite: true`:**
+
+If a handler maps to a single proto RPC - even if it triggers downstream operations internally - use `proto_ref`. The composite marker is for handlers whose parameter shape genuinely cannot be represented by one proto message.
+
 ## 3. Trigger Grammar
 
 Sagas bind to execution triggers. The trigger determines *when* a saga runs.

--- a/shared/pkg/saga/schema/handlers.yaml
+++ b/shared/pkg/saga/schema/handlers.yaml
@@ -118,11 +118,10 @@ handlers:
     proto_ref:
       proto_rpc: "meridian.financial_accounting.v1.FinancialAccountingService/InitiateFinancialBookingLog"
 
-  # post_entries is a composite handler (iterates over entries calling CaptureLedgerPosting).
-  # No single proto type; uses legacy inline format.
   financial_accounting.post_entries:
     description: "Post double-entry accounting entries to the ledger"
     compensate: financial_accounting.reverse_entries
+    composite: true
     params: {}
 
   financial_accounting.reverse_entries:

--- a/shared/pkg/saga/schema/handlers_yaml_test.go
+++ b/shared/pkg/saga/schema/handlers_yaml_test.go
@@ -252,8 +252,8 @@ func TestHandlersYAML_CompositePostEntries(t *testing.T) {
 }
 
 func TestHandlersYAML_CompositeHandlerValidation(t *testing.T) {
-	// Verify that a composite handler with empty params and no proto_ref is valid
-	yamlData := []byte(`
+	t.Run("valid composite handler", func(t *testing.T) {
+		yamlData := []byte(`
 service: test
 version: "1.0"
 handlers:
@@ -263,13 +263,31 @@ handlers:
     composite: true
     params: {}
 `)
-	schema, err := Parse(yamlData)
-	require.NoError(t, err, "composite handler with empty params should be valid")
+		schema, err := Parse(yamlData)
+		require.NoError(t, err, "composite handler with empty params should be valid")
 
-	handler := schema.Handlers["test.composite_op"]
-	require.NotNil(t, handler)
-	assert.True(t, handler.IsComposite())
-	assert.False(t, handler.HasProtoRef())
+		handler := schema.Handlers["test.composite_op"]
+		require.NotNil(t, handler)
+		assert.True(t, handler.IsComposite())
+		assert.False(t, handler.HasProtoRef())
+	})
+
+	t.Run("composite with proto_ref is rejected", func(t *testing.T) {
+		yamlData := []byte(`
+service: test
+version: "1.0"
+handlers:
+  test.bad_composite:
+    description: "Invalid: composite with proto_ref"
+    compensation_strategy: none
+    composite: true
+    proto_ref:
+      proto_rpc: "some.Service/Method"
+`)
+		_, err := Parse(yamlData)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "composite handler must not set proto_ref")
+	})
 }
 
 func TestHandlersYAML_SizeReduction(t *testing.T) {

--- a/shared/pkg/saga/schema/handlers_yaml_test.go
+++ b/shared/pkg/saga/schema/handlers_yaml_test.go
@@ -226,7 +226,7 @@ func TestHandlersYAML_ExternalHandlers(t *testing.T) {
 	}
 }
 
-func TestHandlersYAML_LegacyPostEntries(t *testing.T) {
+func TestHandlersYAML_CompositePostEntries(t *testing.T) {
 	yamlPath := filepath.Join(testdataDir(), "handlers.yaml")
 	data, err := os.ReadFile(yamlPath)
 	require.NoError(t, err)
@@ -234,11 +234,42 @@ func TestHandlersYAML_LegacyPostEntries(t *testing.T) {
 	schema, err := Parse(data)
 	require.NoError(t, err)
 
-	// post_entries is a legacy handler (no proto_ref)
 	handler := schema.Handlers["financial_accounting.post_entries"]
 	require.NotNil(t, handler)
-	assert.Nil(t, handler.ProtoRef, "post_entries should not have proto_ref")
+
+	// post_entries is a composite handler: no proto_ref, marked composite
+	assert.True(t, handler.Composite, "post_entries should be marked as composite")
+	assert.True(t, handler.IsComposite(), "IsComposite() should return true")
+	assert.Nil(t, handler.ProtoRef, "composite handler should not have proto_ref")
 	assert.Equal(t, "financial_accounting.reverse_entries", handler.Compensate)
+
+	// Proto resolution should succeed - composite handlers are skipped
+	err = schema.ResolveProtoTypes(protoregistry.GlobalFiles)
+	require.NoError(t, err, "proto resolution should skip composite handlers without error")
+
+	// Params should remain empty (intentionally) after resolution
+	assert.Empty(t, handler.Params, "composite handler params should remain empty after proto resolution")
+}
+
+func TestHandlersYAML_CompositeHandlerValidation(t *testing.T) {
+	// Verify that a composite handler with empty params and no proto_ref is valid
+	yamlData := []byte(`
+service: test
+version: "1.0"
+handlers:
+  test.composite_op:
+    description: "A composite handler"
+    compensation_strategy: none
+    composite: true
+    params: {}
+`)
+	schema, err := Parse(yamlData)
+	require.NoError(t, err, "composite handler with empty params should be valid")
+
+	handler := schema.Handlers["test.composite_op"]
+	require.NotNil(t, handler)
+	assert.True(t, handler.IsComposite())
+	assert.False(t, handler.HasProtoRef())
 }
 
 func TestHandlersYAML_SizeReduction(t *testing.T) {

--- a/shared/pkg/saga/schema/handlers_yaml_test.go
+++ b/shared/pkg/saga/schema/handlers_yaml_test.go
@@ -286,7 +286,7 @@ handlers:
 `)
 		_, err := Parse(yamlData)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "composite handler must not set proto_ref")
+		assert.ErrorIs(t, err, ErrCompositeWithProtoRef)
 	})
 }
 

--- a/shared/pkg/saga/schema/proto_resolve.go
+++ b/shared/pkg/saga/schema/proto_resolve.go
@@ -18,6 +18,9 @@ func (s *Schema) ResolveProtoTypes(files *protoregistry.Files) error {
 	}
 	for handlerName, handler := range s.Handlers {
 		if handler.ProtoRef == nil {
+			// Composite handlers intentionally have no proto_ref - they orchestrate
+			// multiple sub-operations and define their own parameter handling.
+			// Non-composite handlers without proto_ref use legacy inline format.
 			continue
 		}
 		if err := resolveHandlerProto(handlerName, handler, files); err != nil {
@@ -165,4 +168,10 @@ func leafFieldName(path string) string {
 // HasProtoRef returns true if the handler uses proto-referenced format.
 func (h *HandlerDef) HasProtoRef() bool {
 	return h.ProtoRef != nil
+}
+
+// IsComposite returns true if the handler is a composite handler that
+// orchestrates multiple sub-operations and intentionally has no proto_ref.
+func (h *HandlerDef) IsComposite() bool {
+	return h.Composite
 }

--- a/shared/pkg/saga/schema/schema.go
+++ b/shared/pkg/saga/schema/schema.go
@@ -254,6 +254,11 @@ func (h *HandlerDef) Validate(handlerName string) error {
 		h.Version = 1
 	}
 
+	// Composite handlers must not declare proto_ref.
+	if h.Composite && h.ProtoRef != nil {
+		return fmt.Errorf("handler %s: composite handler must not set proto_ref", handlerName)
+	}
+
 	// Proto-referenced handlers: validate the reference format.
 	// Params/Returns are resolved later via ResolveProtoTypes, so skip field validation.
 	if h.ProtoRef != nil {

--- a/shared/pkg/saga/schema/schema.go
+++ b/shared/pkg/saga/schema/schema.go
@@ -162,6 +162,11 @@ type HandlerDef struct {
 	// Version is the handler version number. Defaults to 1 if unset.
 	Version int `yaml:"version,omitempty"`
 
+	// Composite marks this handler as a composite handler - one that orchestrates
+	// multiple underlying operations and has no single proto request/response shape.
+	// Composite handlers use params: {} intentionally and skip proto_ref validation.
+	Composite bool `yaml:"composite,omitempty"`
+
 	// IsDeprecated marks this handler as deprecated. Scripts calling it will receive a warning.
 	Deprecated bool `yaml:"deprecated,omitempty"`
 

--- a/shared/pkg/saga/schema/schema.go
+++ b/shared/pkg/saga/schema/schema.go
@@ -88,6 +88,7 @@ var (
 	ErrUnknownAliasSource           = errors.New("param_alias references unknown field")
 	ErrAliasCollision               = errors.New("param_alias target already exists as a field")
 	ErrDuplicateLeafName            = errors.New("duplicate leaf field name from exposed paths")
+	ErrCompositeWithProtoRef        = errors.New("composite handler must not set proto_ref")
 )
 
 // Schema represents a collection of handler definitions for a service.
@@ -256,7 +257,7 @@ func (h *HandlerDef) Validate(handlerName string) error {
 
 	// Composite handlers must not declare proto_ref.
 	if h.Composite && h.ProtoRef != nil {
-		return fmt.Errorf("handler %s: composite handler must not set proto_ref", handlerName)
+		return fmt.Errorf("handler %s: %w", handlerName, ErrCompositeWithProtoRef)
 	}
 
 	// Proto-referenced handlers: validate the reference format.


### PR DESCRIPTION
## Summary

- Adds `composite: true` schema field to distinguish handlers that orchestrate multiple sub-operations from handlers with missing proto references
- Marks `financial_accounting.post_entries` as composite in `handlers.yaml`
- Documents the composite handler pattern in `saga-contract.md` (Section 2.7)
- Adds `Composite` bool field and `IsComposite()` accessor to `HandlerDef` struct
- Proto resolution skips composite handlers without error (same codepath, now documented)

## Context

`post_entries` processes a variable-length array of ledger entries, calling `CaptureLedgerPosting` for each one. No single proto message represents its input shape, so it intentionally uses `params: {}`. The `composite: true` marker makes this design intent explicit rather than relying on convention.

## Test plan

- [x] Existing `TestHandlersYAML_LegacyPostEntries` renamed to `TestHandlersYAML_CompositePostEntries` - validates composite flag, IsComposite(), no proto_ref, compensation wiring, and proto resolution skip
- [x] New `TestHandlersYAML_CompositeHandlerValidation` - validates standalone composite handler parsing
- [x] All existing schema tests pass unchanged