### PR TITLE
docs: Correct production DB target - CockroachDB not Postgres

### DIFF
--- a/docs/adr/0003-database-schema-migrations.md
+++ b/docs/adr/0003-database-schema-migrations.md
@@ -153,7 +153,7 @@ Database: meridian_current_account
        └── Tables: account, lien, audit_log, audit_outbox
 ```
 
-- Each service has its own PostgreSQL database
+- Each service has its own database (PostgreSQL in develop/demo, CockroachDB in production)
 - Each organization gets its own schema within each service database
 - The search_path is set transactionally via `SET LOCAL search_path TO org_<id>` by `shared/platform/db/gorm_tenant_scope.go`
 - Queries use unqualified table names; PostgreSQL resolves via `search_path`
@@ -485,11 +485,11 @@ If migrating from golang-migrate:
 * Maintain migration history (no need to replay all migrations)
 * Continue using immutability principles
 
-### CockroachDB Compatibility Considerations (Historical)
+### CockroachDB Compatibility Considerations
 
-> **Note:** Meridian now targets PostgreSQL 16 exclusively. The constraints below are retained because existing migrations were authored under CockroachDB compatibility rules and continue to follow them (no PL/pgSQL, split column-add from partial-index-add, explicit timestamp columns instead of range types). New migrations should follow the same conventions for consistency, but the underlying runtime is Postgres. See [data-model.md](../architecture/data-model.md) for the current topology and [docs/reports/cockroachdb-migration-audit.md](../reports/cockroachdb-migration-audit.md) for historical context.
+> **Production target:** Meridian's production deployment target is **CockroachDB**. The `develop` and `demo` environments currently run PostgreSQL 16 (faster local boot, wire-compatible), but every migration and runtime SQL path must work unchanged on CockroachDB. The constraints below are binding for all new migrations. See [data-model.md](../architecture/data-model.md) for the current topology and [docs/reports/cockroachdb-migration-audit.md](../reports/cockroachdb-migration-audit.md) for the compatibility audit.
 
-While CockroachDB is PostgreSQL-compatible, some PostgreSQL features are **not supported**:
+While CockroachDB is PostgreSQL wire-compatible, some PostgreSQL features are **not supported**:
 
 | Feature | PostgreSQL | CockroachDB | Workaround |
 |---------|------------|-------------|------------|

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -29,7 +29,9 @@ This document is the single reference for how Meridian stores relational data. I
 4. Per-service table ownership
 5. Cross-tenant access (the only permitted pattern)
 
-**Database target.** Meridian is designed to run on **CockroachDB in production**. The `develop` and `demo` environments currently run PostgreSQL 16 because it is faster to boot locally and sufficient for end-to-end testing, and CockroachDB is PostgreSQL wire-compatible. Migrations, schema DDL, and runtime SQL are therefore written to the **common subset** of PostgreSQL and CockroachDB: no PL/pgSQL, no range types (`TSTZRANGE`), no exclusion constraints, no `LISTEN/NOTIFY`, split column-add from partial-index-add, and so on. See [ADR-0003](../adr/0003-database-schema-migrations.md) for the full compatibility rules and [docs/reports/cockroachdb-migration-audit.md](../reports/cockroachdb-migration-audit.md) for the compatibility audit. Anything in this document that says "Postgres" applies equally to CockroachDB unless explicitly noted.
+**Database target.** Meridian is designed to run on **CockroachDB in production**. The `develop` and `demo` environments currently run PostgreSQL 16 because it is faster to boot locally and sufficient for end-to-end testing, and CockroachDB is PostgreSQL wire-compatible. Migrations, schema DDL, and runtime SQL are written to the **common subset** of PostgreSQL and CockroachDB: no PL/pgSQL, no range types (`TSTZRANGE`), no exclusion constraints, no `LISTEN/NOTIFY`, split column-add from partial-index-add, and so on. See [ADR-0003](../adr/0003-database-schema-migrations.md) for the full compatibility rules and [docs/reports/cockroachdb-migration-audit.md](../reports/cockroachdb-migration-audit.md) for the compatibility audit. Anything in this document that says "Postgres" applies equally to CockroachDB unless explicitly noted.
+
+> **Enforcement.** Atlas currently validates migrations against a `docker://postgres/16/dev` dev database. CockroachDB compatibility is enforced by **developer discipline and code review**, not by automated tooling. When adding a migration, verify it against the compatibility rules in ADR-0003 manually.
 
 ## Topology at a Glance
 
@@ -309,9 +311,11 @@ erDiagram
     PARTY_TYPE_DEFINITION {
         uuid id PK
         varchar tenant_id
-        string code
-        jsonb json_schema
-        string cel_expression
+        varchar party_type
+        text attribute_schema
+        text validation_cel
+        text eligibility_cel
+        bigint version
     }
 ```
 
@@ -353,22 +357,28 @@ erDiagram
     ACCOUNT ||--o{ WEBHOOK_DELIVERIES : notifies
     ACCOUNT {
         uuid id PK
-        string account_number
+        varchar account_id
+        varchar account_identification
+        varchar account_type
+        varchar currency
         uuid party_id
-        string status
+        bigint balance
+        bigint available_balance
+        varchar status
     }
     LIEN {
         uuid id PK
         uuid account_id FK
-        decimal amount
-        string status
-        uuid payment_order_id
+        bigint amount_cents
+        varchar currency
+        varchar status
+        varchar payment_order_reference
     }
     WITHDRAWAL {
         uuid id PK
         uuid account_id FK
-        decimal amount
-        string reference
+        bigint amount_cents
+        varchar reference
     }
 ```
 
@@ -687,7 +697,7 @@ flowchart LR
     IBA -. account_type_code .-> ATD
     POS -. instrument_code .-> INST
     IBA -. asset_code .-> INST
-    CAL -. payment_order_id .-> PMO
+    CAL -. payment_order_reference .-> PMO
     PMO -. lien_id .-> CAL
     INV -. payment_order_id .-> PMO
     FBL -. reference_id .-> FPL
