### PR TITLE
fix: action-aware saga script and org code mapping for live-state diff

### DIFF
--- a/services/control-plane/internal/applier/bootstrap_test.go
+++ b/services/control-plane/internal/applier/bootstrap_test.go
@@ -15,7 +15,7 @@ func TestLoadEmbeddedApplyManifest(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, script)
-	assert.Equal(t, "1.3.0", version)
+	assert.Equal(t, "1.4.0", version)
 	assert.Contains(t, script, "apply_manifest")
 	assert.Contains(t, script, "execute_apply_manifest")
 	assert.Contains(t, script, "reference_data.register_instrument")
@@ -195,7 +195,7 @@ func TestLoadEmbeddedApplyManifest_ReturnsLatestVersion(t *testing.T) {
 	// loadEmbeddedApplyManifest should return v1.3.0 as the latest
 	script, version, err := loadEmbeddedApplyManifest()
 	require.NoError(t, err)
-	assert.Equal(t, "1.3.0", version)
+	assert.Equal(t, "1.4.0", version)
 	assert.NotEmpty(t, script)
 	// Verify TrimSpace was applied: no leading whitespace
 	assert.NotEqual(t, ' ', rune(script[0]))

--- a/services/control-plane/internal/applier/defaults/apply_manifest/v1.4.0.star
+++ b/services/control-plane/internal/applier/defaults/apply_manifest/v1.4.0.star
@@ -1,0 +1,352 @@
+# Saga: apply_manifest
+# Version: 1.4.0
+# Previous: 1.3.0
+# Changed: Action-aware execution. Each resource checks its "action" field
+#          (set by the live-state diff planner) and routes to the correct
+#          handler: CREATE runs register+activate, UPDATE runs update,
+#          DEPRECATE runs deprecate. Resources without an action field
+#          default to CREATE for backward compatibility.
+# Author: Platform Team
+# Date: 2026-04-02
+#
+# This Starlark script defines the apply_manifest saga workflow for the Control Plane.
+# It executes phased gRPC calls to provision tenant resources from a manifest definition.
+#
+# Phases (executed sequentially, parallel within each phase):
+#   Phase 10: Instruments (CREATE: register+activate, UPDATE: update)
+#   Phase 20: Account types (CREATE: draft+activate, UPDATE: update)
+#   Phase 30: Market data sources (CREATE: register, UPDATE: update)
+#   Phase 35: Market data sets (CREATE: register+activate, UPDATE: update)
+#   Phase 40: Valuation rules (CREATE: register, UPDATE: update)
+#   Phase 55: Organizations (CREATE: register, UPDATE: register [idempotent])
+#   Phase 60: Internal accounts (CREATE: initiate, UPDATE: update)
+#   Phase 70: Saga definitions (CREATE: register, UPDATE: update)
+#   Phase 90: Operational gateway (upsert for both CREATE and UPDATE)
+
+apply_manifest_saga = saga(name="apply_manifest")
+
+def execute_apply_manifest():
+    manifest_version = input_data["manifest_version"]
+    instruments = input_data.get("instruments", [])
+    account_types = input_data.get("account_types", [])
+    market_data_sources = input_data.get("market_data_sources", [])
+    market_data_sets = input_data.get("market_data_sets", [])
+    valuation_rules = input_data.get("valuation_rules", [])
+    organizations = input_data.get("organizations", [])
+    internal_accounts = input_data.get("internal_accounts", [])
+    saga_definitions = input_data.get("saga_definitions", [])
+    provider_connections = input_data.get("provider_connections", [])
+    instruction_routes = input_data.get("instruction_routes", [])
+
+    registered_instruments = []
+    registered_account_types = []
+    registered_market_data_sources = []
+    registered_market_data_sets = []
+    registered_valuation_rules = []
+    registered_organizations = []
+    registered_internal_accounts = []
+    registered_saga_definitions = []
+    registered_connections = []
+    registered_routes = []
+
+    # Phase 10: Instruments
+    for instrument in instruments:
+        action = instrument.get("action", "CREATE")
+        if action == "UPDATE":
+            step(name="update_instrument_" + instrument["code"])
+            reference_data.update_instrument(
+                instrument_code=instrument["code"],
+                display_name=instrument.get("display_name", instrument["code"]),
+                dimension=instrument.get("dimension", "CURRENCY"),
+                decimal_places=instrument.get("decimal_places", 2),
+                description=instrument.get("description", ""),
+            )
+        else:
+            step(name="register_instrument_" + instrument["code"])
+            result = reference_data.register_instrument(
+                instrument_code=instrument["code"],
+                display_name=instrument.get("display_name", instrument["code"]),
+                dimension=instrument.get("dimension", "CURRENCY"),
+                decimal_places=instrument.get("decimal_places", 2),
+                description=instrument.get("description", ""),
+            )
+
+            step(name="activate_instrument_" + instrument["code"])
+            reference_data.activate_instrument(
+                instrument_code=instrument["code"],
+            )
+
+        registered_instruments.append({
+            "instrument_code": instrument["code"],
+            "status": "ACTIVE",
+        })
+
+    # Phase 20: Account types
+    for account_type in account_types:
+        action = account_type.get("action", "CREATE")
+        if action == "UPDATE":
+            step(name="update_account_type_" + account_type["code"])
+            reference_data.update_account_type(
+                code=account_type["code"],
+                display_name=account_type.get("display_name", account_type["code"]),
+                behavior_class=account_type.get("behavior_class", "CLEARING"),
+                normal_balance=account_type.get("normal_balance", "DEBIT"),
+                instrument_code=account_type.get("instrument_code", ""),
+                description=account_type.get("description", ""),
+                default_saga_prefix=account_type.get("default_saga_prefix", ""),
+                default_conversion_method=account_type.get("default_conversion_method", ""),
+                validation_cel=account_type.get("validation_cel", ""),
+                eligibility_cel=account_type.get("eligibility_cel", ""),
+                attribute_schema=account_type.get("attribute_schema", ""),
+                valuation_methods=account_type.get("valuation_methods", []),
+            )
+        else:
+            step(name="register_account_type_" + account_type["code"])
+            reference_data.register_account_type(
+                code=account_type["code"],
+                display_name=account_type.get("display_name", account_type["code"]),
+                behavior_class=account_type.get("behavior_class", "CLEARING"),
+                normal_balance=account_type.get("normal_balance", "DEBIT"),
+                instrument_code=account_type.get("instrument_code", ""),
+                description=account_type.get("description", ""),
+                default_saga_prefix=account_type.get("default_saga_prefix", ""),
+                default_conversion_method=account_type.get("default_conversion_method", ""),
+                validation_cel=account_type.get("validation_cel", ""),
+                eligibility_cel=account_type.get("eligibility_cel", ""),
+                attribute_schema=account_type.get("attribute_schema", ""),
+                valuation_methods=account_type.get("valuation_methods", []),
+            )
+
+        registered_account_types.append({
+            "account_type_code": account_type["code"],
+            "status": "REGISTERED",
+        })
+
+    # Phase 30: Market data sources
+    for source in market_data_sources:
+        action = source.get("action", "CREATE")
+        if action == "UPDATE":
+            step(name="update_data_source_" + source["code"])
+            market_information.update_data_source(
+                code=source["code"],
+                name=source.get("name", source["code"]),
+                description=source.get("description", ""),
+                trust_level=source.get("trust_level", 0),
+            )
+        else:
+            step(name="register_data_source_" + source["code"])
+            market_information.register_data_source(
+                code=source["code"],
+                name=source.get("name", source["code"]),
+                description=source.get("description", ""),
+                trust_level=source.get("trust_level", 0),
+            )
+        registered_market_data_sources.append({
+            "code": source["code"],
+            "status": "REGISTERED",
+        })
+
+    # Phase 35: Market data sets
+    for dataset in market_data_sets:
+        action = dataset.get("action", "CREATE")
+        if action == "UPDATE":
+            step(name="update_data_set_" + dataset["code"])
+            market_information.update_data_set(
+                code=dataset["code"],
+                category=dataset.get("category", ""),
+                unit=dataset.get("unit", ""),
+                source_code=dataset.get("source_code", ""),
+                display_name=dataset.get("display_name", dataset["code"]),
+                description=dataset.get("description", ""),
+                validation_expression=dataset.get("validation_expression", "") or "true",
+                resolution_key_expression=dataset.get("resolution_key_expression", "") or "observed_at",
+            )
+        else:
+            step(name="register_data_set_" + dataset["code"])
+            ds_result = market_information.register_data_set(
+                code=dataset["code"],
+                category=dataset.get("category", ""),
+                unit=dataset.get("unit", ""),
+                source_code=dataset.get("source_code", ""),
+                display_name=dataset.get("display_name", dataset["code"]),
+                description=dataset.get("description", ""),
+                validation_expression=dataset.get("validation_expression", "") or "true",
+                resolution_key_expression=dataset.get("resolution_key_expression", "") or "observed_at",
+            )
+
+            step(name="activate_data_set_" + dataset["code"])
+            market_information.activate_data_set(
+                code=dataset["code"],
+                version=getattr(ds_result, "version", 1),
+            )
+
+        registered_market_data_sets.append({
+            "code": dataset["code"],
+            "status": "ACTIVE",
+        })
+
+    # Phase 40: Valuation rules
+    for rule in valuation_rules:
+        action = rule.get("action", "CREATE")
+        if action == "UPDATE":
+            step(name="update_valuation_rule_" + rule["from_instrument"] + "_" + rule["to_instrument"])
+            reference_data.update_instrument(
+                from_instrument=rule["from_instrument"],
+                to_instrument=rule["to_instrument"],
+                rule_type=rule.get("rule_type", "FIXED_RATE"),
+                expression=rule.get("expression", ""),
+                description=rule.get("description", ""),
+            )
+        else:
+            step(name="register_valuation_rule_" + rule["from_instrument"] + "_" + rule["to_instrument"])
+            reference_data.register_valuation_rule(
+                from_instrument=rule["from_instrument"],
+                to_instrument=rule["to_instrument"],
+                rule_type=rule.get("rule_type", "FIXED_RATE"),
+                expression=rule.get("expression", ""),
+                description=rule.get("description", ""),
+            )
+        registered_valuation_rules.append({
+            "from_instrument": rule["from_instrument"],
+            "to_instrument": rule["to_instrument"],
+            "status": "REGISTERED",
+        })
+
+    # Phase 55: Organizations
+    for org in organizations:
+        step(name="register_organization_" + org["code"])
+        party.register_organization(
+            legal_name=org.get("legal_name", org.get("name", org["code"])),
+            display_name=org.get("display_name", org.get("legal_name", org.get("name", org["code"]))),
+            party_type=org.get("party_type", "ORGANIZATION"),
+            external_reference=org.get("external_reference", org["code"]),
+            external_reference_type=org.get("external_reference_type", ""),
+            attributes=org.get("attributes", {}),
+        )
+        registered_organizations.append({
+            "code": org["code"],
+            "status": "REGISTERED",
+        })
+
+    # Phase 60: Internal accounts
+    effective_internal_accounts = internal_accounts
+    if len(effective_internal_accounts) == 0:
+        for account_type in account_types:
+            effective_internal_accounts.append({
+                "code": account_type["code"],
+                "account_type": account_type.get("account_type", "CLEARING"),
+                "instrument_code": account_type.get("instrument_code", ""),
+                "description": account_type.get("description", ""),
+            })
+
+    for ia in effective_internal_accounts:
+        action = ia.get("action", "CREATE")
+        if action == "UPDATE":
+            step(name="update_account_" + ia["code"])
+            internal_account.update(
+                account_code=ia["code"],
+                name=ia.get("name", ia["code"]),
+                account_type=ia.get("account_type", "CLEARING"),
+                instrument_code=ia.get("instrument_code", ""),
+                description=ia.get("description", ""),
+                owner_organization=ia.get("owner_organization", ""),
+            )
+            registered_internal_accounts.append({
+                "account_code": ia["code"],
+                "status": "UPDATED",
+            })
+        else:
+            step(name="initiate_account_" + ia["code"])
+            account_result = internal_account.initiate(
+                account_code=ia["code"],
+                name=ia.get("name", ia["code"]),
+                account_type=ia.get("account_type", "CLEARING"),
+                instrument_code=ia.get("instrument_code", ""),
+                description=ia.get("description", ""),
+                owner_organization=ia.get("owner_organization", ""),
+            )
+            registered_internal_accounts.append({
+                "account_code": ia["code"],
+                "account_id": account_result.account_id,
+                "status": "ACTIVE",
+            })
+
+    # Phase 70: Saga definitions
+    for saga_def in saga_definitions:
+        action = saga_def.get("action", "CREATE")
+        if action == "UPDATE":
+            step(name="update_saga_definition_" + saga_def["name"])
+            reference_data.update_saga_definition(
+                saga_name=saga_def["name"],
+                display_name=saga_def.get("display_name", saga_def["name"]),
+                description=saga_def.get("description", ""),
+                script=saga_def.get("script", ""),
+                version=saga_def.get("version", "1.0.0"),
+            )
+        else:
+            step(name="register_saga_definition_" + saga_def["name"])
+            reference_data.register_saga_definition(
+                saga_name=saga_def["name"],
+                display_name=saga_def.get("display_name", saga_def["name"]),
+                description=saga_def.get("description", ""),
+                script=saga_def.get("script", ""),
+                version=saga_def.get("version", "1.0.0"),
+            )
+        registered_saga_definitions.append({
+            "saga_name": saga_def["name"],
+            "status": "REGISTERED",
+        })
+
+    # Phase 90: Operational gateway (upsert handles both CREATE and UPDATE)
+    for conn in provider_connections:
+        step(name="upsert_provider_connection_" + conn["connection_id"])
+        result = operational_gateway.upsert_connection(
+            connection_id=conn["connection_id"],
+            provider_name=conn["provider_name"],
+            provider_type=conn.get("provider_type", ""),
+            protocol=conn["protocol"],
+            base_url=conn["base_url"],
+            auth_type=conn["auth_type"],
+            auth_config=conn.get("auth_config", {}),
+            retry_policy=conn.get("retry_policy", {}),
+            rate_limit_config=conn.get("rate_limit_config", {}),
+        )
+        registered_connections.append({
+            "connection_id": conn["connection_id"],
+            "status": getattr(result, "status", "UPSERTED"),
+        })
+
+    for route in instruction_routes:
+        step(name="upsert_instruction_route_" + route["instruction_type"])
+        result = operational_gateway.upsert_route(
+            instruction_type=route["instruction_type"],
+            connection_id=route["connection_id"],
+            fallback_connection_id=route.get("fallback_connection_id", ""),
+            outbound_mapping=route.get("outbound_mapping", ""),
+            inbound_mapping=route.get("inbound_mapping", ""),
+            http_method=route.get("http_method", ""),
+            path_template=route.get("path_template", ""),
+        )
+        registered_routes.append({
+            "instruction_type": route["instruction_type"],
+            "status": getattr(result, "status", "UPSERTED"),
+        })
+
+    result = {
+        "status": "applied",
+        "version": manifest_version,
+        "instruments_registered": len(registered_instruments),
+        "account_types_registered": len(registered_account_types),
+        "market_data_sources_registered": len(registered_market_data_sources),
+        "market_data_sets_registered": len(registered_market_data_sets),
+        "valuation_rules_registered": len(registered_valuation_rules),
+        "organizations_registered": len(registered_organizations),
+        "internal_accounts_initiated": len(registered_internal_accounts),
+        "saga_definitions_registered": len(registered_saga_definitions),
+        "provider_connections_upserted": len(registered_connections),
+        "instruction_routes_upserted": len(registered_routes),
+    }
+    return result
+
+# Execute the saga
+execute_apply_manifest()

--- a/services/control-plane/internal/applier/executor_test.go
+++ b/services/control-plane/internal/applier/executor_test.go
@@ -392,7 +392,7 @@ func TestApplyManifestSaga_ZeroLocalSagaDefinitions(t *testing.T) {
 	// Step 1: Load embedded saga script (simulates platform default fallback)
 	script, version, err := loadEmbeddedApplyManifest()
 	require.NoError(t, err, "embedded apply_manifest saga must be loadable")
-	assert.Equal(t, "1.3.0", version)
+	assert.Equal(t, "1.4.0", version)
 	assert.Contains(t, script, "execute_apply_manifest")
 
 	// Step 2: Set up handler registry with mock handlers

--- a/services/control-plane/internal/applier/grpc_handler_mappers.go
+++ b/services/control-plane/internal/applier/grpc_handler_mappers.go
@@ -268,6 +268,14 @@ func extractPartyAndAccountsFromPlan(mf *controlplanev1.Manifest, input *ApplyMa
 		if extRef == "" {
 			extRef = org.GetCode()
 		}
+		// Inject _manifest_code into attributes so the live-state adapter can
+		// map the party back to its manifest code (party_id is a UUID).
+		attrs := make(map[string]string)
+		for k, v := range org.GetAttributes() {
+			attrs[k] = v
+		}
+		attrs["_manifest_code"] = org.GetCode()
+
 		input.Organizations = append(input.Organizations, OrganizationInput{
 			Code:                  org.GetCode(),
 			Name:                  org.GetName(),
@@ -276,7 +284,7 @@ func extractPartyAndAccountsFromPlan(mf *controlplanev1.Manifest, input *ApplyMa
 			ExternalReference:     extRef,
 			ExternalReferenceType: org.GetExternalReferenceType(),
 			PartyType:             org.GetPartyType(),
-			Attributes:            org.GetAttributes(),
+			Attributes:            attrs,
 			Action:                string(action),
 		})
 	}
@@ -408,6 +416,12 @@ func extractPartyAndAccounts(mf *controlplanev1.Manifest, input *ApplyManifestIn
 			extRef = org.GetCode()
 		}
 
+		attrs := make(map[string]string)
+		for k, v := range org.GetAttributes() {
+			attrs[k] = v
+		}
+		attrs["_manifest_code"] = org.GetCode()
+
 		input.Organizations = append(input.Organizations, OrganizationInput{
 			Code:                  org.GetCode(),
 			Name:                  org.GetName(),
@@ -416,7 +430,7 @@ func extractPartyAndAccounts(mf *controlplanev1.Manifest, input *ApplyManifestIn
 			ExternalReference:     extRef,
 			ExternalReferenceType: org.GetExternalReferenceType(),
 			PartyType:             org.GetPartyType(),
-			Attributes:            org.GetAttributes(),
+			Attributes:            attrs,
 		})
 	}
 	for _, ia := range mf.GetInternalAccounts() {

--- a/services/control-plane/internal/differ/grpc_live_state_adapters.go
+++ b/services/control-plane/internal/differ/grpc_live_state_adapters.go
@@ -461,10 +461,31 @@ func mapMarketDataSet(ds *marketinformationv1.DataSetDefinition) *controlplanev1
 }
 
 func mapOrganization(p *partyv1.Party) *controlplanev1.OrganizationDefinition {
+	// Derive the manifest code from attributes or external_reference.
+	// The Party service has no dedicated "code" field - party_id is a UUID.
+	// The manifest applier stores the org code as external_reference (fallback)
+	// or the _manifest_code attribute.
+	code := ""
+	for _, a := range p.GetAttributes() {
+		if a.GetKey() == "_manifest_code" {
+			code = a.GetValue()
+			break
+		}
+	}
+	if code == "" {
+		code = p.GetExternalReference()
+	}
+	if code == "" {
+		code = p.GetPartyId()
+	}
+
+	// Strip proto enum prefix: "PARTY_TYPE_ORGANIZATION" -> "ORGANIZATION"
+	partyType := strings.TrimPrefix(p.GetPartyType().String(), "PARTY_TYPE_")
+
 	def := &controlplanev1.OrganizationDefinition{
-		Code:      p.GetPartyId(),
+		Code:      code,
 		Name:      p.GetLegalName(),
-		PartyType: p.GetPartyType().String(),
+		PartyType: partyType,
 	}
 	if v := p.GetLegalName(); v != "" {
 		def.LegalName = &v

--- a/services/control-plane/internal/differ/grpc_live_state_adapters_test.go
+++ b/services/control-plane/internal/differ/grpc_live_state_adapters_test.go
@@ -172,7 +172,7 @@ func TestMapMarketDataSet_NoOptionalFields(t *testing.T) {
 
 func TestMapOrganization(t *testing.T) {
 	p := &partyv1.Party{
-		PartyId:               "ACME_CORP",
+		PartyId:               "a1b2c3d4-uuid",
 		PartyType:             partyv1.PartyType_PARTY_TYPE_ORGANIZATION,
 		LegalName:             "ACME Corporation Ltd",
 		DisplayName:           "ACME Corp",
@@ -180,19 +180,35 @@ func TestMapOrganization(t *testing.T) {
 		ExternalReferenceType: partyv1.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_COMPANIES_HOUSE,
 		Attributes: []*quantityv1.AttributeEntry{
 			{Key: "region", Value: "UK"},
+			{Key: "_manifest_code", Value: "ACME_CORP"},
 		},
 	}
 
 	got := mapOrganization(p)
 
+	// Code should come from _manifest_code attribute, not party_id (UUID)
 	assert.Equal(t, "ACME_CORP", got.GetCode())
 	assert.Equal(t, "ACME Corporation Ltd", got.GetName())
-	assert.Equal(t, "PARTY_TYPE_ORGANIZATION", got.GetPartyType())
+	assert.Equal(t, "ORGANIZATION", got.GetPartyType())
 	assert.Equal(t, "ACME Corporation Ltd", got.GetLegalName())
 	assert.Equal(t, "ACME Corp", got.GetDisplayName())
 	assert.Equal(t, "12345678", got.GetExternalReference())
 	assert.Equal(t, "EXTERNAL_REFERENCE_TYPE_COMPANIES_HOUSE", got.GetExternalReferenceType())
-	assert.Equal(t, map[string]string{"region": "UK"}, got.GetAttributes())
+	assert.Equal(t, map[string]string{"region": "UK", "_manifest_code": "ACME_CORP"}, got.GetAttributes())
+}
+
+func TestMapOrganization_FallsBackToExternalReference(t *testing.T) {
+	p := &partyv1.Party{
+		PartyId:           "a1b2c3d4-uuid",
+		PartyType:         partyv1.PartyType_PARTY_TYPE_ORGANIZATION,
+		LegalName:         "Old Corp",
+		ExternalReference: "OLD_CORP",
+	}
+
+	got := mapOrganization(p)
+
+	// No _manifest_code attribute, so falls back to external_reference
+	assert.Equal(t, "OLD_CORP", got.GetCode())
 }
 
 func TestMapOrganization_MinimalFields(t *testing.T) {


### PR DESCRIPTION
## Summary

Two fixes that unblock deploy after live-state diff was wired in (#2095, #2096):

1. **v1.4.0 saga script**: Checks the `action` field on each resource. CREATE runs register+activate, UPDATE runs update handler. v1.3.0 always ran the full CREATE flow regardless of action, causing `FailedPrecondition` for already-ACTIVE instruments.

2. **mapOrganization code derivation**: Uses `_manifest_code` attribute (injected during registration) instead of `party_id` (UUID). Falls back to `external_reference`. Fixes the diff producing 5 false CREATE + 5 false DEPRECATE for organizations.

3. **PartyType prefix stripping**: `PARTY_TYPE_ORGANIZATION` -> `ORGANIZATION` to match manifest format.

## Context

After #2095 and #2096, the live-state diff correctly queries services and produces a diff plan. However:
- The saga script ignored the `action` field, always running register+activate even for UPDATE resources
- `mapOrganization` used UUID `party_id` as Code, which never matched manifest org codes

## Test Plan

- [x] `TestMapOrganization` - uses `_manifest_code` attribute as code
- [x] `TestMapOrganization_FallsBackToExternalReference` - no attribute, uses ext ref
- [x] `TestLoadEmbeddedApplyManifest_ReturnsLatestVersion` - v1.4.0
- [x] All control-plane unit tests pass
- [ ] CI passes
- [ ] Deploy to develop/demo reaches further (ideally full success)