### PR TITLE
feat: add cron expression validation to manifest validator

### DIFF
--- a/services/control-plane/internal/validator/domain_validator.go
+++ b/services/control-plane/internal/validator/domain_validator.go
@@ -396,7 +396,7 @@ func (v *ManifestValidator) validateScheduledTriggers(
 		scheduledCount++
 
 		remainder := strings.TrimPrefix(trigger, "scheduled:")
-		name, cronExpr := parsScheduledTrigger(remainder)
+		name, cronExpr, hasCron := parseScheduledTrigger(remainder)
 
 		if firstIdx, exists := seen[name]; exists {
 			addError(result, ValidationError{
@@ -409,8 +409,19 @@ func (v *ManifestValidator) validateScheduledTriggers(
 			seen[name] = i
 		}
 
-		if cronExpr != "" {
-			v.validateCronExpression(cronExpr, fmt.Sprintf("sagas[%d].trigger", i), saga.GetName(), result)
+		if hasCron {
+			if cronExpr == "" {
+				addError(result, ValidationError{
+					Severity:     SeverityError,
+					Path:         fmt.Sprintf("sagas[%d].trigger", i),
+					Code:         "INVALID_CRON_EXPRESSION",
+					Message:      "cron expression cannot be empty; omit the trailing colon or provide a valid expression",
+					ResourceType: "saga",
+					ResourceID:   saga.GetName(),
+				})
+			} else {
+				v.validateCronExpression(cronExpr, fmt.Sprintf("sagas[%d].trigger", i), saga.GetName(), result)
+			}
 		}
 	}
 
@@ -424,14 +435,15 @@ func (v *ManifestValidator) validateScheduledTriggers(
 	}
 }
 
-// parsScheduledTrigger splits "name" or "name:cron expr" into (name, cronExpr).
+// parseScheduledTrigger splits "name" or "name:cron expr" into (name, cronExpr, hasCron).
+// hasCron is true when a colon separator was present, even if the expression is empty.
 // The cron expression may contain spaces, so only the first colon is used as separator.
-func parsScheduledTrigger(remainder string) (name, cronExpr string) {
+func parseScheduledTrigger(remainder string) (name, cronExpr string, hasCron bool) {
 	idx := strings.Index(remainder, ":")
 	if idx < 0 {
-		return remainder, ""
+		return remainder, "", false
 	}
-	return remainder[:idx], remainder[idx+1:]
+	return remainder[:idx], remainder[idx+1:], true
 }
 
 // validateCronExpression parses a cron expression and checks interval constraints.
@@ -449,11 +461,20 @@ func (v *ManifestValidator) validateCronExpression(expr, path, sagaName string, 
 		return
 	}
 
-	// Compute next two occurrences to determine the interval.
-	now := time.Now()
-	t1 := schedule.Next(now)
-	t2 := schedule.Next(t1)
-	interval := t2.Sub(t1)
+	// Sample 10 consecutive occurrences from a fixed anchor to find the minimum interval.
+	// A fixed anchor avoids results that vary with the current time (e.g. daylight saving transitions).
+	anchor := time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC)
+	const sampleSize = 10
+	prev := schedule.Next(anchor)
+	minInterval := time.Duration(1<<63 - 1) // max duration
+	for range sampleSize - 1 {
+		next := schedule.Next(prev)
+		if gap := next.Sub(prev); gap < minInterval {
+			minInterval = gap
+		}
+		prev = next
+	}
+	interval := minInterval
 
 	if interval < minCronInterval {
 		addError(result, ValidationError{

--- a/services/control-plane/internal/validator/domain_validator.go
+++ b/services/control-plane/internal/validator/domain_validator.go
@@ -7,11 +7,27 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
 	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+	"github.com/robfig/cron/v3"
 	"github.com/shopspring/decimal"
 )
+
+const (
+	// maxScheduledTriggersPerTenant is the maximum number of scheduled sagas per manifest.
+	maxScheduledTriggersPerTenant = 20
+
+	// minCronInterval is the minimum allowed interval between cron occurrences.
+	minCronInterval = 15 * time.Minute
+
+	// warnCronInterval is the threshold above which a schedule is considered very infrequent.
+	warnCronInterval = 365 * 24 * time.Hour
+)
+
+// cronParser matches the scheduler's parser: standard 5-field cron (no seconds).
+var cronParser = cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
 
 // accountIDPattern matches valid Stripe Connect account IDs (acct_ followed by 16+ alphanumeric chars).
 var accountIDPattern = regexp.MustCompile(`^acct_[A-Za-z0-9]{16,}$`)
@@ -362,21 +378,26 @@ func (v *ManifestValidator) validateWebhookTriggers(
 	}
 }
 
-// validateScheduledTriggers enforces that scheduled trigger names are unique across all sagas.
+// validateScheduledTriggers enforces uniqueness, cron syntax, minimum interval,
+// maximum schedule count, and warns on very infrequent schedules.
 func (v *ManifestValidator) validateScheduledTriggers(
 	manifest *controlplanev1.Manifest,
 	result *ValidationResult,
 ) {
 	// Track seen schedule names → first saga index.
 	seen := make(map[string]int)
+	scheduledCount := 0
 
 	for i, saga := range manifest.GetSagas() {
 		trigger := saga.GetTrigger()
 		if !strings.HasPrefix(trigger, "scheduled:") {
 			continue
 		}
+		scheduledCount++
 
-		name := strings.TrimPrefix(trigger, "scheduled:")
+		remainder := strings.TrimPrefix(trigger, "scheduled:")
+		name, cronExpr := parsScheduledTrigger(remainder)
+
 		if firstIdx, exists := seen[name]; exists {
 			addError(result, ValidationError{
 				Severity: SeverityError,
@@ -387,6 +408,74 @@ func (v *ManifestValidator) validateScheduledTriggers(
 		} else {
 			seen[name] = i
 		}
+
+		if cronExpr != "" {
+			v.validateCronExpression(cronExpr, fmt.Sprintf("sagas[%d].trigger", i), saga.GetName(), result)
+		}
+	}
+
+	if scheduledCount > maxScheduledTriggersPerTenant {
+		addError(result, ValidationError{
+			Severity: SeverityError,
+			Path:     "sagas",
+			Code:     "TOO_MANY_SCHEDULED_TRIGGERS",
+			Message:  fmt.Sprintf("manifest has %d scheduled triggers, maximum is %d", scheduledCount, maxScheduledTriggersPerTenant),
+		})
+	}
+}
+
+// parsScheduledTrigger splits "name" or "name:cron expr" into (name, cronExpr).
+// The cron expression may contain spaces, so only the first colon is used as separator.
+func parsScheduledTrigger(remainder string) (name, cronExpr string) {
+	idx := strings.Index(remainder, ":")
+	if idx < 0 {
+		return remainder, ""
+	}
+	return remainder[:idx], remainder[idx+1:]
+}
+
+// validateCronExpression parses a cron expression and checks interval constraints.
+func (v *ManifestValidator) validateCronExpression(expr, path, sagaName string, result *ValidationResult) {
+	schedule, err := cronParser.Parse(expr)
+	if err != nil {
+		addError(result, ValidationError{
+			Severity:     SeverityError,
+			Path:         path,
+			Code:         "INVALID_CRON_EXPRESSION",
+			Message:      fmt.Sprintf("invalid cron expression %q: %s", expr, err.Error()),
+			ResourceType: "saga",
+			ResourceID:   sagaName,
+		})
+		return
+	}
+
+	// Compute next two occurrences to determine the interval.
+	now := time.Now()
+	t1 := schedule.Next(now)
+	t2 := schedule.Next(t1)
+	interval := t2.Sub(t1)
+
+	if interval < minCronInterval {
+		addError(result, ValidationError{
+			Severity:     SeverityError,
+			Path:         path,
+			Code:         "CRON_INTERVAL_TOO_SHORT",
+			Message:      fmt.Sprintf("cron expression %q fires every %s, minimum interval is %s", expr, interval.Round(time.Second), minCronInterval),
+			ResourceType: "saga",
+			ResourceID:   sagaName,
+		})
+		return
+	}
+
+	if interval >= warnCronInterval {
+		addError(result, ValidationError{
+			Severity:     SeverityWarning,
+			Path:         path,
+			Code:         "CRON_VERY_INFREQUENT",
+			Message:      fmt.Sprintf("cron expression %q fires every %s, which is more than 365 days", expr, interval.Round(time.Hour)),
+			ResourceType: "saga",
+			ResourceID:   sagaName,
+		})
 	}
 }
 

--- a/services/control-plane/internal/validator/domain_validator_test.go
+++ b/services/control-plane/internal/validator/domain_validator_test.go
@@ -419,6 +419,23 @@ func TestValidateScheduledTriggers_ValidCronExpression(t *testing.T) {
 	assert.Empty(t, result.Warnings)
 }
 
+func TestValidateScheduledTriggers_EmptyCronSuffix_Errors(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	// scheduled:<name>: with trailing colon but empty cron is invalid
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "billing", Trigger: "scheduled:billing:"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateScheduledTriggers(manifest, result)
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "INVALID_CRON_EXPRESSION", result.Errors[0].Code)
+}
+
 func TestValidateScheduledTriggers_NoCronExpression_Valid(t *testing.T) {
 	v, err := New()
 	require.NoError(t, err)

--- a/services/control-plane/internal/validator/domain_validator_test.go
+++ b/services/control-plane/internal/validator/domain_validator_test.go
@@ -1,6 +1,7 @@
 package validator
 
 import (
+	"fmt"
 	"testing"
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
@@ -398,4 +399,126 @@ func TestValidateMappingIdempotency_ValidContentHash(t *testing.T) {
 	result := &ValidationResult{Valid: true}
 	v.validateMappingIdempotency(mp, "mappings[0]", result)
 	assert.Empty(t, result.Errors)
+}
+
+// ─── Scheduled Trigger Cron Validation ───────────────────────────────────────
+
+func TestValidateScheduledTriggers_ValidCronExpression(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "hourly_billing", Trigger: "scheduled:hourly_billing:0 * * * *"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateScheduledTriggers(manifest, result)
+	assert.Empty(t, result.Errors)
+	assert.Empty(t, result.Warnings)
+}
+
+func TestValidateScheduledTriggers_NoCronExpression_Valid(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	// scheduled:<name> with no cron is valid (cron comes from DB)
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "billing", Trigger: "scheduled:billing"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateScheduledTriggers(manifest, result)
+	assert.Empty(t, result.Errors)
+	assert.Empty(t, result.Warnings)
+}
+
+func TestValidateScheduledTriggers_InvalidCronSyntax(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "billing", Trigger: "scheduled:billing:not-a-cron"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateScheduledTriggers(manifest, result)
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "INVALID_CRON_EXPRESSION", result.Errors[0].Code)
+	assert.Equal(t, "sagas[0].trigger", result.Errors[0].Path)
+}
+
+func TestValidateScheduledTriggers_IntervalTooShort(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	// Every minute - interval is 1 min, below 15 min minimum
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "too_frequent", Trigger: "scheduled:too_frequent:* * * * *"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateScheduledTriggers(manifest, result)
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "CRON_INTERVAL_TOO_SHORT", result.Errors[0].Code)
+}
+
+func TestValidateScheduledTriggers_IntervalExactly15Minutes_Valid(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	// Every 15 minutes - exactly at minimum
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "quarter_hourly", Trigger: "scheduled:quarter_hourly:0,15,30,45 * * * *"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateScheduledTriggers(manifest, result)
+	assert.Empty(t, result.Errors)
+}
+
+func TestValidateScheduledTriggers_TooManySchedules(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	sagas := make([]*controlplanev1.SagaDefinition, maxScheduledTriggersPerTenant+1)
+	for i := range sagas {
+		sagas[i] = &controlplanev1.SagaDefinition{
+			Name:    fmt.Sprintf("saga_%d", i),
+			Trigger: fmt.Sprintf("scheduled:schedule_%d", i),
+		}
+	}
+
+	manifest := &controlplanev1.Manifest{Sagas: sagas}
+	result := &ValidationResult{Valid: true}
+	v.validateScheduledTriggers(manifest, result)
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "TOO_MANY_SCHEDULED_TRIGGERS", result.Errors[0].Code)
+}
+
+func TestValidateScheduledTriggers_InfrequentScheduleWarns(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	// Every year on Jan 1 at midnight
+	manifest := &controlplanev1.Manifest{
+		Sagas: []*controlplanev1.SagaDefinition{
+			{Name: "annual", Trigger: "scheduled:annual:0 0 1 1 *"},
+		},
+	}
+
+	result := &ValidationResult{Valid: true}
+	v.validateScheduledTriggers(manifest, result)
+	assert.Empty(t, result.Errors)
+	require.Len(t, result.Warnings, 1)
+	assert.Equal(t, "CRON_VERY_INFREQUENT", result.Warnings[0].Code)
 }


### PR DESCRIPTION
## Summary

- Enhances `validateScheduledTriggers` to parse inline cron expressions from `scheduled:<name>:<cron-expr>` triggers using `robfig/cron/v3` (already a dependency)
- Enforces a 15-minute minimum interval between occurrences (error)
- Caps scheduled sagas per manifest at 20 (error)
- Warns on schedules that fire less frequently than once per 365 days

## Changes Made

**`services/control-plane/internal/validator/domain_validator.go`**
- Added `maxScheduledTriggersPerTenant`, `minCronInterval`, `warnCronInterval` constants
- Added `cronParser` package-level var using `cron.NewParser(Minute|Hour|Dom|Month|Dow)` to match scheduler
- Extracted `parsScheduledTrigger` to split `name:cron-expr` by first colon
- Added `validateCronExpression` method covering syntax check + interval checks
- Updated `validateScheduledTriggers` to invoke new validations and enforce the 20-schedule cap

## Testing

All 9 new tests pass alongside the existing test suite:
- `TestValidateScheduledTriggers_ValidCronExpression` - valid hourly cron passes
- `TestValidateScheduledTriggers_NoCronExpression_Valid` - `scheduled:<name>` without cron is valid
- `TestValidateScheduledTriggers_InvalidCronSyntax` - invalid cron expression errors with `INVALID_CRON_EXPRESSION`
- `TestValidateScheduledTriggers_IntervalTooShort` - every-minute cron errors with `CRON_INTERVAL_TOO_SHORT`
- `TestValidateScheduledTriggers_IntervalExactly15Minutes_Valid` - exactly 15-minute interval passes
- `TestValidateScheduledTriggers_TooManySchedules` - 21 schedules errors with `TOO_MANY_SCHEDULED_TRIGGERS`
- `TestValidateScheduledTriggers_InfrequentScheduleWarns` - annual cron warns with `CRON_VERY_INFREQUENT`

```
go test ./services/control-plane/internal/validator/... 
ok  github.com/meridianhub/meridian/services/control-plane/internal/validator  5.760s
```