@@ -734,7 +744,7 @@ Meridian uses [Atlas](https://atlasgo.io/) for schema management. Each service h
 - `services/<service>/atlas/atlas.hcl` — Atlas config (env: local, ci, production)
 - `atlas.sum` — integrity hash, must be regenerated after any migration change (`atlas migrate hash`)
 
-Atlas diffs against GORM models loaded by `utilities/atlas-loader`, which is the source of truth for desired schema. See [ADR-0003](../adr/0003-database-schema-migrations.md) for the full workflow and the CockroachDB compatibility rules that all migrations must follow (split column-add from partial-index-add, no PL/pgSQL, no range types, etc.).
+Atlas diffs against GORM models loaded by `utilities/atlas-loader`, which is the source of truth for desired schema. Atlas's dev database is `docker://postgres/16/dev`, so it validates SQL syntax against PostgreSQL - **not** against CockroachDB. See [ADR-0003](../adr/0003-database-schema-migrations.md) for the full workflow and the CockroachDB compatibility rules that developers must follow when authoring migrations (split column-add from partial-index-add, no PL/pgSQL, no range types, etc.). Compliance is enforced via code review, not tooling.
 
 ## Recent Changes
 

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -1,6 +1,6 @@
 ---
 name: data-model-reference
-description: End-to-end reference for Meridian's Postgres data model - services, databases, schemas, tenant isolation, and table ownership
+description: End-to-end reference for Meridian's data model - services, databases, schemas, tenant isolation, and table ownership
 triggers:
   - Understanding how data is organised across services
   - Writing migrations or queries that cross service boundaries
@@ -11,7 +11,7 @@ triggers:
 # Meridian Data Model Reference
 
 **Document Version:** 1.0
-**Last Updated:** 2026-04-04
+**Last Updated:** 2026-04-05
 **Status:** Active
 **Related:**
 - [ADR-0002: Microservices Per BIAN Domain](../adr/0002-microservices-per-bian-domain.md)
@@ -21,7 +21,7 @@ triggers:
 
 ## Overview
 
-This document is the single reference for how Meridian stores data in Postgres. It covers:
+This document is the single reference for how Meridian stores relational data. It covers:
 
 1. The database-per-service plus schema-per-tenant topology
 2. What lives in the `public` schema vs tenant (`org_<id>`) schemas
@@ -29,7 +29,7 @@ This document is the single reference for how Meridian stores data in Postgres. 
 4. Per-service table ownership
 5. Cross-tenant access (the only permitted pattern)
 
-Meridian runs on **PostgreSQL**. Earlier migrations were written to remain CockroachDB-compatible (see [docs/reports/cockroachdb-migration-audit.md](../reports/cockroachdb-migration-audit.md) for historical context), but the current deployment target is Postgres 16.
+**Database target.** Meridian is designed to run on **CockroachDB in production**. The `develop` and `demo` environments currently run PostgreSQL 16 because it is faster to boot locally and sufficient for end-to-end testing, and CockroachDB is PostgreSQL wire-compatible. Migrations, schema DDL, and runtime SQL are therefore written to the **common subset** of PostgreSQL and CockroachDB: no PL/pgSQL, no range types (`TSTZRANGE`), no exclusion constraints, no `LISTEN/NOTIFY`, split column-add from partial-index-add, and so on. See [ADR-0003](../adr/0003-database-schema-migrations.md) for the full compatibility rules and [docs/reports/cockroachdb-migration-audit.md](../reports/cockroachdb-migration-audit.md) for the compatibility audit. Anything in this document that says "Postgres" applies equally to CockroachDB unless explicitly noted.
 
 ## Topology at a Glance
 
@@ -54,7 +54,7 @@ Meridian runs on **PostgreSQL**. Earlier migrations were written to remain Cockr
 
 **Two axes of isolation:**
 
-- **Database-per-service** — each BIAN domain service owns a distinct Postgres database (`meridian_current_account`, `meridian_party`, ...). No service reads another's database; cross-service communication is gRPC or Kafka.
+- **Database-per-service** — each BIAN domain service owns a distinct database (`meridian_current_account`, `meridian_party`, ...). No service reads another's database; cross-service communication is gRPC or Kafka.
 - **Schema-per-tenant** — within each service database, each tenant has its own schema named `org_<tenant_id>`. All tenant-owned tables are replicated into every tenant schema.
 
 Platform-level services (`control-plane`, `tenant`) share a single `meridian_platform` database and store their data in the `public` schema because their concerns span all tenants.
@@ -263,7 +263,7 @@ Meridian uses [Atlas](https://atlasgo.io/) for schema management. Each service h
 - `services/<service>/atlas/atlas.hcl` — Atlas config (env: local, ci, production)
 - `atlas.sum` — integrity hash, must be regenerated after any migration change (`atlas migrate hash`)
 
-Atlas diffs against GORM models loaded by `utilities/atlas-loader`, which is the source of truth for desired schema. See [ADR-0003](../adr/0003-database-schema-migrations.md) for the full workflow and CockroachDB-era compatibility notes that remain in the migration style (split column-add from partial-index-add, no PL/pgSQL, etc.).
+Atlas diffs against GORM models loaded by `utilities/atlas-loader`, which is the source of truth for desired schema. See [ADR-0003](../adr/0003-database-schema-migrations.md) for the full workflow and the CockroachDB compatibility rules that all migrations must follow (split column-add from partial-index-add, no PL/pgSQL, no range types, etc.).
 
 ## Recent Changes
 

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -252,7 +252,7 @@ erDiagram
         jsonb metadata
     }
     TENANT_PROVISIONING {
-        varchar tenant_id PK_FK
+        varchar tenant_id PK "FK to tenant.id"
         varchar state
         jsonb service_schemas
         text error_message

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -231,7 +231,7 @@ Tables listed below live in the `org_<tenant_id>` schema of the service database
 
 The diagrams below show intra-service relationships (enforced by foreign keys inside each service database). Cross-service references - for example `current_account.account.party_id` pointing at `party.party.id` - are **not** foreign keys; they are UUIDs resolved via gRPC at write time. The final diagram shows those logical references.
 
-Audit tables (`audit_log`, `audit_outbox`, `event_outbox`) and outbox tables are present in most services but omitted from these diagrams for readability.
+Audit tables (`audit_log`, `audit_outbox`, `event_outbox`) and outbox tables are present in most services but omitted from these diagrams for readability. Attribute blocks show the most meaningful ~8-10 columns per table; housekeeping columns (`created_at`, `updated_at`, `created_by`, `updated_by`, `deleted_at`, `version`) are omitted unless they carry domain meaning. Column names and types are taken from the canonical Atlas migrations in `services/<service>/migrations/` (the source of truth for `develop` and `demo`).
 
 ### Platform Tier (`meridian_platform`)
 
@@ -243,40 +243,61 @@ erDiagram
     STAFF_USER ||--o{ API_KEY : issues
     TENANT {
         varchar id PK
-        string display_name
-        string settlement_asset
-        string status
+        varchar display_name
+        varchar settlement_asset
+        varchar subdomain
+        varchar slug
+        varchar party_id
+        varchar status
+        jsonb metadata
     }
     TENANT_PROVISIONING {
-        varchar tenant_id PK
-        string state
+        varchar tenant_id PK_FK
+        varchar state
         jsonb service_schemas
+        text error_message
     }
     TENANT_PROVISIONING_STATUS {
-        serial id PK
+        int id PK
         varchar tenant_id FK
-        string service_name
-        string status
+        varchar service_name
+        varchar status
+        varchar migration_version
+        int retry_count
     }
     MANIFEST_VERSION {
         uuid id PK
-        jsonb manifest
-        jsonb relationship_graph
+        int version
+        jsonb manifest_json
+        varchar applied_by
+        varchar apply_status
+        uuid apply_job_id
+        text diff_summary
     }
     MANIFEST_APPLY_JOB {
         uuid id PK
-        uuid manifest_version_id
+        int manifest_version
         uuid saga_execution_id
+        varchar status
+        text error
     }
     STAFF_USER {
         uuid id PK
-        string email
-        string role
+        varchar email
+        varchar name
+        varchar role
+        varchar status
+        varchar auth_provider_id
     }
     API_KEY {
         uuid id PK
         uuid staff_user_id FK
-        timestamp revoked_at
+        varchar key_prefix
+        bytea key_hash
+        text_arr scopes
+        int rate_limit_rps
+        timestamptz expires_at
+        timestamptz revoked_at
     }
 ```
 
@@ -293,20 +314,60 @@ erDiagram
     PARTY_TYPE_DEFINITION ||--o{ PARTY : typed_by
     PARTY {
         uuid id PK
-        string type
-        string status
-        string external_reference
+        varchar party_type
+        varchar legal_name
+        varchar display_name
+        varchar status
+        varchar external_reference
+        varchar external_reference_type
     }
     PARTY_ASSOCIATION {
         uuid id PK
         uuid party_id FK
         uuid related_party_id FK
-        string relationship_type
+        varchar relationship_type
+    }
+    PARTY_DEMOGRAPHIC {
+        uuid id PK
+        uuid party_id FK
+        jsonb socio_economic_data
+        jsonb employment_history
+        varchar income_level
+        varchar education_level
+    }
+    PARTY_BANK_RELATION {
+        uuid id PK
+        uuid party_id FK
+        varchar account_officer_id
+        varchar relationship_manager_id
+        varchar assigned_branch
+    }
+    PARTY_REFERENCE {
+        uuid id PK
+        uuid party_id FK
+        varchar reference_type
+        varchar reference_value
+        varchar issuing_authority
+        date expiry_date
+    }
+    PARTY_PAYMENT_METHOD {
+        uuid id PK
+        uuid party_id FK
+        varchar provider
+        varchar provider_customer_id
+        varchar provider_method_id
+        varchar method_type
+        boolean is_default
+        varchar status
     }
     PARTY_VERIFICATION {
         uuid id PK
         uuid party_id FK
-        string verification_status
+        varchar verification_id
+        varchar provider
+        varchar status
+        decimal risk_score
+        timestamptz completed_at
     }
     PARTY_TYPE_DEFINITION {
         uuid id PK
@@ -315,7 +376,7 @@ erDiagram
         text attribute_schema
         text validation_cel
         text eligibility_cel
-        bigint version
+        text error_message_cel
     }
 ```
 
@@ -329,22 +390,45 @@ erDiagram
     IDENTITY ||--o{ PASSWORD_RESET_TOKEN : resets
     IDENTITY {
         uuid id PK
-        string email
-        string status
-        string external_idp_subject
+        varchar email
+        varchar status
+        varchar password_hash
+        varchar external_idp
+        varchar external_sub
+        bigint failed_attempts
     }
     ROLE_ASSIGNMENT {
         uuid id PK
         uuid identity_id FK
-        string role
-        timestamp expires_at
-        timestamp revoked_at
+        uuid granted_by FK
+        varchar role
+        timestamptz expires_at
+        timestamptz revoked_at
+        uuid revoked_by FK
     }
     INVITATION {
         uuid id PK
         uuid identity_id FK
-        string token_hash
-        string status
+        uuid invited_by FK
+        varchar token_hash
+        timestamptz expires_at
+        varchar status
+    }
+    EMAIL_VERIFICATION_TOKEN {
+        uuid id PK
+        varchar tenant_id
+        uuid identity_id FK
+        varchar token_hash
+        timestamptz expires_at
+        timestamptz consumed_at
+    }
+    PASSWORD_RESET_TOKEN {
+        uuid id PK
+        varchar tenant_id
+        uuid identity_id FK
+        varchar token_hash
+        timestamptz expires_at
+        timestamptz consumed_at
     }
 ```
 
@@ -364,6 +448,7 @@ erDiagram
         uuid party_id
         bigint balance
         bigint available_balance
+        bigint overdraft_limit
         varchar status
     }
     LIEN {
@@ -373,12 +458,25 @@ erDiagram
         varchar currency
         varchar status
         varchar payment_order_reference
+        timestamptz expires_at
     }
     WITHDRAWAL {
         uuid id PK
         uuid account_id FK
         bigint amount_cents
+        varchar currency
+        varchar status
         varchar reference
+    }
+    WEBHOOK_DELIVERIES {
+        uuid id PK
+        varchar event_id
+        varchar event_type
+        varchar tenant_id
+        varchar account_id
+        varchar webhook_url
+        varchar status
+        int attempts
     }
 ```
 
@@ -390,23 +488,35 @@ erDiagram
     INTERNAL_BANK_ACCOUNT ||--o{ LIEN : reserves
     INTERNAL_BANK_ACCOUNT {
         uuid id PK
-        string account_type
-        string dimension
-        string asset_code
-        string status
+        varchar account_id
+        varchar account_code
+        varchar name
+        varchar account_type
+        varchar instrument_code
+        varchar dimension
+        varchar status
+        varchar correspondent_bank_id
+        jsonb attributes
     }
     INTERNAL_BANK_ACCOUNT_STATUS_HISTORY {
         uuid id PK
-        uuid account_id FK
-        string from_status
-        string to_status
+        varchar account_id FK
+        varchar from_status
+        varchar to_status
+        text reason
+        varchar changed_by
+        timestamptz changed_at
     }
     LIEN {
         uuid id PK
         uuid account_id FK
-        decimal reserved_quantity
-        decimal valued_amount
-        string status
+        bigint amount_cents
+        varchar currency
+        varchar bucket_id
+        varchar status
+        varchar payment_order_reference
+        jsonb reserved_quantity
+        jsonb valued_amount
     }
 ```
 
@@ -420,27 +530,68 @@ erDiagram
     FINANCIAL_POSITION_LOG ||--o{ MEASUREMENT : measures
     FINANCIAL_POSITION_LOG {
         uuid id PK
-        uuid reference_id
-        string status
-        decimal opening_balance
+        uuid log_id
+        varchar account_id
+        varchar current_status
+        varchar reconciliation_status
+        decimal opening_balance_amount
+        char opening_balance_currency
+        text failure_reason
     }
     TRANSACTION_LOG_ENTRY {
         uuid id PK
+        uuid entry_id
         uuid financial_position_log_id FK
-        string direction
-        decimal amount
+        uuid transaction_id
+        varchar account_id
+        bigint amount_cents
+        char currency
+        varchar direction
+        varchar source
+    }
+    AUDIT_TRAIL_ENTRY {
+        uuid id PK
+        uuid audit_id
+        uuid financial_position_log_id FK
+        varchar user_id
+        varchar action
+        text details
+        jsonb system_context
+    }
+    TRANSACTION_LINEAGE {
+        uuid id PK
+        uuid financial_position_log_id FK
+        uuid transaction_id
+        uuid parent_transaction_id
+        jsonb child_transaction_ids
+        varchar transaction_type
+    }
+    MEASUREMENT {
+        uuid id PK
+        uuid financial_position_log_id FK
+        varchar measurement_type
+        decimal value
+        varchar unit
+        jsonb metadata
     }
     POSITION {
         uuid id PK
+        varchar account_id
+        varchar instrument_code
+        varchar bucket_key
+        decimal amount
+        varchar dimension
+        jsonb attributes
         uuid reference_id
-        string dimension
-        string bucket_key
-        decimal quantity
     }
     RESERVATION {
         uuid lien_id PK
-        uuid reference_id
-        decimal projected_balance
+        varchar account_id
+        varchar instrument_code
+        varchar bucket_id
+        decimal reserved_amount
+        varchar status
+        timestamptz executed_at
     }
 ```
 
@@ -453,16 +604,24 @@ erDiagram
     FINANCIAL_BOOKING_LOG ||--o{ LEDGER_POSTING : posts
     FINANCIAL_BOOKING_LOG {
         uuid id PK
-        string idempotency_key
+        varchar financial_account_type
+        varchar product_service_reference
+        varchar business_unit_reference
         text chart_of_accounts_rules
-        string status
+        varchar base_currency
+        varchar status
+        varchar idempotency_key
     }
     LEDGER_POSTING {
         uuid id PK
         uuid financial_booking_log_id FK
-        string posting_direction
-        decimal amount
-        date value_date
+        varchar posting_direction
+        bigint amount_cents
+        varchar currency
+        varchar account_id
+        timestamptz value_date
+        varchar status
+        varchar correlation_id
     }
 ```
 
@@ -476,37 +635,70 @@ erDiagram
     SAGA_DEFINITION ||--o| SAGA_DEFINITION : superseded_by
     INSTRUMENT_DEFINITION {
         uuid id PK
-        string code
+        varchar code
         int version
-        string dimension
+        varchar dimension
         int precision
-        string status
+        varchar status
+        text validation_expression
+        text fungibility_key_expression
+        jsonb attribute_schema
+        varchar display_name
     }
     VALUATION_METHOD {
         uuid id PK
-        text starlark_script
-        timestamp valid_from
-        timestamp valid_to
-        string status
+        varchar name
+        int version
+        varchar input_instrument
+        varchar output_instrument
+        text logic_script
+        varchar logic_hash
+        text_arr required_policies
+        varchar lifecycle_status
+        boolean is_system
+        timestamptz valid_from
+        timestamptz valid_to
     }
     VALUATION_POLICY {
         uuid id PK
-        string cel_expression
+        varchar name
+        int version
+        text cel_expression
+        varchar cel_hash
+        jsonb input_schema
+        varchar output_type
         int estimated_cost
-        timestamp valid_from
+        varchar lifecycle_status
+        boolean is_system
     }
     SAGA_DEFINITION {
         uuid id PK
-        text starlark_script
+        varchar name
+        int version
+        text script
+        varchar status
+        boolean is_system
+        text preconditions_expression
         uuid successor_id FK
-        string status
     }
     ACCOUNT_TYPE_DEFINITIONS {
         uuid id PK
-        string code
+        varchar code
         int version
-        string behavior_class
+        varchar display_name
+        varchar normal_balance
+        varchar behavior_class
+        varchar instrument_code
+        text validation_cel
+        text bucketing_cel
+        jsonb attribute_schema
+        varchar status
+        boolean is_system
         uuid successor_id FK
+    }
+    ACCOUNT_TYPE_VALUATION_METHODS {
+        uuid account_type_id FK
+        uuid valuation_method_id FK
     }
 ```
 
@@ -519,34 +711,59 @@ erDiagram
     INVOICE }o--o| PAYMENT_ORDER : settled_by
     PAYMENT_ORDER {
         uuid id PK
-        string idempotency_key
-        string status
-        string lien_execution_status
+        varchar debtor_account_id
+        varchar creditor_reference
+        bigint amount_cents
+        char currency
+        varchar status
+        varchar lien_id
+        varchar gateway_reference_id
+        varchar ledger_booking_id
+        varchar idempotency_key
+        varchar lien_execution_status
     }
     SAGA_EXECUTIONS {
         uuid id PK
-        uuid payment_order_id
-        string saga_name
-        string status
+        uuid payment_order_id FK
+        varchar saga_name
+        int saga_version
+        varchar status
+        varchar correlation_id
+        jsonb input
+        jsonb output
+        bigint duration_ms
     }
     BILLING_RUN {
         uuid id PK
         varchar tenant_id
-        date period_start
-        date period_end
-        string status
+        timestamptz cycle_start
+        timestamptz cycle_end
+        varchar status
+        int dunning_level
     }
     INVOICE {
         uuid id PK
         uuid billing_run_id FK
-        uuid payment_order_id
+        varchar party_id
+        varchar account_id
+        varchar invoice_number
         jsonb line_items
+        bigint subtotal_cents
+        char currency
+        varchar status
+        uuid payment_order_id
     }
     EMAIL_OUTBOX {
         uuid id PK
         varchar tenant_id
-        string idempotency_key
-        string status
+        varchar idempotency_key
+        text_arr to_addresses
+        varchar from_address
+        varchar subject
+        varchar template_name
+        jsonb template_data
+        varchar status
+        int attempts
     }
 ```
 
@@ -560,30 +777,45 @@ erDiagram
     TENANT_DATA_ENTITLEMENTS }o--|| DATASET_DEFINITION : grants
     DATASET_DEFINITION {
         uuid id PK
-        string code
+        varchar code
         int version
-        string validation_cel
-        string status
+        varchar name
+        varchar data_category
+        text validation_expression
+        text resolution_key_expression
+        jsonb attribute_schema
+        varchar status
+        boolean is_shared
+        varchar access_level
     }
     DATA_SOURCE {
         uuid id PK
-        string name
+        varchar code
+        varchar name
         int trust_level
+        varchar status
     }
     MARKET_PRICE_OBSERVATION {
         uuid id PK
         uuid dataset_definition_id FK
         uuid data_source_id FK
+        varchar resolution_key
+        timestamptz observed_at
+        timestamptz valid_from
+        timestamptz valid_to
         int quality
-        timestamp valid_from
-        timestamp valid_to
+        numeric numeric_value
+        text text_value
         uuid superseded_by FK
+        uuid causation_id
     }
     TENANT_DATA_ENTITLEMENTS {
-        varchar tenant_id PK
-        string dataset_code PK
-        bool is_active
-        timestamp expires_at
+        uuid id PK
+        varchar tenant_id
+        varchar dataset_code
+        boolean is_active
+        timestamptz granted_at
+        timestamptz expires_at
     }
 ```
 
@@ -600,29 +832,59 @@ erDiagram
     SETTLEMENT_RUN ||--o{ BALANCE_ASSERTION : asserts
     SETTLEMENT_RUN {
         uuid id PK
-        string run_id
-        string scope
-        string settlement_type
-        string status
+        uuid run_id
+        varchar account_id
+        varchar scope
+        varchar settlement_type
+        varchar status
+        timestamptz period_start
+        timestamptz period_end
+        int variance_count
     }
     SETTLEMENT_SNAPSHOT {
         uuid id PK
+        uuid snapshot_id
         uuid run_id FK
-        decimal expected
-        decimal actual
+        varchar account_id
+        varchar instrument_code
+        decimal expected_balance
+        decimal actual_balance
         decimal variance_amount
+        varchar source_system
     }
     VARIANCE {
         uuid id PK
+        uuid variance_id
         uuid run_id FK
         uuid snapshot_id FK
-        string reason
-        string status
+        varchar account_id
+        decimal expected_amount
+        decimal actual_amount
+        decimal variance_amount
+        varchar reason
+        varchar status
+        varchar resolved_by
     }
     DISPUTE {
         uuid id PK
+        uuid dispute_id
         uuid variance_id FK
-        string status
+        uuid run_id FK
+        varchar status
+        text reason
+        text resolution
+        varchar raised_by
+    }
+    BALANCE_ASSERTION {
+        uuid id PK
+        uuid assertion_id
+        uuid run_id FK
+        varchar account_id
+        varchar instrument_code
+        text expression
+        decimal expected_balance
+        decimal actual_balance
+        varchar status
     }
 ```
 
@@ -633,26 +895,40 @@ erDiagram
     PROVIDER_CONNECTIONS ||--o{ INSTRUCTIONS : dispatches
     INSTRUCTIONS ||--o{ INSTRUCTION_ATTEMPTS : attempts
     PROVIDER_CONNECTIONS {
-        varchar tenant_id PK
+        uuid tenant_id PK
         uuid connection_id PK
-        string protocol
+        varchar provider_name
+        varchar provider_type
+        varchar protocol
+        varchar base_url
         jsonb auth_config
-        string health_status
-        string circuit_state
+        jsonb retry_policy
+        varchar health_status
+        varchar circuit_state
     }
     INSTRUCTIONS {
         uuid id PK
-        varchar tenant_id FK
+        uuid tenant_id
+        varchar instruction_type
         uuid provider_connection_id FK
-        string idempotency_key
-        string status
-        int priority
+        varchar correlation_id
+        varchar causation_id
+        jsonb payload
+        smallint priority
+        varchar status
+        timestamptz scheduled_at
+        int attempt_count
+        varchar idempotency_key
     }
     INSTRUCTION_ATTEMPTS {
         uuid id PK
         uuid instruction_id FK
         int attempt_number
-        timestamp started_at
+        timestamptz dispatched_at
+        timestamptz completed_at
+        int response_status_code
+        text error_message
+        bigint duration_ms
     }
 ```
 

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -225,6 +225,477 @@ Tables listed below live in the `org_<tenant_id>` schema of the service database
 **financial-gateway** — external payment provider integration
 - `event_outbox` — outbound payment instructions (most state is delegated to providers)
 
+## Entity Relationships
+
+The diagrams below show intra-service relationships (enforced by foreign keys inside each service database). Cross-service references - for example `current_account.account.party_id` pointing at `party.party.id` - are **not** foreign keys; they are UUIDs resolved via gRPC at write time. The final diagram shows those logical references.
+
+Audit tables (`audit_log`, `audit_outbox`, `event_outbox`) and outbox tables are present in most services but omitted from these diagrams for readability.
+
+### Platform Tier (`meridian_platform`)
+
+```mermaid
+erDiagram
+    TENANT ||--|| TENANT_PROVISIONING : tracks
+    TENANT ||--o{ TENANT_PROVISIONING_STATUS : per_service
+    MANIFEST_VERSION ||--o{ MANIFEST_APPLY_JOB : applies
+    STAFF_USER ||--o{ API_KEY : issues
+    TENANT {
+        varchar id PK
+        string display_name
+        string settlement_asset
+        string status
+    }
+    TENANT_PROVISIONING {
+        varchar tenant_id PK
+        string state
+        jsonb service_schemas
+    }
+    TENANT_PROVISIONING_STATUS {
+        serial id PK
+        varchar tenant_id FK
+        string service_name
+        string status
+    }
+    MANIFEST_VERSION {
+        uuid id PK
+        jsonb manifest
+        jsonb relationship_graph
+    }
+    MANIFEST_APPLY_JOB {
+        uuid id PK
+        uuid manifest_version_id
+        uuid saga_execution_id
+    }
+    STAFF_USER {
+        uuid id PK
+        string email
+        string role
+    }
+    API_KEY {
+        uuid id PK
+        uuid staff_user_id FK
+        timestamp revoked_at
+    }
+```
+
+### Party
+
+```mermaid
+erDiagram
+    PARTY ||--o{ PARTY_ASSOCIATION : related_to
+    PARTY ||--|| PARTY_DEMOGRAPHIC : has
+    PARTY ||--|| PARTY_BANK_RELATION : has
+    PARTY ||--o{ PARTY_REFERENCE : identified_by
+    PARTY ||--o{ PARTY_PAYMENT_METHOD : pays_with
+    PARTY ||--o{ PARTY_VERIFICATION : verified_by
+    PARTY_TYPE_DEFINITION ||--o{ PARTY : typed_by
+    PARTY {
+        uuid id PK
+        string type
+        string status
+        string external_reference
+    }
+    PARTY_ASSOCIATION {
+        uuid id PK
+        uuid party_id FK
+        uuid related_party_id FK
+        string relationship_type
+    }
+    PARTY_VERIFICATION {
+        uuid id PK
+        uuid party_id FK
+        string verification_status
+    }
+    PARTY_TYPE_DEFINITION {
+        uuid id PK
+        varchar tenant_id
+        string code
+        jsonb json_schema
+        string cel_expression
+    }
+```
+
+### Identity
+
+```mermaid
+erDiagram
+    IDENTITY ||--o{ ROLE_ASSIGNMENT : granted
+    IDENTITY ||--o{ INVITATION : invited_by
+    IDENTITY ||--o{ EMAIL_VERIFICATION_TOKEN : verifies
+    IDENTITY ||--o{ PASSWORD_RESET_TOKEN : resets
+    IDENTITY {
+        uuid id PK
+        string email
+        string status
+        string external_idp_subject
+    }
+    ROLE_ASSIGNMENT {
+        uuid id PK
+        uuid identity_id FK
+        string role
+        timestamp expires_at
+        timestamp revoked_at
+    }
+    INVITATION {
+        uuid id PK
+        uuid identity_id FK
+        string token_hash
+        string status
+    }
+```
+
+### Current Account
+
+```mermaid
+erDiagram
+    ACCOUNT ||--o{ LIEN : reserves
+    ACCOUNT ||--o{ WITHDRAWAL : debits
+    ACCOUNT ||--o{ WEBHOOK_DELIVERIES : notifies
+    ACCOUNT {
+        uuid id PK
+        string account_number
+        uuid party_id
+        string status
+    }
+    LIEN {
+        uuid id PK
+        uuid account_id FK
+        decimal amount
+        string status
+        uuid payment_order_id
+    }
+    WITHDRAWAL {
+        uuid id PK
+        uuid account_id FK
+        decimal amount
+        string reference
+    }
+```
+
+### Internal Account
+
+```mermaid
+erDiagram
+    INTERNAL_BANK_ACCOUNT ||--o{ INTERNAL_BANK_ACCOUNT_STATUS_HISTORY : audits
+    INTERNAL_BANK_ACCOUNT ||--o{ LIEN : reserves
+    INTERNAL_BANK_ACCOUNT {
+        uuid id PK
+        string account_type
+        string dimension
+        string asset_code
+        string status
+    }
+    INTERNAL_BANK_ACCOUNT_STATUS_HISTORY {
+        uuid id PK
+        uuid account_id FK
+        string from_status
+        string to_status
+    }
+    LIEN {
+        uuid id PK
+        uuid account_id FK
+        decimal reserved_quantity
+        decimal valued_amount
+        string status
+    }
+```
+
+### Position Keeping
+
+```mermaid
+erDiagram
+    FINANCIAL_POSITION_LOG ||--o{ TRANSACTION_LOG_ENTRY : contains
+    FINANCIAL_POSITION_LOG ||--o{ AUDIT_TRAIL_ENTRY : audits
+    FINANCIAL_POSITION_LOG ||--o{ TRANSACTION_LINEAGE : lineage
+    FINANCIAL_POSITION_LOG ||--o{ MEASUREMENT : measures
+    FINANCIAL_POSITION_LOG {
+        uuid id PK
+        uuid reference_id
+        string status
+        decimal opening_balance
+    }
+    TRANSACTION_LOG_ENTRY {
+        uuid id PK
+        uuid financial_position_log_id FK
+        string direction
+        decimal amount
+    }
+    POSITION {
+        uuid id PK
+        uuid reference_id
+        string dimension
+        string bucket_key
+        decimal quantity
+    }
+    RESERVATION {
+        uuid lien_id PK
+        uuid reference_id
+        decimal projected_balance
+    }
+```
+
+`POSITION` is append-only and not foreign-keyed to `FINANCIAL_POSITION_LOG`; it joins by `reference_id` at read time.
+
+### Financial Accounting
+
+```mermaid
+erDiagram
+    FINANCIAL_BOOKING_LOG ||--o{ LEDGER_POSTING : posts
+    FINANCIAL_BOOKING_LOG {
+        uuid id PK
+        string idempotency_key
+        text chart_of_accounts_rules
+        string status
+    }
+    LEDGER_POSTING {
+        uuid id PK
+        uuid financial_booking_log_id FK
+        string posting_direction
+        decimal amount
+        date value_date
+    }
+```
+
+### Reference Data
+
+```mermaid
+erDiagram
+    ACCOUNT_TYPE_DEFINITIONS ||--o{ ACCOUNT_TYPE_VALUATION_METHODS : valued_by
+    VALUATION_METHOD ||--o{ ACCOUNT_TYPE_VALUATION_METHODS : applied_via
+    ACCOUNT_TYPE_DEFINITIONS ||--o| ACCOUNT_TYPE_DEFINITIONS : superseded_by
+    SAGA_DEFINITION ||--o| SAGA_DEFINITION : superseded_by
+    INSTRUMENT_DEFINITION {
+        uuid id PK
+        string code
+        int version
+        string dimension
+        int precision
+        string status
+    }
+    VALUATION_METHOD {
+        uuid id PK
+        text starlark_script
+        timestamp valid_from
+        timestamp valid_to
+        string status
+    }
+    VALUATION_POLICY {
+        uuid id PK
+        string cel_expression
+        int estimated_cost
+        timestamp valid_from
+    }
+    SAGA_DEFINITION {
+        uuid id PK
+        text starlark_script
+        uuid successor_id FK
+        string status
+    }
+    ACCOUNT_TYPE_DEFINITIONS {
+        uuid id PK
+        string code
+        int version
+        string behavior_class
+        uuid successor_id FK
+    }
+```
+
+### Payment Order and Billing
+
+```mermaid
+erDiagram
+    PAYMENT_ORDER ||--o{ SAGA_EXECUTIONS : runs
+    BILLING_RUN ||--o{ INVOICE : generates
+    INVOICE }o--o| PAYMENT_ORDER : settled_by
+    PAYMENT_ORDER {
+        uuid id PK
+        string idempotency_key
+        string status
+        string lien_execution_status
+    }
+    SAGA_EXECUTIONS {
+        uuid id PK
+        uuid payment_order_id
+        string saga_name
+        string status
+    }
+    BILLING_RUN {
+        uuid id PK
+        varchar tenant_id
+        date period_start
+        date period_end
+        string status
+    }
+    INVOICE {
+        uuid id PK
+        uuid billing_run_id FK
+        uuid payment_order_id
+        jsonb line_items
+    }
+    EMAIL_OUTBOX {
+        uuid id PK
+        varchar tenant_id
+        string idempotency_key
+        string status
+    }
+```
+
+### Market Information
+
+```mermaid
+erDiagram
+    DATASET_DEFINITION ||--o{ MARKET_PRICE_OBSERVATION : observed_as
+    DATA_SOURCE ||--o{ MARKET_PRICE_OBSERVATION : provided_by
+    MARKET_PRICE_OBSERVATION ||--o| MARKET_PRICE_OBSERVATION : superseded_by
+    TENANT_DATA_ENTITLEMENTS }o--|| DATASET_DEFINITION : grants
+    DATASET_DEFINITION {
+        uuid id PK
+        string code
+        int version
+        string validation_cel
+        string status
+    }
+    DATA_SOURCE {
+        uuid id PK
+        string name
+        int trust_level
+    }
+    MARKET_PRICE_OBSERVATION {
+        uuid id PK
+        uuid dataset_definition_id FK
+        uuid data_source_id FK
+        int quality
+        timestamp valid_from
+        timestamp valid_to
+        uuid superseded_by FK
+    }
+    TENANT_DATA_ENTITLEMENTS {
+        varchar tenant_id PK
+        string dataset_code PK
+        bool is_active
+        timestamp expires_at
+    }
+```
+
+`TENANT_DATA_ENTITLEMENTS` lives in the `public` schema of `meridian_market_information` - see [Cross-Tenant Access](#cross-tenant-access).
+
+### Reconciliation
+
+```mermaid
+erDiagram
+    SETTLEMENT_RUN ||--o{ SETTLEMENT_SNAPSHOT : snapshots
+    SETTLEMENT_RUN ||--o{ VARIANCE : detects
+    SETTLEMENT_SNAPSHOT ||--o{ VARIANCE : attributed_to
+    VARIANCE ||--o{ DISPUTE : disputed_as
+    SETTLEMENT_RUN ||--o{ BALANCE_ASSERTION : asserts
+    SETTLEMENT_RUN {
+        uuid id PK
+        string run_id
+        string scope
+        string settlement_type
+        string status
+    }
+    SETTLEMENT_SNAPSHOT {
+        uuid id PK
+        uuid run_id FK
+        decimal expected
+        decimal actual
+        decimal variance_amount
+    }
+    VARIANCE {
+        uuid id PK
+        uuid run_id FK
+        uuid snapshot_id FK
+        string reason
+        string status
+    }
+    DISPUTE {
+        uuid id PK
+        uuid variance_id FK
+        string status
+    }
+```
+
+### Operational Gateway
+
+```mermaid
+erDiagram
+    PROVIDER_CONNECTIONS ||--o{ INSTRUCTIONS : dispatches
+    INSTRUCTIONS ||--o{ INSTRUCTION_ATTEMPTS : attempts
+    PROVIDER_CONNECTIONS {
+        varchar tenant_id PK
+        uuid connection_id PK
+        string protocol
+        jsonb auth_config
+        string health_status
+        string circuit_state
+    }
+    INSTRUCTIONS {
+        uuid id PK
+        varchar tenant_id FK
+        uuid provider_connection_id FK
+        string idempotency_key
+        string status
+        int priority
+    }
+    INSTRUCTION_ATTEMPTS {
+        uuid id PK
+        uuid instruction_id FK
+        int attempt_number
+        timestamp started_at
+    }
+```
+
+### Cross-Service Logical References
+
+These are UUID references resolved via gRPC at write time - there are no foreign keys crossing service boundaries. Arrows point from the holder of the reference to the authoritative owner.
+
+```mermaid
+flowchart LR
+    subgraph Party["party service"]
+        P[party]
+    end
+    subgraph CA["current-account service"]
+        ACC[account]
+        CAL[lien]
+    end
+    subgraph IA["internal-account service"]
+        IBA[internal_bank_account]
+    end
+    subgraph PK["position-keeping service"]
+        FPL[financial_position_log]
+        POS[position]
+    end
+    subgraph FA["financial-accounting service"]
+        FBL[financial_booking_log]
+    end
+    subgraph PO["payment-order service"]
+        PMO[payment_order]
+        INV[invoice]
+    end
+    subgraph RD["reference-data service"]
+        INST[instrument_definition]
+        ATD[account_type_definitions]
+    end
+    subgraph MI["market-information service"]
+        OBS[market_price_observation]
+    end
+
+    ACC -. party_id .-> P
+    IBA -. counterparty_party_id .-> P
+    ACC -. account_type_code .-> ATD
+    IBA -. account_type_code .-> ATD
+    POS -. instrument_code .-> INST
+    IBA -. asset_code .-> INST
+    CAL -. payment_order_id .-> PMO
+    PMO -. lien_id .-> CAL
+    INV -. payment_order_id .-> PMO
+    FBL -. reference_id .-> FPL
+    ACC -. balance_ref .-> FPL
+    IBA -. balance_ref .-> FPL
+    OBS -. dataset .-> INST
+```
+
 ## Cross-Tenant Access
 
 There is **exactly one** cross-tenant access pattern in the codebase:

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -167,8 +167,8 @@ Tables listed below live in the `org_<tenant_id>` schema of the service database
 - `valuation_features` — per-account valuation cache
 
 **internal-account** — counterparty and operational accounts
-- `internal_bank_account` — CLEARING / NOSTRO / VOSTRO / HOLDING / SUSPENSE / REVENUE / EXPENSE / INVENTORY. Multi-asset dimension support. No balance columns — delegates to `position-keeping`.
-- `internal_bank_account_status_history` — ACTIVE / SUSPENDED / CLOSED transitions
+- `internal_account` — CLEARING / NOSTRO / VOSTRO / HOLDING / SUSPENSE / REVENUE / EXPENSE / INVENTORY. Multi-asset dimension support. No balance columns — delegates to `position-keeping`. Counterparty fields are `counterparty_id` / `counterparty_name` / `counterparty_external_ref` (renamed from `correspondent_bank_*` in 2026-02).
+- `internal_account_status_history` — ACTIVE / SUSPENDED / CLOSED transitions
 - `lien` — fund reservations with bucket-aware multi-asset valuation
 - `valuation_features`
 
@@ -482,11 +482,13 @@ erDiagram
 
 ### Internal Account
 
+The service is still packaged as `internal-account` but the underlying tables were renamed in PR-era 2026-02-25: `internal_bank_account` → `internal_account`, `correspondent_bank_*` → `counterparty_*`. The `lien.currency` column was subsequently renamed to `instrument_code`.
+
 ```mermaid
 erDiagram
-    INTERNAL_BANK_ACCOUNT ||--o{ INTERNAL_BANK_ACCOUNT_STATUS_HISTORY : audits
-    INTERNAL_BANK_ACCOUNT ||--o{ LIEN : reserves
-    INTERNAL_BANK_ACCOUNT {
+    INTERNAL_ACCOUNT ||--o{ INTERNAL_ACCOUNT_STATUS_HISTORY : audits
+    INTERNAL_ACCOUNT ||--o{ LIEN : reserves
+    INTERNAL_ACCOUNT {
         uuid id PK
         varchar account_id
         varchar account_code
@@ -495,10 +497,12 @@ erDiagram
         varchar instrument_code
         varchar dimension
         varchar status
-        varchar correspondent_bank_id
+        varchar counterparty_id
+        varchar counterparty_name
+        varchar counterparty_external_ref
         jsonb attributes
     }
-    INTERNAL_BANK_ACCOUNT_STATUS_HISTORY {
+    INTERNAL_ACCOUNT_STATUS_HISTORY {
         uuid id PK
         varchar account_id FK
         varchar from_status
@@ -511,7 +515,7 @@ erDiagram
         uuid id PK
         uuid account_id FK
         bigint amount_cents
-        varchar currency
+        varchar instrument_code
         varchar bucket_id
         varchar status
         varchar payment_order_reference
@@ -946,7 +950,7 @@ flowchart LR
         CAL[lien]
     end
     subgraph IA["internal-account service"]
-        IBA[internal_bank_account]
+        IBA[internal_account]
     end
     subgraph PK["position-keeping service"]
         FPL[financial_position_log]
@@ -963,23 +967,18 @@ flowchart LR
         INST[instrument_definition]
         ATD[account_type_definitions]
     end
-    subgraph MI["market-information service"]
-        OBS[market_price_observation]
-    end
 
     ACC -. party_id .-> P
-    IBA -. counterparty_party_id .-> P
-    ACC -. account_type_code .-> ATD
-    IBA -. account_type_code .-> ATD
+    ACC -. account_type .-> ATD
+    IBA -. account_type .-> ATD
     POS -. instrument_code .-> INST
-    IBA -. asset_code .-> INST
+    IBA -. instrument_code .-> INST
     CAL -. payment_order_reference .-> PMO
     PMO -. lien_id .-> CAL
     INV -. payment_order_id .-> PMO
-    FBL -. reference_id .-> FPL
-    ACC -. balance_ref .-> FPL
-    IBA -. balance_ref .-> FPL
-    OBS -. dataset .-> INST
+    FBL -. account_id .-> FPL
+    ACC -. account_id .-> FPL
+    IBA -. account_id .-> FPL
 ```
 
 ## Cross-Tenant Access


### PR DESCRIPTION
## Summary

Follow-up to #2127. Two corrections rolled into one PR:

### 1. Production DB target

The merged doc stated Meridian's deployment target was PostgreSQL 16. That is only true for `develop` and `demo`. **Production targets CockroachDB.** Framing the CockroachDB compatibility rules in ADR-0003 as "(Historical)" would actively mislead anyone authoring a new migration into using Postgres-only features that break in prod.

- `docs/architecture/data-model.md` - Rewrote the database target paragraph: CockroachDB in production, Postgres in develop/demo for local boot speed and wire compatibility, migrations written to the common subset.
- `docs/adr/0003-database-schema-migrations.md` - Removed the "(Historical)" framing; rules are binding for all new migrations. Fixed one bullet that said "its own PostgreSQL database".

### 2. Mermaid ER diagrams

Added a new **Entity Relationships** section to `data-model.md` with per-service Mermaid ER diagrams:

- Platform tier (tenant, manifest, staff identity)
- Party, Identity
- Current Account, Internal Account
- Position Keeping, Financial Accounting
- Reference Data
- Payment Order and Billing
- Market Information
- Reconciliation
- Operational Gateway

Plus a **Cross-Service Logical References** flowchart showing the UUID references that cross service boundaries via gRPC (no foreign keys enforced).

## Test plan

- [ ] Markdown lint passes (pre-commit hook - passed)
- [ ] Link integrity passes
- [ ] Mermaid diagrams render on GitHub
- [ ] No remaining claims that production runs Postgres