### PR TITLE
fix: Skip missing tenant schemas in demo user seeding

### DIFF
--- a/services/identity/bootstrap/bootstrap.go
+++ b/services/identity/bootstrap/bootstrap.go
@@ -18,6 +18,7 @@ import (
 	"github.com/meridianhub/meridian/services/identity/domain"
 	"github.com/meridianhub/meridian/shared/pkg/credentials"
 	"github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/meridianhub/meridian/shared/platform/db"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
 
@@ -213,6 +214,16 @@ func SeedDemoUsers(ctx context.Context, repo domain.Repository) error {
 
 	for _, u := range users {
 		if err := seedDemoUser(ctx, repo, u); err != nil {
+			// Skip tenants whose schemas have not been provisioned.
+			// DEMO_OPERATOR_TENANT may list multiple tenants but not all
+			// of them exist in every environment (e.g. payg_energy is
+			// configured but only volterra_energy is provisioned on demo).
+			if errors.Is(err, db.ErrTenantSchemaNotProvisioned) {
+				slog.WarnContext(ctx, "demo user seeding skipped: tenant schema not provisioned",
+					"email", u.Email,
+					"tenant", u.TenantID)
+				continue
+			}
 			return fmt.Errorf("seeding demo user %s: %w", u.Email, err)
 		}
 	}

--- a/services/identity/bootstrap/demo_users_test.go
+++ b/services/identity/bootstrap/demo_users_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/services/identity/domain"
+	"github.com/meridianhub/meridian/shared/platform/db"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,6 +20,9 @@ type fakeRepo struct {
 	roles      map[uuid.UUID][]*domain.RoleAssignment // keyed by identity ID
 
 	saveWithRolesCalled bool
+	// schemaNotProvisioned makes FindByEmail return ErrTenantSchemaNotProvisioned
+	// for any email lookup, simulating a missing tenant schema.
+	schemaNotProvisioned bool
 }
 
 func newFakeRepo() *fakeRepo {
@@ -43,6 +47,9 @@ func (f *fakeRepo) FindByID(_ context.Context, id uuid.UUID) (*domain.Identity, 
 }
 
 func (f *fakeRepo) FindByEmail(_ context.Context, email string) (*domain.Identity, error) {
+	if f.schemaNotProvisioned {
+		return nil, db.ErrTenantSchemaNotProvisioned
+	}
 	if ident, ok := f.identities[email]; ok {
 		return ident, nil
 	}
@@ -239,4 +246,17 @@ func TestSeedDemoUsers_ReconcilesRole_ExistingUserMissingRole(t *testing.T) {
 	roles := repo.roles[identity.ID()]
 	require.Len(t, roles, 1)
 	assert.Equal(t, domain.RoleOperator, roles[0].Role())
+}
+
+func TestSeedDemoUsers_SkipsMissingTenantSchema(t *testing.T) {
+	t.Setenv("DEMO_OPERATOR_EMAIL", "operator@volterra.energy")
+	t.Setenv("DEMO_OPERATOR_PASSWORD", "demo2026")
+	t.Setenv("DEMO_OPERATOR_TENANT", "missing_tenant")
+
+	repo := newFakeRepo()
+	repo.schemaNotProvisioned = true
+
+	err := SeedDemoUsers(context.Background(), repo)
+	require.NoError(t, err, "should skip tenants with missing schemas instead of failing")
+	assert.False(t, repo.saveWithRolesCalled, "should not have attempted to save identity")
 }


### PR DESCRIPTION
## Summary
\`SeedDemoUsers\` fails hard when any tenant in the comma-separated \`DEMO_OPERATOR_TENANT\` list has no provisioned schema. On demo, \`payg_energy\` is listed but not provisioned, so the seeder aborts after successfully creating \`operator@volterra.energy\` - the exit code 1 fails the deploy pipeline.

Skip tenants with \`ErrTenantSchemaNotProvisioned\` instead of failing. Log a warning so the skip is visible.

## Evidence
\`\`\`
INFO demo user seeded successfully email=operator@volterra.energy tenant=volterra_energy role=OPERATOR
Error: seed demo operator: ... tenant schema not provisioned: schema does not exist in database: org_payg_energy
\`\`\`

## Test plan
- [x] \`go test -short ./services/identity/bootstrap/... ./cmd/seed-dev/...\` passes
- [ ] CI green
- [ ] After merge + demo deploy: seed-dev exits 0, Dex login works