### PR TITLE
feat: self-service sign-up to tenant creation end-to-end flow

### DIFF
--- a/cmd/meridian/gateway.go
+++ b/cmd/meridian/gateway.go
@@ -17,6 +17,7 @@ import (
 	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/env"
 	platformgateway "github.com/meridianhub/meridian/shared/platform/gateway"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -205,6 +206,7 @@ var errNilTenantResponse = fmt.Errorf("InitiateTenant returned nil tenant")
 // gateway.TenantCreator interface used by RegistrationHandler.
 type loopbackTenantCreator struct {
 	client     tenantv1.TenantServiceClient
+	tenantRepo *tenantpersistence.Repository
 	baseDomain string
 	logger     *slog.Logger
 }
@@ -224,13 +226,14 @@ func (a *loopbackTenantCreator) CreateTenant(ctx context.Context, tenantID, slug
 	}
 
 	// Pass registration metadata through to the tenant record.
+	// Metadata conversion must succeed - async provisioning relies on credentials
+	// being present in the tenant record for the post-provisioning hook.
 	if len(metadata) > 0 {
 		pbMeta, err := structpb.NewStruct(metadata)
 		if err != nil {
-			a.logger.Warn("failed to convert registration metadata to protobuf struct", "error", err)
-		} else {
-			req.Metadata = pbMeta
+			return nil, fmt.Errorf("failed to convert registration metadata: %w", err)
 		}
+		req.Metadata = pbMeta
 	}
 
 	resp, err := a.client.InitiateTenant(ctx, req)
@@ -252,6 +255,17 @@ func (a *loopbackTenantCreator) DeleteTenant(ctx context.Context, tenantID strin
 		Status:   tenantv1.TenantStatus_TENANT_STATUS_DEPROVISIONED,
 	})
 	return err
+}
+
+func (a *loopbackTenantCreator) ClearTenantMetadata(ctx context.Context, tenantID string) error {
+	if a.tenantRepo == nil {
+		return nil
+	}
+	tid, err := tenant.NewTenantID(tenantID)
+	if err != nil {
+		return fmt.Errorf("invalid tenant ID: %w", err)
+	}
+	return a.tenantRepo.UpdateMetadata(ctx, tid, map[string]interface{}{})
 }
 
 // loopbackSlugChecker adapts the tenant persistence repository to the
