### PR TITLE
refactor: Quote SQL identifiers in tests via pq.QuoteIdentifier

### DIFF
--- a/cmd/position-tool/internal/exporter/exporter.go
+++ b/cmd/position-tool/internal/exporter/exporter.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
 	"github.com/meridianhub/meridian/cmd/position-tool/internal/infra"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/shopspring/decimal"
@@ -377,8 +378,10 @@ func (e *Exporter) streamPositions(ctx context.Context, opts ExportOptions, hand
 		return err
 	}
 
-	// Use server-side cursor for memory efficiency
-	cursorName := "export_cursor"
+	// Use server-side cursor for memory efficiency. cursorName is a hardcoded
+	// literal; quoting it with pq.QuoteIdentifier keeps the pattern uniform
+	// with other dynamic-identifier sites so copy-paste stays safe.
+	cursorName := pq.QuoteIdentifier("export_cursor")
 	query, args := e.buildSelectQuery(opts)
 
 	// Declare cursor

--- a/services/market-information/adapters/persistence/testhelpers/testcontainer.go
+++ b/services/market-information/adapters/persistence/testhelpers/testcontainer.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
 	"github.com/meridianhub/meridian/services/market-information/adapters/persistence"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/stretchr/testify/require"
@@ -77,14 +78,15 @@ func SetupTestContainer(t *testing.T) *TestContainer {
 func setupMasterSchema(ctx context.Context, t *testing.T, pool *pgxpool.Pool, poolConfig *pgxpool.Config) *pgxpool.Pool {
 	t.Helper()
 	masterSchema := "org_test_master"
+	quoted := pq.QuoteIdentifier(masterSchema)
 
-	_, err := pool.Exec(ctx, "CREATE SCHEMA IF NOT EXISTS "+masterSchema)
+	_, err := pool.Exec(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", quoted))
 	require.NoError(t, err, "Failed to create master tenant schema")
 	err = loadSchemaInSchema(ctx, pool, masterSchema)
 	require.NoError(t, err, "Failed to load schema into master tenant schema")
 
 	// Set default search_path so non-tenant-scoped queries use the master schema
-	_, err = pool.Exec(ctx, "ALTER DATABASE test_market_information SET search_path TO "+masterSchema)
+	_, err = pool.Exec(ctx, fmt.Sprintf("ALTER DATABASE test_market_information SET search_path TO %s", quoted))
 	require.NoError(t, err, "Failed to set default search_path")
 
 	// Reconnect to pick up the new default search_path

--- a/services/operational-gateway/adapters/persistence/setup_test.go
+++ b/services/operational-gateway/adapters/persistence/setup_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lib/pq"
 	"github.com/testcontainers/testcontainers-go/modules/cockroachdb"
 	gormpg "gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -192,7 +193,7 @@ func cleanTables(t *testing.T, db *gorm.DB) {
 	t.Helper()
 	tables := []string{"instruction_attempts", "instructions", "instruction_routes", "provider_connections"}
 	for _, tbl := range tables {
-		if err := db.Exec("DELETE FROM " + tbl).Error; err != nil {
+		if err := db.Exec(fmt.Sprintf("DELETE FROM %s", pq.QuoteIdentifier(tbl))).Error; err != nil {
 			t.Fatalf("failed to clean table %s: %v", tbl, err)
 		}
 	}

--- a/services/operational-gateway/e2e/e2e_test.go
+++ b/services/operational-gateway/e2e/e2e_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 	"github.com/meridianhub/meridian/services/operational-gateway/adapters/passthrough"
 	"github.com/meridianhub/meridian/services/operational-gateway/adapters/persistence"
 	"github.com/meridianhub/meridian/services/operational-gateway/domain"
@@ -165,7 +166,7 @@ func fixHealthStatusCheck(db *gorm.DB) error {
 		return nil // no constraint to fix
 	}
 
-	if err := db.Exec("ALTER TABLE provider_connections DROP CONSTRAINT " + constraintName).Error; err != nil {
+	if err := db.Exec(fmt.Sprintf("ALTER TABLE provider_connections DROP CONSTRAINT %s", pq.QuoteIdentifier(constraintName))).Error; err != nil {
 		return fmt.Errorf("drop old CHECK: %w", err)
 	}
 	if err := db.Exec("ALTER TABLE provider_connections ALTER COLUMN health_status SET DEFAULT 'UNKNOWN'").Error; err != nil {
@@ -192,7 +193,7 @@ func cleanTables(t *testing.T, db *gorm.DB) {
 	t.Helper()
 	tables := []string{"instruction_attempts", "instructions", "instruction_routes", "provider_connections"}
 	for _, tbl := range tables {
-		if err := db.Exec("DELETE FROM " + tbl).Error; err != nil {
+		if err := db.Exec(fmt.Sprintf("DELETE FROM %s", pq.QuoteIdentifier(tbl))).Error; err != nil {
 			t.Fatalf("failed to clean table %s: %v", tbl, err)
 		}
 	}

--- a/services/reference-data/migrations_test.go
+++ b/services/reference-data/migrations_test.go
@@ -597,7 +597,7 @@ func TestMigration_SchemaIsolation(t *testing.T) {
 	t.Run("same code+version can exist in different tenants", func(t *testing.T) {
 		// Insert same code+version in each tenant
 		for _, tenant := range tenants {
-			_, err := tc.pool.Exec(ctx, `SET search_path TO `+tenant)
+			_, err := tc.pool.Exec(ctx, fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(tenant)))
 			require.NoError(t, err)
 			_, err = tc.pool.Exec(ctx, `
 				INSERT INTO instrument_definition (id, code, version, dimension, precision, status, fungibility_key_expression)
@@ -608,7 +608,7 @@ func TestMigration_SchemaIsolation(t *testing.T) {
 
 		// Verify each tenant has exactly one record
 		for _, tenant := range tenants {
-			_, err := tc.pool.Exec(ctx, `SET search_path TO `+tenant)
+			_, err := tc.pool.Exec(ctx, fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(tenant)))
 			require.NoError(t, err)
 
 			var count int

--- a/services/reference-data/migrations_test.go
+++ b/services/reference-data/migrations_test.go
@@ -2,6 +2,7 @@ package migrations_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -544,8 +546,9 @@ func TestMigration_SchemaIsolation(t *testing.T) {
 	tenants := []string{"tenant_alpha", "tenant_beta", "tenant_gamma"}
 
 	for _, tenant := range tenants {
+		quoted := pq.QuoteIdentifier(tenant)
 		// Create schema for tenant
-		_, err := tc.pool.Exec(ctx, `CREATE SCHEMA IF NOT EXISTS `+tenant)
+		_, err := tc.pool.Exec(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", quoted))
 		require.NoError(t, err)
 
 		// Read and apply migration to this tenant's schema
@@ -554,7 +557,7 @@ func TestMigration_SchemaIsolation(t *testing.T) {
 		require.NoError(t, err)
 
 		// Set search_path to tenant schema and apply migration
-		_, err = tc.pool.Exec(ctx, `SET search_path TO `+tenant)
+		_, err = tc.pool.Exec(ctx, fmt.Sprintf("SET search_path TO %s", quoted))
 		require.NoError(t, err)
 		_, err = tc.pool.Exec(ctx, string(migrationSQL))
 		require.NoError(t, err)

--- a/services/reference-data/saga/e2e_seeder_test.go
+++ b/services/reference-data/saga/e2e_seeder_test.go
@@ -2,10 +2,12 @@ package saga
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -118,6 +120,7 @@ func TestE2E_SeededSagasAreActive(t *testing.T) {
 
 	tenantID := tenant.TenantID("active_check")
 	schemaName := tenantID.SchemaName()
+	quoted := pq.QuoteIdentifier(schemaName)
 	setupTenantSchemaForSeeder(t, pool, ctx, schemaName)
 
 	seeder := NewSeeder(pool)
@@ -126,7 +129,7 @@ func TestE2E_SeededSagasAreActive(t *testing.T) {
 
 	// Verify all seeded sagas are ACTIVE with scripts copied directly
 	rows, err := pool.Query(ctx,
-		"SELECT name, status, script FROM "+schemaName+".saga_definition WHERE is_system = true ORDER BY name")
+		fmt.Sprintf("SELECT name, status, script FROM %s.saga_definition WHERE is_system = true ORDER BY name", quoted))
 	require.NoError(t, err)
 	defer rows.Close()
 
@@ -160,6 +163,7 @@ func TestE2E_ReseedingDoesNotDuplicate(t *testing.T) {
 
 	tenantID := tenant.TenantID("reseed_test")
 	schemaName := tenantID.SchemaName()
+	quoted := pq.QuoteIdentifier(schemaName)
 	setupTenantSchemaForSeeder(t, pool, ctx, schemaName)
 
 	seeder := NewSeeder(pool)
@@ -179,7 +183,7 @@ func TestE2E_ReseedingDoesNotDuplicate(t *testing.T) {
 	// Count should still be exactly 8
 	var count int
 	err = pool.QueryRow(ctx,
-		"SELECT COUNT(*) FROM "+schemaName+".saga_definition WHERE is_system = true").
+		fmt.Sprintf("SELECT COUNT(*) FROM %s.saga_definition WHERE is_system = true", quoted)).
 		Scan(&count)
 	require.NoError(t, err)
 	assert.Equal(t, 8, count, "re-seeding should not create duplicates")
@@ -199,6 +203,7 @@ func TestE2E_PlatformRefIntegrityConstraint(t *testing.T) {
 
 	tenantID := tenant.TenantID("constraint_test")
 	schemaName := tenantID.SchemaName()
+	quoted := pq.QuoteIdentifier(schemaName)
 	setupTenantSchemaForSeeder(t, pool, ctx, schemaName)
 
 	// Get a platform saga ID
@@ -209,11 +214,11 @@ func TestE2E_PlatformRefIntegrityConstraint(t *testing.T) {
 	require.NoError(t, err)
 
 	// Try to insert with BOTH platform_ref and script - should fail
-	_, err = pool.Exec(ctx, `
-		INSERT INTO `+schemaName+`.saga_definition (
+	_, err = pool.Exec(ctx, fmt.Sprintf(`
+		INSERT INTO %s.saga_definition (
 			name, version, script, platform_ref, status, is_system,
 			created_at, updated_at
-		) VALUES ('bad_saga', 1, 'some script', $1, 'DRAFT', false, now(), now())`,
+		) VALUES ('bad_saga', 1, 'some script', $1, 'DRAFT', false, now(), now())`, quoted),
 		platformRefID)
 	require.Error(t, err, "should reject saga with both platform_ref and script")
 	assert.Contains(t, err.Error(), "23514", "should be a CHECK constraint violation")
@@ -251,8 +256,8 @@ func TestE2E_MigratorReport(t *testing.T) {
 func createSagaReferenceTable(t *testing.T, pool *pgxpool.Pool, ctx context.Context, schemaName string) {
 	t.Helper()
 
-	_, err := pool.Exec(ctx, `
-		CREATE TABLE IF NOT EXISTS `+schemaName+`.saga_reference (
+	_, err := pool.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s.saga_reference (
 			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 			saga_definition_id UUID NOT NULL,
 			reference_type VARCHAR(32) NOT NULL,
@@ -262,6 +267,6 @@ func createSagaReferenceTable(t *testing.T, pool *pgxpool.Pool, ctx context.Cont
 			line_number INT NOT NULL DEFAULT 0,
 			extracted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
 			CONSTRAINT uq_saga_ref UNIQUE (saga_definition_id, reference_type, reference_key)
-		)`)
+		)`, pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 }

--- a/services/reference-data/saga/grpc_handler_test.go
+++ b/services/reference-data/saga/grpc_handler_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
 	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
 	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
 	"github.com/meridianhub/meridian/shared/pkg/saga/validation"
@@ -45,7 +46,8 @@ func setupTestPostgres(t *testing.T) (*pgxpool.Pool, tenant.TenantID, func()) {
 	require.NoError(t, err)
 
 	schemaName := tenantID.SchemaName()
-	_, err = pool.Exec(ctx, "CREATE SCHEMA IF NOT EXISTS "+schemaName)
+	quoted := pq.QuoteIdentifier(schemaName)
+	_, err = pool.Exec(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", quoted))
 	require.NoError(t, err)
 
 	// Create platform_saga_definition in public schema (needed for FK constraints and platform-level operations)
@@ -65,8 +67,8 @@ func setupTestPostgres(t *testing.T) (*pgxpool.Pool, tenant.TenantID, func()) {
 	_, err = pool.Exec(ctx, platformTableSQL)
 	require.NoError(t, err)
 
-	createTableSQL := `
-		CREATE TABLE ` + schemaName + `.saga_definition (
+	createTableSQL := fmt.Sprintf(`
+		CREATE TABLE %s.saga_definition (
 			id uuid NOT NULL DEFAULT gen_random_uuid(),
 			name varchar(64) NOT NULL,
 			version integer NOT NULL DEFAULT 1,
@@ -94,12 +96,12 @@ func setupTestPostgres(t *testing.T) (*pgxpool.Pool, tenant.TenantID, func()) {
 				FOREIGN KEY (platform_ref) REFERENCES public.platform_saga_definition (id) ON DELETE SET NULL,
 			CONSTRAINT chk_saga_definition_script_source
 				CHECK (NOT (platform_ref IS NOT NULL AND script IS NOT NULL AND script != ''))
-		)`
+		)`, quoted)
 	_, err = pool.Exec(ctx, createTableSQL)
 	require.NoError(t, err)
 
 	cleanup := func() {
-		_, _ = pool.Exec(ctx, "DROP SCHEMA IF EXISTS "+schemaName+" CASCADE")
+		_, _ = pool.Exec(ctx, fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", quoted))
 	}
 
 	return pool, tenantID, cleanup

--- a/services/reference-data/saga/grpc_handler_test.go
+++ b/services/reference-data/saga/grpc_handler_test.go
@@ -576,13 +576,14 @@ func TestRegistryHandler_TenantOverride(t *testing.T) {
 
 	ctx := tenant.WithTenant(context.Background(), tenantID)
 	schemaName := tenantID.SchemaName()
+	quoted := pq.QuoteIdentifier(schemaName)
 
 	// Seed a system saga
-	_, err := pool.Exec(ctx, `
-		INSERT INTO `+schemaName+`.saga_definition
+	_, err := pool.Exec(ctx, fmt.Sprintf(`
+		INSERT INTO %s.saga_definition
 			(name, version, script, status, is_system, display_name, activated_at)
 		VALUES
-			('system_saga', 1, 'saga(name="system_saga")', 'ACTIVE', true, 'System Saga', now())`)
+			('system_saga', 1, 'saga(name="system_saga")', 'ACTIVE', true, 'System Saga', now())`, quoted))
 	require.NoError(t, err)
 
 	registry := NewPostgresRegistry(pool, nil)
@@ -614,9 +615,9 @@ func TestRegistryHandler_TenantOverride(t *testing.T) {
 	t.Run("cannot modify system saga", func(t *testing.T) {
 		// Try to get the system saga's ID
 		var systemID string
-		err := pool.QueryRow(ctx, `
-			SELECT id FROM `+schemaName+`.saga_definition
-			WHERE name = 'system_saga' AND is_system = true`).Scan(&systemID)
+		err := pool.QueryRow(ctx, fmt.Sprintf(`
+			SELECT id FROM %s.saga_definition
+			WHERE name = 'system_saga' AND is_system = true`, quoted)).Scan(&systemID)
 		require.NoError(t, err)
 
 		// Try to update it
@@ -1077,11 +1078,11 @@ func TestRegistryHandler_ListSagas_Pagination(t *testing.T) {
 	t.Run("ExcludeSystem filter", func(t *testing.T) {
 		// Insert a system saga directly
 		schemaName := tenantID.SchemaName()
-		_, err := pool.Exec(ctx, `
-			INSERT INTO `+schemaName+`.saga_definition
+		_, err := pool.Exec(ctx, fmt.Sprintf(`
+			INSERT INTO %s.saga_definition
 				(name, version, script, status, is_system)
 			VALUES
-				('system_list_test', 1, 'saga(name="system")', 'DRAFT', true)`)
+				('system_list_test', 1, 'saga(name="system")', 'DRAFT', true)`, pq.QuoteIdentifier(schemaName)))
 		require.NoError(t, err)
 
 		// Without ExcludeSystem — system saga should be present

--- a/services/reference-data/saga/override_api_test.go
+++ b/services/reference-data/saga/override_api_test.go
@@ -2,8 +2,10 @@ package saga
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	"github.com/lib/pq"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -152,6 +154,7 @@ func TestOverrideService_MigrateToPlatformRef(t *testing.T) {
 	// Create tenant schema with saga_definition table
 	tenantID := tenant.TenantID("migrate_tenant")
 	schemaName := tenantID.SchemaName()
+	quoted := pq.QuoteIdentifier(schemaName)
 	setupTenantSchemaForSeeder(t, pool, ctx, schemaName)
 
 	// Manually insert script-copied sagas (old style, without platform_ref)
@@ -164,11 +167,11 @@ func TestOverrideService_MigrateToPlatformRef(t *testing.T) {
 		script, ok := scripts[meta.Filename+".star"]
 		require.True(t, ok, "expected embedded script %s.star", meta.Filename)
 		require.NotEmpty(t, script)
-		_, err := pool.Exec(ctx, `
-			INSERT INTO `+schemaName+`.saga_definition (
+		_, err := pool.Exec(ctx, fmt.Sprintf(`
+			INSERT INTO %s.saga_definition (
 				name, version, script, status, is_system,
 				display_name, description, created_at, updated_at, activated_at
-			) VALUES ($1, 1, $2, 'ACTIVE', true, $3, $4, now(), now(), now())`,
+			) VALUES ($1, 1, $2, 'ACTIVE', true, $3, $4, now(), now(), now())`, quoted),
 			meta.Name, script, meta.DisplayName, meta.Description)
 		require.NoError(t, err)
 	}
@@ -196,7 +199,7 @@ func TestOverrideService_MigrateToPlatformRef(t *testing.T) {
 		// Verify nothing actually changed
 		var scriptCount int
 		err = pool.QueryRow(ctx,
-			"SELECT COUNT(*) FROM "+schemaName+".saga_definition WHERE script IS NOT NULL AND script != ''").
+			fmt.Sprintf("SELECT COUNT(*) FROM %s.saga_definition WHERE script IS NOT NULL AND script != ''", quoted)).
 			Scan(&scriptCount)
 		require.NoError(t, err)
 		assert.Equal(t, 8, scriptCount, "dry run should not modify data")
@@ -217,7 +220,7 @@ func TestOverrideService_MigrateToPlatformRef(t *testing.T) {
 		// Verify scripts are now NULL and platform_ref is set
 		var refCount int
 		err = pool.QueryRow(ctx,
-			"SELECT COUNT(*) FROM "+schemaName+".saga_definition WHERE platform_ref IS NOT NULL AND (script IS NULL OR script = '')").
+			fmt.Sprintf("SELECT COUNT(*) FROM %s.saga_definition WHERE platform_ref IS NOT NULL AND (script IS NULL OR script = '')", quoted)).
 			Scan(&refCount)
 		require.NoError(t, err)
 		assert.Equal(t, 8, refCount, "all sagas should now use platform_ref")

--- a/services/reference-data/saga/seeder_test.go
+++ b/services/reference-data/saga/seeder_test.go
@@ -2,10 +2,12 @@ package saga
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -88,6 +90,7 @@ func TestSeeder_SeedTenant(t *testing.T) {
 	// Create tenant schema and saga_definition table
 	tenantID := tenant.TenantID("test_tenant")
 	schemaName := tenantID.SchemaName()
+	quoted := pq.QuoteIdentifier(schemaName)
 	setupTenantSchemaForSeeder(t, pool, ctx, schemaName)
 
 	// Create seeder and seed - no PlatformSync prerequisite needed
@@ -99,16 +102,16 @@ func TestSeeder_SeedTenant(t *testing.T) {
 
 		// Verify sagas were seeded
 		var count int
-		err = pool.QueryRow(ctx, "SELECT COUNT(*) FROM "+schemaName+".saga_definition WHERE is_system = true").Scan(&count)
+		err = pool.QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s.saga_definition WHERE is_system = true", quoted)).Scan(&count)
 		require.NoError(t, err)
 		assert.Equal(t, 8, count, "expected 8 system sagas")
 
 		// Verify each saga has script content (not platform_ref)
-		rows, err := pool.Query(ctx, `
+		rows, err := pool.Query(ctx, fmt.Sprintf(`
 			SELECT name, version, status, is_system, script, display_name, activated_at
-			FROM `+schemaName+`.saga_definition
+			FROM %s.saga_definition
 			WHERE is_system = true
-			ORDER BY name`)
+			ORDER BY name`, quoted))
 		require.NoError(t, err)
 		defer rows.Close()
 
@@ -141,7 +144,7 @@ func TestSeeder_SeedTenant(t *testing.T) {
 
 		// Count should still be 8
 		var count int
-		err = pool.QueryRow(ctx, "SELECT COUNT(*) FROM "+schemaName+".saga_definition WHERE is_system = true").Scan(&count)
+		err = pool.QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s.saga_definition WHERE is_system = true", quoted)).Scan(&count)
 		require.NoError(t, err)
 		assert.Equal(t, 8, count, "idempotent seed should not create duplicates")
 	})
@@ -149,7 +152,7 @@ func TestSeeder_SeedTenant(t *testing.T) {
 	t.Run("deterministic UUIDs", func(t *testing.T) {
 		// Verify UUIDs are deterministic based on saga name
 		var ids []uuid.UUID
-		rows, err := pool.Query(ctx, "SELECT id FROM "+schemaName+".saga_definition WHERE is_system = true ORDER BY name")
+		rows, err := pool.Query(ctx, fmt.Sprintf("SELECT id FROM %s.saga_definition WHERE is_system = true ORDER BY name", quoted))
 		require.NoError(t, err)
 		defer rows.Close()
 
@@ -178,11 +181,11 @@ func TestSeeder_SeedTenant(t *testing.T) {
 
 	t.Run("seeded sagas have script content", func(t *testing.T) {
 		var script string
-		err := pool.QueryRow(ctx, `
+		err := pool.QueryRow(ctx, fmt.Sprintf(`
 			SELECT script
-			FROM `+schemaName+`.saga_definition
+			FROM %s.saga_definition
 			WHERE name = 'current_account_withdrawal' AND is_system = true
-		`).Scan(&script)
+		`, quoted)).Scan(&script)
 		require.NoError(t, err)
 
 		assert.NotEmpty(t, script, "script should not be empty")
@@ -209,7 +212,7 @@ func TestSeeder_SeedTenant_SelfContained(t *testing.T) {
 
 	// Verify sagas were seeded with script content
 	var count int
-	err = pool.QueryRow(ctx, "SELECT COUNT(*) FROM "+schemaName+".saga_definition WHERE is_system = true AND script IS NOT NULL AND script != ''").Scan(&count)
+	err = pool.QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s.saga_definition WHERE is_system = true AND script IS NOT NULL AND script != ''", pq.QuoteIdentifier(schemaName))).Scan(&count)
 	require.NoError(t, err)
 	assert.Equal(t, 8, count, "expected 8 system sagas with script content")
 }
@@ -219,13 +222,14 @@ func TestSeeder_SeedTenant_SelfContained(t *testing.T) {
 func setupTenantSchemaForSeeder(t *testing.T, pool *pgxpool.Pool, ctx context.Context, schemaName string) {
 	t.Helper()
 
-	_, err := pool.Exec(ctx, "CREATE SCHEMA IF NOT EXISTS "+schemaName)
+	quoted := pq.QuoteIdentifier(schemaName)
+	_, err := pool.Exec(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", quoted))
 	require.NoError(t, err)
 
 	// Create saga_definition table matching the full migrated schema
 	// Note: no FK reference to public.platform_saga_definition (tenant isolation)
-	createTableSQL := `
-		CREATE TABLE IF NOT EXISTS ` + schemaName + `.saga_definition (
+	createTableSQL := fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s.saga_definition (
 			id uuid NOT NULL DEFAULT gen_random_uuid(),
 			name varchar(64) NOT NULL,
 			version integer NOT NULL DEFAULT 1,
@@ -249,7 +253,7 @@ func setupTenantSchemaForSeeder(t *testing.T, pool *pgxpool.Pool, ctx context.Co
 			validated_at timestamptz NULL,
 			PRIMARY KEY (id),
 			CONSTRAINT uq_saga_definition_name_version UNIQUE (name, version)
-		)`
+		)`, quoted)
 	_, err = pool.Exec(ctx, createTableSQL)
 	require.NoError(t, err)
 }

--- a/services/reference-data/saga_migrations_test.go
+++ b/services/reference-data/saga_migrations_test.go
@@ -2,6 +2,7 @@ package migrations_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -537,8 +539,9 @@ func TestSagaMigration_SchemaIsolation(t *testing.T) {
 	tenants := []string{"tenant_alpha", "tenant_beta", "tenant_gamma"}
 
 	for _, tenant := range tenants {
+		quoted := pq.QuoteIdentifier(tenant)
 		// Create schema for tenant
-		_, err := tc.pool.Exec(ctx, `CREATE SCHEMA IF NOT EXISTS `+tenant)
+		_, err := tc.pool.Exec(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", quoted))
 		require.NoError(t, err)
 
 		// Apply saga migrations to this tenant's schema
@@ -553,7 +556,7 @@ func TestSagaMigration_SchemaIsolation(t *testing.T) {
 			require.NoError(t, err)
 
 			// Set search_path to tenant schema and apply migration
-			_, err = tc.pool.Exec(ctx, `SET search_path TO `+tenant)
+			_, err = tc.pool.Exec(ctx, fmt.Sprintf("SET search_path TO %s", quoted))
 			require.NoError(t, err)
 			_, err = tc.pool.Exec(ctx, string(migrationSQL))
 			require.NoError(t, err)

--- a/services/reference-data/saga_migrations_test.go
+++ b/services/reference-data/saga_migrations_test.go
@@ -597,7 +597,7 @@ func TestSagaMigration_SchemaIsolation(t *testing.T) {
 	t.Run("same name+version can exist in different tenants", func(t *testing.T) {
 		// Insert same name+version in each tenant
 		for _, tenant := range tenants {
-			_, err := tc.pool.Exec(ctx, `SET search_path TO `+tenant)
+			_, err := tc.pool.Exec(ctx, fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(tenant)))
 			require.NoError(t, err)
 			_, err = tc.pool.Exec(ctx, `
 				INSERT INTO saga_definition (id, name, version, script, status)
@@ -608,7 +608,7 @@ func TestSagaMigration_SchemaIsolation(t *testing.T) {
 
 		// Verify each tenant has exactly one record
 		for _, tenant := range tenants {
-			_, err := tc.pool.Exec(ctx, `SET search_path TO `+tenant)
+			_, err := tc.pool.Exec(ctx, fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(tenant)))
 			require.NoError(t, err)
 
 			var count int

--- a/shared/platform/testdb/integration_test.go
+++ b/shared/platform/testdb/integration_test.go
@@ -1,10 +1,12 @@
 package testdb
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/lib/pq"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -60,7 +62,7 @@ func TestPostgresSetupFunctions(t *testing.T) {
 		)`)
 
 		schemaName := tc.Tenant.SchemaName()
-		err := db.Exec("INSERT INTO " + schemaName + ".test_items (id, name) VALUES (gen_random_uuid(), 'hello')").Error
+		err := db.Exec(fmt.Sprintf("INSERT INTO %s.test_items (id, name) VALUES (gen_random_uuid(), 'hello')", pq.QuoteIdentifier(schemaName))).Error
 		require.NoError(t, err)
 	})
 


### PR DESCRIPTION
## Summary
- Replace 10 instances of raw SQL string concatenation (`"CREATE SCHEMA " + schemaName`, `"SELECT ... " + schemaName + ".table"`, etc.) with `fmt.Sprintf` + `pq.QuoteIdentifier`.
- Follows the SQL audit we ran against the codebase: production code is clean, these were the only stragglers, all in tests or one CLI helper.
- Not exploitable in practice (all values were hardcoded literals or known-safe slices), but the pattern was wrong and copy-paste-dangerous.

## Why this matters
Production repositories already use `pq.QuoteIdentifier` uniformly for dynamic identifiers (schema names from validated tenant IDs, etc). The tests drifted from that convention and were using raw `+` concatenation. Three risks:

1. Copy-paste into non-test code spreads the pattern to a place where the input is not a safe constant.
2. If a test generates schema/table names from untrusted input in the future (e.g. fuzzing), these become injectable.
3. Identifiers that happen to contain reserved words or mixed case break without proper quoting.

Using `pq.QuoteIdentifier` is the same mechanism the production code uses, so there is one convention across the whole repo.

## Files touched
**Tests (9):**
- services/reference-data/saga_migrations_test.go - tenant loop var
- services/reference-data/migrations_test.go - tenant loop var
- services/reference-data/saga/seeder_test.go - schemaName, cached quoted form
- services/reference-data/saga/grpc_handler_test.go - schemaName, DROP SCHEMA
- services/reference-data/saga/override_api_test.go - schemaName
- services/reference-data/saga/e2e_seeder_test.go - schemaName, createSagaReferenceTable helper
- services/market-information/adapters/persistence/testhelpers/testcontainer.go - masterSchema constant
- services/operational-gateway/e2e/e2e_test.go - constraintName from query, table names in DELETE loop
- shared/platform/testdb/integration_test.go - INSERT into tenant schema

**Non-test (1):**
- cmd/position-tool/internal/exporter/exporter.go - hardcoded cursor name, quoted for pattern uniformity

## Skipped from audit
- `shared/platform/db/pool.go:76` `SET statement_timeout = '%dms'` with an integer. Not a security risk (numeric value, not identifier) and PostgreSQL's SET does not accept parameterized values cleanly. Left as-is.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -short ./services/reference-data/saga/... ./shared/platform/testdb/... ./cmd/position-tool/internal/exporter/...` all pass
- [x] pre-commit hooks (gitleaks, gofumpt, golangci-lint) all pass
- [ ] CI green