### PR TITLE
feat: wire GRPCLiveStateProvider into production service bootstrap

### DIFF
--- a/cmd/meridian/wire_grpc.go
+++ b/cmd/meridian/wire_grpc.go
@@ -436,6 +436,7 @@ func wireControlPlane(ctx context.Context, server *grpc.Server, pool *pgxpool.Po
 		Pool:        pool,
 		Logger:      logger,
 		HandlerDeps: deps,
+		GRPCConn:    loopback.rawConn,
 	}); err != nil {
 		return err
 	}

--- a/services/control-plane/internal/differ/grpc_live_state_adapters.go
+++ b/services/control-plane/internal/differ/grpc_live_state_adapters.go
@@ -240,6 +240,9 @@ func (c *GRPCPartyClient) ListOrganizations(ctx context.Context) ([]*controlplan
 			return nil, fmt.Errorf("list organizations: %w", err)
 		}
 		for _, p := range resp.GetParties() {
+			if p.GetPartyType() != partyv1.PartyType_PARTY_TYPE_ORGANIZATION {
+				continue
+			}
 			result = append(result, mapOrganization(p))
 		}
 		pageToken = resp.GetNextPageToken()
@@ -394,10 +397,12 @@ func mapDimensionToInstrumentType(d referencedatav1.Dimension) controlplanev1.In
 
 func mapAccountType(at *referencedatav1.AccountTypeDefinition) *controlplanev1.AccountTypeDefinition {
 	def := &controlplanev1.AccountTypeDefinition{
-		Code:               at.GetCode(),
-		Name:               at.GetDisplayName(),
-		NormalBalance:      controlplanev1.NormalBalance(at.GetNormalBalance()),
-		AllowedInstruments: []string{at.GetInstrumentCode()},
+		Code:          at.GetCode(),
+		Name:          at.GetDisplayName(),
+		NormalBalance: controlplanev1.NormalBalance(at.GetNormalBalance()),
+	}
+	if ic := at.GetInstrumentCode(); ic != "" {
+		def.AllowedInstruments = []string{ic}
 	}
 	if at.GetValidationCel() != "" || at.GetBucketingCel() != "" {
 		def.Policies = &controlplanev1.AccountTypePolicies{

--- a/services/control-plane/internal/differ/grpc_live_state_adapters.go
+++ b/services/control-plane/internal/differ/grpc_live_state_adapters.go
@@ -13,7 +13,18 @@ import (
 	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
 	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+// isUnimplemented returns true if the error indicates the gRPC service is not
+// registered on the target server. This happens when the unified binary does
+// not include a particular service (e.g., operational-gateway runs as a
+// separate process). Returning true allows callers to treat the resource type
+// as having no live state rather than failing the entire diff.
+func isUnimplemented(err error) bool {
+	return status.Code(err) == codes.Unimplemented
+}
 
 // defaultPageSize is the page size used when paginating through list RPCs.
 const defaultPageSize = 500
@@ -46,6 +57,9 @@ func (c *GRPCReferenceDataClient) ListInstruments(ctx context.Context) ([]*contr
 			PageToken: pageToken,
 		})
 		if err != nil {
+			if isUnimplemented(err) {
+				return nil, nil
+			}
 			return nil, fmt.Errorf("list instruments: %w", err)
 		}
 		for _, inst := range resp.GetInstruments() {
@@ -68,6 +82,9 @@ func (c *GRPCReferenceDataClient) ListAccountTypes(ctx context.Context) ([]*cont
 			PageToken: pageToken,
 		})
 		if err != nil {
+			if isUnimplemented(err) {
+				return nil, nil
+			}
 			return nil, fmt.Errorf("list account types: %w", err)
 		}
 		for _, at := range resp.GetDefinitions() {
@@ -107,6 +124,9 @@ func (c *GRPCSagaRegistryClient) ListSagas(ctx context.Context) ([]*controlplane
 			PageToken: pageToken,
 		})
 		if err != nil {
+			if isUnimplemented(err) {
+				return nil, nil
+			}
 			return nil, fmt.Errorf("list sagas: %w", err)
 		}
 		for _, s := range resp.GetSagas() {
@@ -146,6 +166,9 @@ func (c *GRPCMarketInformationClient) ListMarketDataSources(ctx context.Context)
 			PageToken: pageToken,
 		})
 		if err != nil {
+			if isUnimplemented(err) {
+				return nil, nil
+			}
 			return nil, fmt.Errorf("list data sources: %w", err)
 		}
 		for _, src := range resp.GetSources() {
@@ -168,6 +191,9 @@ func (c *GRPCMarketInformationClient) ListMarketDataSets(ctx context.Context) ([
 			PageToken: pageToken,
 		})
 		if err != nil {
+			if isUnimplemented(err) {
+				return nil, nil
+			}
 			return nil, fmt.Errorf("list data sets: %w", err)
 		}
 		for _, ds := range resp.GetDatasets() {
@@ -208,6 +234,9 @@ func (c *GRPCPartyClient) ListOrganizations(ctx context.Context) ([]*controlplan
 			PartyType: partyv1.PartyType_PARTY_TYPE_ORGANIZATION,
 		})
 		if err != nil {
+			if isUnimplemented(err) {
+				return nil, nil
+			}
 			return nil, fmt.Errorf("list organizations: %w", err)
 		}
 		for _, p := range resp.GetParties() {
@@ -249,6 +278,9 @@ func (c *GRPCInternalAccountClient) ListInternalAccounts(ctx context.Context) ([
 			},
 		})
 		if err != nil {
+			if isUnimplemented(err) {
+				return nil, nil
+			}
 			return nil, fmt.Errorf("list internal accounts: %w", err)
 		}
 		for _, f := range resp.GetFacilities() {
@@ -293,6 +325,9 @@ func (c *GRPCOperationalGatewayClient) ListProviderConnections(ctx context.Conte
 			},
 		})
 		if err != nil {
+			if isUnimplemented(err) {
+				return nil, nil
+			}
 			return nil, fmt.Errorf("list provider connections: %w", err)
 		}
 		for _, conn := range resp.GetConnections() {
@@ -310,6 +345,9 @@ func (c *GRPCOperationalGatewayClient) ListProviderConnections(ctx context.Conte
 func (c *GRPCOperationalGatewayClient) ListInstructionRoutes(ctx context.Context) ([]*controlplanev1.InstructionRouteConfig, error) {
 	resp, err := c.routeClient.ListRoutes(ctx, &opgatewayv1.ListRoutesRequest{})
 	if err != nil {
+		if isUnimplemented(err) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("list instruction routes: %w", err)
 	}
 	result := make([]*controlplanev1.InstructionRouteConfig, 0, len(resp.GetRoutes()))

--- a/services/control-plane/internal/differ/grpc_live_state_adapters.go
+++ b/services/control-plane/internal/differ/grpc_live_state_adapters.go
@@ -36,6 +36,7 @@ func NewGRPCReferenceDataClient(conn *grpc.ClientConn) *GRPCReferenceDataClient 
 	}
 }
 
+// ListInstruments implements ReferenceDataClient.
 func (c *GRPCReferenceDataClient) ListInstruments(ctx context.Context) ([]*controlplanev1.InstrumentDefinition, error) {
 	var result []*controlplanev1.InstrumentDefinition
 	pageToken := ""
@@ -57,6 +58,7 @@ func (c *GRPCReferenceDataClient) ListInstruments(ctx context.Context) ([]*contr
 	}
 }
 
+// ListAccountTypes implements ReferenceDataClient.
 func (c *GRPCReferenceDataClient) ListAccountTypes(ctx context.Context) ([]*controlplanev1.AccountTypeDefinition, error) {
 	var result []*controlplanev1.AccountTypeDefinition
 	pageToken := ""
@@ -95,6 +97,7 @@ func NewGRPCSagaRegistryClient(conn *grpc.ClientConn) *GRPCSagaRegistryClient {
 	}
 }
 
+// ListSagas implements SagaRegistryClient.
 func (c *GRPCSagaRegistryClient) ListSagas(ctx context.Context) ([]*controlplanev1.SagaDefinition, error) {
 	var result []*controlplanev1.SagaDefinition
 	pageToken := ""
@@ -133,6 +136,7 @@ func NewGRPCMarketInformationClient(conn *grpc.ClientConn) *GRPCMarketInformatio
 	}
 }
 
+// ListMarketDataSources implements MarketInformationClient.
 func (c *GRPCMarketInformationClient) ListMarketDataSources(ctx context.Context) ([]*controlplanev1.MarketDataSourceDefinition, error) {
 	var result []*controlplanev1.MarketDataSourceDefinition
 	pageToken := ""
@@ -154,6 +158,7 @@ func (c *GRPCMarketInformationClient) ListMarketDataSources(ctx context.Context)
 	}
 }
 
+// ListMarketDataSets implements MarketInformationClient.
 func (c *GRPCMarketInformationClient) ListMarketDataSets(ctx context.Context) ([]*controlplanev1.MarketDataSetDefinition, error) {
 	var result []*controlplanev1.MarketDataSetDefinition
 	pageToken := ""
@@ -192,6 +197,7 @@ func NewGRPCPartyClient(conn *grpc.ClientConn) *GRPCPartyClient {
 	}
 }
 
+// ListOrganizations implements PartyClient.
 func (c *GRPCPartyClient) ListOrganizations(ctx context.Context) ([]*controlplanev1.OrganizationDefinition, error) {
 	var result []*controlplanev1.OrganizationDefinition
 	pageToken := ""
@@ -231,6 +237,7 @@ func NewGRPCInternalAccountClient(conn *grpc.ClientConn) *GRPCInternalAccountCli
 	}
 }
 