@@ -307,8 +321,9 @@ func wireRegistration(identityDB, tenantDB *gorm.DB, rawConn *grpc.ClientConn, b
 	identityRepo := identitypersistence.NewRepository(identityDB)
 	tenantClient := tenantv1.NewTenantServiceClient(rawConn)
 
-	creator := &loopbackTenantCreator{client: tenantClient, baseDomain: baseDomain, logger: logger}
-	slugChecker := &loopbackSlugChecker{repo: tenantpersistence.NewRepository(tenantDB)}
+	tenantRepo := tenantpersistence.NewRepository(tenantDB)
+	creator := &loopbackTenantCreator{client: tenantClient, tenantRepo: tenantRepo, baseDomain: baseDomain, logger: logger}
+	slugChecker := &loopbackSlugChecker{repo: tenantRepo}
 
 	emailVerificationRequired := env.GetEnvAsBool("EMAIL_VERIFICATION_REQUIRED", false)
 

--- a/cmd/meridian/gateway.go
+++ b/cmd/meridian/gateway.go
@@ -19,6 +19,7 @@ import (
 	platformgateway "github.com/meridianhub/meridian/shared/platform/gateway"
 
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/structpb"
 	"gorm.io/gorm"
 )
 
@@ -208,26 +209,41 @@ type loopbackTenantCreator struct {
 	logger     *slog.Logger
 }
 
-func (a *loopbackTenantCreator) CreateTenant(ctx context.Context, tenantID, slug, displayName string) (string, error) {
+func (a *loopbackTenantCreator) CreateTenant(ctx context.Context, tenantID, slug, displayName string, metadata map[string]interface{}) (*gateway.CreateTenantResult, error) {
 	subdomain := slug
 	if a.baseDomain != "" {
 		subdomain = slug + "." + a.baseDomain
 	}
 
-	resp, err := a.client.InitiateTenant(ctx, &tenantv1.InitiateTenantRequest{
+	req := &tenantv1.InitiateTenantRequest{
 		TenantId:        tenantID,
 		DisplayName:     displayName,
 		Slug:            slug,
 		Subdomain:       subdomain,
 		SettlementAsset: "USD",
-	})
+	}
+
+	// Pass registration metadata through to the tenant record.
+	if len(metadata) > 0 {
+		pbMeta, err := structpb.NewStruct(metadata)
+		if err != nil {
+			a.logger.Warn("failed to convert registration metadata to protobuf struct", "error", err)
+		} else {
+			req.Metadata = pbMeta
+		}
+	}
+
+	resp, err := a.client.InitiateTenant(ctx, req)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if resp.Tenant == nil {
-		return "", errNilTenantResponse
+		return nil, errNilTenantResponse
 	}
-	return resp.Tenant.TenantId, nil
+	return &gateway.CreateTenantResult{
+		TenantID:            resp.Tenant.TenantId,
+		ProvisioningPending: resp.Tenant.Status == tenantv1.TenantStatus_TENANT_STATUS_PROVISIONING_PENDING,
+	}, nil
 }
 
 func (a *loopbackTenantCreator) DeleteTenant(ctx context.Context, tenantID string) error {

--- a/cmd/meridian/registration_wiring_test.go
+++ b/cmd/meridian/registration_wiring_test.go
@@ -58,7 +58,10 @@ func (s *stubTenantServiceClient) UpdateTenantStatus(_ context.Context, req *ten
 func TestLoopbackTenantCreator_CreateTenant(t *testing.T) {
 	stub := &stubTenantServiceClient{
 		initiateResp: &tenantv1.InitiateTenantResponse{
-			Tenant: &tenantv1.Tenant{TenantId: "acme_corp"},
+			Tenant: &tenantv1.Tenant{
+				TenantId: "acme_corp",
+				Status:   tenantv1.TenantStatus_TENANT_STATUS_PROVISIONING_PENDING,
+			},
 		},
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -69,10 +72,11 @@ func TestLoopbackTenantCreator_CreateTenant(t *testing.T) {
 		logger:     logger,
 	}
 
-	tenantID, err := creator.CreateTenant(context.Background(), "acme_corp", "acme-corp", "Acme Corp")
+	result, err := creator.CreateTenant(context.Background(), "acme_corp", "acme-corp", "Acme Corp", nil)
 
 	require.NoError(t, err)
-	assert.Equal(t, "acme_corp", tenantID)
+	assert.Equal(t, "acme_corp", result.TenantID)
+	assert.True(t, result.ProvisioningPending)
 	assert.True(t, stub.initiateCalled)
 	assert.Equal(t, "acme_corp", stub.initiateReq.TenantId)
 	assert.Equal(t, "Acme Corp", stub.initiateReq.DisplayName)
@@ -85,7 +89,10 @@ func TestLoopbackTenantCreator_CreateTenant(t *testing.T) {
 func TestLoopbackTenantCreator_CreateTenant_EmptyBaseDomain(t *testing.T) {
 	stub := &stubTenantServiceClient{
 		initiateResp: &tenantv1.InitiateTenantResponse{
-			Tenant: &tenantv1.Tenant{TenantId: "acme_corp"},
+			Tenant: &tenantv1.Tenant{
+				TenantId: "acme_corp",
+				Status:   tenantv1.TenantStatus_TENANT_STATUS_ACTIVE,
+			},
 		},
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -96,9 +103,10 @@ func TestLoopbackTenantCreator_CreateTenant_EmptyBaseDomain(t *testing.T) {
 		logger:     logger,
 	}
 
-	_, err := creator.CreateTenant(context.Background(), "acme_corp", "acme-corp", "Acme Corp")
+	result, err := creator.CreateTenant(context.Background(), "acme_corp", "acme-corp", "Acme Corp", nil)
 
 	require.NoError(t, err)
+	assert.False(t, result.ProvisioningPending)
 	assert.Equal(t, "acme-corp", stub.initiateReq.Subdomain,
 		"when baseDomain is empty, subdomain should be just the slug")
 }
@@ -111,10 +119,35 @@ func TestLoopbackTenantCreator_CreateTenant_NilTenantInResponse(t *testing.T) {
 
 	creator := &loopbackTenantCreator{client: stub, logger: logger}
 
-	_, err := creator.CreateTenant(context.Background(), "acme_corp", "acme-corp", "Acme Corp")
+	_, err := creator.CreateTenant(context.Background(), "acme_corp", "acme-corp", "Acme Corp", nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "nil tenant")
+}
+
+func TestLoopbackTenantCreator_CreateTenant_PassesMetadata(t *testing.T) {
+	stub := &stubTenantServiceClient{
+		initiateResp: &tenantv1.InitiateTenantResponse{
+			Tenant: &tenantv1.Tenant{
+				TenantId: "acme_corp",
+				Status:   tenantv1.TenantStatus_TENANT_STATUS_PROVISIONING_PENDING,
+			},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	creator := &loopbackTenantCreator{client: stub, baseDomain: "test.local", logger: logger}
+
+	metadata := map[string]interface{}{
+		"_registration_email":         "admin@acme.com",
+		"_registration_password_hash": "$2a$10$fakehash",
+	}
+	_, err := creator.CreateTenant(context.Background(), "acme_corp", "acme-corp", "Acme Corp", metadata)
+
+	require.NoError(t, err)
+	require.NotNil(t, stub.initiateReq.Metadata)
+	assert.Equal(t, "admin@acme.com", stub.initiateReq.Metadata.Fields["_registration_email"].GetStringValue())
+	assert.Equal(t, "$2a$10$fakehash", stub.initiateReq.Metadata.Fields["_registration_password_hash"].GetStringValue())
 }
 
 func TestLoopbackTenantCreator_DeleteTenant(t *testing.T) {

--- a/cmd/meridian/wire_services.go
+++ b/cmd/meridian/wire_services.go
@@ -243,6 +243,17 @@ func startProvisioningWorker(ctx context.Context, prov *tenantprovisioner.Postgr
 	valuationSeeder := refvaluation.NewSeeder(refDataPool)
 	w.RegisterPostProvisioningHook("valuation-defaults", valuationSeeder.AsPostProvisioningHook())
 
+	// Self-registered admin: creates the admin identity from registration metadata
+	// stored by the registration handler. Must run after all reference data hooks
+	// so the identity schema has instruments, account types, etc. available.
+	tenantRepo := tenantpersistence.NewRepository(conns.gormDB("tenant"))
+	selfRegHook, hookErr := identitybootstrap.NewSelfRegisteredAdminHook(identityRepo, tenantRepo, logger)
+	if hookErr != nil {
+		_ = prov.Close()
+		return nil, nil, fmt.Errorf("self-registered admin hook: %w", hookErr)
+	}
+	w.RegisterPostProvisioningHook("self-registered-admin", selfRegHook.AsPostProvisioningHook())
+
 	go w.Start(ctx)
 	logger.Info("provisioning worker started")
 

--- a/cmd/meridian/wire_services.go
+++ b/cmd/meridian/wire_services.go
@@ -246,8 +246,7 @@ func startProvisioningWorker(ctx context.Context, prov *tenantprovisioner.Postgr
 	// Self-registered admin: creates the admin identity from registration metadata
 	// stored by the registration handler. Must run after all reference data hooks
 	// so the identity schema has instruments, account types, etc. available.
-	tenantRepo := tenantpersistence.NewRepository(conns.gormDB("tenant"))
-	selfRegHook, hookErr := identitybootstrap.NewSelfRegisteredAdminHook(identityRepo, tenantRepo, logger)
+	selfRegHook, hookErr := identitybootstrap.NewSelfRegisteredAdminHook(identityRepo, repo, logger)
 	if hookErr != nil {
 		_ = prov.Close()
 		return nil, nil, fmt.Errorf("self-registered admin hook: %w", hookErr)

--- a/services/api-gateway/registration_handler.go
+++ b/services/api-gateway/registration_handler.go
@@ -204,8 +204,9 @@ func (h *RegistrationHandler) parseAndValidateRequest(r *http.Request) (*registr
 // These are read by the self-registered admin post-provisioning hook and cleared after
 // the identity is created, so they never persist beyond tenant activation.
 const (
-	MetaKeyRegistrationEmail        = "_registration_email"
-	MetaKeyRegistrationPasswordHash = "_registration_password_hash"
+	MetaKeyRegistrationEmail               = "_registration_email"
+	MetaKeyRegistrationPasswordHash        = "_registration_password_hash"
+	MetaKeyRegistrationEmailVerifyRequired = "_registration_email_verify_required"
 )
 
 // executeRegistration performs tenant creation and identity provisioning.
@@ -231,8 +232,9 @@ func (h *RegistrationHandler) executeRegistration(ctx context.Context, req *regi
 	// Include registration credentials in tenant metadata so the post-provisioning
 	// hook can create the admin identity after schema provisioning completes.
 	metadata := map[string]interface{}{
-		MetaKeyRegistrationEmail:        req.Email,
-		MetaKeyRegistrationPasswordHash: passwordHash,
+		MetaKeyRegistrationEmail:               req.Email,
+		MetaKeyRegistrationPasswordHash:        passwordHash,
+		MetaKeyRegistrationEmailVerifyRequired: h.emailVerificationRequired,
 	}
 
 	result, err := h.tenantCreator.CreateTenant(ctx, tenantID, req.Slug, displayName, metadata)

--- a/services/api-gateway/registration_handler.go
+++ b/services/api-gateway/registration_handler.go
@@ -55,6 +55,9 @@ type TenantCreator interface {
 	// DeleteTenant removes a tenant. Used as compensation when identity provisioning
 	// fails after tenant creation, preventing orphaned tenants.
 	DeleteTenant(ctx context.Context, tenantID string) error
+	// ClearTenantMetadata removes all metadata from a tenant record.
+	// Used to clean up registration credentials after sync identity provisioning.
+	ClearTenantMetadata(ctx context.Context, tenantID string) error
 }
 
 // SlugChecker abstracts slug availability checks for the registration handler.
@@ -258,6 +261,11 @@ func (h *RegistrationHandler) executeRegistration(ctx context.Context, req *regi
 					"tenant_id", result.TenantID, "error", delErr)
 			}
 			return regErr.status, nil, regErr
+		}
+		// Clear registration credentials from tenant metadata (best-effort).
+		if clearErr := h.tenantCreator.ClearTenantMetadata(ctx, result.TenantID); clearErr != nil {
+			h.logger.WarnContext(ctx, "registration: failed to clear credentials from tenant metadata",
+				"tenant_id", result.TenantID, "error", clearErr)
 		}
 	}
 

--- a/services/api-gateway/registration_handler.go
+++ b/services/api-gateway/registration_handler.go
@@ -37,11 +37,21 @@ var (
 	errEmailAlreadyRegistered   = errors.New("email already registered in this tenant")
 )
 
+// CreateTenantResult holds the outcome of a tenant creation request.
+type CreateTenantResult struct {
+	TenantID string
+	// ProvisioningPending is true when the tenant requires async schema provisioning
+	// before it becomes active. When true, identity creation must be deferred to
+	// a post-provisioning hook and credentials stored in tenant metadata.
+	ProvisioningPending bool
+}
+
 // TenantCreator abstracts tenant creation for the registration handler.
 type TenantCreator interface {
 	// CreateTenant creates a new tenant with the given ID, slug, and display name.
-	// Returns the tenant ID on success.
-	CreateTenant(ctx context.Context, tenantID, slug, displayName string) (string, error)
+	// The metadata map is stored on the tenant record (used for registration credentials
+	// when provisioning is async).
+	CreateTenant(ctx context.Context, tenantID, slug, displayName string, metadata map[string]interface{}) (*CreateTenantResult, error)
 	// DeleteTenant removes a tenant. Used as compensation when identity provisioning
 	// fails after tenant creation, preventing orphaned tenants.
 	DeleteTenant(ctx context.Context, tenantID string) error
@@ -119,6 +129,7 @@ type registrationResponse struct {
 	TenantID             string `json:"tenant_id"`
 	LoginURL             string `json:"login_url"`
 	VerificationRequired bool   `json:"verification_required"`
+	ProvisioningPending  bool   `json:"provisioning_pending"`
 }
 
 // HandleRegister handles POST /api/v1/register.
@@ -155,9 +166,10 @@ func (h *RegistrationHandler) HandleRegister(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	h.logger.InfoContext(ctx, "registration: tenant and admin identity created",
+	h.logger.InfoContext(ctx, "registration: tenant created",
 		"tenant_id", resp.TenantID,
 		"slug", req.Slug,
+		"provisioning_pending", resp.ProvisioningPending,
 		"client_ip", clientIP)
 
 	writeJSON(w, http.StatusCreated, resp)
@@ -185,7 +197,19 @@ func (h *RegistrationHandler) parseAndValidateRequest(r *http.Request) (*registr
 	return &req, nil
 }
 
+// Metadata keys used to store self-registered admin credentials on the tenant record.
+// These are read by the self-registered admin post-provisioning hook and cleared after
+// the identity is created, so they never persist beyond tenant activation.
+const (
+	MetaKeyRegistrationEmail        = "_registration_email"
+	MetaKeyRegistrationPasswordHash = "_registration_password_hash"
+)
+
 // executeRegistration performs tenant creation and identity provisioning.
+// When the tenant requires async provisioning, admin credentials are stored in tenant
+// metadata and identity creation is deferred to a post-provisioning hook.
+// When provisioning is synchronous (tenant immediately active), the identity is
+// created inline as before.
 // Returns (httpStatus, response, error). On success error is nil.
 func (h *RegistrationHandler) executeRegistration(ctx context.Context, req *registrationRequest) (int, *registrationResponse, error) {
 	tenantID := strings.ReplaceAll(req.Slug, "-", "_")
@@ -194,7 +218,21 @@ func (h *RegistrationHandler) executeRegistration(ctx context.Context, req *regi
 		displayName = req.Slug
 	}
 
-	createdTenantID, err := h.tenantCreator.CreateTenant(ctx, tenantID, req.Slug, displayName)
+	// Hash password early so we can store it in metadata for async provisioning.
+	passwordHash, err := credentials.HashPassword(req.Password)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "registration: failed to hash password", "error", err)
+		return http.StatusInternalServerError, nil, errIdentityCreationFailed
+	}
+
+	// Include registration credentials in tenant metadata so the post-provisioning
+	// hook can create the admin identity after schema provisioning completes.
+	metadata := map[string]interface{}{
+		MetaKeyRegistrationEmail:        req.Email,
+		MetaKeyRegistrationPasswordHash: passwordHash,
+	}
+
+	result, err := h.tenantCreator.CreateTenant(ctx, tenantID, req.Slug, displayName, metadata)
 	if err != nil {
 		if isAlreadyExistsError(err) {
 			return http.StatusConflict, nil, errSlugTaken
@@ -204,14 +242,23 @@ func (h *RegistrationHandler) executeRegistration(ctx context.Context, req *regi
 		return http.StatusInternalServerError, nil, errTenantCreationFailed
 	}
 
-	regErr := h.provisionAdminIdentity(ctx, createdTenantID, req.Email, req.Password)
-	if regErr != nil {
-		// Compensate: delete orphaned tenant to allow the user to retry.
-		if delErr := h.tenantCreator.DeleteTenant(ctx, createdTenantID); delErr != nil {
-			h.logger.ErrorContext(ctx, "registration: failed to compensate (delete tenant)",
-				"tenant_id", createdTenantID, "error", delErr)
+	if result.ProvisioningPending {
+		// Tenant requires async provisioning - identity will be created by the
+		// self-registered admin post-provisioning hook after schemas are ready.
+		h.logger.InfoContext(ctx, "registration: tenant created with async provisioning, identity deferred to post-provisioning hook",
+			"tenant_id", result.TenantID,
+			"slug", req.Slug)
+	} else {
+		// Tenant is immediately active - create identity inline.
+		regErr := h.provisionAdminIdentity(ctx, result.TenantID, req.Email, passwordHash)
+		if regErr != nil {
+			// Compensate: delete orphaned tenant to allow the user to retry.
+			if delErr := h.tenantCreator.DeleteTenant(ctx, result.TenantID); delErr != nil {
+				h.logger.ErrorContext(ctx, "registration: failed to compensate (delete tenant)",
+					"tenant_id", result.TenantID, "error", delErr)
+			}
+			return regErr.status, nil, regErr
 		}
-		return regErr.status, nil, regErr
 	}
 
 	loginURL := fmt.Sprintf("https://%s.%s/login", req.Slug, h.baseDomain)
@@ -220,9 +267,10 @@ func (h *RegistrationHandler) executeRegistration(ctx context.Context, req *regi
 	}
 
 	return http.StatusCreated, &registrationResponse{
-		TenantID:             createdTenantID,
+		TenantID:             result.TenantID,
 		LoginURL:             loginURL,
 		VerificationRequired: h.emailVerificationRequired,
+		ProvisioningPending:  result.ProvisioningPending,
 	}, nil
 }
 
@@ -240,7 +288,8 @@ func newRegistrationError(status int, inner error) *registrationError {
 }
 
 // provisionAdminIdentity creates the initial admin identity within the new tenant's scope.
-func (h *RegistrationHandler) provisionAdminIdentity(ctx context.Context, tenantIDStr, emailAddr, password string) *registrationError {
+// The passwordHash parameter is a pre-computed bcrypt hash.
+func (h *RegistrationHandler) provisionAdminIdentity(ctx context.Context, tenantIDStr, emailAddr, passwordHash string) *registrationError {
 	tid, err := tenant.NewTenantID(tenantIDStr)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "registration: invalid tenant ID from creation",
@@ -250,7 +299,7 @@ func (h *RegistrationHandler) provisionAdminIdentity(ctx context.Context, tenant
 
 	tenantCtx := tenant.WithTenant(ctx, tid)
 
-	identity, regErr := h.buildAdminIdentity(ctx, tid, emailAddr, password)
+	identity, regErr := h.buildAdminIdentity(ctx, tid, emailAddr, passwordHash)
 	if regErr != nil {
 		return regErr
 	}
@@ -273,9 +322,9 @@ func (h *RegistrationHandler) provisionAdminIdentity(ctx context.Context, tenant
 	return nil
 }
 
-// buildAdminIdentity creates a new identity with the given credentials and activates it
-// if email verification is not required.
-func (h *RegistrationHandler) buildAdminIdentity(ctx context.Context, tid tenant.TenantID, emailAddr, password string) (*identitydomain.Identity, *registrationError) {
+// buildAdminIdentity creates a new identity with the given pre-computed password hash
+// and activates it if email verification is not required.
+func (h *RegistrationHandler) buildAdminIdentity(ctx context.Context, tid tenant.TenantID, emailAddr, passwordHash string) (*identitydomain.Identity, *registrationError) {
 	var identity *identitydomain.Identity
 	var err error
 	if h.emailVerificationRequired {
@@ -287,13 +336,7 @@ func (h *RegistrationHandler) buildAdminIdentity(ctx context.Context, tid tenant
 		return nil, newRegistrationError(http.StatusBadRequest, fmt.Errorf("%w: %w", errIdentityCreationFailed, err))
 	}
 
-	hash, err := credentials.HashPassword(password)
-	if err != nil {
-		h.logger.ErrorContext(ctx, "registration: failed to hash password", "error", err)
-		return nil, newRegistrationError(http.StatusInternalServerError, errIdentityCreationFailed)
-	}
-
-	if err := identity.SetPassword(hash); err != nil {
+	if err := identity.SetPassword(passwordHash); err != nil {
 		h.logger.ErrorContext(ctx, "registration: failed to set password", "error", err)
 		return nil, newRegistrationError(http.StatusInternalServerError, errIdentityCreationFailed)
 	}

--- a/services/api-gateway/registration_handler_test.go
+++ b/services/api-gateway/registration_handler_test.go
@@ -747,6 +747,7 @@ func TestRegistrationHandler_AsyncProvisioning_DefersIdentityCreation(t *testing
 	assert.Equal(t, "admin@acme.com", capturedMetadata[gateway.MetaKeyRegistrationEmail])
 	assert.Contains(t, capturedMetadata, gateway.MetaKeyRegistrationPasswordHash)
 	assert.NotEmpty(t, capturedMetadata[gateway.MetaKeyRegistrationPasswordHash])
+	assert.Contains(t, capturedMetadata, gateway.MetaKeyRegistrationEmailVerifyRequired)
 }
 
 func TestRegistrationHandler_SyncProvisioning_CreatesIdentityInline(t *testing.T) {

--- a/services/api-gateway/registration_handler_test.go
+++ b/services/api-gateway/registration_handler_test.go
@@ -24,8 +24,9 @@ import (
 // --- Stub implementations ---
 
 type stubTenantCreator struct {
-	createFn func(ctx context.Context, tenantID, slug, displayName string, metadata map[string]interface{}) (*gateway.CreateTenantResult, error)
-	deleteFn func(ctx context.Context, tenantID string) error
+	createFn        func(ctx context.Context, tenantID, slug, displayName string, metadata map[string]interface{}) (*gateway.CreateTenantResult, error)
+	deleteFn        func(ctx context.Context, tenantID string) error
+	clearMetadataFn func(ctx context.Context, tenantID string) error
 }
 
 func (s *stubTenantCreator) CreateTenant(ctx context.Context, tenantID, slug, displayName string, metadata map[string]interface{}) (*gateway.CreateTenantResult, error) {
@@ -35,6 +36,13 @@ func (s *stubTenantCreator) CreateTenant(ctx context.Context, tenantID, slug, di
 func (s *stubTenantCreator) DeleteTenant(ctx context.Context, tenantID string) error {
 	if s.deleteFn != nil {
 		return s.deleteFn(ctx, tenantID)
+	}
+	return nil
+}
+
+func (s *stubTenantCreator) ClearTenantMetadata(ctx context.Context, tenantID string) error {
+	if s.clearMetadataFn != nil {
+		return s.clearMetadataFn(ctx, tenantID)
 	}
 	return nil
 }

--- a/services/api-gateway/registration_handler_test.go
+++ b/services/api-gateway/registration_handler_test.go
@@ -24,12 +24,12 @@ import (
 // --- Stub implementations ---
 
 type stubTenantCreator struct {
-	createFn func(ctx context.Context, tenantID, slug, displayName string) (string, error)
+	createFn func(ctx context.Context, tenantID, slug, displayName string, metadata map[string]interface{}) (*gateway.CreateTenantResult, error)
 	deleteFn func(ctx context.Context, tenantID string) error
 }
 
-func (s *stubTenantCreator) CreateTenant(ctx context.Context, tenantID, slug, displayName string) (string, error) {
-	return s.createFn(ctx, tenantID, slug, displayName)
+func (s *stubTenantCreator) CreateTenant(ctx context.Context, tenantID, slug, displayName string, metadata map[string]interface{}) (*gateway.CreateTenantResult, error) {
+	return s.createFn(ctx, tenantID, slug, displayName, metadata)
 }
 
 func (s *stubTenantCreator) DeleteTenant(ctx context.Context, tenantID string) error {
@@ -158,8 +158,8 @@ func (s *stubSlugChecker) IsSlugAvailable(ctx context.Context, slug string) (boo
 
 func defaultStubs() (*stubTenantCreator, *stubIdentityRepo) {
 	tc := &stubTenantCreator{
-		createFn: func(_ context.Context, tenantID, _, _ string) (string, error) {
-			return tenantID, nil
+		createFn: func(_ context.Context, tenantID, _, _ string, _ map[string]interface{}) (*gateway.CreateTenantResult, error) {
+			return &gateway.CreateTenantResult{TenantID: tenantID}, nil
 		},
 	}
 	ir := &stubIdentityRepo{}
@@ -215,11 +215,11 @@ func TestRegistrationHandler_Success(t *testing.T) {
 	tc, ir := defaultStubs()
 
 	var capturedTenantID, capturedSlug, capturedDisplayName string
-	tc.createFn = func(_ context.Context, tenantID, slug, displayName string) (string, error) {
+	tc.createFn = func(_ context.Context, tenantID, slug, displayName string, _ map[string]interface{}) (*gateway.CreateTenantResult, error) {
 		capturedTenantID = tenantID
 		capturedSlug = slug
 		capturedDisplayName = displayName
-		return tenantID, nil
+		return &gateway.CreateTenantResult{TenantID: tenantID}, nil
 	}
 
 	var capturedIdentityEmail string
@@ -258,9 +258,9 @@ func TestRegistrationHandler_DefaultDisplayName(t *testing.T) {
 	tc, ir := defaultStubs()
 
 	var capturedDisplayName string
-	tc.createFn = func(_ context.Context, tenantID, _, displayName string) (string, error) {
+	tc.createFn = func(_ context.Context, tenantID, _, displayName string, _ map[string]interface{}) (*gateway.CreateTenantResult, error) {
 		capturedDisplayName = displayName
-		return tenantID, nil
+		return &gateway.CreateTenantResult{TenantID: tenantID}, nil
 	}
 
 	h := newRegistrationHandler(t, tc, ir)
@@ -344,8 +344,8 @@ func TestRegistrationHandler_WeakPassword(t *testing.T) {
 
 func TestRegistrationHandler_SlugTaken(t *testing.T) {
 	tc, ir := defaultStubs()
-	tc.createFn = func(_ context.Context, _, _, _ string) (string, error) {
-		return "", status.Error(codes.AlreadyExists, "tenant acme_corp already exists")
+	tc.createFn = func(_ context.Context, _, _, _ string, _ map[string]interface{}) (*gateway.CreateTenantResult, error) {
+		return nil, status.Error(codes.AlreadyExists, "tenant acme_corp already exists")
 	}
 
 	h := newRegistrationHandler(t, tc, ir)
@@ -364,8 +364,8 @@ func TestRegistrationHandler_SlugTaken(t *testing.T) {
 
 func TestRegistrationHandler_TenantCreationFails(t *testing.T) {
 	tc, ir := defaultStubs()
-	tc.createFn = func(_ context.Context, _, _, _ string) (string, error) {
-		return "", errors.New("database connection lost")
+	tc.createFn = func(_ context.Context, _, _, _ string, _ map[string]interface{}) (*gateway.CreateTenantResult, error) {
+		return nil, errors.New("database connection lost")
 	}
 
 	h := newRegistrationHandler(t, tc, ir)
@@ -636,8 +636,8 @@ func TestSlugAvailable_MethodNotAllowed(t *testing.T) {
 
 func TestRegistrationHandler_VerificationRequired_Success(t *testing.T) {
 	tc := &stubTenantCreator{
-		createFn: func(_ context.Context, tenantID, _, _ string) (string, error) {
-			return tenantID, nil
+		createFn: func(_ context.Context, tenantID, _, _ string, _ map[string]interface{}) (*gateway.CreateTenantResult, error) {
+			return &gateway.CreateTenantResult{TenantID: tenantID}, nil
 		},
 	}
 
@@ -693,4 +693,84 @@ func TestRegistrationHandler_NoVerificationRequired_DefaultBehavior(t *testing.T
 	assert.Equal(t, http.StatusCreated, w.Code)
 	resp := parseResponse(t, w)
 	assert.Equal(t, false, resp["verification_required"])
+}
+
+// --- Async Provisioning Tests ---
+
+func TestRegistrationHandler_AsyncProvisioning_DefersIdentityCreation(t *testing.T) {
+	var capturedMetadata map[string]interface{}
+	tc := &stubTenantCreator{
+		createFn: func(_ context.Context, tenantID, _, _ string, metadata map[string]interface{}) (*gateway.CreateTenantResult, error) {
+			capturedMetadata = metadata
+			return &gateway.CreateTenantResult{
+				TenantID:            tenantID,
+				ProvisioningPending: true,
+			}, nil
+		},
+	}
+
+	identitySaveCalled := false
+	ir := &stubIdentityRepo{
+		saveIdentityWithRolesFn: func(_ context.Context, _ *identitydomain.Identity, _ []*identitydomain.RoleAssignment) error {
+			identitySaveCalled = true
+			return nil
+		},
+	}
+
+	h := newRegistrationHandler(t, tc, ir)
+	w := postRegister(h, map[string]string{
+		"slug":     "acme-corp",
+		"email":    "admin@acme.com",
+		"password": "SecurePass123!",
+	})
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	resp := parseResponse(t, w)
+	assert.Equal(t, true, resp["provisioning_pending"])
+	assert.Equal(t, "acme_corp", resp["tenant_id"])
+	assert.Equal(t, "https://acme-corp.meridian.app/login", resp["login_url"])
+
+	// Identity should NOT be created inline - deferred to post-provisioning hook.
+	assert.False(t, identitySaveCalled, "identity should not be created when provisioning is pending")
+
+	// Registration metadata should be passed to tenant creation.
+	assert.Contains(t, capturedMetadata, gateway.MetaKeyRegistrationEmail)
+	assert.Equal(t, "admin@acme.com", capturedMetadata[gateway.MetaKeyRegistrationEmail])
+	assert.Contains(t, capturedMetadata, gateway.MetaKeyRegistrationPasswordHash)
+	assert.NotEmpty(t, capturedMetadata[gateway.MetaKeyRegistrationPasswordHash])
+}
+
+func TestRegistrationHandler_SyncProvisioning_CreatesIdentityInline(t *testing.T) {
+	tc := &stubTenantCreator{
+		createFn: func(_ context.Context, tenantID, _, _ string, _ map[string]interface{}) (*gateway.CreateTenantResult, error) {
+			return &gateway.CreateTenantResult{
+				TenantID:            tenantID,
+				ProvisioningPending: false,
+			}, nil
+		},
+	}
+
+	identitySaveCalled := false
+	ir := &stubIdentityRepo{
+		saveIdentityWithRolesFn: func(_ context.Context, _ *identitydomain.Identity, _ []*identitydomain.RoleAssignment) error {
+			identitySaveCalled = true
+			return nil
+		},
+	}
+
+	h := newRegistrationHandler(t, tc, ir)
+	w := postRegister(h, map[string]string{
+		"slug":     "acme-corp",
+		"email":    "admin@acme.com",
+		"password": "SecurePass123!",
+	})
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	resp := parseResponse(t, w)
+	assert.Equal(t, false, resp["provisioning_pending"])
+
+	// Identity should be created inline when no async provisioning.
+	assert.True(t, identitySaveCalled, "identity should be created inline when provisioning is not pending")
 }

--- a/services/identity/bootstrap/self_registered_admin.go
+++ b/services/identity/bootstrap/self_registered_admin.go
@@ -15,9 +15,15 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/services/identity/domain"
-	tenantpersistence "github.com/meridianhub/meridian/services/tenant/adapters/persistence"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
+
+// TenantMetadataStore provides read/write access to tenant metadata.
+// Implemented by the tenant persistence repository.
+type TenantMetadataStore interface {
+	GetMetadata(ctx context.Context, id tenant.TenantID) (map[string]interface{}, error)
+	UpdateMetadata(ctx context.Context, id tenant.TenantID, metadata map[string]interface{}) error
+}
 
 // Metadata keys for self-registered admin credentials stored on the tenant record.
 // These MUST match the exported constants in services/api-gateway/registration_handler.go
@@ -37,16 +43,16 @@ var ErrNilTenantRepo = errors.New("self-registered admin hook: tenant repository
 // tenant-owner role, and clears the credentials from metadata.
 type SelfRegisteredAdminHook struct {
 	identityRepo domain.Repository
-	tenantRepo   *tenantpersistence.Repository
+	tenantStore  TenantMetadataStore
 	logger       *slog.Logger
 }
 
 // NewSelfRegisteredAdminHook creates a new hook for provisioning self-registered admin identities.
-func NewSelfRegisteredAdminHook(identityRepo domain.Repository, tenantRepo *tenantpersistence.Repository, logger *slog.Logger) (*SelfRegisteredAdminHook, error) {
+func NewSelfRegisteredAdminHook(identityRepo domain.Repository, tenantStore TenantMetadataStore, logger *slog.Logger) (*SelfRegisteredAdminHook, error) {
 	if identityRepo == nil {
 		return nil, ErrNilRepository
 	}
-	if tenantRepo == nil {
+	if tenantStore == nil {
 		return nil, ErrNilTenantRepo
 	}
 	if logger == nil {
@@ -54,7 +60,7 @@ func NewSelfRegisteredAdminHook(identityRepo domain.Repository, tenantRepo *tena
 	}
 	return &SelfRegisteredAdminHook{
 		identityRepo: identityRepo,
-		tenantRepo:   tenantRepo,
+		tenantStore:  tenantStore,
 		logger:       logger,
 	}, nil
 }
@@ -74,14 +80,14 @@ func (h *SelfRegisteredAdminHook) AsPostProvisioningHook() func(ctx context.Cont
 // If no registration metadata is present (e.g., tenant was created via API, not
 // self-registration), this is a no-op.
 func (h *SelfRegisteredAdminHook) Provision(ctx context.Context, tenantID tenant.TenantID) error {
-	// Read tenant to get registration metadata.
-	t, err := h.tenantRepo.GetByID(ctx, tenantID)
+	// Read tenant metadata to check for registration credentials.
+	metadata, err := h.tenantStore.GetMetadata(ctx, tenantID)
 	if err != nil {
-		return fmt.Errorf("reading tenant %s: %w", tenantID, err)
+		return fmt.Errorf("reading tenant metadata for %s: %w", tenantID, err)
 	}
 
-	emailRaw, hasEmail := t.Metadata[MetaKeyRegistrationEmail]
-	hashRaw, hasHash := t.Metadata[MetaKeyRegistrationPasswordHash]
+	emailRaw, hasEmail := metadata[MetaKeyRegistrationEmail]
+	hashRaw, hasHash := metadata[MetaKeyRegistrationPasswordHash]
 
 	if !hasEmail || !hasHash {
 		h.logger.InfoContext(ctx, "self-registered admin hook: no registration metadata, skipping",
@@ -110,7 +116,7 @@ func (h *SelfRegisteredAdminHook) Provision(ctx context.Context, tenantID tenant
 
 	// Clear registration credentials from tenant metadata.
 	// This is fatal: leaving a bcrypt hash in metadata violates minimal credential retention.
-	if err := h.clearRegistrationMetadata(ctx, tenantID, t.Metadata); err != nil {
+	if err := h.clearRegistrationMetadata(ctx, tenantID, metadata); err != nil {
 		return fmt.Errorf("clearing registration metadata for tenant %s: %w", tenantID, err)
 	}
 
@@ -178,5 +184,5 @@ func (h *SelfRegisteredAdminHook) clearRegistrationMetadata(ctx context.Context,
 		cleaned[k] = v
 	}
 
-	return h.tenantRepo.UpdateMetadata(ctx, tenantID, cleaned)
+	return h.tenantStore.UpdateMetadata(ctx, tenantID, cleaned)
 }

--- a/services/identity/bootstrap/self_registered_admin.go
+++ b/services/identity/bootstrap/self_registered_admin.go
@@ -1,0 +1,181 @@
+// Package bootstrap - self-registered admin provisioning hook.
+//
+// When a user self-registers via POST /api/v1/register and the tenant requires
+// async provisioning, the registration handler stores the admin email and password
+// hash in the tenant's metadata. This hook runs after schema provisioning completes
+// and creates the self-registered admin identity in the now-available tenant schema.
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/identity/domain"
+	tenantpersistence "github.com/meridianhub/meridian/services/tenant/adapters/persistence"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// Metadata keys matching the registration handler constants.
+const (
+	metaKeyRegistrationEmail        = "_registration_email"
+	metaKeyRegistrationPasswordHash = "_registration_password_hash"
+)
+
+// ErrNilTenantRepo is returned when a nil tenant repository is passed to NewSelfRegisteredAdminHook.
+var ErrNilTenantRepo = errors.New("self-registered admin hook: tenant repository must not be nil")
+
+// SelfRegisteredAdminHook creates self-registered admin identities from tenant
+// metadata after schema provisioning completes. It reads the admin email and
+// password hash stored by the registration handler, creates the identity with
+// tenant-owner role, and clears the credentials from metadata.
+type SelfRegisteredAdminHook struct {
+	identityRepo domain.Repository
+	tenantRepo   *tenantpersistence.Repository
+	logger       *slog.Logger
+}
+
+// NewSelfRegisteredAdminHook creates a new hook for provisioning self-registered admin identities.
+func NewSelfRegisteredAdminHook(identityRepo domain.Repository, tenantRepo *tenantpersistence.Repository, logger *slog.Logger) (*SelfRegisteredAdminHook, error) {
+	if identityRepo == nil {
+		return nil, ErrNilRepository
+	}
+	if tenantRepo == nil {
+		return nil, ErrNilTenantRepo
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &SelfRegisteredAdminHook{
+		identityRepo: identityRepo,
+		tenantRepo:   tenantRepo,
+		logger:       logger,
+	}, nil
+}
+
+// AsPostProvisioningHook returns a function compatible with the provisioning worker's
+// PostProvisioningHook type.
+//
+// Usage:
+//
+//	hook, _ := bootstrap.NewSelfRegisteredAdminHook(identityRepo, tenantRepo, logger)
+//	worker.RegisterPostProvisioningHook("self-registered-admin", hook.AsPostProvisioningHook())
+func (h *SelfRegisteredAdminHook) AsPostProvisioningHook() func(ctx context.Context, tenantID tenant.TenantID) error {
+	return h.Provision
+}
+
+// Provision creates the self-registered admin identity from tenant metadata.
+// If no registration metadata is present (e.g., tenant was created via API, not
+// self-registration), this is a no-op.
+func (h *SelfRegisteredAdminHook) Provision(ctx context.Context, tenantID tenant.TenantID) error {
+	// Read tenant to get registration metadata.
+	t, err := h.tenantRepo.GetByID(ctx, tenantID)
+	if err != nil {
+		return fmt.Errorf("reading tenant %s: %w", tenantID, err)
+	}
+
+	emailRaw, hasEmail := t.Metadata[metaKeyRegistrationEmail]
+	hashRaw, hasHash := t.Metadata[metaKeyRegistrationPasswordHash]
+
+	if !hasEmail || !hasHash {
+		h.logger.InfoContext(ctx, "self-registered admin hook: no registration metadata, skipping",
+			"tenant_id", tenantID)
+		return nil
+	}
+
+	email, ok := emailRaw.(string)
+	if !ok || email == "" {
+		h.logger.WarnContext(ctx, "self-registered admin hook: invalid email in metadata, skipping",
+			"tenant_id", tenantID)
+		return nil
+	}
+
+	passwordHash, ok := hashRaw.(string)
+	if !ok || passwordHash == "" {
+		h.logger.WarnContext(ctx, "self-registered admin hook: invalid password hash in metadata, skipping",
+			"tenant_id", tenantID)
+		return nil
+	}
+
+	// Create the identity in the tenant's schema.
+	if err := h.createAdminIdentity(ctx, tenantID, email, passwordHash); err != nil {
+		return fmt.Errorf("creating self-registered admin identity in tenant %s: %w", tenantID, err)
+	}
+
+	// Clear registration credentials from tenant metadata.
+	if err := h.clearRegistrationMetadata(ctx, tenantID, t.Metadata); err != nil {
+		// Non-fatal: identity was created successfully. Log and continue.
+		h.logger.WarnContext(ctx, "self-registered admin hook: failed to clear registration metadata",
+			"tenant_id", tenantID,
+			"error", err)
+	}
+
+	h.logger.InfoContext(ctx, "self-registered admin identity provisioned",
+		"tenant_id", tenantID,
+		"email", email)
+	return nil
+}
+
+// createAdminIdentity creates an active identity with tenant-owner role.
+func (h *SelfRegisteredAdminHook) createAdminIdentity(ctx context.Context, tenantID tenant.TenantID, email, passwordHash string) error {
+	tenantCtx := tenant.WithTenant(ctx, tenantID)
+
+	// Check if identity already exists (idempotency).
+	existing, err := h.identityRepo.FindByEmail(tenantCtx, email)
+	if err != nil && !errors.Is(err, domain.ErrIdentityNotFound) {
+		return fmt.Errorf("checking for existing identity: %w", err)
+	}
+	if existing != nil {
+		h.logger.InfoContext(ctx, "self-registered admin already exists, skipping creation",
+			"tenant_id", tenantID,
+			"email", email)
+		return nil
+	}
+
+	identity, err := domain.NewIdentity(tenantID, email)
+	if err != nil {
+		return fmt.Errorf("creating identity domain object: %w", err)
+	}
+
+	if err := identity.SetPassword(passwordHash); err != nil {
+		return fmt.Errorf("setting password: %w", err)
+	}
+
+	if err := identity.Activate(); err != nil {
+		return fmt.Errorf("activating identity: %w", err)
+	}
+
+	now := time.Now()
+	ra := domain.ReconstructRoleAssignment(
+		uuid.New(),
+		tenantID,
+		identity.ID(),
+		identity.ID(),
+		domain.RoleTenantOwner,
+		nil, nil, nil,
+		now, now,
+	)
+
+	if err := h.identityRepo.SaveIdentityWithRoles(tenantCtx, identity, []*domain.RoleAssignment{ra}); err != nil {
+		return fmt.Errorf("saving identity with roles: %w", err)
+	}
+
+	return nil
+}
+
+// clearRegistrationMetadata removes the registration credential keys from tenant metadata.
+func (h *SelfRegisteredAdminHook) clearRegistrationMetadata(ctx context.Context, tenantID tenant.TenantID, metadata map[string]interface{}) error {
+	// Copy metadata without registration keys.
+	cleaned := make(map[string]interface{}, len(metadata))
+	for k, v := range metadata {
+		if k == metaKeyRegistrationEmail || k == metaKeyRegistrationPasswordHash {
+			continue
+		}
+		cleaned[k] = v
+	}
+
+	return h.tenantRepo.UpdateMetadata(ctx, tenantID, cleaned)
+}

--- a/services/identity/bootstrap/self_registered_admin.go
+++ b/services/identity/bootstrap/self_registered_admin.go
@@ -19,10 +19,13 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
 
-// Metadata keys matching the registration handler constants.
+// Metadata keys for self-registered admin credentials stored on the tenant record.
+// These MUST match the exported constants in services/api-gateway/registration_handler.go
+// (MetaKeyRegistrationEmail, MetaKeyRegistrationPasswordHash). The test file verifies
+// they stay in sync.
 const (
-	metaKeyRegistrationEmail        = "_registration_email"
-	metaKeyRegistrationPasswordHash = "_registration_password_hash"
+	MetaKeyRegistrationEmail        = "_registration_email"
+	MetaKeyRegistrationPasswordHash = "_registration_password_hash"
 )
 
 // ErrNilTenantRepo is returned when a nil tenant repository is passed to NewSelfRegisteredAdminHook.
@@ -77,8 +80,8 @@ func (h *SelfRegisteredAdminHook) Provision(ctx context.Context, tenantID tenant
 		return fmt.Errorf("reading tenant %s: %w", tenantID, err)
 	}
 
-	emailRaw, hasEmail := t.Metadata[metaKeyRegistrationEmail]
-	hashRaw, hasHash := t.Metadata[metaKeyRegistrationPasswordHash]
+	emailRaw, hasEmail := t.Metadata[MetaKeyRegistrationEmail]
+	hashRaw, hasHash := t.Metadata[MetaKeyRegistrationPasswordHash]
 
 	if !hasEmail || !hasHash {
 		h.logger.InfoContext(ctx, "self-registered admin hook: no registration metadata, skipping",
@@ -106,11 +109,9 @@ func (h *SelfRegisteredAdminHook) Provision(ctx context.Context, tenantID tenant
 	}
 
 	// Clear registration credentials from tenant metadata.
+	// This is fatal: leaving a bcrypt hash in metadata violates minimal credential retention.
 	if err := h.clearRegistrationMetadata(ctx, tenantID, t.Metadata); err != nil {
-		// Non-fatal: identity was created successfully. Log and continue.
-		h.logger.WarnContext(ctx, "self-registered admin hook: failed to clear registration metadata",
-			"tenant_id", tenantID,
-			"error", err)
+		return fmt.Errorf("clearing registration metadata for tenant %s: %w", tenantID, err)
 	}
 
 	h.logger.InfoContext(ctx, "self-registered admin identity provisioned",
@@ -171,7 +172,7 @@ func (h *SelfRegisteredAdminHook) clearRegistrationMetadata(ctx context.Context,
 	// Copy metadata without registration keys.
 	cleaned := make(map[string]interface{}, len(metadata))
 	for k, v := range metadata {
-		if k == metaKeyRegistrationEmail || k == metaKeyRegistrationPasswordHash {
+		if k == MetaKeyRegistrationEmail || k == MetaKeyRegistrationPasswordHash {
 			continue
 		}
 		cleaned[k] = v

--- a/services/identity/bootstrap/self_registered_admin.go
+++ b/services/identity/bootstrap/self_registered_admin.go
@@ -30,12 +30,17 @@ type TenantMetadataStore interface {
 // (MetaKeyRegistrationEmail, MetaKeyRegistrationPasswordHash). The test file verifies
 // they stay in sync.
 const (
-	MetaKeyRegistrationEmail        = "_registration_email"
-	MetaKeyRegistrationPasswordHash = "_registration_password_hash"
+	MetaKeyRegistrationEmail               = "_registration_email"
+	MetaKeyRegistrationPasswordHash        = "_registration_password_hash"
+	MetaKeyRegistrationEmailVerifyRequired = "_registration_email_verify_required"
 )
 
-// ErrNilTenantRepo is returned when a nil tenant repository is passed to NewSelfRegisteredAdminHook.
-var ErrNilTenantRepo = errors.New("self-registered admin hook: tenant repository must not be nil")
+var (
+	// ErrNilTenantRepo is returned when a nil tenant repository is passed to NewSelfRegisteredAdminHook.
+	ErrNilTenantRepo = errors.New("self-registered admin hook: tenant repository must not be nil")
+	// ErrInvalidRegistrationMetadata is returned when registration metadata is malformed.
+	ErrInvalidRegistrationMetadata = errors.New("self-registered admin hook: invalid registration metadata")
+)
 
 // SelfRegisteredAdminHook creates self-registered admin identities from tenant
 // metadata after schema provisioning completes. It reads the admin email and
@@ -89,28 +94,29 @@ func (h *SelfRegisteredAdminHook) Provision(ctx context.Context, tenantID tenant
 	emailRaw, hasEmail := metadata[MetaKeyRegistrationEmail]
 	hashRaw, hasHash := metadata[MetaKeyRegistrationPasswordHash]
 
-	if !hasEmail || !hasHash {
+	// No registration metadata at all - not a self-registration, skip.
+	if !hasEmail && !hasHash {
 		h.logger.InfoContext(ctx, "self-registered admin hook: no registration metadata, skipping",
 			"tenant_id", tenantID)
 		return nil
 	}
 
+	// Partial metadata is an error - both keys must be present and valid.
 	email, ok := emailRaw.(string)
 	if !ok || email == "" {
-		h.logger.WarnContext(ctx, "self-registered admin hook: invalid email in metadata, skipping",
-			"tenant_id", tenantID)
-		return nil
+		return fmt.Errorf("%w: missing or invalid email for tenant %s", ErrInvalidRegistrationMetadata, tenantID)
 	}
 
 	passwordHash, ok := hashRaw.(string)
 	if !ok || passwordHash == "" {
-		h.logger.WarnContext(ctx, "self-registered admin hook: invalid password hash in metadata, skipping",
-			"tenant_id", tenantID)
-		return nil
+		return fmt.Errorf("%w: missing or invalid password hash for tenant %s", ErrInvalidRegistrationMetadata, tenantID)
 	}
 
+	// Check if email verification is required (stored by registration handler).
+	emailVerifyRequired, _ := metadata[MetaKeyRegistrationEmailVerifyRequired].(bool)
+
 	// Create the identity in the tenant's schema.
-	if err := h.createAdminIdentity(ctx, tenantID, email, passwordHash); err != nil {
+	if err := h.createAdminIdentity(ctx, tenantID, email, passwordHash, emailVerifyRequired); err != nil {
 		return fmt.Errorf("creating self-registered admin identity in tenant %s: %w", tenantID, err)
 	}
 
@@ -121,13 +127,14 @@ func (h *SelfRegisteredAdminHook) Provision(ctx context.Context, tenantID tenant
 	}
 
 	h.logger.InfoContext(ctx, "self-registered admin identity provisioned",
-		"tenant_id", tenantID,
-		"email", email)
+		"tenant_id", tenantID)
 	return nil
 }
 
-// createAdminIdentity creates an active identity with tenant-owner role.
-func (h *SelfRegisteredAdminHook) createAdminIdentity(ctx context.Context, tenantID tenant.TenantID, email, passwordHash string) error {
+// createAdminIdentity creates an identity with tenant-owner role.
+// When emailVerifyRequired is true, the identity is created in PENDING_VERIFICATION state;
+// otherwise it is activated immediately.
+func (h *SelfRegisteredAdminHook) createAdminIdentity(ctx context.Context, tenantID tenant.TenantID, email, passwordHash string, emailVerifyRequired bool) error {
 	tenantCtx := tenant.WithTenant(ctx, tenantID)
 
 	// Check if identity already exists (idempotency).
@@ -137,12 +144,16 @@ func (h *SelfRegisteredAdminHook) createAdminIdentity(ctx context.Context, tenan
 	}
 	if existing != nil {
 		h.logger.InfoContext(ctx, "self-registered admin already exists, skipping creation",
-			"tenant_id", tenantID,
-			"email", email)
+			"tenant_id", tenantID)
 		return nil
 	}
 
-	identity, err := domain.NewIdentity(tenantID, email)
+	var identity *domain.Identity
+	if emailVerifyRequired {
+		identity, err = domain.NewSelfRegisteredIdentity(tenantID, email, true)
+	} else {
+		identity, err = domain.NewIdentity(tenantID, email)
+	}
 	if err != nil {
 		return fmt.Errorf("creating identity domain object: %w", err)
 	}
@@ -151,8 +162,10 @@ func (h *SelfRegisteredAdminHook) createAdminIdentity(ctx context.Context, tenan
 		return fmt.Errorf("setting password: %w", err)
 	}
 
-	if err := identity.Activate(); err != nil {
-		return fmt.Errorf("activating identity: %w", err)
+	if !emailVerifyRequired {
+		if err := identity.Activate(); err != nil {
+			return fmt.Errorf("activating identity: %w", err)
+		}
 	}
 
 	now := time.Now()
@@ -178,7 +191,7 @@ func (h *SelfRegisteredAdminHook) clearRegistrationMetadata(ctx context.Context,
 	// Copy metadata without registration keys.
 	cleaned := make(map[string]interface{}, len(metadata))
 	for k, v := range metadata {
-		if k == MetaKeyRegistrationEmail || k == MetaKeyRegistrationPasswordHash {
+		if k == MetaKeyRegistrationEmail || k == MetaKeyRegistrationPasswordHash || k == MetaKeyRegistrationEmailVerifyRequired {
 			continue
 		}
 		cleaned[k] = v

--- a/services/identity/bootstrap/self_registered_admin_test.go
+++ b/services/identity/bootstrap/self_registered_admin_test.go
@@ -7,22 +7,32 @@ import (
 
 	gateway "github.com/meridianhub/meridian/services/api-gateway"
 	"github.com/meridianhub/meridian/services/identity/domain"
-	tenantpersistence "github.com/meridianhub/meridian/services/tenant/adapters/persistence"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewSelfRegisteredAdminHook_NilIdentityRepo(t *testing.T) {
-	_, err := NewSelfRegisteredAdminHook(nil, &tenantpersistence.Repository{}, slog.Default())
-	assert.ErrorIs(t, err, ErrNilRepository)
-}
-
-// mockIdentityRepo satisfies domain.Repository for testing nil tenant repo validation.
+// mockIdentityRepo satisfies domain.Repository for testing.
 type mockIdentityRepo struct {
 	domain.Repository
 }
 
-func TestNewSelfRegisteredAdminHook_NilTenantRepo(t *testing.T) {
+// mockTenantMetadataStore satisfies TenantMetadataStore for testing.
+type mockTenantMetadataStore struct{}
+
+func (m *mockTenantMetadataStore) GetMetadata(_ context.Context, _ tenant.TenantID) (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (m *mockTenantMetadataStore) UpdateMetadata(_ context.Context, _ tenant.TenantID, _ map[string]interface{}) error {
+	return nil
+}
+
+func TestNewSelfRegisteredAdminHook_NilIdentityRepo(t *testing.T) {
+	_, err := NewSelfRegisteredAdminHook(nil, &mockTenantMetadataStore{}, slog.Default())
+	assert.ErrorIs(t, err, ErrNilRepository)
+}
+
+func TestNewSelfRegisteredAdminHook_NilTenantStore(t *testing.T) {
 	_, err := NewSelfRegisteredAdminHook(&mockIdentityRepo{}, nil, slog.Default())
 	assert.ErrorIs(t, err, ErrNilTenantRepo)
 }

--- a/services/identity/bootstrap/self_registered_admin_test.go
+++ b/services/identity/bootstrap/self_registered_admin_test.go
@@ -44,6 +44,8 @@ func TestMetadataKeyConstants_InSyncWithGateway(t *testing.T) {
 		"bootstrap.MetaKeyRegistrationEmail must match gateway.MetaKeyRegistrationEmail")
 	assert.Equal(t, gateway.MetaKeyRegistrationPasswordHash, MetaKeyRegistrationPasswordHash,
 		"bootstrap.MetaKeyRegistrationPasswordHash must match gateway.MetaKeyRegistrationPasswordHash")
+	assert.Equal(t, gateway.MetaKeyRegistrationEmailVerifyRequired, MetaKeyRegistrationEmailVerifyRequired,
+		"bootstrap.MetaKeyRegistrationEmailVerifyRequired must match gateway.MetaKeyRegistrationEmailVerifyRequired")
 }
 
 func TestSelfRegisteredAdminHook_AsPostProvisioningHook(t *testing.T) {

--- a/services/identity/bootstrap/self_registered_admin_test.go
+++ b/services/identity/bootstrap/self_registered_admin_test.go
@@ -5,55 +5,41 @@ import (
 	"log/slog"
 	"testing"
 
+	gateway "github.com/meridianhub/meridian/services/api-gateway"
 	"github.com/meridianhub/meridian/services/identity/domain"
 	tenantpersistence "github.com/meridianhub/meridian/services/tenant/adapters/persistence"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestNewSelfRegisteredAdminHook_Validation(t *testing.T) {
-	logger := slog.Default()
-
-	_, err := NewSelfRegisteredAdminHook(nil, &tenantpersistence.Repository{}, logger)
+func TestNewSelfRegisteredAdminHook_NilIdentityRepo(t *testing.T) {
+	_, err := NewSelfRegisteredAdminHook(nil, &tenantpersistence.Repository{}, slog.Default())
 	assert.ErrorIs(t, err, ErrNilRepository)
-
-	// Can't easily test with a real identity repo since it requires a DB,
-	// but we verify that nil tenant repo is rejected.
-	// Note: We can't construct a non-nil domain.Repository without a DB connection,
-	// so we test the nil-identity-repo case only.
 }
 
-func TestSelfRegisteredAdminHook_NoMetadata_IsNoop(t *testing.T) {
-	// This tests the core logic: when tenant has no registration metadata,
-	// the hook should be a no-op.
-	//
-	// Full integration test would require a DB. Unit test verifies the
-	// metadata extraction logic by checking that Provision returns nil
-	// for tenants without registration metadata.
-	//
-	// This is tested indirectly through the provisioning worker integration tests.
-	t.Log("self-registered admin hook with no metadata is a no-op - tested via integration")
+// mockIdentityRepo satisfies domain.Repository for testing nil tenant repo validation.
+type mockIdentityRepo struct {
+	domain.Repository
 }
 
-func TestMetadataKeyConstants(t *testing.T) {
-	// Verify the metadata keys match between the registration handler and hook.
-	// These must stay in sync.
-	assert.Equal(t, "_registration_email", metaKeyRegistrationEmail)
-	assert.Equal(t, "_registration_password_hash", metaKeyRegistrationPasswordHash)
+func TestNewSelfRegisteredAdminHook_NilTenantRepo(t *testing.T) {
+	_, err := NewSelfRegisteredAdminHook(&mockIdentityRepo{}, nil, slog.Default())
+	assert.ErrorIs(t, err, ErrNilTenantRepo)
+}
+
+func TestMetadataKeyConstants_InSyncWithGateway(t *testing.T) {
+	// These constants are duplicated across packages (identity/bootstrap and api-gateway)
+	// because a circular import prevents direct sharing. This test ensures they stay in sync.
+	assert.Equal(t, gateway.MetaKeyRegistrationEmail, MetaKeyRegistrationEmail,
+		"bootstrap.MetaKeyRegistrationEmail must match gateway.MetaKeyRegistrationEmail")
+	assert.Equal(t, gateway.MetaKeyRegistrationPasswordHash, MetaKeyRegistrationPasswordHash,
+		"bootstrap.MetaKeyRegistrationPasswordHash must match gateway.MetaKeyRegistrationPasswordHash")
 }
 
 func TestSelfRegisteredAdminHook_AsPostProvisioningHook(t *testing.T) {
 	// Verify the hook function signature is compatible with the provisioning worker.
-	// We can't create a real hook without DB connections, but we verify the
-	// function type matches what the worker expects.
 	var hookFn func(ctx context.Context, tenantID tenant.TenantID) error
 	_ = hookFn // proves the type signature
-
-	// Also verify the Identity creation logic with known constants.
-	tid, err := tenant.NewTenantID("test_tenant")
-	require.NoError(t, err)
-	assert.Equal(t, "test_tenant", tid.String())
 
 	// Verify RoleTenantOwner is the correct role for self-registered admins.
 	assert.Equal(t, domain.Role("TENANT_OWNER"), domain.RoleTenantOwner)

--- a/services/identity/bootstrap/self_registered_admin_test.go
+++ b/services/identity/bootstrap/self_registered_admin_test.go
@@ -1,0 +1,60 @@
+package bootstrap
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/identity/domain"
+	tenantpersistence "github.com/meridianhub/meridian/services/tenant/adapters/persistence"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSelfRegisteredAdminHook_Validation(t *testing.T) {
+	logger := slog.Default()
+
+	_, err := NewSelfRegisteredAdminHook(nil, &tenantpersistence.Repository{}, logger)
+	assert.ErrorIs(t, err, ErrNilRepository)
+
+	// Can't easily test with a real identity repo since it requires a DB,
+	// but we verify that nil tenant repo is rejected.
+	// Note: We can't construct a non-nil domain.Repository without a DB connection,
+	// so we test the nil-identity-repo case only.
+}
+
+func TestSelfRegisteredAdminHook_NoMetadata_IsNoop(t *testing.T) {
+	// This tests the core logic: when tenant has no registration metadata,
+	// the hook should be a no-op.
+	//
+	// Full integration test would require a DB. Unit test verifies the
+	// metadata extraction logic by checking that Provision returns nil
+	// for tenants without registration metadata.
+	//
+	// This is tested indirectly through the provisioning worker integration tests.
+	t.Log("self-registered admin hook with no metadata is a no-op - tested via integration")
+}
+
+func TestMetadataKeyConstants(t *testing.T) {
+	// Verify the metadata keys match between the registration handler and hook.
+	// These must stay in sync.
+	assert.Equal(t, "_registration_email", metaKeyRegistrationEmail)
+	assert.Equal(t, "_registration_password_hash", metaKeyRegistrationPasswordHash)
+}
+
+func TestSelfRegisteredAdminHook_AsPostProvisioningHook(t *testing.T) {
+	// Verify the hook function signature is compatible with the provisioning worker.
+	// We can't create a real hook without DB connections, but we verify the
+	// function type matches what the worker expects.
+	var hookFn func(ctx context.Context, tenantID tenant.TenantID) error
+	_ = hookFn // proves the type signature
+
+	// Also verify the Identity creation logic with known constants.
+	tid, err := tenant.NewTenantID("test_tenant")
+	require.NoError(t, err)
+	assert.Equal(t, "test_tenant", tid.String())
+
+	// Verify RoleTenantOwner is the correct role for self-registered admins.
+	assert.Equal(t, domain.Role("TENANT_OWNER"), domain.RoleTenantOwner)
+}

--- a/services/tenant/adapters/persistence/repository.go
+++ b/services/tenant/adapters/persistence/repository.go
@@ -414,6 +414,23 @@ func (r *Repository) FindProvisioningStatusByTenantID(ctx context.Context, tenan
 	return statuses, nil
 }
 
+// UpdateMetadata replaces the metadata JSONB column for a tenant.
+// Used by post-provisioning hooks to clear registration credentials after identity creation.
+func (r *Repository) UpdateMetadata(ctx context.Context, id tenant.TenantID, metadata map[string]interface{}) error {
+	result := r.conn(ctx).
+		Model(&TenantEntity{}).
+		Where("id = ?", id.String()).
+		Update("metadata", JSONMap(metadata))
+
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return ErrTenantNotFound
+	}
+	return nil
+}
+
 // Ping checks database connectivity.
 func (r *Repository) Ping(ctx context.Context) error {
 	var result int

--- a/services/tenant/adapters/persistence/repository.go
+++ b/services/tenant/adapters/persistence/repository.go
@@ -431,6 +431,16 @@ func (r *Repository) UpdateMetadata(ctx context.Context, id tenant.TenantID, met
 	return nil
 }
 
+// GetMetadata returns the metadata map for a tenant. Returns ErrTenantNotFound if
+// the tenant does not exist.
+func (r *Repository) GetMetadata(ctx context.Context, id tenant.TenantID) (map[string]interface{}, error) {
+	t, err := r.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return t.Metadata, nil
+}
+
 // Ping checks database connectivity.
 func (r *Repository) Ping(ctx context.Context) error {
 	var result int


### PR DESCRIPTION
## Summary

- Defer admin identity creation to a post-provisioning hook when tenant requires async schema provisioning, fixing the broken registration flow where identity writes fail because the tenant schema doesn't exist yet
- Store self-registered admin credentials (email + bcrypt hash) in tenant metadata during registration, consumed and cleared by the hook after provisioning
- Add `provisioning_pending` field to registration response so the frontend knows the tenant is being set up

## Changes

**Registration handler** (`services/api-gateway/registration_handler.go`):
- Extend `TenantCreator` interface to accept metadata and return `CreateTenantResult` with provisioning status
- When `ProvisioningPending=true`: store credentials in metadata, skip inline identity creation
- When `ProvisioningPending=false`: create identity inline (existing behavior preserved)
- Hash password once upfront, reuse for both metadata storage and inline identity creation

**Self-registered admin hook** (`services/identity/bootstrap/self_registered_admin.go`):
- New post-provisioning hook that reads admin email + password hash from tenant metadata
- Creates identity with tenant-owner role in the now-available tenant schema
- Clears registration credentials from metadata after identity creation
- Idempotent: no-op if identity already exists or no metadata present

**Wiring** (`cmd/meridian/wire_services.go`, `cmd/meridian/gateway.go`):
- Register self-registered admin hook after all reference data hooks
- Pass metadata through `InitiateTenant` gRPC call via protobuf Struct
- Use `Tenant.Status` instead of deprecated `ProvisioningHint` field

**Tenant repo** (`services/tenant/adapters/persistence/repository.go`):
- Add `UpdateMetadata` method for clearing registration credentials post-provisioning

## End-to-end flow

1. User submits registration form (frontend already exists)
2. Registration handler creates tenant with `provisioning_pending` status + admin credentials in metadata
3. Provisioning worker creates schemas, runs migrations, seeds reference data
4. Self-registered admin hook creates the admin identity from metadata
5. Platform admin hook provisions platform admin (existing behavior)
6. Tenant becomes active
7. User sees provisioning progress page (PR #2124), auto-redirects to login on completion
8. User logs in with their registered email/password

## Test plan

- [x] Unit tests for async provisioning path (identity NOT created inline)
- [x] Unit tests for sync provisioning path (identity created inline, backwards compatible)
- [x] Unit tests for metadata passthrough in `loopbackTenantCreator`
- [x] Unit tests for self-registered admin hook metadata key constants
- [x] All existing registration handler tests updated and passing
- [x] All existing wiring tests updated and passing
- [x] Pre-commit hooks pass (gofumpt, golangci-lint, gitleaks)