### PR TITLE
refactor: Remove PlatformRefs field from LiveState (control-plane differ)

### DIFF
--- a/services/control-plane/internal/differ/live_state.go
+++ b/services/control-plane/internal/differ/live_state.go
@@ -29,18 +29,10 @@ type LiveState struct {
 	// Outer key is ResourceType, inner key is the resource code/name.
 	// Resources in this set are excluded from diff planning by filterTenantOwned.
 	SystemCodes map[ResourceType]map[string]bool
-
-	// PlatformRefs tracks resources that are tenant overrides of platform defaults
-	// (is_system=false with a non-nil platform_ref in the service layer).
-	// These are tenant-owned resources and must be included in diff planning.
-	// Outer key is ResourceType, inner key is the resource code/name.
-	PlatformRefs map[ResourceType]map[string]bool
 }
 
 // filterTenantOwned returns a copy of live with platform default resources removed.
 // Resources present in SystemCodes (is_system=true) are excluded from all resource slices.
-// Resources present in PlatformRefs (is_system=false with platform_ref) are tenant overrides
-// and are naturally retained - they are not in SystemCodes and pass through unchanged.
 // This function must be called before DiffAgainstLiveState to ensure system resources
 // do not appear as CREATE or UPDATE actions.
 func filterTenantOwned(live *LiveState) *LiveState {
@@ -48,8 +40,7 @@ func filterTenantOwned(live *LiveState) *LiveState {
 		return nil
 	}
 	return &LiveState{
-		SystemCodes:  live.SystemCodes,
-		PlatformRefs: live.PlatformRefs,
+		SystemCodes: live.SystemCodes,
 		Instruments: filterBySystemCodes(live.Instruments, live.SystemCodes, ResourceInstrument,
 			func(r *controlplanev1.InstrumentDefinition) string { return r.GetCode() }),
 		AccountTypes: filterBySystemCodes(live.AccountTypes, live.SystemCodes, ResourceAccountType,

--- a/services/control-plane/internal/differ/live_state_filter_test.go
+++ b/services/control-plane/internal/differ/live_state_filter_test.go
@@ -88,37 +88,6 @@ func TestFilterTenantOwned_Sagas_SystemFiltered(t *testing.T) {
 	assert.Equal(t, "tenant_custom_saga", result.Sagas[0].GetName())
 }
 
-// TestFilterTenantOwned_SagaOverride_Retained verifies that a tenant override saga
-// (is_system=false with platform_ref) is retained after filtering.
-// Tenant overrides are not in SystemCodes (they are not platform defaults), so they
-// pass through filterTenantOwned and must be included in diff planning.
-func TestFilterTenantOwned_SagaOverride_Retained(t *testing.T) {
-	live := &LiveState{
-		Sagas: []*controlplanev1.SagaDefinition{
-			// Platform default: is_system=true, filtered out.
-			{Name: "platform_saga"},
-			// Tenant override: is_system=false, has platform_ref (tracked in PlatformRefs).
-			{Name: "override_saga"},
-			// Regular tenant saga: no platform_ref.
-			{Name: "custom_saga"},
-		},
-		SystemCodes: map[ResourceType]map[string]bool{
-			ResourceSaga: {"platform_saga": true},
-		},
-		// PlatformRefs documents which sagas are tenant overrides of platform defaults.
-		PlatformRefs: map[ResourceType]map[string]bool{
-			ResourceSaga: {"override_saga": true},
-		},
-	}
-	result := filterTenantOwned(live)
-	require.NotNil(t, result)
-	require.Len(t, result.Sagas, 2, "both override_saga and custom_saga should be retained")
-	names := sagaNames(result.Sagas)
-	assert.Contains(t, names, "override_saga")
-	assert.Contains(t, names, "custom_saga")
-	assert.NotContains(t, names, "platform_saga")
-}
-
 func TestFilterTenantOwned_MultipleTypes(t *testing.T) {
 	live := &LiveState{
 		Instruments: []*controlplanev1.InstrumentDefinition{
@@ -226,20 +195,15 @@ func TestFilterTenantOwned_AllResourceTypesFiltered(t *testing.T) {
 	assert.Equal(t, "tenant-route", result.InstructionRoutes[0].GetInstructionType())
 }
 
-func TestFilterTenantOwned_PreservesSystemAndPlatformRefMaps(t *testing.T) {
+func TestFilterTenantOwned_PreservesSystemCodesMap(t *testing.T) {
 	systemCodes := map[ResourceType]map[string]bool{
 		ResourceInstrument: {"SYS_GBP": true},
 	}
-	platformRefs := map[ResourceType]map[string]bool{
-		ResourceSaga: {"override_saga": true},
-	}
 	live := &LiveState{
-		SystemCodes:  systemCodes,
-		PlatformRefs: platformRefs,
+		SystemCodes: systemCodes,
 	}
 	result := filterTenantOwned(live)
 	assert.Equal(t, systemCodes, result.SystemCodes)
-	assert.Equal(t, platformRefs, result.PlatformRefs)
 }
 
 // --- helpers ---
@@ -250,12 +214,4 @@ func instrumentCodes(instruments []*controlplanev1.InstrumentDefinition) []strin
 		codes[i] = inst.GetCode()
 	}
 	return codes
-}
-
-func sagaNames(sagas []*controlplanev1.SagaDefinition) []string {
-	names := make([]string, len(sagas))
-	for i, s := range sagas {
-		names[i] = s.GetName()
-	}
-	return names
 }


### PR DESCRIPTION
## Summary

- Removes `PlatformRefs` from `LiveState` struct in `services/control-plane/internal/differ/live_state.go`
- Removes `PlatformRefs: live.PlatformRefs` from `filterTenantOwned` return value
- Simplifies comment on `filterTenantOwned` to remove stale `PlatformRefs` references
- Removes `TestFilterTenantOwned_SagaOverride_Retained` test (tested PlatformRefs propagation)
- Renames `TestFilterTenantOwned_PreservesSystemAndPlatformRefMaps` to `TestFilterTenantOwned_PreservesSystemCodesMap` and strips PlatformRefs assertions
- Removes unused `sagaNames` test helper

## Context

`PlatformRefs` was a documentation-only field. Tenant override sagas (is_system=false with a platform_ref) are not in `SystemCodes`, so they pass through `filterTenantOwned` without any special handling. The field tracked metadata that was never used for filtering logic, adding complexity with no behavioural value.

Part of the broader `remove-platform-ref` refactor.

## Test plan

- [x] `go test ./services/control-plane/internal/differ/... -count=1` - all tests pass
- [x] `go build ./services/control-plane/...` - compiles cleanly
- [x] golangci-lint - 0 issues