### PR TITLE
fix: update saga activation test to match idempotent behavior

### DIFF
--- a/services/reference-data/saga/grpc_handler_test.go
+++ b/services/reference-data/saga/grpc_handler_test.go
@@ -269,17 +269,15 @@ func TestRegistryHandler_ActivateSaga(t *testing.T) {
 		assert.NotNil(t, resp.Saga.ActivatedAt)
 	})
 
-	t.Run("rejects activation of already active saga", func(t *testing.T) {
+	t.Run("activation of already active saga is idempotent", func(t *testing.T) {
 		req := &sagav1.ActivateSagaRequest{
 			Id: sagaID,
 		}
 
-		_, err := handler.ActivateSaga(ctx, req)
-		require.Error(t, err)
+		resp, err := handler.ActivateSaga(ctx, req)
+		require.NoError(t, err)
 
-		st, ok := status.FromError(err)
-		require.True(t, ok)
-		assert.Equal(t, codes.FailedPrecondition, st.Code())
+		assert.Equal(t, sagav1.SagaStatus_SAGA_STATUS_ACTIVE, resp.Saga.Status)
 	})
 }
 


### PR DESCRIPTION
## Summary
- PR #2102 made saga ACTIVE->ACTIVE transitions idempotent (returns nil instead of error) for convergent manifest apply
- The integration test `TestRegistryHandler_ActivateSaga/rejects_activation_of_already_active_saga` was not updated and still expected a FailedPrecondition error
- Nightly CI caught this as the only real test failure (2 failures out of 26,335 tests)

## Other Nightly/CI Failures (already resolved)
- **Security scan**: GO-2026-4883/4887 allowlist already added in f92f6e9b (#2106) - scan ran on older commit
- **Deploy develop**: GBP instrument not ACTIVE - fixed by 155bbbc2 (#2105) - deploy ran on older commit
- **Tag develop**: Transient GitHub API 500 - not actionable

## Test plan
- [ ] CI passes on this PR (specifically the saga integration tests)