### PR TITLE
fix: Resolve nightly slow integration test failures

### DIFF
--- a/services/party/service/kafka_cascade_integration_test.go
+++ b/services/party/service/kafka_cascade_integration_test.go
@@ -148,8 +148,8 @@ func setupKafkaCascadeTest(t *testing.T) *kafkaCascadeTestEnv {
 		user_agent TEXT
 	)`, pq.QuoteIdentifier(schemaName))).Error)
 
-	// Create event_outbox in the public schema (the outbox publisher uses unqualified table name)
-	require.NoError(t, db.Exec(`CREATE TABLE IF NOT EXISTS event_outbox (
+	// Create event_outbox in the tenant schema (search_path is tenant-only, no public fallback)
+	require.NoError(t, db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.event_outbox (
 		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 		event_type VARCHAR(200) NOT NULL,
 		aggregate_id VARCHAR(100) NOT NULL,
@@ -165,7 +165,7 @@ func setupKafkaCascadeTest(t *testing.T) *kafkaCascadeTestEnv {
 		retry_count INTEGER NOT NULL DEFAULT 0,
 		last_error TEXT,
 		service_name VARCHAR(100) NOT NULL
-	)`).Error)
+	)`, pq.QuoteIdentifier(schemaName))).Error)
 
 	require.NoError(t, db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(schemaName))).Error)
 

--- a/services/reference-data/saga/override_api.go
+++ b/services/reference-data/saga/override_api.go
@@ -1,15 +1,15 @@
 // Package saga provides the CreateTenantOverride API for replacing platform
-// references with custom tenant scripts.
+// default sagas with custom tenant scripts.
 //
-// When a tenant is provisioned, saga_definition rows are created with platform_ref
-// pointing to public.platform_saga_definition (no script copy). This API allows
-// tenants to replace these references with custom scripts when they need different
+// When a tenant is provisioned, saga_definition rows are created as system sagas
+// with scripts copied directly from the platform defaults. This API allows tenants
+// to replace these system defaults with custom scripts when they need different
 // saga behavior.
 //
 // Validation rules:
 //   - The override script must be meaningfully different from the platform default
 //     (similarity check via Levenshtein distance)
-//   - The saga must currently use a platform reference (platform_ref IS NOT NULL)
+//   - The saga must be a system default (either via platform_ref or is_system=true)
 //   - A saga that already has a custom script cannot be overridden again through this API
 //   - The override creates a new version of the saga (is_system=false) and
 //     records audit metadata (override_reason, platform_version_at_override)
@@ -167,19 +167,30 @@ func (s *OverrideService) CreateTenantOverride(ctx context.Context, req Override
 	}, nil
 }
 
-// validateOverrideEligibility checks that the saga is platform-referenced, not already overridden,
-// and that the override script is sufficiently different from the platform default.
+// validateOverrideEligibility checks that the saga is a platform default (either via platform_ref
+// or as a system saga with a copied script), not already overridden, and that the override script
+// is sufficiently different from the platform default.
 func (s *OverrideService) validateOverrideEligibility(ctx context.Context, existingDef *Definition, req OverrideRequest) (*PlatformSagaDefinition, *SimilarityResult, error) {
-	if existingDef.PlatformRef == nil {
-		return nil, nil, fmt.Errorf("%w: saga %q (id=%s)", ErrNotPlatformReferenced, req.SagaName, existingDef.ID)
-	}
 	if !existingDef.IsSystem && existingDef.Script != "" {
 		return nil, nil, fmt.Errorf("%w: saga %q already has custom script", ErrAlreadyOverridden, req.SagaName)
 	}
 
-	platformDef, err := s.registry.GetPlatformSagaByID(ctx, *existingDef.PlatformRef)
-	if err != nil {
-		return nil, nil, fmt.Errorf("load platform saga for comparison: %w", err)
+	// Look up the platform saga: by ID if platform_ref is set, otherwise by name
+	// for system sagas that were seeded with scripts copied directly.
+	var platformDef *PlatformSagaDefinition
+	var err error
+	if existingDef.PlatformRef != nil {
+		platformDef, err = s.registry.GetPlatformSagaByID(ctx, *existingDef.PlatformRef)
+		if err != nil {
+			return nil, nil, fmt.Errorf("load platform saga for comparison: %w", err)
+		}
+	} else if existingDef.IsSystem {
+		platformDef, err = s.registry.GetPlatformSagaByName(ctx, req.SagaName)
+		if err != nil {
+			return nil, nil, fmt.Errorf("load platform saga by name for comparison: %w", err)
+		}
+	} else {
+		return nil, nil, fmt.Errorf("%w: saga %q (id=%s)", ErrNotPlatformReferenced, req.SagaName, existingDef.ID)
 	}
 
 	threshold := req.SimilarityThreshold

--- a/services/reference-data/saga/seeder_test.go
+++ b/services/reference-data/saga/seeder_test.go
@@ -252,7 +252,10 @@ func setupTenantSchemaForSeeder(t *testing.T, pool *pgxpool.Pool, ctx context.Co
 			handler_call_count integer NULL,
 			validated_at timestamptz NULL,
 			PRIMARY KEY (id),
-			CONSTRAINT uq_saga_definition_name_version UNIQUE (name, version)
+			CONSTRAINT uq_saga_definition_name_version UNIQUE (name, version),
+			CONSTRAINT chk_saga_definition_script_source CHECK (
+				NOT (platform_ref IS NOT NULL AND script IS NOT NULL AND script != '')
+			)
 		)`, quoted)
 	_, err = pool.Exec(ctx, createTableSQL)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Cascade tests (party service): event_outbox table created in public schema but search_path is tenant-only after tenant isolation refactor (007371ee). Moved to tenant schema with qualified name.
- Override API tests (reference-data): Seeder copies scripts directly (platform_ref=NULL) but override API required platform_ref. Updated `validateOverrideEligibility` to look up platform default by name for system sagas.
- Platform ref integrity constraint: CHECK constraint missing from test helper's table creation. Added `chk_saga_definition_script_source`.

## Evidence

- Failing runs: [Nightly Apr 6](https://github.com/meridianhub/meridian/actions/runs/24019101605), [Nightly Apr 5](https://github.com/meridianhub/meridian/actions/runs/23999527114)
- Same 10 tests failing consistently across both nights
- Root cause: tenant isolation refactor (007371ee) removed public from search_path without updating dependent tests/code

## Test plan

- [ ] CI Build & Test passes
- [ ] Nightly slow integration tests should pass (cascade + override + integrity tests)