### PR TITLE
feat: update audit context to check Actor for scheduler attribution

### DIFF
--- a/shared/platform/audit/context.go
+++ b/shared/platform/audit/context.go
@@ -14,11 +14,15 @@ const (
 )
 
 // GetUserFromContext extracts the user identifier from the request context.
-// Returns the user ID from JWT claims if available, otherwise returns DefaultAuditUser.
+// Checks in order: Actor (scheduler/worker identity), UserID (JWT claims), DefaultAuditUser.
 // This function is safe to call with any context and will never return an empty string.
 func GetUserFromContext(ctx context.Context) string {
 	if ctx == nil {
 		return DefaultAuditUser
+	}
+
+	if actor, ok := auth.ActorFromContext(ctx); ok && actor.ID != "" {
+		return actor.ID
 	}
 
 	userID, ok := auth.GetUserIDFromContext(ctx)

--- a/shared/platform/audit/context_test.go
+++ b/shared/platform/audit/context_test.go
@@ -50,3 +50,54 @@ func TestGetUserFromContext_WithWrongType(t *testing.T) {
 
 	assert.Equal(t, DefaultAuditUser, result)
 }
+
+func TestGetUserFromContext_WithActor(t *testing.T) {
+	actor := auth.Actor{
+		ID:     "system:scheduler:billing",
+		Type:   auth.ActorTypeScheduler,
+		Source: "cron-scheduler",
+	}
+	ctx := auth.WithActor(context.Background(), actor)
+
+	result := GetUserFromContext(ctx)
+
+	assert.Equal(t, "system:scheduler:billing", result)
+}
+
+func TestGetUserFromContext_ActorTakesPriorityOverUserID(t *testing.T) {
+	actor := auth.Actor{
+		ID:   "system:scheduler:billing",
+		Type: auth.ActorTypeScheduler,
+	}
+	ctx := auth.WithActor(context.Background(), actor)
+	ctx = context.WithValue(ctx, auth.UserIDContextKey, "user-12345")
+
+	result := GetUserFromContext(ctx)
+
+	assert.Equal(t, "system:scheduler:billing", result)
+}
+
+func TestGetUserFromContext_ActorWithEmptyID_FallsBackToUserID(t *testing.T) {
+	actor := auth.Actor{
+		ID:   "",
+		Type: auth.ActorTypeScheduler,
+	}
+	ctx := auth.WithActor(context.Background(), actor)
+	ctx = context.WithValue(ctx, auth.UserIDContextKey, "user-12345")
+
+	result := GetUserFromContext(ctx)
+
+	assert.Equal(t, "user-12345", result)
+}
+
+func TestGetUserFromContext_ActorWithEmptyID_FallsBackToDefault(t *testing.T) {
+	actor := auth.Actor{
+		ID:   "",
+		Type: auth.ActorTypeScheduler,
+	}
+	ctx := auth.WithActor(context.Background(), actor)
+
+	result := GetUserFromContext(ctx)
+
+	assert.Equal(t, DefaultAuditUser, result)
+}


### PR DESCRIPTION
## Summary

- `GetUserFromContext` now checks for an `Actor` in context first (returning `actor.ID` if non-empty)
- Falls back to existing `UserIDContextKey` path (JWT claims), then `DefaultAuditUser`
- Schedulers and workers that inject an `Actor` via `auth.WithActor` are now correctly attributed in audit trails instead of appearing as `"system"`

## Changes Made

`shared/platform/audit/context.go`: Added Actor check at the top of `GetUserFromContext` before the existing UserID lookup.

`shared/platform/audit/context_test.go`: Added four new test cases:
- Actor in context returns actor.ID
- Actor takes priority over UserID when both present
- Actor with empty ID falls back to UserID
- Actor with empty ID falls back to DefaultAuditUser

## Technical Details

Uses `auth.ActorFromContext(ctx)` (added in #2147). The `actorContextKey` type is distinct from `UserIDContextKey` so there is no collision. The guard `actor.ID != ""` ensures a zero-value Actor (e.g. from a bug or test setup) does not shadow a real UserID.

## Testing

All existing tests pass. New tests cover Actor priority and fallback paths.

```
ok  github.com/meridianhub/meridian/shared/platform/audit  33.331s
```