### PR TITLE
fix: Ignore docker image prune race in demo deploy

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -210,7 +210,7 @@ jobs:
             docker tag ghcr.io/meridianhub/meridian@${IMAGE_DIGEST} ghcr.io/meridianhub/meridian:demo
             docker compose up -d --remove-orphans
             docker compose exec -T caddy caddy reload --config /etc/caddy/Caddyfile
-            docker image prune -f
+            docker image prune -f || true
 
       - name: Ensure databases exist
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5


### PR DESCRIPTION
## Summary
\`docker image prune -f\` in the demo deploy step fails with \`a prune operation is already running\` when another prune is in flight. This is a best-effort cleanup - the deploy itself already succeeded (image pulled, containers recreated and started). Add \`|| true\` so the step doesn't abort the pipeline.

## Evidence
Deploy Demo run on 2026-04-06 failed at "Deploy via SSH" step:
\`\`\`
Container meridian-meridian-1 Started
Container meridian-mcp-server-1 Started
Error response from daemon: a prune operation is already running
Process exited with status 1
\`\`\`
Everything before the prune succeeded.