### PR TITLE
feat: rewrite financial-accounting adapters and PostingService for asset-agnostic amounts

### DIFF
--- a/services/financial-accounting/adapters/messaging/deposit_consumer.go
+++ b/services/financial-accounting/adapters/messaging/deposit_consumer.go
@@ -9,6 +9,8 @@ import (
 
 	"buf.build/go/protovalidate"
 	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
 	eventsv1 "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
 	"github.com/meridianhub/meridian/services/financial-accounting/service"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
@@ -217,12 +219,17 @@ func (dc *DepositConsumer) processAndStoreResult(ctx context.Context, event *eve
 		return fmt.Errorf("%w: %v", ErrInvalidCurrency, event.InstrumentCode)
 	}
 
+	// Convert cents to decimal string for the asset-agnostic DepositEvent.
+	// The proto still carries AmountCents for backward compatibility;
+	// the PostingService resolves precision from the instrument.
+	amount := decimal.NewFromInt(event.AmountCents).Div(decimal.NewFromInt(100))
+
 	depositEvent := service.DepositEvent{
-		AccountID:     event.AccountId,
-		AmountCents:   event.AmountCents,
-		Currency:      currencyCode,
-		CorrelationID: event.CorrelationId,
-		ValueDate:     event.ValueDate.AsTime(),
+		AccountID:      event.AccountId,
+		Amount:         amount.String(),
+		InstrumentCode: currencyCode,
+		CorrelationID:  event.CorrelationId,
+		ValueDate:      event.ValueDate.AsTime(),
 	}
 
 	if err := dc.postingService.ProcessDeposit(ctx, depositEvent); err != nil {

--- a/services/financial-accounting/adapters/messaging/deposit_consumer.go
+++ b/services/financial-accounting/adapters/messaging/deposit_consumer.go
@@ -9,7 +9,6 @@ import (
 
 	"buf.build/go/protovalidate"
 	"github.com/google/uuid"
-	"github.com/shopspring/decimal"
 
 	eventsv1 "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
 	"github.com/meridianhub/meridian/services/financial-accounting/service"
@@ -219,17 +218,16 @@ func (dc *DepositConsumer) processAndStoreResult(ctx context.Context, event *eve
 		return fmt.Errorf("%w: %v", ErrInvalidCurrency, event.InstrumentCode)
 	}
 
-	// Convert cents to decimal string for the asset-agnostic DepositEvent.
-	// The proto still carries AmountCents for backward compatibility;
-	// the PostingService resolves precision from the instrument.
-	amount := decimal.NewFromInt(event.AmountCents).Div(decimal.NewFromInt(100))
-
+	// Pass the raw minor-unit value as a string. The PostingService will
+	// resolve instrument precision and convert from minor to major units.
+	// This avoids hardcoding a /100 divisor that would be wrong for
+	// non-2dp instruments (e.g., JPY=0dp, KWH=3dp).
 	depositEvent := service.DepositEvent{
-		AccountID:      event.AccountId,
-		Amount:         amount.String(),
-		InstrumentCode: currencyCode,
-		CorrelationID:  event.CorrelationId,
-		ValueDate:      event.ValueDate.AsTime(),
+		AccountID:       event.AccountId,
+		AmountMinorUnit: event.AmountCents,
+		InstrumentCode:  currencyCode,
+		CorrelationID:   event.CorrelationId,
+		ValueDate:       event.ValueDate.AsTime(),
 	}
 
 	if err := dc.postingService.ProcessDeposit(ctx, depositEvent); err != nil {

--- a/services/financial-accounting/observability/metrics.go
+++ b/services/financial-accounting/observability/metrics.go
@@ -237,6 +237,12 @@ func RecordPostingAmount(direction, currency string, amountCents int64) {
 	postingAmountTotal.WithLabelValues(direction, currency).Add(float64(amountCents))
 }
 
+// RecordPostingAmountFloat records the amount of a posting as a float for tracking total volume.
+// Used for asset-agnostic amounts where the unit may not be cents.
+func RecordPostingAmountFloat(direction, instrumentCode string, amount float64) {
+	postingAmountTotal.WithLabelValues(direction, instrumentCode).Add(amount)
+}
+
 // RecordBookingLog records a booking log creation with status.
 func RecordBookingLog(status string) {
 	bookingLogsTotal.WithLabelValues(status).Inc()

--- a/services/financial-accounting/observability/metrics.go
+++ b/services/financial-accounting/observability/metrics.go
@@ -84,6 +84,14 @@ var (
 		[]string{"direction", "currency"},
 	)
 
+	postingAmountMajorTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "financial_accounting_posting_amount_major_total",
+			Help: "Total amount posted in major instrument units by instrument and direction",
+		},
+		[]string{"direction", "instrument"},
+	)
+
 	// Booking log metrics
 	bookingLogsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -237,10 +245,11 @@ func RecordPostingAmount(direction, currency string, amountCents int64) {
 	postingAmountTotal.WithLabelValues(direction, currency).Add(float64(amountCents))
 }
 
-// RecordPostingAmountFloat records the amount of a posting as a float for tracking total volume.
-// Used for asset-agnostic amounts where the unit may not be cents.
+// RecordPostingAmountFloat records the amount of a posting in major units for tracking total volume.
+// This uses a separate counter from RecordPostingAmount (which tracks minor units/cents)
+// to avoid mixing units in the same metric series.
 func RecordPostingAmountFloat(direction, instrumentCode string, amount float64) {
-	postingAmountTotal.WithLabelValues(direction, instrumentCode).Add(amount)
+	postingAmountMajorTotal.WithLabelValues(direction, instrumentCode).Add(amount)
 }
 
 // RecordBookingLog records a booking log creation with status.

--- a/services/financial-accounting/service/adapters.go
+++ b/services/financial-accounting/service/adapters.go
@@ -41,7 +41,9 @@ func NewInstrumentAmountConverter(resolver refdata.InstrumentResolver) *Instrume
 }
 
 // FromProto converts protobuf InstrumentAmount to domain Money using the InstrumentResolver.
-// Falls back to legacy ParseCurrency logic when the resolver is nil or returns an error.
+// When a resolver is configured, it is the primary path. Legacy ParseCurrency fallback
+// only applies when the resolver is nil (not configured) or for known ISO 4217 currencies
+// when the resolver returns ErrUnknownInstrument.
 func (c *InstrumentAmountConverter) FromProto(ctx context.Context, ia *quantityv1.InstrumentAmount) (domain.Money, error) {
 	if ia == nil {
 		return domain.Money{}, ErrNilInstrumentAmount
@@ -63,10 +65,16 @@ func (c *InstrumentAmountConverter) FromProto(ctx context.Context, ia *quantityv
 			if instErr == nil {
 				return domain.NewMoney(amount, inst), nil
 			}
+			return domain.Money{}, fmt.Errorf("invalid instrument metadata for %q: %w", ia.InstrumentCode, instErr)
+		}
+		// Only fall back to legacy for known currencies; non-currency codes must
+		// come from the resolver to avoid silently guessed precision.
+		if _, currErr := domain.ParseCurrency(ia.InstrumentCode); currErr != nil {
+			return domain.Money{}, fmt.Errorf("failed to resolve instrument %q: %w", ia.InstrumentCode, resolveErr)
 		}
 	}
 
-	// Fall back to legacy resolution
+	// Legacy fallback: resolver is nil or code is a known ISO 4217 currency
 	return fromProtoInstrumentAmount(ia)
 }
 

--- a/services/financial-accounting/service/adapters.go
+++ b/services/financial-accounting/service/adapters.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -12,6 +13,7 @@ import (
 	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
 	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
 	"github.com/meridianhub/meridian/services/financial-accounting/domain"
+	"github.com/meridianhub/meridian/shared/pkg/refdata"
 )
 
 var (
@@ -21,7 +23,58 @@ var (
 
 	// ErrNilInstrumentAmount is returned when proto InstrumentAmount is nil
 	ErrNilInstrumentAmount = errors.New("instrument amount cannot be nil")
+
+	// ErrEmptyInstrumentCode is returned when the instrument code is empty
+	ErrEmptyInstrumentCode = errors.New("instrument code cannot be empty")
 )
+
+// InstrumentAmountConverter converts between proto InstrumentAmount and domain Money
+// using an InstrumentResolver for proper instrument metadata lookup.
+type InstrumentAmountConverter struct {
+	resolver refdata.InstrumentResolver
+}
+
+// NewInstrumentAmountConverter creates a converter with the given resolver.
+// If resolver is nil, conversions fall back to legacy currency-based resolution.
+func NewInstrumentAmountConverter(resolver refdata.InstrumentResolver) *InstrumentAmountConverter {
+	return &InstrumentAmountConverter{resolver: resolver}
+}
+
+// FromProto converts protobuf InstrumentAmount to domain Money using the InstrumentResolver.
+// Falls back to legacy ParseCurrency logic when the resolver is nil or returns an error.
+func (c *InstrumentAmountConverter) FromProto(ctx context.Context, ia *quantityv1.InstrumentAmount) (domain.Money, error) {
+	if ia == nil {
+		return domain.Money{}, ErrNilInstrumentAmount
+	}
+	if ia.InstrumentCode == "" {
+		return domain.Money{}, ErrEmptyInstrumentCode
+	}
+
+	amount, err := decimal.NewFromString(ia.Amount)
+	if err != nil {
+		return domain.Money{}, fmt.Errorf("invalid amount: %w", err)
+	}
+
+	// Try resolver first for proper instrument metadata
+	if c.resolver != nil {
+		props, resolveErr := c.resolver.Resolve(ctx, ia.InstrumentCode)
+		if resolveErr == nil {
+			inst, instErr := domain.NewInstrument(props.Code, uint32(ia.Version), props.Dimension, props.Precision)
+			if instErr == nil {
+				return domain.NewMoney(amount, inst), nil
+			}
+		}
+	}
+
+	// Fall back to legacy resolution
+	return fromProtoInstrumentAmount(ia)
+}
+
+// ToProtoInstrumentAmount converts domain Money to protobuf InstrumentAmount.
+// Preserves full decimal precision via string representation.
+func ToProtoInstrumentAmount(m domain.Money) *quantityv1.InstrumentAmount {
+	return toProtoInstrumentAmount(m)
+}
 
 // parseUUID parses and validates a UUID string.
 //

--- a/services/financial-accounting/service/adapters_test.go
+++ b/services/financial-accounting/service/adapters_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
 	"github.com/meridianhub/meridian/services/financial-accounting/domain"
+	"github.com/meridianhub/meridian/shared/pkg/refdata"
 )
 
 func TestFromProtoPostingDirection(t *testing.T) {
@@ -258,4 +260,152 @@ func TestParseUUID_Invalid(t *testing.T) {
 	_, err := parseUUID("not-a-uuid")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid UUID format")
+}
+
+// =============================================================================
+// InstrumentAmountConverter tests
+// =============================================================================
+
+// adapterMockInstrumentResolver implements refdata.InstrumentResolver for testing.
+type adapterMockInstrumentResolver struct {
+	instruments map[string]refdata.InstrumentProperties
+	err         error
+}
+
+func (m *adapterMockInstrumentResolver) Resolve(_ context.Context, code string) (refdata.InstrumentProperties, error) {
+	if m.err != nil {
+		return refdata.InstrumentProperties{}, m.err
+	}
+	if props, ok := m.instruments[code]; ok {
+		return props, nil
+	}
+	return refdata.InstrumentProperties{}, refdata.ErrUnknownInstrument
+}
+
+func TestInstrumentAmountConverter_FromProto_WithResolver(t *testing.T) {
+	resolver := &adapterMockInstrumentResolver{
+		instruments: map[string]refdata.InstrumentProperties{
+			"GBP":        {Code: "GBP", Dimension: "CURRENCY", Precision: 2, RoundingMode: "HALF_EVEN"},
+			"KWH":        {Code: "KWH", Dimension: "ENERGY", Precision: 3, RoundingMode: "HALF_UP"},
+			"TONNE_CO2E": {Code: "TONNE_CO2E", Dimension: "CARBON", Precision: 6, RoundingMode: "HALF_EVEN"},
+			"GPU_HOUR":   {Code: "GPU_HOUR", Dimension: "COMPUTE", Precision: 4, RoundingMode: "HALF_EVEN"},
+		},
+	}
+	converter := NewInstrumentAmountConverter(resolver)
+	ctx := context.Background()
+
+	tests := []struct {
+		name           string
+		instrumentCode string
+		amount         string
+		wantCode       string
+		wantDimension  string
+		wantPrecision  int
+	}{
+		{"GBP currency", "GBP", "100.50", "GBP", "CURRENCY", 2},
+		{"KWH energy", "KWH", "123.456", "KWH", "ENERGY", 3},
+		{"TONNE_CO2E carbon", "TONNE_CO2E", "0.001234", "TONNE_CO2E", "CARBON", 6},
+		{"GPU_HOUR compute", "GPU_HOUR", "24.5000", "GPU_HOUR", "COMPUTE", 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ia := &quantityv1.InstrumentAmount{
+				Amount:         tt.amount,
+				InstrumentCode: tt.instrumentCode,
+				Version:        1,
+			}
+
+			result, err := converter.FromProto(ctx, ia)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantCode, result.Instrument.Code)
+			assert.Equal(t, tt.wantDimension, result.Instrument.Dimension)
+			assert.Equal(t, tt.wantPrecision, result.Instrument.Precision)
+		})
+	}
+}
+
+func TestInstrumentAmountConverter_FromProto_NilInput(t *testing.T) {
+	converter := NewInstrumentAmountConverter(nil)
+	_, err := converter.FromProto(context.Background(), nil)
+	require.ErrorIs(t, err, ErrNilInstrumentAmount)
+}
+
+func TestInstrumentAmountConverter_FromProto_EmptyInstrumentCode(t *testing.T) {
+	converter := NewInstrumentAmountConverter(nil)
+	ia := &quantityv1.InstrumentAmount{Amount: "100", InstrumentCode: ""}
+	_, err := converter.FromProto(context.Background(), ia)
+	require.ErrorIs(t, err, ErrEmptyInstrumentCode)
+}
+
+func TestInstrumentAmountConverter_FromProto_InvalidAmount(t *testing.T) {
+	converter := NewInstrumentAmountConverter(nil)
+	ia := &quantityv1.InstrumentAmount{Amount: "not-a-number", InstrumentCode: "GBP"}
+	_, err := converter.FromProto(context.Background(), ia)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid amount")
+}
+
+func TestInstrumentAmountConverter_FromProto_FallbackToLegacy(t *testing.T) {
+	// Resolver returns error - should fall back to ParseCurrency for GBP
+	resolver := &adapterMockInstrumentResolver{err: refdata.ErrUnknownInstrument}
+	converter := NewInstrumentAmountConverter(resolver)
+
+	ia := &quantityv1.InstrumentAmount{
+		Amount:         "100.00",
+		InstrumentCode: "GBP",
+		Version:        1,
+	}
+
+	result, err := converter.FromProto(context.Background(), ia)
+	require.NoError(t, err)
+	assert.Equal(t, "GBP", result.Instrument.Code)
+	assert.Equal(t, "100", result.Amount.String())
+}
+
+func TestInstrumentAmountConverter_FromProto_NilResolver(t *testing.T) {
+	// No resolver - should use legacy fromProtoInstrumentAmount
+	converter := NewInstrumentAmountConverter(nil)
+
+	ia := &quantityv1.InstrumentAmount{
+		Amount:         "50.25",
+		InstrumentCode: "USD",
+		Version:        1,
+	}
+
+	result, err := converter.FromProto(context.Background(), ia)
+	require.NoError(t, err)
+	assert.Equal(t, "USD", result.Instrument.Code)
+	assert.Equal(t, "50.25", result.Amount.String())
+}
+
+func TestInstrumentAmountConverter_Roundtrip(t *testing.T) {
+	resolver := &adapterMockInstrumentResolver{
+		instruments: map[string]refdata.InstrumentProperties{
+			"KWH": {Code: "KWH", Dimension: "ENERGY", Precision: 3, RoundingMode: "HALF_UP"},
+		},
+	}
+	converter := NewInstrumentAmountConverter(resolver)
+
+	ia := &quantityv1.InstrumentAmount{
+		Amount:         "123.456",
+		InstrumentCode: "KWH",
+		Version:        1,
+	}
+
+	money, err := converter.FromProto(context.Background(), ia)
+	require.NoError(t, err)
+
+	roundtripped := ToProtoInstrumentAmount(money)
+	assert.Equal(t, "123.456", roundtripped.Amount)
+	assert.Equal(t, "KWH", roundtripped.InstrumentCode)
+}
+
+func TestToProtoInstrumentAmount_Exported(t *testing.T) {
+	inst := domain.MustCurrencyToInstrument(domain.CurrencyGBP)
+	m := domain.NewMoney(decimal.NewFromInt(42), inst)
+
+	result := ToProtoInstrumentAmount(m)
+	assert.Equal(t, "GBP", result.InstrumentCode)
+	assert.Equal(t, "42", result.Amount)
 }

--- a/services/financial-accounting/service/adapters_test.go
+++ b/services/financial-accounting/service/adapters_test.go
@@ -401,6 +401,23 @@ func TestInstrumentAmountConverter_Roundtrip(t *testing.T) {
 	assert.Equal(t, "KWH", roundtripped.InstrumentCode)
 }
 
+func TestInstrumentAmountConverter_FromProto_RejectsUnknownNonCurrency(t *testing.T) {
+	// Resolver is configured but doesn't know "UNKNOWN_ASSET". Since it's not
+	// a known ISO 4217 currency, it should error rather than infer precision.
+	resolver := &adapterMockInstrumentResolver{err: refdata.ErrUnknownInstrument}
+	converter := NewInstrumentAmountConverter(resolver)
+
+	ia := &quantityv1.InstrumentAmount{
+		Amount:         "100.00",
+		InstrumentCode: "UNKNOWN_ASSET",
+		Version:        1,
+	}
+
+	_, err := converter.FromProto(context.Background(), ia)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve instrument")
+}
+
 func TestToProtoInstrumentAmount_Exported(t *testing.T) {
 	inst := domain.MustCurrencyToInstrument(domain.CurrencyGBP)
 	m := domain.NewMoney(decimal.NewFromInt(42), inst)

--- a/services/financial-accounting/service/posting_service.go
+++ b/services/financial-accounting/service/posting_service.go
@@ -83,14 +83,21 @@ func NewPostingServiceWithConfig(cfg PostingServiceConfig) *PostingService {
 }
 
 // DepositEvent represents a deposit event from CurrentAccount service.
-// Amount is a decimal string (e.g., "100.00") for full precision with any asset type.
 // InstrumentCode identifies the instrument (e.g., "GBP", "KWH", "TONNE_CO2E").
+//
+// Callers should populate exactly one of Amount or AmountMinorUnit:
+//   - Amount: decimal string in major units (e.g., "100.50" GBP). Used by callers
+//     that already know the decimal amount.
+//   - AmountMinorUnit: integer in the instrument's smallest unit (e.g., 10050 for
+//     GBP cents). Used by the Kafka deposit consumer where the proto carries int64.
+//     The PostingService converts to major units using the instrument's precision.
 type DepositEvent struct {
-	AccountID      string
-	Amount         string // Decimal as string for precision
-	InstrumentCode string // e.g., "GBP", "KWH"
-	CorrelationID  string
-	ValueDate      time.Time
+	AccountID       string
+	Amount          string // Decimal string in major units (mutually exclusive with AmountMinorUnit)
+	AmountMinorUnit int64  // Amount in minor units; converted using instrument precision
+	InstrumentCode  string // e.g., "GBP", "KWH"
+	CorrelationID   string
+	ValueDate       time.Time
 }
 
 // ProcessDeposit creates double-entry postings for a deposit
@@ -129,9 +136,9 @@ func (s *PostingService) ProcessDeposit(ctx context.Context, event DepositEvent)
 		return fmt.Errorf("failed to save postings: %w", err)
 	}
 
-	// Record successful metrics
+	// Record successful metrics using the resolved amount from the debit posting
 	timer.ObserveSuccess()
-	recordDepositSuccessMetrics(event)
+	recordDepositSuccessMetrics(event.InstrumentCode, debitPosting.Amount.Amount)
 
 	return nil
 }
