### PR TITLE
fix: Reset tenant.status in deploy-develop so worker re-provisions

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -286,12 +286,24 @@ jobs:
             #   - tenants stuck in "pending" or "failed" from a prior broken deploy
             #   - tenants with service_schemas entries marked "migrated" but whose
             #     physical tables were never created (silent-success state)
-            # service_schemas is cleared to '[]' so provisionAllServices does not
-            # short-circuit via "service already provisioned, skipping".
+            #
+            # Two tables must be reset in tandem because the code tracks
+            # provisioning state in two places:
+            #   - tenant.status: the provisioning worker polls this via
+            #     ListByStatus(StatusProvisioningPending) (provisioning_worker.go).
+            #     Without resetting this, the worker never claims the tenant for
+            #     re-provisioning regardless of what tenant_provisioning says.
+            #   - tenant_provisioning.service_schemas: the provisioner checks this
+            #     JSONB per-service and short-circuits via "service already
+            #     provisioned, skipping" (postgres_provisioner.go) if an entry is
+            #     marked 'migrated'. Clearing to '[]' forces a full re-run.
+            #
             # Must run AFTER migrations so the provisioner uses up-to-date DDL.
             # Safe when schemas already exist (CREATE SCHEMA IF NOT EXISTS).
-            docker exec postgres-develop psql -U meridian -d meridian_platform -c \
-              "UPDATE tenant_provisioning SET state = 'pending', service_schemas = '[]'::jsonb, error_message = '' WHERE state != 'deprovisioned'"
+            docker exec postgres-develop psql -U meridian -d meridian_platform -c "
+              UPDATE tenant SET status = 'provisioning_pending', updated_at = NOW() WHERE status != 'deprovisioned';
+              UPDATE tenant_provisioning SET state = 'pending', service_schemas = '[]'::jsonb, error_message = '' WHERE state != 'deprovisioned';
+            "
             # Restart so the app picks up migrated schemas and provisions tenant
             # schemas (SCHEMA_PROVISIONING_ENABLED=true). Without this, seed-dev
             # fails on fresh databases because tenant schemas don't exist yet.


### PR DESCRIPTION
## Summary
- PR #2128 reset the wrong table. The workflow updated `tenant_provisioning` but the provisioning worker polls `tenant.status` via `ListByStatus(StatusProvisioningPending)`. Worker never picked up existing tenants, provisioning never re-ran, manifest apply still failed.
- Also, `seed-dev`'s `waitForTenantReady` calls `GetTenantProvisioningStatus` whose `OverallStatus` is derived from `tenant.status`. With `tenant.status='active'` stale, seed-dev returned immediately and fired the manifest apply before the worker could act.
- Reset **both** tables in the same psql call.

## Evidence
On develop right now (post-PR #2128 merge + deploy):
```
tenant_id        | state
volterra_energy  | pending      <- tenant_provisioning
meridian_master  | pending      <- tenant_provisioning

id               | status
volterra_energy  | active       <- tenant (still)
meridian_master  | active       <- tenant (still)
```
Deploy Develop CI log, 2026-04-05 08:06:
```
UPDATE 2                                                                  <- tenant_provisioning reset worked
Creating tenant 'volterra_energy' ...
Dev tenant already exists (idempotent).
Waiting for tenant provisioning ...
Tenant provisioned and active.                                            <- lie, tenant.status was just stale
Step [diff]: STEP_RESULT_STATUS_FAILED - relation "data_source" does not exist
```

## Code references
- `services/tenant/worker/provisioning_worker.go:292` - `w.repo.ListByStatus(ctx, domain.StatusProvisioningPending, ...)` - the worker only picks up tenants whose `tenant.status = 'provisioning_pending'`.
- `services/tenant/service/grpc_provisioning_endpoints.go:151` - `OverallStatus: s.toProtoStatus(tenant.Status)` - seed-dev's wait loop reads this.
- `services/tenant/provisioner/postgres_provisioner.go:262` - the `"service already provisioned, skipping"` short-circuit still needs `service_schemas = '[]'` to bypass (kept from PR #2128).

## Test plan
- [ ] Merge and trigger develop deploy
- [ ] Watch droplet: `tenant.status` should flip to `provisioning_pending` → `provisioning` → `active` before seed-dev runs
- [ ] Deploy Develop CI goes green
- [ ] Manually verify `org_volterra_energy` schemas contain actual tables afterwards