### PR TITLE
refactor: replace legacy inline format terminology with composite/inline-param

### DIFF
--- a/shared/pkg/saga/schema/handlers_yaml_test.go
+++ b/shared/pkg/saga/schema/handlers_yaml_test.go
@@ -56,7 +56,7 @@ func TestHandlersYAML_ProtoResolution(t *testing.T) {
 
 	// Verify proto-referenced handlers have populated params
 	protoRefHandlers := 0
-	legacyHandlers := 0
+	inlineHandlers := 0
 
 	for name, handler := range schema.Handlers {
 		if handler.HasProtoRef() {
@@ -67,12 +67,12 @@ func TestHandlersYAML_ProtoResolution(t *testing.T) {
 			assert.NotNil(t, handler.Returns,
 				"handler %s: returns should be resolved from proto", name)
 		} else {
-			legacyHandlers++
+			inlineHandlers++
 		}
 	}
 
-	t.Logf("Proto-referenced: %d, Legacy: %d, Total: %d",
-		protoRefHandlers, legacyHandlers, protoRefHandlers+legacyHandlers)
+	t.Logf("Proto-referenced: %d, Inline: %d, Total: %d",
+		protoRefHandlers, inlineHandlers, protoRefHandlers+inlineHandlers)
 
 	assert.GreaterOrEqual(t, protoRefHandlers, 36,
 		"at least 36 handlers should use proto-referenced format")

--- a/shared/pkg/saga/schema/proto_resolve.go
+++ b/shared/pkg/saga/schema/proto_resolve.go
@@ -10,7 +10,7 @@ import (
 
 // ResolveProtoTypes resolves proto-referenced handlers in the schema by looking up
 // proto service/method descriptors and populating Params/Returns from proto reflection.
-// Handlers without ProtoRef are left unchanged (legacy inline format).
+// Handlers without ProtoRef are left unchanged (composite handlers or inline-param handlers).
 // Uses the global proto registry by default; pass a custom resolver for testing.
 func (s *Schema) ResolveProtoTypes(files *protoregistry.Files) error {
 	if files == nil {
@@ -20,7 +20,7 @@ func (s *Schema) ResolveProtoTypes(files *protoregistry.Files) error {
 		if handler.ProtoRef == nil {
 			// Composite handlers intentionally have no proto_ref - they orchestrate
 			// multiple sub-operations and define their own parameter handling.
-			// Non-composite handlers without proto_ref use legacy inline format.
+			// Non-composite handlers without proto_ref define params inline.
 			continue
 		}
 		if err := resolveHandlerProto(handlerName, handler, files); err != nil {

--- a/shared/pkg/saga/schema/proto_resolve_test.go
+++ b/shared/pkg/saga/schema/proto_resolve_test.go
@@ -127,13 +127,13 @@ func TestResolveProtoTypes_MethodNotFound(t *testing.T) {
 	assert.ErrorIs(t, err, ErrProtoMethodNotFound)
 }
 
-func TestResolveProtoTypes_LegacyHandlersUntouched(t *testing.T) {
+func TestResolveProtoTypes_InlineHandlersUntouched(t *testing.T) {
 	s := &Schema{
 		Service: "test",
 		Version: "1.0",
 		Handlers: map[string]*HandlerDef{
-			"test.legacy_handler": {
-				Description:          "Legacy handler with inline params",
+			"test.inline_handler": {
+				Description:          "Handler with inline params",
 				CompensationStrategy: CompensationStrategyNone,
 				Params: map[string]*FieldDef{
 					"id": {Type: TypeString, Required: true},
@@ -148,20 +148,20 @@ func TestResolveProtoTypes_LegacyHandlersUntouched(t *testing.T) {
 	err := s.ResolveProtoTypes(protoregistry.GlobalFiles)
 	require.NoError(t, err)
 
-	handler := s.Handlers["test.legacy_handler"]
+	handler := s.Handlers["test.inline_handler"]
 	assert.Len(t, handler.Params, 1)
 	assert.Equal(t, TypeString, handler.Params["id"].Type)
 	assert.Len(t, handler.Returns, 1)
 }
 
 func TestResolveProtoTypes_MixedFormat(t *testing.T) {
-	// Schema with both legacy and proto-referenced handlers
+	// Schema with both inline-param and proto-referenced handlers
 	s := &Schema{
 		Service: "test",
 		Version: "1.0",
 		Handlers: map[string]*HandlerDef{
-			"test.legacy": {
-				Description:          "Legacy inline handler",
+			"test.inline": {
+				Description:          "Inline-param handler",
 				CompensationStrategy: CompensationStrategyNone,
 				Params: map[string]*FieldDef{
 					"name": {Type: TypeString, Required: true},
@@ -181,10 +181,10 @@ func TestResolveProtoTypes_MixedFormat(t *testing.T) {
 	err := s.ResolveProtoTypes(protoregistry.GlobalFiles)
 	require.NoError(t, err)
 
-	// Legacy handler unchanged
-	legacy := s.Handlers["test.legacy"]
-	assert.Len(t, legacy.Params, 1)
-	assert.Equal(t, TypeString, legacy.Params["name"].Type)
+	// Inline-param handler unchanged
+	inline := s.Handlers["test.inline"]
+	assert.Len(t, inline.Params, 1)
+	assert.Equal(t, TypeString, inline.Params["name"].Type)
 
 	// Proto-referenced handler resolved
 	protoRef := s.Handlers["position_keeping.proto_ref"]


### PR DESCRIPTION
## Summary

- Replace "legacy inline format" comments in `proto_resolve.go` with accurate terminology: composite handlers and inline-param handlers
- Rename test functions and variables in `proto_resolve_test.go`: `TestResolveProtoTypes_LegacyHandlersUntouched` → `InlineHandlersUntouched`, handler keys updated from `test.legacy_handler`/`test.legacy` to `test.inline_handler`/`test.inline`
- Update `handlers_yaml_test.go` counter variable `legacyHandlers` → `inlineHandlers` and log message to match

## Changes Made

- `shared/pkg/saga/schema/proto_resolve.go`: Updated two comments to use composite/inline-param terminology
- `shared/pkg/saga/schema/proto_resolve_test.go`: Renamed test, handler keys, variable, and comments
- `shared/pkg/saga/schema/handlers_yaml_test.go`: Renamed counter variable and log message

## Testing

- `go test ./shared/pkg/saga/...` passes - no behavioral changes

## Notes

Follows on from #2093 which formally defined composite handlers. This PR removes the "legacy" label that described composite/inline handlers before the terminology was established.