### PR TITLE
fix: treat schema-not-provisioned as empty state in live-state diff

### DIFF
--- a/services/control-plane/internal/differ/grpc_live_state_adapters.go
+++ b/services/control-plane/internal/differ/grpc_live_state_adapters.go
@@ -3,6 +3,7 @@ package differ
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
@@ -17,13 +18,22 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// isUnimplemented returns true if the error indicates the gRPC service is not
-// registered on the target server. This happens when the unified binary does
-// not include a particular service (e.g., operational-gateway runs as a
-// separate process). Returning true allows callers to treat the resource type
-// as having no live state rather than failing the entire diff.
-func isUnimplemented(err error) bool {
-	return status.Code(err) == codes.Unimplemented
+// isEmptyState returns true if the error indicates the service has no data for
+// this tenant rather than a real failure. This covers two cases:
+//   - codes.Unimplemented: the gRPC service is not registered on the target
+//     server (e.g., operational-gateway runs as a separate process)
+//   - "schema not provisioned" / "schema does not exist": the tenant's schema
+//     has not been created in this service's database yet (first manifest apply)
+//
+// Returning true allows callers to treat the resource type as having no live
+// state rather than failing the entire diff.
+func isEmptyState(err error) bool {
+	if status.Code(err) == codes.Unimplemented {
+		return true
+	}
+	msg := status.Convert(err).Message()
+	return strings.Contains(msg, "schema not provisioned") ||
+		strings.Contains(msg, "schema does not exist")
 }
 
 // defaultPageSize is the page size used when paginating through list RPCs.
@@ -57,7 +67,7 @@ func (c *GRPCReferenceDataClient) ListInstruments(ctx context.Context) ([]*contr
 			PageToken: pageToken,
 		})
 		if err != nil {
-			if isUnimplemented(err) {
+			if isEmptyState(err) {
 				return nil, nil
 			}
 			return nil, fmt.Errorf("list instruments: %w", err)
@@ -82,7 +92,7 @@ func (c *GRPCReferenceDataClient) ListAccountTypes(ctx context.Context) ([]*cont
 			PageToken: pageToken,
 		})
 		if err != nil {
-			if isUnimplemented(err) {
+			if isEmptyState(err) {
 				return nil, nil
 			}
 			return nil, fmt.Errorf("list account types: %w", err)
@@ -124,7 +134,7 @@ func (c *GRPCSagaRegistryClient) ListSagas(ctx context.Context) ([]*controlplane
 			PageToken: pageToken,
 		})
 		if err != nil {
-			if isUnimplemented(err) {
+			if isEmptyState(err) {
 				return nil, nil
 			}
 			return nil, fmt.Errorf("list sagas: %w", err)
@@ -166,7 +176,7 @@ func (c *GRPCMarketInformationClient) ListMarketDataSources(ctx context.Context)
 			PageToken: pageToken,
 		})
 		if err != nil {
-			if isUnimplemented(err) {
+			if isEmptyState(err) {
 				return nil, nil
 			}
 			return nil, fmt.Errorf("list data sources: %w", err)
@@ -191,7 +201,7 @@ func (c *GRPCMarketInformationClient) ListMarketDataSets(ctx context.Context) ([
 			PageToken: pageToken,
 		})
 		if err != nil {
-			if isUnimplemented(err) {
+			if isEmptyState(err) {
 				return nil, nil
 			}
 			return nil, fmt.Errorf("list data sets: %w", err)
@@ -234,7 +244,7 @@ func (c *GRPCPartyClient) ListOrganizations(ctx context.Context) ([]*controlplan
 			PartyType: partyv1.PartyType_PARTY_TYPE_ORGANIZATION,
 		})
 		if err != nil {
-			if isUnimplemented(err) {
+			if isEmptyState(err) {
 				return nil, nil
 			}
 			return nil, fmt.Errorf("list organizations: %w", err)
@@ -281,7 +291,7 @@ func (c *GRPCInternalAccountClient) ListInternalAccounts(ctx context.Context) ([
 			},
 		})
 		if err != nil {
-			if isUnimplemented(err) {
+			if isEmptyState(err) {
 				return nil, nil
 			}
 			return nil, fmt.Errorf("list internal accounts: %w", err)
@@ -328,7 +338,7 @@ func (c *GRPCOperationalGatewayClient) ListProviderConnections(ctx context.Conte
 			},
 		})
 		if err != nil {
-			if isUnimplemented(err) {
+			if isEmptyState(err) {
 				return nil, nil
 			}
 			return nil, fmt.Errorf("list provider connections: %w", err)
@@ -348,7 +358,7 @@ func (c *GRPCOperationalGatewayClient) ListProviderConnections(ctx context.Conte
 func (c *GRPCOperationalGatewayClient) ListInstructionRoutes(ctx context.Context) ([]*controlplanev1.InstructionRouteConfig, error) {
 	resp, err := c.routeClient.ListRoutes(ctx, &opgatewayv1.ListRoutesRequest{})
 	if err != nil {
-		if isUnimplemented(err) {
+		if isEmptyState(err) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("list instruction routes: %w", err)

--- a/services/control-plane/internal/differ/grpc_live_state_adapters_test.go
+++ b/services/control-plane/internal/differ/grpc_live_state_adapters_test.go
@@ -12,6 +12,8 @@ import (
 	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
 	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestMapInstrument(t *testing.T) {
@@ -421,6 +423,45 @@ func TestMapAuthConfig_AllTypes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := mapAuthConfig(tt.conn)
 			tt.check(t, got)
+		})
+	}
+}
+
+func TestIsEmptyState(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "Unimplemented",
+			err:      status.Error(codes.Unimplemented, "unknown service"),
+			expected: true,
+		},
+		{
+			name:     "schema not provisioned",
+			err:      status.Error(codes.Internal, "failed to list accounts: tenant schema not provisioned: schema does not exist in database: org_volterra_energy"),
+			expected: true,
+		},
+		{
+			name:     "schema does not exist",
+			err:      status.Error(codes.Internal, "schema does not exist"),
+			expected: true,
+		},
+		{
+			name:     "other internal error",
+			err:      status.Error(codes.Internal, "connection refused"),
+			expected: false,
+		},
+		{
+			name:     "not found",
+			err:      status.Error(codes.NotFound, "resource not found"),
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isEmptyState(tt.err))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Renames `isUnimplemented` to `isEmptyState` in the live-state gRPC adapters
- Adds tolerance for "schema not provisioned" / "schema does not exist" errors, treating them as empty state (no resources for this tenant in that service)
- Unblocks both develop and demo deployments where the live-state diff fails because the tenant schema hasn't been created in all service databases yet

## Context

After #2095 wired `GRPCLiveStateProvider` into production, both develop and demo deploys fail at the diff step:
```
query internal accounts: list internal accounts: rpc error: code = Internal
desc = failed to list accounts: tenant schema not provisioned: schema does not exist in database: org_volterra_energy
```

This is the first manifest apply for a newly provisioned tenant - the tenant schema doesn't exist in all service databases yet. The manifest apply itself would create these resources, so the correct behavior is to treat missing schemas as empty state (the tenant has no resources in that service).

## Test Plan

- [x] `TestIsEmptyState` covers Unimplemented, schema-not-provisioned, schema-does-not-exist, and negative cases
- [ ] CI passes
- [ ] Deploy to develop succeeds (diff shows "0 to create" for existing resources)
- [ ] Deploy to demo succeeds