### PR TITLE
fix: Apply CockroachDB->Postgres DDL adapter in tenant provisioner

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -280,26 +280,37 @@ jobs:
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           script: |
             cd /opt/meridian-develop
-            # Reset tenant provisioning state so every deploy re-runs schema
-            # migrations against tenant schemas. This catches:
-            #   - stale "active" tenants whose schemas are missing (fresh DBs)
-            #   - tenants stuck in "pending" or "failed" from a prior broken deploy
-            #   - tenants with service_schemas entries marked "migrated" but whose
-            #     physical tables were never created (silent-success state)
+            # Reset tenant provisioning state and drop tenant schemas so every
+            # deploy re-provisions from scratch. Three states must be reconciled:
             #
-            # Two tables must be reset in tandem because the code tracks
-            # provisioning state in two places:
-            #   - tenant.status: the provisioning worker polls this via
-            #     ListByStatus(StatusProvisioningPending) (provisioning_worker.go).
-            #     Without resetting this, the worker never claims the tenant for
-            #     re-provisioning regardless of what tenant_provisioning says.
-            #   - tenant_provisioning.service_schemas: the provisioner checks this
-            #     JSONB per-service and short-circuits via "service already
-            #     provisioned, skipping" (postgres_provisioner.go) if an entry is
-            #     marked 'migrated'. Clearing to '[]' forces a full re-run.
+            #   1. tenant.status - the provisioning worker polls this via
+            #      ListByStatus(StatusProvisioningPending) (provisioning_worker.go).
+            #      Without resetting, the worker never claims the tenant.
+            #
+            #   2. tenant_provisioning.service_schemas - the provisioner checks
+            #      this JSONB per-service and short-circuits via "service already
+            #      provisioned, skipping" (postgres_provisioner.go). Clearing to
+            #      '[]' forces a full re-run of the loop.
+            #
+            #   3. Physical org_<tenant> schemas in each service database - if
+            #      left in place they may contain partial/stale tables from a
+            #      previous broken run, causing migrations to fail with "relation
+            #      does not exist" when they reference objects that got renamed
+            #      or dropped earlier. DROP SCHEMA CASCADE ensures migrations
+            #      run against completely empty schemas, matching the E2E path
+            #      which is known to pass.
             #
             # Must run AFTER migrations so the provisioner uses up-to-date DDL.
-            # Safe when schemas already exist (CREATE SCHEMA IF NOT EXISTS).
+            SERVICE_DBS="meridian_party meridian_current_account meridian_position_keeping meridian_financial_accounting meridian_payment_order meridian_market_information meridian_reference_data meridian_internal_account meridian_reconciliation meridian_identity meridian_control_plane"
+            for DB in $SERVICE_DBS; do
+              docker exec postgres-develop psql -U meridian -d $DB -tA -c "
+                SELECT format('DROP SCHEMA IF EXISTS %I CASCADE', nspname)
+                FROM pg_namespace WHERE nspname LIKE 'org\_%' ESCAPE '\\'
+              " | while read stmt; do
+                [ -z "$stmt" ] && continue
+                docker exec postgres-develop psql -U meridian -d $DB -c "$stmt"
+              done
+            done
             docker exec postgres-develop psql -U meridian -d meridian_platform -c "
               UPDATE tenant SET status = 'provisioning_pending', updated_at = NOW() WHERE status != 'deprovisioned';
               UPDATE tenant_provisioning SET state = 'pending', service_schemas = '[]'::jsonb, error_message = '' WHERE state != 'deprovisioned';

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -300,7 +300,17 @@ jobs:
             #      run against completely empty schemas, matching the E2E path
             #      which is known to pass.
             #
+            # Stop meridian-develop BEFORE resetting state. The worker polls
+            # tenant.status every 10s, so if the app is still running when we
+            # flip tenants to provisioning_pending it will race with this
+            # script: start provisioning against half-cleaned databases and
+            # then get interrupted when we issue the restart. Stopping first
+            # eliminates the race, and starting (not restarting) afterwards
+            # lets the worker observe the fully-reset state on boot.
+            #
             # Must run AFTER migrations so the provisioner uses up-to-date DDL.
+            docker compose -f docker-compose.develop.yml stop meridian-develop
+
             SERVICE_DBS="meridian_party meridian_current_account meridian_position_keeping meridian_financial_accounting meridian_payment_order meridian_market_information meridian_reference_data meridian_internal_account meridian_reconciliation meridian_identity meridian_control_plane"
             for DB in $SERVICE_DBS; do
               docker exec postgres-develop psql -U meridian -d $DB -tA -c "
