### PR TITLE
fix: Verify all compose services survive deploy recreate cycle

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -209,6 +209,25 @@ jobs:
             docker pull ghcr.io/meridianhub/meridian@${IMAGE_DIGEST}
             docker tag ghcr.io/meridianhub/meridian@${IMAGE_DIGEST} ghcr.io/meridianhub/meridian:demo
             docker compose up -d --remove-orphans
+
+            # Verify all services came up. Docker compose can lose containers
+            # during recreate due to depends_on race conditions (the MCP server
+            # receives SIGTERM, exits cleanly, and isn't restarted because Docker
+            # marks it as "manually stopped").
+            sleep 5
+            failed=$(docker compose ps --status exited --format '{{.Service}}')
+            if [ -n "$failed" ]; then
+              echo "Services failed to start: $failed - retrying"
+              docker compose up -d $failed
+              sleep 3
+              still_failed=$(docker compose ps --status exited --format '{{.Service}}')
+              if [ -n "$still_failed" ]; then
+                echo "Services still down after retry: $still_failed"
+                exit 1
+              fi
+            fi
+            echo "All services running"
+
             docker compose exec -T caddy caddy reload --config /etc/caddy/Caddyfile
             docker image prune -f
 

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -220,6 +220,22 @@ jobs:
             docker pull ghcr.io/meridianhub/meridian@${IMAGE_DIGEST}
             docker tag ghcr.io/meridianhub/meridian@${IMAGE_DIGEST} ghcr.io/meridianhub/meridian:develop
             docker compose -f docker-compose.develop.yml up -d --remove-orphans
+
+            # Verify all services came up (see deploy-demo.yml for rationale)
+            sleep 5
+            failed=$(docker compose -f docker-compose.develop.yml ps --status exited --format '{{.Service}}')
+            if [ -n "$failed" ]; then
+              echo "Services failed to start: $failed - retrying"
+              docker compose -f docker-compose.develop.yml up -d $failed
+              sleep 3
+              still_failed=$(docker compose -f docker-compose.develop.yml ps --status exited --format '{{.Service}}')
+              if [ -n "$still_failed" ]; then
+                echo "Services still down after retry: $still_failed"
+                exit 1
+              fi
+            fi
+            echo "All services running"
+
             # Reload Caddy from the demo stack (Caddy runs there, serves both environments)
             docker compose -f /opt/meridian/docker-compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile
             docker image prune -f


### PR DESCRIPTION
## Summary

- Add post-deploy verification to both demo and develop deploy workflows
- After `docker compose up -d`, check for any exited services and retry them
- Fail the deploy step loudly if services can't be recovered

## Root cause

Docker compose marks containers as "manually stopped" during the recreate cycle of `docker compose up -d`. When a sidecar like `mcp-server` receives SIGTERM and exits cleanly (code 0), the `restart: unless-stopped` policy refuses to restart it because Docker believes it was intentionally stopped. The main `meridian` service gets recreated successfully but the MCP server stays dead.

This was observed on 2026-04-06 when a deploy left the MCP server container exited, causing HTTP 502 on all `/mcp` and `/.well-known/oauth-authorization-server` endpoints.

## Test plan

- [ ] Merge and trigger a demo deploy, verify CI logs show "All services running"
- [ ] Verify MCP server is accessible after deploy at `https://volterra-energy.demo.meridianhub.cloud/.well-known/oauth-authorization-server`