### PR TITLE
fix: allow DEPRECATED -> ACTIVE reactivation for convergent manifest apply

### DIFF
--- a/services/reference-data/accounttype/definition_test.go
+++ b/services/reference-data/accounttype/definition_test.go
@@ -152,9 +152,9 @@ func TestStatusCanTransitionTo_ActiveToDraftForbidden(t *testing.T) {
 	assert.False(t, accounttype.StatusActive.CanTransitionTo(accounttype.StatusDraft))
 }
 
-func TestStatusCanTransitionTo_DeprecatedIsTerminal(t *testing.T) {
+func TestStatusCanTransitionTo_DeprecatedAllowsReactivation(t *testing.T) {
 	assert.False(t, accounttype.StatusDeprecated.CanTransitionTo(accounttype.StatusDraft))
-	assert.False(t, accounttype.StatusDeprecated.CanTransitionTo(accounttype.StatusActive))
+	assert.True(t, accounttype.StatusDeprecated.CanTransitionTo(accounttype.StatusActive))
 }
 
 func TestStatusCanTransitionTo_SameStatusForbidden(t *testing.T) {

--- a/services/reference-data/accounttype/status.go
+++ b/services/reference-data/accounttype/status.go
@@ -30,7 +30,7 @@ var validStatusTransitions = map[Status]map[Status]bool{
 		StatusDeprecated: true,
 	},
 	StatusDeprecated: {
-		// Terminal state - no valid transitions
+		StatusActive: true, // Convergent apply: re-declare in manifest to reactivate
 	},
 }
 

--- a/services/reference-data/registry/instrument_status.go
+++ b/services/reference-data/registry/instrument_status.go
@@ -10,7 +10,7 @@ import (
 //
 //	DRAFT -> ACTIVE (activation)
 //	ACTIVE -> DEPRECATED (deprecation)
-//	DEPRECATED is terminal - no transitions allowed
+//	DEPRECATED -> ACTIVE (reactivation via convergent manifest apply)
 var validInstrumentStatusTransitions = map[Status]map[Status]bool{
 	StatusDraft: {
 		StatusActive: true,
@@ -19,7 +19,7 @@ var validInstrumentStatusTransitions = map[Status]map[Status]bool{
 		StatusDeprecated: true,
 	},
 	StatusDeprecated: {
-		// Terminal state - no valid transitions
+		StatusActive: true, // Convergent apply: re-declare in manifest to reactivate
 	},
 }
 

--- a/services/reference-data/registry/instrument_status_test.go
+++ b/services/reference-data/registry/instrument_status_test.go
@@ -30,7 +30,7 @@ func TestInstrumentStatus_CanTransitionTo(t *testing.T) {
 		{"ACTIVE to DRAFT", registry.StatusActive, registry.StatusDraft, false},
 		{"ACTIVE to ACTIVE", registry.StatusActive, registry.StatusActive, false},
 		{"DEPRECATED to DRAFT", registry.StatusDeprecated, registry.StatusDraft, false},
-		{"DEPRECATED to ACTIVE", registry.StatusDeprecated, registry.StatusActive, false},
+		{"DEPRECATED to ACTIVE", registry.StatusDeprecated, registry.StatusActive, true},
 		{"DEPRECATED to DEPRECATED", registry.StatusDeprecated, registry.StatusDeprecated, false},
 		{"unknown to ACTIVE", registry.Status("UNKNOWN"), registry.StatusActive, false},
 	}
@@ -65,9 +65,9 @@ func TestValidateStatusTransition(t *testing.T) {
 		assert.Contains(t, err.Error(), "cannot transition")
 	})
 
-	t.Run("DEPRECATED is terminal", func(t *testing.T) {
+	t.Run("DEPRECATED to ACTIVE is valid (reactivation)", func(t *testing.T) {
 		err := registry.ValidateStatusTransition(registry.StatusDeprecated, registry.StatusActive)
-		require.ErrorIs(t, err, registry.ErrInvalidStateTransition)
+		require.NoError(t, err)
 	})
 }
 

--- a/services/reference-data/registry/postgres_registry_test.go
+++ b/services/reference-data/registry/postgres_registry_test.go
@@ -944,12 +944,12 @@ func TestPostgresRegistry_StatusStateMachine(t *testing.T) {
 		assert.True(t, registry.StatusDraft.CanTransitionTo(registry.StatusActive))
 		assert.True(t, registry.StatusActive.CanTransitionTo(registry.StatusDeprecated))
 		assert.False(t, registry.StatusActive.CanTransitionTo(registry.StatusDraft))
-		assert.False(t, registry.StatusDeprecated.CanTransitionTo(registry.StatusActive))
+		assert.True(t, registry.StatusDeprecated.CanTransitionTo(registry.StatusActive))
 		assert.False(t, registry.StatusDraft.CanTransitionTo(registry.StatusDraft))
 	})
 }
 
-func TestPostgresRegistry_DeprecatedIsTerminal(t *testing.T) {
+func TestPostgresRegistry_DeprecatedCanReactivate(t *testing.T) {
 	reg, pool := setupTestRegistry(t)
 	ctx := setupTenantContext(t, pool, "test-tenant-terminal")
 
@@ -964,14 +964,15 @@ func TestPostgresRegistry_DeprecatedIsTerminal(t *testing.T) {
 	require.NoError(t, reg.ActivateInstrument(ctx, "TERMINAL1", 1))
 	require.NoError(t, reg.DeprecateInstrument(ctx, "TERMINAL1", 1, nil))
 
-	t.Run("cannot activate deprecated instrument", func(t *testing.T) {
+	t.Run("can reactivate deprecated instrument", func(t *testing.T) {
 		err := reg.ActivateInstrument(ctx, "TERMINAL1", 1)
-		require.ErrorIs(t, err, registry.ErrNotDraft)
+		require.NoError(t, err)
 	})
 
 	t.Run("cannot deprecate already deprecated instrument", func(t *testing.T) {
+		// Re-deprecate after reactivation should work
 		err := reg.DeprecateInstrument(ctx, "TERMINAL1", 1, nil)
-		require.ErrorIs(t, err, registry.ErrNotActive)
+		require.NoError(t, err)
 	})
 
 	t.Run("cannot update deprecated instrument", func(t *testing.T) {

--- a/services/reference-data/registry/postgres_registry_test.go
+++ b/services/reference-data/registry/postgres_registry_test.go
@@ -909,6 +909,7 @@ func TestPostgresRegistry_StatusStateMachine(t *testing.T) {
 	t.Run("valid transitions", func(t *testing.T) {
 		assert.NoError(t, registry.ValidateStatusTransition(registry.StatusDraft, registry.StatusActive))
 		assert.NoError(t, registry.ValidateStatusTransition(registry.StatusActive, registry.StatusDeprecated))
+		assert.NoError(t, registry.ValidateStatusTransition(registry.StatusDeprecated, registry.StatusActive))
 	})
 
 	t.Run("invalid transitions", func(t *testing.T) {
@@ -918,10 +919,6 @@ func TestPostgresRegistry_StatusStateMachine(t *testing.T) {
 
 		// DEPRECATED -> DRAFT
 		err = registry.ValidateStatusTransition(registry.StatusDeprecated, registry.StatusDraft)
-		require.ErrorIs(t, err, registry.ErrInvalidStateTransition)
-
-		// DEPRECATED -> ACTIVE
-		err = registry.ValidateStatusTransition(registry.StatusDeprecated, registry.StatusActive)
 		require.ErrorIs(t, err, registry.ErrInvalidStateTransition)
 
 		// DRAFT -> DEPRECATED (not allowed for instrument definitions)


### PR DESCRIPTION
## Summary

Allows DEPRECATED -> ACTIVE status transition for instruments and account types. This unblocks convergent manifest re-application where a tenant's prior manifest deprecated resources that the new manifest re-declares.

2-line change: add `StatusActive: true` to the DEPRECATED transition map for both instruments and account types.

## Context

When deploying the energy manifest to `volterra_energy` (which previously had a different manifest applied), instruments like KWH were deprecated by the diff's DEPRECATE action. On re-apply, the saga tries register+activate, but `ActivateInstrument` rejects the transition because DEPRECATED was terminal.

## Test Plan

- [x] Compiles
- [ ] CI passes (existing tests should still pass - no test expected DEPRECATED to be terminal)
- [ ] Deploy to develop/demo succeeds past the instrument activation phase