### PR TITLE
fix: always include all manifest instruments in saga input

### DIFF
--- a/services/control-plane/internal/applier/grpc_handler_mappers.go
+++ b/services/control-plane/internal/applier/grpc_handler_mappers.go
@@ -94,12 +94,13 @@ func buildExecutorInput(mf *controlplanev1.Manifest) *ApplyManifestInput {
 // Each included resource carries its Action field so handlers can behave differently.
 func buildExecutorInputFromPlan(mf *controlplanev1.Manifest, plan *differ.DiffPlan) *ApplyManifestInput {
 	actionable := buildActionableMap(plan)
+	deleted := buildDeletedSet(plan)
 
 	input := &ApplyManifestInput{
 		ManifestVersion: mf.GetVersion(),
 	}
 
-	extractInstrumentsFromPlan(mf, input, actionable)
+	extractInstrumentsFromPlan(mf, input, actionable, deleted)
 	extractAccountTypesFromPlan(mf, input, actionable)
 	extractValuationRulesFromPlan(mf, input, actionable)
 	extractMarketDataFromPlan(mf, input, actionable)
@@ -123,14 +124,29 @@ func buildActionableMap(plan *differ.DiffPlan) map[string]differ.ActionType {
 	return actionable
 }
 
-// extractInstrumentsFromPlan adds ALL manifest instruments to the input.
-// Instruments are always included regardless of diff action because:
+// buildDeletedSet returns a set of resource keys that have DELETE actions.
+func buildDeletedSet(plan *differ.DiffPlan) map[string]bool {
+	deleted := make(map[string]bool)
+	for _, a := range plan.Actions {
+		if a.Action == differ.ActionDelete {
+			deleted[resourceKey(a.ResourceType, a.ResourceCode)] = true
+		}
+	}
+	return deleted
+}
+
+// extractInstrumentsFromPlan adds ALL manifest instruments to the input unless
+// they are explicitly marked for DELETE. Instruments are always included because:
 // 1. register+activate handlers are fully idempotent
 // 2. Account type pre-checks require instruments to be ACTIVE in the tenant schema
 // 3. The diff may mark instruments as NO_CHANGE even when they need reactivation
-func extractInstrumentsFromPlan(mf *controlplanev1.Manifest, input *ApplyManifestInput, actionable map[string]differ.ActionType) {
+func extractInstrumentsFromPlan(mf *controlplanev1.Manifest, input *ApplyManifestInput, actionable map[string]differ.ActionType, deleted map[string]bool) {
 	for _, inst := range mf.GetInstruments() {
-		action, ok := actionable[resourceKey(differ.ResourceInstrument, inst.GetCode())]
+		key := resourceKey(differ.ResourceInstrument, inst.GetCode())
+		if deleted[key] {
+			continue
+		}
+		action, ok := actionable[key]
 		if !ok {
 			action = differ.ActionCreate
 		}

--- a/services/control-plane/internal/applier/grpc_handler_mappers.go
+++ b/services/control-plane/internal/applier/grpc_handler_mappers.go
@@ -123,12 +123,16 @@ func buildActionableMap(plan *differ.DiffPlan) map[string]differ.ActionType {
 	return actionable
 }
 
-// extractInstrumentsFromPlan adds instruments with actionable changes to the input.
+// extractInstrumentsFromPlan adds ALL manifest instruments to the input.
+// Instruments are always included regardless of diff action because:
+// 1. register+activate handlers are fully idempotent
+// 2. Account type pre-checks require instruments to be ACTIVE in the tenant schema
+// 3. The diff may mark instruments as NO_CHANGE even when they need reactivation
 func extractInstrumentsFromPlan(mf *controlplanev1.Manifest, input *ApplyManifestInput, actionable map[string]differ.ActionType) {
 	for _, inst := range mf.GetInstruments() {
 		action, ok := actionable[resourceKey(differ.ResourceInstrument, inst.GetCode())]
 		if !ok {
-			continue
+			action = differ.ActionCreate
 		}
 		dim := instrumentTypeToDimension(inst.GetType(), inst.GetDimensions().GetUnit())
 		if dim == "" {

--- a/services/control-plane/internal/applier/grpc_handler_mappers_plan_test.go
+++ b/services/control-plane/internal/applier/grpc_handler_mappers_plan_test.go
@@ -59,7 +59,7 @@ func TestBuildExecutorInputFromPlan_FiltersNoChangeActions(t *testing.T) {
 	// All instruments always included (idempotent, needed for account type pre-checks)
 	assert.Len(t, input.Instruments, 3)
 	assert.Equal(t, "GBP", input.Instruments[0].Code)
-	assert.Equal(t, "NO_CHANGE", input.Instruments[0].Action)
+	assert.Equal(t, "CREATE", input.Instruments[0].Action) // defaults to CREATE when not in actionable map
 	assert.Equal(t, "USD", input.Instruments[1].Code)
 	assert.Equal(t, "CREATE", input.Instruments[1].Action)
 	assert.Equal(t, "KWH", input.Instruments[2].Code)
@@ -191,8 +191,9 @@ func TestBuildExecutorInputFromPlan_MultipleResourceTypes(t *testing.T) {
 
 	input := buildExecutorInputFromPlan(mf, plan)
 
-	// GBP instrument: NO_CHANGE -> excluded
-	assert.Empty(t, input.Instruments)
+	// GBP instrument: always included (idempotent activation)
+	require.Len(t, input.Instruments, 1)
+	assert.Equal(t, "GBP", input.Instruments[0].Code)
 
 	// CURRENT account type: UPDATE -> included
 	require.Len(t, input.AccountTypes, 1)
@@ -241,7 +242,9 @@ func TestBuildExecutorInputFromPlan_EmptyPlan(t *testing.T) {
 	input := buildExecutorInputFromPlan(mf, plan)
 
 	assert.Equal(t, "1.0", input.ManifestVersion)
-	assert.Empty(t, input.Instruments)
+	// Instruments always included even when NO_CHANGE
+	require.Len(t, input.Instruments, 1)
+	assert.Equal(t, "GBP", input.Instruments[0].Code)
 	assert.Empty(t, input.AccountTypes)
 }
 

--- a/services/control-plane/internal/applier/grpc_handler_mappers_plan_test.go
+++ b/services/control-plane/internal/applier/grpc_handler_mappers_plan_test.go
@@ -56,12 +56,14 @@ func TestBuildExecutorInputFromPlan_FiltersNoChangeActions(t *testing.T) {
 	require.NotNil(t, input)
 	assert.Equal(t, "2.0", input.ManifestVersion)
 
-	// GBP is NO_CHANGE and should be excluded
-	assert.Len(t, input.Instruments, 2)
-	assert.Equal(t, "USD", input.Instruments[0].Code)
-	assert.Equal(t, "CREATE", input.Instruments[0].Action)
-	assert.Equal(t, "KWH", input.Instruments[1].Code)
-	assert.Equal(t, "UPDATE", input.Instruments[1].Action)
+	// All instruments always included (idempotent, needed for account type pre-checks)
+	assert.Len(t, input.Instruments, 3)
+	assert.Equal(t, "GBP", input.Instruments[0].Code)
+	assert.Equal(t, "NO_CHANGE", input.Instruments[0].Action)
+	assert.Equal(t, "USD", input.Instruments[1].Code)
+	assert.Equal(t, "CREATE", input.Instruments[1].Action)
+	assert.Equal(t, "KWH", input.Instruments[2].Code)
+	assert.Equal(t, "UPDATE", input.Instruments[2].Action)
 }
 
 func TestBuildExecutorInputFromPlan_IncludesDeprecateActions(t *testing.T) {


### PR DESCRIPTION
## Summary

Always include ALL manifest instruments in the saga input, regardless of diff action. This fixes the account type activation pre-check failure where GBP was marked as NO_CHANGE by the diff but wasn't ACTIVE in the tenant schema.

The register+activate flow is fully idempotent, so including NO_CHANGE instruments is safe and ensures all manifest instruments are ACTIVE before account type pre-checks run.

## Test Plan

- [x] All applier tests pass
- [ ] CI passes
- [ ] Deploy to develop gets past account type phase