+// ListInternalAccounts implements InternalAccountClient.
 func (c *GRPCInternalAccountClient) ListInternalAccounts(ctx context.Context) ([]*controlplanev1.InternalAccountDefinition, error) {
 	var result []*controlplanev1.InternalAccountDefinition
 	pageToken := ""
@@ -274,6 +281,7 @@ func NewGRPCOperationalGatewayClient(conn *grpc.ClientConn) *GRPCOperationalGate
 	}
 }
 
+// ListProviderConnections implements OperationalGatewayClient.
 func (c *GRPCOperationalGatewayClient) ListProviderConnections(ctx context.Context) ([]*controlplanev1.ProviderConnectionConfig, error) {
 	var result []*controlplanev1.ProviderConnectionConfig
 	pageToken := ""
@@ -298,6 +306,7 @@ func (c *GRPCOperationalGatewayClient) ListProviderConnections(ctx context.Conte
 	}
 }
 
+// ListInstructionRoutes implements OperationalGatewayClient.
 func (c *GRPCOperationalGatewayClient) ListInstructionRoutes(ctx context.Context) ([]*controlplanev1.InstructionRouteConfig, error) {
 	resp, err := c.routeClient.ListRoutes(ctx, &opgatewayv1.ListRoutesRequest{})
 	if err != nil {
@@ -335,9 +344,14 @@ func mapDimensionToInstrumentType(d referencedatav1.Dimension) controlplanev1.In
 		referencedatav1.Dimension_DIMENSION_VOLUME,
 		referencedatav1.Dimension_DIMENSION_CARBON:
 		return controlplanev1.InstrumentType_INSTRUMENT_TYPE_COMMODITY
-	default:
+	case referencedatav1.Dimension_DIMENSION_UNSPECIFIED,
+		referencedatav1.Dimension_DIMENSION_TIME,
+		referencedatav1.Dimension_DIMENSION_COMPUTE,
+		referencedatav1.Dimension_DIMENSION_DATA,
+		referencedatav1.Dimension_DIMENSION_COUNT:
 		return controlplanev1.InstrumentType_INSTRUMENT_TYPE_UNSPECIFIED
 	}
+	return controlplanev1.InstrumentType_INSTRUMENT_TYPE_UNSPECIFIED
 }
 
 func mapAccountType(at *referencedatav1.AccountTypeDefinition) *controlplanev1.AccountTypeDefinition {
@@ -469,9 +483,10 @@ func mapProtocol(p opgatewayv1.Protocol) controlplanev1.ProviderProtocol {
 		return controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_MQTT
 	case opgatewayv1.Protocol_PROTOCOL_AMQP:
 		return controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_AMQP
-	default:
+	case opgatewayv1.Protocol_PROTOCOL_UNSPECIFIED:
 		return controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_UNSPECIFIED
 	}
+	return controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_UNSPECIFIED
 }
 
 func mapAuthConfig(conn *opgatewayv1.ProviderConnection) *controlplanev1.AuthConfigManifest {
@@ -537,13 +552,13 @@ func mapAuthConfig(conn *opgatewayv1.ProviderConnection) *controlplanev1.AuthCon
 
 func mapInstructionRoute(r *opgatewayv1.InstructionRoute) *controlplanev1.InstructionRouteConfig {
 	return &controlplanev1.InstructionRouteConfig{
-		InstructionType:    r.GetInstructionType(),
-		ConnectionId:       r.GetConnectionId(),
+		InstructionType:      r.GetInstructionType(),
+		ConnectionId:         r.GetConnectionId(),
 		FallbackConnectionId: r.GetFallbackConnectionId(),
-		OutboundMappingId:  r.GetOutboundMapping(),
-		InboundMappingId:   r.GetInboundMapping(),
-		HttpMethod:         r.GetHttpMethod(),
-		PathTemplate:       r.GetPathTemplate(),
+		OutboundMappingId:    r.GetOutboundMapping(),
+		InboundMappingId:     r.GetInboundMapping(),
+		HttpMethod:           r.GetHttpMethod(),
+		PathTemplate:         r.GetPathTemplate(),
 	}
 }
 

--- a/services/control-plane/internal/differ/grpc_live_state_adapters.go
+++ b/services/control-plane/internal/differ/grpc_live_state_adapters.go
@@ -1,0 +1,561 @@
+package differ
+
+import (
+	"context"
+	"fmt"
+
+	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	internalaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_account/v1"
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
+	"google.golang.org/grpc"
+)
+
+// defaultPageSize is the page size used when paginating through list RPCs.
+const defaultPageSize = 500
+
+// ── Reference Data Adapter ──────────────────────────────────────────────────
+
+// GRPCReferenceDataClient implements ReferenceDataClient by calling the
+// reference-data and account-type gRPC services and mapping responses to
+// control-plane manifest types.
+type GRPCReferenceDataClient struct {
+	instruments  referencedatav1.ReferenceDataServiceClient
+	accountTypes referencedatav1.AccountTypeRegistryServiceClient
+}
+
+// NewGRPCReferenceDataClient creates a new adapter from a gRPC connection.
+func NewGRPCReferenceDataClient(conn *grpc.ClientConn) *GRPCReferenceDataClient {
+	return &GRPCReferenceDataClient{
+		instruments:  referencedatav1.NewReferenceDataServiceClient(conn),
+		accountTypes: referencedatav1.NewAccountTypeRegistryServiceClient(conn),
+	}
+}
+
+func (c *GRPCReferenceDataClient) ListInstruments(ctx context.Context) ([]*controlplanev1.InstrumentDefinition, error) {
+	var result []*controlplanev1.InstrumentDefinition
+	pageToken := ""
+	for {
+		resp, err := c.instruments.ListInstruments(ctx, &referencedatav1.ListInstrumentsRequest{
+			PageSize:  defaultPageSize,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list instruments: %w", err)
+		}
+		for _, inst := range resp.GetInstruments() {
+			result = append(result, mapInstrument(inst))
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			return result, nil
+		}
+	}
+}
+
+func (c *GRPCReferenceDataClient) ListAccountTypes(ctx context.Context) ([]*controlplanev1.AccountTypeDefinition, error) {
+	var result []*controlplanev1.AccountTypeDefinition
+	pageToken := ""
+	for {
+		resp, err := c.accountTypes.ListAll(ctx, &referencedatav1.ListAllRequest{
+			PageSize:  defaultPageSize,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list account types: %w", err)
+		}
+		for _, at := range resp.GetDefinitions() {
+			result = append(result, mapAccountType(at))
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			return result, nil
+		}
+	}
+}
+
+var _ ReferenceDataClient = (*GRPCReferenceDataClient)(nil)
+
+// ── Saga Registry Adapter ───────────────────────────────────────────────────
+
+// GRPCSagaRegistryClient implements SagaRegistryClient by calling the saga
+// registry gRPC service and mapping responses to control-plane manifest types.
+type GRPCSagaRegistryClient struct {
+	client sagav1.SagaRegistryServiceClient
+}
+
+// NewGRPCSagaRegistryClient creates a new adapter from a gRPC connection.
+func NewGRPCSagaRegistryClient(conn *grpc.ClientConn) *GRPCSagaRegistryClient {
+	return &GRPCSagaRegistryClient{
+		client: sagav1.NewSagaRegistryServiceClient(conn),
+	}
+}
+
+func (c *GRPCSagaRegistryClient) ListSagas(ctx context.Context) ([]*controlplanev1.SagaDefinition, error) {
+	var result []*controlplanev1.SagaDefinition
+	pageToken := ""
+	for {
+		resp, err := c.client.ListSagas(ctx, &sagav1.ListSagasRequest{
+			PageSize:  defaultPageSize,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list sagas: %w", err)
+		}
+		for _, s := range resp.GetSagas() {
+			result = append(result, mapSaga(s))
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			return result, nil
+		}
+	}
+}
+
+var _ SagaRegistryClient = (*GRPCSagaRegistryClient)(nil)
+
+// ── Market Information Adapter ──────────────────────────────────────────────
+
+// GRPCMarketInformationClient implements MarketInformationClient by calling the
+// market-information gRPC service and mapping responses to control-plane types.
+type GRPCMarketInformationClient struct {
+	client marketinformationv1.MarketInformationServiceClient
+}
+
+// NewGRPCMarketInformationClient creates a new adapter from a gRPC connection.
+func NewGRPCMarketInformationClient(conn *grpc.ClientConn) *GRPCMarketInformationClient {
+	return &GRPCMarketInformationClient{
+		client: marketinformationv1.NewMarketInformationServiceClient(conn),
+	}
+}
+
+func (c *GRPCMarketInformationClient) ListMarketDataSources(ctx context.Context) ([]*controlplanev1.MarketDataSourceDefinition, error) {
+	var result []*controlplanev1.MarketDataSourceDefinition
+	pageToken := ""
+	for {
+		resp, err := c.client.ListDataSources(ctx, &marketinformationv1.ListDataSourcesRequest{
+			PageSize:  defaultPageSize,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list data sources: %w", err)
+		}
+		for _, src := range resp.GetSources() {
+			result = append(result, mapMarketDataSource(src))
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			return result, nil
+		}
+	}
+}
+
+func (c *GRPCMarketInformationClient) ListMarketDataSets(ctx context.Context) ([]*controlplanev1.MarketDataSetDefinition, error) {
+	var result []*controlplanev1.MarketDataSetDefinition
+	pageToken := ""
+	for {
+		resp, err := c.client.ListDataSets(ctx, &marketinformationv1.ListDataSetsRequest{
+			PageSize:  defaultPageSize,
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list data sets: %w", err)
+		}
+		for _, ds := range resp.GetDatasets() {
+			result = append(result, mapMarketDataSet(ds))
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			return result, nil
+		}
+	}
+}
+
+var _ MarketInformationClient = (*GRPCMarketInformationClient)(nil)
+
+// ── Party Adapter ───────────────────────────────────────────────────────────
+
+// GRPCPartyClient implements PartyClient by calling the party gRPC service
+// and mapping organization-type parties to control-plane OrganizationDefinition.
+type GRPCPartyClient struct {
+	client partyv1.PartyServiceClient
+}
+
+// NewGRPCPartyClient creates a new adapter from a gRPC connection.
+func NewGRPCPartyClient(conn *grpc.ClientConn) *GRPCPartyClient {
+	return &GRPCPartyClient{
+		client: partyv1.NewPartyServiceClient(conn),
+	}
+}
+
+func (c *GRPCPartyClient) ListOrganizations(ctx context.Context) ([]*controlplanev1.OrganizationDefinition, error) {
+	var result []*controlplanev1.OrganizationDefinition
+	pageToken := ""
+	for {
+		resp, err := c.client.ListParties(ctx, &partyv1.ListPartiesRequest{
+			PageSize:  defaultPageSize,
+			PageToken: pageToken,
+			PartyType: partyv1.PartyType_PARTY_TYPE_ORGANIZATION,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list organizations: %w", err)
+		}
+		for _, p := range resp.GetParties() {
+			result = append(result, mapOrganization(p))
+		}
+		pageToken = resp.GetNextPageToken()
+		if pageToken == "" {
+			return result, nil
+		}
+	}
+}
+
+var _ PartyClient = (*GRPCPartyClient)(nil)
+
+// ── Internal Account Adapter ────────────────────────────────────────────────
+
+// GRPCInternalAccountClient implements InternalAccountClient by calling the
+// internal-account gRPC service and mapping responses to control-plane types.
+type GRPCInternalAccountClient struct {
+	client internalaccountv1.InternalAccountServiceClient
+}
+
+// NewGRPCInternalAccountClient creates a new adapter from a gRPC connection.
+func NewGRPCInternalAccountClient(conn *grpc.ClientConn) *GRPCInternalAccountClient {
+	return &GRPCInternalAccountClient{
+		client: internalaccountv1.NewInternalAccountServiceClient(conn),
+	}
+}
+
+func (c *GRPCInternalAccountClient) ListInternalAccounts(ctx context.Context) ([]*controlplanev1.InternalAccountDefinition, error) {
+	var result []*controlplanev1.InternalAccountDefinition
+	pageToken := ""
+	for {
+		resp, err := c.client.ListInternalAccounts(ctx, &internalaccountv1.ListInternalAccountsRequest{
+			Pagination: &commonv1.Pagination{
+				PageSize:  defaultPageSize,
+				PageToken: pageToken,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list internal accounts: %w", err)
+		}
+		for _, f := range resp.GetFacilities() {
+			result = append(result, mapInternalAccount(f))
+		}
+		pag := resp.GetPagination()
+		if pag == nil || pag.GetNextPageToken() == "" {
+			return result, nil
+		}
+		pageToken = pag.GetNextPageToken()
+	}
+}
+
+var _ InternalAccountClient = (*GRPCInternalAccountClient)(nil)
+
+// ── Operational Gateway Adapter ─────────────────────────────────────────────
+
+// GRPCOperationalGatewayClient implements OperationalGatewayClient by calling
+// the operational-gateway gRPC services and mapping responses to control-plane types.
+type GRPCOperationalGatewayClient struct {
+	connClient  opgatewayv1.ProviderConnectionServiceClient
+	routeClient opgatewayv1.InstructionRouteServiceClient
+}
+
+// NewGRPCOperationalGatewayClient creates a new adapter from a gRPC connection.
+func NewGRPCOperationalGatewayClient(conn *grpc.ClientConn) *GRPCOperationalGatewayClient {
+	return &GRPCOperationalGatewayClient{
+		connClient:  opgatewayv1.NewProviderConnectionServiceClient(conn),
+		routeClient: opgatewayv1.NewInstructionRouteServiceClient(conn),
+	}
+}
+
+func (c *GRPCOperationalGatewayClient) ListProviderConnections(ctx context.Context) ([]*controlplanev1.ProviderConnectionConfig, error) {
+	var result []*controlplanev1.ProviderConnectionConfig
+	pageToken := ""
+	for {
+		resp, err := c.connClient.ListConnections(ctx, &opgatewayv1.ListConnectionsRequest{
+			Pagination: &commonv1.Pagination{
+				PageSize:  defaultPageSize,
+				PageToken: pageToken,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list provider connections: %w", err)
+		}
+		for _, conn := range resp.GetConnections() {
+			result = append(result, mapProviderConnection(conn))
+		}
+		pag := resp.GetPagination()
+		if pag == nil || pag.GetNextPageToken() == "" {
+			return result, nil
+		}
+		pageToken = pag.GetNextPageToken()
+	}
+}
+
+func (c *GRPCOperationalGatewayClient) ListInstructionRoutes(ctx context.Context) ([]*controlplanev1.InstructionRouteConfig, error) {
+	resp, err := c.routeClient.ListRoutes(ctx, &opgatewayv1.ListRoutesRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("list instruction routes: %w", err)
+	}
+	result := make([]*controlplanev1.InstructionRouteConfig, 0, len(resp.GetRoutes()))
+	for _, r := range resp.GetRoutes() {
+		result = append(result, mapInstructionRoute(r))
+	}
+	return result, nil
+}
+
+var _ OperationalGatewayClient = (*GRPCOperationalGatewayClient)(nil)
+
+// ── Mapping Functions ───────────────────────────────────────────────────────
+
+func mapInstrument(inst *referencedatav1.InstrumentDefinition) *controlplanev1.InstrumentDefinition {
+	return &controlplanev1.InstrumentDefinition{
+		Code: inst.GetCode(),
+		Name: inst.GetDisplayName(),
+		Type: mapDimensionToInstrumentType(inst.GetDimension()),
+		Dimensions: &controlplanev1.InstrumentDimensions{
+			Unit:      inst.GetCode(),
+			Precision: inst.GetPrecision(),
+		},
+	}
+}
+
+func mapDimensionToInstrumentType(d referencedatav1.Dimension) controlplanev1.InstrumentType {
+	switch d {
+	case referencedatav1.Dimension_DIMENSION_CURRENCY:
+		return controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT
+	case referencedatav1.Dimension_DIMENSION_ENERGY,
+		referencedatav1.Dimension_DIMENSION_MASS,
+		referencedatav1.Dimension_DIMENSION_VOLUME,
+		referencedatav1.Dimension_DIMENSION_CARBON:
+		return controlplanev1.InstrumentType_INSTRUMENT_TYPE_COMMODITY
+	default:
+		return controlplanev1.InstrumentType_INSTRUMENT_TYPE_UNSPECIFIED
+	}
+}
+
+func mapAccountType(at *referencedatav1.AccountTypeDefinition) *controlplanev1.AccountTypeDefinition {
+	def := &controlplanev1.AccountTypeDefinition{
+		Code:               at.GetCode(),
+		Name:               at.GetDisplayName(),
+		NormalBalance:      controlplanev1.NormalBalance(at.GetNormalBalance()),
+		AllowedInstruments: []string{at.GetInstrumentCode()},
+	}
+	if at.GetValidationCel() != "" || at.GetBucketingCel() != "" {
+		def.Policies = &controlplanev1.AccountTypePolicies{
+			Validation: at.GetValidationCel(),
+			Bucketing:  at.GetBucketingCel(),
+		}
+	}
+	return def
+}
+
+func mapSaga(s *sagav1.SagaDefinition) *controlplanev1.SagaDefinition {
+	def := &controlplanev1.SagaDefinition{
+		Name:   s.GetName(),
+		Script: s.GetScript(),
+	}
+	if v := s.GetPreconditionsExpression(); v != "" {
+		def.Filter = &v
+	}
+	return def
+}
+
+func mapMarketDataSource(src *marketinformationv1.DataSource) *controlplanev1.MarketDataSourceDefinition {
+	return &controlplanev1.MarketDataSourceDefinition{
+		Code:        src.GetCode(),
+		Name:        src.GetName(),
+		Description: src.GetDescription(),
+		TrustLevel:  src.GetTrustLevel(),
+	}
+}
+
+func mapMarketDataSet(ds *marketinformationv1.DataSetDefinition) *controlplanev1.MarketDataSetDefinition {
+	def := &controlplanev1.MarketDataSetDefinition{
+		Code:        ds.GetCode(),
+		Category:    ds.GetCategory(),
+		Unit:        ds.GetUnit(),
+		DisplayName: ds.GetDisplayName(),
+		Description: ds.GetDescription(),
+	}
+	if v := ds.GetValidationExpression(); v != "" {
+		def.ValidationExpression = &v
+	}
+	if v := ds.GetResolutionKeyExpression(); v != "" {
+		def.ResolutionKeyExpression = &v
+	}
+	return def
+}
+
+func mapOrganization(p *partyv1.Party) *controlplanev1.OrganizationDefinition {
+	def := &controlplanev1.OrganizationDefinition{
+		Code:      p.GetPartyId(),
+		Name:      p.GetLegalName(),
+		PartyType: p.GetPartyType().String(),
+	}
+	if v := p.GetLegalName(); v != "" {
+		def.LegalName = &v
+	}
+	if v := p.GetDisplayName(); v != "" {
+		def.DisplayName = &v
+	}
+	if v := p.GetExternalReference(); v != "" {
+		def.ExternalReference = &v
+	}
+	if p.GetExternalReferenceType() != partyv1.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_UNSPECIFIED {
+		s := p.GetExternalReferenceType().String()
+		def.ExternalReferenceType = &s
+	}
+	if attrs := p.GetAttributes(); len(attrs) > 0 {
+		def.Attributes = make(map[string]string, len(attrs))
+		for _, a := range attrs {
+			def.Attributes[a.GetKey()] = a.GetValue()
+		}
+	}
+	return def
+}
+
+func mapInternalAccount(f *internalaccountv1.InternalAccountFacility) *controlplanev1.InternalAccountDefinition {
+	return &controlplanev1.InternalAccountDefinition{
+		Code:              f.GetAccountCode(),
+		AccountType:       f.GetBehaviorClass(),
+		Instrument:        f.GetInstrumentCode(),
+		OwnerOrganization: f.GetOrgPartyId(),
+		Description:       f.GetDescription(),
+	}
+}
+
+func mapProviderConnection(conn *opgatewayv1.ProviderConnection) *controlplanev1.ProviderConnectionConfig {
+	cfg := &controlplanev1.ProviderConnectionConfig{
+		ConnectionId: conn.GetConnectionId(),
+		ProviderName: conn.GetProviderName(),
+		ProviderType: conn.GetProviderType(),
+		Protocol:     mapProtocol(conn.GetProtocol()),
+		BaseUrl:      conn.GetBaseUrl(),
+		Auth:         mapAuthConfig(conn),
+	}
+	if rp := conn.GetRetryPolicy(); rp != nil {
+		cfg.RetryPolicy = &controlplanev1.RetryPolicyConfig{
+			MaxAttempts:           rp.GetMaxAttempts(),
+			InitialBackoffSeconds: rp.GetInitialBackoffSeconds(),
+			MaxBackoffSeconds:     rp.GetMaxBackoffSeconds(),
+			BackoffMultiplier:     rp.GetBackoffMultiplier(),
+		}
+	}
+	if rl := conn.GetRateLimit(); rl != nil {
+		cfg.RateLimit = &controlplanev1.RateLimitConfig{
+			RequestsPerSecond: rl.GetRequestsPerSecond(),
+			BurstSize:         rl.GetBurstSize(),
+		}
+	}
+	return cfg
+}
+
+func mapProtocol(p opgatewayv1.Protocol) controlplanev1.ProviderProtocol {
+	switch p {
+	case opgatewayv1.Protocol_PROTOCOL_HTTPS:
+		return controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_HTTPS
+	case opgatewayv1.Protocol_PROTOCOL_GRPC:
+		return controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_GRPC
+	case opgatewayv1.Protocol_PROTOCOL_WEBHOOK:
+		return controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_WEBHOOK
+	case opgatewayv1.Protocol_PROTOCOL_MQTT:
+		return controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_MQTT
+	case opgatewayv1.Protocol_PROTOCOL_AMQP:
+		return controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_AMQP
+	default:
+		return controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_UNSPECIFIED
+	}
+}
+
+func mapAuthConfig(conn *opgatewayv1.ProviderConnection) *controlplanev1.AuthConfigManifest {
+	switch auth := conn.GetAuthConfig().(type) {
+	case *opgatewayv1.ProviderConnection_ApiKey:
+		ak := auth.ApiKey
+		return &controlplanev1.AuthConfigManifest{
+			AuthConfig: &controlplanev1.AuthConfigManifest_ApiKey{
+				ApiKey: &controlplanev1.ApiKeyAuthConfig{
+					HeaderName:      ak.GetHeaderName(),
+					ApiKeySecretRef: ak.GetSecretRef(),
+				},
+			},
+		}
+	case *opgatewayv1.ProviderConnection_Basic:
+		b := auth.Basic
+		return &controlplanev1.AuthConfigManifest{
+			AuthConfig: &controlplanev1.AuthConfigManifest_Basic{
+				Basic: &controlplanev1.BasicAuthConfig{
+					Username:          b.GetUsername(),
+					PasswordSecretRef: b.GetPasswordSecretRef(),
+				},
+			},
+		}
+	case *opgatewayv1.ProviderConnection_Oauth2:
+		o := auth.Oauth2
+		return &controlplanev1.AuthConfigManifest{
+			AuthConfig: &controlplanev1.AuthConfigManifest_Oauth2{
+				Oauth2: &controlplanev1.OAuth2AuthConfig{
+					TokenUrl:        o.GetTokenUrl(),
+					ClientId:        o.GetClientId(),
+					ClientSecretRef: o.GetClientSecretRef(),
+					Scopes:          o.GetScopes(),
+				},
+			},
+		}
+	case *opgatewayv1.ProviderConnection_Hmac:
+		h := auth.Hmac
+		return &controlplanev1.AuthConfigManifest{
+			AuthConfig: &controlplanev1.AuthConfigManifest_Hmac{
+				Hmac: &controlplanev1.HMACAuthConfig{
+					Algorithm:       h.GetAlgorithm(),
+					SecretRef:       h.GetSecretRef(),
+					SignatureHeader: h.GetSignatureHeader(),
+				},
+			},
+		}
+	case *opgatewayv1.ProviderConnection_Mtls:
+		m := auth.Mtls
+		return &controlplanev1.AuthConfigManifest{
+			AuthConfig: &controlplanev1.AuthConfigManifest_Mtls{
+				Mtls: &controlplanev1.MTLSAuthConfig{
+					ClientCertSecretRef: m.GetClientCertSecretRef(),
+					ClientKeySecretRef:  m.GetClientKeySecretRef(),
+					CaCertSecretRef:     m.GetCaCertSecretRef(),
+				},
+			},
+		}
+	default:
+		return nil
+	}
+}
+
+func mapInstructionRoute(r *opgatewayv1.InstructionRoute) *controlplanev1.InstructionRouteConfig {
+	return &controlplanev1.InstructionRouteConfig{
+		InstructionType:    r.GetInstructionType(),
+		ConnectionId:       r.GetConnectionId(),
+		FallbackConnectionId: r.GetFallbackConnectionId(),
+		OutboundMappingId:  r.GetOutboundMapping(),
+		InboundMappingId:   r.GetInboundMapping(),
+		HttpMethod:         r.GetHttpMethod(),
+		PathTemplate:       r.GetPathTemplate(),
+	}
+}
+
+// NewLiveStateClients creates all six differ client adapters from a single gRPC
+// connection and returns a fully-wired GRPCLiveStateProvider.
+func NewLiveStateClients(conn *grpc.ClientConn) (*GRPCLiveStateProvider, error) {
+	return NewGRPCLiveStateProvider(
+		NewGRPCReferenceDataClient(conn),
+		NewGRPCSagaRegistryClient(conn),
+		NewGRPCMarketInformationClient(conn),
+		NewGRPCPartyClient(conn),
+		NewGRPCInternalAccountClient(conn),
+		NewGRPCOperationalGatewayClient(conn),
+	)
+}

--- a/services/control-plane/internal/differ/grpc_live_state_adapters_test.go
+++ b/services/control-plane/internal/differ/grpc_live_state_adapters_test.go
@@ -81,6 +81,18 @@ func TestMapAccountType_NoPolicies(t *testing.T) {
 	assert.Nil(t, got.GetPolicies())
 }
 
+func TestMapAccountType_NoInstrumentCode(t *testing.T) {
+	at := &referencedatav1.AccountTypeDefinition{
+		Code:          "UNRESTRICTED",
+		DisplayName:   "Unrestricted Account",
+		NormalBalance: referencedatav1.NormalBalance_NORMAL_BALANCE_DEBIT,
+	}
+
+	got := mapAccountType(at)
+
+	assert.Empty(t, got.GetAllowedInstruments(), "empty instrument code should not produce AllowedInstruments entry")
+}
+
 func TestMapSaga(t *testing.T) {
 	s := &sagav1.SagaDefinition{
 		Name:                    "process_payment",

--- a/services/control-plane/internal/differ/grpc_live_state_adapters_test.go
+++ b/services/control-plane/internal/differ/grpc_live_state_adapters_test.go
@@ -412,4 +412,3 @@ func TestMapAuthConfig_AllTypes(t *testing.T) {
 		})
 	}
 }
-

--- a/services/control-plane/internal/differ/grpc_live_state_adapters_test.go
+++ b/services/control-plane/internal/differ/grpc_live_state_adapters_test.go
@@ -308,13 +308,13 @@ func TestMapProviderConnection_NoRetryOrRateLimit(t *testing.T) {
 
 func TestMapInstructionRoute(t *testing.T) {
 	r := &opgatewayv1.InstructionRoute{
-		InstructionType:    "payment.initiate",
-		ConnectionId:       "stripe-main",
+		InstructionType:      "payment.initiate",
+		ConnectionId:         "stripe-main",
 		FallbackConnectionId: "stripe-backup",
-		OutboundMapping:    "payment_outbound",
-		InboundMapping:     "payment_inbound",
-		HttpMethod:         "POST",
-		PathTemplate:       "/v1/charges",
+		OutboundMapping:      "payment_outbound",
+		InboundMapping:       "payment_inbound",
+		HttpMethod:           "POST",
+		PathTemplate:         "/v1/charges",
 	}
 
 	got := mapInstructionRoute(r)
@@ -347,8 +347,8 @@ func TestMapProtocol(t *testing.T) {
 
 func TestMapAuthConfig_AllTypes(t *testing.T) {
 	tests := []struct {
-		name string
-		conn *opgatewayv1.ProviderConnection
+		name  string
+		conn  *opgatewayv1.ProviderConnection
 		check func(t *testing.T, auth *controlplanev1.AuthConfigManifest)
 	}{
 		{
@@ -413,10 +413,3 @@ func TestMapAuthConfig_AllTypes(t *testing.T) {
 	}
 }
 
-func TestNewLiveStateClients_NilConn(t *testing.T) {
-	// Passing a nil conn to the constructors will create clients with nil stubs.
-	// This test verifies the wiring function itself doesn't panic when given
-	// a valid (non-nil) connection shape. We can't test actual gRPC calls without
-	// a server, but we verify the constructor wiring completes.
-	// The nil-client validation is tested by the existing GRPCLiveStateProvider tests.
-}

--- a/services/control-plane/internal/differ/grpc_live_state_adapters_test.go
+++ b/services/control-plane/internal/differ/grpc_live_state_adapters_test.go
@@ -1,0 +1,422 @@
+package differ
+
+import (
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	internalaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_account/v1"
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
+	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapInstrument(t *testing.T) {
+	inst := &referencedatav1.InstrumentDefinition{
+		Code:        "GBP",
+		DisplayName: "British Pound Sterling",
+		Dimension:   referencedatav1.Dimension_DIMENSION_CURRENCY,
+		Precision:   2,
+	}
+
+	got := mapInstrument(inst)
+
+	assert.Equal(t, "GBP", got.GetCode())
+	assert.Equal(t, "British Pound Sterling", got.GetName())
+	assert.Equal(t, controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT, got.GetType())
+	assert.Equal(t, int32(2), got.GetDimensions().GetPrecision())
+	assert.Equal(t, "GBP", got.GetDimensions().GetUnit())
+}
+
+func TestMapDimensionToInstrumentType(t *testing.T) {
+	tests := []struct {
+		dimension referencedatav1.Dimension
+		expected  controlplanev1.InstrumentType
+	}{
+		{referencedatav1.Dimension_DIMENSION_CURRENCY, controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT},
+		{referencedatav1.Dimension_DIMENSION_ENERGY, controlplanev1.InstrumentType_INSTRUMENT_TYPE_COMMODITY},
+		{referencedatav1.Dimension_DIMENSION_MASS, controlplanev1.InstrumentType_INSTRUMENT_TYPE_COMMODITY},
+		{referencedatav1.Dimension_DIMENSION_CARBON, controlplanev1.InstrumentType_INSTRUMENT_TYPE_COMMODITY},
+		{referencedatav1.Dimension_DIMENSION_COMPUTE, controlplanev1.InstrumentType_INSTRUMENT_TYPE_UNSPECIFIED},
+		{referencedatav1.Dimension_DIMENSION_UNSPECIFIED, controlplanev1.InstrumentType_INSTRUMENT_TYPE_UNSPECIFIED},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, mapDimensionToInstrumentType(tt.dimension), "dimension=%v", tt.dimension)
+	}
+}
+
+func TestMapAccountType(t *testing.T) {
+	at := &referencedatav1.AccountTypeDefinition{
+		Code:           "CUSTOMER_CURRENT",
+		DisplayName:    "Customer Current Account",
+		NormalBalance:  referencedatav1.NormalBalance_NORMAL_BALANCE_CREDIT,
+		InstrumentCode: "GBP",
+		ValidationCel:  "amount > 0",
+		BucketingCel:   "instrument_code",
+	}
+
+	got := mapAccountType(at)
+
+	assert.Equal(t, "CUSTOMER_CURRENT", got.GetCode())
+	assert.Equal(t, "Customer Current Account", got.GetName())
+	assert.Equal(t, controlplanev1.NormalBalance_NORMAL_BALANCE_CREDIT, got.GetNormalBalance())
+	assert.Equal(t, []string{"GBP"}, got.GetAllowedInstruments())
+	assert.Equal(t, "amount > 0", got.GetPolicies().GetValidation())
+	assert.Equal(t, "instrument_code", got.GetPolicies().GetBucketing())
+}
+
+func TestMapAccountType_NoPolicies(t *testing.T) {
+	at := &referencedatav1.AccountTypeDefinition{
+		Code:           "SIMPLE",
+		DisplayName:    "Simple Account",
+		NormalBalance:  referencedatav1.NormalBalance_NORMAL_BALANCE_DEBIT,
+		InstrumentCode: "USD",
+	}
+
+	got := mapAccountType(at)
+
+	assert.Nil(t, got.GetPolicies())
+}
+
+func TestMapSaga(t *testing.T) {
+	s := &sagav1.SagaDefinition{
+		Name:                    "process_payment",
+		Script:                  "def main(ctx):\n  pass",
+		PreconditionsExpression: "event.type == 'payment'",
+	}
+
+	got := mapSaga(s)
+
+	assert.Equal(t, "process_payment", got.GetName())
+	assert.Equal(t, "def main(ctx):\n  pass", got.GetScript())
+	assert.Equal(t, "event.type == 'payment'", got.GetFilter())
+}
+
+func TestMapSaga_NoFilter(t *testing.T) {
+	s := &sagav1.SagaDefinition{
+		Name:   "simple_saga",
+		Script: "def main(ctx):\n  pass",
+	}
+
+	got := mapSaga(s)
+
+	assert.Equal(t, "", got.GetFilter())
+	assert.Nil(t, got.Filter)
+}
+
+func TestMapMarketDataSource(t *testing.T) {
+	src := &marketinformationv1.DataSource{
+		Code:        "BLOOMBERG",
+		Name:        "Bloomberg LP",
+		Description: "Global market data",
+		TrustLevel:  95,
+	}
+
+	got := mapMarketDataSource(src)
+
+	assert.Equal(t, "BLOOMBERG", got.GetCode())
+	assert.Equal(t, "Bloomberg LP", got.GetName())
+	assert.Equal(t, "Global market data", got.GetDescription())
+	assert.Equal(t, int32(95), got.GetTrustLevel())
+}
+
+func TestMapMarketDataSet(t *testing.T) {
+	ds := &marketinformationv1.DataSetDefinition{
+		Code:                    "USD_EUR_FX",
+		Category:                marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE,
+		Unit:                    "USD/EUR",
+		DisplayName:             "USD/EUR Exchange Rate",
+		Description:             "FX rate",
+		ValidationExpression:    "value > 0",
+		ResolutionKeyExpression: "date",
+	}
+
+	got := mapMarketDataSet(ds)
+
+	assert.Equal(t, "USD_EUR_FX", got.GetCode())
+	assert.Equal(t, marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE, got.GetCategory())
+	assert.Equal(t, "USD/EUR", got.GetUnit())
+	assert.Equal(t, "USD/EUR Exchange Rate", got.GetDisplayName())
+	assert.Equal(t, "value > 0", got.GetValidationExpression())
+	assert.Equal(t, "date", got.GetResolutionKeyExpression())
+}
+
+func TestMapMarketDataSet_NoOptionalFields(t *testing.T) {
+	ds := &marketinformationv1.DataSetDefinition{
+		Code: "SIMPLE",
+		Unit: "USD",
+	}
+
+	got := mapMarketDataSet(ds)
+
+	assert.Nil(t, got.ValidationExpression)
+	assert.Nil(t, got.ResolutionKeyExpression)
+}
+
+func TestMapOrganization(t *testing.T) {
+	p := &partyv1.Party{
+		PartyId:               "ACME_CORP",
+		PartyType:             partyv1.PartyType_PARTY_TYPE_ORGANIZATION,
+		LegalName:             "ACME Corporation Ltd",
+		DisplayName:           "ACME Corp",
+		ExternalReference:     "12345678",
+		ExternalReferenceType: partyv1.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_COMPANIES_HOUSE,
+		Attributes: []*quantityv1.AttributeEntry{
+			{Key: "region", Value: "UK"},
+		},
+	}
+
+	got := mapOrganization(p)
+
+	assert.Equal(t, "ACME_CORP", got.GetCode())
+	assert.Equal(t, "ACME Corporation Ltd", got.GetName())
+	assert.Equal(t, "PARTY_TYPE_ORGANIZATION", got.GetPartyType())
+	assert.Equal(t, "ACME Corporation Ltd", got.GetLegalName())
+	assert.Equal(t, "ACME Corp", got.GetDisplayName())
+	assert.Equal(t, "12345678", got.GetExternalReference())
+	assert.Equal(t, "EXTERNAL_REFERENCE_TYPE_COMPANIES_HOUSE", got.GetExternalReferenceType())
+	assert.Equal(t, map[string]string{"region": "UK"}, got.GetAttributes())
+}
+
+func TestMapOrganization_MinimalFields(t *testing.T) {
+	p := &partyv1.Party{
+		PartyId:   "SIMPLE_ORG",
+		PartyType: partyv1.PartyType_PARTY_TYPE_ORGANIZATION,
+	}
+
+	got := mapOrganization(p)
+
+	assert.Equal(t, "SIMPLE_ORG", got.GetCode())
+	assert.Nil(t, got.LegalName)
+	assert.Nil(t, got.DisplayName)
+	assert.Nil(t, got.ExternalReference)
+	assert.Nil(t, got.ExternalReferenceType)
+	assert.Nil(t, got.Attributes)
+}
+
+func TestMapInternalAccount(t *testing.T) {
+	f := &internalaccountv1.InternalAccountFacility{
+		AccountCode:    "CLR-001",
+		BehaviorClass:  "CLEARING",
+		InstrumentCode: "GBP",
+		OrgPartyId:     "ACME_CORP",
+		Description:    "Main clearing account",
+	}
+
+	got := mapInternalAccount(f)
+
+	assert.Equal(t, "CLR-001", got.GetCode())
+	assert.Equal(t, "CLEARING", got.GetAccountType())
+	assert.Equal(t, "GBP", got.GetInstrument())
+	assert.Equal(t, "ACME_CORP", got.GetOwnerOrganization())
+	assert.Equal(t, "Main clearing account", got.GetDescription())
+}
+
+func TestMapProviderConnection(t *testing.T) {
+	conn := &opgatewayv1.ProviderConnection{
+		ConnectionId: "stripe-main",
+		ProviderName: "Stripe",
+		ProviderType: "payment_gateway",
+		Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
+		BaseUrl:      "https://api.stripe.com",
+		AuthConfig: &opgatewayv1.ProviderConnection_ApiKey{
+			ApiKey: &opgatewayv1.ApiKeyAuth{
+				HeaderName: "Authorization",
+				SecretRef:  "stripe-api-key",
+			},
+		},
+		RetryPolicy: &opgatewayv1.RetryPolicy{
+			MaxAttempts:           3,
+			InitialBackoffSeconds: 1,
+			MaxBackoffSeconds:     30,
+			BackoffMultiplier:     2.0,
+		},
+		RateLimit: &opgatewayv1.RateLimit{
+			RequestsPerSecond: 100.0,
+			BurstSize:         10,
+		},
+	}
+
+	got := mapProviderConnection(conn)
+
+	assert.Equal(t, "stripe-main", got.GetConnectionId())
+	assert.Equal(t, "Stripe", got.GetProviderName())
+	assert.Equal(t, "payment_gateway", got.GetProviderType())
+	assert.Equal(t, controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_HTTPS, got.GetProtocol())
+	assert.Equal(t, "https://api.stripe.com", got.GetBaseUrl())
+
+	auth := got.GetAuth().GetApiKey()
+	assert.Equal(t, "Authorization", auth.GetHeaderName())
+	assert.Equal(t, "stripe-api-key", auth.GetApiKeySecretRef())
+
+	rp := got.GetRetryPolicy()
+	assert.Equal(t, int32(3), rp.GetMaxAttempts())
+	assert.Equal(t, int32(1), rp.GetInitialBackoffSeconds())
+	assert.Equal(t, int32(30), rp.GetMaxBackoffSeconds())
+	assert.Equal(t, 2.0, rp.GetBackoffMultiplier())
+
+	rl := got.GetRateLimit()
+	assert.Equal(t, 100.0, rl.GetRequestsPerSecond())
+	assert.Equal(t, int32(10), rl.GetBurstSize())
+}
+
+func TestMapProviderConnection_OAuth2Auth(t *testing.T) {
+	conn := &opgatewayv1.ProviderConnection{
+		ConnectionId: "oauth-svc",
+		AuthConfig: &opgatewayv1.ProviderConnection_Oauth2{
+			Oauth2: &opgatewayv1.OAuth2Auth{
+				TokenUrl:        "https://auth.example.com/token",
+				ClientId:        "client-123",
+				ClientSecretRef: "oauth-secret",
+				Scopes:          []string{"read", "write"},
+			},
+		},
+	}
+
+	got := mapProviderConnection(conn)
+
+	auth := got.GetAuth().GetOauth2()
+	assert.Equal(t, "https://auth.example.com/token", auth.GetTokenUrl())
+	assert.Equal(t, "client-123", auth.GetClientId())
+	assert.Equal(t, "oauth-secret", auth.GetClientSecretRef())
+	assert.Equal(t, []string{"read", "write"}, auth.GetScopes())
+}
+
+func TestMapProviderConnection_NoAuthConfig(t *testing.T) {
+	conn := &opgatewayv1.ProviderConnection{
+		ConnectionId: "no-auth",
+	}
+
+	got := mapProviderConnection(conn)
+
+	assert.Nil(t, got.GetAuth())
+}
+
+func TestMapProviderConnection_NoRetryOrRateLimit(t *testing.T) {
+	conn := &opgatewayv1.ProviderConnection{
+		ConnectionId: "minimal",
+	}
+
+	got := mapProviderConnection(conn)
+
+	assert.Nil(t, got.GetRetryPolicy())
+	assert.Nil(t, got.GetRateLimit())
+}
+
+func TestMapInstructionRoute(t *testing.T) {
+	r := &opgatewayv1.InstructionRoute{
+		InstructionType:    "payment.initiate",
+		ConnectionId:       "stripe-main",
+		FallbackConnectionId: "stripe-backup",
+		OutboundMapping:    "payment_outbound",
+		InboundMapping:     "payment_inbound",
+		HttpMethod:         "POST",
+		PathTemplate:       "/v1/charges",
+	}
+
+	got := mapInstructionRoute(r)
+
+	assert.Equal(t, "payment.initiate", got.GetInstructionType())
+	assert.Equal(t, "stripe-main", got.GetConnectionId())
+	assert.Equal(t, "stripe-backup", got.GetFallbackConnectionId())
+	assert.Equal(t, "payment_outbound", got.GetOutboundMappingId())
+	assert.Equal(t, "payment_inbound", got.GetInboundMappingId())
+	assert.Equal(t, "POST", got.GetHttpMethod())
+	assert.Equal(t, "/v1/charges", got.GetPathTemplate())
+}
+
+func TestMapProtocol(t *testing.T) {
+	tests := []struct {
+		input    opgatewayv1.Protocol
+		expected controlplanev1.ProviderProtocol
+	}{
+		{opgatewayv1.Protocol_PROTOCOL_HTTPS, controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_HTTPS},
+		{opgatewayv1.Protocol_PROTOCOL_GRPC, controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_GRPC},
+		{opgatewayv1.Protocol_PROTOCOL_WEBHOOK, controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_WEBHOOK},
+		{opgatewayv1.Protocol_PROTOCOL_MQTT, controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_MQTT},
+		{opgatewayv1.Protocol_PROTOCOL_AMQP, controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_AMQP},
+		{opgatewayv1.Protocol_PROTOCOL_UNSPECIFIED, controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_UNSPECIFIED},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, mapProtocol(tt.input), "protocol=%v", tt.input)
+	}
+}
+
+func TestMapAuthConfig_AllTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		conn *opgatewayv1.ProviderConnection
+		check func(t *testing.T, auth *controlplanev1.AuthConfigManifest)
+	}{
+		{
+			name: "basic",
+			conn: &opgatewayv1.ProviderConnection{
+				AuthConfig: &opgatewayv1.ProviderConnection_Basic{
+					Basic: &opgatewayv1.BasicAuth{
+						Username:          "user",
+						PasswordSecretRef: "pass-ref",
+					},
+				},
+			},
+			check: func(t *testing.T, auth *controlplanev1.AuthConfigManifest) {
+				b := auth.GetBasic()
+				assert.Equal(t, "user", b.GetUsername())
+				assert.Equal(t, "pass-ref", b.GetPasswordSecretRef())
+			},
+		},
+		{
+			name: "hmac",
+			conn: &opgatewayv1.ProviderConnection{
+				AuthConfig: &opgatewayv1.ProviderConnection_Hmac{
+					Hmac: &opgatewayv1.HMACAuth{
+						Algorithm:       "SHA256",
+						SecretRef:       "hmac-secret",
+						SignatureHeader: "X-Signature",
+					},
+				},
+			},
+			check: func(t *testing.T, auth *controlplanev1.AuthConfigManifest) {
+				h := auth.GetHmac()
+				assert.Equal(t, "SHA256", h.GetAlgorithm())
+				assert.Equal(t, "hmac-secret", h.GetSecretRef())
+				assert.Equal(t, "X-Signature", h.GetSignatureHeader())
+			},
+		},
+		{
+			name: "mtls",
+			conn: &opgatewayv1.ProviderConnection{
+				AuthConfig: &opgatewayv1.ProviderConnection_Mtls{
+					Mtls: &opgatewayv1.MTLSAuth{
+						ClientCertSecretRef: "cert-ref",
+						ClientKeySecretRef:  "key-ref",
+						CaCertSecretRef:     "ca-ref",
+					},
+				},
+			},
+			check: func(t *testing.T, auth *controlplanev1.AuthConfigManifest) {
+				m := auth.GetMtls()
+				assert.Equal(t, "cert-ref", m.GetClientCertSecretRef())
+				assert.Equal(t, "key-ref", m.GetClientKeySecretRef())
+				assert.Equal(t, "ca-ref", m.GetCaCertSecretRef())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapAuthConfig(tt.conn)
+			tt.check(t, got)
+		})
+	}
+}
+
+func TestNewLiveStateClients_NilConn(t *testing.T) {
+	// Passing a nil conn to the constructors will create clients with nil stubs.
+	// This test verifies the wiring function itself doesn't panic when given
+	// a valid (non-nil) connection shape. We can't test actual gRPC calls without
+	// a server, but we verify the constructor wiring completes.
+	// The nil-client validation is tested by the existing GRPCLiveStateProvider tests.
+}

--- a/services/control-plane/internal/planner/manifest_planner.go
+++ b/services/control-plane/internal/planner/manifest_planner.go
@@ -15,9 +15,9 @@ var ErrNilDiffPlan = errors.New("diff plan cannot be nil")
 // ErrNoMethodMapping is returned when no gRPC method mapping exists for a resource type/action combination.
 var ErrNoMethodMapping = errors.New("no gRPC method mapping")
 
-// ErrDeleteNotSupportedForPartyType is returned when a DELETE action is attempted on a party type.
+// ErrMutationNotSupportedForPartyType is returned when a DELETE or DEPRECATE action is attempted on a party type.
 // Party types are managed through schema updates; deletion via manifest apply is not supported.
-var ErrDeleteNotSupportedForPartyType = errors.New("delete not supported for party types: update the schema instead")
+var ErrMutationNotSupportedForPartyType = errors.New("delete/deprecate not supported for party types: update the schema instead")
 
 // ManifestPlanner transforms a DiffPlan into a dependency-ordered
 // ExecutionPlan of gRPC calls. It assigns each action to a phase
@@ -126,8 +126,8 @@ func phaseForResource(rt differ.ResourceType) Phase {
 
 // grpcMethodFor returns the gRPC method for a resource type and action.
 func grpcMethodFor(rt differ.ResourceType, action differ.ActionType) (GRPCMethod, error) {
-	if rt == differ.ResourcePartyType && action == differ.ActionDelete {
-		return "", ErrDeleteNotSupportedForPartyType
+	if rt == differ.ResourcePartyType && (action == differ.ActionDelete || action == differ.ActionDeprecate) {
+		return "", ErrMutationNotSupportedForPartyType
 	}
 	key := methodKey{rt, action}
 	method, ok := grpcMethodMap[key]

--- a/services/control-plane/internal/planner/manifest_planner.go
+++ b/services/control-plane/internal/planner/manifest_planner.go
@@ -145,69 +145,78 @@ type methodKey struct {
 // grpcMethodMap maps (resource type, action) pairs to gRPC methods.
 var grpcMethodMap = map[methodKey]GRPCMethod{
 	// Instruments
-	{differ.ResourceInstrument, differ.ActionCreate}: MethodRegisterInstrument,
-	{differ.ResourceInstrument, differ.ActionUpdate}: MethodUpdateInstrument,
-	{differ.ResourceInstrument, differ.ActionDelete}: MethodDeprecateInstrument,
+	{differ.ResourceInstrument, differ.ActionCreate}:    MethodRegisterInstrument,
+	{differ.ResourceInstrument, differ.ActionUpdate}:    MethodUpdateInstrument,
+	{differ.ResourceInstrument, differ.ActionDelete}:    MethodDeprecateInstrument,
+	{differ.ResourceInstrument, differ.ActionDeprecate}: MethodDeprecateInstrument,
 
 	// Account Types: mapped to Reference Data AccountTypeRegistryService.
 	// CREATE → CreateDraft (the handler calls Activate internally for idempotent flow).
 	// UPDATE → UpdateDefinition.
-	// DELETE → DeprecateAccountType.
-	{differ.ResourceAccountType, differ.ActionCreate}: MethodCreateAccountTypeDraft,
-	{differ.ResourceAccountType, differ.ActionUpdate}: MethodUpdateAccountTypeDefinition,
-	{differ.ResourceAccountType, differ.ActionDelete}: MethodDeprecateAccountType,
+	// DELETE/DEPRECATE → DeprecateAccountType.
+	{differ.ResourceAccountType, differ.ActionCreate}:    MethodCreateAccountTypeDraft,
+	{differ.ResourceAccountType, differ.ActionUpdate}:    MethodUpdateAccountTypeDefinition,
+	{differ.ResourceAccountType, differ.ActionDelete}:    MethodDeprecateAccountType,
+	{differ.ResourceAccountType, differ.ActionDeprecate}: MethodDeprecateAccountType,
 
 	// Valuation Rules: mapped to Reference Data Service instrument operations
 	// (valuation rules are registered alongside instrument definitions).
-	{differ.ResourceValuationRule, differ.ActionCreate}: MethodRegisterInstrument,
-	{differ.ResourceValuationRule, differ.ActionUpdate}: MethodUpdateInstrument,
-	{differ.ResourceValuationRule, differ.ActionDelete}: MethodDeprecateInstrument,
+	{differ.ResourceValuationRule, differ.ActionCreate}:    MethodRegisterInstrument,
+	{differ.ResourceValuationRule, differ.ActionUpdate}:    MethodUpdateInstrument,
+	{differ.ResourceValuationRule, differ.ActionDelete}:    MethodDeprecateInstrument,
+	{differ.ResourceValuationRule, differ.ActionDeprecate}: MethodDeprecateInstrument,
 
 	// Sagas
-	{differ.ResourceSaga, differ.ActionCreate}: MethodCreateSagaDraft,
-	{differ.ResourceSaga, differ.ActionUpdate}: MethodUpdateSagaDefinition,
-	{differ.ResourceSaga, differ.ActionDelete}: MethodDeprecateSaga,
+	{differ.ResourceSaga, differ.ActionCreate}:    MethodCreateSagaDraft,
+	{differ.ResourceSaga, differ.ActionUpdate}:    MethodUpdateSagaDefinition,
+	{differ.ResourceSaga, differ.ActionDelete}:    MethodDeprecateSaga,
+	{differ.ResourceSaga, differ.ActionDeprecate}: MethodDeprecateSaga,
 
 	// Party Types
 	{differ.ResourcePartyType, differ.ActionCreate}: MethodRegisterPartyType,
 	{differ.ResourcePartyType, differ.ActionUpdate}: MethodUpdatePartyType,
-	// DELETE for party types is not supported (party types are managed through schema updates)
-	// No delete method registered intentionally.
+	// DELETE/DEPRECATE for party types is not supported (party types are managed through schema updates)
+	// No delete/deprecate method registered intentionally.
 
 	// Mappings
-	{differ.ResourceMapping, differ.ActionCreate}: MethodCreateMapping,
-	{differ.ResourceMapping, differ.ActionUpdate}: MethodUpdateMapping,
-	{differ.ResourceMapping, differ.ActionDelete}: MethodDeprecateMapping,
+	{differ.ResourceMapping, differ.ActionCreate}:    MethodCreateMapping,
+	{differ.ResourceMapping, differ.ActionUpdate}:    MethodUpdateMapping,
+	{differ.ResourceMapping, differ.ActionDelete}:    MethodDeprecateMapping,
+	{differ.ResourceMapping, differ.ActionDeprecate}: MethodDeprecateMapping,
 
 	// Provider Connections (Operational Gateway)
 	{differ.ResourceProviderConnection, differ.ActionCreate}: MethodUpsertProviderConnection,
 	{differ.ResourceProviderConnection, differ.ActionUpdate}: MethodUpsertProviderConnection,
-	// No delete method: proto does not define DeleteConnection RPC.
+	// No delete/deprecate method: proto does not define DeleteConnection RPC.
 
 	// Instruction Routes (Operational Gateway)
 	{differ.ResourceInstructionRoute, differ.ActionCreate}: MethodUpsertInstructionRoute,
 	{differ.ResourceInstructionRoute, differ.ActionUpdate}: MethodUpsertInstructionRoute,
-	// No delete method: proto does not define DeleteRoute RPC.
+	// No delete/deprecate method: proto does not define DeleteRoute RPC.
 
 	// Market Data Sources
-	{differ.ResourceMarketDataSource, differ.ActionCreate}: MethodRegisterDataSource,
-	{differ.ResourceMarketDataSource, differ.ActionUpdate}: MethodUpdateDataSource,
-	{differ.ResourceMarketDataSource, differ.ActionDelete}: MethodDeactivateDataSource,
+	{differ.ResourceMarketDataSource, differ.ActionCreate}:    MethodRegisterDataSource,
+	{differ.ResourceMarketDataSource, differ.ActionUpdate}:    MethodUpdateDataSource,
+	{differ.ResourceMarketDataSource, differ.ActionDelete}:    MethodDeactivateDataSource,
+	{differ.ResourceMarketDataSource, differ.ActionDeprecate}: MethodDeactivateDataSource,
 
 	// Market Data Sets
-	{differ.ResourceMarketDataSet, differ.ActionCreate}: MethodRegisterDataSet,
-	{differ.ResourceMarketDataSet, differ.ActionUpdate}: MethodUpdateDataSet,
-	{differ.ResourceMarketDataSet, differ.ActionDelete}: MethodDeprecateDataSet,
+	{differ.ResourceMarketDataSet, differ.ActionCreate}:    MethodRegisterDataSet,
+	{differ.ResourceMarketDataSet, differ.ActionUpdate}:    MethodUpdateDataSet,
+	{differ.ResourceMarketDataSet, differ.ActionDelete}:    MethodDeprecateDataSet,
+	{differ.ResourceMarketDataSet, differ.ActionDeprecate}: MethodDeprecateDataSet,
 
 	// Organizations
-	{differ.ResourceOrganization, differ.ActionCreate}: MethodRegisterOrganization,
-	{differ.ResourceOrganization, differ.ActionUpdate}: MethodRegisterOrganization,
-	{differ.ResourceOrganization, differ.ActionDelete}: MethodControlOrganization,
+	{differ.ResourceOrganization, differ.ActionCreate}:    MethodRegisterOrganization,
+	{differ.ResourceOrganization, differ.ActionUpdate}:    MethodRegisterOrganization,
+	{differ.ResourceOrganization, differ.ActionDelete}:    MethodControlOrganization,
+	{differ.ResourceOrganization, differ.ActionDeprecate}: MethodControlOrganization,
 
 	// Internal Accounts
-	{differ.ResourceInternalAccount, differ.ActionCreate}: MethodInitiateAccount,
-	{differ.ResourceInternalAccount, differ.ActionUpdate}: MethodUpdateInternalAccount,
-	{differ.ResourceInternalAccount, differ.ActionDelete}: MethodControlInternalAccount,
+	{differ.ResourceInternalAccount, differ.ActionCreate}:    MethodInitiateAccount,
+	{differ.ResourceInternalAccount, differ.ActionUpdate}:    MethodUpdateInternalAccount,
+	{differ.ResourceInternalAccount, differ.ActionDelete}:    MethodControlInternalAccount,
+	{differ.ResourceInternalAccount, differ.ActionDeprecate}: MethodControlInternalAccount,
 }
 
 // GenerateIdempotencyKey produces a deterministic SHA-256 based idempotency key.

--- a/services/control-plane/internal/planner/manifest_planner_test.go
+++ b/services/control-plane/internal/planner/manifest_planner_test.go
@@ -597,7 +597,20 @@ func TestPlan_PartyType_Delete_NotSupported(t *testing.T) {
 
 	_, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
 	assert.Error(t, err, "DELETE for party types should fail")
-	assert.ErrorIs(t, err, ErrDeleteNotSupportedForPartyType)
+	assert.ErrorIs(t, err, ErrMutationNotSupportedForPartyType)
+}
+
+func TestPlan_PartyType_Deprecate_NotSupported(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourcePartyType, ResourceCode: "tenant-1:PERSON", Action: differ.ActionDeprecate},
+		},
+	}
+
+	_, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	assert.Error(t, err, "DEPRECATE for party types should fail")
+	assert.ErrorIs(t, err, ErrMutationNotSupportedForPartyType)
 }
 
 // --- Market Data Source planner tests ---

--- a/services/control-plane/service/apply_manifest.go
+++ b/services/control-plane/service/apply_manifest.go
@@ -29,6 +29,11 @@ type ApplyManifestServiceConfig struct {
 	// When nil, the handler validates, diffs, and plans manifests but does
 	// not execute them (suitable for lightweight deployments).
 	HandlerDeps *applier.HandlerDependencies
+
+	// GRPCConn is a gRPC connection to downstream services used to build
+	// the live-state provider for convergent manifest diffs. When nil, the
+	// differ falls back to stored-manifest comparison only.
+	GRPCConn *grpc.ClientConn
 }
 
 // ErrPoolRequired is returned when Pool is nil during service registration.
@@ -51,7 +56,16 @@ func RegisterApplyManifestService(server *grpc.Server, cfg ApplyManifestServiceC
 	}
 
 	versionStore := persistence.NewPostgresManifestVersionStore(cfg.Pool)
-	d := differ.New(nil, nil, nil) // NoOp safety checker, drift detector, and live state provider
+
+	var liveState differ.LiveStateProvider
+	if cfg.GRPCConn != nil {
+		var lsErr error
+		liveState, lsErr = differ.NewLiveStateClients(cfg.GRPCConn)
+		if lsErr != nil {
+			return fmt.Errorf("live state provider: %w", lsErr)
+		}
+	}
+	d := differ.New(nil, nil, liveState)
 	p := planner.NewManifestPlanner()
 
 	var executor *applier.ManifestExecutor


### PR DESCRIPTION
## Summary

- Create 6 gRPC adapter clients in the differ package that implement the live-state provider interfaces by calling downstream List RPCs and mapping responses to control-plane manifest types
- Add `GRPCConn` field to `ApplyManifestServiceConfig` and wire it from the loopback connection in `wireControlPlane()`
- This activates convergent live-state diffing so the handler queries actual service state instead of falling back to stored-manifest comparison

## Changes Made

- **New file**: `services/control-plane/internal/differ/grpc_live_state_adapters.go` - 6 adapter structs (`GRPCReferenceDataClient`, `GRPCSagaRegistryClient`, `GRPCMarketInformationClient`, `GRPCPartyClient`, `GRPCInternalAccountClient`, `GRPCOperationalGatewayClient`) with pagination support and type mapping functions
- **New file**: `services/control-plane/internal/differ/grpc_live_state_adapters_test.go` - Unit tests for all mapping functions
- **Modified**: `services/control-plane/service/apply_manifest.go` - Creates `GRPCLiveStateProvider` from `GRPCConn` and passes to differ
- **Modified**: `cmd/meridian/wire_grpc.go` - Passes `loopback.rawConn` as `GRPCConn`

## Technical Details

Each adapter wraps a generated gRPC client stub and translates between the service-specific proto types and the control-plane manifest types used by the differ. The adapters handle pagination for all List RPCs that support it, and the `NewLiveStateClients()` convenience function creates all six adapters from a single gRPC connection.

The party adapter filters to `PARTY_TYPE_ORGANIZATION` only, matching what manifests declare.

## Test plan

- [x] All mapping functions unit tested (dimension mapping, auth config variants, optional fields, edge cases)
- [x] `go test ./services/control-plane/... -short -count=1` - all 16 packages pass
- [x] `go build ./cmd/meridian/` - full binary compiles cleanly
- [x] `go vet ./services/control-plane/...` - no issues
- [ ] CI passes