### PR TITLE
feat: add Actor struct and context key for scheduler attribution

### DIFF
--- a/shared/platform/auth/actor.go
+++ b/shared/platform/auth/actor.go
@@ -18,24 +18,29 @@ const (
 
 // Actor identifies who is performing an operation and how that identity was established.
 //
-// The Authenticated field is set to true only by the gRPC auth interceptor. Scheduler
-// and worker code sets it to false, creating a clear security boundary: callers cannot
-// escalate trust by constructing an Actor themselves.
+// Security model: Authenticated must only be set to true by the gRPC auth interceptor,
+// which is the sole authority that can verify a JWT and confirm the actor identity.
+// All other code paths (schedulers, workers, migrations, and any constructor that builds
+// an Actor from external/untrusted input) must leave Authenticated as false. Never copy
+// an incoming Authenticated value from external data (e.g., proto messages, HTTP headers,
+// or request bodies) - always default to false and let the interceptor set it.
 type Actor struct {
 	// ID is the actor's identifier, e.g. a user UUID or "system:scheduler:billing".
 	ID string
 	// Type classifies the actor.
 	Type ActorType
-	// Authenticated is true only when the Actor was set by the auth interceptor.
-	// Scheduler, worker, and migration actors must leave this false.
+	// Authenticated is true only when set by the gRPC auth interceptor after JWT
+	// verification. All other callers must leave this false.
 	Authenticated bool
 	// Source describes the mechanism that placed this Actor in context,
 	// e.g. "grpc-interceptor", "cron-scheduler", "catch-up".
 	Source string
 }
 
-// actorContextKey is a separate unexported type so it cannot collide with
-// contextKey (used for UserIDContextKey etc.) even though both are string-typed.
+// actorContextKey is an unexported struct type. Using a distinct unexported type
+// (rather than a string alias) guarantees no collision with other context key types
+// such as contextKey (used for UserIDContextKey), even if they were to hold the
+// same underlying value.
 type actorContextKey struct{}
 
 // WithActor returns a new context carrying the given Actor.

--- a/shared/platform/auth/actor.go
+++ b/shared/platform/auth/actor.go
@@ -1,0 +1,51 @@
+package auth
+
+import "context"
+
+// ActorType identifies the kind of actor performing an operation.
+type ActorType string
+
+const (
+	// ActorTypeHuman represents an authenticated human user.
+	ActorTypeHuman ActorType = "human"
+	// ActorTypeScheduler represents a scheduled job (e.g. billing cron, catch-up runner).
+	ActorTypeScheduler ActorType = "scheduler"
+	// ActorTypeWorker represents a background worker process.
+	ActorTypeWorker ActorType = "worker"
+	// ActorTypeMigration represents a data migration process.
+	ActorTypeMigration ActorType = "migration"
+)
+
+// Actor identifies who is performing an operation and how that identity was established.
+//
+// The Authenticated field is set to true only by the gRPC auth interceptor. Scheduler
+// and worker code sets it to false, creating a clear security boundary: callers cannot
+// escalate trust by constructing an Actor themselves.
+type Actor struct {
+	// ID is the actor's identifier, e.g. a user UUID or "system:scheduler:billing".
+	ID string
+	// Type classifies the actor.
+	Type ActorType
+	// Authenticated is true only when the Actor was set by the auth interceptor.
+	// Scheduler, worker, and migration actors must leave this false.
+	Authenticated bool
+	// Source describes the mechanism that placed this Actor in context,
+	// e.g. "grpc-interceptor", "cron-scheduler", "catch-up".
+	Source string
+}
+
+// actorContextKey is a separate unexported type so it cannot collide with
+// contextKey (used for UserIDContextKey etc.) even though both are string-typed.
+type actorContextKey struct{}
+
+// WithActor returns a new context carrying the given Actor.
+func WithActor(ctx context.Context, actor Actor) context.Context {
+	return context.WithValue(ctx, actorContextKey{}, actor)
+}
+
+// ActorFromContext retrieves the Actor stored in ctx.
+// The second return value is false when no Actor has been set.
+func ActorFromContext(ctx context.Context) (Actor, bool) {
+	actor, ok := ctx.Value(actorContextKey{}).(Actor)
+	return actor, ok
+}

--- a/shared/platform/auth/actor_test.go
+++ b/shared/platform/auth/actor_test.go
@@ -1,0 +1,81 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActorFromContext_RoundTrip(t *testing.T) {
+	actor := Actor{
+		ID:            "user-uuid-123",
+		Type:          ActorTypeHuman,
+		Authenticated: true,
+		Source:        "grpc-interceptor",
+	}
+
+	ctx := WithActor(context.Background(), actor)
+
+	got, ok := ActorFromContext(ctx)
+
+	require.True(t, ok)
+	assert.Equal(t, actor, got)
+}
+
+func TestActorFromContext_Missing(t *testing.T) {
+	_, ok := ActorFromContext(context.Background())
+	assert.False(t, ok)
+}
+
+func TestActorFromContext_ActorTypes(t *testing.T) {
+	cases := []struct {
+		actorType ActorType
+		id        string
+		source    string
+		auth      bool
+	}{
+		{ActorTypeHuman, "user-uuid-abc", "grpc-interceptor", true},
+		{ActorTypeScheduler, "system:scheduler:billing", "cron-scheduler", false},
+		{ActorTypeWorker, "system:worker:settlement", "background-worker", false},
+		{ActorTypeMigration, "system:migration:v42", "catch-up", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.actorType), func(t *testing.T) {
+			actor := Actor{
+				ID:            tc.id,
+				Type:          tc.actorType,
+				Authenticated: tc.auth,
+				Source:        tc.source,
+			}
+
+			ctx := WithActor(context.Background(), actor)
+			got, ok := ActorFromContext(ctx)
+
+			require.True(t, ok)
+			assert.Equal(t, actor, got)
+		})
+	}
+}
+
+func TestActorContextKey_DoesNotCollideWithUserIDContextKey(t *testing.T) {
+	// Storing an Actor must not interfere with UserIDContextKey lookups and vice-versa.
+	actor := Actor{
+		ID:     "user-uuid-456",
+		Type:   ActorTypeHuman,
+		Source: "grpc-interceptor",
+	}
+
+	ctx := WithActor(context.Background(), actor)
+	ctx = context.WithValue(ctx, UserIDContextKey, "different-user-id")
+
+	gotActor, ok := ActorFromContext(ctx)
+	require.True(t, ok)
+	assert.Equal(t, actor, gotActor)
+
+	gotUserID, ok := ctx.Value(UserIDContextKey).(string)
+	require.True(t, ok)
+	assert.Equal(t, "different-user-id", gotUserID)
+}


