### PR TITLE
docs: Postgres data model reference + stale schema doc cleanup

### DIFF
--- a/docs/adr/0002-microservices-per-bian-domain.md
+++ b/docs/adr/0002-microservices-per-bian-domain.md
@@ -667,12 +667,7 @@ GRANT ALL ON DATABASE meridian_current_account TO current_account_svc;
 
 ### Migration Strategy
 
-See [Database-Per-Service Migration Runbook](../runbooks/database-per-service-migration.md) for:
-
-- Step-by-step migration guide
-- Rollback procedures
-- Verification checklists
-- Lessons learned
+The initial database-per-service migration is complete. See the [archived migration runbook](../archive/database-per-service-migration.md) for historical context, or the [Data Model Reference](../architecture/data-model.md) for the current topology.
 
 ### Consequences
 
@@ -693,4 +688,5 @@ See [Database-Per-Service Migration Runbook](../runbooks/database-per-service-mi
 ### References
 
 * [ADR-003: Database Schema Migrations](./0003-database-schema-migrations.md)
-* [Migration Runbook](../runbooks/database-per-service-migration.md)
+* [Data Model Reference](../architecture/data-model.md)
+* [Migration Runbook (archived)](../archive/database-per-service-migration.md)

--- a/docs/adr/0003-database-schema-migrations.md
+++ b/docs/adr/0003-database-schema-migrations.md
@@ -155,8 +155,9 @@ Database: meridian_current_account
 
 - Each service has its own PostgreSQL database
 - Each organization gets its own schema within each service database
-- Connection URL includes `search_path` for org routing: `postgres://...?search_path=org_acme_bank`
+- The search_path is set transactionally via `SET LOCAL search_path TO org_<id>` by `shared/platform/db/gorm_tenant_scope.go`
 - Queries use unqualified table names; PostgreSQL resolves via `search_path`
+- As of PR #2125, `public` is **not** in the search_path — reference data is replicated into each tenant schema on provisioning rather than shared via public. See [data-model.md](../architecture/data-model.md#tenant-isolation-mechanism) for the current mechanism.
 
 ### Naming Conventions
 
@@ -484,7 +485,9 @@ If migrating from golang-migrate:
 * Maintain migration history (no need to replay all migrations)
 * Continue using immutability principles
 
-### CockroachDB Compatibility Considerations
+### CockroachDB Compatibility Considerations (Historical)
+
+> **Note:** Meridian now targets PostgreSQL 16 exclusively. The constraints below are retained because existing migrations were authored under CockroachDB compatibility rules and continue to follow them (no PL/pgSQL, split column-add from partial-index-add, explicit timestamp columns instead of range types). New migrations should follow the same conventions for consistency, but the underlying runtime is Postgres. See [data-model.md](../architecture/data-model.md) for the current topology and [docs/reports/cockroachdb-migration-audit.md](../reports/cockroachdb-migration-audit.md) for historical context.
 
 While CockroachDB is PostgreSQL-compatible, some PostgreSQL features are **not supported**:
 

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -1,0 +1,281 @@
+---
+name: data-model-reference
+description: End-to-end reference for Meridian's Postgres data model - services, databases, schemas, tenant isolation, and table ownership
+triggers:
+  - Understanding how data is organised across services
+  - Writing migrations or queries that cross service boundaries
+  - Onboarding a new service into tenant provisioning
+  - Debugging tenant isolation or search_path issues
+---
+
+# Meridian Data Model Reference
+
+**Document Version:** 1.0
+**Last Updated:** 2026-04-04
+**Status:** Active
+**Related:**
+- [ADR-0002: Microservices Per BIAN Domain](../adr/0002-microservices-per-bian-domain.md)
+- [ADR-0003: Database Schema Migrations with Atlas](../adr/0003-database-schema-migrations.md)
+- [ADR-0016: Tenant ID Naming Strategy](../adr/0016-tenant-id-naming-strategy.md)
+- [BIAN Service Boundaries](bian-service-boundaries.md)
+
+## Overview
+
+This document is the single reference for how Meridian stores data in Postgres. It covers:
+
+1. The database-per-service plus schema-per-tenant topology
+2. What lives in the `public` schema vs tenant (`org_<id>`) schemas
+3. How tenant schemas are provisioned and request routing works
+4. Per-service table ownership
+5. Cross-tenant access (the only permitted pattern)
+
+Meridian runs on **PostgreSQL**. Earlier migrations were written to remain CockroachDB-compatible (see [docs/reports/cockroachdb-migration-audit.md](../reports/cockroachdb-migration-audit.md) for historical context), but the current deployment target is Postgres 16.
+
+## Topology at a Glance
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                       meridian_platform (DB)                        │
+│  public schema: tenant, tenant_provisioning, manifest_version,      │
+│                 manifest_apply_job, platform_saga_definition,       │
+│                 staff_user, api_key                                 │
+└─────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────┐
+│                     meridian_<service> (DB, one per service)        │
+│  public schema:   (empty - see PR #2125)                            │
+│                   exception: market_information.tenant_data_        │
+│                              entitlements (cross-tenant ACL)        │
+│  org_<tenant_a>:  full service table set, reference data seeded     │
+│  org_<tenant_b>:  full service table set, reference data seeded     │
+│  org_<tenant_c>:  ...                                               │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+**Two axes of isolation:**
+
+- **Database-per-service** — each BIAN domain service owns a distinct Postgres database (`meridian_current_account`, `meridian_party`, ...). No service reads another's database; cross-service communication is gRPC or Kafka.
+- **Schema-per-tenant** — within each service database, each tenant has its own schema named `org_<tenant_id>`. All tenant-owned tables are replicated into every tenant schema.
+
+Platform-level services (`control-plane`, `tenant`) share a single `meridian_platform` database and store their data in the `public` schema because their concerns span all tenants.
+
+## Tenant Isolation Mechanism
+
+### Provisioning
+
+When a tenant is created, `services/tenant/provisioner/postgres_provisioner.go` drives the following sequence against every service database:
+
+1. `CREATE SCHEMA IF NOT EXISTS org_<tenant_id>`
+2. Apply service-specific Atlas migrations inside that schema
+3. Run post-provisioning seeders (see [Reference Data Replication](#reference-data-replication))
+4. Record success or failure in `public.tenant_provisioning` / `public.tenant_provisioning_status` inside `meridian_platform`
+
+Provisioning is **fail-hard**. Any seeder failure leaves the tenant in `provisioning_failed` and blocks activation.
+
+### Request Routing
+
+At request time, tenant scoping is enforced by `shared/platform/db/gorm_tenant_scope.go`:
+
+- `tenant.FromContext(ctx)` extracts the tenant id from the request context
+- `tenantID.SchemaName()` returns `org_<id>`
+- A transaction is opened and `SET LOCAL search_path TO org_<id>` is issued
+- The helper verifies the schema exists in `pg_namespace`; a missing schema or missing tenant context fails the request immediately
+
+`SET LOCAL` is transaction-scoped so the search_path never leaks between requests.
+
+> **Important — PR #2125:** `public` was removed from the search_path across the codebase. Previously `SET LOCAL search_path TO org_<id>, public` allowed implicit fall-through to platform data. That fallback is gone. Any table a service needs at runtime must exist in the tenant schema, or be accessed via a fully-qualified `public.<table>` reference (only `tenant_data_entitlements` does this — see [Cross-Tenant Access](#cross-tenant-access)).
+
+### Reference Data Replication
+
+Because tenant schemas no longer inherit from `public`, reference data is physically copied into every tenant schema on provisioning. The seeders registered in `cmd/meridian/wire_services.go`:
+
+| Seeder | What it writes | Target |
+|---|---|---|
+| `InstrumentSeeder` | Platform instruments (GBP, USD, EUR, KWH, TONNE_CO2E) | `reference_data.instrument_definition` |
+| `SagaSeeder` | Embedded saga scripts from `defaults/` | `reference_data.saga_definition` |
+| `AccountTypeSeeder` | Canonical account-type blueprints | `reference_data.account_type_definitions` |
+| `ValuationSeeder` | System valuation methods and policies | `reference_data.valuation_method`, `valuation_policy` |
+| `IdentityBootstrap` | Initial tenant admin (self-service signup) | `identity.identity`, `role_assignment` |
+
+All seeders are idempotent via `ON CONFLICT` clauses so re-provisioning is safe.
+
+## Service Inventory
+
+Each service owns one database. The schema location column indicates whether tables live in `public` (platform concerns) or per-tenant `org_<id>` schemas.
+
+| Service | Database | Schema Location | BIAN Domain |
+|---|---|---|---|
+| api-gateway | _(stateless)_ | — | _infrastructure_ |
+| audit-worker | _(stateless, consumes outboxes)_ | — | _infrastructure_ |
+| control-plane | `meridian_platform` | `public` | _infrastructure_ |
+| current-account | `meridian_current_account` | `org_<id>` | Current Account |
+| event-router | _(stateless)_ | — | _infrastructure_ |
+| financial-accounting | `meridian_financial_accounting` | `org_<id>` | Financial Accounting |
+| financial-gateway | `meridian_financial_gateway` | `org_<id>` | _infrastructure_ |
+| forecasting | `meridian_forecasting` | `org_<id>` | _analytics_ |
+| identity | `meridian_identity` | `org_<id>` | _infrastructure_ |
+| internal-account | `meridian_internal_account` | `org_<id>` | Internal Account |
+| market-information | `meridian_market_information` | `org_<id>` + `public` ACL | Market Information Management |
+| mcp-server | _(stateless)_ | — | _infrastructure_ |
+| operational-gateway | `meridian_operational_gateway` | `org_<id>` | _infrastructure_ |
+| party | `meridian_party` | `org_<id>` | Party Reference Data Directory |
+| payment-order | `meridian_payment_order` | `org_<id>` | Payment Order |
+| position-keeping | `meridian_position_keeping` | `org_<id>` | Position Keeping |
+| reconciliation | `meridian_reconciliation` | `org_<id>` | Account Reconciliation |
+| reference-data | `meridian_reference_data` | `org_<id>` | Reference Data Directory |
+| tenant | `meridian_platform` | `public` | _infrastructure_ |
+
+## Table Ownership by Service
+
+Tables listed below live in the `org_<tenant_id>` schema of the service database unless explicitly marked **[public]**. Audit infrastructure tables (`audit_log`, `audit_outbox`, `event_outbox`) exist in most services and are omitted from each entry for brevity — assume they are present unless noted otherwise.
+
+### Platform Tier (meridian_platform, public schema)
+
+**control-plane** — manifest lifecycle and staff identity
+- `staff_user` — platform admin console users (distinct from `party`)
+- `api_key` — platform API keys scoped to `staff_user`
+- `manifest_version` — immutable manifest snapshots with extracted `relationship_graph` JSONB
+- `manifest_apply_job` — apply orchestration state, links to saga executions
+- `platform_saga_definition` — shared saga definitions used by `apply_manifest`
+
+**tenant** — multi-tenant registry and provisioning
+- `tenant` — tenant id (VARCHAR), display name, settlement asset, status
+- `tenant_provisioning` — provisioning state machine with per-service schema map (JSONB)
+- `tenant_provisioning_status` — per (tenant, service) provisioning row
+
+### BIAN Domain Tier (one database per service, tenant schemas)
+
+**party** — customer and counterparty identity
+- `party`, `party_association`, `party_demographic`, `party_reference`
+- `party_bank_relation`, `party_payment_method`, `party_verification`
+- `party_type_definition`, `party_attributes` — tenant-configurable party schemas (JSON Schema + CEL)
+- Enum: `verification_status` (PENDING / APPROVED / REJECTED / MANUAL_REVIEW)
+
+**identity** — OIDC-backed user identities per tenant
+- `identity` — user records (PENDING_INVITE / ACTIVE / SUSPENDED / LOCKED)
+- `role_assignment` — VIEWER / OPERATOR / ADMIN / TENANT_OWNER / PLATFORM with grant/revoke audit
+- `invitation` — user invitation workflow with token hash
+- `email_verification_token`, `password_reset_token` — self-service signup flows
+
+**current-account** — customer deposit accounts
+- `account` — account identification; balances are authoritative in `position-keeping`
+- `lien` — holds on account balances, linked to payment orders
+- `withdrawal` — withdrawal tracking with idempotency reference
+- `webhook_deliveries` — outbound Freeze / Close notifications
+- `valuation_features` — per-account valuation cache
+
+**internal-account** — counterparty and operational accounts
+- `internal_bank_account` — CLEARING / NOSTRO / VOSTRO / HOLDING / SUSPENSE / REVENUE / EXPENSE / INVENTORY. Multi-asset dimension support. No balance columns — delegates to `position-keeping`.
+- `internal_bank_account_status_history` — ACTIVE / SUSPENDED / CLOSED transitions
+- `lien` — fund reservations with bucket-aware multi-asset valuation
+- `valuation_features`
+
+**position-keeping** — authoritative transaction log and balance source
+- `financial_position_log` — aggregate root, max 10k entries, status PENDING / RECONCILED / POSTED / CANCELLED / FAILED / REJECTED / AMENDED / REVERSED
+- `transaction_log_entry` — individual DEBIT/CREDIT entries
+- `audit_trail_entry`, `transaction_lineage` — parent/child relationships
+- `position` — append-only, O(1) writes, dimensioned (Monetary / Energy / Compute / Carbon / Time / Physical / Custom) with `bucket_key` for fungibility
+- `measurement` — multi-unit measurement audit (kWh, GPU-hours, CPU-hours, Storage-GB, Carbon-tonnes, Water-litres)
+- `reservation` — lien-backed projections
+- `rebucketing_audit_log`, `import_manifest`
+
+**financial-accounting** — double-entry general ledger
+- `financial_booking_log` — booking aggregate with chart-of-accounts rules, immutable idempotency key
+- `ledger_posting` — DEBIT / CREDIT postings with `value_date`
+
+**payment-order** — payment saga orchestration and billing
+- `payment_order` — state machine tracking lien execution and retries
+- `saga_executions` — saga audit trail linked to payment orders
+- `billing_run`, `invoice`, `billing_dunning` — platform billing cycles
+- `email_outbox`, `email_audit_log`, `suppressed_addresses`, `communication_preferences`, `party_global_unsubscribe` — customer communications
+
+**reference-data** — instruments, sagas, account types, valuation rules
+- `instrument_definition` — versioned (code, version); dimensions MONETARY / ENERGY / QUANTITY / COMPUTE / TIME / MASS / VOLUME; status DRAFT / ACTIVE / DEPRECATED
+- `valuation_method` — Starlark conversion logic, bi-temporal
+- `valuation_policy` — CEL expressions, bi-temporal, `estimated_cost` budgeting
+- `saga_definition` — Starlark saga scripts with successor lineage
+- `saga_reference`
+- `account_type_definitions` — versioned account type blueprints, behavior class CUSTOMER / CLEARING / NOSTRO / VOSTRO / HOLDING / SUSPENSE / REVENUE / EXPENSE / INVENTORY
+- `account_type_valuation_methods`, `mapping_definition`, `reference_data_node`
+
+**market-information** — bi-temporal market data
+- `dataset_definition` — market data type, CEL validation and resolution, versioned, DRAFT / ACTIVE / DEPRECATED
+- `market_price_observation` — bi-temporal observations (valid_from / valid_to), quality ladder (1=ESTIMATE, 2=ACTUAL, 3=VERIFIED), supersession chain via `superseded_by`
+- `data_source` — external / internal sources with `trust_level`
+- **[public] `tenant_data_entitlements`** — cross-tenant ACL (only cross-tenant pattern in the codebase)
+
+**reconciliation** — settlement reconciliation
+- `settlement_run` — run lifecycle, scope ACCOUNT / INSTRUMENT / PORTFOLIO / FULL
+- `settlement_snapshot` — point-in-time balances, expected vs actual, computed variance
+- `variance` — detected imbalances with reason and status
+- `dispute` — variance dispute workflow
+- `balance_assertion` — CEL-based assertions
+- `imbalance_trend`, `scheduler_execution`, `pause_resume`
+
+**forecasting** — Starlark-based forward curve generation
+- `forecasting_strategy` — horizon (1-168h), granularity, input/output dataset codes, cron schedule
+- `scheduler_execution` — distributed lease tracking
+
+**operational-gateway** — non-financial outbound dispatch
+- `provider_connections` — HTTPS / GRPC / WEBHOOK / MQTT / AMQP endpoints with auth config, health, and circuit state
+- `instructions` — outbox with PENDING / DISPATCHING / DELIVERED / ACKNOWLEDGED / RETRYING / FAILED / EXPIRED / CANCELLED
+- `instruction_attempts` — per-attempt audit
+- `instruction_routes` — routing configuration
+
+**financial-gateway** — external payment provider integration
+- `event_outbox` — outbound payment instructions (most state is delegated to providers)
+
+## Cross-Tenant Access
+
+There is **exactly one** cross-tenant access pattern in the codebase:
+
+`services/market-information/adapters/persistence/observation_repository.go` queries `public.tenant_data_entitlements` directly (bypassing `SET LOCAL search_path`) to check whether a tenant may read a shared dataset:
+
+```sql
+SELECT EXISTS (
+  SELECT 1 FROM public.tenant_data_entitlements
+  WHERE tenant_id = $1 AND dataset_code = $2 AND is_active = TRUE
+    AND (expires_at IS NULL OR expires_at > NOW())
+)
+```
+
+Datasets are tagged PUBLIC, PRIVATE, or RESTRICTED. RESTRICTED datasets require an entitlement row. The TOCTOU window between the entitlement check and the data read is an accepted eventual-consistency tradeoff.
+
+**No other service performs cross-tenant queries.** Any future cross-tenant requirement should be proposed via ADR.
+
+## Shared Patterns
+
+**Outbox pattern.** Most services have `event_outbox` (Kafka publishing) and `audit_outbox` (audit stream publishing). Writes are transactional with domain changes; a background worker drains the outbox. `payment-order` additionally has `email_outbox` for customer communications. See `shared/platform/events/outbox.go`.
+
+**Immutable audit trail.** Every tenant-scoped service writes `audit_log` via GORM hooks, backed by `audit_outbox` for delivery to the audit topic. `audit-worker` is the fallback drain when Kafka is unavailable.
+
+**Bi-temporal data.** `market-information` and `reference-data` (valuation methods/policies) store both transaction time (`created_at`) and valid time (`valid_from` / `valid_to`) separately. This is the pattern underpinning the Temporal Quality Ladder (see ADR-0017).
+
+**Append-only positions.** `position.positions` is write-only; reads aggregate via bucket keys. This removes write contention from the hot path.
+
+**Foreign keys stop at the service boundary.** Cross-service references (e.g. `current-account.account.party_id`) are UUIDs with no FK constraint — integrity is enforced at write time via gRPC lookups.
+
+## Migrations
+
+Meridian uses [Atlas](https://atlasgo.io/) for schema management. Each service has:
+
+- `services/<service>/migrations/` — versioned SQL files named `YYYYMMDD000NNN_description.sql`
+- `services/<service>/atlas/atlas.hcl` — Atlas config (env: local, ci, production)
+- `atlas.sum` — integrity hash, must be regenerated after any migration change (`atlas migrate hash`)
+
+Atlas diffs against GORM models loaded by `utilities/atlas-loader`, which is the source of truth for desired schema. See [ADR-0003](../adr/0003-database-schema-migrations.md) for the full workflow and CockroachDB-era compatibility notes that remain in the migration style (split column-add from partial-index-add, no PL/pgSQL, etc.).
+
+## Recent Changes
+
+- **PR #2126** (2026-04-04) — Self-service signup to tenant creation end-to-end flow. Added `email_verification_token` and `password_reset_token` to `identity`, and `self_registered_admin` bootstrap for new tenant owners.
+- **PR #2125** (2026-04-03) — Removed `public` from `search_path` across the codebase. Reference data (instruments, sagas, account types, valuation methods) now replicated into each tenant schema on provisioning. The `public` schema fallback no longer exists at runtime.
+- **PR #2121** — Tenant isolation audit hardening — see `docs/audits/tenant-isolation-audit-2026-04-04.md`.
+
+## See Also
+
+- [ADR-0002: Microservices Per BIAN Domain](../adr/0002-microservices-per-bian-domain.md)
+- [ADR-0003: Database Schema Migrations with Atlas](../adr/0003-database-schema-migrations.md)
+- [ADR-0016: Tenant ID Naming Strategy](../adr/0016-tenant-id-naming-strategy.md)
+- [ADR-0017: Temporal Quality Ladder](../adr/0017-temporal-quality-ladder.md)
+- [BIAN Service Boundaries](bian-service-boundaries.md)
+- [Tenant Isolation Audit 2026-04-04](../audits/tenant-isolation-audit-2026-04-04.md)

--- a/docs/archive/database-per-service-migration.md
+++ b/docs/archive/database-per-service-migration.md
@@ -390,5 +390,5 @@ kubectl scale deployment current-account --replicas=3 -n production
 
 - [ADR-002: Microservices Per BIAN Domain](../adr/0002-microservices-per-bian-domain.md)
 - [ADR-003: Database Schema Migrations](../adr/0003-database-schema-migrations.md)
-- [Incident Response Runbook](./incident-response.md)
-- [Disaster Recovery Runbook](./disaster-recovery.md)
+- [Incident Response Runbook](../runbooks/incident-response.md)
+- [Disaster Recovery Runbook](../runbooks/disaster-recovery.md)

--- a/docs/archive/database-per-service-migration.md
+++ b/docs/archive/database-per-service-migration.md
@@ -1,18 +1,14 @@
 ---
 name: database-per-service-migration
-description: Step-by-step guide for migrating from single shared database to database-per-service architecture
-triggers:
-
-  - Migrating to database-per-service architecture
-  - Setting up new service databases
-  - Database isolation for microservices
-  - Multi-tenant database setup
+description: "[ARCHIVED] Historical runbook. The database-per-service migration is complete. See docs/architecture/data-model.md for the current topology."
+status: archived
+triggers: []
 
 instructions: |
-  Create separate database per service following naming convention meridian_<service>.
-  Set up schema-per-tenant within each database. Configure dedicated database users
-  with restricted grants. Update Atlas configuration per service. Use gRPC for
-  cross-service data access instead of SQL joins.
+  ARCHIVED. This runbook documented the one-time migration from a shared database
+  to database-per-service. That work is complete - every service already owns its
+  own Postgres database with schema-per-tenant isolation. For the current topology,
+  see docs/architecture/data-model.md.
 ---
 
 # Database-Per-Service Migration Runbook

--- a/docs/guides/new-bian-service-checklist.md
+++ b/docs/guides/new-bian-service-checklist.md
@@ -117,6 +117,7 @@ go build ./...                # Verify generated code compiles
 Create the domain model with business rules and validation.
 
 **Convention references**:
+
 - [Error Conventions](error-conventions.md) — sentinel error naming and where to define them
 - [Repository Conventions](repository-conventions.md) — interface location, method naming, error documentation
 - [Value Types](value-types.md) — choosing between Money, Asset, and Amount for domain fields
@@ -186,6 +187,7 @@ go test ./services/{service}/domain/... -v
 Implement the repository using GORM.
 
 **Convention references**:
+
 - [Repository Conventions](repository-conventions.md) — entity-prefixed errors, TableName, optimistic locking, tenant scoping
 - [Value Types](value-types.md) — mapping Qty/Money/Amount to/from persistence columns
 
@@ -357,7 +359,7 @@ func (EntityName) TableName() string {
 **Why singular**: Natural SQL syntax (`FROM account` not `FROM accounts`)
 **Why unqualified**: Allows `search_path` to route queries to tenant schemas
 
-**Reference**: [Database-Per-Service Migration Runbook](../runbooks/database-per-service-migration.md)
+**Reference**: [Data Model Reference](../architecture/data-model.md)
 
 **Verification:**
 
@@ -1784,4 +1786,4 @@ task-master parse-prd docs/guides/new-{service}-service-checklist.md
 - [Adding Starlark Service Bindings](adding-starlark-service-bindings.md)
 - [Circuit Breaker Usage Guide](circuit-breaker-usage.md)
 - [Testcontainers Usage Guide](testcontainers-usage.md)
-- [Database-Per-Service Migration Runbook](../runbooks/database-per-service-migration.md)
+- [Data Model Reference](../architecture/data-model.md)

--- a/docs/guides/repository-conventions.md
+++ b/docs/guides/repository-conventions.md
@@ -293,6 +293,7 @@ func EncodePartyCursor(c PartyCursor) string {
 ```
 
 Use cursor pagination when:
+
 - The dataset is large (thousands of rows)
 - Stable ordering is required under concurrent inserts
 - The caller needs to resume from a previous position

--- a/docs/prd/046-economy-visualization-completeness.md
+++ b/docs/prd/046-economy-visualization-completeness.md
@@ -101,6 +101,7 @@ both need updating:
    from the manifest. Currently shows 4 types in Resources tab.
 
 These serve complementary roles:
+
 - **Overview** = visual map + high-level summary (graph-first)
 - **Explorer** = detailed browse by resource type (list-first)
 
@@ -225,6 +226,7 @@ extraction paths:
 - `party_type` — from `manifest.partyTypes[]`
 
 Edge types:
+
 - `sourced_by` — market_data_set → market_data_source
 - `typed_as` — internal_account → account_type
 - `denominated_in` — internal_account → instrument
@@ -247,6 +249,7 @@ Add node components following the existing `memo()` pattern
 (`InstrumentNode`, `AccountTypeNode`, etc.).
 
 **ELK layer priorities** (lower = higher in graph):
+
 - Instruments: 50
 - Market Data Sources: 45
 - Market Data Sets: 40
@@ -268,6 +271,7 @@ types, market data) hidden by default — toggled on via filter.
 
 **Grouped filter panel**: Group toggles into 6 categories
 instead of 13 individual checkboxes:
+
 - Financial Core (instruments, account types, valuation rules)
 - Workflows (sagas)
 - Market Data (sources, sets)
@@ -295,6 +299,7 @@ to the Explorer page for the full breakdown.
 #### 2f. Double-click navigation
 
 Add navigation targets for all new types:
+
 - market_data_source/set → `/market-data`
 - organization → `/parties`
 - internal_account → `/internal-accounts`
@@ -370,6 +375,7 @@ type can follow in later PRDs.
 `ReconcileManifest` output. Drift items as a DataTable:
 resource_type, code, drift_type (MISSING, MODIFIED, EXTRA),
 description. "Run Reconciliation" button with:
+
 - Loading state during RPC (can take 5-30 seconds)
 - Warning display when services are unreachable
 - "No manifest applied" message for pre-045 tenants

--- a/docs/prd/047-security-audit-status.md
+++ b/docs/prd/047-security-audit-status.md
@@ -50,6 +50,7 @@ limits, allowing any single container to exhaust host resources.
 ### PR #1712 — Enforce Saga Step Limit + Remove Dead MemoryWarningThreshold
 
 **Findings**:
+
 - HIGH-1 — `MaxStepsPerExecution = 1_000_000` was defined but `SetMaxExecutionSteps()`
   was never called on the saga runtime thread, allowing CPU exhaustion via tenant scripts.
 - HIGH-4 (partial) — `MemoryWarningThreshold` constant was defined but never referenced
@@ -157,6 +158,7 @@ are Wave 2 work (approximately 1 week)
 ### PR #1736 — Add OPA Gatekeeper Constraint + Security Defaults CI Gate
 
 **Findings**:
+
 - HIGH-3 (regression prevention) — OPA Gatekeeper had no policy blocking
   `AUTH_ENABLED: "false"` in ConfigMaps.
 - HIGH-3 (CI gate) — No CI job verified security defaults after PRs.

--- a/docs/prd/052-email-platform.md
+++ b/docs/prd/052-email-platform.md
@@ -174,6 +174,7 @@ type TemplateRenderer interface {
 ```
 
 **Three Sender implementations**:
+
 - `resend.Sender` - production, wraps Resend Go SDK with circuit breaker
 - `log.Sender` - writes to application log, no API call (for `EMAIL_MODE=log`)
 - `noop.Sender` - discards silently (for `EMAIL_MODE=disabled` and tests)
@@ -235,6 +236,7 @@ Four templates using Go `html/template` with `embed.FS`, stored in
 | `account-frozen.html` | Account frozen (dunning level 3) | account ID, frozen reason, support contact |
 
 **Design principles**:
+
 - Single dunning template with severity parameter (reduces duplication,
   ensures brand consistency across escalation levels)
 - Responsive HTML (single-column, mobile-first)
@@ -361,6 +363,7 @@ Adapted from `shared/platform/events/metrics.go` (rename subsystem):
 | `email_circuit_breaker_state` | Gauge | 0=closed, 1=half-open, 2=open |
 
 **Alerting rules** (Prometheus/Alertmanager):
+
 - `email_outbox_pending_total > 100` for 5 minutes -> warn (backlog)
 - `email_outbox_dead_letter_total` increase > 0 -> alert (permanent failure)
 - `email_circuit_breaker_state == 2` for 5 minutes -> alert (Resend down)
@@ -437,6 +440,7 @@ payment-order service.
 ### Task 2: Email service package (3 points)
 
 `shared/pkg/email/`:
+
 - `sender.go` - `Sender` interface, `Message` type
 - `template.go` - `TemplateRenderer` using `html/template` + `embed.FS`
 - `outbox.go` - Outbox repository (write, read pending, update status,
@@ -449,6 +453,7 @@ payment-order service.
 - `noop/provider.go` - No-op sender for tests
 
 **Reuse explicitly**:
+
 - `circuitbreaker.go` wrapping Resend client
 - `shared/pkg/tokens/` for any future token operations
 - Go `html/template` only (lint rule: no `text/template` in email package)
@@ -457,6 +462,7 @@ payment-order service.
 
 Implement `dispatch.DispatchableInstruction` for `EmailOutboxRow`. Write a
 `BatchProcessor` callback that:
+
 1. Renders template via `TemplateRenderer`
 2. For dunning emails: checks invoice status, cancels if PAID
 3. Calls `Sender.Send()` with idempotency key as Resend header
@@ -481,6 +487,7 @@ as the event worker. Add circuit breaker state gauge. Mechanical adaptation.
 ### Task 5: Resend webhook endpoint (2 points)
 
 `POST /api/v1/webhooks/resend`:
+
 - Verify `Svix-Signature` header (Resend webhook signing)
 - Parse event type: `email.delivered`, `email.bounced`, `email.complained`
 - Look up audit log entry by `provider_id`
@@ -493,6 +500,7 @@ is the auth mechanism).
 ### Task 6: Templates (3 points)
 
 Four templates in `shared/pkg/email/templates/`:
+
 - `invoice.html` + `invoice.txt`
 - `dunning-notice.html` + `dunning-notice.txt` (parameterized: severity
   1/2/3 with `{{if eq .Severity 1}}` blocks)
@@ -566,6 +574,7 @@ EMAIL_BASE_URL=https://meridianhub.cloud
 ```
 
 **EMAIL_MODE**:
+
 - `disabled` - No outbox writes, no sending. For unit tests.
 - `log` - Writes outbox + audit log, renders templates, but does not call
   Resend API. For integration tests and CI.

--- a/docs/prd/053-auth-email-flows.md
+++ b/docs/prd/053-auth-email-flows.md
@@ -108,6 +108,7 @@ concern bridging the party service to authentication (see PRD 031).
 ### Task 2: Email verification flow (3 points)
 
 **Backend**:
+
 - Migration: `email_verification_tokens` table (token_hash, identity_id,
   expires_at, consumed_at)
 - On registration (when verification required): generate token via
@@ -119,6 +120,7 @@ concern bridging the party service to authentication (see PRD 031).
   (3/hour per identity via DB count query on outbox)
 
 **Frontend**:
+
 - Post-registration "check your email" page with resend button
 - Verification landing page (success, expired, already-verified, invalid
   states)
@@ -127,6 +129,7 @@ concern bridging the party service to authentication (see PRD 031).
 ### Task 3: Password reset flow (3 points)
 
 **Backend**:
+
 - Migration: `password_reset_tokens` table (token_hash, identity_id,
   expires_at, consumed_at)
 - `POST /api/v1/forgot-password` - always returns 200 (timing-safe:
@@ -142,6 +145,7 @@ concern bridging the party service to authentication (see PRD 031).
   INTERVAL '1 hour'`
 
 **Frontend**:
+
 - "Forgot password?" link on login page
 - Email input form -> "check your email" confirmation
 - Reset form (new password + confirm) -> success -> redirect to login

--- a/docs/prd/054-billing-ui.md
+++ b/docs/prd/054-billing-ui.md
@@ -88,11 +88,13 @@ API. This PRD includes the API work, not just frontend pages.
 New endpoints in payment-order service (or api-gateway BFF):
 
 **Billing Runs**:
+
 - `GET /api/v1/billing/runs` - list billing runs with pagination,
   filter by status
 - `GET /api/v1/billing/runs/{runId}` - detail with invoice summary
 
 **Invoices**:
+
 - `GET /api/v1/billing/invoices` - list invoices with pagination,
   filter by status, party, billing run
 - `GET /api/v1/billing/invoices/{invoiceId}` - detail with line items
@@ -104,6 +106,7 @@ New endpoints in payment-order service (or api-gateway BFF):
   (cancels pending emails)
 
 **Email Status** (joins across billing and notification tables):
+
 - `GET /api/v1/billing/invoices/{invoiceId}/emails` - list email
   audit log entries for this invoice (by idempotency key pattern
   `invoice-{id}` and `dunning-*-{id}`)
@@ -143,6 +146,7 @@ Filters: status, party, billing run.
 **Detail** - Route: `/billing/invoices/:invoiceId`
 
 Tabs:
+
 - **Overview**: Invoice header, party info, status timeline, due date
 - **Line Items**: Table of line items from JSONB (description, quantity,
   unit price, amount)
@@ -150,6 +154,7 @@ Tabs:
   (sent, delivered, bounced with timestamps and bounce reasons)
 
 Actions (conditional on status):
+
 - "Resend Email" (any status) - re-queues invoice email
 - "Mark as Paid" (ISSUED or OVERDUE) - manual payment confirmation
 - "Void Invoice" (ISSUED or OVERDUE) - voids and cancels pending emails

--- a/docs/prd/055-tenant-branding.md
+++ b/docs/prd/055-tenant-branding.md
@@ -42,6 +42,7 @@ resolution, only injecting `tenantID` and `slug` into the request
 context.
 
 JWT minting happens in two places:
+
 - `services/api-gateway/auth_handler.go` - password-based login
 - `services/api-gateway/auth_sso_handler.go` - SSO/OIDC callback
 
@@ -98,6 +99,7 @@ Add `GET /api/tenant-info` to the gateway as a public endpoint
 - This serves the login page where no JWT exists yet
 
 **Abuse protections:**
+
 - The endpoint resolves tenant from the request's subdomain (Host
   header), not from a query parameter. There is no lookup-by-slug
   input - a caller must already be on the tenant's subdomain to
@@ -117,12 +119,14 @@ Add `GET /api/tenant-info` to the gateway as a public endpoint
 ### 4. Frontend: consume tenant display name (frontend)
 
 **Login page:**
+
 - Call `/api/tenant-info` on mount when on a tenant subdomain
 - Show the tenant's display name as the page title
 - Fall back to formatted slug if the endpoint is unavailable
 - Update document title to match
 
 **Header:**
+
 - For tenant users: read `x-tenant-display-name` from JWT claims
 - For platform admins: use `currentTenant.name` (already available
   from tenant selector)
@@ -130,6 +134,7 @@ Add `GET /api/tenant-info` to the gateway as a public endpoint
   `volterra-energy` becomes `Volterra Energy`), then to "Meridian"
 
 **Document title:**
+
 - Set `document.title` dynamically based on tenant context
 - Pattern: `"{Tenant Name} - Operations Console"` on tenant
   subdomains, `"Meridian Operations Console"` on bare domain

--- a/docs/prd/056-correspondence-service.md
+++ b/docs/prd/056-correspondence-service.md
@@ -286,6 +286,7 @@ message UpdateCommunicationPreferencesResponse {
 ```
 
 Key design decisions:
+
 - `category` uses a proto enum (`CorrespondenceCategory`) not a string,
   preventing invalid categories at the wire level
 - `template_data` uses `google.protobuf.Struct` (not `map<string, string>`)

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -24,8 +24,6 @@ scenarios.
 
 ### Operations & Troubleshooting
 
-- **[database-per-service-migration.md](database-per-service-migration.md)** - Procedures for
-  migrating to database-per-service architecture
 - **[internal-account-operations.md](internal-account-operations.md)** - Internal account
   operational procedures and reconciliation
 - **[market-information-operations.md](market-information-operations.md)** - Market data operations,

--- a/docs/runbooks/email-infrastructure.md
+++ b/docs/runbooks/email-infrastructure.md
@@ -84,6 +84,7 @@ After adding records, verify in the Resend dashboard (Settings > Domains). DNS p
 ### Worker not starting
 
 Check logs for `email worker disabled`. Common causes:
+
 - `EMAIL_MODE=disabled` (intentional in dev)
 - `EMAIL_MODE=live` but `RESEND_API_KEY` not set
 - Template parsing failure (check embedded templates)
@@ -120,6 +121,7 @@ Monitor via Prometheus metric:
 ### Webhook delivery failures
 
 If the Resend webhook is not updating delivery status:
+
 - Verify `RESEND_WEBHOOK_SECRET` matches the signing secret in the Resend dashboard
 - Check that the webhook endpoint is accessible: `POST /webhooks/resend`
 - Review audit table for received events:

--- a/docs/runbooks/internal-account-operations.md
+++ b/docs/runbooks/internal-account-operations.md
@@ -802,4 +802,4 @@ kubectl exec -it <iba-pod> -n production -- nc -zv cockroachdb 26257
 - [Incident Response](./incident-response.md) - General incident handling
 - [Disaster Recovery](./disaster-recovery.md) - Full system recovery
 - [Saga Failure Recovery](./saga-failure-recovery.md) - Transaction saga failures
-- [Database Migration](./database-per-service-migration.md) - Schema migration procedures
+- [Data Model Reference](../architecture/data-model.md) - Database topology, tenant schemas, table ownership

--- a/docs/saga-service-catalog.md
+++ b/docs/saga-service-catalog.md
@@ -2,7 +2,6 @@
 
 This document provides a reference for all saga handlers available in the Meridian platform.
 
-
 ## current_account.control
 
 Perform lifecycle control action on an account (FREEZE, UNFREEZE, CLOSE)
@@ -25,7 +24,6 @@ result = current_account.control(
 ```
 
 ---
-
 
 ## current_account.create_lien
 
@@ -52,7 +50,6 @@ result = current_account.create_lien(
 
 ---
 
-
 ## current_account.execute_lien
 
 Execute (consume) a previously created lien
@@ -75,7 +72,6 @@ result = current_account.execute_lien(
 ```
 
 ---
-
 
 ## current_account.save
 
@@ -100,7 +96,6 @@ result = current_account.save(
 
 ---
 
-
 ## current_account.terminate_lien
 
 Terminate (release) a lien without execution (compensation handler)
@@ -123,7 +118,6 @@ result = current_account.terminate_lien(
 ```
 
 ---
-
 
 ## financial_accounting.capture_posting
 
@@ -150,7 +144,6 @@ result = financial_accounting.capture_posting(
 
 ---
 
-
 ## financial_accounting.compensate_posting
 
 Compensate (reverse) a captured posting entry
@@ -173,7 +166,6 @@ result = financial_accounting.compensate_posting(
 ```
 
 ---
-
 
 ## financial_accounting.create_booking
 
@@ -198,7 +190,6 @@ result = financial_accounting.create_booking(
 
 ---
 
-
 ## financial_accounting.initiate_booking_log
 
 Initiate a booking log for a deposit or withdrawal transaction
@@ -221,7 +212,6 @@ result = financial_accounting.initiate_booking_log(
 ```
 
 ---
-
 
 ## financial_accounting.post_entries
 
@@ -248,7 +238,6 @@ result = financial_accounting.post_entries(
 
 ---
 
-
 ## financial_accounting.reverse_entries
 
 Reverse previously posted accounting entries (compensation handler)
@@ -271,7 +260,6 @@ result = financial_accounting.reverse_entries(
 ```
 
 ---
-
 
 ## financial_accounting.update_booking_log
 
@@ -296,7 +284,6 @@ result = financial_accounting.update_booking_log(
 
 ---
 
-
 ## financial_gateway.cancel_payment
 
 Cancel a pending payment dispatch (compensation handler)
@@ -319,7 +306,6 @@ result = financial_gateway.cancel_payment(
 ```
 
 ---
-
 
 ## financial_gateway.dispatch_payment
 
@@ -346,7 +332,6 @@ result = financial_gateway.dispatch_payment(
 
 ---
 
-
 ## financial_gateway.dispatch_refund
 
 Dispatch a refund for a previously processed payment
@@ -369,7 +354,6 @@ result = financial_gateway.dispatch_refund(
 ```
 
 ---
-
 
 ## internal_account.get_balance
 
@@ -394,7 +378,6 @@ result = internal_account.get_balance(
 
 ---
 
-
 ## internal_account.initiate
 
 Initiate a new internal account
@@ -417,7 +400,6 @@ result = internal_account.initiate(
 ```
 
 ---
-
 
 ## internal_account.retrieve
 
@@ -442,7 +424,6 @@ result = internal_account.retrieve(
 
 ---
 
-
 ## market_information.get_rate
 
 Fetch FX rates for currency pair conversion
@@ -466,7 +447,6 @@ result = market_information.get_rate(
 
 ---
 
-
 ## operational_gateway.cancel_instruction
 
 Cancel a pending instruction before dispatch (compensation handler)
@@ -489,7 +469,6 @@ result = operational_gateway.cancel_instruction(
 ```
 
 ---
-
 
 ## operational_gateway.dispatch_instruction
 
@@ -516,7 +495,6 @@ result = operational_gateway.dispatch_instruction(
 
 ---
 
-
 ## operational_gateway.get_instruction
 
 Get instruction status and details by ID
@@ -539,7 +517,6 @@ result = operational_gateway.get_instruction(
 ```
 
 ---
-
 
 ## party.get_default_payment_method
 
@@ -564,7 +541,6 @@ result = party.get_default_payment_method(
 
 ---
 
-
 ## party.get_structuring_data
 
 Retrieve structuring metadata for a participant in a syndicate
@@ -587,7 +563,6 @@ result = party.get_structuring_data(
 ```
 
 ---
-
 
 ## party.list_participants
 
@@ -612,7 +587,6 @@ result = party.list_participants(
 
 ---
 
-
 ## position_keeping.cancel_log
 
 Cancel a position log entry (compensation handler)
@@ -635,7 +609,6 @@ result = position_keeping.cancel_log(
 ```
 
 ---
-
 
 ## position_keeping.initiate_log
 
@@ -662,7 +635,6 @@ result = position_keeping.initiate_log(
 
 ---
 
-
 ## position_keeping.update_log
 
 Update an existing position log entry
@@ -685,7 +657,6 @@ result = position_keeping.update_log(
 ```
 
 ---
-
 
 ## reconciliation.assert_balance
 
@@ -710,7 +681,6 @@ result = reconciliation.assert_balance(
 
 ---
 
-
 ## reconciliation.cancel_run
 
 Cancel a settlement run (compensation handler)
@@ -733,7 +703,6 @@ result = reconciliation.cancel_run(
 ```
 
 ---
-
 
 ## reconciliation.execute_run
 
@@ -758,7 +727,6 @@ result = reconciliation.execute_run(
 
 ---
 
-
 ## reconciliation.initiate_dispute
 
 Raise a formal dispute against a detected variance
@@ -781,7 +749,6 @@ result = reconciliation.initiate_dispute(
 ```
 
 ---
-
 
 ## reconciliation.initiate_run
 
@@ -808,7 +775,6 @@ result = reconciliation.initiate_run(
 
 ---
 
-
 ## reconciliation.retrieve_run
 
 Retrieve a settlement run summary
@@ -832,7 +798,6 @@ result = reconciliation.retrieve_run(
 
 ---
 
-
 ## reference_data.retrieve_instrument
 
 Retrieve an instrument definition by code and version
@@ -855,4 +820,3 @@ result = reference_data.retrieve_instrument(
 ```
 
 ---
-

--- a/shared/README.md
+++ b/shared/README.md
@@ -17,11 +17,13 @@ sub-directories with distinct responsibilities.
 ### Decision Guide
 
 Place new code in **`pkg/`** if it:
+
 - Encodes a domain concept (e.g., a new quantity dimension or settlement type)
 - Is a utility tightly coupled to domain types (e.g., amount arithmetic)
 - Must remain independent of infrastructure concerns for testability
 
 Place new code in **`platform/`** if it:
+
 - Wraps or configures an external dependency (database, message broker, cache, auth)
 - Provides cross-cutting infrastructure with no domain meaning (health checks, rate limiting, sandboxing)
 - Is consumed identically by all services regardless of domain context


### PR DESCRIPTION
## Summary

Adds `docs/architecture/data-model.md` as the consolidated reference for how Meridian stores data in Postgres, and tidies schema docs that drifted after the recent tenant-isolation merges.

### New doc - `docs/architecture/data-model.md`

End-to-end reference covering:

- **Topology** - database-per-service plus schema-per-tenant (`org_<id>`), with `meridian_platform` as the single platform DB for control-plane and tenant services
- **Tenant isolation mechanism** - how `services/tenant/provisioner/postgres_provisioner.go` provisions `org_<id>` schemas, and how `shared/platform/db/gorm_tenant_scope.go` routes requests via `SET LOCAL search_path`
- **Reference data replication** - the seeder pipeline registered in `cmd/meridian/wire_services.go` (InstrumentSeeder, SagaSeeder, AccountTypeSeeder, ValuationSeeder, IdentityBootstrap) that replicates platform reference data into each tenant schema on provisioning
- **Service inventory** - one-row-per-service table mapping service → database → schema location → BIAN domain
- **Table ownership** - what each of the ~85 tables across 19 services stores, organised by platform tier vs BIAN domain tier
- **Cross-tenant access** - the only cross-tenant pattern in the codebase (`public.tenant_data_entitlements` in market-information) and why
- **Shared patterns** - outbox, immutable audit, bi-temporal data, append-only positions, FK-stops-at-service-boundary

### Doc tidy-up

Recent merges that made existing docs partially stale:

- #2125 - Removed `public` from `search_path`, replicating reference data per-tenant
- #2126 - Self-service signup to tenant creation end-to-end flow
- Earlier - Database migration target moved from CockroachDB to Postgres 16

Changes:

1. **`docs/adr/0003-database-schema-migrations.md`** - Added a note marking the CockroachDB Compatibility Considerations section as historical (constraints are retained for migration authoring consistency but the runtime is Postgres). Updated the schema-per-org description to reflect the transactional `SET LOCAL search_path` mechanism and PR #2125's removal of `public` from the search_path. Cross-linked to the new data-model doc.
2. **`docs/runbooks/database-per-service-migration.md` → `docs/archive/`** - This runbook documented a one-time migration that is now complete. Moved to archive with an updated frontmatter note pointing to the current topology doc.

Other stale files (`docs/archive/ARCHITECTURE.md`, `docs/reports/cockroachdb-migration-audit.md`) were already archived or correctly labelled as historical audits, so they are out of scope here.

## Test plan

- [ ] Markdown lint passes (pre-commit hook - passed)
- [ ] Cross-links resolve
- [ ] Table of services matches `services/` directory
- [ ] Claims about tenant provisioning match `services/tenant/provisioner/postgres_provisioner.go` and `shared/platform/db/gorm_tenant_scope.go`
- [ ] Claims about PR #2125 search_path change match `git show 007371ee`