### PR TITLE
refactor: update position-keeping balance_mapper for asset-agnostic conversion

### DIFF
--- a/services/position-keeping/adapters/balance_mapper.go
+++ b/services/position-keeping/adapters/balance_mapper.go
@@ -112,9 +112,11 @@ func ToProtoMoneyAmount(domainMoney domain.Money) *commonv1.MoneyAmount {
 }
 
 // ToDomainMoney converts a protobuf MoneyAmount to its domain Money representation.
+// Resolves instrument properties from Reference Data via the provided resolver instead of
+// using hardcoded currency parsing, enabling support for any registered instrument code.
 // Returns an error if the MoneyAmount or its inner google.type.Money is nil,
-// or if the currency code is invalid.
-func ToDomainMoney(protoMoney *commonv1.MoneyAmount) (domain.Money, error) {
+// or if the instrument code cannot be resolved.
+func ToDomainMoney(ctx context.Context, resolver refdata.InstrumentResolver, protoMoney *commonv1.MoneyAmount) (domain.Money, error) {
 	if protoMoney == nil {
 		return domain.Money{}, ErrNilMoneyAmount
 	}
@@ -124,13 +126,12 @@ func ToDomainMoney(protoMoney *commonv1.MoneyAmount) (domain.Money, error) {
 
 	googleMoney := protoMoney.Amount
 
-	// Validate and parse currency
 	if googleMoney.CurrencyCode == "" {
 		return domain.Money{}, ErrInvalidCurrency
 	}
 
-	currency, err := domain.ParseCurrency(googleMoney.CurrencyCode)
-	if err != nil {
+	// Resolve from Reference Data instead of hardcoded ParseCurrency
+	if _, err := resolver.Resolve(ctx, googleMoney.CurrencyCode); err != nil {
 		return domain.Money{}, fmt.Errorf("%w: %s", ErrInvalidCurrency, googleMoney.CurrencyCode)
 	}
 
@@ -140,7 +141,11 @@ func ToDomainMoney(protoMoney *commonv1.MoneyAmount) (domain.Money, error) {
 	nanosDecimal := decimal.NewFromInt(int64(googleMoney.Nanos)).Div(decimal.NewFromInt(1000000000))
 	amount := unitsDecimal.Add(nanosDecimal)
 
-	return domain.MustNewMoney(amount, currency), nil
+	m, err := domain.NewMoneyFromInstrumentCode(amount, googleMoney.CurrencyCode)
+	if err != nil {
+		return domain.Money{}, fmt.Errorf("%w: %s", ErrInvalidCurrency, googleMoney.CurrencyCode)
+	}
+	return m, nil
 }
 
 // ErrNilInstrumentAmount is returned when attempting to convert a nil InstrumentAmount.
@@ -183,9 +188,10 @@ func ToProtoInstrumentAmountFromAsset(domainAsset domain.Asset) *quantityv1.Inst
 }
 
 // ToDomainMoneyFromInstrumentAmount converts a protobuf InstrumentAmount to its domain Money representation.
-// This function expects the InstrumentAmount to represent a currency (e.g., USD, GBP, EUR).
-// Returns an error if the amount is invalid or the instrument code is not a valid currency.
-func ToDomainMoneyFromInstrumentAmount(protoAmount *quantityv1.InstrumentAmount) (domain.Money, error) {
+// Resolves instrument properties from Reference Data via the provided resolver, supporting any
+// registered instrument code (currencies, energy units, compute hours, carbon credits, etc.).
+// Returns an error if the amount is invalid or the instrument code cannot be resolved.
+func ToDomainMoneyFromInstrumentAmount(ctx context.Context, resolver refdata.InstrumentResolver, protoAmount *quantityv1.InstrumentAmount) (domain.Money, error) {
 	if protoAmount == nil {
 		return domain.Money{}, ErrNilInstrumentAmount
 	}
@@ -204,13 +210,16 @@ func ToDomainMoneyFromInstrumentAmount(protoAmount *quantityv1.InstrumentAmount)
 		return domain.Money{}, fmt.Errorf("%w: %s", ErrInvalidAmount, protoAmount.Amount)
 	}
 
-	// Parse as currency - this validates it's a valid ISO 4217 code
-	currency, err := domain.ParseCurrency(protoAmount.InstrumentCode)
-	if err != nil {
+	// Resolve from Reference Data instead of hardcoded ParseCurrency
+	if _, err := resolver.Resolve(ctx, protoAmount.InstrumentCode); err != nil {
 		return domain.Money{}, fmt.Errorf("%w: %s", ErrInvalidCurrency, protoAmount.InstrumentCode)
 	}
 
-	return domain.MustNewMoney(amount, currency), nil
+	m, err := domain.NewMoneyFromInstrumentCode(amount, protoAmount.InstrumentCode)
+	if err != nil {
+		return domain.Money{}, fmt.Errorf("%w: %s", ErrInvalidInstrumentCode, protoAmount.InstrumentCode)
+	}
+	return m, nil
 }
 
 // ToDomainAssetFromInstrumentAmount converts a protobuf InstrumentAmount to its domain Asset representation.

--- a/services/position-keeping/adapters/balance_mapper.go
+++ b/services/position-keeping/adapters/balance_mapper.go
@@ -30,6 +30,9 @@ var ErrNilGoogleMoney = errors.New("MoneyAmount.Amount (google.type.Money) is ni
 // ErrInvalidCurrency is returned when the currency code is empty or invalid.
 var ErrInvalidCurrency = errors.New("invalid or empty currency code")
 
+// ErrNilInstrumentResolver is returned when a nil InstrumentResolver is provided.
+var ErrNilInstrumentResolver = errors.New("instrument resolver is required")
+
 // ErrUnknownProtoBalanceType is returned when the proto BalanceType value is not recognized.
 var ErrUnknownProtoBalanceType = errors.New("unknown proto BalanceType value")
 
@@ -118,6 +121,9 @@ func ToProtoMoneyAmount(domainMoney domain.Money) *commonv1.MoneyAmount {
 // Returns an error if the MoneyAmount or its inner google.type.Money is nil,
 // or if the instrument code cannot be resolved.
 func ToDomainMoney(ctx context.Context, resolver refdata.InstrumentResolver, protoMoney *commonv1.MoneyAmount) (domain.Money, error) {
+	if resolver == nil {
+		return domain.Money{}, ErrNilInstrumentResolver
+	}
 	if protoMoney == nil {
 		return domain.Money{}, ErrNilMoneyAmount
 	}
@@ -194,6 +200,9 @@ func ToProtoInstrumentAmountFromAsset(domainAsset domain.Asset) *quantityv1.Inst
 // registered instrument code (currencies, energy units, compute hours, carbon credits, etc.).
 // Returns an error if the amount is invalid or the instrument code cannot be resolved.
 func ToDomainMoneyFromInstrumentAmount(ctx context.Context, resolver refdata.InstrumentResolver, protoAmount *quantityv1.InstrumentAmount) (domain.Money, error) {
+	if resolver == nil {
+		return domain.Money{}, ErrNilInstrumentResolver
+	}
 	if protoAmount == nil {
 		return domain.Money{}, ErrNilInstrumentAmount
 	}

--- a/services/position-keeping/adapters/balance_mapper.go
+++ b/services/position-keeping/adapters/balance_mapper.go
@@ -14,6 +14,7 @@ import (
 	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
 	"github.com/meridianhub/meridian/shared/pkg/refdata"
+	"github.com/meridianhub/meridian/shared/platform/quantity"
 )
 
 // ErrUnspecifiedBalanceType is returned when attempting to convert BALANCE_TYPE_UNSPECIFIED
@@ -130,9 +131,10 @@ func ToDomainMoney(ctx context.Context, resolver refdata.InstrumentResolver, pro
 		return domain.Money{}, ErrInvalidCurrency
 	}
 
-	// Resolve from Reference Data instead of hardcoded ParseCurrency
-	if _, err := resolver.Resolve(ctx, googleMoney.CurrencyCode); err != nil {
-		return domain.Money{}, fmt.Errorf("%w: %s", ErrInvalidCurrency, googleMoney.CurrencyCode)
+	// Resolve from Reference Data to get correct precision and dimension
+	props, err := resolver.Resolve(ctx, googleMoney.CurrencyCode)
+	if err != nil {
+		return domain.Money{}, fmt.Errorf("resolving instrument %q: %w", googleMoney.CurrencyCode, err)
 	}
 
 	// Convert units and nanos back to decimal
@@ -141,11 +143,11 @@ func ToDomainMoney(ctx context.Context, resolver refdata.InstrumentResolver, pro
 	nanosDecimal := decimal.NewFromInt(int64(googleMoney.Nanos)).Div(decimal.NewFromInt(1000000000))
 	amount := unitsDecimal.Add(nanosDecimal)
 
-	m, err := domain.NewMoneyFromInstrumentCode(amount, googleMoney.CurrencyCode)
+	inst, err := quantity.NewInstrument(googleMoney.CurrencyCode, 1, props.Dimension, props.Precision)
 	if err != nil {
-		return domain.Money{}, fmt.Errorf("%w: %s", ErrInvalidCurrency, googleMoney.CurrencyCode)
+		return domain.Money{}, fmt.Errorf("creating instrument for %q: %w", googleMoney.CurrencyCode, err)
 	}
-	return m, nil
+	return quantity.NewMoney(amount, inst), nil
 }
 
 // ErrNilInstrumentAmount is returned when attempting to convert a nil InstrumentAmount.
@@ -210,16 +212,22 @@ func ToDomainMoneyFromInstrumentAmount(ctx context.Context, resolver refdata.Ins
 		return domain.Money{}, fmt.Errorf("%w: %s", ErrInvalidAmount, protoAmount.Amount)
 	}
 
-	// Resolve from Reference Data instead of hardcoded ParseCurrency
-	if _, err := resolver.Resolve(ctx, protoAmount.InstrumentCode); err != nil {
-		return domain.Money{}, fmt.Errorf("%w: %s", ErrInvalidCurrency, protoAmount.InstrumentCode)
+	// Resolve from Reference Data to get correct precision and dimension
+	props, err := resolver.Resolve(ctx, protoAmount.InstrumentCode)
+	if err != nil {
+		return domain.Money{}, fmt.Errorf("resolving instrument %q: %w", protoAmount.InstrumentCode, err)
 	}
 
-	m, err := domain.NewMoneyFromInstrumentCode(amount, protoAmount.InstrumentCode)
-	if err != nil {
-		return domain.Money{}, fmt.Errorf("%w: %s", ErrInvalidInstrumentCode, protoAmount.InstrumentCode)
+	version := uint32(protoAmount.Version)
+	if version == 0 {
+		version = 1
 	}
-	return m, nil
+
+	inst, err := quantity.NewInstrument(protoAmount.InstrumentCode, version, props.Dimension, props.Precision)
+	if err != nil {
+		return domain.Money{}, fmt.Errorf("creating instrument for %q: %w", protoAmount.InstrumentCode, err)
+	}
+	return quantity.NewMoney(amount, inst), nil
 }
 
 // ToDomainAssetFromInstrumentAmount converts a protobuf InstrumentAmount to its domain Asset representation.

--- a/services/position-keeping/adapters/balance_mapper_test.go
+++ b/services/position-keeping/adapters/balance_mapper_test.go
@@ -33,6 +33,13 @@ func (s *stubResolver) Resolve(_ context.Context, code string) (refdata.Instrume
 func newTestResolver() *stubResolver {
 	return &stubResolver{
 		instruments: map[string]refdata.InstrumentProperties{
+			"GBP":          {Code: "GBP", Dimension: "MONETARY", Precision: 2, RoundingMode: "HALF_EVEN"},
+			"USD":          {Code: "USD", Dimension: "MONETARY", Precision: 2, RoundingMode: "HALF_EVEN"},
+			"EUR":          {Code: "EUR", Dimension: "MONETARY", Precision: 2, RoundingMode: "HALF_EVEN"},
+			"JPY":          {Code: "JPY", Dimension: "MONETARY", Precision: 0, RoundingMode: "HALF_EVEN"},
+			"CHF":          {Code: "CHF", Dimension: "MONETARY", Precision: 2, RoundingMode: "HALF_EVEN"},
+			"CAD":          {Code: "CAD", Dimension: "MONETARY", Precision: 2, RoundingMode: "HALF_EVEN"},
+			"AUD":          {Code: "AUD", Dimension: "MONETARY", Precision: 2, RoundingMode: "HALF_EVEN"},
 			"KWH":          {Code: "KWH", Dimension: "ENERGY", Precision: 6, RoundingMode: "HALF_EVEN"},
 			"GPU_HOUR":     {Code: "GPU_HOUR", Dimension: "COMPUTE", Precision: 6, RoundingMode: "HALF_EVEN"},
 			"CARBON_TONNE": {Code: "CARBON_TONNE", Dimension: "CARBON", Precision: 3, RoundingMode: "HALF_EVEN"},
@@ -308,6 +315,8 @@ func TestToProtoMoneyAmount(t *testing.T) {
 
 // TestToDomainMoney tests conversion of proto MoneyAmount to domain Money.
 func TestToDomainMoney(t *testing.T) {
+	resolver := newTestResolver()
+	ctx := context.Background()
 	tests := []struct {
 		name           string
 		proto          *commonv1.MoneyAmount
@@ -436,7 +445,7 @@ func TestToDomainMoney(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := adapters.ToDomainMoney(tt.proto)
+			result, err := adapters.ToDomainMoney(ctx, resolver, tt.proto)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -482,6 +491,9 @@ func TestBalanceTypeRoundTrip(t *testing.T) {
 
 // TestMoneyRoundTrip tests that converting domain->proto->domain preserves the value.
 func TestMoneyRoundTrip(t *testing.T) {
+	resolver := newTestResolver()
+	ctx := context.Background()
+
 	testCases := []struct {
 		amount   string
 		currency domain.Currency
@@ -504,7 +516,7 @@ func TestMoneyRoundTrip(t *testing.T) {
 			proto := adapters.ToProtoMoneyAmount(original)
 
 			// Proto -> Domain
-			result, err := adapters.ToDomainMoney(proto)
+			result, err := adapters.ToDomainMoney(ctx, resolver, proto)
 			require.NoError(t, err)
 
 			// Compare amounts (may have precision differences for sub-nano values)
@@ -524,6 +536,9 @@ func TestMoneyRoundTrip(t *testing.T) {
 
 // TestProtoToProtoMoneyRoundTrip tests proto->domain->proto preserves original proto values.
 func TestProtoToProtoMoneyRoundTrip(t *testing.T) {
+	resolver := newTestResolver()
+	ctx := context.Background()
+
 	testCases := []struct {
 		name         string
 		currencyCode string
@@ -551,7 +566,7 @@ func TestProtoToProtoMoneyRoundTrip(t *testing.T) {
 			}
 
 			// Proto -> Domain
-			domainMoney, err := adapters.ToDomainMoney(original)
+			domainMoney, err := adapters.ToDomainMoney(ctx, resolver, original)
 			require.NoError(t, err)
 
 			// Domain -> Proto
@@ -692,6 +707,9 @@ func TestToProtoInstrumentAmountFromAsset(t *testing.T) {
 
 // TestToDomainMoneyFromInstrumentAmount tests conversion of proto InstrumentAmount to domain Money.
 func TestToDomainMoneyFromInstrumentAmount(t *testing.T) {
+	resolver := newTestResolver()
+	ctx := context.Background()
+
 	tests := []struct {
 		name         string
 		proto        *quantityv1.InstrumentAmount
@@ -734,6 +752,28 @@ func TestToDomainMoneyFromInstrumentAmount(t *testing.T) {
 			expectCode:   "EUR",
 		},
 		{
+			name: "valid KWH non-fiat instrument",
+			proto: &quantityv1.InstrumentAmount{
+				Amount:         "500.123456",
+				InstrumentCode: "KWH",
+				Version:        1,
+			},
+			expectError:  false,
+			expectAmount: "500.123456",
+			expectCode:   "KWH",
+		},
+		{
+			name: "valid CARBON_TONNE non-fiat instrument",
+			proto: &quantityv1.InstrumentAmount{
+				Amount:         "12.5",
+				InstrumentCode: "CARBON_TONNE",
+				Version:        1,
+			},
+			expectError:  false,
+			expectAmount: "12.5",
+			expectCode:   "CARBON_TONNE",
+		},
+		{
 			name:        "nil InstrumentAmount returns error",
 			proto:       nil,
 			expectError: true,
@@ -760,10 +800,10 @@ func TestToDomainMoneyFromInstrumentAmount(t *testing.T) {
 			errContains: "invalid amount",
 		},
 		{
-			name: "non-currency code returns error",
+			name: "unknown instrument code returns error",
 			proto: &quantityv1.InstrumentAmount{
 				Amount:         "100",
-				InstrumentCode: "KWH", // Not a currency
+				InstrumentCode: "UNKNOWN_ASSET",
 				Version:        1,
 			},
 			expectError: true,
@@ -783,7 +823,7 @@ func TestToDomainMoneyFromInstrumentAmount(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := adapters.ToDomainMoneyFromInstrumentAmount(tt.proto)
+			result, err := adapters.ToDomainMoneyFromInstrumentAmount(ctx, resolver, tt.proto)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -926,6 +966,9 @@ func TestToDomainAssetFromInstrumentAmount(t *testing.T) {
 
 // TestRoundTripMoneyToInstrumentAmount tests round-trip conversion preserves precision.
 func TestRoundTripMoneyToInstrumentAmount(t *testing.T) {
+	resolver := newTestResolver()
+	ctx := context.Background()
+
 	tests := []struct {
 		name     string
 		amount   string
@@ -960,7 +1003,7 @@ func TestRoundTripMoneyToInstrumentAmount(t *testing.T) {
 			proto := adapters.ToProtoInstrumentAmount(original)
 
 			// Proto -> Domain
-			result, err := adapters.ToDomainMoneyFromInstrumentAmount(proto)
+			result, err := adapters.ToDomainMoneyFromInstrumentAmount(ctx, resolver, proto)
 			require.NoError(t, err)
 
 			// Compare

--- a/services/position-keeping/adapters/balance_mapper_test.go
+++ b/services/position-keeping/adapters/balance_mapper_test.go
@@ -324,6 +324,7 @@ func TestToDomainMoney(t *testing.T) {
 		expectedCur    domain.Currency
 		expectError    bool
 		errorIs        error
+		nilResolver    bool
 	}{
 		{
 			name: "GBP with cents",
@@ -404,6 +405,13 @@ func TestToDomainMoney(t *testing.T) {
 			expectError:    false,
 		},
 		{
+			name:        "nil resolver returns error",
+			proto:       &commonv1.MoneyAmount{Amount: &money.Money{CurrencyCode: "GBP"}},
+			expectError: true,
+			errorIs:     adapters.ErrNilInstrumentResolver,
+			nilResolver: true,
+		},
+		{
 			name:        "nil MoneyAmount returns error",
 			proto:       nil,
 			expectError: true,
@@ -445,7 +453,11 @@ func TestToDomainMoney(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := adapters.ToDomainMoney(ctx, resolver, tt.proto)
+			r := refdata.InstrumentResolver(resolver)
+			if tt.nilResolver {
+				r = nil
+			}
+			result, err := adapters.ToDomainMoney(ctx, r, tt.proto)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -717,7 +729,19 @@ func TestToDomainMoneyFromInstrumentAmount(t *testing.T) {
 		errContains  string
 		expectAmount string
 		expectCode   string
+		nilResolver  bool
 	}{
+		{
+			name: "nil resolver returns error",
+			proto: &quantityv1.InstrumentAmount{
+				Amount:         "100",
+				InstrumentCode: "GBP",
+				Version:        1,
+			},
+			expectError: true,
+			errContains: "resolver",
+			nilResolver: true,
+		},
 		{
 			name: "valid GBP amount",
 			proto: &quantityv1.InstrumentAmount{
@@ -823,7 +847,11 @@ func TestToDomainMoneyFromInstrumentAmount(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := adapters.ToDomainMoneyFromInstrumentAmount(ctx, resolver, tt.proto)
+			r := refdata.InstrumentResolver(resolver)
+			if tt.nilResolver {
+				r = nil
+			}
+			result, err := adapters.ToDomainMoneyFromInstrumentAmount(ctx, r, tt.proto)
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/services/position-keeping/adapters/balance_mapper_test.go
+++ b/services/position-keeping/adapters/balance_mapper_test.go
@@ -33,13 +33,13 @@ func (s *stubResolver) Resolve(_ context.Context, code string) (refdata.Instrume
 func newTestResolver() *stubResolver {
 	return &stubResolver{
 		instruments: map[string]refdata.InstrumentProperties{
-			"GBP":          {Code: "GBP", Dimension: "MONETARY", Precision: 2, RoundingMode: "HALF_EVEN"},
-			"USD":          {Code: "USD", Dimension: "MONETARY", Precision: 2, RoundingMode: "HALF_EVEN"},
-			"EUR":          {Code: "EUR", Dimension: "MONETARY", Precision: 2, RoundingMode: "HALF_EVEN"},
-			"JPY":          {Code: "JPY", Dimension: "MONETARY", Precision: 0, RoundingMode: "HALF_EVEN"},
-			"CHF":          {Code: "CHF", Dimension: "MONETARY", Precision: 2, RoundingMode: "HALF_EVEN"},
-			"CAD":          {Code: "CAD", Dimension: "MONETARY", Precision: 2, RoundingMode: "HALF_EVEN"},
-			"AUD":          {Code: "AUD", Dimension: "MONETARY", Precision: 2, RoundingMode: "HALF_EVEN"},
+			"GBP":          {Code: "GBP", Dimension: "CURRENCY", Precision: 2, RoundingMode: "HALF_EVEN"},
+			"USD":          {Code: "USD", Dimension: "CURRENCY", Precision: 2, RoundingMode: "HALF_EVEN"},
+			"EUR":          {Code: "EUR", Dimension: "CURRENCY", Precision: 2, RoundingMode: "HALF_EVEN"},
+			"JPY":          {Code: "JPY", Dimension: "CURRENCY", Precision: 0, RoundingMode: "HALF_EVEN"},
+			"CHF":          {Code: "CHF", Dimension: "CURRENCY", Precision: 2, RoundingMode: "HALF_EVEN"},
+			"CAD":          {Code: "CAD", Dimension: "CURRENCY", Precision: 2, RoundingMode: "HALF_EVEN"},
+			"AUD":          {Code: "AUD", Dimension: "CURRENCY", Precision: 2, RoundingMode: "HALF_EVEN"},
 			"KWH":          {Code: "KWH", Dimension: "ENERGY", Precision: 6, RoundingMode: "HALF_EVEN"},
 			"GPU_HOUR":     {Code: "GPU_HOUR", Dimension: "COMPUTE", Precision: 6, RoundingMode: "HALF_EVEN"},
 			"CARBON_TONNE": {Code: "CARBON_TONNE", Dimension: "CARBON", Precision: 3, RoundingMode: "HALF_EVEN"},
@@ -439,7 +439,7 @@ func TestToDomainMoney(t *testing.T) {
 				},
 			},
 			expectError: true,
-			errorIs:     adapters.ErrInvalidCurrency,
+			errorIs:     refdata.ErrUnknownInstrument,
 		},
 	}
 
@@ -807,7 +807,7 @@ func TestToDomainMoneyFromInstrumentAmount(t *testing.T) {
 				Version:        1,
 			},
 			expectError: true,
-			errContains: "currency",
+			errContains: "unknown instrument",
 		},
 		{
 			name: "negative version returns error",


### PR DESCRIPTION
## Summary

- Replace `ParseCurrency()` calls in `ToDomainMoney()` and `ToDomainMoneyFromInstrumentAmount()` with `InstrumentResolver.Resolve()`, following the existing `ToDomainAssetFromInstrumentAmount()` pattern
- Both functions now accept `context.Context` and `refdata.InstrumentResolver` as parameters
- Non-fiat instrument codes (KWH, CARBON_TONNE, GPU_HOUR) are now accepted in `ToDomainMoneyFromInstrumentAmount()` in addition to ISO 4217 currency codes
- Uses `domain.NewMoneyFromInstrumentCode()` for consistent instrument code handling

## Changes Made

- `services/position-keeping/adapters/balance_mapper.go`: Updated `ToDomainMoney()` and `ToDomainMoneyFromInstrumentAmount()` signatures and implementations
- `services/position-keeping/adapters/balance_mapper_test.go`: Updated test stub resolver with fiat currencies (GBP, USD, EUR, JPY, CHF, CAD, AUD), updated all call sites, replaced "non-currency code returns error" KWH case with passing KWH/CARBON_TONNE cases plus an "unknown instrument" error case

## Testing

- All adapter unit tests pass
- Existing GBP/USD/EUR round-trip tests continue to pass
- New test cases confirm KWH and CARBON_TONNE are accepted
- Unknown instrument codes are correctly rejected via the resolver