@@ -144,14 +151,14 @@ func (s *PostingService) buildDepositPostings(
 	bookingLogID uuid.UUID,
 	event DepositEvent,
 ) (*domain.LedgerPosting, *domain.LedgerPosting, error) {
-	amount, err := decimal.NewFromString(event.Amount)
-	if err != nil {
-		return nil, nil, fmt.Errorf("invalid amount %q: %w", event.Amount, err)
-	}
-
 	instrument, err := s.resolveInstrument(ctx, event.InstrumentCode)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to resolve instrument %q: %w", event.InstrumentCode, err)
+	}
+
+	amount, err := s.resolveAmount(event, instrument)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	money := domain.NewMoney(amount, instrument)
@@ -185,6 +192,23 @@ func (s *PostingService) buildDepositPostings(
 	return debitPosting, creditPosting, nil
 }
 
+// resolveAmount extracts the decimal amount from a DepositEvent.
+// If Amount (string) is set, it takes precedence. Otherwise AmountMinorUnit
+// is converted to major units using the instrument's precision.
+func (s *PostingService) resolveAmount(event DepositEvent, instrument domain.Instrument) (decimal.Decimal, error) {
+	if event.Amount != "" {
+		amount, err := decimal.NewFromString(event.Amount)
+		if err != nil {
+			return decimal.Zero, fmt.Errorf("invalid amount %q: %w", event.Amount, err)
+		}
+		return amount, nil
+	}
+
+	// Convert minor units to major units: e.g., 10050 cents with precision 2 = 100.50
+	divisor := decimal.NewFromInt(10).Pow(decimal.NewFromInt(int64(instrument.Precision)))
+	return decimal.NewFromInt(event.AmountMinorUnit).Div(divisor), nil
+}
+
 // resolveInstrument resolves an instrument code to a domain Instrument.
 // Tries InstrumentResolver first, then falls back to legacy ParseCurrency.
 func (s *PostingService) resolveInstrument(ctx context.Context, code string) (domain.Instrument, error) {
@@ -207,17 +231,15 @@ func (s *PostingService) resolveInstrument(ctx context.Context, code string) (do
 }
 
 // recordDepositSuccessMetrics records all metrics for a successful deposit processing.
-func recordDepositSuccessMetrics(event DepositEvent) {
-	observability.RecordDepositProcessed(event.InstrumentCode, observability.StatusSuccess)
-	observability.RecordPosting(observability.DirectionDebit, event.InstrumentCode)
-	observability.RecordPosting(observability.DirectionCredit, event.InstrumentCode)
+// The amount is the resolved major-unit decimal from the posting (not raw event data).
+func recordDepositSuccessMetrics(instrumentCode string, amount decimal.Decimal) {
+	observability.RecordDepositProcessed(instrumentCode, observability.StatusSuccess)
+	observability.RecordPosting(observability.DirectionDebit, instrumentCode)
+	observability.RecordPosting(observability.DirectionCredit, instrumentCode)
 
-	// Convert amount string to float64 for metrics (precision loss acceptable for counters)
-	if amountDec, err := decimal.NewFromString(event.Amount); err == nil {
-		amountFloat, _ := amountDec.Float64()
-		observability.RecordPostingAmountFloat(observability.DirectionDebit, event.InstrumentCode, amountFloat)
-		observability.RecordPostingAmountFloat(observability.DirectionCredit, event.InstrumentCode, amountFloat)
-	}
+	amountFloat, _ := amount.Float64()
+	observability.RecordPostingAmountFloat(observability.DirectionDebit, instrumentCode, amountFloat)
+	observability.RecordPostingAmountFloat(observability.DirectionCredit, instrumentCode, amountFloat)
 }
 
 // GetPostingsByBookingLog retrieves all postings for a booking log

--- a/services/financial-accounting/service/posting_service.go
+++ b/services/financial-accounting/service/posting_service.go
@@ -10,15 +10,17 @@ import (
 	"github.com/meridianhub/meridian/services/financial-accounting/adapters/persistence"
 	"github.com/meridianhub/meridian/services/financial-accounting/domain"
 	"github.com/meridianhub/meridian/services/financial-accounting/observability"
+	"github.com/meridianhub/meridian/shared/pkg/refdata"
 	"github.com/shopspring/decimal"
 )
 
 // PostingService handles ledger posting operations
 type PostingService struct {
-	repo              *persistence.LedgerRepository
-	bankCashAccountID string
-	accountResolver   *AccountResolver
-	logger            *slog.Logger
+	repo               *persistence.LedgerRepository
+	bankCashAccountID  string
+	accountResolver    *AccountResolver
+	instrumentResolver refdata.InstrumentResolver
+	logger             *slog.Logger
 }
 
 // PostingServiceConfig holds configuration for creating a PostingService.
@@ -33,6 +35,11 @@ type PostingServiceConfig struct {
 	// AccountResolver is optional. When provided, enables dynamic clearing account
 	// lookup by instrument. Falls back to BankCashAccountID on lookup failure.
 	AccountResolver *AccountResolver
+
+	// InstrumentResolver is optional. When provided, resolves instrument metadata
+	// (dimension, precision) from Reference Data instead of relying on ParseCurrency.
+	// When nil, falls back to legacy currency-based resolution.
+	InstrumentResolver refdata.InstrumentResolver
 
 	// Logger is optional. If nil, a default logger is used.
 	Logger *slog.Logger
@@ -67,25 +74,23 @@ func NewPostingServiceWithConfig(cfg PostingServiceConfig) *PostingService {
 		"static_account_id", cfg.BankCashAccountID)
 
 	return &PostingService{
-		repo:              cfg.Repo,
-		bankCashAccountID: cfg.BankCashAccountID,
-		accountResolver:   cfg.AccountResolver,
-		logger:            logger,
+		repo:               cfg.Repo,
+		bankCashAccountID:  cfg.BankCashAccountID,
+		accountResolver:    cfg.AccountResolver,
+		instrumentResolver: cfg.InstrumentResolver,
+		logger:             logger,
 	}
 }
 
-// decimalFromCents converts cents (int64) to decimal amount
-func decimalFromCents(cents int64) decimal.Decimal {
-	return decimal.NewFromInt(cents).Div(decimal.NewFromInt(100))
-}
-
-// DepositEvent represents a deposit event from CurrentAccount service
+// DepositEvent represents a deposit event from CurrentAccount service.
+// Amount is a decimal string (e.g., "100.00") for full precision with any asset type.
+// InstrumentCode identifies the instrument (e.g., "GBP", "KWH", "TONNE_CO2E").
 type DepositEvent struct {
-	AccountID     string
-	AmountCents   int64
-	Currency      string
-	CorrelationID string
-	ValueDate     time.Time
+	AccountID      string
+	Amount         string // Decimal as string for precision
+	InstrumentCode string // e.g., "GBP", "KWH"
+	CorrelationID  string
+	ValueDate      time.Time
 }
 
 // ProcessDeposit creates double-entry postings for a deposit
@@ -100,27 +105,27 @@ func (s *PostingService) ProcessDeposit(ctx context.Context, event DepositEvent)
 	debitPosting, creditPosting, err := s.buildDepositPostings(ctx, bookingLogID, event)
 	if err != nil {
 		timer.ObserveError(observability.ErrorCategoryValidation)
-		observability.RecordDepositProcessed(event.Currency, observability.StatusError)
+		observability.RecordDepositProcessed(event.InstrumentCode, observability.StatusError)
 		return err
 	}
 
 	// Post both entries
 	if err := debitPosting.Post("Deposit processed"); err != nil {
 		timer.ObserveError(observability.ErrorCategoryInternal)
-		observability.RecordDepositProcessed(event.Currency, observability.StatusError)
+		observability.RecordDepositProcessed(event.InstrumentCode, observability.StatusError)
 		return fmt.Errorf("failed to post debit: %w", err)
 	}
 
 	if err := creditPosting.Post("Deposit processed"); err != nil {
 		timer.ObserveError(observability.ErrorCategoryInternal)
-		observability.RecordDepositProcessed(event.Currency, observability.StatusError)
+		observability.RecordDepositProcessed(event.InstrumentCode, observability.StatusError)
 		return fmt.Errorf("failed to post credit: %w", err)
 	}
 
 	// Save both postings atomically in a transaction
 	if err := s.repo.SavePostingsInTransaction(ctx, []*domain.LedgerPosting{debitPosting, creditPosting}); err != nil {
 		timer.ObserveError(observability.ErrorCategoryDatabase)
-		observability.RecordDepositProcessed(event.Currency, observability.StatusError)
+		observability.RecordDepositProcessed(event.InstrumentCode, observability.StatusError)
 		return fmt.Errorf("failed to save postings: %w", err)
 	}
 
@@ -132,21 +137,21 @@ func (s *PostingService) ProcessDeposit(ctx context.Context, event DepositEvent)
 }
 
 // buildDepositPostings creates the debit and credit postings for a deposit event.
+// Uses InstrumentResolver when available for proper instrument metadata; falls back
+// to legacy ParseCurrency for known ISO 4217 currency codes.
 func (s *PostingService) buildDepositPostings(
 	ctx context.Context,
 	bookingLogID uuid.UUID,
 	event DepositEvent,
 ) (*domain.LedgerPosting, *domain.LedgerPosting, error) {
-	amount := decimalFromCents(event.AmountCents)
-
-	currency, err := domain.ParseCurrency(event.Currency)
+	amount, err := decimal.NewFromString(event.Amount)
 	if err != nil {
-		return nil, nil, fmt.Errorf("invalid currency: %w", err)
+		return nil, nil, fmt.Errorf("invalid amount %q: %w", event.Amount, err)
 	}
 
-	instrument, err := domain.CurrencyToInstrument(currency)
+	instrument, err := s.resolveInstrument(ctx, event.InstrumentCode)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create instrument: %w", err)
+		return nil, nil, fmt.Errorf("failed to resolve instrument %q: %w", event.InstrumentCode, err)
 	}
 
 	money := domain.NewMoney(amount, instrument)
@@ -180,13 +185,39 @@ func (s *PostingService) buildDepositPostings(
 	return debitPosting, creditPosting, nil
 }
 
+// resolveInstrument resolves an instrument code to a domain Instrument.
+// Tries InstrumentResolver first, then falls back to legacy ParseCurrency.
+func (s *PostingService) resolveInstrument(ctx context.Context, code string) (domain.Instrument, error) {
+	if s.instrumentResolver != nil {
+		props, err := s.instrumentResolver.Resolve(ctx, code)
+		if err == nil {
+			return domain.NewInstrument(props.Code, 1, props.Dimension, props.Precision)
+		}
+		s.logger.Debug("instrument resolver failed, trying legacy currency lookup",
+			"instrument_code", code,
+			"error", err)
+	}
+
+	// Legacy fallback for known ISO 4217 currencies
+	currency, err := domain.ParseCurrency(code)
+	if err != nil {
+		return domain.Instrument{}, fmt.Errorf("unknown instrument: %w", err)
+	}
+	return domain.CurrencyToInstrument(currency)
+}
+
 // recordDepositSuccessMetrics records all metrics for a successful deposit processing.
 func recordDepositSuccessMetrics(event DepositEvent) {
-	observability.RecordDepositProcessed(event.Currency, observability.StatusSuccess)
-	observability.RecordPosting(observability.DirectionDebit, event.Currency)
-	observability.RecordPosting(observability.DirectionCredit, event.Currency)
-	observability.RecordPostingAmount(observability.DirectionDebit, event.Currency, event.AmountCents)
-	observability.RecordPostingAmount(observability.DirectionCredit, event.Currency, event.AmountCents)
+	observability.RecordDepositProcessed(event.InstrumentCode, observability.StatusSuccess)
+	observability.RecordPosting(observability.DirectionDebit, event.InstrumentCode)
+	observability.RecordPosting(observability.DirectionCredit, event.InstrumentCode)
+
+	// Convert amount string to float64 for metrics (precision loss acceptable for counters)
+	if amountDec, err := decimal.NewFromString(event.Amount); err == nil {
+		amountFloat, _ := amountDec.Float64()
+		observability.RecordPostingAmountFloat(observability.DirectionDebit, event.InstrumentCode, amountFloat)
+		observability.RecordPostingAmountFloat(observability.DirectionCredit, event.InstrumentCode, amountFloat)
+	}
 }
 
 // GetPostingsByBookingLog retrieves all postings for a booking log

--- a/services/financial-accounting/service/posting_service_bench_test.go
+++ b/services/financial-accounting/service/posting_service_bench_test.go
@@ -60,12 +60,14 @@ func setupBenchContainer(b *testing.B) *benchTestContainer {
 
 // createBenchDepositEvent creates a realistic deposit event for benchmarking.
 func createBenchDepositEvent(i int) DepositEvent {
+	// Vary amounts: base 100.00 + cents variation
+	amount := decimal.NewFromInt(int64(10000 + (i % 100000))).Div(decimal.NewFromInt(100))
 	return DepositEvent{
-		AccountID:     fmt.Sprintf("ACC-BENCH-%08d", i),
-		AmountCents:   int64(10000 + (i % 100000)), // Vary amounts
-		Currency:      "GBP",
-		CorrelationID: fmt.Sprintf("deposit-bench-%s", uuid.New().String()[:8]),
-		ValueDate:     time.Now().UTC(),
+		AccountID:      fmt.Sprintf("ACC-BENCH-%08d", i),
+		Amount:         amount.String(),
+		InstrumentCode: "GBP",
+		CorrelationID:  fmt.Sprintf("deposit-bench-%s", uuid.New().String()[:8]),
+		ValueDate:      time.Now().UTC(),
 	}
 }
 
@@ -123,24 +125,24 @@ func BenchmarkProcessDeposit_VariedAmounts(b *testing.B) {
 	tc := setupBenchContainer(b)
 	ctx := context.Background()
 
-	amounts := []int64{
-		100,         // £1.00
-		10000,       // £100.00
-		100000,      // £1,000.00
-		10000000,    // £100,000.00
-		10000000000, // £100,000,000.00
+	amounts := []string{
+		"1.00",         // £1.00
+		"100.00",       // £100.00
+		"1000.00",      // £1,000.00
+		"100000.00",    // £100,000.00
+		"100000000.00", // £100,000,000.00
 	}
 
 	for _, amount := range amounts {
-		b.Run(fmt.Sprintf("Amount_%d", amount), func(b *testing.B) {
+		b.Run(fmt.Sprintf("Amount_%s", amount), func(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				event := DepositEvent{
-					AccountID:     fmt.Sprintf("ACC-VAR-%08d", i),
-					AmountCents:   amount,
-					Currency:      "GBP",
-					CorrelationID: fmt.Sprintf("deposit-var-%s", uuid.New().String()[:8]),
-					ValueDate:     time.Now().UTC(),
+					AccountID:      fmt.Sprintf("ACC-VAR-%08d", i),
+					Amount:         amount,
+					InstrumentCode: "GBP",
+					CorrelationID:  fmt.Sprintf("deposit-var-%s", uuid.New().String()[:8]),
+					ValueDate:      time.Now().UTC(),
 				}
 				err := tc.service.ProcessDeposit(ctx, event)
 				if err != nil {

--- a/services/financial-accounting/service/posting_service_test.go
+++ b/services/financial-accounting/service/posting_service_test.go
@@ -12,6 +12,7 @@ import (
 	internalaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_account/v1"
 	"github.com/meridianhub/meridian/services/financial-accounting/adapters/persistence"
 	"github.com/meridianhub/meridian/services/financial-accounting/domain"
+	"github.com/meridianhub/meridian/shared/pkg/refdata"
 	"github.com/meridianhub/meridian/shared/platform/audit"
 	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/shopspring/decimal"
@@ -40,11 +41,11 @@ func TestProcessDeposit(t *testing.T) {
 	service := NewPostingService(repo, "BANK-CASH-001")
 
 	event := DepositEvent{
-		AccountID:     "ACC-123",
-		AmountCents:   10000, // £100.00
-		Currency:      "GBP",
-		CorrelationID: "deposit-001",
-		ValueDate:     time.Now(),
+		AccountID:      "ACC-123",
+		Amount:         "100.00",
+		InstrumentCode: "GBP",
+		CorrelationID:  "deposit-001",
+		ValueDate:      time.Now(),
 	}
 	err := service.ProcessDeposit(ctx, event)
 	if err != nil {
@@ -98,11 +99,11 @@ func TestValidateDoubleEntry(t *testing.T) {
 
 	// Process a deposit (creates balanced entries)
 	event := DepositEvent{
-		AccountID:     "ACC-456",
-		AmountCents:   50000,
-		Currency:      "GBP",
-		CorrelationID: "deposit-002",
-		ValueDate:     time.Now(),
+		AccountID:      "ACC-456",
+		Amount:         "500.00",
+		InstrumentCode: "GBP",
+		CorrelationID:  "deposit-002",
+		ValueDate:      time.Now(),
 	}
 
 	err := service.ProcessDeposit(ctx, event)
@@ -132,11 +133,11 @@ func TestProcessDeposit_InvalidAmount(t *testing.T) {
 	service := NewPostingService(repo, "BANK-CASH-001")
 
 	event := DepositEvent{
-		AccountID:     "ACC-789",
-		AmountCents:   0, // Invalid
-		Currency:      "GBP",
-		CorrelationID: "deposit-003",
-		ValueDate:     time.Now(),
+		AccountID:      "ACC-789",
+		Amount:         "0", // Invalid - zero amount
+		InstrumentCode: "GBP",
+		CorrelationID:  "deposit-003",
+		ValueDate:      time.Now(),
 	}
 	err := service.ProcessDeposit(ctx, event)
 	if err == nil {
@@ -152,11 +153,11 @@ func TestGetPostingsByBookingLog(t *testing.T) {
 
 	// Create some postings
 	event := DepositEvent{
-		AccountID:     "ACC-999",
-		AmountCents:   25000,
-		Currency:      "GBP",
-		CorrelationID: "deposit-004",
-		ValueDate:     time.Now(),
+		AccountID:      "ACC-999",
+		Amount:         "250.00",
+		InstrumentCode: "GBP",
+		CorrelationID:  "deposit-004",
+		ValueDate:      time.Now(),
 	}
 
 	err := service.ProcessDeposit(ctx, event)
@@ -267,11 +268,11 @@ func TestProcessDeposit_WithDynamicClearingAccount(t *testing.T) {
 	})
 
 	event := DepositEvent{
-		AccountID:     "ACC-DYNAMIC-123",
-		AmountCents:   10000,
-		Currency:      "GBP",
-		CorrelationID: "deposit-dynamic-001",
-		ValueDate:     time.Now(),
+		AccountID:      "ACC-DYNAMIC-123",
+		Amount:         "100.00",
+		InstrumentCode: "GBP",
+		CorrelationID:  "deposit-dynamic-001",
+		ValueDate:      time.Now(),
 	}
 
 	err = service.ProcessDeposit(ctx, event)
@@ -308,11 +309,11 @@ func TestProcessDeposit_FallbackOnResolverError(t *testing.T) {
 	})
 
 	event := DepositEvent{
-		AccountID:     "ACC-FALLBACK-123",
-		AmountCents:   10000,
-		Currency:      "GBP",
-		CorrelationID: "deposit-fallback-001",
-		ValueDate:     time.Now(),
+		AccountID:      "ACC-FALLBACK-123",
+		Amount:         "100.00",
+		InstrumentCode: "GBP",
+		CorrelationID:  "deposit-fallback-001",
+		ValueDate:      time.Now(),
 	}
 
 	err = service.ProcessDeposit(ctx, event)
@@ -339,11 +340,11 @@ func TestProcessDeposit_WithoutResolver_UsesStaticAccount(t *testing.T) {
 	})
 
 	event := DepositEvent{
-		AccountID:     "ACC-STATIC-123",
-		AmountCents:   10000,
-		Currency:      "GBP",
-		CorrelationID: "deposit-static-001",
-		ValueDate:     time.Now(),
+		AccountID:      "ACC-STATIC-123",
+		Amount:         "100.00",
+		InstrumentCode: "GBP",
+		CorrelationID:  "deposit-static-001",
+		ValueDate:      time.Now(),
 	}
 
 	err := service.ProcessDeposit(ctx, event)
@@ -380,11 +381,11 @@ func TestProcessDeposit_FallbackOnNoClearingAccountFound(t *testing.T) {
 	})
 
 	event := DepositEvent{
-		AccountID:     "ACC-EMPTY-123",
-		AmountCents:   10000,
-		Currency:      "GBP",
-		CorrelationID: "deposit-empty-001",
-		ValueDate:     time.Now(),
+		AccountID:      "ACC-EMPTY-123",
+		Amount:         "100.00",
+		InstrumentCode: "GBP",
+		CorrelationID:  "deposit-empty-001",
+		ValueDate:      time.Now(),
 	}
 
 	err = service.ProcessDeposit(ctx, event)
@@ -425,22 +426,22 @@ func TestProcessDeposit_MultiAsset_DynamicLookup(t *testing.T) {
 
 	// Process GBP deposit
 	gbpEvent := DepositEvent{
-		AccountID:     "ACC-GBP-123",
-		AmountCents:   10000,
-		Currency:      "GBP",
-		CorrelationID: "deposit-gbp-001",
-		ValueDate:     time.Now(),
+		AccountID:      "ACC-GBP-123",
+		Amount:         "100.00",
+		InstrumentCode: "GBP",
+		CorrelationID:  "deposit-gbp-001",
+		ValueDate:      time.Now(),
 	}
 	err = service.ProcessDeposit(ctx, gbpEvent)
 	require.NoError(t, err)
 
 	// Process USD deposit
 	usdEvent := DepositEvent{
-		AccountID:     "ACC-USD-123",
-		AmountCents:   20000,
-		Currency:      "USD",
-		CorrelationID: "deposit-usd-001",
-		ValueDate:     time.Now(),
+		AccountID:      "ACC-USD-123",
+		Amount:         "200.00",
+		InstrumentCode: "USD",
+		CorrelationID:  "deposit-usd-001",
+		ValueDate:      time.Now(),
 	}
 	err = service.ProcessDeposit(ctx, usdEvent)
 	require.NoError(t, err)
@@ -459,8 +460,133 @@ func TestProcessDeposit_MultiAsset_DynamicLookup(t *testing.T) {
 }
 
 // =============================================================================
+// Tests for asset-agnostic deposits with InstrumentResolver
+// =============================================================================
+
+func TestProcessDeposit_KWH_WithResolver(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+	repo := persistence.NewLedgerRepository(db)
+
+	resolver := &postingServiceMockInstrumentResolver{
+		instruments: map[string]refdata.InstrumentProperties{
+			"KWH": {Code: "KWH", Dimension: "ENERGY", Precision: 3, RoundingMode: "HALF_UP"},
+		},
+	}
+
+	service := NewPostingServiceWithConfig(PostingServiceConfig{
+		Repo:               repo,
+		BankCashAccountID:  "ENERGY-CLEARING-001",
+		InstrumentResolver: resolver,
+		Logger:             postingTestLogger(),
+	})
+
+	event := DepositEvent{
+		AccountID:      "ACC-ENERGY-001",
+		Amount:         "123.456",
+		InstrumentCode: "KWH",
+		CorrelationID:  "deposit-kwh-001",
+		ValueDate:      time.Now(),
+	}
+
+	err := service.ProcessDeposit(ctx, event)
+	require.NoError(t, err)
+
+	// Verify debit posting exists
+	var debitEntity persistence.LedgerPostingEntity
+	err = db.Where("account_id = ? AND posting_direction = ?", "ACC-ENERGY-001", "DEBIT").First(&debitEntity).Error
+	require.NoError(t, err)
+	require.Equal(t, "KWH", debitEntity.Currency)
+
+	// Verify credit posting exists
+	var creditEntity persistence.LedgerPostingEntity
+	err = db.Where("account_id = ? AND posting_direction = ?", "ENERGY-CLEARING-001", "CREDIT").First(&creditEntity).Error
+	require.NoError(t, err)
+}
+
+func TestProcessDeposit_UnknownInstrument_WithResolver(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+	repo := persistence.NewLedgerRepository(db)
+
+	// Resolver that doesn't know "UNKNOWN"
+	resolver := &postingServiceMockInstrumentResolver{
+		instruments: map[string]refdata.InstrumentProperties{},
+	}
+
+	service := NewPostingServiceWithConfig(PostingServiceConfig{
+		Repo:               repo,
+		BankCashAccountID:  "FALLBACK",
+		InstrumentResolver: resolver,
+		Logger:             postingTestLogger(),
+	})
+
+	event := DepositEvent{
+		AccountID:      "ACC-UNKNOWN",
+		Amount:         "100.00",
+		InstrumentCode: "UNKNOWN_ASSET",
+		CorrelationID:  "deposit-unknown-001",
+		ValueDate:      time.Now(),
+	}
+
+	err := service.ProcessDeposit(ctx, event)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to resolve instrument")
+}
+
+func TestProcessDeposit_Precision_Preserved(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+	repo := persistence.NewLedgerRepository(db)
+
+	resolver := &postingServiceMockInstrumentResolver{
+		instruments: map[string]refdata.InstrumentProperties{
+			"KWH": {Code: "KWH", Dimension: "ENERGY", Precision: 3, RoundingMode: "HALF_UP"},
+		},
+	}
+
+	service := NewPostingServiceWithConfig(PostingServiceConfig{
+		Repo:               repo,
+		BankCashAccountID:  "CLEARING",
+		InstrumentResolver: resolver,
+		Logger:             postingTestLogger(),
+	})
+
+	event := DepositEvent{
+		AccountID:      "ACC-PRECISION",
+		Amount:         "123.456",
+		InstrumentCode: "KWH",
+		CorrelationID:  "deposit-precision-001",
+		ValueDate:      time.Now(),
+	}
+
+	err := service.ProcessDeposit(ctx, event)
+	require.NoError(t, err)
+
+	// Retrieve and verify amount preserved through the pipeline
+	var entity persistence.LedgerPostingEntity
+	err = db.Where("account_id = ? AND posting_direction = ?", "ACC-PRECISION", "DEBIT").First(&entity).Error
+	require.NoError(t, err)
+
+	// 123.456 with precision 3 = 123456 minor units
+	require.Equal(t, int64(123456), entity.AmountMinorUnits)
+}
+
+// =============================================================================
 // Test helpers
 // =============================================================================
+
+// postingServiceMockInstrumentResolver implements refdata.InstrumentResolver for PostingService tests.
+type postingServiceMockInstrumentResolver struct {
+	instruments map[string]refdata.InstrumentProperties
+}
+
+func (m *postingServiceMockInstrumentResolver) Resolve(_ context.Context, code string) (refdata.InstrumentProperties, error) {
+	if props, ok := m.instruments[code]; ok {
+		return props, nil
+	}
+	return refdata.InstrumentProperties{}, refdata.ErrUnknownInstrument
+}
 
 // Sentinel error for testing fallback behavior
 var errMockServiceUnavailable = errors.New("mock: service unavailable")

--- a/services/financial-accounting/service/posting_service_test.go
+++ b/services/financial-accounting/service/posting_service_test.go
@@ -572,6 +572,80 @@ func TestProcessDeposit_Precision_Preserved(t *testing.T) {
 	require.Equal(t, int64(123456), entity.AmountMinorUnits)
 }
 
+func TestProcessDeposit_MinorUnit_Conversion(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+	repo := persistence.NewLedgerRepository(db)
+
+	resolver := &postingServiceMockInstrumentResolver{
+		instruments: map[string]refdata.InstrumentProperties{
+			"KWH": {Code: "KWH", Dimension: "ENERGY", Precision: 3, RoundingMode: "HALF_UP"},
+		},
+	}
+
+	service := NewPostingServiceWithConfig(PostingServiceConfig{
+		Repo:               repo,
+		BankCashAccountID:  "CLEARING",
+		InstrumentResolver: resolver,
+		Logger:             postingTestLogger(),
+	})
+
+	// 123456 minor units with precision 3 = 123.456 KWH
+	event := DepositEvent{
+		AccountID:       "ACC-MINOR-UNIT",
+		AmountMinorUnit: 123456,
+		InstrumentCode:  "KWH",
+		CorrelationID:   "deposit-minor-001",
+		ValueDate:       time.Now(),
+	}
+
+	err := service.ProcessDeposit(ctx, event)
+	require.NoError(t, err)
+
+	var entity persistence.LedgerPostingEntity
+	err = db.Where("account_id = ? AND posting_direction = ?", "ACC-MINOR-UNIT", "DEBIT").First(&entity).Error
+	require.NoError(t, err)
+	// 123.456 with precision 3 = 123456 minor units in storage
+	require.Equal(t, int64(123456), entity.AmountMinorUnits)
+}
+
+func TestProcessDeposit_MinorUnit_JPY_ZeroPrecision(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+	repo := persistence.NewLedgerRepository(db)
+
+	resolver := &postingServiceMockInstrumentResolver{
+		instruments: map[string]refdata.InstrumentProperties{
+			"JPY": {Code: "JPY", Dimension: "CURRENCY", Precision: 0, RoundingMode: "HALF_EVEN"},
+		},
+	}
+
+	service := NewPostingServiceWithConfig(PostingServiceConfig{
+		Repo:               repo,
+		BankCashAccountID:  "CLEARING-JPY",
+		InstrumentResolver: resolver,
+		Logger:             postingTestLogger(),
+	})
+
+	// 500 minor units with precision 0 = 500 JPY (no division)
+	event := DepositEvent{
+		AccountID:       "ACC-JPY",
+		AmountMinorUnit: 500,
+		InstrumentCode:  "JPY",
+		CorrelationID:   "deposit-jpy-001",
+		ValueDate:       time.Now(),
+	}
+
+	err := service.ProcessDeposit(ctx, event)
+	require.NoError(t, err)
+
+	var entity persistence.LedgerPostingEntity
+	err = db.Where("account_id = ? AND posting_direction = ?", "ACC-JPY", "DEBIT").First(&entity).Error
+	require.NoError(t, err)
+	// 500 JPY with precision 0 = 500 minor units
+	require.Equal(t, int64(500), entity.AmountMinorUnits)
+}
+
 // =============================================================================
 // Test helpers
 // =============================================================================

--- a/services/financial-accounting/service/pure_functions_test.go
+++ b/services/financial-accounting/service/pure_functions_test.go
@@ -81,30 +81,6 @@ func TestExtractUserFromContext_NoContextReturnsSystem(t *testing.T) {
 	assert.Equal(t, "system", result)
 }
 
-// --- decimalFromCents ---
-
-func TestDecimalFromCents(t *testing.T) {
-	tests := []struct {
-		name     string
-		cents    int64
-		expected string
-	}{
-		{"zero", 0, "0"},
-		{"100 cents is 1.00", 100, "1"},
-		{"150 cents is 1.50", 150, "1.5"},
-		{"1 cent is 0.01", 1, "0.01"},
-		{"negative cents", -500, "-5"},
-		{"large amount", 1234567, "12345.67"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := decimalFromCents(tt.cents)
-			assert.Equal(t, tt.expected, result.String())
-		})
-	}
-}
-
 // --- toProtoFinancialBookingLog ---
 
 func TestToProtoFinancialBookingLog_Nil(t *testing.T) {
@@ -561,16 +537,16 @@ func TestToProtoFinancialBookingLog_CancelledStatus(t *testing.T) {
 
 func TestDepositEvent_StructConstruction(t *testing.T) {
 	event := DepositEvent{
-		AccountID:     "ACC-001",
-		AmountCents:   15000,
-		Currency:      "GBP",
-		CorrelationID: "corr-123",
-		ValueDate:     time.Now().UTC(),
+		AccountID:      "ACC-001",
+		Amount:         "150.00",
+		InstrumentCode: "GBP",
+		CorrelationID:  "corr-123",
+		ValueDate:      time.Now().UTC(),
 	}
 
 	assert.Equal(t, "ACC-001", event.AccountID)
-	assert.Equal(t, int64(15000), event.AmountCents)
-	assert.Equal(t, "GBP", event.Currency)
+	assert.Equal(t, "150.00", event.Amount)
+	assert.Equal(t, "GBP", event.InstrumentCode)
 	assert.Equal(t, "corr-123", event.CorrelationID)
 	assert.False(t, event.ValueDate.IsZero())
 }
@@ -892,31 +868,31 @@ func TestExecuteUpdateLedgerPosting_UnspecifiedStatus(t *testing.T) {
 
 // --- ProcessDeposit error branches ---
 
-func TestProcessDeposit_InvalidCurrency(t *testing.T) {
+func TestProcessDeposit_InvalidInstrument(t *testing.T) {
 	svc := NewPostingService(nil, "BANK-CASH-001")
 
 	event := DepositEvent{
-		AccountID:     "ACC-INVALID-CURRENCY",
-		AmountCents:   10000,
-		Currency:      "INVALID_CURRENCY",
-		CorrelationID: "deposit-invalid-curr",
-		ValueDate:     time.Now(),
+		AccountID:      "ACC-INVALID-INSTRUMENT",
+		Amount:         "100.00",
+		InstrumentCode: "INVALID_INSTRUMENT",
+		CorrelationID:  "deposit-invalid-inst",
+		ValueDate:      time.Now(),
 	}
 
 	err := svc.ProcessDeposit(context.Background(), event)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid currency")
+	assert.Contains(t, err.Error(), "failed to resolve instrument")
 }
 
 func TestProcessDeposit_NegativeAmount(t *testing.T) {
 	svc := NewPostingService(nil, "BANK-CASH-001")
 
 	event := DepositEvent{
-		AccountID:     "ACC-NEG-AMOUNT",
-		AmountCents:   -500,
-		Currency:      "GBP",
-		CorrelationID: "deposit-neg-amount",
-		ValueDate:     time.Now(),
+		AccountID:      "ACC-NEG-AMOUNT",
+		Amount:         "-5.00",
+		InstrumentCode: "GBP",
+		CorrelationID:  "deposit-neg-amount",
+		ValueDate:      time.Now(),
 	}
 
 	err := svc.ProcessDeposit(context.Background(), event)
@@ -928,16 +904,32 @@ func TestProcessDeposit_EmptyAccountID(t *testing.T) {
 	svc := NewPostingService(nil, "BANK-CASH-001")
 
 	event := DepositEvent{
-		AccountID:     "",
-		AmountCents:   10000,
-		Currency:      "GBP",
-		CorrelationID: "deposit-empty-acct",
-		ValueDate:     time.Now(),
+		AccountID:      "",
+		Amount:         "100.00",
+		InstrumentCode: "GBP",
+		CorrelationID:  "deposit-empty-acct",
+		ValueDate:      time.Now(),
 	}
 
 	err := svc.ProcessDeposit(context.Background(), event)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create debit posting")
+}
+
+func TestProcessDeposit_InvalidAmountString(t *testing.T) {
+	svc := NewPostingService(nil, "BANK-CASH-001")
+
+	event := DepositEvent{
+		AccountID:      "ACC-BAD-AMOUNT",
+		Amount:         "not-a-number",
+		InstrumentCode: "GBP",
+		CorrelationID:  "deposit-bad-amount",
+		ValueDate:      time.Now(),
+	}
+
+	err := svc.ProcessDeposit(context.Background(), event)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid amount")
 }
 
 // --- fromProtoInstrumentAmount nil input ---


### PR DESCRIPTION
## Summary

- Adds `InstrumentAmountConverter` struct with `InstrumentResolver` dependency for resolving instrument metadata (dimension, precision) from Reference Data, with fallback to legacy `ParseCurrency`
- Redesigns `DepositEvent` from cent-based (`AmountCents int64`, `Currency string`) to decimal string-based (`Amount string`, `InstrumentCode string`) enabling support for non-currency assets (KWH, TONNE_CO2E, GPU_HOUR)
- Adds `InstrumentResolver` to `PostingService` and `PostingServiceConfig`; rewrites `buildDepositPostings` to use `resolveInstrument()` which tries the resolver first, falls back to legacy currency lookup
- Updates deposit consumer to convert proto `AmountCents` to decimal string for the new `DepositEvent` format
- Exports `ToProtoInstrumentAmount` for cross-package use
- Adds `RecordPostingAmountFloat` metric for asset-agnostic amount tracking
- Removes `decimalFromCents` (replaced by string-based decimal parsing)

## Changes Made

### Task 3: Go adapters for InstrumentAmount
- `adapters.go`: New `InstrumentAmountConverter` with `FromProto(ctx, *InstrumentAmount)` using resolver, plus exported `ToProtoInstrumentAmount`
- `adapters_test.go`: Tests for converter with GBP/KWH/TONNE_CO2E/GPU_HOUR, nil input, empty code, invalid amount, fallback, roundtrip

### Task 4: PostingService asset-agnostic rewrite
- `posting_service.go`: Redesigned `DepositEvent`, added `resolveInstrument()` method, updated `buildDepositPostings` and metrics
- `posting_service_test.go`: New tests for KWH deposits with resolver, unknown instrument rejection, precision preservation through pipeline
- `deposit_consumer.go`: Converts `AmountCents` to decimal string when constructing `DepositEvent`
- `observability/metrics.go`: Added `RecordPostingAmountFloat` for float-based amount tracking

## Test plan

- [x] Unit: `InstrumentAmountConverter.FromProto()` accepts GBP, KWH, TONNE_CO2E, GPU_HOUR
- [x] Unit: `FromProto()` rejects empty instrument code, invalid amount, nil input
- [x] Unit: `ToProtoInstrumentAmount()` produces correct output
- [x] Unit: Round-trip `FromProto(ToProto(money))` preserves amount
- [x] Unit: `buildDepositPostings` with unknown instrument returns error
- [x] Unit: `DepositEvent` with invalid amount string returns error
- [x] Integration: KWH deposit with resolver succeeds (CI - testcontainer)
- [x] Integration: Precision '123.456' KWH preserves through pipeline (CI - testcontainer)
- [ ] CI: Full test suite `go test ./services/financial-accounting/...`