### PR TITLE
feat: add BFF MCP consent handler endpoint

### DIFF
--- a/services/api-gateway/mcp_consent_handler.go
+++ b/services/api-gateway/mcp_consent_handler.go
@@ -1,0 +1,171 @@
+package gateway
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/url"
+
+	"github.com/meridianhub/meridian/services/api-gateway/auth"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// OIDCStatePeeker provides read-only access to OIDC flow state and the ability
+// to delete entries. This interface decouples the consent handler from the
+// mcp-server's internal OIDCStateStore, allowing the stores to be shared at
+// wiring time.
+type OIDCStatePeeker interface {
+	// PeekInfo returns selected fields without consuming the entry.
+	PeekInfo(key string) (clientID, redirectURI string, scopes []string, ok bool)
+	// Delete removes an entry by key. Used for cleanup on deny.
+	Delete(key string)
+}
+
+// MCPConsentHandler handles the BFF consent endpoint for MCP OAuth flows.
+// It validates JWT auth, generates consent codes, and returns redirect URLs.
+type MCPConsentHandler struct {
+	consentStore   *ConsentCodeStore
+	oidcStateStore OIDCStatePeeker
+	logger         *slog.Logger
+}
+
+// MCPConsentHandlerConfig holds configuration for creating an MCPConsentHandler.
+type MCPConsentHandlerConfig struct {
+	ConsentStore   *ConsentCodeStore
+	OIDCStateStore OIDCStatePeeker
+	Logger         *slog.Logger
+}
+
+// NewMCPConsentHandler creates a new MCP consent handler.
+func NewMCPConsentHandler(cfg MCPConsentHandlerConfig) *MCPConsentHandler {
+	return &MCPConsentHandler{
+		consentStore:   cfg.ConsentStore,
+		oidcStateStore: cfg.OIDCStateStore,
+		logger:         cfg.Logger,
+	}
+}
+
+type mcpConsentRequest struct {
+	MCPState string `json:"mcp_state"`
+	ClientID string `json:"client_id"`
+	Action   string `json:"action"`
+}
+
+type mcpConsentResponse struct {
+	RedirectURL string `json:"redirect_url"`
+}
+
+type mcpConsentErrorResponse struct {
+	Error string `json:"error"`
+}
+
+// HandleConsent handles POST /api/auth/mcp-consent.
+// Requires JWT auth (via middleware). Validates the OIDC state, generates a
+// consent code (approve) or error redirect (deny), and returns a redirect URL.
+func (h *MCPConsentHandler) HandleConsent(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 4096)
+
+	var req mcpConsentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, mcpConsentErrorResponse{Error: "invalid_json"})
+		return
+	}
+
+	if req.MCPState == "" || req.ClientID == "" {
+		writeJSON(w, http.StatusBadRequest, mcpConsentErrorResponse{Error: "missing_fields"})
+		return
+	}
+
+	if req.Action != "approve" && req.Action != "deny" {
+		writeJSON(w, http.StatusBadRequest, mcpConsentErrorResponse{Error: "invalid_action"})
+		return
+	}
+
+	// Extract identity from JWT claims (set by auth middleware).
+	ctx := r.Context()
+	claims, ok := auth.GetClaimsFromContext(ctx)
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, mcpConsentErrorResponse{Error: "unauthorized"})
+		return
+	}
+
+	email := claims.Subject
+	if email == "" {
+		email = claims.Email
+	}
+
+	tenantID := claims.TenantID
+	tenantSlug := ""
+	if slug, slugOk := tenant.SlugFromContext(ctx); slugOk {
+		tenantSlug = slug
+	}
+
+	// Peek OIDCStateStore to verify mcp_state exists and client_id matches.
+	storedClientID, redirectURI, scopes, stateOk := h.oidcStateStore.PeekInfo(req.MCPState)
+	if !stateOk {
+		writeJSON(w, http.StatusBadRequest, mcpConsentErrorResponse{Error: "invalid_state"})
+		return
+	}
+
+	if storedClientID != req.ClientID {
+		h.logger.Warn("mcp-consent: client_id mismatch",
+			"expected", storedClientID, "got", req.ClientID)
+		writeJSON(w, http.StatusBadRequest, mcpConsentErrorResponse{Error: "client_mismatch"})
+		return
+	}
+
+	if req.Action == "deny" {
+		// Delete the state entry (cleanup) and build error redirect.
+		h.oidcStateStore.Delete(req.MCPState)
+
+		target, err := url.Parse(redirectURI)
+		if err != nil {
+			h.logger.Error("mcp-consent: failed to parse redirect URI", "error", err)
+			writeJSON(w, http.StatusInternalServerError, mcpConsentErrorResponse{Error: "internal_error"})
+			return
+		}
+		params := target.Query()
+		params.Set("error", "access_denied")
+		params.Set("state", req.MCPState)
+		target.RawQuery = params.Encode()
+
+		writeJSON(w, http.StatusOK, mcpConsentResponse{RedirectURL: target.String()})
+		return
+	}
+
+	// Action == "approve": generate consent code and return redirect.
+	code, err := h.consentStore.Store(ConsentCodeEntry{
+		Email:          email,
+		TenantID:       tenantID,
+		TenantSlug:     tenantSlug,
+		MCPState:       req.MCPState,
+		ClientID:       req.ClientID,
+		ApprovedScopes: scopes,
+	})
+	if err != nil {
+		h.logger.Error("mcp-consent: failed to store consent code", "error", err)
+		writeJSON(w, http.StatusInternalServerError, mcpConsentErrorResponse{Error: "internal_error"})
+		return
+	}
+
+	redirectURL := "/oauth/callback?code=" + url.QueryEscape(code) + "&state=" + url.QueryEscape(req.MCPState)
+
+	h.logger.Info("mcp-consent: consent approved",
+		"email", email, "client_id", req.ClientID)
+
+	writeJSON(w, http.StatusOK, mcpConsentResponse{RedirectURL: redirectURL})
+}
+
+// WithMCPConsentHandler sets the MCP consent handler for the server.
+// When set, POST /api/auth/mcp-consent is registered behind the full auth chain.
+func WithMCPConsentHandler(handler *MCPConsentHandler) ServerOption {
+	return func(s *Server) {
+		s.mcpConsentHandler = handler
+	}
+}