@@ -315,10 +325,10 @@ jobs:
               UPDATE tenant SET status = 'provisioning_pending', updated_at = NOW() WHERE status != 'deprovisioned';
               UPDATE tenant_provisioning SET state = 'pending', service_schemas = '[]'::jsonb, error_message = '' WHERE state != 'deprovisioned';
             "
-            # Restart so the app picks up migrated schemas and provisions tenant
-            # schemas (SCHEMA_PROVISIONING_ENABLED=true). Without this, seed-dev
-            # fails on fresh databases because tenant schemas don't exist yet.
-            docker compose -f docker-compose.develop.yml restart meridian-develop
+            # Start the app back up with the reset state in place. The
+            # provisioning worker will claim the pending tenants on its first
+            # poll and re-run all migrations against the newly empty schemas.
+            docker compose -f docker-compose.develop.yml start meridian-develop
 
       - name: Seed develop data
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5

--- a/internal/migrations/adapt_test.go
+++ b/internal/migrations/adapt_test.go
@@ -8,26 +8,26 @@ import (
 
 func TestAdaptCockroachDDLForPostgres_NoChanges(t *testing.T) {
 	input := `CREATE TABLE foo (id UUID PRIMARY KEY);`
-	assert.Equal(t, input, adaptCockroachDDLForPostgres(input))
+	assert.Equal(t, input, AdaptCockroachDDLForPostgres(input))
 }
 
 func TestAdaptCockroachDDLForPostgres_ManifestVersionUniqueConstraint(t *testing.T) {
 	input := `DROP INDEX IF EXISTS uq_manifest_version_version CASCADE;`
-	result := adaptCockroachDDLForPostgres(input)
+	result := AdaptCockroachDDLForPostgres(input)
 	assert.Contains(t, result, "ALTER TABLE manifest_version DROP CONSTRAINT IF EXISTS uq_manifest_version_version")
 	assert.NotContains(t, result, "DROP INDEX")
 }
 
 func TestAdaptCockroachDDLForPostgres_SagaDefinitionUniqueConstraint(t *testing.T) {
 	input := `DROP INDEX IF EXISTS "public"."uq_platform_saga_definition_name" CASCADE;`
-	result := adaptCockroachDDLForPostgres(input)
+	result := AdaptCockroachDDLForPostgres(input)
 	assert.Contains(t, result, `ALTER TABLE "public"."platform_saga_definition" DROP CONSTRAINT IF EXISTS "uq_platform_saga_definition_name"`)
 	assert.NotContains(t, result, "DROP INDEX")
 }
 
 func TestAdaptCockroachDDLForPostgres_AddConstraintCheck(t *testing.T) {
 	input := `ALTER TABLE public.my_table ADD CONSTRAINT chk_status CHECK (status IN ('a','b'));`
-	result := adaptCockroachDDLForPostgres(input)
+	result := AdaptCockroachDDLForPostgres(input)
 	assert.Contains(t, result, "DO $compat$ BEGIN")
 	assert.Contains(t, result, "EXCEPTION WHEN duplicate_object THEN NULL")
 	assert.Contains(t, result, "ADD CONSTRAINT chk_status CHECK")
@@ -35,7 +35,7 @@ func TestAdaptCockroachDDLForPostgres_AddConstraintCheck(t *testing.T) {
 
 func TestAdaptCockroachDDLForPostgres_AddConstraintIfNotExists(t *testing.T) {
 	input := `ALTER TABLE public.my_table ADD CONSTRAINT IF NOT EXISTS chk_val CHECK (val > 0);`
-	result := adaptCockroachDDLForPostgres(input)
+	result := AdaptCockroachDDLForPostgres(input)
 	assert.Contains(t, result, "DO $compat$ BEGIN")
 	assert.NotContains(t, result, "IF NOT EXISTS")
 	assert.Contains(t, result, "ADD CONSTRAINT chk_val CHECK")
@@ -48,7 +48,7 @@ DROP INDEX IF EXISTS uq_manifest_version_version CASCADE;
 DROP INDEX IF EXISTS idx_manifest_version_version;
 ALTER TABLE manifest_version DROP COLUMN version;`
 
-	result := adaptCockroachDDLForPostgres(input)
+	result := AdaptCockroachDDLForPostgres(input)
 
 	// The DROP INDEX CASCADE for the unique constraint should be rewritten
 	assert.Contains(t, result, "ALTER TABLE manifest_version DROP CONSTRAINT IF EXISTS uq_manifest_version_version")

--- a/internal/migrations/runner.go
+++ b/internal/migrations/runner.go
@@ -403,7 +403,7 @@ func applyDatabaseMigrations(ctx context.Context, dsn, dbName string, migrations
 
 		sql := m.sql
 		if driver == DriverPostgres {
-			sql = adaptCockroachDDLForPostgres(sql)
+			sql = AdaptCockroachDDLForPostgres(sql)
 		}
 
 		if _, err := conn.Exec(ctx, sql); err != nil {
@@ -597,15 +597,18 @@ func runPostgresPreMigrationFixups(ctx context.Context, superuserDSN string, dri
 	return nil
 }
 
-// adaptCockroachDDLForPostgres rewrites CockroachDB-specific DDL to work on PostgreSQL.
+// AdaptCockroachDDLForPostgres rewrites CockroachDB-specific DDL to work on PostgreSQL.
 //
 // Migrations are written for CockroachDB (production). When running against
-// PostgreSQL (demo, local dev), this function translates known incompatibilities:
+// PostgreSQL (demo, develop, local dev), this function translates known
+// incompatibilities:
 //   - DROP INDEX CASCADE for unique constraints -> ALTER TABLE DROP CONSTRAINT
 //   - ADD CONSTRAINT [IF NOT EXISTS] CHECK on public-schema tables -> idempotent DO block
 //
 // This mirrors shared/platform/testdb/pgx.go:adaptCockroachDDLForPostgres.
-func adaptCockroachDDLForPostgres(sql string) string {
+// Exported so both the CLI --migrate path and the tenant provisioner can apply
+// the same adaptations when running migrations against a PostgreSQL backend.
+func AdaptCockroachDDLForPostgres(sql string) string {
 	// CockroachDB uses DROP INDEX CASCADE for unique constraints;
 	// PostgreSQL requires ALTER TABLE DROP CONSTRAINT.
 	sql = strings.ReplaceAll(sql,

--- a/services/tenant/provisioner/migration_runner.go
+++ b/services/tenant/provisioner/migration_runner.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	internalmigrations "github.com/meridianhub/meridian/internal/migrations"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"gorm.io/gorm"
 )
@@ -268,23 +269,7 @@ func (p *PostgresProvisioner) applyMigrationList(ctx context.Context, db *gorm.D
 			return lastVersion, ctx.Err()
 		}
 
-		// Execute migration within a transaction
-		err := db.WithContext(bypassCtx(ctx)).Transaction(func(tx *gorm.DB) error {
-			if err := tx.Exec(setPathQuery).Error; err != nil {
-				return fmt.Errorf("set search_path: %w", err)
-			}
-
-			processedSQL := p.processMigrationSQL(mig.Content, schemaName)
-			statements := splitSQLStatements(processedSQL)
-
-			for _, stmt := range statements {
-				if err := tx.Exec(stmt).Error; err != nil {
-					return fmt.Errorf("execute migration %s: %w", mig.Filename, err)
-				}
-			}
-
-			return nil
-		})
+		err := p.applyMigrationInTransaction(ctx, db, schemaName, setPathQuery, mig)
 		if err != nil {
 			// IDEMPOTENCY: If error indicates objects already exist (duplicate_table,
 			// duplicate_schema, duplicate_object), treat as success. This handles the
@@ -300,6 +285,37 @@ func (p *PostgresProvisioner) applyMigrationList(ctx context.Context, db *gorm.D
 	}
 
 	return lastVersion, nil
+}
+
+// applyMigrationInTransaction runs a single migration file inside its own
+// transaction: SET search_path, process+adapt the SQL, then execute each
+// statement. Extracted from applyMigrationList to keep cognitive complexity
+// under the architecture baseline.
+func (p *PostgresProvisioner) applyMigrationInTransaction(ctx context.Context, db *gorm.DB, schemaName, setPathQuery string, mig migration) error {
+	return db.WithContext(bypassCtx(ctx)).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec(setPathQuery).Error; err != nil {
+			return fmt.Errorf("set search_path: %w", err)
+		}
+
+		processedSQL := p.processMigrationSQL(mig.Content, schemaName)
+		// When running against PostgreSQL, rewrite CockroachDB-specific DDL
+		// (e.g., DROP INDEX CASCADE for unique constraints) to Postgres-compatible
+		// equivalents. The same adaptation runs in internal/migrations.RunMigrations
+		// for the CLI --migrate path; applying it here keeps tenant schema
+		// provisioning consistent with database-level provisioning.
+		if internalmigrations.DriverFromEnv() == internalmigrations.DriverPostgres {
+			processedSQL = internalmigrations.AdaptCockroachDDLForPostgres(processedSQL)
+		}
+		statements := splitSQLStatements(processedSQL)
+
+		for _, stmt := range statements {
+			if err := tx.Exec(stmt).Error; err != nil {
+				return fmt.Errorf("execute migration %s: %w", mig.Filename, err)
+			}
+		}
+
+		return nil
+	})
 }
 
 // readMigrationFiles reads all .sql files from the migration path, sorted by filename.

--- a/services/tenant/provisioner/migration_runner.go
+++ b/services/tenant/provisioner/migration_runner.go
@@ -298,17 +298,24 @@ func (p *PostgresProvisioner) applyMigrationInTransaction(ctx context.Context, d
 		}
 
 		processedSQL := p.processMigrationSQL(mig.Content, schemaName)
-		// When running against PostgreSQL, rewrite CockroachDB-specific DDL
-		// (e.g., DROP INDEX CASCADE for unique constraints) to Postgres-compatible
-		// equivalents. The same adaptation runs in internal/migrations.RunMigrations
-		// for the CLI --migrate path; applying it here keeps tenant schema
-		// provisioning consistent with database-level provisioning.
-		if internalmigrations.DriverFromEnv() == internalmigrations.DriverPostgres {
-			processedSQL = internalmigrations.AdaptCockroachDDLForPostgres(processedSQL)
-		}
 		statements := splitSQLStatements(processedSQL)
 
+		// When running against PostgreSQL, rewrite CockroachDB-specific DDL
+		// (e.g., DROP INDEX CASCADE for unique constraints) to Postgres-compatible
+		// equivalents on a per-statement basis AFTER splitSQLStatements. The
+		// adapter may wrap statements in DO $compat$ BEGIN ...; ...; END $compat$
+		// blocks whose internal semicolons would otherwise be split as separate
+		// statements — splitSQLStatements does not recognize dollar-quoted bodies.
+		// Splitting first and then adapting keeps each adapted unit intact.
+		usePostgresAdapter := internalmigrations.DriverFromEnv() == internalmigrations.DriverPostgres
+
 		for _, stmt := range statements {
+			if usePostgresAdapter {
+				// AdaptCockroachDDLForPostgres's regex matches patterns
+				// terminated by `;`; splitSQLStatements strips terminators,
+				// so re-add one before adaptation.
+				stmt = internalmigrations.AdaptCockroachDDLForPostgres(stmt + ";")
+			}
 			if err := tx.Exec(stmt).Error; err != nil {
 				return fmt.Errorf("execute migration %s: %w", mig.Filename, err)
 			}

--- a/services/tenant/provisioner/migration_runner_test.go
+++ b/services/tenant/provisioner/migration_runner_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	internalmigrations "github.com/meridianhub/meridian/internal/migrations"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -646,4 +647,61 @@ func TestProcessMigrationSQL_AllMigrations_Parse(t *testing.T) {
 	}
 
 	assert.Greater(t, tested, 0, "expected to test at least one migration file")
+}
+
+// TestPostgresAdapter_PerStatementAdaptation_PreservesDOBlocks verifies the
+// interaction between splitSQLStatements and AdaptCockroachDDLForPostgres that
+// the provisioner relies on. The adapter wraps public-schema CHECK constraints
+// in a DO $compat$ BEGIN ...; EXCEPTION WHEN duplicate_object THEN NULL; END
+// $compat$; block whose internal semicolons would otherwise be split into
+// separate fragments by splitSQLStatements (which does not understand
+// dollar-quoted bodies).
+//
+// The fix is to split first, then adapt each statement. This test pins that
+// sequence: if someone re-orders the calls or alters the splitter, the test
+// fails and the real bug is caught before tenant provisioning executes broken
+// SQL against a live database.
+func TestPostgresAdapter_PerStatementAdaptation_PreservesDOBlocks(t *testing.T) {
+	// Minimal migration that will trigger the DO-block wrapping in the
+	// adapter's regex branch for public-schema CHECK constraints.
+	sql := `CREATE TABLE foo (id UUID PRIMARY KEY);
+ALTER TABLE public.my_table ADD CONSTRAINT chk_status CHECK (status IN ('a','b'));`
+
+	// Mirror the provisioner's sequence: split raw SQL, then adapt each
+	// statement individually, re-adding the `;` the splitter stripped so the
+	// adapter's `;`-anchored regex matches.
+	statements := splitSQLStatements(sql)
+	require.Len(t, statements, 2, "expected two statements before adaptation")
+
+	adapted := make([]string, 0, len(statements))
+	for _, stmt := range statements {
+		adapted = append(adapted, internalmigrations.AdaptCockroachDDLForPostgres(stmt+";"))
+	}
+
+	// Find the DO-wrapped statement.
+	var doStmt string
+	for _, a := range adapted {
+		if strings.Contains(a, "DO $compat$") {
+			doStmt = a
+			break
+		}
+	}
+	require.NotEmpty(t, doStmt, "expected one statement to be wrapped in DO $compat$ block")
+
+	// The DO block must remain intact: opening tag, the ALTER TABLE body,
+	// the EXCEPTION clause, and the closing tag must all live in the same
+	// string. If the old pre-split adaptation flow is ever restored, the
+	// splitter would cut these into separate fragments and this assertion
+	// would fail because doStmt would only contain the opening segment.
+	assert.Contains(t, doStmt, "DO $compat$ BEGIN")
+	assert.Contains(t, doStmt, "ALTER TABLE public.my_table ADD CONSTRAINT chk_status CHECK")
+	assert.Contains(t, doStmt, "EXCEPTION WHEN duplicate_object THEN NULL")
+	assert.Contains(t, doStmt, "END $compat$")
+
+	// Sanity: if you split the DO-wrapped statement itself, you get
+	// multiple fragments — proving the bug exists if adaptation runs
+	// before splitSQLStatements.
+	fragments := splitSQLStatements(doStmt)
+	assert.Greater(t, len(fragments), 1,
+		"splitSQLStatements does not understand dollar-quoted bodies; this is why adaptation must run per-statement after splitting")
 }


### PR DESCRIPTION
## Summary
- Export `AdaptCockroachDDLForPostgres` from `internal/migrations` and call it from the tenant provisioner's migration runner when `DB_DRIVER=postgres`. The adapter was previously only applied by the CLI `--migrate` path that runs against public schemas; tenant schema provisioning bypassed it and hit "cannot drop index because constraint requires it" on Postgres.
- Update `deploy-develop.yml` to `DROP SCHEMA IF EXISTS org_* CASCADE` across all service databases before forcing re-provisioning. The previous reset cleared metadata but left ghost tables from broken runs, and migrations that rename tables (e.g. internal-account/20260225) could not reconcile the resulting mixed state.

## Why two fixes in one PR
Both problems surfaced on the same deploy cycle after PR #2131 merged. With only the DDL adapter fix, the CRDB-specific DROP INDEX CASCADE statements succeed, but tenant schemas still contain ghost state. With only the DROP SCHEMA fix, schemas are clean but CRDB syntax still fails on Postgres. Both are required for the deploy to reach a green state.

## Evidence
Post-#2131 merge deploy on c49d82b failed with:
\`\`\`
meridian_master: control-plane migrations failed: execute migration 20260401000002_migrate_version_to_varchar.sql:
  ERROR: cannot drop index uq_manifest_version_version because constraint uq_manifest_version_version on table manifest_version requires it (SQLSTATE 2BP01)

volterra_energy: internal-account migrations failed: execute migration 20260116000001_add_clearing_purpose_column.sql:
  ERROR: relation "internal_bank_account" does not exist (SQLSTATE 42P01)
\`\`\`
The first is the CRDB->Postgres adapter gap. The second is ghost state from a previous broken run that left the schema with the renamed \`internal_account\` table but no \`internal_bank_account\`, breaking later re-runs that expect to ADD a column to it.

## Changes
**internal/migrations/runner.go + adapt_test.go**
- Rename \`adaptCockroachDDLForPostgres\` to \`AdaptCockroachDDLForPostgres\` (exported).
- Update internal callsite and test file references.

**services/tenant/provisioner/migration_runner.go**
- Import \`internal/migrations\` (aliased as \`internalmigrations\` because the local \`migration\` type shadows the package name).
- Call \`AdaptCockroachDDLForPostgres\` in \`applyMigrationInTransaction\` when \`DriverFromEnv() == DriverPostgres\`.
- Extract \`applyMigrationInTransaction\` helper to keep \`applyMigrationList\` under the gocognit complexity limit.

**.github/workflows/deploy-develop.yml**
- Before the tenant_provisioning reset, iterate each service DB and \`DROP SCHEMA IF EXISTS org_* CASCADE\`. Uses \`pg_namespace\` with an ESCAPE clause to match \`org_%\` literally.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./internal/migrations/... ./services/tenant/provisioner/...\` passes locally (335s)
- [x] pre-commit (gitleaks, gofumpt, golangci-lint, gocognit) all green
- [ ] CI green on this branch
- [ ] After merge: develop deploy reaches "Tenant provisioned and active" and seed-dev manifest apply succeeds
- [ ] Verify on droplet: \`tenant.status\` reaches \`active\` for both \`volterra_energy\` and \`meridian_master\`, and tenant schemas contain the full table set