### PR TITLE
test: Move event_outbox to tenant schema in party cascade test

### DIFF
--- a/services/party/service/kafka_cascade_integration_test.go
+++ b/services/party/service/kafka_cascade_integration_test.go
@@ -157,17 +157,28 @@ func setupKafkaCascadeTest(t *testing.T) *kafkaCascadeTestEnv {
 		event_payload BYTEA NOT NULL,
 		correlation_id VARCHAR(100),
 		causation_id VARCHAR(100),
-		status VARCHAR(20) NOT NULL DEFAULT 'pending',
+		status VARCHAR(20) NOT NULL,
 		topic VARCHAR(200) NOT NULL,
 		partition_key VARCHAR(200),
-		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
-		processed_at TIMESTAMP WITH TIME ZONE,
+		created_at TIMESTAMPTZ NOT NULL,
+		processed_at TIMESTAMPTZ,
 		retry_count INTEGER NOT NULL DEFAULT 0,
 		last_error TEXT,
-		service_name VARCHAR(100) NOT NULL
+		service_name VARCHAR(100) NOT NULL,
+		tenant_id VARCHAR(100) NOT NULL
 	)`, pq.QuoteIdentifier(schemaName))).Error)
 
-	require.NoError(t, db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error)
+	// Set search_path at the database level so all pool connections (including the outbox
+	// worker's) resolve unqualified table names to the tenant schema. A session-level
+	// SET search_path only affects a single pool connection; the load test needs all
+	// connections to share the same schema routing.
+	require.NoError(t, db.Exec(fmt.Sprintf("ALTER DATABASE test_db SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error)
+	// Close idle connections so they reconnect and pick up the new database default.
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxIdleConns(0) // closes idle connections immediately
+	// Also set it on the current session for any in-flight use of this connection.
+	require.NoError(t, db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error)
 
 	ctx := tenant.WithTenant(bgCtx, tid)
 

--- a/services/party/service/kafka_cascade_integration_test.go
+++ b/services/party/service/kafka_cascade_integration_test.go
@@ -101,11 +101,11 @@ func setupKafkaCascadeTest(t *testing.T) *kafkaCascadeTestEnv {
 	// Create the party.controlled.v1 topic
 	createKafkaTopic(t, broker, topics.PartyControlledV1)
 
-	// Setup CockroachDB with party + event_outbox tables
+	// Setup CockroachDB with party and audit tables in the public schema.
+	// event_outbox is created explicitly in the tenant schema below.
 	db, dbCleanup := testdb.SetupPostgres(t, []interface{}{
 		&persistence.PartyEntity{},
 		&audit.AuditOutbox{},
-		&events.EventOutbox{},
 	})
 
 	tid := tenant.TenantID(testTenantID)


### PR DESCRIPTION
## Summary

- Creates `event_outbox` table in the tenant schema instead of the public schema in `kafka_cascade_integration_test.go`, matching the pattern in `internal-account/service/outbox_test.go`
- Adds `tenant_id` column to match the production table definition
- Sets database-level `search_path` via `ALTER DATABASE` so all connection pool connections resolve unqualified table names to the tenant schema

## Changes Made

**`services/party/service/kafka_cascade_integration_test.go`**
- Replaced unqualified `CREATE TABLE IF NOT EXISTS event_outbox` (public schema) with qualified `CREATE TABLE IF NOT EXISTS %q.event_outbox` (tenant schema)
- Added `tenant_id VARCHAR(100) NOT NULL` column
- Replaced session-level `SET search_path TO` with `ALTER DATABASE test_db SET search_path TO schemaName, public` + idle connection flush

## Technical Details

The session-level `SET search_path` only affects a single pool connection. The outbox worker acquires connections from the pool for each poll cycle; under the load test (100 concurrent terminations), new connections were created without the tenant search_path, causing the worker to find 0 events and publish nothing to Kafka.

`ALTER DATABASE` sets the default search_path for all new connections. Flushing idle connections (`SetMaxIdleConns(0)`) forces the pool to reconnect, picking up the new default.

## Testing

All 5 cascade tests pass:
- `TestCascade_PartyTerminatedPublishesEvent`
- `TestCascade_EventReplayIdempotency`
- `TestCascade_PartialFailureRecovery`
- `TestCascade_LoadTest100Terminations`
- `TestCascade_NegativeControlNonExistentParty`