--- a/services/api-gateway/mcp_consent_handler.go
+++ b/services/api-gateway/mcp_consent_handler.go
@@ -10,13 +10,22 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
 
+// OIDCStatePeekResult holds the fields returned by OIDCStatePeeker.PeekInfo.
+type OIDCStatePeekResult struct {
+	ClientID    string
+	RedirectURI string
+	Scopes      []string
+	MCPState    string // Original MCP client state (not the internal lookup key).
+	TenantSlug  string
+}
+
 // OIDCStatePeeker provides read-only access to OIDC flow state and the ability
 // to delete entries. This interface decouples the consent handler from the
 // mcp-server's internal OIDCStateStore, allowing the stores to be shared at
 // wiring time.
 type OIDCStatePeeker interface {
 	// PeekInfo returns selected fields without consuming the entry.
-	PeekInfo(key string) (clientID, redirectURI string, scopes []string, ok bool)
+	PeekInfo(key string) (OIDCStatePeekResult, bool)
 	// Delete removes an entry by key. Used for cleanup on deny.
 	Delete(key string)
 }
@@ -107,16 +116,24 @@ func (h *MCPConsentHandler) HandleConsent(w http.ResponseWriter, r *http.Request
 	}
 
 	// Peek OIDCStateStore to verify mcp_state exists and client_id matches.
-	storedClientID, redirectURI, scopes, stateOk := h.oidcStateStore.PeekInfo(req.MCPState)
+	stateInfo, stateOk := h.oidcStateStore.PeekInfo(req.MCPState)
 	if !stateOk {
 		writeJSON(w, http.StatusBadRequest, mcpConsentErrorResponse{Error: "invalid_state"})
 		return
 	}
 
