### PR TITLE
fix: Connect seed-dev demo operator seeder to identity database

### DIFF
--- a/cmd/seed-dev/cmd/root.go
+++ b/cmd/seed-dev/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -400,13 +401,22 @@ func seedDemoOperator(ctx context.Context) error {
 
 	fmt.Println("\n--- Seed Demo Operator ---")
 
-	dsn := os.Getenv("DATABASE_URL")
-	if dsn == "" {
+	baseDSN := os.Getenv("DATABASE_URL")
+	if baseDSN == "" {
 		return ErrDatabaseURLRequired
 	}
 
+	// DATABASE_URL points to the platform database (meridian_platform).
+	// The identity repo needs meridian_identity. Derive the DSN by
+	// replacing the database component, matching how the main binary
+	// routes per-service connections via ServiceDatabases.
+	identityDSN, err := replaceDatabase(baseDSN, "meridian_identity")
+	if err != nil {
+		return fmt.Errorf("derive identity DSN: %w", err)
+	}
+
 	db, err := bootstrap.NewDatabase(ctx, bootstrap.DatabaseConfig{
-		DSN:          dsn,
+		DSN:          identityDSN,
 		MaxOpenConns: 2,
 		MaxIdleConns: 1,
 	})
@@ -425,4 +435,14 @@ func seedDemoOperator(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// replaceDatabase swaps the database name in a PostgreSQL DSN URL.
+func replaceDatabase(baseDSN, database string) (string, error) {
+	parsed, err := url.Parse(baseDSN)
+	if err != nil {
+		return "", fmt.Errorf("parse DSN: %w", err)
+	}
+	parsed.Path = "/" + database
+	return parsed.String(), nil
 }


### PR DESCRIPTION
## Summary
\`seedDemoOperator\` (added in #2137) used \`DATABASE_URL\` directly, which points to \`meridian_platform\`. The identity repository needs \`meridian_identity\` where the \`org_<tenant>\` schemas contain the identity tables. Derive the correct DSN by replacing the database component.

## Evidence
Demo deploy on 8d9b639 - manifest applied successfully, then:
\`\`\`
ERROR tenant scope: schema not provisioned schema=org_volterra_energy
Error: seed demo operator: seed demo users: seeding demo user operator@volterra.energy:
  checking for existing demo user: tenant schema not provisioned: schema does not exist in database: org_volterra_energy
\`\`\`
The \`org_volterra_energy\` schema exists in \`meridian_identity\` but not in \`meridian_platform\` (where \`DATABASE_URL\` points).

## Fix
Add \`replaceDatabase(baseDSN, "meridian_identity")\` to swap the database component before connecting, matching how the main binary routes per-service connections via \`ServiceDatabases\`.

## Test plan
- [x] \`go build ./...\` + \`go test -short ./cmd/seed-dev/...\` pass
- [ ] CI green
- [ ] After merge + push to demo: seed-dev creates \`operator@volterra.energy\` successfully, Dex login works