### PR TITLE
Remove public from search_path - replicate reference data per-tenant

### DIFF
--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -186,7 +186,7 @@ func run(logger *slog.Logger, grpcPort, httpPort int) error {
 	}
 
 	// Start workers
-	provisioningWorker, provisionerCleanup, err := startProvisioningWorker(ctx, infra.schemaProv, infra.conns.gormDB("tenant"), infra.conns.gormDB("identity"), logger)
+	provisioningWorker, provisionerCleanup, err := startProvisioningWorker(ctx, infra.schemaProv, infra.conns, logger)
 	if err != nil {
 		return fmt.Errorf("provisioning worker: %w", err)
 	}

--- a/cmd/meridian/wire_services.go
+++ b/cmd/meridian/wire_services.go
@@ -12,6 +12,8 @@ import (
 	refcel "github.com/meridianhub/meridian/services/reference-data/cel"
 	refhandler "github.com/meridianhub/meridian/services/reference-data/handler"
 	refregistry "github.com/meridianhub/meridian/services/reference-data/registry"
+	refsaga "github.com/meridianhub/meridian/services/reference-data/saga"
+	refvaluation "github.com/meridianhub/meridian/services/reference-data/valuation"
 	tenantpersistence "github.com/meridianhub/meridian/services/tenant/adapters/persistence"
 	tenantprovisioner "github.com/meridianhub/meridian/services/tenant/provisioner"
 	tenantworker "github.com/meridianhub/meridian/services/tenant/worker"
@@ -186,12 +188,21 @@ func createSchemaProvisioner(baseDSN string, platformDB *gorm.DB, logger *slog.L
 
 // startProvisioningWorker starts the background worker using an initialized provisioner.
 // When prov is nil (provisioning disabled) both return values are nil.
-func startProvisioningWorker(ctx context.Context, prov *tenantprovisioner.PostgresProvisioner, platformDB *gorm.DB, identityDB *gorm.DB, logger *slog.Logger) (*tenantworker.ProvisioningWorker, func(), error) {
+//
+// Registers all post-provisioning hooks in dependency order:
+//  1. admin-identity: Provisions platform admin identity
+//  2. instruments: Seeds platform instrument definitions (GBP, USD, EUR, etc.)
+//  3. saga-definitions: Seeds platform default saga scripts into tenant schema
+//  4. account-type-blueprints: Seeds canonical account type blueprints
+//  5. valuation-defaults: Seeds system valuation methods and policies
+//
+// All hooks are fail-hard: any failure prevents tenant activation.
+func startProvisioningWorker(ctx context.Context, prov *tenantprovisioner.PostgresProvisioner, conns *serviceConns, logger *slog.Logger) (*tenantworker.ProvisioningWorker, func(), error) {
 	if prov == nil {
 		return nil, nil, nil
 	}
 
-	repo := tenantpersistence.NewRepository(platformDB)
+	repo := tenantpersistence.NewRepository(conns.gormDB("tenant"))
 	w, err := tenantworker.NewProvisioningWorker(
 		repo,
 		prov,
@@ -209,8 +220,28 @@ func startProvisioningWorker(ctx context.Context, prov *tenantprovisioner.Postgr
 		return nil, nil, fmt.Errorf("create provisioning worker: %w", err)
 	}
 
-	identityRepo := identitypersistence.NewRepository(identityDB)
+	// Register post-provisioning hooks in dependency order.
+	// All hooks are fail-hard: failure prevents tenant activation.
+	identityRepo := identitypersistence.NewRepository(conns.gormDB("identity"))
 	w.RegisterPostProvisioningHook("admin-identity", identitybootstrap.AsPostProvisioningHook(identityRepo))
+
+	refDataPool := conns.pgxPool("reference-data")
+	instrumentSeeder := refregistry.NewInstrumentSeeder(refDataPool)
+	w.RegisterPostProvisioningHook("instruments", instrumentSeeder.AsPostProvisioningHook())
+
+	sagaSeeder := refsaga.NewSeeder(refDataPool)
+	w.RegisterPostProvisioningHook("saga-definitions", sagaSeeder.AsPostProvisioningHook())
+
+	accountTypeRegistry, atErr := accounttype.NewPostgresRegistry(refDataPool)
+	if atErr != nil {
+		_ = prov.Close()
+		return nil, nil, fmt.Errorf("account type registry: %w", atErr)
+	}
+	blueprintSeeder := accounttype.NewBlueprintSeeder(accountTypeRegistry)
+	w.RegisterPostProvisioningHook("account-type-blueprints", blueprintSeeder.AsPostProvisioningHook())
+
+	valuationSeeder := refvaluation.NewSeeder(refDataPool)
+	w.RegisterPostProvisioningHook("valuation-defaults", valuationSeeder.AsPostProvisioningHook())
 
 	go w.Start(ctx)
 	logger.Info("provisioning worker started")

--- a/cmd/position-tool/internal/exporter/exporter.go
+++ b/cmd/position-tool/internal/exporter/exporter.go
@@ -564,7 +564,7 @@ func (e *Exporter) setSearchPath(ctx context.Context, tx pgx.Tx) error {
 	}
 
 	schemaName := pgx.Identifier{tenantID.SchemaName()}.Sanitize()
-	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	query := fmt.Sprintf("SET LOCAL search_path TO %s", schemaName)
 
 	_, err := tx.Exec(ctx, query)
 	if err != nil {

--- a/cmd/position-tool/internal/infra/tenant.go
+++ b/cmd/position-tool/internal/infra/tenant.go
@@ -103,7 +103,7 @@ func (h *TenantHelper) setSearchPath(ctx context.Context, tx pgx.Tx) error {
 	}
 
 	schemaName := pgx.Identifier{tenantID.SchemaName()}.Sanitize()
-	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	query := fmt.Sprintf("SET LOCAL search_path TO %s", schemaName)
 
 	_, err := tx.Exec(ctx, query)
 	if err != nil {

--- a/cmd/position-tool/internal/rebucket/executor.go
+++ b/cmd/position-tool/internal/rebucket/executor.go
@@ -359,7 +359,7 @@ func (e *Executor) setSearchPath(ctx context.Context, tx pgx.Tx) error {
 
 	// SchemaName() returns "org_" + lowercase(tenantID), validated at construction
 	schemaName := pgx.Identifier{tenantID.SchemaName()}.Sanitize()
-	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	query := fmt.Sprintf("SET LOCAL search_path TO %s", schemaName)
 	_, err := tx.Exec(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to set tenant schema scope: %w", err)

--- a/scripts/backfill-tenant-reference-data.sh
+++ b/scripts/backfill-tenant-reference-data.sh
@@ -122,6 +122,9 @@ for SCHEMA in $SCHEMAS; do
                     id, code, version, dimension, precision, status, is_system,
                     fungibility_key_expression, display_name, description,
                     created_at, updated_at, activated_at
+                -- Note: gen_random_uuid() differs from InstrumentSeeder's deterministic UUIDs
+                -- (uuid.NewSHA1). This is acceptable for backfill of existing tenants since
+                -- ON CONFLICT ensures idempotency by code+version, not by ID.
                 ) VALUES (
                     gen_random_uuid(), '$CODE', 1, '$DIMENSION', $PRECISION, 'ACTIVE', true,
                     '', '$CODE instrument', 'Platform default instrument: $CODE',

--- a/scripts/backfill-tenant-reference-data.sh
+++ b/scripts/backfill-tenant-reference-data.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# backfill-tenant-reference-data.sh
+#
+# Backfills reference data (instruments, saga scripts) into existing tenant schemas.
+# This is needed after the tenant isolation migration that removes public from search_path.
+#
+# Previously, tenant saga_definition rows used platform_ref pointing to
+# public.platform_saga_definition with NULL scripts. This script copies the actual
+# script content from the platform table into each tenant's saga_definition.
+#
+# Usage:
+#   ./scripts/backfill-tenant-reference-data.sh <database-url>
+#
+# Example:
+#   ./scripts/backfill-tenant-reference-data.sh "postgres://user:pass@localhost:26257/meridian_reference_data?sslmode=disable"
+#
+# What it does:
+#   1. Finds all tenant schemas (org_* pattern)
+#   2. For each tenant schema:
+#      a. Copies saga scripts from public.platform_saga_definition into
+#         tenant saga_definition rows that have platform_ref but NULL script
+#      b. Seeds missing platform instruments (GBP, USD, EUR, TONNE_CO2E, KWH)
+#   3. Reports summary of changes
+#
+# This script is idempotent - safe to run multiple times.
+# Dry-run mode: set DRY_RUN=1 to see what would change without modifying data.
+
+set -euo pipefail
+
+DATABASE_URL="${1:?Usage: $0 <database-url>}"
+DRY_RUN="${DRY_RUN:-0}"
+
+if [ "$DRY_RUN" = "1" ]; then
+    echo "=== DRY RUN MODE - no changes will be made ==="
+fi
+
+echo "Backfilling tenant reference data..."
+echo "Database: ${DATABASE_URL%%@*}@***"
+
+# Find all tenant schemas
+SCHEMAS=$(psql "$DATABASE_URL" -t -A -c "
+    SELECT nspname FROM pg_namespace
+    WHERE nspname LIKE 'org_%'
+    ORDER BY nspname
+")
+
+if [ -z "$SCHEMAS" ]; then
+    echo "No tenant schemas found. Nothing to backfill."
+    exit 0
+fi
+
+SCHEMA_COUNT=$(echo "$SCHEMAS" | wc -l | tr -d ' ')
+echo "Found $SCHEMA_COUNT tenant schema(s)"
+
+TOTAL_SAGAS_UPDATED=0
+TOTAL_INSTRUMENTS_SEEDED=0
+
+for SCHEMA in $SCHEMAS; do
+    echo ""
+    echo "--- Processing $SCHEMA ---"
+
+    # Step 1: Copy saga scripts from platform table into tenant rows with platform_ref
+    if [ "$DRY_RUN" = "1" ]; then
+        COUNT=$(psql "$DATABASE_URL" -t -A -c "
+            SELECT COUNT(*)
+            FROM \"$SCHEMA\".saga_definition sd
+            JOIN public.platform_saga_definition psd ON sd.platform_ref = psd.id
+            WHERE (sd.script IS NULL OR sd.script = '')
+        ")
+        echo "  Would update $COUNT saga(s) with script content"
+    else
+        RESULT=$(psql "$DATABASE_URL" -t -A -c "
+            UPDATE \"$SCHEMA\".saga_definition sd
+            SET script = psd.script,
+                updated_at = NOW()
+            FROM public.platform_saga_definition psd
+            WHERE sd.platform_ref = psd.id
+              AND (sd.script IS NULL OR sd.script = '')
+            RETURNING sd.name
+        ")
+        COUNT=$(echo "$RESULT" | grep -c . || true)
+        if [ "$COUNT" -gt 0 ]; then
+            echo "  Updated $COUNT saga(s) with script content"
+            TOTAL_SAGAS_UPDATED=$((TOTAL_SAGAS_UPDATED + COUNT))
+        else
+            echo "  No sagas needed script backfill"
+        fi
+    fi
+
+    # Step 2: Seed platform instruments if missing
+    INSTRUMENTS="GBP:MONETARY:2 USD:MONETARY:2 EUR:MONETARY:2 TONNE_CO2E:CARBON:6 KWH:ENERGY:3"
+    for SPEC in $INSTRUMENTS; do
+        CODE=$(echo "$SPEC" | cut -d: -f1)
+        DIMENSION=$(echo "$SPEC" | cut -d: -f2)
+        PRECISION=$(echo "$SPEC" | cut -d: -f3)
+
+        # Check if table exists in this schema
+        TABLE_EXISTS=$(psql "$DATABASE_URL" -t -A -c "
+            SELECT EXISTS(
+                SELECT 1 FROM information_schema.tables
+                WHERE table_schema = '$SCHEMA' AND table_name = 'instrument_definition'
+            )
+        ")
+
+        if [ "$TABLE_EXISTS" != "t" ]; then
+            continue
+        fi
+
+        if [ "$DRY_RUN" = "1" ]; then
+            EXISTS=$(psql "$DATABASE_URL" -t -A -c "
+                SELECT EXISTS(
+                    SELECT 1 FROM \"$SCHEMA\".instrument_definition
+                    WHERE code = '$CODE' AND version = 1
+                )
+            ")
+            if [ "$EXISTS" = "f" ]; then
+                echo "  Would seed instrument: $CODE ($DIMENSION, precision=$PRECISION)"
+            fi
+        else
+            INSERTED=$(psql "$DATABASE_URL" -t -A -c "
+                INSERT INTO \"$SCHEMA\".instrument_definition (
+                    id, code, version, dimension, precision, status, is_system,
+                    fungibility_key_expression, display_name, description,
+                    created_at, updated_at, activated_at
+                ) VALUES (
+                    gen_random_uuid(), '$CODE', 1, '$DIMENSION', $PRECISION, 'ACTIVE', true,
+                    '', '$CODE instrument', 'Platform default instrument: $CODE',
+                    NOW(), NOW(), NOW()
+                ) ON CONFLICT (code, version) DO NOTHING
+                RETURNING code
+            ")
+            if [ -n "$INSERTED" ]; then
+                echo "  Seeded instrument: $CODE"
+                TOTAL_INSTRUMENTS_SEEDED=$((TOTAL_INSTRUMENTS_SEEDED + 1))
+            fi
+        fi
+    done
+done
+
+echo ""
+echo "=== Summary ==="
+echo "Schemas processed: $SCHEMA_COUNT"
+echo "Sagas updated with scripts: $TOTAL_SAGAS_UPDATED"
+echo "Instruments seeded: $TOTAL_INSTRUMENTS_SEEDED"
+
+if [ "$DRY_RUN" = "1" ]; then
+    echo ""
+    echo "This was a dry run. Run without DRY_RUN=1 to apply changes."
+fi

--- a/scripts/backfill-tenant-reference-data.sh
+++ b/scripts/backfill-tenant-reference-data.sh
@@ -35,7 +35,7 @@ if [ "$DRY_RUN" = "1" ]; then
 fi
 
 echo "Backfilling tenant reference data..."
-echo "Database: ${DATABASE_URL%%@*}@***"
+echo "Database: ${DATABASE_URL%%://*}://***"
 
 # Find all tenant schemas
 SCHEMAS=$(psql "$DATABASE_URL" -t -A -c "

--- a/services/control-plane/internal/differ/persistence/manifest_version_store.go
+++ b/services/control-plane/internal/differ/persistence/manifest_version_store.go
@@ -111,7 +111,7 @@ func (s *PostgresManifestVersionStore) setSearchPath(ctx context.Context, tx pgx
 	}
 
 	schemaName := pgx.Identifier{tenantID.SchemaName()}.Sanitize()
-	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	query := fmt.Sprintf("SET LOCAL search_path TO %s", schemaName)
 	_, err := tx.Exec(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to set tenant schema scope: %w", err)

--- a/services/control-plane/internal/staff/service_test.go
+++ b/services/control-plane/internal/staff/service_test.go
@@ -397,7 +397,7 @@ func TestStaffIsolation_DifferentTenants(t *testing.T) {
 	schemaB := tenant.TenantID("tenant_b").SchemaName()
 	err := gormDB.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaB)).Error
 	require.NoError(t, err)
-	err = gormDB.Exec(fmt.Sprintf("SET search_path TO %q, public", schemaB)).Error
+	err = gormDB.Exec(fmt.Sprintf("SET search_path TO %q", schemaB)).Error
 	require.NoError(t, err)
 	createStaffTables(t, gormDB, schemaB)
 	ctxB := tenant.WithTenant(context.Background(), "tenant_b")

--- a/services/current-account/adapters/persistence/lien_repository_test.go
+++ b/services/current-account/adapters/persistence/lien_repository_test.go
@@ -58,7 +58,7 @@ func setupLienTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 
 	// Set default search_path to include tenant schema so Create/Update work in the tenant schema
 	// This ensures consistency - all operations use the tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	// Create context with tenant

--- a/services/current-account/adapters/persistence/org_scoped_account_test.go
+++ b/services/current-account/adapters/persistence/org_scoped_account_test.go
@@ -56,7 +56,7 @@ func setupOrgScopedTestDB(t *testing.T) (*gorm.DB, *Repository, context.Context,
 	)`, pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	ctx := tenant.WithTenant(context.Background(), tid)

--- a/services/current-account/adapters/persistence/repository_contract_test.go
+++ b/services/current-account/adapters/persistence/repository_contract_test.go
@@ -30,7 +30,7 @@ var contractTestTenantID = tenant.MustNewTenantID("contract_test")
 func TestFindByID_UsesAccountID(t *testing.T) {
 	db, cleanup := testdb.SetupPostgres(t, []interface{}{&CurrentAccountEntity{}})
 	defer cleanup()
-	testdb.CreateTenantSchema(t, db, contractTestTenantID)
+	testdb.CreateTenantSchema(t, db, contractTestTenantID, &CurrentAccountEntity{})
 
 	repo := NewRepository(db)
 	ctx := tenant.WithTenant(context.Background(), contractTestTenantID)
@@ -62,7 +62,7 @@ func TestFindByID_UsesAccountID(t *testing.T) {
 func TestFindByIDForUpdate_UsesAccountID(t *testing.T) {
 	db, cleanup := testdb.SetupPostgres(t, []interface{}{&CurrentAccountEntity{}})
 	defer cleanup()
-	testdb.CreateTenantSchema(t, db, contractTestTenantID)
+	testdb.CreateTenantSchema(t, db, contractTestTenantID, &CurrentAccountEntity{})
 
 	repo := NewRepository(db)
 	ctx := tenant.WithTenant(context.Background(), contractTestTenantID)
@@ -87,7 +87,7 @@ func TestFindByIDForUpdate_UsesAccountID(t *testing.T) {
 func TestDelete_UsesAccountID(t *testing.T) {
 	db, cleanup := testdb.SetupPostgres(t, []interface{}{&CurrentAccountEntity{}})
 	defer cleanup()
-	testdb.CreateTenantSchema(t, db, contractTestTenantID)
+	testdb.CreateTenantSchema(t, db, contractTestTenantID, &CurrentAccountEntity{})
 
 	repo := NewRepository(db)
 	ctx := tenant.WithTenant(context.Background(), contractTestTenantID)

--- a/services/current-account/adapters/persistence/valuation_feature_repository_test.go
+++ b/services/current-account/adapters/persistence/valuation_feature_repository_test.go
@@ -52,7 +52,7 @@ func setupValuationFeatureTestDB(t *testing.T) (*gorm.DB, context.Context, func(
 	require.NoError(t, err)
 
 	// Set default search_path to include tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %q, public", schemaName)).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %q", schemaName)).Error
 	require.NoError(t, err)
 
 	// Create context with tenant

--- a/services/current-account/adapters/persistence/withdrawal_repository_test.go
+++ b/services/current-account/adapters/persistence/withdrawal_repository_test.go
@@ -53,7 +53,7 @@ func setupWithdrawalTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	require.NoError(t, err)
 
 	// Set default search_path to include tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	// Create context with tenant
@@ -487,7 +487,7 @@ func TestWithdrawalRepository_WithTx(t *testing.T) {
 	// Set search_path for the transaction
 	tid := tenant.TenantID(withdrawalTestTenantID)
 	schemaName := tid.SchemaName()
-	err := tx.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err := tx.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	// Use WithTx to create repository scoped to transaction

--- a/services/current-account/service/account_control_integration_test.go
+++ b/services/current-account/service/account_control_integration_test.go
@@ -36,7 +36,7 @@ func setupControlTestDB(t *testing.T) (*persistence.Repository, *persistence.Lie
 	require.NoError(t, err)
 
 	// Set search_path
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", quotedSchema)).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", quotedSchema)).Error
 	require.NoError(t, err)
 
 	// Create account table with status_history support using raw DDL

--- a/services/current-account/service/control_outbox_integration_test.go
+++ b/services/current-account/service/control_outbox_integration_test.go
@@ -94,14 +94,11 @@ func setupControlOutboxDB(t *testing.T) (*gorm.DB, *persistence.Repository, *per
 	)`, quotedSchema)).Error
 	require.NoError(t, err)
 
-	// Create event_outbox table in public schema (shared across tenants).
-	// Temporarily reset search_path since AutoMigrate uses unqualified table names.
-	err = db.Exec("SET search_path TO public").Error
-	require.NoError(t, err)
+	// Create event_outbox table in tenant schema.
+	// The outbox insert happens within a tenant-scoped transaction (search_path = tenant schema),
+	// so the table must exist in the tenant schema, not public.
 	err = db.AutoMigrate(&events.EventOutbox{})
 	require.NoError(t, err, "failed to create event_outbox table")
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s", quotedSchema)).Error
-	require.NoError(t, err)
 
 	repo := persistence.NewRepository(db)
 	lienRepo := persistence.NewLienRepository(db)

--- a/services/current-account/service/control_outbox_integration_test.go
+++ b/services/current-account/service/control_outbox_integration_test.go
@@ -36,7 +36,7 @@ func setupControlOutboxDB(t *testing.T) (*gorm.DB, *persistence.Repository, *per
 	require.NoError(t, err)
 
 	// Set search_path (applies to the pinned connection for all subsequent queries)
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", quotedSchema)).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", quotedSchema)).Error
 	require.NoError(t, err)
 
 	// Create account table (same DDL as setupControlTestDB)

--- a/services/current-account/service/control_outbox_integration_test.go
+++ b/services/current-account/service/control_outbox_integration_test.go
@@ -94,9 +94,14 @@ func setupControlOutboxDB(t *testing.T) (*gorm.DB, *persistence.Repository, *per
 	)`, quotedSchema)).Error
 	require.NoError(t, err)
 
-	// Create event_outbox table in public schema (shared across tenants)
+	// Create event_outbox table in public schema (shared across tenants).
+	// Temporarily reset search_path since AutoMigrate uses unqualified table names.
+	err = db.Exec("SET search_path TO public").Error
+	require.NoError(t, err)
 	err = db.AutoMigrate(&events.EventOutbox{})
 	require.NoError(t, err, "failed to create event_outbox table")
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", quotedSchema)).Error
+	require.NoError(t, err)
 
 	repo := persistence.NewRepository(db)
 	lienRepo := persistence.NewLienRepository(db)

--- a/services/current-account/service/coverage_unit_test.go
+++ b/services/current-account/service/coverage_unit_test.go
@@ -6228,7 +6228,7 @@ func setupWithdrawalTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	schemaName := tid.SchemaName()
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 	err = db.AutoMigrate(&persistence.CurrentAccountEntity{}, &persistence.LienEntity{}, &persistence.WithdrawalEntity{})
 	require.NoError(t, err)

--- a/services/current-account/service/grpc_service_integration_test.go
+++ b/services/current-account/service/grpc_service_integration_test.go
@@ -434,7 +434,7 @@ func setupIntegrationTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	require.NoError(t, err)
 
 	// Set search_path so AutoMigrate creates tables in the tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	// AutoMigrate in the tenant schema

--- a/services/current-account/service/grpc_service_party_integration_test.go
+++ b/services/current-account/service/grpc_service_party_integration_test.go
@@ -135,7 +135,7 @@ func setupPartyIntegrationTestDB(t *testing.T) (*gorm.DB, context.Context, func(
 	require.NoError(t, err)
 
 	// Set default search_path to include tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", quotedSchema)).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", quotedSchema)).Error
 	require.NoError(t, err)
 
 	// AutoMigrate the account entity in the tenant schema

--- a/services/current-account/service/grpc_service_product_type_test.go
+++ b/services/current-account/service/grpc_service_product_type_test.go
@@ -99,7 +99,7 @@ func setupProductTypeTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	require.NoError(t, err)
 
 	// AutoMigrate tables in tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", quotedSchema)).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", quotedSchema)).Error
 	require.NoError(t, err)
 
 	err = db.AutoMigrate(&persistence.CurrentAccountEntity{}, &vf.Entity{})

--- a/services/current-account/service/grpc_service_test.go
+++ b/services/current-account/service/grpc_service_test.go
@@ -327,7 +327,7 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	require.NoError(t, err)
 
 	// Set search_path so AutoMigrate creates tables in the tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	// AutoMigrate in the tenant schema

--- a/services/current-account/service/grpc_withdrawal_tenant_isolation_test.go
+++ b/services/current-account/service/grpc_withdrawal_tenant_isolation_test.go
@@ -48,7 +48,7 @@ func setupMultiTenantTestDB(t *testing.T) (db *gorm.DB, ctxA context.Context, ct
 		require.NoError(t, err, "failed to create schema %s", schema)
 
 		// Set search_path to the tenant schema so AutoMigrate creates tables there
-		err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schema))).Error
+		err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schema))).Error
 		require.NoError(t, err, "failed to set search_path for %s", schema)
 
 		err = db.AutoMigrate(

--- a/services/current-account/service/health_test.go
+++ b/services/current-account/service/health_test.go
@@ -33,7 +33,7 @@ func setupTestRepository(t *testing.T) *persistence.Repository {
 	require.NoError(t, err)
 
 	// Set search_path so AutoMigrate creates tables in the tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	// AutoMigrate in the tenant schema

--- a/services/current-account/service/lien_service_test.go
+++ b/services/current-account/service/lien_service_test.go
@@ -38,7 +38,7 @@ func setupLienTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	require.NoError(t, err)
 
 	// Set search_path so tables are created in the tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	// AutoMigrate account and lien entities
@@ -1411,7 +1411,7 @@ func setupAtomicValuationLienTest(t *testing.T, engine ValuationEngine, accountB
 	require.NoError(t, err)
 
 	// Set search_path so tables are created in the tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	// Create account table (uses "account" table name like valuation engine tests)

--- a/services/current-account/service/valuation_engine_test.go
+++ b/services/current-account/service/valuation_engine_test.go
@@ -124,7 +124,7 @@ func setupValuationEngineTestWithEngine(t *testing.T, engine ValuationEngine) (*
 		WHERE lifecycle_status = 'ACTIVE' AND valid_to = '9999-12-31 23:59:59+00'`, schemaName)).Error
 	require.NoError(t, err)
 
-	err = db.Exec(fmt.Sprintf("SET search_path TO %q, public", schemaName)).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %q", schemaName)).Error
 	require.NoError(t, err)
 
 	ctx := tenant.WithTenant(context.Background(), tid)

--- a/services/current-account/service/valuation_feature_service_test.go
+++ b/services/current-account/service/valuation_feature_service_test.go
@@ -85,7 +85,7 @@ func setupValuationFeatureServiceTest(t *testing.T) (*Service, context.Context, 
 	require.NoError(t, err)
 
 	// Set default search_path to include tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %q, public", schemaName)).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %q", schemaName)).Error
 	require.NoError(t, err)
 
 	// Create context with tenant

--- a/services/financial-accounting/adapters/messaging/deposit_consumer_test.go
+++ b/services/financial-accounting/adapters/messaging/deposit_consumer_test.go
@@ -178,7 +178,7 @@ func setupTestServices(t *testing.T) (*service.PostingService, context.Context, 
 	require.NoError(t, err)
 
 	// Set default search_path to include tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	// Create context with tenant

--- a/services/financial-accounting/e2e/e2e_test.go
+++ b/services/financial-accounting/e2e/e2e_test.go
@@ -97,7 +97,7 @@ func setupMultiServiceTenantSchema(t *testing.T, db *gorm.DB, tenantID tenant.Te
 	applyPositionKeepingSchema(t, db, schemaName)
 
 	// Set search_path to tenant schema for all subsequent GORM operations
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err, "Failed to set search_path to tenant schema")
 
 	// Create context with tenant

--- a/services/financial-accounting/service/grpc_integration_test.go
+++ b/services/financial-accounting/service/grpc_integration_test.go
@@ -142,7 +142,7 @@ func setupIntegrationTest(t *testing.T) (*testServer, context.Context) {
 	require.NoError(t, err)
 
 	// Set search_path to tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	// Create context with tenant

--- a/services/identity/adapters/persistence/repository_test.go
+++ b/services/identity/adapters/persistence/repository_test.go
@@ -48,7 +48,7 @@ func setupTenantSchema(t *testing.T, db *gorm.DB, tid tenant.TenantID) context.C
 
 	// Wrap in transaction to guarantee session affinity for search_path operations
 	err = db.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error; err != nil {
+		if err := tx.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error; err != nil {
 			return err
 		}
 		if err := tx.AutoMigrate(identityModels...); err != nil {
@@ -56,7 +56,7 @@ func setupTenantSchema(t *testing.T, db *gorm.DB, tid tenant.TenantID) context.C
 		}
 		// Restore search_path to the primary tenant schema
 		primarySchema := tenant.TenantID(testTenantIDStr).SchemaName()
-		return tx.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(primarySchema))).Error
+		return tx.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(primarySchema))).Error
 	})
 	require.NoError(t, err)
 

--- a/services/internal-account/adapters/persistence/lien_repository_test.go
+++ b/services/internal-account/adapters/persistence/lien_repository_test.go
@@ -82,7 +82,7 @@ func setupLienTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	)`, pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	ctx := tenant.WithTenant(context.Background(), tid)

--- a/services/internal-account/benchmarks/helpers_test.go
+++ b/services/internal-account/benchmarks/helpers_test.go
@@ -282,7 +282,7 @@ func setupTestContainer(t *testing.T) *testContainer {
 	}
 
 	// Set default search_path to include tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	if err != nil {
 		t.Fatalf("Failed to set search_path: %v", err)
 	}

--- a/services/internal-account/e2e/e2e_test.go
+++ b/services/internal-account/e2e/e2e_test.go
@@ -246,7 +246,7 @@ func applyInternalAccountSchema(t *testing.T, pool *pgxpool.Pool, schemaName str
 	require.NoError(t, err)
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	// Create internal_account table
@@ -346,7 +346,7 @@ func applyPositionKeepingSchema(t *testing.T, pool *pgxpool.Pool, schemaName str
 	require.NoError(t, err)
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	// Create position table (append-only)
@@ -442,7 +442,7 @@ func createAccount(t *testing.T, ctx context.Context, pool *pgxpool.Pool, accoun
 	require.NoError(t, err)
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	_, err = tx.Exec(ctx, `
@@ -475,7 +475,7 @@ func insertPosition(t *testing.T, pool *pgxpool.Pool, ctx context.Context, accou
 	require.NoError(t, err)
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	var attrsJSON interface{}
@@ -506,7 +506,7 @@ func getAggregatedBalance(t *testing.T, pool *pgxpool.Pool, ctx context.Context,
 	require.NoError(t, err)
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	var totalAmount decimal.Decimal
@@ -534,7 +534,7 @@ func updateAccountStatus(t *testing.T, ctx context.Context, pool *pgxpool.Pool, 
 	require.NoError(t, err)
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	// Get current status
@@ -585,7 +585,7 @@ func getStatusHistory(t *testing.T, ctx context.Context, pool *pgxpool.Pool, acc
 	require.NoError(t, err)
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	rows, err := tx.Query(ctx, `
@@ -1713,7 +1713,7 @@ func softDeletePosition(t *testing.T, pool *pgxpool.Pool, ctx context.Context, p
 	require.NoError(t, err)
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	_, err = tx.Exec(ctx, `UPDATE position SET deleted_at = NOW() WHERE id = $1`, positionID)

--- a/services/internal-account/service/lien_integration_test.go
+++ b/services/internal-account/service/lien_integration_test.go
@@ -79,7 +79,7 @@ func setupLienIntegrationDB(t *testing.T) (*Service, *gorm.DB, context.Context, 
 	)`, schemaName)).Error
 	require.NoError(t, err)
 
-	err = db.Exec(fmt.Sprintf("SET search_path TO %q, public", schemaName)).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %q", schemaName)).Error
 	require.NoError(t, err)
 
 	ctx := tenant.WithTenant(context.Background(), tid)

--- a/services/internal-account/service/valuation_engine_test.go
+++ b/services/internal-account/service/valuation_engine_test.go
@@ -100,7 +100,7 @@ func setupValuationEngineTest(t *testing.T) (*Service, *gorm.DB, context.Context
 	require.NoError(t, err)
 
 	// Set default search_path to include tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %q, public", schemaName)).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %q", schemaName)).Error
 	require.NoError(t, err)
 
 	ctx := tenant.WithTenant(context.Background(), tid)

--- a/services/internal-account/service/valuation_feature_service_test.go
+++ b/services/internal-account/service/valuation_feature_service_test.go
@@ -82,7 +82,7 @@ func setupValuationFeatureServiceTest(t *testing.T) (*Service, *gorm.DB, context
 	require.NoError(t, err)
 
 	// Set default search_path to include tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %q, public", schemaName)).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %q", schemaName)).Error
 	require.NoError(t, err)
 
 	ctx := tenant.WithTenant(context.Background(), tid)

--- a/services/market-information/adapters/persistence/base_repository.go
+++ b/services/market-information/adapters/persistence/base_repository.go
@@ -39,7 +39,7 @@ func (r *baseRepository) setSearchPath(ctx context.Context, tx pgx.Tx) error {
 	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
 
 	// SET LOCAL is transaction-scoped - automatically reverts on commit/rollback
-	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	query := fmt.Sprintf("SET LOCAL search_path TO %s", schemaName)
 	_, err := tx.Exec(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to set tenant schema scope: %w", err)

--- a/services/market-information/adapters/persistence/testhelpers/testcontainer.go
+++ b/services/market-information/adapters/persistence/testhelpers/testcontainer.go
@@ -23,9 +23,10 @@ var schemaDDL string
 
 // TestContainer holds the test database container, connection pool, and repository instances.
 type TestContainer struct {
-	container *postgres.PostgresContainer
-	Pool      *pgxpool.Pool
-	Repos     *persistence.Repositories
+	container      *postgres.PostgresContainer
+	Pool           *pgxpool.Pool
+	Repos          *persistence.Repositories
+	MasterTenantID tenant.TenantID // The master tenant used for shared/hierarchical data lookups
 }
 
 // SetupTestContainer creates a PostgreSQL testcontainer with the market_information schema loaded.
@@ -59,16 +60,42 @@ func SetupTestContainer(t *testing.T) *TestContainer {
 	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
 	require.NoError(t, err, "Failed to create connection pool")
 
-	// Load schema
+	// Load schema into public schema (used by non-tenant-scoped tests)
 	loadSchema(t, pool)
 
+	// Create master tenant schema with the same tables.
+	// The market-information service uses a master tenant for hierarchical lookup
+	// (shared dataset fallback). Without public in search_path, the master tenant
+	// needs its own schema with all required tables.
+	masterTenantID := "test_master"
+	masterSchema := "org_" + masterTenantID
+	_, err = pool.Exec(ctx, "CREATE SCHEMA IF NOT EXISTS "+masterSchema)
+	require.NoError(t, err, "Failed to create master tenant schema")
+	err = loadSchemaInSchema(ctx, pool, masterSchema)
+	require.NoError(t, err, "Failed to load schema into master tenant schema")
+
+	// Set default search_path to master tenant schema for non-tenant-scoped queries.
+	// Tests that don't explicitly set a tenant context will use the master schema,
+	// matching production behavior where the master tenant is the default context.
+	_, err = pool.Exec(ctx, "ALTER DATABASE test_market_information SET search_path TO "+masterSchema)
+	require.NoError(t, err, "Failed to set default search_path")
+
+	// Reconnect to pick up the new default search_path
+	pool.Close()
+	pool, err = pgxpool.NewWithConfig(ctx, poolConfig)
+	require.NoError(t, err, "Failed to reconnect with new search_path")
+
 	// Create repositories with test master tenant
-	repos := persistence.NewRepositories(pool, "test_master")
+	repos := persistence.NewRepositories(pool, masterTenantID)
+
+	masterTID, err := tenant.NewTenantID(masterTenantID)
+	require.NoError(t, err, "Failed to parse master tenant ID")
 
 	return &TestContainer{
-		container: pgContainer,
-		Pool:      pool,
-		Repos:     repos,
+		container:      pgContainer,
+		Pool:           pool,
+		Repos:          repos,
+		MasterTenantID: masterTID,
 	}
 }
 
@@ -125,30 +152,31 @@ func (tc *TestContainer) CreateTenantSchema(tenantIDStr string) (tenant.TenantID
 		return tenant.TenantID(""), fmt.Errorf("failed to load schema: %w", err)
 	}
 
-	// Copy shared datasets from public schema to tenant schema.
-	// This allows tenant observations to reference shared dataset definitions.
-	// Note: quotedSchema is safely quoted via pgx.Identifier.Sanitize() above.
+	// Copy shared datasets from master schema to tenant schema.
+	// Reference data is saved to the master schema (org_test_master) via the default search_path,
+	// not to public. This allows tenant observations to reference shared dataset definitions.
+	masterSchema := pgx.Identifier{tc.MasterTenantID.SchemaName()}.Sanitize()
 	_, err = tc.Pool.Exec(ctx, fmt.Sprintf(`
 		INSERT INTO %s.dataset_definition
-		SELECT * FROM public.dataset_definition
+		SELECT * FROM %s.dataset_definition
 		WHERE is_shared = TRUE
-	`, quotedSchema))
+	`, quotedSchema, masterSchema))
 	if err != nil {
 		return tenant.TenantID(""), fmt.Errorf("failed to copy shared datasets: %w", err)
 	}
 
-	// Copy data sources from public schema to tenant schema
+	// Copy data sources from master schema to tenant schema
 	// Data sources are needed for observations to have valid foreign keys
 	_, err = tc.Pool.Exec(ctx, fmt.Sprintf(`
 		INSERT INTO %s.data_source
-		SELECT * FROM public.data_source
-	`, quotedSchema))
+		SELECT * FROM %s.data_source
+	`, quotedSchema, masterSchema))
 	if err != nil {
 		return tenant.TenantID(""), fmt.Errorf("failed to copy data sources: %w", err)
 	}
 
-	// Reset search path to default
-	_, err = tc.Pool.Exec(ctx, "SET search_path TO public")
+	// Reset search path to master schema (the database default)
+	_, err = tc.Pool.Exec(ctx, "SET search_path TO "+masterSchema)
 	if err != nil {
 		return tenant.TenantID(""), fmt.Errorf("failed to reset search_path: %w", err)
 	}
@@ -161,10 +189,19 @@ func (tc *TestContainer) WithTenant(ctx context.Context, tenantID tenant.TenantI
 	return tenant.WithTenant(ctx, tenantID)
 }
 
+// MasterContext returns a context scoped to the master tenant.
+// Use this when saving reference data (datasets, data sources) that the observation
+// repository's hierarchical lookup will query via the master tenant schema.
+func (tc *TestContainer) MasterContext(ctx context.Context) context.Context {
+	return tenant.WithTenant(ctx, tc.MasterTenantID)
+}
+
 // GrantTenantEntitlement grants access to a dataset for a tenant.
+// Uses public.tenant_data_entitlements explicitly because the production code's
+// checkTenantAccess queries public.tenant_data_entitlements directly.
 func (tc *TestContainer) GrantTenantEntitlement(ctx context.Context, tenantID tenant.TenantID, datasetCode string, expiresAt *time.Time) error {
 	query := `
-		INSERT INTO tenant_data_entitlements (tenant_id, dataset_code, is_active, expires_at)
+		INSERT INTO public.tenant_data_entitlements (tenant_id, dataset_code, is_active, expires_at)
 		VALUES ($1, $2, TRUE, $3)
 		ON CONFLICT (tenant_id, dataset_code)
 		DO UPDATE SET is_active = TRUE, expires_at = EXCLUDED.expires_at`
@@ -177,9 +214,10 @@ func (tc *TestContainer) GrantTenantEntitlement(ctx context.Context, tenantID te
 }
 
 // RevokeTenantEntitlement revokes access to a dataset for a tenant.
+// Uses public.tenant_data_entitlements explicitly to match checkTenantAccess.
 func (tc *TestContainer) RevokeTenantEntitlement(ctx context.Context, tenantID tenant.TenantID, datasetCode string) error {
 	query := `
-		UPDATE tenant_data_entitlements
+		UPDATE public.tenant_data_entitlements
 		SET is_active = FALSE
 		WHERE tenant_id = $1 AND dataset_code = $2`
 

--- a/services/market-information/adapters/persistence/testhelpers/testcontainer.go
+++ b/services/market-information/adapters/persistence/testhelpers/testcontainer.go
@@ -32,10 +32,8 @@ type TestContainer struct {
 // SetupTestContainer creates a PostgreSQL testcontainer with the market_information schema loaded.
 func SetupTestContainer(t *testing.T) *TestContainer {
 	t.Helper()
-
 	ctx := context.Background()
 
-	// Create PostgreSQL container with explicit wait strategy
 	pgContainer, err := postgres.Run(ctx,
 		"postgres:16-alpine",
 		postgres.WithDatabase("test_market_information"),
@@ -49,45 +47,20 @@ func SetupTestContainer(t *testing.T) *TestContainer {
 	)
 	require.NoError(t, err, "Failed to start PostgreSQL container")
 
-	// Get connection string
 	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
 	require.NoError(t, err, "Failed to get connection string")
 
-	// Create connection pool
 	poolConfig, err := pgxpool.ParseConfig(connStr)
 	require.NoError(t, err, "Failed to parse pool config")
 
 	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
 	require.NoError(t, err, "Failed to create connection pool")
 
-	// Load schema into public schema (used by non-tenant-scoped tests)
 	loadSchema(t, pool)
+	pool = setupMasterSchema(ctx, t, pool, poolConfig)
 
-	// Create master tenant schema with the same tables.
-	// The market-information service uses a master tenant for hierarchical lookup
-	// (shared dataset fallback). Without public in search_path, the master tenant
-	// needs its own schema with all required tables.
 	masterTenantID := "test_master"
-	masterSchema := "org_" + masterTenantID
-	_, err = pool.Exec(ctx, "CREATE SCHEMA IF NOT EXISTS "+masterSchema)
-	require.NoError(t, err, "Failed to create master tenant schema")
-	err = loadSchemaInSchema(ctx, pool, masterSchema)
-	require.NoError(t, err, "Failed to load schema into master tenant schema")
-
-	// Set default search_path to master tenant schema for non-tenant-scoped queries.
-	// Tests that don't explicitly set a tenant context will use the master schema,
-	// matching production behavior where the master tenant is the default context.
-	_, err = pool.Exec(ctx, "ALTER DATABASE test_market_information SET search_path TO "+masterSchema)
-	require.NoError(t, err, "Failed to set default search_path")
-
-	// Reconnect to pick up the new default search_path
-	pool.Close()
-	pool, err = pgxpool.NewWithConfig(ctx, poolConfig)
-	require.NoError(t, err, "Failed to reconnect with new search_path")
-
-	// Create repositories with test master tenant
 	repos := persistence.NewRepositories(pool, masterTenantID)
-
 	masterTID, err := tenant.NewTenantID(masterTenantID)
 	require.NoError(t, err, "Failed to parse master tenant ID")
 
@@ -97,6 +70,28 @@ func SetupTestContainer(t *testing.T) *TestContainer {
 		Repos:          repos,
 		MasterTenantID: masterTID,
 	}
+}
+
+// setupMasterSchema creates the master tenant schema with tables and sets it as the
+// database default search_path. Returns a reconnected pool that uses the new default.
+func setupMasterSchema(ctx context.Context, t *testing.T, pool *pgxpool.Pool, poolConfig *pgxpool.Config) *pgxpool.Pool {
+	t.Helper()
+	masterSchema := "org_test_master"
+
+	_, err := pool.Exec(ctx, "CREATE SCHEMA IF NOT EXISTS "+masterSchema)
+	require.NoError(t, err, "Failed to create master tenant schema")
+	err = loadSchemaInSchema(ctx, pool, masterSchema)
+	require.NoError(t, err, "Failed to load schema into master tenant schema")
+
+	// Set default search_path so non-tenant-scoped queries use the master schema
+	_, err = pool.Exec(ctx, "ALTER DATABASE test_market_information SET search_path TO "+masterSchema)
+	require.NoError(t, err, "Failed to set default search_path")
+
+	// Reconnect to pick up the new default search_path
+	pool.Close()
+	pool, err = pgxpool.NewWithConfig(ctx, poolConfig)
+	require.NoError(t, err, "Failed to reconnect with new search_path")
+	return pool
 }
 
 // Cleanup closes the connection pool and terminates the container.
@@ -124,64 +119,46 @@ func loadSchema(t *testing.T, pool *pgxpool.Pool) {
 // CreateTenantSchema creates a tenant-specific schema for testing multi-tenant scenarios.
 func (tc *TestContainer) CreateTenantSchema(tenantIDStr string) (tenant.TenantID, error) {
 	ctx := context.Background()
-
 	tenantID, err := tenant.NewTenantID(tenantIDStr)
 	if err != nil {
 		return tenant.TenantID(""), fmt.Errorf("invalid tenant ID: %w", err)
 	}
 
 	schemaName := tenantID.SchemaName()
-	// Use pgx.Identifier for proper SQL identifier quoting to prevent injection
 	quotedSchema := pgx.Identifier{schemaName}.Sanitize()
 
-	// Create schema
-	_, err = tc.Pool.Exec(ctx, "CREATE SCHEMA IF NOT EXISTS "+quotedSchema)
-	if err != nil {
+	if _, err = tc.Pool.Exec(ctx, "CREATE SCHEMA IF NOT EXISTS "+quotedSchema); err != nil {
 		return tenant.TenantID(""), fmt.Errorf("failed to create schema %s: %w", schemaName, err)
 	}
-
-	// Set search path and create tables in tenant schema
-	_, err = tc.Pool.Exec(ctx, "SET search_path TO "+quotedSchema)
-	if err != nil {
-		return tenant.TenantID(""), fmt.Errorf("failed to set search_path: %w", err)
-	}
-
-	// Create tenant-specific tables (same structure as public schema)
-	err = loadSchemaInSchema(ctx, tc.Pool, schemaName)
-	if err != nil {
+	if err = loadSchemaInSchema(ctx, tc.Pool, schemaName); err != nil {
 		return tenant.TenantID(""), fmt.Errorf("failed to load schema: %w", err)
 	}
 
-	// Copy shared datasets from master schema to tenant schema.
-	// Reference data is saved to the master schema (org_test_master) via the default search_path,
-	// not to public. This allows tenant observations to reference shared dataset definitions.
+	// Copy reference data from master schema (where repos save it) to tenant schema
 	masterSchema := pgx.Identifier{tc.MasterTenantID.SchemaName()}.Sanitize()
-	_, err = tc.Pool.Exec(ctx, fmt.Sprintf(`
-		INSERT INTO %s.dataset_definition
-		SELECT * FROM %s.dataset_definition
-		WHERE is_shared = TRUE
-	`, quotedSchema, masterSchema))
-	if err != nil {
-		return tenant.TenantID(""), fmt.Errorf("failed to copy shared datasets: %w", err)
-	}
-
-	// Copy data sources from master schema to tenant schema
-	// Data sources are needed for observations to have valid foreign keys
-	_, err = tc.Pool.Exec(ctx, fmt.Sprintf(`
-		INSERT INTO %s.data_source
-		SELECT * FROM %s.data_source
-	`, quotedSchema, masterSchema))
-	if err != nil {
-		return tenant.TenantID(""), fmt.Errorf("failed to copy data sources: %w", err)
-	}
-
-	// Reset search path to master schema (the database default)
-	_, err = tc.Pool.Exec(ctx, "SET search_path TO "+masterSchema)
-	if err != nil {
-		return tenant.TenantID(""), fmt.Errorf("failed to reset search_path: %w", err)
+	if err = tc.copyReferenceData(ctx, quotedSchema, masterSchema); err != nil {
+		return tenant.TenantID(""), err
 	}
 
 	return tenantID, nil
+}
+
+// copyReferenceData copies shared datasets and data sources from master to tenant schema.
+func (tc *TestContainer) copyReferenceData(ctx context.Context, tenantSchema, masterSchema string) error {
+	_, err := tc.Pool.Exec(ctx, fmt.Sprintf(
+		`INSERT INTO %s.dataset_definition SELECT * FROM %s.dataset_definition WHERE is_shared = TRUE`,
+		tenantSchema, masterSchema))
+	if err != nil {
+		return fmt.Errorf("failed to copy shared datasets: %w", err)
+	}
+
+	_, err = tc.Pool.Exec(ctx, fmt.Sprintf(
+		`INSERT INTO %s.data_source SELECT * FROM %s.data_source`,
+		tenantSchema, masterSchema))
+	if err != nil {
+		return fmt.Errorf("failed to copy data sources: %w", err)
+	}
+	return nil
 }
 
 // WithTenant wraps a context with tenant information.

--- a/services/party/adapters/persistence/party_type_definition_repository_test.go
+++ b/services/party/adapters/persistence/party_type_definition_repository_test.go
@@ -43,7 +43,7 @@ func setupPartyTypeTestDB(t *testing.T) (*gorm.DB, interface{ String() string },
 	)`, pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	return db, tid, cleanup

--- a/services/party/adapters/persistence/payment_method_repository_test.go
+++ b/services/party/adapters/persistence/payment_method_repository_test.go
@@ -107,7 +107,7 @@ func setupPaymentMethodTestDB(t *testing.T) (*gorm.DB, context.Context, func()) 
 	require.NoError(t, err)
 
 	// Set default search_path to include tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	// Create context with tenant

--- a/services/party/adapters/persistence/repository_test.go
+++ b/services/party/adapters/persistence/repository_test.go
@@ -474,10 +474,9 @@ func TestFindByID_WithOrganizationContext_IsolatesData(t *testing.T) {
 	_, err = repo.FindByID(ctx, party.ID())
 	require.NoError(t, err, "Party should be findable with tenant context")
 
-	// With organization context, the search_path changes to org_acme_bank,public.
-	// Since the parties table only exists in public, this should still work
-	// (public is included in search_path), but the isolation is enforced at the
-	// schema level when org schemas are properly set up.
+	// With organization context, the search_path changes to org_acme_bank.
+	// The parties table must exist in the tenant schema for queries to work.
+	// Complete tenant isolation means no public schema fallback.
 	orgID := tenant.TenantID("acme_bank")
 	orgCtx := tenant.WithTenant(ctx, orgID)
 

--- a/services/party/adapters/persistence/verification_repository_test.go
+++ b/services/party/adapters/persistence/verification_repository_test.go
@@ -90,7 +90,7 @@ func setupVerificationTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	require.NoError(t, err)
 
 	// Set default search_path to include tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	// Create context with tenant

--- a/services/party/service/grpc_payment_methods_integration_test.go
+++ b/services/party/service/grpc_payment_methods_integration_test.go
@@ -112,7 +112,7 @@ func setupPaymentMethodIntegrationTest(t *testing.T) (*Service, *gorm.DB, contex
 	require.NoError(t, err)
 
 	// Set search_path
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	ctx := tenant.WithTenant(context.Background(), tid)

--- a/services/party/service/grpc_service_integration_test.go
+++ b/services/party/service/grpc_service_integration_test.go
@@ -97,7 +97,7 @@ func setupIntegrationTest(t *testing.T) (*Service, *gorm.DB, context.Context, fu
 	require.NoError(t, err)
 
 	// Set default search_path to include tenant schema so Create/Update work in the tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	// Create context with tenant

--- a/services/party/service/kafka_cascade_integration_test.go
+++ b/services/party/service/kafka_cascade_integration_test.go
@@ -167,7 +167,7 @@ func setupKafkaCascadeTest(t *testing.T) *kafkaCascadeTestEnv {
 		service_name VARCHAR(100) NOT NULL
 	)`).Error)
 
-	require.NoError(t, db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error)
+	require.NoError(t, db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error)
 
 	ctx := tenant.WithTenant(bgCtx, tid)
 

--- a/services/party/service/kyc_guard_test.go
+++ b/services/party/service/kyc_guard_test.go
@@ -80,7 +80,7 @@ func setupKYCTest(t *testing.T) (*Service, *gorm.DB, context.Context, func()) {
 	require.NoError(t, err)
 
 	// Set default search_path to include tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	// Create context with tenant

--- a/services/party/service/lifecycle_integration_test.go
+++ b/services/party/service/lifecycle_integration_test.go
@@ -180,7 +180,7 @@ func setupLifecycleIntegrationTest(t *testing.T) (*Service, *gorm.DB, context.Co
 	require.NoError(t, err)
 
 	// Set default search_path to include tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	// Create context with tenant

--- a/services/payment-order/adapters/persistence/repository_bench_test.go
+++ b/services/payment-order/adapters/persistence/repository_bench_test.go
@@ -79,7 +79,7 @@ func setupBenchDB(b *testing.B) (*gorm.DB, context.Context, func()) {
 	}
 
 	// Set search_path to tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	if err != nil {
 		b.Fatalf("setupBenchDB: failed to set search_path: %v", err)
 	}

--- a/services/payment-order/e2e/e2e_test.go
+++ b/services/payment-order/e2e/e2e_test.go
@@ -229,7 +229,7 @@ func setupMultiServiceSchema(t *testing.T, db *gorm.DB, tenantID tenant.TenantID
 	applyPaymentOrderSchema(t, db, schemaName)
 
 	// Set search_path to tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	ctx := tenant.WithTenant(context.Background(), tenantID)

--- a/services/payment-order/service/integration_test.go
+++ b/services/payment-order/service/integration_test.go
@@ -124,7 +124,7 @@ func setupIntegrationTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	require.NoError(t, err)
 
 	// Set search_path to tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	// Create context with tenant

--- a/services/position-keeping/adapters/persistence/measurement_repository.go
+++ b/services/position-keeping/adapters/persistence/measurement_repository.go
@@ -40,7 +40,7 @@ func (r *MeasurementRepository) setSearchPath(ctx context.Context, tx pgx.Tx) er
 	}
 
 	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
-	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	query := fmt.Sprintf("SET LOCAL search_path TO %s", schemaName)
 	_, err := tx.Exec(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to set tenant schema scope: %w", err)

--- a/services/position-keeping/adapters/persistence/position_repository.go
+++ b/services/position-keeping/adapters/persistence/position_repository.go
@@ -45,7 +45,7 @@ func (r *PositionRepository) setSearchPath(ctx context.Context, tx pgx.Tx) error
 	}
 
 	schemaName := pgx.Identifier{tenantID.SchemaName()}.Sanitize()
-	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	query := fmt.Sprintf("SET LOCAL search_path TO %s", schemaName)
 	_, err := tx.Exec(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to set tenant schema scope: %w", err)

--- a/services/position-keeping/adapters/persistence/postgres_repository.go
+++ b/services/position-keeping/adapters/persistence/postgres_repository.go
@@ -56,7 +56,7 @@ func (r *PostgresRepository) setSearchPath(ctx context.Context, tx pgx.Tx) error
 	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
 
 	// SET LOCAL is transaction-scoped - automatically reverts on commit/rollback
-	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	query := fmt.Sprintf("SET LOCAL search_path TO %s", schemaName)
 	_, err := tx.Exec(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to set tenant schema scope: %w", err)

--- a/services/position-keeping/adapters/persistence/postgres_repository_test.go
+++ b/services/position-keeping/adapters/persistence/postgres_repository_test.go
@@ -48,7 +48,7 @@ func setupTestContainer(t *testing.T) *testContainer {
 	require.NoError(t, err)
 
 	// Get connection string with search_path configured
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable", "search_path=position_keeping,public")
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable", "search_path=position_keeping")
 	require.NoError(t, err)
 
 	// Create connection pool

--- a/services/position-keeping/adapters/persistence/reservation_repository.go
+++ b/services/position-keeping/adapters/persistence/reservation_repository.go
@@ -33,7 +33,7 @@ func (r *ReservationRepository) setSearchPath(ctx context.Context, tx pgx.Tx) er
 	}
 
 	schemaName := pgx.Identifier{tenantID.SchemaName()}.Sanitize()
-	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	query := fmt.Sprintf("SET LOCAL search_path TO %s", schemaName)
 	_, err := tx.Exec(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to set tenant schema scope: %w", err)

--- a/services/position-keeping/adapters/persistence/testhelpers/testcontainer.go
+++ b/services/position-keeping/adapters/persistence/testhelpers/testcontainer.go
@@ -91,7 +91,7 @@ func SetupTestContainer(t *testing.T) *TestContainer {
 	require.NoError(t, err, "Failed to start PostgreSQL container")
 
 	// Get connection string with search_path configured
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable", "search_path=position_keeping,public")
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable", "search_path=position_keeping")
 	require.NoError(t, err, "Failed to get connection string")
 
 	// Create connection pool

--- a/services/position-keeping/service/balance_integration_test.go
+++ b/services/position-keeping/service/balance_integration_test.go
@@ -54,7 +54,7 @@ func SetupBalanceIntegrationTestContainer(t *testing.T) *BalanceIntegrationTestC
 	require.NoError(t, err, "Failed to start PostgreSQL container")
 
 	// Get connection string with search_path configured
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable", "search_path=position_keeping,public")
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable", "search_path=position_keeping")
 	require.NoError(t, err, "Failed to get connection string")
 
 	// Create connection pool
@@ -112,7 +112,7 @@ func SetupBalanceIntegrationTestContainerWithClient(t *testing.T, client domain.
 	)
 	require.NoError(t, err, "Failed to start PostgreSQL container")
 
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable", "search_path=position_keeping,public")
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable", "search_path=position_keeping")
 	require.NoError(t, err, "Failed to get connection string")
 
 	poolConfig, err := pgxpool.ParseConfig(connStr)

--- a/services/position-keeping/worker/compaction_worker.go
+++ b/services/position-keeping/worker/compaction_worker.go
@@ -608,7 +608,7 @@ func (w *CompactionWorker) setSearchPath(ctx context.Context, tx pgx.Tx) error {
 	}
 
 	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
-	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	query := fmt.Sprintf("SET LOCAL search_path TO %s", schemaName)
 	_, err := tx.Exec(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to set tenant schema scope: %w", err)

--- a/services/reconciliation/adapters/persistence/main_test.go
+++ b/services/reconciliation/adapters/persistence/main_test.go
@@ -88,7 +88,7 @@ func runMigrations(db *gorm.DB) error {
 
 	migrationSQL := `
 		CREATE SCHEMA IF NOT EXISTS ` + quoted + `;
-		SET search_path TO ` + quoted + `, public;
+		SET search_path TO ` + quoted + `;
 
 		CREATE TABLE IF NOT EXISTS "settlement_run" (
 			"id" uuid NOT NULL DEFAULT gen_random_uuid(),

--- a/services/reconciliation/cmd/main_test.go
+++ b/services/reconciliation/cmd/main_test.go
@@ -47,7 +47,7 @@ func setupIntegrationDB(t *testing.T) (*gorm.DB, func()) {
 	require.NoError(t, err)
 
 	migrationSQL := `
-		SET search_path TO ` + quoted + `, public;
+		SET search_path TO ` + quoted + `;
 
 		CREATE TABLE IF NOT EXISTS "settlement_run" (
 			"id" uuid NOT NULL DEFAULT gen_random_uuid(),

--- a/services/reconciliation/migrations/20260209000001_initial.sql
+++ b/services/reconciliation/migrations/20260209000001_initial.sql
@@ -1,6 +1,6 @@
 -- Reconciliation Service Schema
 -- Uses unqualified table names (relies on database-per-service architecture)
--- Tenant isolation via SET LOCAL search_path TO org_{tenant_id}, public
+-- Tenant isolation via SET LOCAL search_path TO org_{tenant_id}
 
 -- Create "settlement_run" table (CR - Command Record)
 CREATE TABLE "settlement_run" (

--- a/services/reference-data/accounttype/postgres_registry.go
+++ b/services/reference-data/accounttype/postgres_registry.go
@@ -50,7 +50,7 @@ func (r *PostgresRegistry) setSearchPath(ctx context.Context, tx pgx.Tx) error {
 	}
 
 	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
-	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	query := fmt.Sprintf("SET LOCAL search_path TO %s", schemaName)
 	_, err := tx.Exec(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to set tenant schema scope: %w", err)

--- a/services/reference-data/accounttype/postgres_registry_test.go
+++ b/services/reference-data/accounttype/postgres_registry_test.go
@@ -44,7 +44,7 @@ func seedInstrument(t *testing.T, pool *pgxpool.Pool, ctx context.Context, code 
 	tx, err := pool.Begin(ctx)
 	require.NoError(t, err)
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	query := `
@@ -751,7 +751,7 @@ func seedValuationMethod(t *testing.T, pool *pgxpool.Pool, ctx context.Context) 
 	tx, err := pool.Begin(ctx)
 	require.NoError(t, err)
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	query := `
@@ -780,7 +780,7 @@ func getSeededValuationMethodID(t *testing.T, pool *pgxpool.Pool, ctx context.Co
 	require.NoError(t, err)
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	var vmID uuid.UUID

--- a/services/reference-data/e2e/e2e_test.go
+++ b/services/reference-data/e2e/e2e_test.go
@@ -112,7 +112,7 @@ func applyReferenceDataSchema(t *testing.T, pool *pgxpool.Pool, schemaName strin
 	require.NoError(t, err)
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	// Create instrument_definition table
@@ -236,7 +236,7 @@ func applyPositionKeepingSchema(t *testing.T, pool *pgxpool.Pool, schemaName str
 	require.NoError(t, err)
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	// Create position table (append-only)
@@ -333,7 +333,7 @@ func seedSystemInstrument(t *testing.T, pool *pgxpool.Pool, ctx context.Context,
 	tx, err := pool.Begin(ctx)
 	require.NoError(t, err)
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	_, err = tx.Exec(ctx, query, code, dimension, precision)
@@ -356,7 +356,7 @@ func insertPositionErr(pool *pgxpool.Pool, ctx context.Context, accountID, instr
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	if _, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName))); err != nil {
+	if _, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName))); err != nil {
 		return uuid.Nil, err
 	}
 
@@ -395,7 +395,7 @@ func getAggregatedPosition(t *testing.T, pool *pgxpool.Pool, ctx context.Context
 	require.NoError(t, err)
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	var totalAmount decimal.Decimal
@@ -778,7 +778,7 @@ func TestE2E_BucketAggregation(t *testing.T) {
 		require.NoError(t, err)
 		defer func() { _ = tx.Rollback(ctx) }()
 
-		_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+		_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 		require.NoError(t, err)
 
 		// Query all aggregated positions for the account/instrument
@@ -1223,7 +1223,7 @@ func TestE2E_CrossServiceValidationFlow(t *testing.T) {
 		require.NoError(t, err)
 		defer func() { _ = tx.Rollback(ctx) }()
 
-		_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+		_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 		require.NoError(t, err)
 
 		var totalCredits decimal.Decimal
@@ -1393,7 +1393,7 @@ func TestE2E_HighVolumeAggregation(t *testing.T) {
 		tx, err := pool.Begin(ctx)
 		require.NoError(t, err)
 
-		_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+		_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 		require.NoError(t, err)
 
 		// Prepare batch insert
@@ -1428,7 +1428,7 @@ func TestE2E_HighVolumeAggregation(t *testing.T) {
 		require.NoError(t, err)
 		defer func() { _ = tx.Rollback(ctx) }()
 
-		_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+		_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 		require.NoError(t, err)
 
 		aggregateStart := time.Now()

--- a/services/reference-data/e2e/product_directory_e2e_test.go
+++ b/services/reference-data/e2e/product_directory_e2e_test.go
@@ -68,7 +68,7 @@ func applyAccountTypeSchema(t *testing.T, pool *pgxpool.Pool, schemaName string)
 	require.NoError(t, err)
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	// account_type_definitions table
@@ -128,7 +128,7 @@ func applyAccountTypeSchema(t *testing.T, pool *pgxpool.Pool, schemaName string)
 	require.NoError(t, err)
 	defer func() { _ = tx2.Rollback(ctx) }()
 
-	_, err = tx2.Exec(ctx, fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx2.Exec(ctx, fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	_, err = tx2.Exec(ctx, `
@@ -175,7 +175,7 @@ func applyAccountTypeSchema(t *testing.T, pool *pgxpool.Pool, schemaName string)
 	require.NoError(t, err)
 	defer func() { _ = tx3.Rollback(ctx) }()
 
-	_, err = tx3.Exec(ctx, fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx3.Exec(ctx, fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	_, err = tx3.Exec(ctx, `
@@ -196,7 +196,7 @@ func applySagaSchema(t *testing.T, pool *pgxpool.Pool, schemaName string) {
 	require.NoError(t, err)
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	_, err = tx.Exec(ctx, `
@@ -279,7 +279,7 @@ func seedInstrument(t *testing.T, pool *pgxpool.Pool, ctx context.Context, code,
 	require.NoError(t, err)
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	_, err = tx.Exec(ctx, `
@@ -306,7 +306,7 @@ func seedActiveSaga(t *testing.T, pool *pgxpool.Pool, ctx context.Context, name,
 	require.NoError(t, err)
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	_, err = tx.Exec(ctx, `
@@ -346,7 +346,7 @@ func countActiveDefinitions(t *testing.T, pool *pgxpool.Pool, ctx context.Contex
 	require.NoError(t, err)
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	var count int
@@ -368,7 +368,7 @@ func countAllDefinitions(t *testing.T, pool *pgxpool.Pool, ctx context.Context, 
 	require.NoError(t, err)
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	var count int

--- a/services/reference-data/mapping/repository.go
+++ b/services/reference-data/mapping/repository.go
@@ -48,7 +48,7 @@ func (r *PostgresRepository) setSearchPath(ctx context.Context, tx pgx.Tx) error
 	}
 
 	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
-	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	query := fmt.Sprintf("SET LOCAL search_path TO %s", schemaName)
 	_, err := tx.Exec(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to set tenant schema scope: %w", err)

--- a/services/reference-data/node/postgres_repository.go
+++ b/services/reference-data/node/postgres_repository.go
@@ -35,7 +35,7 @@ func (r *PostgresRepository) setSearchPath(ctx context.Context, tx pgx.Tx) error
 		return tenant.ErrMissingTenantContext
 	}
 	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
-	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	query := fmt.Sprintf("SET LOCAL search_path TO %s", schemaName)
 	_, err := tx.Exec(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to set tenant schema scope: %w", err)

--- a/services/reference-data/registry/postgres_registry.go
+++ b/services/reference-data/registry/postgres_registry.go
@@ -53,7 +53,7 @@ func (r *PostgresRegistry) setSearchPath(ctx context.Context, tx pgx.Tx) error {
 	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
 
 	// SET LOCAL is transaction-scoped - automatically reverts on commit/rollback
-	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	query := fmt.Sprintf("SET LOCAL search_path TO %s", schemaName)
 	_, err := tx.Exec(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to set tenant schema scope: %w", err)

--- a/services/reference-data/registry/postgres_registry_test.go
+++ b/services/reference-data/registry/postgres_registry_test.go
@@ -54,7 +54,7 @@ func seedSystemInstrument(t *testing.T, pool *pgxpool.Pool, ctx context.Context,
 	tx, err := pool.Begin(ctx)
 	require.NoError(t, err)
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	_, err = tx.Exec(ctx, query, code)

--- a/services/reference-data/registry/seeder.go
+++ b/services/reference-data/registry/seeder.go
@@ -1,0 +1,121 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// namespaceInstrument is the fixed UUID namespace for deterministic instrument IDs.
+var namespaceInstrument = uuid.MustParse("6ba7b812-9dad-11d1-80b4-00c04fd430c8")
+
+// platformInstrumentSpec defines a platform-level instrument definition.
+type platformInstrumentSpec struct {
+	Code        string
+	Dimension   Dimension
+	Precision   int
+	DisplayName string
+	Description string
+}
+
+// platformInstruments defines the canonical platform instruments covering all
+// dimensions referenced by the platform account type blueprints. These are seeded
+// into every new tenant as system definitions with IsSystem=true.
+var platformInstruments = []platformInstrumentSpec{
+	{Code: "GBP", Dimension: DimensionMonetary, Precision: 2, DisplayName: "British Pound Sterling", Description: "ISO 4217 currency: GBP"},
+	{Code: "USD", Dimension: DimensionMonetary, Precision: 2, DisplayName: "US Dollar", Description: "ISO 4217 currency: USD"},
+	{Code: "EUR", Dimension: DimensionMonetary, Precision: 2, DisplayName: "Euro", Description: "ISO 4217 currency: EUR"},
+	{Code: "TONNE_CO2E", Dimension: DimensionCarbon, Precision: 6, DisplayName: "Tonne CO2 Equivalent", Description: "Carbon credit unit - tonnes of CO2 equivalent"},
+	{Code: "KWH", Dimension: DimensionEnergy, Precision: 3, DisplayName: "Kilowatt Hour", Description: "Energy unit - kilowatt hours"},
+}
+
+// InstrumentSeeder seeds platform instrument definitions into tenant schemas.
+type InstrumentSeeder struct {
+	pool   *pgxpool.Pool
+	logger *slog.Logger
+}
+
+// NewInstrumentSeeder creates a new InstrumentSeeder.
+func NewInstrumentSeeder(pool *pgxpool.Pool) *InstrumentSeeder {
+	return &InstrumentSeeder{
+		pool:   pool,
+		logger: slog.Default().With("component", "instrument_seeder"),
+	}
+}
+
+// SeedTenant seeds all platform instruments into a specific tenant's schema.
+// Idempotent: uses ON CONFLICT (code, version) DO NOTHING.
+func (s *InstrumentSeeder) SeedTenant(ctx context.Context, tenantID tenant.TenantID) error {
+	logger := s.logger.With("tenant_id", tenantID.String())
+	logger.Info("seeding platform instruments")
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
+	if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", schemaName)); err != nil {
+		return fmt.Errorf("set search_path: %w", err)
+	}
+
+	seeded := 0
+	for _, inst := range platformInstruments {
+		inserted, seedErr := s.seedInstrument(ctx, tx, inst)
+		if seedErr != nil {
+			return fmt.Errorf("seed %s: %w", inst.Code, seedErr)
+		}
+		if inserted {
+			seeded++
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+
+	logger.Info("platform instruments seeded",
+		"total", len(platformInstruments),
+		"seeded", seeded,
+		"skipped", len(platformInstruments)-seeded)
+	return nil
+}
+
+func (s *InstrumentSeeder) seedInstrument(ctx context.Context, tx pgx.Tx, spec platformInstrumentSpec) (bool, error) {
+	id := uuid.NewSHA1(namespaceInstrument, []byte(spec.Code))
+	now := time.Now()
+
+	result, err := tx.Exec(ctx, `
+		INSERT INTO instrument_definition (
+			id, code, version, dimension, precision, status, is_system,
+			fungibility_key_expression, display_name, description,
+			created_at, updated_at, activated_at
+		) VALUES (
+			$1, $2, 1, $3, $4, 'ACTIVE', true,
+			'', $5, $6,
+			$7, $8, $9
+		) ON CONFLICT (code, version) DO NOTHING`,
+		id, spec.Code, string(spec.Dimension), spec.Precision,
+		spec.DisplayName, spec.Description,
+		now, now, now,
+	)
+	if err != nil {
+		return false, fmt.Errorf("insert instrument: %w", err)
+	}
+
+	return result.RowsAffected() > 0, nil
+}
+
+// AsPostProvisioningHook returns a function compatible with the provisioning worker's
+// PostProvisioningHook signature.
+func (s *InstrumentSeeder) AsPostProvisioningHook() func(ctx context.Context, tenantID tenant.TenantID) error {
+	return s.SeedTenant
+}

--- a/services/reference-data/saga/e2e_seeder_test.go
+++ b/services/reference-data/saga/e2e_seeder_test.go
@@ -11,15 +11,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestE2E_ProvisioningOverrideMigration exercises the full lifecycle:
+// TestE2E_ProvisioningOverride exercises the full lifecycle:
 // 1. Sync platform defaults
-// 2. Provision a new tenant (seeder creates platform_ref entries)
-// 3. Verify platform fallback resolution works
+// 2. Provision a new tenant (seeder copies scripts directly into tenant schema)
+// 3. Verify scripts are resolved from tenant schema (no public fallback)
 // 4. Override a saga with custom script
-// 5. Verify override takes priority over platform default
-// 6. Provision another tenant with old-style copies
-// 7. Migrate old tenant to platform refs
-func TestE2E_ProvisioningOverrideMigration(t *testing.T) {
+// 5. Verify override takes priority over system default
+func TestE2E_ProvisioningOverride(t *testing.T) {
 	pool, cleanup := setupPlatformTestDB(t)
 	defer cleanup()
 
@@ -30,7 +28,7 @@ func TestE2E_ProvisioningOverrideMigration(t *testing.T) {
 	err := platformSync.SyncPlatformDefaults(ctx)
 	require.NoError(t, err)
 
-	// Step 2: Provision tenant alpha (new-style with platform_ref)
+	// Step 2: Provision tenant alpha (scripts copied directly into tenant schema)
 	alphaID := tenant.TenantID("alpha_corp")
 	alphaSchema := alphaID.SchemaName()
 	setupTenantSchemaForSeeder(t, pool, ctx, alphaSchema)
@@ -40,16 +38,19 @@ func TestE2E_ProvisioningOverrideMigration(t *testing.T) {
 	err = seeder.SeedTenant(ctx, alphaID)
 	require.NoError(t, err)
 
-	// Step 3: Verify platform fallback resolution
+	// Step 3: Verify scripts are self-contained in tenant schema
 	alphaCtx := tenant.WithTenant(ctx, alphaID)
 	registry := NewPostgresRegistry(pool, nil)
 
 	activeDef, err := registry.GetActive(alphaCtx, "current_account_withdrawal")
 	require.NoError(t, err)
 	assert.True(t, activeDef.IsSystem, "should resolve system saga")
-	assert.True(t, activeDef.UsedPlatformFallback, "should use platform fallback")
+	assert.False(t, activeDef.UsedPlatformFallback,
+		"should not use platform fallback - scripts copied directly")
 	assert.NotEmpty(t, activeDef.ResolvedScript, "resolved script should not be empty")
-	assert.NotNil(t, activeDef.PlatformRef, "platform_ref should be set")
+	assert.NotEmpty(t, activeDef.Script, "script should be copied directly into tenant")
+	assert.Nil(t, activeDef.PlatformRef,
+		"platform_ref should be nil - scripts are self-contained")
 
 	// Step 4: Create tenant override
 	overrideSvc := NewOverrideService(pool, registry)
@@ -95,55 +96,13 @@ def posting_rules(ctx):
 	assert.Equal(t, "Alpha Corp requires UK compliance checks on all withdrawals",
 		activeDef.OverrideReason)
 
-	// Non-overridden sagas should still use platform fallback
+	// Non-overridden sagas should resolve from tenant's own script copy
 	depositDef, err := registry.GetActive(alphaCtx, "current_account_deposit")
 	require.NoError(t, err)
 	assert.True(t, depositDef.IsSystem, "deposit should still use system saga")
-	assert.True(t, depositDef.UsedPlatformFallback, "deposit should use platform fallback")
-
-	// Step 6: Provision tenant beta (old-style with script copies)
-	betaID := tenant.TenantID("beta_corp")
-	betaSchema := betaID.SchemaName()
-	setupTenantSchemaForSeeder(t, pool, ctx, betaSchema)
-
-	// Insert old-style script-copied sagas
-	scripts, err := GetEmbeddedScripts()
-	require.NoError(t, err)
-
-	e2eDefaults, e2eDefaultsErr := PlatformDefaults()
-	require.NoError(t, e2eDefaultsErr)
-	for _, meta := range e2eDefaults {
-		script, ok := scripts[meta.Filename+".star"]
-		require.True(t, ok, "expected embedded script %s.star", meta.Filename)
-		require.NotEmpty(t, script)
-		_, err := pool.Exec(ctx, `
-			INSERT INTO `+betaSchema+`.saga_definition (
-				name, version, script, status, is_system,
-				display_name, description, created_at, updated_at, activated_at
-			) VALUES ($1, 1, $2, 'ACTIVE', true, $3, $4, now(), now(), now())`,
-			meta.Name, script, meta.DisplayName, meta.Description)
-		require.NoError(t, err)
-	}
-
-	// Step 7: Migrate beta to platform refs
-	migrationResults, err := overrideSvc.MigrateToPlatformRef(ctx, betaID, false)
-	require.NoError(t, err)
-
-	migratedCount := 0
-	for _, r := range migrationResults {
-		if r.Action == "migrated" {
-			migratedCount++
-		}
-	}
-	assert.Equal(t, 8, migratedCount, "all 8 sagas should be migrated")
-
-	// Verify beta's sagas now use platform_ref
-	betaCtx := tenant.WithTenant(ctx, betaID)
-	betaWithdrawal, err := registry.GetActive(betaCtx, "current_account_withdrawal")
-	require.NoError(t, err)
-	assert.True(t, betaWithdrawal.IsSystem)
-	assert.NotNil(t, betaWithdrawal.PlatformRef, "should now have platform_ref")
-	assert.True(t, betaWithdrawal.UsedPlatformFallback, "should use platform fallback after migration")
+	assert.False(t, depositDef.UsedPlatformFallback,
+		"deposit should use copied script, not platform fallback")
+	assert.NotEmpty(t, depositDef.ResolvedScript, "deposit should have script content")
 }
 
 // TestE2E_SeededSagasAreActive verifies that seeded sagas are immediately ACTIVE.
@@ -165,18 +124,23 @@ func TestE2E_SeededSagasAreActive(t *testing.T) {
 	err = seeder.SeedTenant(ctx, tenantID)
 	require.NoError(t, err)
 
-	// Verify all seeded sagas are ACTIVE
+	// Verify all seeded sagas are ACTIVE with scripts copied directly
 	rows, err := pool.Query(ctx,
-		"SELECT name, status FROM "+schemaName+".saga_definition WHERE is_system = true ORDER BY name")
+		"SELECT name, status, script FROM "+schemaName+".saga_definition WHERE is_system = true ORDER BY name")
 	require.NoError(t, err)
 	defer rows.Close()
 
 	var count int
 	for rows.Next() {
 		var name, status string
-		err := rows.Scan(&name, &status)
+		var script *string
+		err := rows.Scan(&name, &status, &script)
 		require.NoError(t, err)
 		assert.Equal(t, "ACTIVE", status, "seeded saga %s should be ACTIVE", name)
+		assert.NotNil(t, script, "seeded saga %s should have script content (not NULL)", name)
+		if script != nil {
+			assert.NotEmpty(t, *script, "seeded saga %s should have non-empty script", name)
+		}
 		count++
 	}
 	require.NoError(t, rows.Err())

--- a/services/reference-data/saga/fallback_resolution_test.go
+++ b/services/reference-data/saga/fallback_resolution_test.go
@@ -37,7 +37,9 @@ func seedPlatformSaga(t *testing.T, pool *pgxpool.Pool, ctx context.Context, nam
 }
 
 // seedTenantSagaWithPlatformRef inserts a saga_definition with platform_ref into a tenant schema.
-// The saga has NULL script and inherits from the platform.
+// The saga has NULL script - a legacy pattern from before tenant isolation.
+// With tenant isolation, the read queries no longer JOIN to public.platform_saga_definition,
+// so these sagas will have empty ResolvedScript.
 func seedTenantSagaWithPlatformRef(
 	t *testing.T, pool *pgxpool.Pool, ctx context.Context,
 	name string, version int, platformRefID uuid.UUID, status string,
@@ -84,6 +86,54 @@ func seedTenantSagaWithPlatformRef(
 	return id
 }
 
+// seedTenantSagaWithScript inserts a saga_definition with an actual script into a tenant schema.
+// This is the new model: scripts are copied directly into tenant schemas.
+func seedTenantSagaWithScript(
+	t *testing.T, pool *pgxpool.Pool, ctx context.Context,
+	name string, version int, script, status string,
+) uuid.UUID {
+	t.Helper()
+
+	tenantID, _ := tenant.FromContext(ctx)
+	schemaName := tenantID.SchemaName()
+
+	id := uuid.New()
+	isActive := status == "ACTIVE"
+
+	var query string
+	if isActive {
+		query = `
+			INSERT INTO saga_definition (
+				id, name, version, script, status, is_system,
+				created_at, updated_at, activated_at
+			) VALUES (
+				$1, $2, $3, $4, $5, false,
+				NOW(), NOW(), NOW()
+			)`
+	} else {
+		query = `
+			INSERT INTO saga_definition (
+				id, name, version, script, status, is_system,
+				created_at, updated_at
+			) VALUES (
+				$1, $2, $3, $4, $5, false,
+				NOW(), NOW()
+			)`
+	}
+
+	tx, err := pool.Begin(ctx)
+	require.NoError(t, err)
+
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
+	require.NoError(t, err)
+
+	_, err = tx.Exec(ctx, query, id, name, version, script, status)
+	require.NoError(t, err)
+
+	require.NoError(t, tx.Commit(ctx))
+	return id
+}
+
 // --- Subtask 8.1: Schema extension tests ---
 
 func TestFallbackResolution_SchemaConstraints(t *testing.T) {
@@ -97,9 +147,6 @@ func TestFallbackResolution_SchemaConstraints(t *testing.T) {
 	})
 
 	t.Run("allows saga with neither script nor platform_ref for ON DELETE SET NULL compatibility", func(t *testing.T) {
-		// NOTE: The constraint allows this state because ON DELETE SET NULL on the
-		// platform_ref FK can create orphaned sagas. Application logic handles validation
-		// of "at least one source" during create/update operations.
 		tenantID, _ := tenant.FromContext(ctx)
 		schemaName := tenantID.SchemaName()
 
@@ -152,31 +199,42 @@ func TestFallbackResolution_SchemaConstraints(t *testing.T) {
 	})
 }
 
-// --- Subtask 8.2: COALESCE fallback resolution tests ---
+// --- Subtask 8.2: Tenant isolation - no public schema fallback ---
 
-func TestFallbackResolution_GetActive_PlatformFallback(t *testing.T) {
+func TestFallbackResolution_GetActive_NoPublicFallback(t *testing.T) {
 	reg, pool := setupTestRegistry(t)
 	ctx := setupTenantContext(t, pool, "test-fallback-getactive")
 
-	t.Run("resolves script via platform fallback when tenant has platform_ref", func(t *testing.T) {
+	t.Run("legacy platform_ref saga has empty resolved script (no fallback)", func(t *testing.T) {
 		platformScript := "def posting_rules(ctx):\n    return ['platform_step1', 'platform_step2']"
 		platformID := seedPlatformSaga(t, pool, ctx, "fb_platform_test", platformScript)
 
-		// Create tenant saga with platform_ref (no custom script)
+		// Create tenant saga with platform_ref (no custom script) - legacy pattern
 		seedTenantSagaWithPlatformRef(t, pool, ctx, "fb_platform_test", 1, platformID, "ACTIVE")
 
-		// GetActive should resolve using platform script via COALESCE
+		// With tenant isolation, the read query no longer JOINs to public.platform_saga_definition
 		result, err := reg.GetActive(ctx, "fb_platform_test")
 		require.NoError(t, err)
-		assert.Equal(t, platformScript, result.ResolvedScript,
-			"ResolvedScript should contain platform script via COALESCE")
-		assert.True(t, result.UsedPlatformFallback,
-			"UsedPlatformFallback should be true")
+		assert.Equal(t, "", result.ResolvedScript,
+			"ResolvedScript should be empty - no public schema fallback")
+		assert.False(t, result.UsedPlatformFallback,
+			"UsedPlatformFallback should be false - fallback removed")
 		assert.Equal(t, "", result.Script,
 			"Script (tenant's own) should be empty")
 		assert.NotNil(t, result.PlatformRef,
-			"PlatformRef should be set")
+			"PlatformRef should still be set in the DB")
 		assert.Equal(t, platformID, *result.PlatformRef)
+	})
+
+	t.Run("saga with copied script resolves correctly", func(t *testing.T) {
+		tenantScript := "def posting_rules(ctx):\n    return ['tenant_custom_step']"
+		seedTenantSagaWithScript(t, pool, ctx, "fb_copied_script", 1, tenantScript, "ACTIVE")
+
+		result, err := reg.GetActive(ctx, "fb_copied_script")
+		require.NoError(t, err)
+		assert.Equal(t, tenantScript, result.ResolvedScript)
+		assert.False(t, result.UsedPlatformFallback)
+		assert.Nil(t, result.PlatformRef)
 	})
 
 	t.Run("returns tenant override script when tenant has custom script", func(t *testing.T) {
@@ -194,28 +252,28 @@ func TestFallbackResolution_GetActive_PlatformFallback(t *testing.T) {
 		result, err := reg.GetActive(ctx, "fb_tenant_override")
 		require.NoError(t, err)
 		assert.Equal(t, tenantScript, result.ResolvedScript)
-		assert.False(t, result.UsedPlatformFallback,
-			"UsedPlatformFallback should be false for custom scripts")
-		assert.Nil(t, result.PlatformRef,
-			"PlatformRef should be nil for custom scripts")
+		assert.False(t, result.UsedPlatformFallback)
+		assert.Nil(t, result.PlatformRef)
 	})
 
 	t.Run("tenant override takes precedence over system saga", func(t *testing.T) {
-		// Seed platform definition
-		platformScript := "def posting_rules(ctx): return 'system'"
-		platformID := seedPlatformSaga(t, pool, ctx, "fb_precedence", platformScript)
-
 		// Seed system saga (is_system=true, has script)
 		seedSystemSaga(t, pool, ctx, "fb_precedence")
 
-		// Create tenant override with platform_ref (should be chosen over system saga)
-		seedTenantSagaWithPlatformRef(t, pool, ctx, "fb_precedence", 2, platformID, "ACTIVE")
+		// Create tenant override (version 2, since system saga has version 1)
+		tenantDef := &saga.Definition{
+			Name:    "fb_precedence",
+			Version: 2,
+			Script:  "def posting_rules(ctx): return 'tenant'",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, tenantDef))
+		require.NoError(t, reg.ActivateSaga(ctx, tenantDef.ID))
 
 		result, err := reg.GetActive(ctx, "fb_precedence")
 		require.NoError(t, err)
 		assert.False(t, result.IsSystem,
 			"tenant override should be returned, not system saga")
-		assert.True(t, result.UsedPlatformFallback)
+		assert.False(t, result.UsedPlatformFallback)
 	})
 
 	t.Run("returns platform default when no tenant override exists", func(t *testing.T) {
@@ -228,11 +286,11 @@ func TestFallbackResolution_GetActive_PlatformFallback(t *testing.T) {
 	})
 }
 
-func TestFallbackResolution_GetByID_PlatformFallback(t *testing.T) {
+func TestFallbackResolution_GetByID_NoPublicFallback(t *testing.T) {
 	reg, pool := setupTestRegistry(t)
 	ctx := setupTenantContext(t, pool, "test-fallback-getbyid")
 
-	t.Run("GetByID resolves platform script via COALESCE", func(t *testing.T) {
+	t.Run("GetByID returns empty resolved script for legacy platform_ref saga", func(t *testing.T) {
 		platformScript := "def posting_rules(ctx): return 'from_platform'"
 		platformID := seedPlatformSaga(t, pool, ctx, "getbyid_platform", platformScript)
 
@@ -240,16 +298,27 @@ func TestFallbackResolution_GetByID_PlatformFallback(t *testing.T) {
 
 		result, err := reg.GetByID(ctx, sagaID)
 		require.NoError(t, err)
-		assert.Equal(t, platformScript, result.ResolvedScript)
-		assert.True(t, result.UsedPlatformFallback)
+		assert.Equal(t, "", result.ResolvedScript,
+			"ResolvedScript should be empty - no fallback")
+		assert.False(t, result.UsedPlatformFallback)
+	})
+
+	t.Run("GetByID returns script for saga with copied script", func(t *testing.T) {
+		script := "def posting_rules(ctx): return 'direct'"
+		sagaID := seedTenantSagaWithScript(t, pool, ctx, "getbyid_direct", 1, script, "ACTIVE")
+
+		result, err := reg.GetByID(ctx, sagaID)
+		require.NoError(t, err)
+		assert.Equal(t, script, result.ResolvedScript)
+		assert.False(t, result.UsedPlatformFallback)
 	})
 }
 
-func TestFallbackResolution_GetDefinition_PlatformFallback(t *testing.T) {
+func TestFallbackResolution_GetDefinition_NoPublicFallback(t *testing.T) {
 	reg, pool := setupTestRegistry(t)
 	ctx := setupTenantContext(t, pool, "test-fallback-getdef")
 
-	t.Run("GetDefinition resolves platform script via COALESCE", func(t *testing.T) {
+	t.Run("GetDefinition returns empty resolved script for legacy platform_ref saga", func(t *testing.T) {
 		platformScript := "def posting_rules(ctx): return 'getdef_platform'"
 		platformID := seedPlatformSaga(t, pool, ctx, "getdef_test", platformScript)
 
@@ -257,22 +326,23 @@ func TestFallbackResolution_GetDefinition_PlatformFallback(t *testing.T) {
 
 		result, err := reg.GetDefinition(ctx, "getdef_test", 1)
 		require.NoError(t, err)
-		assert.Equal(t, platformScript, result.ResolvedScript)
-		assert.True(t, result.UsedPlatformFallback)
+		assert.Equal(t, "", result.ResolvedScript,
+			"ResolvedScript should be empty - no fallback")
+		assert.False(t, result.UsedPlatformFallback)
 	})
 }
 
-func TestFallbackResolution_ListByStatus_PlatformFallback(t *testing.T) {
+func TestFallbackResolution_ListByStatus_NoPublicFallback(t *testing.T) {
 	reg, pool := setupTestRegistry(t)
 	ctx := setupTenantContext(t, pool, "test-fallback-list")
 
 	platformScript := "def posting_rules(ctx): return 'list_platform'"
 	platformID := seedPlatformSaga(t, pool, ctx, "list_fb_test", platformScript)
 
-	// Create saga with platform_ref
+	// Create saga with platform_ref (legacy pattern)
 	seedTenantSagaWithPlatformRef(t, pool, ctx, "list_fb_test", 1, platformID, "ACTIVE")
 
-	// Also create a regular saga
+	// Also create a regular saga with actual script
 	regularDef := &saga.Definition{
 		Name:    "list_regular",
 		Version: 1,
@@ -281,7 +351,7 @@ func TestFallbackResolution_ListByStatus_PlatformFallback(t *testing.T) {
 	require.NoError(t, reg.CreateDraft(ctx, regularDef))
 	require.NoError(t, reg.ActivateSaga(ctx, regularDef.ID))
 
-	t.Run("ListByStatus includes resolved platform scripts", func(t *testing.T) {
+	t.Run("ListByStatus shows empty script for legacy platform_ref and real script for regular", func(t *testing.T) {
 		results, err := reg.ListByStatus(ctx, saga.StatusActive)
 		require.NoError(t, err)
 		require.True(t, len(results) >= 2)
@@ -297,8 +367,9 @@ func TestFallbackResolution_ListByStatus_PlatformFallback(t *testing.T) {
 		}
 
 		require.NotNil(t, platformRefSaga, "should find platform-ref saga")
-		assert.Equal(t, platformScript, platformRefSaga.ResolvedScript)
-		assert.True(t, platformRefSaga.UsedPlatformFallback)
+		assert.Equal(t, "", platformRefSaga.ResolvedScript,
+			"legacy platform_ref saga should have empty resolved script")
+		assert.False(t, platformRefSaga.UsedPlatformFallback)
 
 		require.NotNil(t, regularSaga, "should find regular saga")
 		assert.Equal(t, "def posting_rules(ctx): return 'regular'", regularSaga.ResolvedScript)
@@ -306,7 +377,7 @@ func TestFallbackResolution_ListByStatus_PlatformFallback(t *testing.T) {
 	})
 }
 
-// --- Subtask 8.2 negative: platform_ref pointing to deleted platform saga ---
+// --- Legacy platform_ref saga behavior ---
 
 func TestFallbackResolution_DeletedPlatformSaga(t *testing.T) {
 	reg, pool := setupTestRegistry(t)
@@ -319,18 +390,17 @@ func TestFallbackResolution_DeletedPlatformSaga(t *testing.T) {
 		// Create tenant saga pointing to it
 		seedTenantSagaWithPlatformRef(t, pool, ctx, "deleted_platform_test", 1, platformID, "ACTIVE")
 
-		// Delete the platform saga
+		// Delete the platform saga (ON DELETE SET NULL clears platform_ref)
 		_, err := pool.Exec(ctx,
 			"DELETE FROM public.platform_saga_definition WHERE id = $1", platformID)
 		require.NoError(t, err)
 
-		// GetActive should return empty resolved script (LEFT JOIN produces NULL)
+		// GetActive should return empty resolved script
 		result, err := reg.GetActive(ctx, "deleted_platform_test")
 		require.NoError(t, err)
 		assert.Equal(t, "", result.ResolvedScript,
 			"resolved script should be empty when platform definition is deleted")
-		assert.False(t, result.UsedPlatformFallback,
-			"platform fallback flag should be false when platform is missing")
+		assert.False(t, result.UsedPlatformFallback)
 	})
 }
 
@@ -372,27 +442,24 @@ func TestFallbackResolution_VersionPinning(t *testing.T) {
 
 	vp := saga.NewVersionPinning(reg)
 
-	t.Run("PinVersion pins platform version on instance", func(t *testing.T) {
-		platformScript := "def posting_rules(ctx): return 'pinned'"
-		platformID := seedPlatformSaga(t, pool, ctx, "pin_test", platformScript)
-		seedTenantSagaWithPlatformRef(t, pool, ctx, "pin_test", 1, platformID, "ACTIVE")
+	t.Run("PinVersion pins saga with copied script", func(t *testing.T) {
+		script := "def posting_rules(ctx): return 'pinned'"
+		seedTenantSagaWithScript(t, pool, ctx, "pin_test", 1, script, "ACTIVE")
 
-		// Create a new saga instance
 		instance := &pkgsaga.SagaInstance{}
 
 		def, err := vp.PinVersion(ctx, instance, "pin_test")
 		require.NoError(t, err)
 
 		assert.Equal(t, "pin_test", def.Name)
-		assert.Equal(t, platformScript, def.ResolvedScript)
-		assert.NotNil(t, instance.PlatformSagaVersionID,
-			"PlatformSagaVersionID should be set for platform-ref sagas")
-		assert.Equal(t, platformID, *instance.PlatformSagaVersionID)
+		assert.Equal(t, script, def.ResolvedScript)
+		assert.Nil(t, instance.PlatformSagaVersionID,
+			"PlatformSagaVersionID should be nil for sagas with direct scripts")
 		assert.NotEmpty(t, instance.ScriptHashAtStart)
-		assert.Equal(t, saga.ComputeScriptHash(platformScript), instance.ScriptHashAtStart)
+		assert.Equal(t, saga.ComputeScriptHash(script), instance.ScriptHashAtStart)
 	})
 
-	t.Run("PinVersion does not pin platform version for custom scripts", func(t *testing.T) {
+	t.Run("PinVersion works for custom tenant scripts", func(t *testing.T) {
 		tenantScript := "def posting_rules(ctx): return 'custom'"
 		tenantDef := &saga.Definition{
 			Name:    "pin_custom_test",
@@ -429,12 +496,13 @@ func TestFallbackResolution_ResolveForReplay(t *testing.T) {
 
 	vp := saga.NewVersionPinning(reg)
 
-	t.Run("replay resolves pinned platform version", func(t *testing.T) {
+	t.Run("replay resolves pinned platform version directly", func(t *testing.T) {
+		// Platform saga lookup bypasses search_path (queries public directly)
 		platformScript := "def posting_rules(ctx): return 'pinned_v1'"
 		platformID := seedPlatformSaga(t, pool, ctx, "replay_pin_test", platformScript)
-		sagaID := seedTenantSagaWithPlatformRef(t, pool, ctx, "replay_pin_test", 1, platformID, "ACTIVE")
+		sagaID := seedTenantSagaWithScript(t, pool, ctx, "replay_pin_test", 1, platformScript, "ACTIVE")
 
-		// Simulate a pinned instance
+		// Simulate a pinned instance from the old model (with PlatformSagaVersionID)
 		instance := &pkgsaga.SagaInstance{
 			ID:                    uuid.New(),
 			SagaDefinitionID:      sagaID,
@@ -472,7 +540,7 @@ func TestFallbackResolution_ResolveForReplay(t *testing.T) {
 		// Original platform saga
 		originalScript := "def posting_rules(ctx): return 'original'"
 		platformID := seedPlatformSaga(t, pool, ctx, "replay_update_test", originalScript)
-		sagaID := seedTenantSagaWithPlatformRef(t, pool, ctx, "replay_update_test", 1, platformID, "ACTIVE")
+		sagaID := seedTenantSagaWithScript(t, pool, ctx, "replay_update_test", 1, originalScript, "ACTIVE")
 
 		// Pin version on instance (using original script)
 		instance := &pkgsaga.SagaInstance{
@@ -494,11 +562,9 @@ func TestFallbackResolution_ResolveForReplay(t *testing.T) {
 		assert.ErrorIs(t, err, saga.ErrScriptHashMismatch)
 	})
 
-	t.Run("new instance uses NEW platform version after update", func(t *testing.T) {
-		// Create new platform saga
+	t.Run("new instance uses current script", func(t *testing.T) {
 		newScript := "def posting_rules(ctx): return 'new_version'"
-		platformID := seedPlatformSaga(t, pool, ctx, "replay_newversion_test", newScript)
-		seedTenantSagaWithPlatformRef(t, pool, ctx, "replay_newversion_test", 1, platformID, "ACTIVE")
+		seedTenantSagaWithScript(t, pool, ctx, "replay_newversion_test", 1, newScript, "ACTIVE")
 
 		// Pin version on NEW instance (should use current script)
 		instance := &pkgsaga.SagaInstance{}
@@ -524,7 +590,7 @@ func TestFallbackResolution_ResolveForReplay_Negative(t *testing.T) {
 	t.Run("replay fails when pinned platform version is deleted", func(t *testing.T) {
 		platformScript := "def posting_rules(ctx): return 'soon_deleted'"
 		platformID := seedPlatformSaga(t, pool, ctx, "replay_deleted_test", platformScript)
-		sagaID := seedTenantSagaWithPlatformRef(t, pool, ctx, "replay_deleted_test", 1, platformID, "ACTIVE")
+		sagaID := seedTenantSagaWithScript(t, pool, ctx, "replay_deleted_test", 1, platformScript, "ACTIVE")
 
 		instance := &pkgsaga.SagaInstance{
 			ID:                    uuid.New(),
@@ -533,13 +599,12 @@ func TestFallbackResolution_ResolveForReplay_Negative(t *testing.T) {
 			ScriptHashAtStart:     saga.ComputeScriptHash(platformScript),
 		}
 
-		// Delete the platform saga (ON DELETE SET NULL will null out saga_definition.platform_ref)
+		// Delete the platform saga
 		_, err := pool.Exec(ctx,
 			"DELETE FROM public.platform_saga_definition WHERE id = $1", platformID)
 		require.NoError(t, err)
 
 		// Replay should fail because the saga instance still references the platform version
-		// via PlatformSagaVersionID (which is NOT affected by ON DELETE SET NULL on saga_definition.platform_ref)
 		_, err = vp.ResolveForReplay(ctx, instance)
 		require.Error(t, err, "replay should fail when pinned platform version is deleted")
 		assert.ErrorIs(t, err, saga.ErrPinnedVersionNotFound)
@@ -548,7 +613,7 @@ func TestFallbackResolution_ResolveForReplay_Negative(t *testing.T) {
 	t.Run("replay fails with corrupted script hash", func(t *testing.T) {
 		platformScript := "def posting_rules(ctx): return 'original'"
 		platformID := seedPlatformSaga(t, pool, ctx, "replay_corrupt_test", platformScript)
-		sagaID := seedTenantSagaWithPlatformRef(t, pool, ctx, "replay_corrupt_test", 1, platformID, "ACTIVE")
+		sagaID := seedTenantSagaWithScript(t, pool, ctx, "replay_corrupt_test", 1, platformScript, "ACTIVE")
 
 		instance := &pkgsaga.SagaInstance{
 			ID:                    uuid.New(),
@@ -581,13 +646,14 @@ func TestFallbackResolution_CreateDraft_PlatformRef(t *testing.T) {
 		err := reg.CreateDraft(ctx, def)
 		require.NoError(t, err)
 
-		// Verify via GetByID
+		// Verify via GetByID - with tenant isolation, no fallback resolution
 		result, err := reg.GetByID(ctx, def.ID)
 		require.NoError(t, err)
 		assert.NotNil(t, result.PlatformRef)
 		assert.Equal(t, platformID, *result.PlatformRef)
-		assert.Equal(t, "def posting_rules(ctx): pass", result.ResolvedScript)
-		assert.True(t, result.UsedPlatformFallback)
+		assert.Equal(t, "", result.ResolvedScript,
+			"ResolvedScript should be empty - no public schema fallback")
+		assert.False(t, result.UsedPlatformFallback)
 	})
 }
 

--- a/services/reference-data/saga/fallback_resolution_test.go
+++ b/services/reference-data/saga/fallback_resolution_test.go
@@ -74,7 +74,7 @@ func seedTenantSagaWithPlatformRef(
 	tx, err := pool.Begin(ctx)
 	require.NoError(t, err)
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	_, err = tx.Exec(ctx, query, id, name, version, status, platformRefID)
@@ -106,7 +106,7 @@ func TestFallbackResolution_SchemaConstraints(t *testing.T) {
 		tx, err := pool.Begin(ctx)
 		require.NoError(t, err)
 
-		_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+		_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 		require.NoError(t, err)
 
 		// Insert with NULL script AND no platform_ref -- allowed at DB level
@@ -132,7 +132,7 @@ func TestFallbackResolution_SchemaConstraints(t *testing.T) {
 		tx, err := pool.Begin(ctx)
 		require.NoError(t, err)
 
-		_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+		_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 		require.NoError(t, err)
 
 		// Try to insert with BOTH script AND platform_ref

--- a/services/reference-data/saga/grpc_handler_test.go
+++ b/services/reference-data/saga/grpc_handler_test.go
@@ -48,7 +48,7 @@ func setupTestPostgres(t *testing.T) (*pgxpool.Pool, tenant.TenantID, func()) {
 	_, err = pool.Exec(ctx, "CREATE SCHEMA IF NOT EXISTS "+schemaName)
 	require.NoError(t, err)
 
-	// Create platform_saga_definition in public schema (needed for LEFT JOINs in queries)
+	// Create platform_saga_definition in public schema (needed for FK constraints and platform-level operations)
 	platformTableSQL := `
 		CREATE TABLE IF NOT EXISTS public.platform_saga_definition (
 			id uuid NOT NULL DEFAULT gen_random_uuid(),

--- a/services/reference-data/saga/override_api.go
+++ b/services/reference-data/saga/override_api.go
@@ -283,7 +283,7 @@ func (s *OverrideService) runMigrationTx(
 		_ = tx.Rollback(ctx)
 	}()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", schemaName))
 	if err != nil {
 		return nil, fmt.Errorf("set search_path: %w", err)
 	}

--- a/services/reference-data/saga/postgres_registry.go
+++ b/services/reference-data/saga/postgres_registry.go
@@ -43,7 +43,7 @@ func (r *PostgresRegistry) setSearchPath(ctx context.Context, tx pgx.Tx) error {
 	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
 
 	// SET LOCAL is transaction-scoped - automatically reverts on commit/rollback
-	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	query := fmt.Sprintf("SET LOCAL search_path TO %s", schemaName)
 	_, err := tx.Exec(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to set tenant schema scope: %w", err)

--- a/services/reference-data/saga/postgres_registry_read.go
+++ b/services/reference-data/saga/postgres_registry_read.go
@@ -9,23 +9,26 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-// GetByID retrieves a specific saga by its UUID, resolving platform fallback if needed.
+// sagaSelectColumns is the standard column list for saga definition queries.
+// Scripts are stored directly in the tenant schema (no cross-schema fallback).
+const sagaSelectColumns = `
+	sd.id, sd.name, sd.version,
+	COALESCE(sd.script, '') AS resolved_script,
+	sd.script,
+	sd.status, sd.is_system,
+	sd.preconditions_expression, sd.display_name, sd.description,
+	sd.created_at, sd.updated_at, sd.activated_at, sd.deprecated_at, sd.successor_id,
+	sd.platform_ref, sd.override_reason, sd.platform_version_at_override,
+	false AS used_platform_fallback,
+	sd.validation_status, sd.complexity_score, sd.handler_call_count, sd.validated_at`
+
+// GetByID retrieves a specific saga by its UUID.
 func (r *PostgresRegistry) GetByID(ctx context.Context, id uuid.UUID) (*Definition, error) {
 	var result *Definition
 
 	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
-		query := `
-			SELECT sd.id, sd.name, sd.version,
-				COALESCE(NULLIF(sd.script, ''), psd.script, '') AS resolved_script,
-				sd.script,
-				sd.status, sd.is_system,
-				sd.preconditions_expression, sd.display_name, sd.description,
-				sd.created_at, sd.updated_at, sd.activated_at, sd.deprecated_at, sd.successor_id,
-				sd.platform_ref, sd.override_reason, sd.platform_version_at_override,
-				psd.script IS NOT NULL AND (sd.script IS NULL OR sd.script = '') AS used_platform_fallback,
-				sd.validation_status, sd.complexity_score, sd.handler_call_count, sd.validated_at
+		query := `SELECT ` + sagaSelectColumns + `
 			FROM saga_definition sd
-			LEFT JOIN public.platform_saga_definition psd ON sd.platform_ref = psd.id
 			WHERE sd.id = $1`
 
 		row := tx.QueryRow(ctx, query, id)
@@ -47,23 +50,13 @@ func (r *PostgresRegistry) GetByID(ctx context.Context, id uuid.UUID) (*Definiti
 	return result, nil
 }
 
-// GetDefinition retrieves a specific saga by name and version, resolving platform fallback if needed.
+// GetDefinition retrieves a specific saga by name and version.
 func (r *PostgresRegistry) GetDefinition(ctx context.Context, name string, version int) (*Definition, error) {
 	var result *Definition
 
 	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
-		query := `
-			SELECT sd.id, sd.name, sd.version,
-				COALESCE(NULLIF(sd.script, ''), psd.script, '') AS resolved_script,
-				sd.script,
-				sd.status, sd.is_system,
-				sd.preconditions_expression, sd.display_name, sd.description,
-				sd.created_at, sd.updated_at, sd.activated_at, sd.deprecated_at, sd.successor_id,
-				sd.platform_ref, sd.override_reason, sd.platform_version_at_override,
-				psd.script IS NOT NULL AND (sd.script IS NULL OR sd.script = '') AS used_platform_fallback,
-				sd.validation_status, sd.complexity_score, sd.handler_call_count, sd.validated_at
+		query := `SELECT ` + sagaSelectColumns + `
 			FROM saga_definition sd
-			LEFT JOIN public.platform_saga_definition psd ON sd.platform_ref = psd.id
 			WHERE sd.name = $1 AND sd.version = $2`
 
 		row := tx.QueryRow(ctx, query, name, version)
@@ -85,27 +78,20 @@ func (r *PostgresRegistry) GetDefinition(ctx context.Context, name string, versi
 	return result, nil
 }
 
-// GetActive retrieves the active saga for a name using tenant resolution with platform fallback.
+// GetActive retrieves the active saga for a name using tenant resolution.
 // Resolution order:
 //  1. Tenant override (is_system=FALSE, status=ACTIVE, highest version)
-//     - If tenant saga has platform_ref, resolve script via COALESCE with platform
 //  2. Platform default (is_system=TRUE, status=ACTIVE, highest version)
-//     - System sagas may also have platform_ref for script inheritance
 func (r *PostgresRegistry) GetActive(ctx context.Context, name string) (*Definition, error) {
 	var result *Definition
 
 	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
-		// Step 1: Try tenant override (is_system=FALSE) with platform fallback via LEFT JOIN
+		// Step 1: Try tenant override (is_system=FALSE)
 		row := tx.QueryRow(ctx, activeSagaQuery(false), name)
 		def, err := r.scanDefinitionWithFallback(row)
 		if err == nil {
-			if def.UsedPlatformFallback {
-				r.logger.Debug("resolved saga using platform fallback",
-					"name", name, "saga_id", def.ID, "platform_ref", def.PlatformRef)
-			} else {
-				r.logger.Debug("resolved saga using tenant override",
-					"name", name, "saga_id", def.ID)
-			}
+			r.logger.Debug("resolved saga using tenant override",
+				"name", name, "saga_id", def.ID)
 			result = def
 			return nil
 		}
@@ -135,43 +121,23 @@ func (r *PostgresRegistry) GetActive(ctx context.Context, name string) (*Definit
 	return result, nil
 }
 
-// activeSagaQuery returns the SQL query for fetching active saga definitions with platform fallback.
+// activeSagaQuery returns the SQL query for fetching active saga definitions.
 // The isSystem parameter controls whether to query tenant overrides (false) or platform defaults (true).
 func activeSagaQuery(isSystem bool) string {
-	return `
-		SELECT sd.id, sd.name, sd.version,
-			COALESCE(NULLIF(sd.script, ''), psd.script, '') AS resolved_script,
-			sd.script,
-			sd.status, sd.is_system,
-			sd.preconditions_expression, sd.display_name, sd.description,
-			sd.created_at, sd.updated_at, sd.activated_at, sd.deprecated_at, sd.successor_id,
-			sd.platform_ref, sd.override_reason, sd.platform_version_at_override,
-			psd.script IS NOT NULL AND (sd.script IS NULL OR sd.script = '') AS used_platform_fallback,
-			sd.validation_status, sd.complexity_score, sd.handler_call_count, sd.validated_at
+	return `SELECT ` + sagaSelectColumns + `
 		FROM saga_definition sd
-		LEFT JOIN public.platform_saga_definition psd ON sd.platform_ref = psd.id
 		WHERE sd.name = $1 AND sd.status = 'ACTIVE' AND sd.is_system = ` + fmt.Sprintf("%t", isSystem) + `
 		ORDER BY sd.version DESC
 		LIMIT 1`
 }
 
-// ListByStatus retrieves all sagas with the specified status, resolving platform fallback.
+// ListByStatus retrieves all sagas with the specified status.
 func (r *PostgresRegistry) ListByStatus(ctx context.Context, status Status) ([]*Definition, error) {
 	var result []*Definition
 
 	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
-		query := `
-			SELECT sd.id, sd.name, sd.version,
-				COALESCE(NULLIF(sd.script, ''), psd.script, '') AS resolved_script,
-				sd.script,
-				sd.status, sd.is_system,
-				sd.preconditions_expression, sd.display_name, sd.description,
-				sd.created_at, sd.updated_at, sd.activated_at, sd.deprecated_at, sd.successor_id,
-				sd.platform_ref, sd.override_reason, sd.platform_version_at_override,
-				psd.script IS NOT NULL AND (sd.script IS NULL OR sd.script = '') AS used_platform_fallback,
-				sd.validation_status, sd.complexity_score, sd.handler_call_count, sd.validated_at
+		query := `SELECT ` + sagaSelectColumns + `
 			FROM saga_definition sd
-			LEFT JOIN public.platform_saga_definition psd ON sd.platform_ref = psd.id
 			WHERE sd.status = $1
 			ORDER BY sd.name, sd.version DESC`
 

--- a/services/reference-data/saga/postgres_registry_test.go
+++ b/services/reference-data/saga/postgres_registry_test.go
@@ -59,7 +59,7 @@ func seedSystemSaga(t *testing.T, pool *pgxpool.Pool, ctx context.Context, name 
 	tx, err := pool.Begin(ctx)
 	require.NoError(t, err)
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	_, err = tx.Exec(ctx, query, id, name)

--- a/services/reference-data/saga/seeder.go
+++ b/services/reference-data/saga/seeder.go
@@ -22,9 +22,8 @@ import (
 //go:embed all:defaults
 var defaultSagas embed.FS
 
-// ErrPlatformSagaNotSynced is returned when a platform saga referenced by the seeder
-// has not been synced to the platform_saga_definition table.
-var ErrPlatformSagaNotSynced = errors.New("platform saga not synced: run PlatformSync.SyncPlatformDefaults first")
+// ErrEmbeddedScriptMissing is returned when a saga's embedded script file is not found.
+var ErrEmbeddedScriptMissing = errors.New("embedded script not found for saga")
 
 // Metadata defines metadata for a platform default saga.
 type Metadata struct {
@@ -89,14 +88,13 @@ func sagaNameFromDir(dirName string) string {
 }
 
 // Seeder seeds platform default saga definitions into tenant schemas.
-// Platform defaults are seeded with is_system=true, status=ACTIVE, and a platform_ref
-// pointing to the corresponding entry in public.platform_saga_definition.
+// Platform defaults are seeded with is_system=true, status=ACTIVE, and the
+// actual script content copied directly into the tenant's saga_definition table.
 //
-// The seeder creates reference-based entries (platform_ref) rather than copying
-// script content. This means:
-//   - Tenant saga_definition rows have script=NULL and platform_ref set
-//   - The actual script is resolved at query time via COALESCE with platform_saga_definition
-//   - Platform script updates automatically propagate to all tenants using references
+// The seeder copies script content from embedded .star files:
+//   - Tenant saga_definition rows have script=<content> (self-contained)
+//   - No cross-schema references to public.platform_saga_definition
+//   - Complete tenant isolation - each tenant has its own copy of all saga scripts
 //   - Tenants can override by creating their own saga with a custom script
 type Seeder struct {
 	pool   *pgxpool.Pool
@@ -114,17 +112,14 @@ func NewSeeder(pool *pgxpool.Pool) *Seeder {
 // SeedTenant seeds all platform default sagas into a specific tenant's schema.
 // This is called during tenant provisioning after the schema is created.
 //
-// Prerequisites: PlatformSync.SyncPlatformDefaults must have been called first
-// to populate the public.platform_saga_definition table.
-//
 // Idempotency: Uses ON CONFLICT (name, version) DO NOTHING, so calling this
 // multiple times for the same tenant is safe - existing sagas are skipped.
 //
 // The function:
-//  1. Looks up each platform default in public.platform_saga_definition
+//  1. Loads saga scripts from embedded .star files
 //  2. Sets search_path to the tenant's schema
 //  3. For each platform default saga:
-//     - Creates a saga_definition with platform_ref (no script copy)
+//     - Creates a saga_definition with the actual script content
 //     - Inserts with is_system=true, status=ACTIVE, version=1
 //     - Skips if already exists (idempotent)
 func (s *Seeder) SeedTenant(ctx context.Context, tenantID tenant.TenantID) error {
@@ -137,10 +132,10 @@ func (s *Seeder) SeedTenant(ctx context.Context, tenantID tenant.TenantID) error
 		return err
 	}
 
-	// Look up platform saga IDs from public.platform_saga_definition
-	platformRefs, err := s.lookupPlatformRefs(ctx, defaults)
+	// Load scripts from embedded filesystem
+	scripts, err := GetEmbeddedScripts()
 	if err != nil {
-		logger.Error("failed to look up platform saga references", "error", err)
+		logger.Error("failed to load embedded scripts", "error", err)
 		return err
 	}
 
@@ -148,16 +143,21 @@ func (s *Seeder) SeedTenant(ctx context.Context, tenantID tenant.TenantID) error
 
 	err = s.withTenantTransaction(ctx, tenantID, func(tx pgx.Tx) error {
 		for _, meta := range defaults {
-			platformRefID := platformRefs[meta.Name]
-			seeded, seedErr := s.seedSaga(ctx, tx, meta, platformRefID)
+			// Look up the script content from embedded files using the flat key
+			scriptKey := meta.Filename + ".star"
+			script, ok := scripts[scriptKey]
+			if !ok {
+				return fmt.Errorf("%w: %s (key: %s)", ErrEmbeddedScriptMissing, meta.Name, scriptKey)
+			}
+
+			seeded, seedErr := s.seedSaga(ctx, tx, meta, script)
 			if seedErr != nil {
 				return fmt.Errorf("seed %s: %w", meta.Name, seedErr)
 			}
 			if seeded {
 				seededCount++
-				logger.Debug("seeded platform saga reference",
-					"name", meta.Name,
-					"platform_ref", platformRefID)
+				logger.Debug("seeded platform saga with script",
+					"name", meta.Name)
 			} else {
 				logger.Debug("platform saga already exists", "name", meta.Name)
 			}
@@ -176,32 +176,6 @@ func (s *Seeder) SeedTenant(ctx context.Context, tenantID tenant.TenantID) error
 	return nil
 }
 
-// lookupPlatformRefs resolves the ACTIVE platform_saga_definition ID for each default saga.
-// Returns a map of saga name to platform saga definition UUID.
-func (s *Seeder) lookupPlatformRefs(ctx context.Context, defaults []Metadata) (map[string]uuid.UUID, error) {
-	refs := make(map[string]uuid.UUID, len(defaults))
-
-	for _, meta := range defaults {
-		var platformID uuid.UUID
-		err := s.pool.QueryRow(ctx,
-			`SELECT id FROM public.platform_saga_definition
-			WHERE name = $1 AND status = 'ACTIVE'
-			ORDER BY COALESCE(NULLIF(split_part(version, '.', 1), ''), '0')::int DESC, COALESCE(NULLIF(split_part(version, '.', 2), ''), '0')::int DESC, COALESCE(NULLIF(split_part(version, '.', 3), ''), '0')::int DESC
-			LIMIT 1`,
-			meta.Name,
-		).Scan(&platformID)
-		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, fmt.Errorf("%w: %s (no ACTIVE version)", ErrPlatformSagaNotSynced, meta.Name)
-			}
-			return nil, fmt.Errorf("lookup platform saga %s: %w", meta.Name, err)
-		}
-		refs[meta.Name] = platformID
-	}
-
-	return refs, nil
-}
-
 // withTenantTransaction executes a function within a transaction scoped to a tenant's schema.
 func (s *Seeder) withTenantTransaction(ctx context.Context, tenantID tenant.TenantID, fn func(tx pgx.Tx) error) error {
 	tx, err := s.pool.Begin(ctx)
@@ -212,9 +186,9 @@ func (s *Seeder) withTenantTransaction(ctx context.Context, tenantID tenant.Tena
 		_ = tx.Rollback(ctx)
 	}()
 
-	// Set search_path to tenant schema
+	// Set search_path to tenant schema only (no public fallback)
 	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
-	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	query := fmt.Sprintf("SET LOCAL search_path TO %s", schemaName)
 	if _, err := tx.Exec(ctx, query); err != nil {
 		return fmt.Errorf("set search_path: %w", err)
 	}
@@ -226,11 +200,10 @@ func (s *Seeder) withTenantTransaction(ctx context.Context, tenantID tenant.Tena
 	return tx.Commit(ctx)
 }
 
-// seedSaga inserts a single platform saga reference if it doesn't already exist.
-// The saga_definition row has script=NULL and platform_ref pointing to the
-// platform_saga_definition entry. The script is resolved at query time.
+// seedSaga inserts a single platform saga with its script content.
+// The saga_definition row has the actual script content (self-contained).
 // Returns true if the saga was inserted, false if it already existed.
-func (s *Seeder) seedSaga(ctx context.Context, tx pgx.Tx, meta Metadata, platformRefID uuid.UUID) (bool, error) {
+func (s *Seeder) seedSaga(ctx context.Context, tx pgx.Tx, meta Metadata, script string) (bool, error) {
 	// Generate deterministic UUID based on name for idempotency
 	// Using UUIDv5 with the saga name ensures the same saga always gets the same ID
 	id := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("saga.meridian."+meta.Name))
@@ -238,26 +211,26 @@ func (s *Seeder) seedSaga(ctx context.Context, tx pgx.Tx, meta Metadata, platfor
 	now := time.Now()
 
 	// Insert with ON CONFLICT DO NOTHING for idempotency
-	// Note: script is NULL because the saga inherits its script via platform_ref
+	// Script content is copied directly - no cross-schema reference needed
 	query := `
 		INSERT INTO saga_definition (
 			id, name, version, script, status, is_system,
-			platform_ref, display_name, description,
+			display_name, description,
 			created_at, updated_at, activated_at
 		) VALUES (
-			$1, $2, $3, NULL, $4, $5,
-			$6, $7, $8,
+			$1, $2, $3, $4, $5, $6,
+			$7, $8,
 			$9, $10, $11
 		)
 		ON CONFLICT (name, version) DO NOTHING`
 
 	result, err := tx.Exec(ctx, query,
-		id,            // id
-		meta.Name,     // name
-		1,             // version (always 1 for platform defaults)
-		"ACTIVE",      // status (platform defaults are immediately active)
-		true,          // is_system (platform defaults are system sagas)
-		platformRefID, // platform_ref -> public.platform_saga_definition
+		id,        // id
+		meta.Name, // name
+		1,         // version (always 1 for platform defaults)
+		script,    // script (actual content, not a reference)
+		"ACTIVE",  // status (platform defaults are immediately active)
+		true,      // is_system (platform defaults are system sagas)
 		meta.DisplayName,
 		meta.Description,
 		now, // created_at

--- a/services/reference-data/saga/seeder_test.go
+++ b/services/reference-data/saga/seeder_test.go
@@ -85,20 +85,15 @@ func TestSeeder_SeedTenant(t *testing.T) {
 
 	ctx := context.Background()
 
-	// First, sync platform defaults (prerequisite for seeder)
-	platformSync := NewPlatformSync(pool)
-	err := platformSync.SyncPlatformDefaults(ctx)
-	require.NoError(t, err)
-
 	// Create tenant schema and saga_definition table
 	tenantID := tenant.TenantID("test_tenant")
 	schemaName := tenantID.SchemaName()
 	setupTenantSchemaForSeeder(t, pool, ctx, schemaName)
 
-	// Create seeder and seed
+	// Create seeder and seed - no PlatformSync prerequisite needed
 	seeder := NewSeeder(pool)
 
-	t.Run("initial seed creates platform_ref entries", func(t *testing.T) {
+	t.Run("initial seed copies scripts directly", func(t *testing.T) {
 		err := seeder.SeedTenant(ctx, tenantID)
 		require.NoError(t, err)
 
@@ -108,9 +103,9 @@ func TestSeeder_SeedTenant(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 8, count, "expected 8 system sagas")
 
-		// Verify each saga has platform_ref and no script
+		// Verify each saga has script content (not platform_ref)
 		rows, err := pool.Query(ctx, `
-			SELECT name, version, status, is_system, platform_ref, script, display_name, activated_at
+			SELECT name, version, status, is_system, script, display_name, activated_at
 			FROM `+schemaName+`.saga_definition
 			WHERE is_system = true
 			ORDER BY name`)
@@ -122,29 +117,19 @@ func TestSeeder_SeedTenant(t *testing.T) {
 			var version int
 			var status string
 			var isSystem bool
-			var platformRef *uuid.UUID
 			var script *string
 			var displayName *string
 			var activatedAt interface{}
 
-			err := rows.Scan(&name, &version, &status, &isSystem, &platformRef, &script, &displayName, &activatedAt)
+			err := rows.Scan(&name, &version, &status, &isSystem, &script, &displayName, &activatedAt)
 			require.NoError(t, err)
 
 			assert.Equal(t, 1, version, "platform default should have version 1")
 			assert.Equal(t, "ACTIVE", status, "platform default should be ACTIVE")
 			assert.True(t, isSystem, "platform default should be is_system=true")
-			assert.NotNil(t, platformRef, "platform default should have platform_ref set")
-			assert.True(t, script == nil || *script == "", "platform default should NOT have a copied script")
+			assert.NotNil(t, script, "platform default should have script content")
+			assert.NotEmpty(t, *script, "platform default script should not be empty")
 			assert.NotNil(t, activatedAt, "platform default should have activated_at")
-
-			// Verify platform_ref points to actual platform saga
-			var platformName string
-			err = pool.QueryRow(ctx,
-				"SELECT name FROM public.platform_saga_definition WHERE id = $1",
-				*platformRef,
-			).Scan(&platformName)
-			require.NoError(t, err, "platform_ref should point to existing platform saga")
-			assert.Equal(t, name, platformName, "platform_ref should point to same-named platform saga")
 		}
 		require.NoError(t, rows.Err())
 	})
@@ -191,47 +176,46 @@ func TestSeeder_SeedTenant(t *testing.T) {
 		assert.Equal(t, expectedIDs, ids, "UUIDs should be deterministic")
 	})
 
-	t.Run("seeded sagas resolve script via platform fallback", func(t *testing.T) {
-		// Query using LEFT JOIN to resolve the script, matching how postgres_registry.go works
-		var resolvedScript string
-		var usedFallback bool
+	t.Run("seeded sagas have script content", func(t *testing.T) {
+		var script string
 		err := pool.QueryRow(ctx, `
-			SELECT
-				COALESCE(NULLIF(sd.script, ''), psd.script, '') AS resolved_script,
-				psd.script IS NOT NULL AND (sd.script IS NULL OR sd.script = '') AS used_platform_fallback
-			FROM `+schemaName+`.saga_definition sd
-			LEFT JOIN public.platform_saga_definition psd ON sd.platform_ref = psd.id
-			WHERE sd.name = 'current_account_withdrawal' AND sd.is_system = true
-		`).Scan(&resolvedScript, &usedFallback)
+			SELECT script
+			FROM `+schemaName+`.saga_definition
+			WHERE name = 'current_account_withdrawal' AND is_system = true
+		`).Scan(&script)
 		require.NoError(t, err)
 
-		assert.NotEmpty(t, resolvedScript, "resolved script should not be empty")
-		assert.True(t, usedFallback, "script should come from platform fallback")
-		assert.Contains(t, resolvedScript, "current_account_withdrawal",
-			"resolved script should contain withdrawal saga content")
+		assert.NotEmpty(t, script, "script should not be empty")
+		assert.Contains(t, script, "current_account_withdrawal",
+			"script should contain withdrawal saga content")
 	})
 }
 
-func TestSeeder_SeedTenant_FailsWithoutPlatformSync(t *testing.T) {
+func TestSeeder_SeedTenant_SelfContained(t *testing.T) {
 	pool, cleanup := setupPlatformTestDB(t)
 	defer cleanup()
 
 	ctx := context.Background()
 
-	// Do NOT sync platform defaults
-	// Create tenant schema
+	// Do NOT sync platform defaults - seeder should be self-contained
+	// (reads from embedded filesystem, not public.platform_saga_definition)
 	tenantID := tenant.TenantID("no_sync_tenant")
 	schemaName := tenantID.SchemaName()
 	setupTenantSchemaForSeeder(t, pool, ctx, schemaName)
 
 	seeder := NewSeeder(pool)
 	err := seeder.SeedTenant(ctx, tenantID)
-	require.Error(t, err, "seeding should fail when platform sagas are not synced")
-	assert.ErrorIs(t, err, ErrPlatformSagaNotSynced)
+	require.NoError(t, err, "seeding should succeed without PlatformSync")
+
+	// Verify sagas were seeded with script content
+	var count int
+	err = pool.QueryRow(ctx, "SELECT COUNT(*) FROM "+schemaName+".saga_definition WHERE is_system = true AND script IS NOT NULL AND script != ''").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 8, count, "expected 8 system sagas with script content")
 }
 
 // setupTenantSchemaForSeeder creates the tenant schema and saga_definition table
-// for seeder integration tests. It applies the relevant migrations.
+// for seeder integration tests.
 func setupTenantSchemaForSeeder(t *testing.T, pool *pgxpool.Pool, ctx context.Context, schemaName string) {
 	t.Helper()
 
@@ -239,6 +223,7 @@ func setupTenantSchemaForSeeder(t *testing.T, pool *pgxpool.Pool, ctx context.Co
 	require.NoError(t, err)
 
 	// Create saga_definition table matching the full migrated schema
+	// Note: no FK reference to public.platform_saga_definition (tenant isolation)
 	createTableSQL := `
 		CREATE TABLE IF NOT EXISTS ` + schemaName + `.saga_definition (
 			id uuid NOT NULL DEFAULT gen_random_uuid(),
@@ -255,7 +240,7 @@ func setupTenantSchemaForSeeder(t *testing.T, pool *pgxpool.Pool, ctx context.Co
 			activated_at timestamptz NULL,
 			deprecated_at timestamptz NULL,
 			successor_id uuid NULL,
-			platform_ref uuid NULL REFERENCES public.platform_saga_definition(id) ON DELETE SET NULL,
+			platform_ref uuid NULL,
 			override_reason text NULL,
 			platform_version_at_override varchar(16) NULL,
 			validation_status text NOT NULL DEFAULT 'UNVALIDATED',
@@ -263,9 +248,7 @@ func setupTenantSchemaForSeeder(t *testing.T, pool *pgxpool.Pool, ctx context.Co
 			handler_call_count integer NULL,
 			validated_at timestamptz NULL,
 			PRIMARY KEY (id),
-			CONSTRAINT uq_saga_definition_name_version UNIQUE (name, version),
-			CONSTRAINT chk_saga_definition_script_source
-				CHECK (NOT (platform_ref IS NOT NULL AND script IS NOT NULL AND script != ''))
+			CONSTRAINT uq_saga_definition_name_version UNIQUE (name, version)
 		)`
 	_, err = pool.Exec(ctx, createTableSQL)
 	require.NoError(t, err)

--- a/services/reference-data/valuation/postgres_method.go
+++ b/services/reference-data/valuation/postgres_method.go
@@ -33,7 +33,7 @@ func (r *PostgresMethodRepository) setSearchPath(ctx context.Context, tx pgx.Tx)
 		return tenant.ErrMissingTenantContext
 	}
 	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
-	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	query := fmt.Sprintf("SET LOCAL search_path TO %s", schemaName)
 	_, err := tx.Exec(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to set tenant schema scope: %w", err)

--- a/services/reference-data/valuation/postgres_method_test.go
+++ b/services/reference-data/valuation/postgres_method_test.go
@@ -50,7 +50,7 @@ func seedSystemMethod(t *testing.T, pool *pgxpool.Pool, ctx context.Context, nam
 	id := uuid.New()
 	tx, err := pool.Begin(ctx)
 	require.NoError(t, err)
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 	_, err = tx.Exec(ctx, `
 		INSERT INTO valuation_method (

--- a/services/reference-data/valuation/postgres_policy.go
+++ b/services/reference-data/valuation/postgres_policy.go
@@ -36,7 +36,7 @@ func (r *PostgresPolicyRepository) setSearchPath(ctx context.Context, tx pgx.Tx)
 		return tenant.ErrMissingTenantContext
 	}
 	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
-	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	query := fmt.Sprintf("SET LOCAL search_path TO %s", schemaName)
 	_, err := tx.Exec(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to set tenant schema scope: %w", err)

--- a/services/reference-data/valuation/postgres_policy_test.go
+++ b/services/reference-data/valuation/postgres_policy_test.go
@@ -50,7 +50,7 @@ func seedSystemPolicy(t *testing.T, pool *pgxpool.Pool, ctx context.Context, nam
 	id := uuid.New()
 	tx, err := pool.Begin(ctx)
 	require.NoError(t, err)
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 	_, err = tx.Exec(ctx, `
 		INSERT INTO valuation_policy (

--- a/services/reference-data/valuation/seeder.go
+++ b/services/reference-data/valuation/seeder.go
@@ -127,7 +127,7 @@ func (s *Seeder) SeedTenant(ctx context.Context, tenantID tenant.TenantID) error
 	defer func() { _ = tx.Rollback(ctx) }()
 
 	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", schemaName))
 	if err != nil {
 		return fmt.Errorf("set search_path: %w", err)
 	}
@@ -194,6 +194,12 @@ func (s *Seeder) seedPolicies(ctx context.Context, tx pgx.Tx) error {
 		}
 	}
 	return nil
+}
+
+// AsPostProvisioningHook returns a function compatible with the provisioning worker's
+// PostProvisioningHook signature.
+func (s *Seeder) AsPostProvisioningHook() func(ctx context.Context, tenantID tenant.TenantID) error {
+	return s.SeedTenant
 }
 
 func sha256Hash(content string) string {

--- a/services/tenant/provisioner/migration_runner.go
+++ b/services/tenant/provisioner/migration_runner.go
@@ -260,7 +260,7 @@ func (p *PostgresProvisioner) applyMigrationList(ctx context.Context, db *gorm.D
 	}
 
 	// Set search_path to the tenant schema for unqualified table names
-	setPathQuery := fmt.Sprintf("SET search_path TO %s, public", quoteIdentifier(schemaName))
+	setPathQuery := fmt.Sprintf("SET search_path TO %s", quoteIdentifier(schemaName))
 
 	var lastVersion string
 	for _, mig := range migrations {

--- a/services/tenant/worker/provisioning_worker.go
+++ b/services/tenant/worker/provisioning_worker.go
@@ -22,9 +22,9 @@ import (
 )
 
 // PostProvisioningHook is called after schema provisioning succeeds but before
-// marking the tenant as active. Hooks are non-blocking - errors are logged but
-// do not prevent tenant activation. This allows for best-effort initialization
-// of tenant-specific resources (e.g., default internal accounts).
+// marking the tenant as active. Hook failures are fatal - they prevent tenant
+// activation and mark provisioning as failed. This ensures tenants are never
+// activated with incomplete reference data (instruments, sagas, account types).
 type PostProvisioningHook func(ctx context.Context, tenantID tenant.TenantID) error
 
 // ProvisioningWorker polls for tenants in PROVISIONING_PENDING status
@@ -220,9 +220,8 @@ func (w *ProvisioningWorker) Stop() {
 }
 
 // RegisterPostProvisioningHook adds a hook to be called after schema provisioning succeeds.
-// Hooks are executed in registration order and are non-blocking - errors are logged
-// but do not prevent tenant activation. Use this for best-effort initialization like
-// creating default internal accounts.
+// Hooks are executed in registration order and are fail-hard - any hook failure
+// prevents tenant activation and marks provisioning as failed.
 //
 // The name parameter is used for logging to identify which hook succeeded or failed.
 func (w *ProvisioningWorker) RegisterPostProvisioningHook(name string, hook PostProvisioningHook) {
@@ -234,18 +233,17 @@ func (w *ProvisioningWorker) RegisterPostProvisioningHook(name string, hook Post
 }
 
 // executePostProvisioningHooks runs all registered hooks sequentially.
-// Errors are logged but do not stop execution of subsequent hooks.
-// Returns the count of hooks that succeeded.
-func (w *ProvisioningWorker) executePostProvisioningHooks(ctx context.Context, tenantID tenant.TenantID) int {
+// Any hook failure is fatal - it stops execution and returns the error.
+// This ensures tenants are never activated with incomplete reference data.
+func (w *ProvisioningWorker) executePostProvisioningHooks(ctx context.Context, tenantID tenant.TenantID) error {
 	if len(w.postProvisioningHooks) == 0 {
-		return 0
+		return nil
 	}
 
 	w.logger.Debug("executing post-provisioning hooks",
 		"tenant_id", tenantID,
 		"hook_count", len(w.postProvisioningHooks))
 
-	succeeded := 0
 	for _, nh := range w.postProvisioningHooks {
 		if err := func() (err error) {
 			defer func() {
@@ -255,25 +253,22 @@ func (w *ProvisioningWorker) executePostProvisioningHooks(ctx context.Context, t
 			}()
 			return nh.hook(ctx, tenantID)
 		}(); err != nil {
-			// Log error but continue - hooks are non-blocking
-			w.logger.Warn("post-provisioning hook failed",
+			w.logger.Error("post-provisioning hook failed - aborting tenant activation",
 				"tenant_id", tenantID,
 				"hook_name", nh.name,
 				"error", err)
-		} else {
-			w.logger.Debug("post-provisioning hook succeeded",
-				"tenant_id", tenantID,
-				"hook_name", nh.name)
-			succeeded++
+			return fmt.Errorf("post-provisioning hook %q failed: %w", nh.name, err)
 		}
+		w.logger.Debug("post-provisioning hook succeeded",
+			"tenant_id", tenantID,
+			"hook_name", nh.name)
 	}
 
-	w.logger.Info("post-provisioning hooks completed",
+	w.logger.Info("all post-provisioning hooks completed",
 		"tenant_id", tenantID,
-		"succeeded", succeeded,
 		"total", len(w.postProvisioningHooks))
 
-	return succeeded
+	return nil
 }
 
 // checkFailedProvisioningAlerts checks for persistent provisioning failures
@@ -423,7 +418,9 @@ func (w *ProvisioningWorker) executeProvisioningWithRetry(ctx context.Context, t
 
 		err := w.provisioner.ProvisionSchemas(ctx, tenantID)
 		if err == nil {
-			w.markTenantAsActive(ctx, tenantID, attempts)
+			if hookErr := w.markTenantAsActive(ctx, tenantID, attempts); hookErr != nil {
+				return attempts, hookErr
+			}
 			return 0, nil
 		}
 
@@ -465,25 +462,26 @@ func (w *ProvisioningWorker) checkContextCancellation(ctx context.Context, tenan
 }
 
 // markTenantAsActive updates tenant status to active after successful provisioning.
-// Before marking as active, it executes any registered post-provisioning hooks
-// (e.g., creating default internal accounts). Hook failures are logged but
-// do not prevent tenant activation.
-func (w *ProvisioningWorker) markTenantAsActive(ctx context.Context, tenantID tenant.TenantID, attempt int) {
+// Before marking as active, it executes any registered post-provisioning hooks.
+// Hook failures are fatal - they prevent tenant activation.
+// Returns nil on success, or an error if hooks or status update failed.
+func (w *ProvisioningWorker) markTenantAsActive(ctx context.Context, tenantID tenant.TenantID, attempt int) error {
 	w.logger.Info("provisioning succeeded",
 		"tenant_id", tenantID,
 		"attempt", attempt)
 
-	// Execute post-provisioning hooks (non-blocking)
-	// These hooks can initialize tenant-specific resources like default internal accounts.
-	// Failures are logged but do not prevent tenant activation.
-	w.executePostProvisioningHooks(ctx, tenantID)
+	// Execute post-provisioning hooks (fail-hard)
+	// Hook failures prevent tenant activation to ensure complete reference data.
+	if err := w.executePostProvisioningHooks(ctx, tenantID); err != nil {
+		return fmt.Errorf("post-provisioning hooks: %w", err)
+	}
 
 	tenant, getErr := w.repo.GetByID(ctx, tenantID)
 	if getErr != nil {
 		w.logger.Error("failed to get tenant after successful provisioning",
 			"tenant_id", tenantID,
 			"error", getErr)
-		return
+		return nil // Schema is provisioned, status update failure is non-fatal
 	}
 
 	_, updateErr := w.repo.UpdateStatus(ctx, tenantID, domain.StatusActive, tenant.Version)
@@ -493,6 +491,7 @@ func (w *ProvisioningWorker) markTenantAsActive(ctx context.Context, tenantID te
 			"version", tenant.Version,
 			"error", updateErr)
 	}
+	return nil
 }
 
 // markTenantAsFailed updates tenant status to provisioning_failed with error details.

--- a/shared/pkg/valuationfeature/seeder_test.go
+++ b/shared/pkg/valuationfeature/seeder_test.go
@@ -288,7 +288,7 @@ func TestProductTypeSeeder_SeedFromProductType_MultipleTenants(t *testing.T) {
 	schemaName2 := tid2.SchemaName()
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(schemaName2))).Error
 	require.NoError(t, err)
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName2))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName2))).Error
 	require.NoError(t, err)
 	err = db.AutoMigrate(&Entity{})
 	require.NoError(t, err)
@@ -298,7 +298,7 @@ func TestProductTypeSeeder_SeedFromProductType_MultipleTenants(t *testing.T) {
 	require.NoError(t, err)
 	// Restore search_path to the primary tenant
 	primarySchema := tenant.TenantID(testTenantID).SchemaName()
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(primarySchema))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(primarySchema))).Error
 	require.NoError(t, err)
 
 	ctx2 := tenant.WithTenant(context.Background(), tid2)

--- a/shared/platform/db/gorm_tenant_scope.go
+++ b/shared/platform/db/gorm_tenant_scope.go
@@ -20,8 +20,7 @@ var ErrTenantScopeRequiresTransaction = errors.New("tenant scope requires an act
 
 // ErrTenantSchemaNotProvisioned is returned when SET LOCAL search_path targets a schema
 // that does not exist in the database. PostgreSQL silently accepts non-existent schemas
-// in search_path, which would cause queries to fall through to the public schema and
-// expose cross-tenant data.
+// in search_path, which would cause queries to fail with missing table errors.
 var ErrTenantSchemaNotProvisioned = errors.New("tenant schema not provisioned: schema does not exist in database")
 
 // hashTenantID creates a short, privacy-preserving hash of the tenant ID for logging.
@@ -38,14 +37,14 @@ func hashTenantID(tenantID tenant.TenantID) string {
 //  1. Extracts the tenant ID from context using tenant.FromContext
 //  2. Returns ErrMissingTenantContext if tenant is missing (fail-fast)
 //  3. Generates schema name via tenantID.SchemaName() (returns "org_{id}")
-//  4. Executes SET LOCAL search_path TO <schema>, public
+//  4. Executes SET LOCAL search_path TO <schema>
 //  5. Returns the same DB for chaining
 //
 // SET LOCAL ensures the search_path automatically reverts when the transaction
 // commits or rolls back - no manual cleanup needed.
 //
-// The public schema is included in search_path to allow read access to shared
-// reference data.
+// The public schema is NOT included in search_path. All reference data
+// is replicated into tenant schemas for complete isolation.
 //
 // Example usage with GORM transactions:
 //
@@ -116,7 +115,7 @@ func validateTenantTransaction(tx *gorm.DB) error {
 
 // setLocalSearchPath executes SET LOCAL search_path for tenant isolation.
 func setLocalSearchPath(ctx context.Context, tx *gorm.DB, quotedSchema string, tenantID tenant.TenantID, logger *slog.Logger) error {
-	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", quotedSchema)
+	query := fmt.Sprintf("SET LOCAL search_path TO %s", quotedSchema)
 	if err := tx.WithContext(ctx).Exec(query).Error; err != nil {
 		logger.ErrorContext(ctx, "tenant scope: failed to set search_path",
 			"tenant_hash", hashTenantID(tenantID),
@@ -128,7 +127,7 @@ func setLocalSearchPath(ctx context.Context, tx *gorm.DB, quotedSchema string, t
 
 // verifySchemaExists checks that the tenant schema exists in pg_namespace.
 // PostgreSQL silently accepts non-existent schemas in search_path, which would
-// cause queries to fall through to public schema and expose cross-tenant data.
+// cause queries to fail with missing table errors.
 func verifySchemaExists(ctx context.Context, tx *gorm.DB, schema string, tenantID tenant.TenantID, logger *slog.Logger) error {
 	var schemaExists bool
 	if err := tx.WithContext(ctx).Raw("SELECT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = ?)", schema).Scan(&schemaExists).Error; err != nil {

--- a/shared/platform/db/gorm_tenant_scope_test.go
+++ b/shared/platform/db/gorm_tenant_scope_test.go
@@ -37,7 +37,7 @@ func TestWithGormTenantScope_SetsSearchPath(t *testing.T) {
 
 	// WithGormTenantScope requires an active transaction
 	mock.ExpectBegin()
-	mock.ExpectExec(`SET LOCAL search_path TO "org_acme_bank", public`).
+	mock.ExpectExec(`SET LOCAL search_path TO "org_acme_bank"`).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery(`SELECT EXISTS`).
 		WithArgs("org_acme_bank").
@@ -120,7 +120,7 @@ func TestWithGormTenantTransaction_SetsSearchPathAndExecutes(t *testing.T) {
 
 	// Expect transaction begin, SET LOCAL, schema check, and commit
 	mock.ExpectBegin()
-	mock.ExpectExec(`SET LOCAL search_path TO "org_acme_bank", public`).
+	mock.ExpectExec(`SET LOCAL search_path TO "org_acme_bank"`).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery(`SELECT EXISTS`).
 		WithArgs("org_acme_bank").
@@ -215,7 +215,7 @@ func TestWithGormTenantScope_SpecialCharacters_QuotedProperly(t *testing.T) {
 
 			// WithGormTenantScope requires an active transaction
 			mock.ExpectBegin()
-			expected := "SET LOCAL search_path TO " + tc.expectedSchema + ", public"
+			expected := "SET LOCAL search_path TO " + tc.expectedSchema
 			mock.ExpectExec(expected).
 				WillReturnResult(sqlmock.NewResult(0, 0))
 			mock.ExpectQuery(`SELECT EXISTS`).
@@ -255,7 +255,7 @@ func TestWithGormTenantScope_DatabaseError_ReturnsError(t *testing.T) {
 
 	// WithGormTenantScope requires an active transaction
 	mock.ExpectBegin()
-	mock.ExpectExec(`SET LOCAL search_path TO "org_acme_bank", public`).
+	mock.ExpectExec(`SET LOCAL search_path TO "org_acme_bank"`).
 		WillReturnError(errDatabaseConnectionLost)
 	mock.ExpectRollback()
 
@@ -292,7 +292,7 @@ func TestWithGormTenantTransaction_DatabaseError_ReturnsError(t *testing.T) {
 
 	// Expect transaction begin, SET LOCAL failure, and rollback
 	mock.ExpectBegin()
-	mock.ExpectExec(`SET LOCAL search_path TO "org_acme_bank", public`).
+	mock.ExpectExec(`SET LOCAL search_path TO "org_acme_bank"`).
 		WillReturnError(errSchemaDoesNotExist)
 	mock.ExpectRollback()
 
@@ -327,7 +327,7 @@ func TestWithGormTenantScope_NonExistentSchema_ReturnsError(t *testing.T) {
 	ctx := tenant.WithTenant(context.Background(), tenantID)
 
 	mock.ExpectBegin()
-	mock.ExpectExec(`SET LOCAL search_path TO "org_nonexistent_tenant", public`).
+	mock.ExpectExec(`SET LOCAL search_path TO "org_nonexistent_tenant"`).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery(`SELECT EXISTS`).
 		WithArgs("org_nonexistent_tenant").
@@ -362,7 +362,7 @@ func TestWithGormTenantScope_SchemaVerificationFailure_ReturnsError(t *testing.T
 	ctx := tenant.WithTenant(context.Background(), tenantID)
 
 	mock.ExpectBegin()
-	mock.ExpectExec(`SET LOCAL search_path TO "org_acme_bank", public`).
+	mock.ExpectExec(`SET LOCAL search_path TO "org_acme_bank"`).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery(`SELECT EXISTS`).
 		WithArgs("org_acme_bank").
@@ -444,7 +444,7 @@ func TestWithGormTenantScope_MaliciousSchemaNames_ProperlyEscaped(t *testing.T) 
 
 			// WithGormTenantScope requires an active transaction
 			mock.ExpectBegin()
-			expected := "SET LOCAL search_path TO " + tc.expectedSchema + ", public"
+			expected := "SET LOCAL search_path TO " + tc.expectedSchema
 			mock.ExpectExec(expected).
 				WillReturnResult(sqlmock.NewResult(0, 0))
 			schemaName := tenant.TenantID(tc.tenantID).SchemaName()

--- a/shared/platform/db/guarded_pgx_pool.go
+++ b/shared/platform/db/guarded_pgx_pool.go
@@ -97,7 +97,7 @@ func (g *GuardedPgxPool) BeginTenantTx(ctx context.Context) (pgx.Tx, error) {
 	}
 
 	schemaName := pq.QuoteIdentifier(tid.SchemaName())
-	if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)); err != nil {
+	if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", schemaName)); err != nil {
 		_ = tx.Rollback(ctx)
 		return nil, fmt.Errorf("set tenant schema: %w", err)
 	}

--- a/shared/platform/db/tenant_audit_test.go
+++ b/shared/platform/db/tenant_audit_test.go
@@ -74,7 +74,7 @@ func TestTenantAudit_LogsSchemaAccess(t *testing.T) {
 
 	// WithGormTenantScopeAndLogger requires an active transaction
 	mock.ExpectBegin()
-	mock.ExpectExec(`SET LOCAL search_path TO "org_acme_bank", public`).
+	mock.ExpectExec(`SET LOCAL search_path TO "org_acme_bank"`).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery(`SELECT EXISTS`).
 		WithArgs("org_acme_bank").
@@ -111,7 +111,7 @@ func TestTenantAudit_LogsSchemaAccessWithService(t *testing.T) {
 
 	// WithGormTenantScopeAndLogger requires an active transaction
 	mock.ExpectBegin()
-	mock.ExpectExec(`SET LOCAL search_path TO "org_beta_corp", public`).
+	mock.ExpectExec(`SET LOCAL search_path TO "org_beta_corp"`).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery(`SELECT EXISTS`).
 		WithArgs("org_beta_corp").
@@ -161,7 +161,7 @@ func TestTenantAudit_NoLogOnDatabaseError(t *testing.T) {
 
 	// WithGormTenantScopeAndLogger requires an active transaction
 	mock.ExpectBegin()
-	mock.ExpectExec(`SET LOCAL search_path TO "org_acme_bank", public`).
+	mock.ExpectExec(`SET LOCAL search_path TO "org_acme_bank"`).
 		WillReturnError(errAuditTestDBFailed)
 	mock.ExpectRollback()
 

--- a/shared/platform/db/tenant_guard_test.go
+++ b/shared/platform/db/tenant_guard_test.go
@@ -107,7 +107,7 @@ func TestTenantGuard_AllowsQueryWithTenantScope(t *testing.T) {
 
 	// WithGormTenantScope requires an active transaction
 	mock.ExpectBegin()
-	mock.ExpectExec(`SET LOCAL search_path TO "org_acme_bank", public`).
+	mock.ExpectExec(`SET LOCAL search_path TO "org_acme_bank"`).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery(`SELECT EXISTS`).
 		WithArgs("org_acme_bank").
@@ -142,7 +142,7 @@ func TestTenantGuard_AllowsCreateWithTenantScope(t *testing.T) {
 
 	// WithGormTenantScope requires an active transaction
 	mock.ExpectBegin()
-	mock.ExpectExec(`SET LOCAL search_path TO "org_acme_bank", public`).
+	mock.ExpectExec(`SET LOCAL search_path TO "org_acme_bank"`).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery(`SELECT EXISTS`).
 		WithArgs("org_acme_bank").
@@ -176,7 +176,7 @@ func TestTenantGuard_AllowsWithinTenantTransaction(t *testing.T) {
 	ctx := tenant.WithTenant(context.Background(), tenantID)
 
 	mock.ExpectBegin()
-	mock.ExpectExec(`SET LOCAL search_path TO "org_acme_bank", public`).
+	mock.ExpectExec(`SET LOCAL search_path TO "org_acme_bank"`).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery(`SELECT EXISTS`).
 		WithArgs("org_acme_bank").

--- a/shared/platform/db/tenant_isolation_integration_test.go
+++ b/shared/platform/db/tenant_isolation_integration_test.go
@@ -325,7 +325,7 @@ func TestWithGormTenantScope_Integration_NonExistentSchema_ReturnsError(t *testi
 // TestWithGormTenantScope_Integration_NonExistentSchema_NeverExposesPublicData is a security
 // regression test that verifies a non-existent tenant schema cannot access data in the
 // public schema. Before the fail-fast fix, PostgreSQL silently accepted non-existent schemas
-// in search_path and fell through to public, leaking cross-tenant data.
+// in search_path. With public removed from search_path, this risk is eliminated.
 func TestWithGormTenantScope_Integration_NonExistentSchema_NeverExposesPublicData(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")

--- a/shared/platform/db/tenant_scope.go
+++ b/shared/platform/db/tenant_scope.go
@@ -16,14 +16,14 @@ import (
 //  1. Extracts the tenant ID from context using tenant.FromContext
 //  2. Returns ErrMissingTenantContext if tenant is missing (fail-fast)
 //  3. Generates schema name via orgID.SchemaName() (returns "org_{id}")
-//  4. Executes SET LOCAL search_path TO <schema>, public
+//  4. Executes SET LOCAL search_path TO <schema>
 //  5. Returns the same DB for chaining
 //
 // SET LOCAL ensures the search_path automatically reverts when the transaction
 // commits or rolls back - no manual cleanup needed.
 //
-// The public schema is included in search_path to allow read access to shared
-// reference data.
+// The public schema is NOT included in search_path. All reference data
+// (instruments, sagas, account types) is replicated into tenant schemas.
 //
 // Example usage:
 //
@@ -45,13 +45,13 @@ func WithTenantScope(ctx context.Context, db DB) (DB, error) {
 	schemaName := pq.QuoteIdentifier(orgID.SchemaName())
 
 	// SET LOCAL is transaction-scoped - automatically reverts on commit/rollback
-	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	query := fmt.Sprintf("SET LOCAL search_path TO %s", schemaName)
 	if _, err := db.ExecContext(ctx, query); err != nil {
 		return nil, fmt.Errorf("failed to set tenant schema scope: %w", err)
 	}
 
 	// Verify the tenant schema actually exists - PostgreSQL allows SET LOCAL to non-existent schemas,
-	// which would silently fall through to public schema and leak cross-tenant data.
+	// which would cause queries to fail with missing table errors.
 	rawSchema := orgID.SchemaName()
 	var schemaExists bool
 	if err := db.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = $1)", rawSchema).Scan(&schemaExists); err != nil {

--- a/shared/platform/db/tenant_scope_test.go
+++ b/shared/platform/db/tenant_scope_test.go
@@ -87,8 +87,8 @@ func TestWithTenantScope_Success(t *testing.T) {
 	if !mock.execCalled {
 		t.Error("WithTenantScope should execute SET LOCAL query")
 	}
-	// Schema name should be quoted and include public
-	expected := `SET LOCAL search_path TO "org_acme_bank", public`
+	// Schema name should be quoted (no public schema fallback)
+	expected := `SET LOCAL search_path TO "org_acme_bank"`
 	if mock.execQuery != expected {
 		t.Errorf("Query = %q, want %q", mock.execQuery, expected)
 	}
@@ -193,7 +193,7 @@ func TestWithTenantScope_SchemaNameQuoting(t *testing.T) {
 			if err != nil {
 				t.Fatalf("WithTenantScope returned unexpected error: %v", err)
 			}
-			expected := "SET LOCAL search_path TO " + tt.expectedSchema + ", public"
+			expected := "SET LOCAL search_path TO " + tt.expectedSchema
 			if mock.execQuery != expected {
 				t.Errorf("Query = %q, want %q", mock.execQuery, expected)
 			}

--- a/shared/platform/scheduler/execution_store.go
+++ b/shared/platform/scheduler/execution_store.go
@@ -199,7 +199,7 @@ func (s *PgExecutionStore) setSearchPath(ctx context.Context, tx pgx.Tx) error {
 		return nil
 	}
 	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
-	_, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName))
+	_, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", schemaName))
 	if err != nil {
 		return fmt.Errorf("set tenant schema: %w", err)
 	}

--- a/shared/platform/testdb/pgx.go
+++ b/shared/platform/testdb/pgx.go
@@ -232,7 +232,7 @@ func applyMigrationsToSchema(t *testing.T, pool *pgxpool.Pool, service string, s
 		_ = tx.Rollback(ctx)
 	}()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName)))
 	if err != nil {
 		t.Fatalf("Failed to set search_path: %v", err)
 	}

--- a/shared/platform/testdb/postgres.go
+++ b/shared/platform/testdb/postgres.go
@@ -52,15 +52,16 @@ func CreateTenantSchema(t *testing.T, db *gorm.DB, tenantID interface{ SchemaNam
 	}
 
 	if len(models) > 0 {
-		// Set search_path to tenant schema, run AutoMigrate, then reset
-		if err := db.Exec(fmt.Sprintf("SET search_path TO %q", schema)).Error; err != nil {
-			t.Fatalf("Failed to set search_path to %s: %v", schema, err)
-		}
-		if err := db.AutoMigrate(models...); err != nil {
+		// Use a transaction so SET LOCAL + AutoMigrate share the same connection.
+		// SET LOCAL is transaction-scoped and auto-reverts on commit.
+		err := db.Transaction(func(tx *gorm.DB) error {
+			if err := tx.Exec(fmt.Sprintf("SET LOCAL search_path TO %q", schema)).Error; err != nil {
+				return fmt.Errorf("set search_path to %s: %w", schema, err)
+			}
+			return tx.AutoMigrate(models...)
+		})
+		if err != nil {
 			t.Fatalf("Failed to auto-migrate models in tenant schema %s: %v", schema, err)
-		}
-		if err := db.Exec("SET search_path TO public").Error; err != nil {
-			t.Fatalf("Failed to reset search_path: %v", err)
 		}
 	}
 }

--- a/shared/platform/testdb/postgres.go
+++ b/shared/platform/testdb/postgres.go
@@ -36,16 +36,32 @@ func WithLogLevel(level logger.LogLevel) PostgresOption {
 // This must be called before any tenant-scoped database operation that targets this tenant,
 // since WithGormTenantScope validates schema existence.
 //
+// When models are provided, GORM AutoMigrate runs inside the tenant schema so that
+// tenant-scoped queries find the same tables that were created in public by SetupPostgres.
+//
 // Example:
 //
-//	db, cleanup := testdb.SetupCockroachDB(t, models)
+//	db, cleanup := testdb.SetupPostgres(t, []interface{}{&MyEntity{}})
 //	defer cleanup()
-//	testdb.CreateTenantSchema(t, db, tenant.MustNewTenantID("test_tenant"))
-func CreateTenantSchema(t *testing.T, db *gorm.DB, tenantID interface{ SchemaName() string }) {
+//	testdb.CreateTenantSchema(t, db, tenant.MustNewTenantID("test_tenant"), &MyEntity{})
+func CreateTenantSchema(t *testing.T, db *gorm.DB, tenantID interface{ SchemaName() string }, models ...interface{}) {
 	t.Helper()
 	schema := tenantID.SchemaName()
 	if err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schema)).Error; err != nil {
 		t.Fatalf("Failed to create tenant schema %s: %v", schema, err)
+	}
+
+	if len(models) > 0 {
+		// Set search_path to tenant schema, run AutoMigrate, then reset
+		if err := db.Exec(fmt.Sprintf("SET search_path TO %q", schema)).Error; err != nil {
+			t.Fatalf("Failed to set search_path to %s: %v", schema, err)
+		}
+		if err := db.AutoMigrate(models...); err != nil {
+			t.Fatalf("Failed to auto-migrate models in tenant schema %s: %v", schema, err)
+		}
+		if err := db.Exec("SET search_path TO public").Error; err != nil {
+			t.Fatalf("Failed to reset search_path: %v", err)
+		}
 	}
 }
 

--- a/shared/platform/testdb/setup.go
+++ b/shared/platform/testdb/setup.go
@@ -143,7 +143,7 @@ func setupTenantSchema(t *testing.T, db *gorm.DB, cfg *setupConfig, cleanup func
 	// Use a transaction to pin the connection for SET search_path +
 	// AutoMigrate so they are guaranteed to execute on the same session.
 	err = db.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error; err != nil {
+		if err := tx.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error; err != nil {
 			return fmt.Errorf("set search_path to %s: %w", schemaName, err)
 		}
 

--- a/shared/platform/testdb/tenant.go
+++ b/shared/platform/testdb/tenant.go
@@ -47,7 +47,7 @@ func SetupTenantSchema(t *testing.T, db *gorm.DB, tenantID string) *TenantTestCo
 	}
 
 	// Set search_path to tenant schema so subsequent operations use it
-	err = db.Exec(fmt.Sprintf("SET search_path TO %q, public", schemaName)).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %q", schemaName)).Error
 	if err != nil {
 		t.Fatalf("Failed to set search_path to %s: %v", schemaName, err)
 	}

--- a/tests/integration/stress_test.go
+++ b/tests/integration/stress_test.go
@@ -74,7 +74,7 @@ func SetupStressTestContainer(t *testing.T) *StressTestContainer {
 	)
 	require.NoError(t, err, "Failed to start PostgreSQL container")
 
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable", "search_path=position_keeping,public")
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable", "search_path=position_keeping")
 	require.NoError(t, err, "Failed to get connection string")
 
 	// Configure pool with higher limits for stress testing

--- a/tests/load/bucket_cardinality_test.go
+++ b/tests/load/bucket_cardinality_test.go
@@ -113,7 +113,7 @@ func setupLoadTestContainer(tb testingTB) *loadTestContainer {
 		tb.Fatalf("Failed to start PostgreSQL container: %v", err)
 	}
 
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable", "search_path=position_keeping,public")
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable", "search_path=position_keeping")
 	if err != nil {
 		tb.Fatalf("Failed to get connection string: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Remove `, public` fallback from all `SET LOCAL search_path` calls across the entire codebase (~88 files), achieving complete tenant schema isolation
- Add fail-hard PostProvisioningHooks that seed reference data (instruments, saga scripts, account types, valuation defaults) directly into tenant schemas during provisioning
- Refactor saga seeder to copy embedded scripts into tenant schemas instead of creating platform_ref pointers to public.platform_saga_definition
- Create idempotent backfill script for existing tenants that copies saga scripts and seeds missing instruments
- Update all test assertions to reflect the new isolation model (no COALESCE fallback, UsedPlatformFallback always false)

## Changes Made

**Post-provisioning hooks (fail-hard):**
- InstrumentSeeder seeds 5 platform instruments (GBP, USD, EUR, TONNE_CO2E, KWH) with deterministic UUIDs
- Saga seeder loads scripts from embedded filesystem instead of querying public.platform_saga_definition
- Valuation and account-type seeders registered as hooks
- Hook failures prevent tenant activation (fail-hard, not best-effort)

**Search path isolation (88 files):**
- All `SET LOCAL search_path TO <schema>, public` changed to `SET LOCAL search_path TO <schema>`
- Shared platform packages (db.WithTenantScope, db.WithGormTenantScope, guarded pgx pool) updated
- All service repositories and test files updated
- Explicitly qualified `public.platform_saga_definition` references in PlatformSync, Bootstrap, and Override API kept as-is (platform-level operations)

**Backfill script:**
- `scripts/backfill-tenant-reference-data.sh` - copies saga scripts from platform table into tenant rows, seeds missing instruments
- Supports DRY_RUN=1 mode, idempotent

## Test plan

- [ ] CI passes (Go tests, lint, build)
- [ ] Saga seeder tests verify scripts are copied directly (not platform_ref)
- [ ] Fallback resolution tests verify no public schema COALESCE (UsedPlatformFallback = false)
- [ ] E2E seeder test verifies full provisioning lifecycle with copied scripts
- [ ] Tenant isolation tests verify schema name quoting without public fallback
- [ ] Run backfill script in DRY_RUN mode against demo environment