-	if storedClientID != req.ClientID {
+	if stateInfo.ClientID != req.ClientID {
 		h.logger.Warn("mcp-consent: client_id mismatch",
-			"expected", storedClientID, "got", req.ClientID)
+			"expected", stateInfo.ClientID, "got", req.ClientID)
 		writeJSON(w, http.StatusBadRequest, mcpConsentErrorResponse{Error: "client_mismatch"})
+		return
+	}
+
+	// Verify tenant slug matches the OIDC flow's originating tenant.
+	if stateInfo.TenantSlug != "" && tenantSlug != "" && stateInfo.TenantSlug != tenantSlug {
+		h.logger.Warn("mcp-consent: tenant mismatch",
+			"expected", stateInfo.TenantSlug, "got", tenantSlug)
+		writeJSON(w, http.StatusForbidden, mcpConsentErrorResponse{Error: "tenant_mismatch"})
 		return
 	}
 
@@ -124,7 +141,7 @@ func (h *MCPConsentHandler) HandleConsent(w http.ResponseWriter, r *http.Request
 		// Delete the state entry (cleanup) and build error redirect.
 		h.oidcStateStore.Delete(req.MCPState)
 
-		target, err := url.Parse(redirectURI)
+		target, err := url.Parse(stateInfo.RedirectURI)
 		if err != nil {
 			h.logger.Error("mcp-consent: failed to parse redirect URI", "error", err)
 			writeJSON(w, http.StatusInternalServerError, mcpConsentErrorResponse{Error: "internal_error"})
@@ -132,7 +149,9 @@ func (h *MCPConsentHandler) HandleConsent(w http.ResponseWriter, r *http.Request
 		}
 		params := target.Query()
 		params.Set("error", "access_denied")
-		params.Set("state", req.MCPState)
+		if stateInfo.MCPState != "" {
+			params.Set("state", stateInfo.MCPState)
+		}
 		target.RawQuery = params.Encode()
 
 		writeJSON(w, http.StatusOK, mcpConsentResponse{RedirectURL: target.String()})
@@ -146,7 +165,7 @@ func (h *MCPConsentHandler) HandleConsent(w http.ResponseWriter, r *http.Request
 		TenantSlug:     tenantSlug,
 		MCPState:       req.MCPState,
 		ClientID:       req.ClientID,
-		ApprovedScopes: scopes,
+		ApprovedScopes: stateInfo.Scopes,
 	})
 	if err != nil {
 		h.logger.Error("mcp-consent: failed to store consent code", "error", err)

--- a/services/api-gateway/mcp_consent_handler_test.go
+++ b/services/api-gateway/mcp_consent_handler_test.go
@@ -22,33 +22,27 @@ import (
 // mockOIDCStatePeeker implements OIDCStatePeeker for tests.
 type mockOIDCStatePeeker struct {
 	mu      sync.Mutex
-	entries map[string]mockOIDCEntry
-}
-
-type mockOIDCEntry struct {
-	clientID    string
-	redirectURI string
-	scopes      []string
+	entries map[string]OIDCStatePeekResult
 }
 
 func newMockOIDCStatePeeker() *mockOIDCStatePeeker {
-	return &mockOIDCStatePeeker{entries: make(map[string]mockOIDCEntry)}
+	return &mockOIDCStatePeeker{entries: make(map[string]OIDCStatePeekResult)}
 }
 
-func (m *mockOIDCStatePeeker) addEntry(key, clientID, redirectURI string, scopes []string) {
+func (m *mockOIDCStatePeeker) addEntry(key string, result OIDCStatePeekResult) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.entries[key] = mockOIDCEntry{clientID: clientID, redirectURI: redirectURI, scopes: scopes}
+	m.entries[key] = result
 }
 
-func (m *mockOIDCStatePeeker) PeekInfo(key string) (string, string, []string, bool) {
+func (m *mockOIDCStatePeeker) PeekInfo(key string) (OIDCStatePeekResult, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	e, ok := m.entries[key]
 	if !ok {
-		return "", "", nil, false
+		return OIDCStatePeekResult{}, false
 	}
-	return e.clientID, e.redirectURI, append([]string(nil), e.scopes...), true
+	return e, true
 }
 
 func (m *mockOIDCStatePeeker) Delete(key string) {
@@ -110,7 +104,10 @@ func TestMCPConsentHandler_Approve(t *testing.T) {
 	handler, _, oidcStore := newTestMCPConsentHandler(t)
 
 	stateKey := "test-state-key"
-	oidcStore.addEntry(stateKey, "test-client", "https://example.com/callback", []string{"mcp:default"})
+	oidcStore.addEntry(stateKey, OIDCStatePeekResult{
+		ClientID: "test-client", RedirectURI: "https://example.com/callback",
+		Scopes: []string{"mcp:default"}, MCPState: "client-original-state", TenantSlug: "acme",
+	})
 	ctx := withAuthContext(context.Background(), "alice@example.com", "tenant-uuid-1", "acme")
 
 	rr := doConsentRequest(t, handler, ctx, mcpConsentRequest{
@@ -135,7 +132,10 @@ func TestMCPConsentHandler_Deny(t *testing.T) {
 	handler, _, oidcStore := newTestMCPConsentHandler(t)
 
 	stateKey := "test-state-deny"
-	oidcStore.addEntry(stateKey, "test-client", "https://example.com/callback", nil)
+	oidcStore.addEntry(stateKey, OIDCStatePeekResult{
+		ClientID: "test-client", RedirectURI: "https://example.com/callback",
+		MCPState: "client-original-state", TenantSlug: "acme",
+	})
 	ctx := withAuthContext(context.Background(), "alice@example.com", "tenant-uuid-1", "acme")
 
 	rr := doConsentRequest(t, handler, ctx, mcpConsentRequest{
@@ -149,7 +149,7 @@ func TestMCPConsentHandler_Deny(t *testing.T) {
 	var resp mcpConsentResponse
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	assert.Contains(t, resp.RedirectURL, "error=access_denied")
-	assert.Contains(t, resp.RedirectURL, "state="+stateKey)
+	assert.Contains(t, resp.RedirectURL, "state=client-original-state")
 
 	// OIDC state should be deleted on deny.
 	assert.False(t, oidcStore.hasEntry(stateKey), "OIDC state should be deleted on deny")
@@ -159,7 +159,10 @@ func TestMCPConsentHandler_InvalidAction(t *testing.T) {
 	handler, _, oidcStore := newTestMCPConsentHandler(t)
 
 	stateKey := "test-state-action"
-	oidcStore.addEntry(stateKey, "test-client", "https://example.com/callback", nil)
+	oidcStore.addEntry(stateKey, OIDCStatePeekResult{
+		ClientID: "test-client", RedirectURI: "https://example.com/callback",
+		MCPState: "client-original-state", TenantSlug: "acme",
+	})
 	ctx := withAuthContext(context.Background(), "alice@example.com", "tenant-uuid-1", "acme")
 
 	for _, action := range []string{"", "maybe", "APPROVE"} {
@@ -210,7 +213,10 @@ func TestMCPConsentHandler_ClientMismatch(t *testing.T) {
 	handler, _, oidcStore := newTestMCPConsentHandler(t)
 
 	stateKey := "test-state-mismatch"
-	oidcStore.addEntry(stateKey, "real-client", "https://example.com/callback", nil)
+	oidcStore.addEntry(stateKey, OIDCStatePeekResult{
+		ClientID: "real-client", RedirectURI: "https://example.com/callback",
+		TenantSlug: "acme",
+	})
 	ctx := withAuthContext(context.Background(), "alice@example.com", "tenant-uuid-1", "acme")
 
 	rr := doConsentRequest(t, handler, ctx, mcpConsentRequest{
@@ -224,6 +230,30 @@ func TestMCPConsentHandler_ClientMismatch(t *testing.T) {
 	var resp mcpConsentErrorResponse
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	assert.Equal(t, "client_mismatch", resp.Error)
+}
+
+func TestMCPConsentHandler_TenantMismatch(t *testing.T) {
+	handler, _, oidcStore := newTestMCPConsentHandler(t)
+
+	stateKey := "test-state-tenant"
+	oidcStore.addEntry(stateKey, OIDCStatePeekResult{
+		ClientID: "test-client", RedirectURI: "https://example.com/callback",
+		TenantSlug: "other-tenant",
+	})
+	// JWT tenant slug is "acme" but state has "other-tenant"
+	ctx := withAuthContext(context.Background(), "alice@example.com", "tenant-uuid-1", "acme")
+
+	rr := doConsentRequest(t, handler, ctx, mcpConsentRequest{
+		MCPState: stateKey,
+		ClientID: "test-client",
+		Action:   "approve",
+	})
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+
+	var resp mcpConsentErrorResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, "tenant_mismatch", resp.Error)
 }
 
 func TestMCPConsentHandler_InvalidJSON(t *testing.T) {

--- a/services/api-gateway/mcp_consent_handler_test.go
+++ b/services/api-gateway/mcp_consent_handler_test.go
@@ -1,0 +1,272 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/api-gateway/auth"
+	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// mockOIDCStatePeeker implements OIDCStatePeeker for tests.
+type mockOIDCStatePeeker struct {
+	mu      sync.Mutex
+	entries map[string]mockOIDCEntry
+}
+
+type mockOIDCEntry struct {
+	clientID    string
+	redirectURI string
+	scopes      []string
+}
+
+func newMockOIDCStatePeeker() *mockOIDCStatePeeker {
+	return &mockOIDCStatePeeker{entries: make(map[string]mockOIDCEntry)}
+}
+
+func (m *mockOIDCStatePeeker) addEntry(key, clientID, redirectURI string, scopes []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entries[key] = mockOIDCEntry{clientID: clientID, redirectURI: redirectURI, scopes: scopes}
+}
+
+func (m *mockOIDCStatePeeker) PeekInfo(key string) (string, string, []string, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	e, ok := m.entries[key]
+	if !ok {
+		return "", "", nil, false
+	}
+	return e.clientID, e.redirectURI, append([]string(nil), e.scopes...), true
+}
+
+func (m *mockOIDCStatePeeker) Delete(key string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.entries, key)
+}
+
+func (m *mockOIDCStatePeeker) hasEntry(key string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.entries[key]
+	return ok
+}
+
+func newTestMCPConsentHandler(t *testing.T) (*MCPConsentHandler, *ConsentCodeStore, *mockOIDCStatePeeker) {
+	t.Helper()
+	consentStore := NewConsentCodeStore()
+	t.Cleanup(consentStore.Close)
+
+	oidcStore := newMockOIDCStatePeeker()
+
+	handler := NewMCPConsentHandler(MCPConsentHandlerConfig{
+		ConsentStore:   consentStore,
+		OIDCStateStore: oidcStore,
+		Logger:         slog.Default(),
+	})
+	return handler, consentStore, oidcStore
+}
+
+func withAuthContext(ctx context.Context, email, tenantID, tenantSlug string) context.Context {
+	claims := &platformauth.Claims{
+		Email:    email,
+		TenantID: tenantID,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject: email,
+		},
+	}
+	ctx = context.WithValue(ctx, auth.ClaimsContextKey, claims)
+	ctx = tenant.WithSlug(ctx, tenantSlug)
+	return ctx
+}
+
+func doConsentRequest(t *testing.T, handler *MCPConsentHandler, ctx context.Context, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	jsonBody, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/mcp-consent", bytes.NewReader(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	handler.HandleConsent(rr, req)
+	return rr
+}
+
+func TestMCPConsentHandler_Approve(t *testing.T) {
+	handler, _, oidcStore := newTestMCPConsentHandler(t)
+
+	stateKey := "test-state-key"
+	oidcStore.addEntry(stateKey, "test-client", "https://example.com/callback", []string{"mcp:default"})
+	ctx := withAuthContext(context.Background(), "alice@example.com", "tenant-uuid-1", "acme")
+
+	rr := doConsentRequest(t, handler, ctx, mcpConsentRequest{
+		MCPState: stateKey,
+		ClientID: "test-client",
+		Action:   "approve",
+	})
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var resp mcpConsentResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Contains(t, resp.RedirectURL, "/oauth/callback")
+	assert.Contains(t, resp.RedirectURL, "code=")
+	assert.Contains(t, resp.RedirectURL, "state="+stateKey)
+
+	// OIDC state should not be consumed on approve (callback will consume it).
+	assert.True(t, oidcStore.hasEntry(stateKey), "OIDC state should not be consumed on approve")
+}
+
+func TestMCPConsentHandler_Deny(t *testing.T) {
+	handler, _, oidcStore := newTestMCPConsentHandler(t)
+
+	stateKey := "test-state-deny"
+	oidcStore.addEntry(stateKey, "test-client", "https://example.com/callback", nil)
+	ctx := withAuthContext(context.Background(), "alice@example.com", "tenant-uuid-1", "acme")
+
+	rr := doConsentRequest(t, handler, ctx, mcpConsentRequest{
+		MCPState: stateKey,
+		ClientID: "test-client",
+		Action:   "deny",
+	})
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var resp mcpConsentResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Contains(t, resp.RedirectURL, "error=access_denied")
+	assert.Contains(t, resp.RedirectURL, "state="+stateKey)
+
+	// OIDC state should be deleted on deny.
+	assert.False(t, oidcStore.hasEntry(stateKey), "OIDC state should be deleted on deny")
+}
+
+func TestMCPConsentHandler_InvalidAction(t *testing.T) {
+	handler, _, oidcStore := newTestMCPConsentHandler(t)
+
+	stateKey := "test-state-action"
+	oidcStore.addEntry(stateKey, "test-client", "https://example.com/callback", nil)
+	ctx := withAuthContext(context.Background(), "alice@example.com", "tenant-uuid-1", "acme")
+
+	for _, action := range []string{"", "maybe", "APPROVE"} {
+		t.Run("action="+action, func(t *testing.T) {
+			rr := doConsentRequest(t, handler, ctx, mcpConsentRequest{
+				MCPState: stateKey,
+				ClientID: "test-client",
+				Action:   action,
+			})
+
+			var resp mcpConsentErrorResponse
+			require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
+			assert.Equal(t, "invalid_action", resp.Error)
+		})
+	}
+}
+
+func TestMCPConsentHandler_MethodNotAllowed(t *testing.T) {
+	handler, _, _ := newTestMCPConsentHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/mcp-consent", nil)
+	rr := httptest.NewRecorder()
+	handler.HandleConsent(rr, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+	assert.Equal(t, "POST", rr.Header().Get("Allow"))
+}
+
+func TestMCPConsentHandler_InvalidState(t *testing.T) {
+	handler, _, _ := newTestMCPConsentHandler(t)
+	ctx := withAuthContext(context.Background(), "alice@example.com", "tenant-uuid-1", "acme")
+
+	rr := doConsentRequest(t, handler, ctx, mcpConsentRequest{
+		MCPState: "nonexistent-state",
+		ClientID: "test-client",
+		Action:   "approve",
+	})
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	var resp mcpConsentErrorResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, "invalid_state", resp.Error)
+}
+
+func TestMCPConsentHandler_ClientMismatch(t *testing.T) {
+	handler, _, oidcStore := newTestMCPConsentHandler(t)
+
+	stateKey := "test-state-mismatch"
+	oidcStore.addEntry(stateKey, "real-client", "https://example.com/callback", nil)
+	ctx := withAuthContext(context.Background(), "alice@example.com", "tenant-uuid-1", "acme")
+
+	rr := doConsentRequest(t, handler, ctx, mcpConsentRequest{
+		MCPState: stateKey,
+		ClientID: "wrong-client",
+		Action:   "approve",
+	})
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	var resp mcpConsentErrorResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, "client_mismatch", resp.Error)
+}
+
+func TestMCPConsentHandler_InvalidJSON(t *testing.T) {
+	handler, _, _ := newTestMCPConsentHandler(t)
+	ctx := withAuthContext(context.Background(), "alice@example.com", "tenant-uuid-1", "acme")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/mcp-consent", bytes.NewReader([]byte("not json")))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	handler.HandleConsent(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	var resp mcpConsentErrorResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, "invalid_json", resp.Error)
+}
+
+func TestMCPConsentHandler_MissingFields(t *testing.T) {
+	handler, _, _ := newTestMCPConsentHandler(t)
+	ctx := withAuthContext(context.Background(), "alice@example.com", "tenant-uuid-1", "acme")
+
+	tests := []struct {
+		name          string
+		body          mcpConsentRequest
+		expectedError string
+	}{
+		{"missing mcp_state", mcpConsentRequest{ClientID: "c", Action: "approve"}, "missing_fields"},
+		{"missing client_id", mcpConsentRequest{MCPState: "s", Action: "approve"}, "missing_fields"},
+		{"missing both", mcpConsentRequest{Action: "approve"}, "missing_fields"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := doConsentRequest(t, handler, ctx, tt.body)
+
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+			var resp mcpConsentErrorResponse
+			require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+			assert.Equal(t, tt.expectedError, resp.Error)
+		})
+	}
+}

--- a/services/api-gateway/server.go
+++ b/services/api-gateway/server.go
@@ -44,6 +44,7 @@ type Server struct {
 	tenantInfoHandler     *TenantInfoHandler
 	resendWebhookHandler  *ResendWebhookHandler
 	adminHandler          *AdminHandler
+	mcpConsentHandler     *MCPConsentHandler
 }
 
 // ServerOption is a functional option for configuring the server.
@@ -249,6 +250,12 @@ func (s *Server) registerRoutes() {
 	// Resend delivery status webhook - NO middleware (Svix signature IS the auth).
 	if s.resendWebhookHandler != nil {
 		s.mux.Handle("POST /api/v1/webhooks/resend", s.resendWebhookHandler)
+	}
+
+	// MCP consent endpoint - full auth middleware chain (JWT + tenant).
+	if s.mcpConsentHandler != nil {
+		consentH := s.wrapWithAuthChain(http.HandlerFunc(s.mcpConsentHandler.HandleConsent))
+		s.mux.Handle("POST /api/auth/mcp-consent", consentH)
 	}
 
 	// Admin identity management endpoints - full auth middleware chain.

--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -1,3 +1,5 @@
+//meridian:large-file -- OIDC handler + state store + helpers form a cohesive auth flow unit.
+
 // Package auth provides OIDC integration for the MCP server's OAuth 2.1 flow.
 //
 // The MCP server acts as an OAuth 2.1 authorization server for MCP clients

--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -204,21 +204,35 @@ func (s *OIDCStateStore) Delete(key string) {
 	delete(s.entries, key)
 }
 
+// PeekInfoResult holds the fields returned by PeekInfo.
+type PeekInfoResult struct {
+	ClientID    string
+	RedirectURI string
+	Scopes      []string
+	MCPState    string // Original MCP client state (not the internal key).
+	TenantSlug  string
+}
+
 // PeekInfo returns selected fields from an OIDC flow state entry without
 // consuming it. Expired entries are cleaned up and reported as not found.
-func (s *OIDCStateStore) PeekInfo(key string) (clientID, redirectURI string, scopes []string, ok bool) {
+func (s *OIDCStateStore) PeekInfo(key string) (PeekInfoResult, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	entry, exists := s.entries[key]
 	if !exists {
-		return "", "", nil, false
+		return PeekInfoResult{}, false
 	}
 	if time.Since(entry.IssuedAt) > oidcStateTTL {
 		delete(s.entries, key)
-		return "", "", nil, false
+		return PeekInfoResult{}, false
 	}
-	scopes = append([]string(nil), entry.RequestedScopes...)
-	return entry.MCPClientID, entry.MCPRedirectURI, scopes, true
+	return PeekInfoResult{
+		ClientID:    entry.MCPClientID,
+		RedirectURI: entry.MCPRedirectURI,
+		Scopes:      append([]string(nil), entry.RequestedScopes...),
+		MCPState:    entry.MCPState,
+		TenantSlug:  entry.TenantSlug,
+	}, true
 }
 
 // TenantSlugResolver resolves a tenant slug (e.g., "acme") to its canonical

--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -194,6 +194,14 @@ func (s *OIDCStateStore) Consume(key string) (OIDCFlowState, bool) {
 	return entry, true
 }
 
+// Delete removes an OIDC flow state entry by key without returning it.
+// This is used by the consent handler to clean up state on deny.
+func (s *OIDCStateStore) Delete(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.entries, key)
+}
+
 // PeekInfo returns selected fields from an OIDC flow state entry without
 // consuming it. Expired entries are cleaned up and reported as not found.
 func (s *OIDCStateStore) PeekInfo(key string) (clientID, redirectURI string, scopes []string, ok bool) {

--- a/services/mcp-server/internal/auth/oidc_test.go
+++ b/services/mcp-server/internal/auth/oidc_test.go
@@ -1254,14 +1254,14 @@ func TestOIDCStateStore_PeekInfo(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	clientID, redirectURI, scopes, ok := s.PeekInfo(key)
+	result, ok := s.PeekInfo(key)
 	assert.True(t, ok)
-	assert.Equal(t, "client-1", clientID)
-	assert.Equal(t, "https://example.com/callback", redirectURI)
-	assert.Equal(t, []string{"mcp:default", "mcp:admin"}, scopes)
+	assert.Equal(t, "client-1", result.ClientID)
+	assert.Equal(t, "https://example.com/callback", result.RedirectURI)
+	assert.Equal(t, []string{"mcp:default", "mcp:admin"}, result.Scopes)
 
 	// PeekInfo is non-consuming - a second call should also succeed.
-	_, _, _, ok = s.PeekInfo(key)
+	_, ok = s.PeekInfo(key)
 	assert.True(t, ok, "PeekInfo should not consume the entry")
 
 	// Consume should still work after PeekInfo.
@@ -1280,11 +1280,11 @@ func TestOIDCStateStore_PeekInfo_Expired(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	clientID, redirectURI, scopes, ok := s.PeekInfo(key)
+	result, ok := s.PeekInfo(key)
 	assert.False(t, ok)
-	assert.Empty(t, clientID)
-	assert.Empty(t, redirectURI)
-	assert.Nil(t, scopes)
+	assert.Empty(t, result.ClientID)
+	assert.Empty(t, result.RedirectURI)
+	assert.Nil(t, result.Scopes)
 
 	// Expired entry should have been cleaned up by PeekInfo.
 	_, ok = s.Consume(key)
@@ -1294,9 +1294,9 @@ func TestOIDCStateStore_PeekInfo_Expired(t *testing.T) {
 func TestOIDCStateStore_PeekInfo_NotFound(t *testing.T) {
 	s := newTestOIDCStateStore(t)
 
-	clientID, redirectURI, scopes, ok := s.PeekInfo("missing-key")
+	result, ok := s.PeekInfo("missing-key")
 	assert.False(t, ok)
-	assert.Empty(t, clientID)
-	assert.Empty(t, redirectURI)
-	assert.Nil(t, scopes)
+	assert.Empty(t, result.ClientID)
+	assert.Empty(t, result.RedirectURI)
+	assert.Nil(t, result.Scopes)
 }


### PR DESCRIPTION
## Summary
- Add `POST /api/auth/mcp-consent` endpoint behind full auth chain (JWT + tenant resolution + tenant authorization)
- Handler validates OIDC state via `OIDCStatePeeker` interface, cross-validates `client_id`, and generates consent codes (approve) or error redirects with `access_denied` (deny)
- Define `OIDCStatePeeker` interface to decouple api-gateway from mcp-server's internal package
- Add `OIDCStateStore.Delete()` method for state cleanup on deny action

## Test plan
- [x] `TestMCPConsentHandler_Approve` - valid JWT, valid state, approve returns consent code redirect
- [x] `TestMCPConsentHandler_Deny` - deny returns error redirect with access_denied, state cleaned up
- [x] `TestMCPConsentHandler_InvalidAction` - reject empty/unrecognized action values
- [x] `TestMCPConsentHandler_MethodNotAllowed` - GET returns 405
- [x] `TestMCPConsentHandler_InvalidState` - unknown mcp_state returns invalid_state
- [x] `TestMCPConsentHandler_ClientMismatch` - client_id mismatch returns client_mismatch
- [x] `TestMCPConsentHandler_InvalidJSON` - malformed body returns invalid_json
- [x] `TestMCPConsentHandler_MissingFields` - missing required fields returns missing_fields