### PR TITLE
feat: reject non-active tenants with 503 at gateway middleware

### DIFF
--- a/services/api-gateway/auth_flows_test.go
+++ b/services/api-gateway/auth_flows_test.go
@@ -56,18 +56,20 @@ type authFlowSlugCache struct {
 	entries map[string]tenant.TenantID
 }
 
-func (c *authFlowSlugCache) Get(_ context.Context, slug string) (tenant.TenantID, error) {
+func (c *authFlowSlugCache) Get(_ context.Context, slug string) (tenant.TenantID, string, error) {
 	id, ok := c.entries[slug]
 	if !ok {
-		return "", nil
+		return "", "", nil
 	}
-	return id, nil
+	return id, "", nil
 }
 
-func (c *authFlowSlugCache) Set(_ context.Context, slug string, tenantID tenant.TenantID) error {
+func (c *authFlowSlugCache) Set(_ context.Context, slug string, tenantID tenant.TenantID, _ string) error {
 	c.entries[slug] = tenantID
 	return nil
 }
+
+func (c *authFlowSlugCache) Invalidate(_ context.Context, _ string) {}
 
 // authFlowTenantRepo satisfies the tenantRepository interface for TenantResolverMiddleware.
 type authFlowTenantRepo struct {

--- a/services/api-gateway/server_test.go
+++ b/services/api-gateway/server_test.go
@@ -848,18 +848,20 @@ func newStubSlugCache() *stubSlugCache {
 	return &stubSlugCache{entries: make(map[string]tenant.TenantID)}
 }
 
-func (c *stubSlugCache) Get(_ context.Context, slug string) (tenant.TenantID, error) {
+func (c *stubSlugCache) Get(_ context.Context, slug string) (tenant.TenantID, string, error) {
 	id, ok := c.entries[slug]
 	if !ok {
-		return "", nil // cache miss
+		return "", "", nil // cache miss
 	}
-	return id, nil
+	return id, "", nil
 }
 
-func (c *stubSlugCache) Set(_ context.Context, slug string, tenantID tenant.TenantID) error {
+func (c *stubSlugCache) Set(_ context.Context, slug string, tenantID tenant.TenantID, _ string) error {
 	c.entries[slug] = tenantID
 	return nil
 }
+
+func (c *stubSlugCache) Invalidate(_ context.Context, _ string) {}
 
 // stubTenantRepo is a minimal tenant repository for testing.
 // It satisfies the unexported tenantRepository interface used by NewTenantResolverMiddleware.

--- a/shared/platform/gateway/inmemory_cache.go
+++ b/shared/platform/gateway/inmemory_cache.go
@@ -15,9 +15,10 @@ const DefaultCacheTTL = 5 * time.Minute
 // DefaultCleanupInterval is the default interval for background cleanup of expired entries.
 const DefaultCleanupInterval = 1 * time.Minute
 
-// cacheEntry holds a cached tenant ID with its expiration time.
+// cacheEntry holds a cached tenant ID and status with its expiration time.
 type cacheEntry struct {
 	tenantID  tenant.TenantID
+	status    string
 	expiresAt time.Time
 }
 
@@ -85,19 +86,19 @@ func NewInMemorySlugCache(opts ...InMemoryCacheOption) *InMemorySlugCache {
 	return c
 }
 
-// Get retrieves a tenant ID for the given slug from the cache.
-// Returns an empty TenantID for cache miss (not an error).
+// Get retrieves a tenant ID and status for the given slug from the cache.
+// Returns an empty TenantID and empty status for cache miss (not an error).
 // Context cancellation is respected.
-func (c *InMemorySlugCache) Get(ctx context.Context, slug string) (tenant.TenantID, error) {
+func (c *InMemorySlugCache) Get(ctx context.Context, slug string) (tenant.TenantID, string, error) {
 	// Check context first
 	select {
 	case <-ctx.Done():
-		return "", ctx.Err()
+		return "", "", ctx.Err()
 	default:
 	}
 
 	if slug == "" {
-		return "", nil
+		return "", "", nil
 	}
 
 	c.mu.RLock()
@@ -105,23 +106,23 @@ func (c *InMemorySlugCache) Get(ctx context.Context, slug string) (tenant.Tenant
 	c.mu.RUnlock()
 
 	if !ok {
-		return "", nil
+		return "", "", nil
 	}
 
 	// Check if entry has expired
 	if entry.isExpired() {
 		// Entry expired - treat as cache miss
 		// Cleanup goroutine will eventually remove it
-		return "", nil
+		return "", "", nil
 	}
 
-	return entry.tenantID, nil
+	return entry.tenantID, entry.status, nil
 }
 
-// Set stores a tenant ID for the given slug in the cache.
+// Set stores a tenant ID and status for the given slug in the cache.
 // The entry will expire after the configured TTL.
 // Context cancellation is respected.
-func (c *InMemorySlugCache) Set(ctx context.Context, slug string, tenantID tenant.TenantID) error {
+func (c *InMemorySlugCache) Set(ctx context.Context, slug string, tenantID tenant.TenantID, status string) error {
 	// Check context first
 	select {
 	case <-ctx.Done():
@@ -136,11 +137,24 @@ func (c *InMemorySlugCache) Set(ctx context.Context, slug string, tenantID tenan
 	c.mu.Lock()
 	c.cache[slug] = cacheEntry{
 		tenantID:  tenantID,
+		status:    status,
 		expiresAt: time.Now().Add(c.ttl),
 	}
 	c.mu.Unlock()
 
 	return nil
+}
+
+// Invalidate removes a slug entry from the cache, forcing the next lookup
+// to query the database. Used when provisioning transitions occur.
+func (c *InMemorySlugCache) Invalidate(_ context.Context, slug string) {
+	if slug == "" {
+		return
+	}
+
+	c.mu.Lock()
+	delete(c.cache, slug)
+	c.mu.Unlock()
 }
 
 // Stop stops the background cleanup goroutine and releases resources.

--- a/shared/platform/gateway/inmemory_cache_test.go
+++ b/shared/platform/gateway/inmemory_cache_test.go
@@ -61,34 +61,37 @@ func TestInMemorySlugCache_Get(t *testing.T) {
 		cache := NewInMemorySlugCache()
 		defer cache.Stop()
 
-		tenantID, err := cache.Get(ctx, "nonexistent")
+		tenantID, status, err := cache.Get(ctx, "nonexistent")
 
 		require.NoError(t, err)
 		assert.True(t, tenantID.IsEmpty(), "should return empty TenantID for cache miss")
+		assert.Empty(t, status)
 	})
 
-	t.Run("returns cached tenant ID on hit", func(t *testing.T) {
+	t.Run("returns cached tenant ID and status on hit", func(t *testing.T) {
 		cache := NewInMemorySlugCache()
 		defer cache.Stop()
 
 		expectedTenantID := tenant.MustNewTenantID("tenant_123")
-		err := cache.Set(ctx, "acme", expectedTenantID)
+		err := cache.Set(ctx, "acme", expectedTenantID, "active")
 		require.NoError(t, err)
 
-		tenantID, err := cache.Get(ctx, "acme")
+		tenantID, status, err := cache.Get(ctx, "acme")
 
 		require.NoError(t, err)
 		assert.Equal(t, expectedTenantID, tenantID)
+		assert.Equal(t, "active", status)
 	})
 
 	t.Run("returns empty TenantID for empty slug", func(t *testing.T) {
 		cache := NewInMemorySlugCache()
 		defer cache.Stop()
 
-		tenantID, err := cache.Get(ctx, "")
+		tenantID, status, err := cache.Get(ctx, "")
 
 		require.NoError(t, err)
 		assert.True(t, tenantID.IsEmpty())
+		assert.Empty(t, status)
 	})
 
 	t.Run("respects context cancellation", func(t *testing.T) {
@@ -98,27 +101,29 @@ func TestInMemorySlugCache_Get(t *testing.T) {
 		cancelledCtx, cancel := context.WithCancel(ctx)
 		cancel()
 
-		tenantID, err := cache.Get(cancelledCtx, "acme")
+		tenantID, status, err := cache.Get(cancelledCtx, "acme")
 
 		assert.ErrorIs(t, err, context.Canceled)
 		assert.True(t, tenantID.IsEmpty())
+		assert.Empty(t, status)
 	})
 }
 
 func TestInMemorySlugCache_Set(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("stores tenant ID successfully", func(t *testing.T) {
+	t.Run("stores tenant ID and status successfully", func(t *testing.T) {
 		cache := NewInMemorySlugCache()
 		defer cache.Stop()
 
 		expectedTenantID := tenant.MustNewTenantID("tenant_123")
-		err := cache.Set(ctx, "acme", expectedTenantID)
+		err := cache.Set(ctx, "acme", expectedTenantID, "active")
 		require.NoError(t, err)
 
-		tenantID, err := cache.Get(ctx, "acme")
+		tenantID, status, err := cache.Get(ctx, "acme")
 		require.NoError(t, err)
 		assert.Equal(t, expectedTenantID, tenantID)
+		assert.Equal(t, "active", status)
 	})
 
 	t.Run("overwrites existing entry", func(t *testing.T) {
@@ -128,22 +133,23 @@ func TestInMemorySlugCache_Set(t *testing.T) {
 		firstTenantID := tenant.MustNewTenantID("tenant_1")
 		secondTenantID := tenant.MustNewTenantID("tenant_2")
 
-		err := cache.Set(ctx, "acme", firstTenantID)
+		err := cache.Set(ctx, "acme", firstTenantID, "provisioning")
 		require.NoError(t, err)
 
-		err = cache.Set(ctx, "acme", secondTenantID)
+		err = cache.Set(ctx, "acme", secondTenantID, "active")
 		require.NoError(t, err)
 
-		tenantID, err := cache.Get(ctx, "acme")
+		tenantID, status, err := cache.Get(ctx, "acme")
 		require.NoError(t, err)
 		assert.Equal(t, secondTenantID, tenantID)
+		assert.Equal(t, "active", status)
 	})
 
 	t.Run("ignores empty slug", func(t *testing.T) {
 		cache := NewInMemorySlugCache()
 		defer cache.Stop()
 
-		err := cache.Set(ctx, "", tenant.MustNewTenantID("tenant_123"))
+		err := cache.Set(ctx, "", tenant.MustNewTenantID("tenant_123"), "active")
 		require.NoError(t, err)
 		assert.Equal(t, 0, cache.Size())
 	})
@@ -155,10 +161,50 @@ func TestInMemorySlugCache_Set(t *testing.T) {
 		cancelledCtx, cancel := context.WithCancel(ctx)
 		cancel()
 
-		err := cache.Set(cancelledCtx, "acme", tenant.MustNewTenantID("tenant_123"))
+		err := cache.Set(cancelledCtx, "acme", tenant.MustNewTenantID("tenant_123"), "active")
 
 		assert.ErrorIs(t, err, context.Canceled)
 		assert.Equal(t, 0, cache.Size())
+	})
+}
+
+func TestInMemorySlugCache_Invalidate(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("removes existing entry", func(t *testing.T) {
+		cache := NewInMemorySlugCache()
+		defer cache.Stop()
+
+		tenantID := tenant.MustNewTenantID("tenant_123")
+		err := cache.Set(ctx, "acme", tenantID, "active")
+		require.NoError(t, err)
+		assert.Equal(t, 1, cache.Size())
+
+		cache.Invalidate(ctx, "acme")
+
+		assert.Equal(t, 0, cache.Size())
+		result, _, err := cache.Get(ctx, "acme")
+		require.NoError(t, err)
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("no-op for nonexistent slug", func(t *testing.T) {
+		cache := NewInMemorySlugCache()
+		defer cache.Stop()
+
+		cache.Invalidate(ctx, "nonexistent")
+		assert.Equal(t, 0, cache.Size())
+	})
+
+	t.Run("no-op for empty slug", func(t *testing.T) {
+		cache := NewInMemorySlugCache()
+		defer cache.Stop()
+
+		err := cache.Set(ctx, "acme", tenant.MustNewTenantID("tenant_123"), "active")
+		require.NoError(t, err)
+
+		cache.Invalidate(ctx, "")
+		assert.Equal(t, 1, cache.Size())
 	})
 }
 
@@ -174,20 +220,21 @@ func TestInMemorySlugCache_TTLExpiration(t *testing.T) {
 		defer cache.Stop()
 
 		tenantID := tenant.MustNewTenantID("tenant_123")
-		err := cache.Set(ctx, "acme", tenantID)
+		err := cache.Set(ctx, "acme", tenantID, "active")
 		require.NoError(t, err)
 
 		// Verify entry exists
-		result, err := cache.Get(ctx, "acme")
+		result, status, err := cache.Get(ctx, "acme")
 		require.NoError(t, err)
 		assert.Equal(t, tenantID, result)
+		assert.Equal(t, "active", status)
 
 		// Wait for expiration using await
 		err = await.New().
 			AtMost(1 * time.Second).
 			PollInterval(10 * time.Millisecond).
 			Until(func() bool {
-				result, _ := cache.Get(ctx, "acme")
+				result, _, _ := cache.Get(ctx, "acme")
 				return result.IsEmpty()
 			})
 
@@ -199,13 +246,14 @@ func TestInMemorySlugCache_TTLExpiration(t *testing.T) {
 		defer cache.Stop()
 
 		tenantID := tenant.MustNewTenantID("tenant_123")
-		err := cache.Set(ctx, "acme", tenantID)
+		err := cache.Set(ctx, "acme", tenantID, "active")
 		require.NoError(t, err)
 
 		// Should still be valid
-		result, err := cache.Get(ctx, "acme")
+		result, status, err := cache.Get(ctx, "acme")
 		require.NoError(t, err)
 		assert.Equal(t, tenantID, result)
+		assert.Equal(t, "active", status)
 	})
 }
 
@@ -220,7 +268,7 @@ func TestInMemorySlugCache_BackgroundCleanup(t *testing.T) {
 		defer cache.Stop()
 
 		tenantID := tenant.MustNewTenantID("tenant_123")
-		err := cache.Set(ctx, "acme", tenantID)
+		err := cache.Set(ctx, "acme", tenantID, "active")
 		require.NoError(t, err)
 
 		assert.Equal(t, 1, cache.Size())
@@ -244,18 +292,19 @@ func TestInMemorySlugCache_BackgroundCleanup(t *testing.T) {
 		defer cache.Stop()
 
 		tenantID := tenant.MustNewTenantID("tenant_123")
-		err := cache.Set(ctx, "acme", tenantID)
+		err := cache.Set(ctx, "acme", tenantID, "active")
 		require.NoError(t, err)
 
 		// Intentional sleep: Wait for multiple cleanup cycles to run (50ms interval x 3 = 150ms)
 		// to verify they don't remove entries that haven't expired (1 hour TTL).
-		time.Sleep(150 * time.Millisecond) //nolint:forbidigo // verifies non-expired entries are NOT removed — no condition to poll against
+		time.Sleep(150 * time.Millisecond) //nolint:forbidigo // verifies non-expired entries are NOT removed - no condition to poll against
 
 		// Entry should still exist
 		assert.Equal(t, 1, cache.Size())
-		result, err := cache.Get(ctx, "acme")
+		result, status, err := cache.Get(ctx, "acme")
 		require.NoError(t, err)
 		assert.Equal(t, tenantID, result)
+		assert.Equal(t, "active", status)
 	})
 }
 
@@ -282,10 +331,10 @@ func TestInMemorySlugCache_ConcurrentAccess(t *testing.T) {
 				for j := 0; j < numOperations; j++ {
 					// Alternate between reads and writes
 					if j%2 == 0 {
-						_, err := cache.Get(ctx, slug)
+						_, _, err := cache.Get(ctx, slug)
 						assert.NoError(t, err)
 					} else {
-						err := cache.Set(ctx, slug, tenantID)
+						err := cache.Set(ctx, slug, tenantID, "active")
 						assert.NoError(t, err)
 					}
 				}
@@ -311,10 +360,10 @@ func TestInMemorySlugCache_ConcurrentAccess(t *testing.T) {
 				slug := fmt.Sprintf("slug_%d", idx)
 				tenantID := tenant.MustNewTenantID(fmt.Sprintf("tenant_%d", idx))
 
-				err := cache.Set(ctx, slug, tenantID)
+				err := cache.Set(ctx, slug, tenantID, "active")
 				assert.NoError(t, err)
 
-				result, err := cache.Get(ctx, slug)
+				result, _, err := cache.Get(ctx, slug)
 				assert.NoError(t, err)
 				assert.False(t, result.IsEmpty(), "should have cached value")
 			}(i)
@@ -362,15 +411,15 @@ func TestInMemorySlugCache_Size(t *testing.T) {
 
 		assert.Equal(t, 0, cache.Size())
 
-		err := cache.Set(ctx, "a", tenant.MustNewTenantID("t1"))
+		err := cache.Set(ctx, "a", tenant.MustNewTenantID("t1"), "active")
 		require.NoError(t, err)
 		assert.Equal(t, 1, cache.Size())
 
-		err = cache.Set(ctx, "b", tenant.MustNewTenantID("t2"))
+		err = cache.Set(ctx, "b", tenant.MustNewTenantID("t2"), "active")
 		require.NoError(t, err)
 		assert.Equal(t, 2, cache.Size())
 
-		err = cache.Set(ctx, "c", tenant.MustNewTenantID("t3"))
+		err = cache.Set(ctx, "c", tenant.MustNewTenantID("t3"), "active")
 		require.NoError(t, err)
 		assert.Equal(t, 3, cache.Size())
 	})

--- a/shared/platform/gateway/mocks_test.go
+++ b/shared/platform/gateway/mocks_test.go
@@ -19,14 +19,18 @@ type MockSlugCache struct {
 	mock.Mock
 }
 
-func (m *MockSlugCache) Get(ctx context.Context, slug string) (tenant.TenantID, error) {
+func (m *MockSlugCache) Get(ctx context.Context, slug string) (tenant.TenantID, string, error) {
 	args := m.Called(ctx, slug)
-	return args.Get(0).(tenant.TenantID), args.Error(1)
+	return args.Get(0).(tenant.TenantID), args.String(1), args.Error(2)
 }
 
-func (m *MockSlugCache) Set(ctx context.Context, slug string, tenantID tenant.TenantID) error {
-	args := m.Called(ctx, slug, tenantID)
+func (m *MockSlugCache) Set(ctx context.Context, slug string, tenantID tenant.TenantID, status string) error {
+	args := m.Called(ctx, slug, tenantID, status)
 	return args.Error(0)
+}
+
+func (m *MockSlugCache) Invalidate(ctx context.Context, slug string) {
+	m.Called(ctx, slug)
 }
 
 // MockTenantRepository is a mock implementation of tenantRepository for testing.

--- a/shared/platform/gateway/tenant_resolver.go
+++ b/shared/platform/gateway/tenant_resolver.go
@@ -41,9 +41,6 @@ var (
 // ErrTenantNotFound is returned when a tenant cannot be found by slug.
 var ErrTenantNotFound = errors.New("tenant not found")
 
-// ErrTenantNotProvisioned is returned when a tenant exists but is not yet active.
-var ErrTenantNotProvisioned = errors.New("tenant not provisioned")
-
 // slugPattern validates tenant slugs extracted from subdomains.
 // This pattern allows periods for multi-level subdomains (e.g., "acme.staging")
 // which differs from domain.slugPattern that only validates single-level slugs.
@@ -335,20 +332,13 @@ func (m *TenantResolverMiddleware) Handler(next http.Handler) http.Handler {
 
 // handleResolutionError writes the appropriate HTTP error for a tenant resolution failure.
 func (m *TenantResolverMiddleware) handleResolutionError(w http.ResponseWriter, slug string, err error, resolutionTimeMs int64) {
-	switch {
-	case errors.Is(err, ErrTenantNotFound):
+	if errors.Is(err, ErrTenantNotFound) {
 		m.logger.Warn("tenant not found",
 			slog.String("tenant_slug", slug),
 			slog.Int64("resolution_time_ms", resolutionTimeMs),
 		)
 		http.Error(w, "Tenant not found", http.StatusNotFound)
-	case errors.Is(err, ErrTenantNotProvisioned):
-		m.logger.Warn("tenant not provisioned",
-			slog.String("tenant_slug", slug),
-			slog.Int64("resolution_time_ms", resolutionTimeMs),
-		)
-		http.Error(w, "Tenant not provisioned", http.StatusServiceUnavailable)
-	default:
+	} else {
 		m.logger.Error("database error during tenant resolution",
 			slog.String("tenant_slug", slug),
 			slog.String("error", err.Error()),

--- a/shared/platform/gateway/tenant_resolver.go
+++ b/shared/platform/gateway/tenant_resolver.go
@@ -41,6 +41,9 @@ var (
 // ErrTenantNotFound is returned when a tenant cannot be found by slug.
 var ErrTenantNotFound = errors.New("tenant not found")
 
+// ErrTenantNotProvisioned is returned when a tenant exists but is not yet active.
+var ErrTenantNotProvisioned = errors.New("tenant not provisioned")
+
 // slugPattern validates tenant slugs extracted from subdomains.
 // This pattern allows periods for multi-level subdomains (e.g., "acme.staging")
 // which differs from domain.slugPattern that only validates single-level slugs.
@@ -58,8 +61,9 @@ func isValidSlug(slug string) bool {
 
 // slugCache defines the caching interface for slug-to-tenant-ID mappings.
 type slugCache interface {
-	Get(ctx context.Context, slug string) (tenant.TenantID, error)
-	Set(ctx context.Context, slug string, tenantID tenant.TenantID) error
+	Get(ctx context.Context, slug string) (tenant.TenantID, string, error)
+	Set(ctx context.Context, slug string, tenantID tenant.TenantID, status string) error
+	Invalidate(ctx context.Context, slug string)
 }
 
 // tenantRepository defines the repository interface for tenant lookups.
@@ -293,6 +297,18 @@ func (m *TenantResolverMiddleware) Handler(next http.Handler) http.Handler {
 			return
 		}
 
+		// Reject non-active tenants early to prevent confusing DB errors downstream
+		if resolved.Status != "" && resolved.Status != domain.StatusActive {
+			m.logger.Warn("tenant not provisioned",
+				slog.String("tenant_slug", slug),
+				slog.String("tenant_id", resolved.ID.String()),
+				slog.String("tenant_status", string(resolved.Status)),
+				slog.Int64("resolution_time_ms", resolutionTimeMs),
+			)
+			http.Error(w, "Tenant not provisioned", http.StatusServiceUnavailable)
+			return
+		}
+
 		m.logger.Debug("tenant resolved successfully",
 			slog.String("tenant_slug", slug),
 			slog.String("tenant_id", resolved.ID.String()),
@@ -319,13 +335,20 @@ func (m *TenantResolverMiddleware) Handler(next http.Handler) http.Handler {
 
 // handleResolutionError writes the appropriate HTTP error for a tenant resolution failure.
 func (m *TenantResolverMiddleware) handleResolutionError(w http.ResponseWriter, slug string, err error, resolutionTimeMs int64) {
-	if errors.Is(err, ErrTenantNotFound) {
+	switch {
+	case errors.Is(err, ErrTenantNotFound):
 		m.logger.Warn("tenant not found",
 			slog.String("tenant_slug", slug),
 			slog.Int64("resolution_time_ms", resolutionTimeMs),
 		)
 		http.Error(w, "Tenant not found", http.StatusNotFound)
-	} else {
+	case errors.Is(err, ErrTenantNotProvisioned):
+		m.logger.Warn("tenant not provisioned",
+			slog.String("tenant_slug", slug),
+			slog.Int64("resolution_time_ms", resolutionTimeMs),
+		)
+		http.Error(w, "Tenant not provisioned", http.StatusServiceUnavailable)
+	default:
 		m.logger.Error("database error during tenant resolution",
 			slog.String("tenant_slug", slug),
 			slog.String("error", err.Error()),
@@ -399,6 +422,7 @@ func (m *TenantResolverMiddleware) extractSlug(hostHeader string) string {
 type resolvedTenant struct {
 	ID          tenant.TenantID
 	DisplayName string
+	Status      domain.Status
 }
 
 // resolveTenant performs cache-first tenant resolution with database fallback.
@@ -418,7 +442,7 @@ func (m *TenantResolverMiddleware) resolveTenant(ctx context.Context, slug strin
 	}
 
 	// Step 1: Try cache first (best-effort)
-	tenantID, err := m.slugCache.Get(ctx, slug)
+	tenantID, cachedStatus, err := m.slugCache.Get(ctx, slug)
 	if err != nil {
 		// Log cache read failure but don't fail the request
 		// Fall through to database lookup for resilience
@@ -427,7 +451,15 @@ func (m *TenantResolverMiddleware) resolveTenant(ctx context.Context, slug strin
 			slog.String("error", err.Error()),
 		)
 	} else if !tenantID.IsEmpty() {
-		return m.resolveDisplayName(ctx, slug, tenantID)
+		resolved, resolveErr := m.resolveDisplayName(ctx, slug, tenantID)
+		if resolveErr != nil {
+			return resolvedTenant{}, resolveErr
+		}
+		// Use cached status if display name came from local cache (no DB call)
+		if resolved.Status == "" && cachedStatus != "" {
+			resolved.Status = domain.Status(cachedStatus)
+		}
+		return resolved, nil
 	}
 
 	// Step 2: Cache miss or error - query database
@@ -441,7 +473,7 @@ func (m *TenantResolverMiddleware) resolveTenant(ctx context.Context, slug strin
 	}
 
 	// Step 3: Populate caches (best-effort)
-	if cacheErr := m.slugCache.Set(ctx, slug, tenantEntity.ID); cacheErr != nil {
+	if cacheErr := m.slugCache.Set(ctx, slug, tenantEntity.ID, string(tenantEntity.Status)); cacheErr != nil {
 		// Log cache write failures but don't fail the request
 		m.logger.Warn("failed to populate slug cache",
 			slog.String("slug", slug),
@@ -455,7 +487,7 @@ func (m *TenantResolverMiddleware) resolveTenant(ctx context.Context, slug strin
 	})
 
 	// Step 4: Return resolved tenant from database
-	return resolvedTenant{ID: tenantEntity.ID, DisplayName: tenantEntity.DisplayName}, nil
+	return resolvedTenant{ID: tenantEntity.ID, DisplayName: tenantEntity.DisplayName, Status: tenantEntity.Status}, nil
 }
 
 // resolveDisplayName handles the slug cache hit path: checks the local display
@@ -481,9 +513,9 @@ func (m *TenantResolverMiddleware) resolveDisplayName(ctx context.Context, slug 
 		})
 		// Refresh slug cache if DB returns a different tenant ID.
 		if tenantEntity.ID != tenantID {
-			_ = m.slugCache.Set(ctx, slug, tenantEntity.ID)
+			_ = m.slugCache.Set(ctx, slug, tenantEntity.ID, string(tenantEntity.Status))
 		}
-		return resolvedTenant{ID: tenantEntity.ID, DisplayName: tenantEntity.DisplayName}, nil
+		return resolvedTenant{ID: tenantEntity.ID, DisplayName: tenantEntity.DisplayName, Status: tenantEntity.Status}, nil
 	}
 	// Slug deleted - treat as authoritative even with a cached ID.
 	if errors.Is(dbErr, domain.ErrNotFound) {

--- a/shared/platform/gateway/tenant_resolver_test.go
+++ b/shared/platform/gateway/tenant_resolver_test.go
@@ -399,7 +399,7 @@ func TestResolveTenant(t *testing.T) {
 		logger := slog.Default()
 
 		// Setup: Cache returns tenant ID
-		mockCache.On("Get", ctx, testSlug).Return(testTenantID, nil)
+		mockCache.On("Get", ctx, testSlug).Return(testTenantID, "active", nil)
 
 		// Create middleware with pre-populated display name cache
 		middleware := &TenantResolverMiddleware{
@@ -431,7 +431,7 @@ func TestResolveTenant(t *testing.T) {
 		logger := slog.Default()
 
 		// Setup: Slug cache hit but display name cache is empty
-		mockCache.On("Get", ctx, testSlug).Return(testTenantID, nil)
+		mockCache.On("Get", ctx, testSlug).Return(testTenantID, "active", nil)
 		mockRepo.On("GetBySlug", ctx, testSlug).Return(testTenant, nil)
 
 		// Create middleware (no pre-populated display name cache)
@@ -461,9 +461,9 @@ func TestResolveTenant(t *testing.T) {
 		logger := slog.Default()
 
 		// Setup: Cache miss (empty TenantID), DB returns tenant
-		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), nil)
+		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), "", nil)
 		mockRepo.On("GetBySlug", ctx, testSlug).Return(testTenant, nil)
-		mockCache.On("Set", ctx, testSlug, testTenantID).Return(nil)
+		mockCache.On("Set", ctx, testSlug, testTenantID, "active").Return(nil)
 
 		// Create middleware
 		middleware := &TenantResolverMiddleware{
@@ -492,7 +492,7 @@ func TestResolveTenant(t *testing.T) {
 		logger := slog.Default()
 
 		// Setup: Cache miss, DB returns domain.ErrNotFound
-		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), nil)
+		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), "", nil)
 		mockRepo.On("GetBySlug", ctx, testSlug).Return(nil, domain.ErrNotFound)
 
 		// Create middleware
@@ -523,9 +523,9 @@ func TestResolveTenant(t *testing.T) {
 		logger := slog.Default()
 
 		// Setup: Cache miss, DB succeeds, but cache write fails
-		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), nil)
+		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), "", nil)
 		mockRepo.On("GetBySlug", ctx, testSlug).Return(testTenant, nil)
-		mockCache.On("Set", ctx, testSlug, testTenantID).Return(errCacheWriteFailed)
+		mockCache.On("Set", ctx, testSlug, testTenantID, "active").Return(errCacheWriteFailed)
 
 		// Create middleware
 		middleware := &TenantResolverMiddleware{
@@ -554,9 +554,9 @@ func TestResolveTenant(t *testing.T) {
 		logger := slog.Default()
 
 		// Setup: Cache read fails, but DB succeeds
-		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), errCacheReadTimeout)
+		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), "", errCacheReadTimeout)
 		mockRepo.On("GetBySlug", ctx, testSlug).Return(testTenant, nil)
-		mockCache.On("Set", ctx, testSlug, testTenantID).Return(nil)
+		mockCache.On("Set", ctx, testSlug, testTenantID, "active").Return(nil)
 
 		// Create middleware
 		middleware := &TenantResolverMiddleware{
@@ -585,7 +585,7 @@ func TestResolveTenant(t *testing.T) {
 		logger := slog.Default()
 
 		// Setup: Cache miss, DB fails with non-not-found error
-		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), nil)
+		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), "", nil)
 		mockRepo.On("GetBySlug", ctx, testSlug).Return(nil, errDatabaseLost)
 
 		// Create middleware
@@ -620,7 +620,7 @@ func TestResolveTenant(t *testing.T) {
 		cancel()
 
 		// Setup: Cache returns context.Canceled error, DB also respects cancellation
-		mockCache.On("Get", cancelledCtx, testSlug).Return(tenant.TenantID(""), context.Canceled)
+		mockCache.On("Get", cancelledCtx, testSlug).Return(tenant.TenantID(""), "", context.Canceled)
 		mockRepo.On("GetBySlug", cancelledCtx, testSlug).Return(nil, context.Canceled)
 
 		// Create middleware
@@ -666,7 +666,7 @@ func TestServeHTTP(t *testing.T) {
 		logger := slog.Default()
 
 		// Setup: Cache hit
-		mockCache.On("Get", ctx, testSlug).Return(testTenantID, nil)
+		mockCache.On("Get", ctx, testSlug).Return(testTenantID, "active", nil)
 
 		// Create middleware with pre-populated display name cache
 		middleware := &TenantResolverMiddleware{
@@ -760,7 +760,7 @@ func TestServeHTTP(t *testing.T) {
 		logger := slog.Default()
 
 		// Setup: Cache miss, DB returns domain.ErrNotFound
-		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), nil)
+		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), "", nil)
 		mockRepo.On("GetBySlug", ctx, testSlug).Return(nil, domain.ErrNotFound)
 
 		// Create middleware
@@ -803,9 +803,9 @@ func TestServeHTTP(t *testing.T) {
 		logger := slog.Default()
 
 		// Setup: Cache miss, DB hit, cache write succeeds
-		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), nil)
+		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), "", nil)
 		mockRepo.On("GetBySlug", ctx, testSlug).Return(testTenant, nil)
-		mockCache.On("Set", ctx, testSlug, testTenantID).Return(nil)
+		mockCache.On("Set", ctx, testSlug, testTenantID, "active").Return(nil)
 
 		// Create middleware
 		middleware := &TenantResolverMiddleware{
@@ -850,7 +850,7 @@ func TestServeHTTP(t *testing.T) {
 		logger := slog.Default()
 
 		// Setup: Cache hit
-		mockCache.On("Get", ctx, testSlug).Return(testTenantID, nil)
+		mockCache.On("Get", ctx, testSlug).Return(testTenantID, "active", nil)
 
 		// Create middleware
 		middleware := &TenantResolverMiddleware{
@@ -889,7 +889,7 @@ func TestServeHTTP(t *testing.T) {
 		multiLevelTenantID := tenant.MustNewTenantID("tenant_456")
 
 		// Setup: Cache hit for multi-level slug
-		mockCache.On("Get", ctx, multiLevelSlug).Return(multiLevelTenantID, nil)
+		mockCache.On("Get", ctx, multiLevelSlug).Return(multiLevelTenantID, "active", nil)
 
 		// Create middleware
 		middleware := &TenantResolverMiddleware{
@@ -929,7 +929,7 @@ func TestServeHTTP(t *testing.T) {
 		logger := slog.Default()
 
 		// Setup: Cache miss, DB error (transient failure)
-		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), nil)
+		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), "", nil)
 		mockRepo.On("GetBySlug", ctx, testSlug).Return(nil, errDatabaseLost)
 
 		// Create middleware
@@ -960,6 +960,166 @@ func TestServeHTTP(t *testing.T) {
 		assert.Contains(t, rec.Body.String(), "Service temporarily unavailable",
 			"response should contain 'Service temporarily unavailable'")
 		assert.False(t, nextCalled, "next handler should not be called")
+
+		mockCache.AssertExpectations(t)
+		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("provisioning_pending tenant returns 503 with Tenant not provisioned", func(t *testing.T) {
+		mockCache := new(MockSlugCache)
+		mockRepo := new(MockTenantRepository)
+		logger := slog.Default()
+
+		pendingTenant := &domain.Tenant{
+			ID:          testTenantID,
+			DisplayName: "Acme Corp",
+			Slug:        testSlug,
+			Status:      domain.StatusProvisioningPending,
+		}
+
+		// Setup: Cache miss, DB returns tenant in provisioning_pending state
+		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), "", nil)
+		mockRepo.On("GetBySlug", ctx, testSlug).Return(pendingTenant, nil)
+		mockCache.On("Set", ctx, testSlug, testTenantID, "provisioning_pending").Return(nil)
+
+		middleware := &TenantResolverMiddleware{
+			slugCache:  mockCache,
+			tenantRepo: mockRepo,
+			baseDomain: baseDomain,
+			logger:     logger,
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "http://"+testHost+"/api/test", nil)
+		req = req.WithContext(ctx)
+		rec := httptest.NewRecorder()
+
+		nextCalled := false
+		next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			nextCalled = true
+		})
+
+		handler := middleware.Handler(next)
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, rec.Code, "should return 503 for non-active tenant")
+		assert.Contains(t, rec.Body.String(), "Tenant not provisioned")
+		assert.False(t, nextCalled, "next handler should not be called")
+
+		mockCache.AssertExpectations(t)
+		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("provisioning tenant returns 503 from cache", func(t *testing.T) {
+		mockCache := new(MockSlugCache)
+		mockRepo := new(MockTenantRepository)
+		logger := slog.Default()
+
+		// Setup: Cache hit with non-active status
+		mockCache.On("Get", ctx, testSlug).Return(testTenantID, "provisioning", nil)
+
+		middleware := &TenantResolverMiddleware{
+			slugCache:  mockCache,
+			tenantRepo: mockRepo,
+			baseDomain: baseDomain,
+			logger:     logger,
+		}
+		middleware.displayNameCache.Store(testSlug, cachedDisplayName{tenantID: testTenantID, displayName: "Acme Corp"})
+
+		req := httptest.NewRequest(http.MethodGet, "http://"+testHost+"/api/test", nil)
+		req = req.WithContext(ctx)
+		rec := httptest.NewRecorder()
+
+		nextCalled := false
+		next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			nextCalled = true
+		})
+
+		handler := middleware.Handler(next)
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, rec.Code, "should return 503 for provisioning tenant")
+		assert.Contains(t, rec.Body.String(), "Tenant not provisioned")
+		assert.False(t, nextCalled, "next handler should not be called")
+
+		mockCache.AssertExpectations(t)
+		mockRepo.AssertNotCalled(t, "GetBySlug")
+	})
+
+	t.Run("suspended tenant returns 503", func(t *testing.T) {
+		mockCache := new(MockSlugCache)
+		mockRepo := new(MockTenantRepository)
+		logger := slog.Default()
+
+		suspendedTenant := &domain.Tenant{
+			ID:          testTenantID,
+			DisplayName: "Acme Corp",
+			Slug:        testSlug,
+			Status:      domain.StatusSuspended,
+		}
+
+		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), "", nil)
+		mockRepo.On("GetBySlug", ctx, testSlug).Return(suspendedTenant, nil)
+		mockCache.On("Set", ctx, testSlug, testTenantID, "suspended").Return(nil)
+
+		middleware := &TenantResolverMiddleware{
+			slugCache:  mockCache,
+			tenantRepo: mockRepo,
+			baseDomain: baseDomain,
+			logger:     logger,
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "http://"+testHost+"/api/test", nil)
+		req = req.WithContext(ctx)
+		rec := httptest.NewRecorder()
+
+		nextCalled := false
+		next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			nextCalled = true
+		})
+
+		handler := middleware.Handler(next)
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, rec.Code, "should return 503 for suspended tenant")
+		assert.Contains(t, rec.Body.String(), "Tenant not provisioned")
+		assert.False(t, nextCalled, "next handler should not be called")
+
+		mockCache.AssertExpectations(t)
+		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("active tenant passes through", func(t *testing.T) {
+		mockCache := new(MockSlugCache)
+		mockRepo := new(MockTenantRepository)
+		logger := slog.Default()
+
+		// Setup: Cache miss, DB returns active tenant
+		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), "", nil)
+		mockRepo.On("GetBySlug", ctx, testSlug).Return(testTenant, nil)
+		mockCache.On("Set", ctx, testSlug, testTenantID, "active").Return(nil)
+
+		middleware := &TenantResolverMiddleware{
+			slugCache:  mockCache,
+			tenantRepo: mockRepo,
+			baseDomain: baseDomain,
+			logger:     logger,
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "http://"+testHost+"/api/test", nil)
+		req = req.WithContext(ctx)
+		rec := httptest.NewRecorder()
+
+		nextCalled := false
+		next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			nextCalled = true
+			w.WriteHeader(http.StatusOK)
+		})
+
+		handler := middleware.Handler(next)
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code, "should return 200 for active tenant")
+		assert.True(t, nextCalled, "next handler should be called")
 
 		mockCache.AssertExpectations(t)
 		mockRepo.AssertExpectations(t)
@@ -1036,7 +1196,7 @@ func TestLocalDevMode(t *testing.T) {
 		logger := slog.Default()
 
 		// Setup: Cache hit for the header-provided slug
-		mockCache.On("Get", ctx, testSlug).Return(testTenantID, nil)
+		mockCache.On("Get", ctx, testSlug).Return(testTenantID, "active", nil)
 
 		// Create middleware with localDevMode enabled
 		middleware := &TenantResolverMiddleware{
@@ -1119,7 +1279,7 @@ func TestLocalDevMode(t *testing.T) {
 		headerTenantID := tenant.MustNewTenantID("tenant_header")
 
 		// Setup: Cache hit for header slug (NOT subdomain slug)
-		mockCache.On("Get", ctx, headerSlug).Return(headerTenantID, nil)
+		mockCache.On("Get", ctx, headerSlug).Return(headerTenantID, "active", nil)
 
 		// Create middleware with localDevMode enabled
 		middleware := &TenantResolverMiddleware{
@@ -1166,7 +1326,7 @@ func TestLocalDevMode(t *testing.T) {
 		subdomainTenantID := tenant.MustNewTenantID("tenant_subdomain")
 
 		// Setup: Cache hit for subdomain slug
-		mockCache.On("Get", ctx, subdomainSlug).Return(subdomainTenantID, nil)
+		mockCache.On("Get", ctx, subdomainSlug).Return(subdomainTenantID, "active", nil)
 
 		// Create middleware with localDevMode enabled
 		middleware := &TenantResolverMiddleware{
@@ -1263,7 +1423,7 @@ func TestLocalDevMode(t *testing.T) {
 		for _, validSlug := range validSlugs {
 			t.Run(validSlug, func(t *testing.T) {
 				mockCache := new(MockSlugCache)
-				mockCache.On("Get", ctx, validSlug).Return(validSlugTenantID, nil)
+				mockCache.On("Get", ctx, validSlug).Return(validSlugTenantID, "active", nil)
 
 				middleware := &TenantResolverMiddleware{
 					slugCache:    mockCache,
@@ -1305,7 +1465,7 @@ func TestHandlerOptionalTenant_WithValidSubdomain(t *testing.T) {
 	mockRepo := new(MockTenantRepository)
 	logger := slog.Default()
 
-	mockCache.On("Get", ctx, testSlug).Return(testTenantID, nil)
+	mockCache.On("Get", ctx, testSlug).Return(testTenantID, "active", nil)
 
 	middleware := &TenantResolverMiddleware{
 		slugCache:  mockCache,
@@ -1427,7 +1587,7 @@ func TestHandlerOptionalTenant_TenantNotFoundInDB(t *testing.T) {
 	logger := slog.Default()
 
 	// Cache miss, DB returns not found
-	mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), nil)
+	mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), "", nil)
 	mockRepo.On("GetBySlug", ctx, testSlug).Return(nil, domain.ErrNotFound)
 
 	middleware := &TenantResolverMiddleware{
@@ -1470,7 +1630,7 @@ func TestHandlerOptionalTenant_LocalDevMode_ValidSlugFromHeader(t *testing.T) {
 	mockCache := new(MockSlugCache)
 	mockRepo := new(MockTenantRepository)
 
-	mockCache.On("Get", ctx, testSlug).Return(testTenantID, nil)
+	mockCache.On("Get", ctx, testSlug).Return(testTenantID, "active", nil)
 
 	middleware := &TenantResolverMiddleware{
 		slugCache:    mockCache,


### PR DESCRIPTION
## Summary

- TenantResolverMiddleware now checks tenant provisioning status after slug resolution
- Non-active tenants (provisioning_pending, provisioning, suspended, deprovisioned, provisioning_failed) receive 503 "Tenant not provisioned" instead of confusing downstream DB errors
- Tenant status is cached alongside the slug-to-ID mapping in the slug cache to avoid extra DB calls
- Adds `Invalidate` method to `InMemorySlugCache` for cache eviction on provisioning transitions

## Changes Made

- **`shared/platform/gateway/tenant_resolver.go`**: Added `ErrTenantNotProvisioned` error, extended `resolvedTenant` to include `Status`, added status check in `Handler` after resolution, updated `handleResolutionError` for new error type
- **`shared/platform/gateway/inmemory_cache.go`**: Extended `cacheEntry` to include `status` field, updated `Get`/`Set` signatures to include status, added `Invalidate` method
- **`shared/platform/gateway/tenant_resolver_test.go`**: Added tests for provisioning_pending, provisioning, suspended, and active tenant status handling at HTTP level
- **`shared/platform/gateway/inmemory_cache_test.go`**: Updated all tests for new `Get`/`Set` signatures, added `Invalidate` tests

## Test plan

- [x] Provisioning_pending tenant returns 503 "Tenant not provisioned"
- [x] Provisioning tenant returns 503 from cached status (no DB call)
- [x] Suspended tenant returns 503
- [x] Active tenant passes through to handler
- [x] All existing tests pass with updated cache signatures
- [x] Cache invalidation removes entries correctly
- [ ] CI passes