### PR DESCRIPTION
## Summary

- Adds `Actor` struct with `ID`, `Type`, `Authenticated`, and `Source` fields to `shared/platform/auth`
- Introduces `ActorType` string enum: `human`, `scheduler`, `worker`, `migration`
- Uses a struct-typed (`actorContextKey{}`) context key, distinct from the string-typed `contextKey` used by `UserIDContextKey` - prevents any collision even if both keys share the same underlying string value
- Provides `WithActor` and `ActorFromContext` helpers

## Changes Made

- `shared/platform/auth/actor.go` - new file with Actor type, ActorType enum, context key, and helpers
- `shared/platform/auth/actor_test.go` - round-trip test, missing-actor test, all actor type variants, non-collision with UserIDContextKey

## Technical Details

The `Authenticated` field is intentionally set only by the gRPC auth interceptor. Scheduler and worker callers must leave it `false`. This is the security boundary: callers cannot escalate trust by constructing an `Actor` with `Authenticated: true` since only the interceptor does so.

The context key uses `type actorContextKey struct{}` (not `type actorContextKey string`) to guarantee zero collision with the existing `contextKey`-typed keys, regardless of string values.

## Testing

- `go test ./shared/platform/auth/...` passes locally
- All pre-commit hooks (gitleaks, gofumpt, golangci-lint) passed

## Risk Assessment

Low - new file only, no existing code modified.