### PR TITLE
feat: Add consent-info endpoint and redirect HandleAuthorize to UI consent page

### DIFF
--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -211,6 +211,33 @@ func (s *OIDCStateStore) PeekInfo(key string) (clientID, redirectURI string, sco
 	return entry.MCPClientID, entry.MCPRedirectURI, scopes, true
 }
 
+// ConsentEntry holds the state stored alongside a consent code. This mirrors
+// the ConsentCodeEntry from api-gateway but avoids a direct import dependency
+// on that package (which pulls in otel transitive dependencies).
+type ConsentEntry struct {
+	Email          string
+	TenantID       string
+	TenantSlug     string
+	MCPState       string
+	ClientID       string
+	ApprovedScopes []string
+}
+
+// ConsentCodeConsumer can consume a consent code exactly once. The canonical
+// implementation is gateway.ConsentCodeStore.
+type ConsentCodeConsumer interface {
+	// Consume atomically retrieves and deletes a consent code.
+	// Returns (entry, true) if the code exists and has not expired.
+	Consume(code string) (ConsentEntry, bool)
+}
+
+// ConsentCodeConsumerFunc is an adapter to use ordinary functions as
+// ConsentCodeConsumer implementations (see also: http.HandlerFunc pattern).
+type ConsentCodeConsumerFunc func(code string) (ConsentEntry, bool)
+
+// Consume calls f(code).
+func (f ConsentCodeConsumerFunc) Consume(code string) (ConsentEntry, bool) { return f(code) }
+
 // TenantSlugResolver resolves a tenant slug (e.g., "acme") to its canonical
 // UUID. This ensures the x-tenant-id JWT claim contains a UUID consistent
 // with BFF-issued tokens, not the raw slug string.
@@ -224,12 +251,14 @@ type OIDCHandler struct {
 	oauthCfg          OAuthConfig
 	stateStore        *OIDCStateStore
 	codeStore         *CodeStore
+	consentStore      ConsentCodeConsumer
 	registry          *ClientRegistry
 	signer            *platformauth.JWTSigner
 	tenantResolver    TenantSlugResolver
 	tokenTTL          time.Duration
 	defaultTenantSlug string
 	baseDomain        string
+	baseURL           string
 	dexAuthBaseURL    string // External Dex base URL for browser redirects (derived from BaseURL + DexIssuerURL path).
 	httpClient        *http.Client
 	logger            *slog.Logger
@@ -243,6 +272,11 @@ type OIDCHandlerConfig struct {
 	CodeStore  *CodeStore
 	Registry   *ClientRegistry
 	Signer     *platformauth.JWTSigner
+	// ConsentStore is the shared consent code store used by both the BFF
+	// (which issues consent codes after user approval) and the OIDC handler
+	// (which consumes them in HandleCallback). When nil, HandleCallback
+	// falls back to Dex token exchange (legacy flow).
+	ConsentStore ConsentCodeConsumer
 	// TenantResolver resolves tenant slugs to UUIDs for JWT claims.
 	// When nil, the raw slug is used as-is (dev/test fallback).
 	TenantResolver TenantSlugResolver
@@ -317,12 +351,14 @@ func NewOIDCHandler(cfg OIDCHandlerConfig) (*OIDCHandler, error) {
 		oauthCfg:          cfg.OAuth,
 		stateStore:        cfg.StateStore,
 		codeStore:         cfg.CodeStore,
+		consentStore:      cfg.ConsentStore,
 		registry:          cfg.Registry,
 		signer:            cfg.Signer,
 		tenantResolver:    cfg.TenantResolver,
 		tokenTTL:          ttl,
 		defaultTenantSlug: cfg.DefaultTenantSlug,
 		baseDomain:        cfg.BaseDomain,
+		baseURL:           cfg.BaseURL,
 		dexAuthBaseURL:    dexAuthBaseURL,
 		httpClient:        httpClient,
 		logger:            cfg.Logger,
@@ -397,6 +433,68 @@ func (h *OIDCHandler) writeDexRedirectError(w http.ResponseWriter, err error) {
 	http.Error(w, "internal server error", http.StatusInternalServerError)
 }
 
+// ConsentInfoResponse is the JSON response returned by HandleConsentInfo.
+type ConsentInfoResponse struct {
+	ClientID    string   `json:"client_id"`
+	ClientName  string   `json:"client_name"`
+	RedirectURI string   `json:"redirect_uri"`
+	Scopes      []string `json:"scopes"`
+	IsDynamic   bool     `json:"is_dynamic"`
+}
+
+// HandleConsentInfo handles GET /oauth/consent-info. It returns metadata about
+// the MCP client that initiated the authorization flow so the UI consent page
+// can display it to the user before they approve or deny.
+func (h *OIDCHandler) HandleConsentInfo(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	q := r.URL.Query()
+	clientID := q.Get("client_id")
+	mcpState := q.Get("mcp_state")
+	if clientID == "" || mcpState == "" {
+		http.Error(w, "client_id and mcp_state are required", http.StatusBadRequest)
+		return
+	}
+
+	stateClientID, redirectURI, scopes, ok := h.stateStore.PeekInfo(mcpState)
+	if !ok {
+		http.Error(w, "invalid or expired state", http.StatusBadRequest)
+		return
+	}
+
+	if stateClientID != clientID {
+		http.Error(w, "client_id mismatch", http.StatusBadRequest)
+		return
+	}
+
+	resp := ConsentInfoResponse{
+		ClientID:    clientID,
+		RedirectURI: redirectURI,
+		Scopes:      scopes,
+	}
+
+	// Resolve client name: static client gets a fixed name, dynamic clients
+	// use their registered client_name.
+	if clientID == h.oauthCfg.ClientID {
+		resp.ClientName = "Meridian CLI"
+		resp.IsDynamic = false
+	} else if h.registry != nil {
+		if client, found := h.registry.Lookup(clientID); found {
+			resp.IsDynamic = true
+			resp.ClientName = client.ClientName
+			if resp.ClientName == "" {
+				resp.ClientName = "Unknown Application"
+			}
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
 // HandleAuthorize handles GET /oauth/authorize from the MCP client.
 // It stores the MCP client's PKCE state and redirects to Dex for authentication.
 func (h *OIDCHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
@@ -447,8 +545,27 @@ func (h *OIDCHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 
 	// Capture requested OAuth scopes from the MCP client (space-delimited per RFC 6749).
 	requestedScopes := strings.Fields(strings.TrimSpace(q.Get("scope")))
+	if len(requestedScopes) == 0 {
+		requestedScopes = []string{"mcp:default"}
+	}
 
-	// Store OIDC flow state and redirect to Dex for authentication.
+	// When the consent store is configured, redirect to the UI consent page
+	// instead of Dex. The consent page handles authentication + authorization
+	// approval in one step.
+	if h.consentStore != nil {
+		redirectURL, err := h.buildConsentRedirect(challenge, clientID, redirectURI, q.Get("state"), tenantSlug, requestedScopes)
+		if err != nil {
+			h.writeDexRedirectError(w, err)
+			return
+		}
+		h.logger.Info("oidc: redirecting to consent page",
+			"tenant", tenantSlug,
+			"client_id", clientID)
+		http.Redirect(w, r, redirectURL, http.StatusFound)
+		return
+	}
+
+	// Legacy path: redirect to Dex for authentication.
 	redirectURL, err := h.buildDexRedirect(challenge, clientID, redirectURI, q.Get("state"), tenantSlug, requestedScopes)
 	if err != nil {
 		h.writeDexRedirectError(w, err)
@@ -462,19 +579,79 @@ func (h *OIDCHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 
-// HandleCallback handles GET /oauth/callback from Dex.
-// It exchanges the Dex authorization code for an ID token, extracts the email,
-// signs a Meridian JWT, and redirects back to the MCP client's redirect_uri.
+// HandleCallback handles GET /oauth/callback.
+// When the consent store is configured, it consumes a consent code issued by
+// the BFF after user approval. Otherwise it falls back to Dex token exchange.
+// In both cases it signs a Meridian JWT and redirects to the MCP client.
 func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
+	q := r.URL.Query()
+	stateKey := q.Get("state")
+	code := q.Get("code")
+
+	if h.consentStore != nil {
+		h.handleConsentCallback(w, r, stateKey, code)
+		return
+	}
+	h.handleDexCallback(w, r, stateKey, code)
+}
+
+// handleConsentCallback processes the consent-code callback path. The BFF
+// issues a consent code after user approval; this method consumes it,
+// cross-validates bindings, and issues the MCP authorization code.
+func (h *OIDCHandler) handleConsentCallback(w http.ResponseWriter, r *http.Request, stateKey, code string) {
+	if stateKey == "" || code == "" {
+		http.Error(w, "missing state or code parameter", http.StatusBadRequest)
+		return
+	}
+
+	consentEntry, ok := h.consentStore.Consume(code)
+	if !ok {
+		http.Error(w, "invalid or expired consent code", http.StatusBadRequest)
+		return
+	}
+
+	flowState, ok := h.stateStore.Consume(stateKey)
+	if !ok {
+		http.Error(w, "invalid or expired state parameter", http.StatusBadRequest)
+		return
+	}
+
+	if consentEntry.MCPState != stateKey || consentEntry.ClientID != flowState.MCPClientID {
+		http.Error(w, "consent code binding mismatch", http.StatusBadRequest)
+		return
+	}
+
+	if consentEntry.TenantSlug != flowState.TenantSlug {
+		http.Error(w, "tenant mismatch", http.StatusBadRequest)
+		return
+	}
+
+	if !isAllowedRedirectURI(flowState.MCPRedirectURI) {
+		h.logger.Error("oidc: unsafe redirect URI scheme", "uri", flowState.MCPRedirectURI)
+		http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
+		return
+	}
+
+	redirectURL, err := h.issueCodeAndRedirect(
+		consentEntry.Email, consentEntry.TenantID, consentEntry.ApprovedScopes, flowState)
+	if err != nil {
+		h.logger.Error("oidc: failed to issue auth code", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
+// handleDexCallback processes the legacy Dex token-exchange callback path.
+func (h *OIDCHandler) handleDexCallback(w http.ResponseWriter, r *http.Request, stateKey, code string) {
 	ctx := r.Context()
 	q := r.URL.Query()
 
-	// Check for Dex error.
 	if errParam := q.Get("error"); errParam != "" {
 		desc := q.Get("error_description")
 		h.logger.Warn("oidc: Dex returned error",
@@ -483,21 +660,17 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	stateKey := q.Get("state")
-	code := q.Get("code")
 	if stateKey == "" || code == "" {
 		http.Error(w, "missing state or code parameter", http.StatusBadRequest)
 		return
 	}
 
-	// Retrieve and consume state (one-time use).
 	flowState, ok := h.stateStore.Consume(stateKey)
 	if !ok {
 		http.Error(w, "invalid or expired state parameter", http.StatusBadRequest)
 		return
 	}
 
-	// Exchange Dex authorization code for tokens.
 	idToken, err := h.exchangeDexCode(ctx, code, flowState.DexCodeVerifier)
 	if err != nil {
 		h.logger.Error("oidc: Dex token exchange failed",
@@ -506,7 +679,6 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Extract email from Dex ID token (trusted server-to-server response).
 	email, err := extractEmailFromJWT(idToken)
 	if err != nil {
 		h.logger.Error("oidc: failed to extract email from ID token",
@@ -515,23 +687,19 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Resolve tenant slug to UUID for JWT consistency with BFF-issued tokens.
 	tenantID, err := h.resolveTenantID(ctx, flowState.TenantSlug)
 	if err != nil {
 		http.Error(w, errTenantResolutionFailed.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	// Defense-in-depth: validate redirect URI scheme before signing tokens.
-	// The URI was validated at authorize-time, but re-check before redirect.
 	if !isAllowedRedirectURI(flowState.MCPRedirectURI) {
 		h.logger.Error("oidc: unsafe redirect URI scheme", "uri", flowState.MCPRedirectURI)
 		http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
 		return
 	}
 
-	// Issue MCP authorization code backed by a Meridian JWT.
-	redirectURL, err := h.issueCodeAndRedirect(email, tenantID, flowState)
+	redirectURL, err := h.issueCodeAndRedirect(email, tenantID, flowState.RequestedScopes, flowState)
 	if err != nil {
 		h.logger.Error("oidc: failed to issue auth code", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
@@ -589,6 +757,58 @@ func (h *OIDCHandler) buildDexRedirect(challenge, clientID, redirectURI, mcpStat
 	return dexAuthURL + "?" + params.Encode(), nil
 }
 
+// buildConsentRedirect stores OIDC flow state and returns the URL of the UI
+// consent page. The consent page authenticates the user (via the existing BFF
+// session) and asks them to approve the requested scopes before redirecting
+// back to /oauth/callback with a consent code.
+func (h *OIDCHandler) buildConsentRedirect(challenge, clientID, redirectURI, mcpState, tenantSlug string, requestedScopes []string) (string, error) {
+	stateKey, err := h.stateStore.Store(OIDCFlowState{
+		MCPCodeChallenge: challenge,
+		MCPClientID:      clientID,
+		MCPRedirectURI:   redirectURI,
+		MCPState:         mcpState,
+		TenantSlug:       tenantSlug,
+		RequestedScopes:  requestedScopes,
+		IssuedAt:         time.Now(),
+	})
+	if err != nil {
+		return "", fmt.Errorf("store state: %w", err)
+	}
+
+	consentURL := h.buildConsentPageURL(tenantSlug, stateKey, clientID)
+	return consentURL, nil
+}
+
+// buildConsentPageURL constructs the UI consent page URL with tenant subdomain.
+func (h *OIDCHandler) buildConsentPageURL(tenantSlug, stateKey, clientID string) string {
+	base := h.baseURL
+	if base == "" {
+		base = "https://" + h.baseDomain
+	}
+
+	// Insert tenant subdomain if base domain is configured.
+	if h.baseDomain != "" && tenantSlug != "" {
+		parsed, err := url.Parse(base)
+		if err == nil {
+			host := parsed.Hostname()
+			port := parsed.Port()
+			if host == h.baseDomain || strings.HasSuffix(host, "."+h.baseDomain) {
+				parsed.Host = tenantSlug + "." + h.baseDomain
+				if port != "" {
+					parsed.Host = tenantSlug + "." + h.baseDomain + ":" + port
+				}
+				base = parsed.String()
+			}
+		}
+	}
+
+	params := url.Values{
+		"mcp_state": {stateKey},
+		"client_id": {clientID},
+	}
+	return base + "/auth/mcp-consent?" + params.Encode()
+}
+
 // resolveTenantID resolves a tenant slug to a tenant UUID via the tenant resolver.
 func (h *OIDCHandler) resolveTenantID(ctx context.Context, tenantSlug string) (string, error) {
 	tenantID := tenantSlug
@@ -605,11 +825,12 @@ func (h *OIDCHandler) resolveTenantID(ctx context.Context, tenantSlug string) (s
 }
 
 // issueCodeAndRedirect signs a Meridian JWT, generates an MCP authorization code, stores it, and returns the redirect URL.
-func (h *OIDCHandler) issueCodeAndRedirect(email, tenantID string, flowState OIDCFlowState) (string, error) {
+func (h *OIDCHandler) issueCodeAndRedirect(email, tenantID string, scopes []string, flowState OIDCFlowState) (string, error) {
 	claims := map[string]interface{}{
 		"sub":         email,
 		"email":       email,
 		"x-tenant-id": tenantID,
+		"scopes":      scopes,
 	}
 	tokenStr, err := h.signer.SignClaims(claims, h.tokenTTL)
 	if err != nil {

--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -511,8 +511,8 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	h.handleDexCallback(w, r, stateKey, code)
 }
 
-// handleDexCallback processes the legacy Dex token-exchange callback path.
-// resolveTenantSlug extracts the tenant slug from the request host subdomain, falling back to the default.
+// resolveTenantSlug extracts the tenant slug from the request host subdomain,
+// falling back to the default.
 func (h *OIDCHandler) resolveTenantSlug(host string) (string, error) {
 	tenantSlug := extractSubdomain(host, h.baseDomain)
 	if tenantSlug == "" && h.defaultTenantSlug != "" {

--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -211,33 +211,6 @@ func (s *OIDCStateStore) PeekInfo(key string) (clientID, redirectURI string, sco
 	return entry.MCPClientID, entry.MCPRedirectURI, scopes, true
 }
 
-// ConsentEntry holds the state stored alongside a consent code. This mirrors
-// the ConsentCodeEntry from api-gateway but avoids a direct import dependency
-// on that package (which pulls in otel transitive dependencies).
-type ConsentEntry struct {
-	Email          string
-	TenantID       string
-	TenantSlug     string
-	MCPState       string
-	ClientID       string
-	ApprovedScopes []string
-}
-
-// ConsentCodeConsumer can consume a consent code exactly once. The canonical
-// implementation is gateway.ConsentCodeStore.
-type ConsentCodeConsumer interface {
-	// Consume atomically retrieves and deletes a consent code.
-	// Returns (entry, true) if the code exists and has not expired.
-	Consume(code string) (ConsentEntry, bool)
-}
-
-// ConsentCodeConsumerFunc is an adapter to use ordinary functions as
-// ConsentCodeConsumer implementations (see also: http.HandlerFunc pattern).
-type ConsentCodeConsumerFunc func(code string) (ConsentEntry, bool)
-
-// Consume calls f(code).
-func (f ConsentCodeConsumerFunc) Consume(code string) (ConsentEntry, bool) { return f(code) }
-
 // TenantSlugResolver resolves a tenant slug (e.g., "acme") to its canonical
 // UUID. This ensures the x-tenant-id JWT claim contains a UUID consistent
 // with BFF-issued tokens, not the raw slug string.
@@ -433,68 +406,6 @@ func (h *OIDCHandler) writeDexRedirectError(w http.ResponseWriter, err error) {
 	http.Error(w, "internal server error", http.StatusInternalServerError)
 }
 
-// ConsentInfoResponse is the JSON response returned by HandleConsentInfo.
-type ConsentInfoResponse struct {
-	ClientID    string   `json:"client_id"`
-	ClientName  string   `json:"client_name"`
-	RedirectURI string   `json:"redirect_uri"`
-	Scopes      []string `json:"scopes"`
-	IsDynamic   bool     `json:"is_dynamic"`
-}
-
-// HandleConsentInfo handles GET /oauth/consent-info. It returns metadata about
-// the MCP client that initiated the authorization flow so the UI consent page
-// can display it to the user before they approve or deny.
-func (h *OIDCHandler) HandleConsentInfo(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
-	q := r.URL.Query()
-	clientID := q.Get("client_id")
-	mcpState := q.Get("mcp_state")
-	if clientID == "" || mcpState == "" {
-		http.Error(w, "client_id and mcp_state are required", http.StatusBadRequest)
-		return
-	}
-
-	stateClientID, redirectURI, scopes, ok := h.stateStore.PeekInfo(mcpState)
-	if !ok {
-		http.Error(w, "invalid or expired state", http.StatusBadRequest)
-		return
-	}
-
-	if stateClientID != clientID {
-		http.Error(w, "client_id mismatch", http.StatusBadRequest)
-		return
-	}
-
-	resp := ConsentInfoResponse{
-		ClientID:    clientID,
-		RedirectURI: redirectURI,
-		Scopes:      scopes,
-	}
-
-	// Resolve client name: static client gets a fixed name, dynamic clients
-	// use their registered client_name.
-	if clientID == h.oauthCfg.ClientID {
-		resp.ClientName = "Meridian CLI"
-		resp.IsDynamic = false
-	} else if h.registry != nil {
-		if client, found := h.registry.Lookup(clientID); found {
-			resp.IsDynamic = true
-			resp.ClientName = client.ClientName
-			if resp.ClientName == "" {
-				resp.ClientName = "Unknown Application"
-			}
-		}
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(resp)
-}
-
 // HandleAuthorize handles GET /oauth/authorize from the MCP client.
 // It stores the MCP client's PKCE state and redirects to Dex for authentication.
 func (h *OIDCHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
@@ -600,114 +511,7 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	h.handleDexCallback(w, r, stateKey, code)
 }
 
-// handleConsentCallback processes the consent-code callback path. The BFF
-// issues a consent code after user approval; this method consumes it,
-// cross-validates bindings, and issues the MCP authorization code.
-func (h *OIDCHandler) handleConsentCallback(w http.ResponseWriter, r *http.Request, stateKey, code string) {
-	if stateKey == "" || code == "" {
-		http.Error(w, "missing state or code parameter", http.StatusBadRequest)
-		return
-	}
-
-	consentEntry, ok := h.consentStore.Consume(code)
-	if !ok {
-		http.Error(w, "invalid or expired consent code", http.StatusBadRequest)
-		return
-	}
-
-	flowState, ok := h.stateStore.Consume(stateKey)
-	if !ok {
-		http.Error(w, "invalid or expired state parameter", http.StatusBadRequest)
-		return
-	}
-
-	if consentEntry.MCPState != stateKey || consentEntry.ClientID != flowState.MCPClientID {
-		http.Error(w, "consent code binding mismatch", http.StatusBadRequest)
-		return
-	}
-
-	if consentEntry.TenantSlug != flowState.TenantSlug {
-		http.Error(w, "tenant mismatch", http.StatusBadRequest)
-		return
-	}
-
-	if !isAllowedRedirectURI(flowState.MCPRedirectURI) {
-		h.logger.Error("oidc: unsafe redirect URI scheme", "uri", flowState.MCPRedirectURI)
-		http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
-		return
-	}
-
-	redirectURL, err := h.issueCodeAndRedirect(
-		consentEntry.Email, consentEntry.TenantID, consentEntry.ApprovedScopes, flowState)
-	if err != nil {
-		h.logger.Error("oidc: failed to issue auth code", "error", err)
-		http.Error(w, "internal server error", http.StatusInternalServerError)
-		return
-	}
-	http.Redirect(w, r, redirectURL, http.StatusFound)
-}
-
 // handleDexCallback processes the legacy Dex token-exchange callback path.
-func (h *OIDCHandler) handleDexCallback(w http.ResponseWriter, r *http.Request, stateKey, code string) {
-	ctx := r.Context()
-	q := r.URL.Query()
-
-	if errParam := q.Get("error"); errParam != "" {
-		desc := q.Get("error_description")
-		h.logger.Warn("oidc: Dex returned error",
-			"error", errParam, "description", desc)
-		http.Error(w, "authentication failed: "+errParam, http.StatusBadRequest)
-		return
-	}
-
-	if stateKey == "" || code == "" {
-		http.Error(w, "missing state or code parameter", http.StatusBadRequest)
-		return
-	}
-
-	flowState, ok := h.stateStore.Consume(stateKey)
-	if !ok {
-		http.Error(w, "invalid or expired state parameter", http.StatusBadRequest)
-		return
-	}
-
-	idToken, err := h.exchangeDexCode(ctx, code, flowState.DexCodeVerifier)
-	if err != nil {
-		h.logger.Error("oidc: Dex token exchange failed",
-			"tenant", flowState.TenantSlug, "error", err)
-		http.Error(w, "authentication token exchange failed", http.StatusBadGateway)
-		return
-	}
-
-	email, err := extractEmailFromJWT(idToken)
-	if err != nil {
-		h.logger.Error("oidc: failed to extract email from ID token",
-			"tenant", flowState.TenantSlug, "error", err)
-		http.Error(w, "failed to process identity", http.StatusBadGateway)
-		return
-	}
-
-	tenantID, err := h.resolveTenantID(ctx, flowState.TenantSlug)
-	if err != nil {
-		http.Error(w, errTenantResolutionFailed.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	if !isAllowedRedirectURI(flowState.MCPRedirectURI) {
-		h.logger.Error("oidc: unsafe redirect URI scheme", "uri", flowState.MCPRedirectURI)
-		http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
-		return
-	}
-
-	redirectURL, err := h.issueCodeAndRedirect(email, tenantID, flowState.RequestedScopes, flowState)
-	if err != nil {
-		h.logger.Error("oidc: failed to issue auth code", "error", err)
-		http.Error(w, "internal server error", http.StatusInternalServerError)
-		return
-	}
-	http.Redirect(w, r, redirectURL, http.StatusFound)
-}
-
 // resolveTenantSlug extracts the tenant slug from the request host subdomain, falling back to the default.
 func (h *OIDCHandler) resolveTenantSlug(host string) (string, error) {
 	tenantSlug := extractSubdomain(host, h.baseDomain)
@@ -755,58 +559,6 @@ func (h *OIDCHandler) buildDexRedirect(challenge, clientID, redirectURI, mcpStat
 		"code_challenge_method": {"S256"},
 	}
 	return dexAuthURL + "?" + params.Encode(), nil
-}
-
-// buildConsentRedirect stores OIDC flow state and returns the URL of the UI
-// consent page. The consent page authenticates the user (via the existing BFF
-// session) and asks them to approve the requested scopes before redirecting
-// back to /oauth/callback with a consent code.
-func (h *OIDCHandler) buildConsentRedirect(challenge, clientID, redirectURI, mcpState, tenantSlug string, requestedScopes []string) (string, error) {
-	stateKey, err := h.stateStore.Store(OIDCFlowState{
-		MCPCodeChallenge: challenge,
-		MCPClientID:      clientID,
-		MCPRedirectURI:   redirectURI,
-		MCPState:         mcpState,
-		TenantSlug:       tenantSlug,
-		RequestedScopes:  requestedScopes,
-		IssuedAt:         time.Now(),
-	})
-	if err != nil {
-		return "", fmt.Errorf("store state: %w", err)
-	}
-
-	consentURL := h.buildConsentPageURL(tenantSlug, stateKey, clientID)
-	return consentURL, nil
-}
-
-// buildConsentPageURL constructs the UI consent page URL with tenant subdomain.
-func (h *OIDCHandler) buildConsentPageURL(tenantSlug, stateKey, clientID string) string {
-	base := h.baseURL
-	if base == "" {
-		base = "https://" + h.baseDomain
-	}
-
-	// Insert tenant subdomain if base domain is configured.
-	if h.baseDomain != "" && tenantSlug != "" {
-		parsed, err := url.Parse(base)
-		if err == nil {
-			host := parsed.Hostname()
-			port := parsed.Port()
-			if host == h.baseDomain || strings.HasSuffix(host, "."+h.baseDomain) {
-				parsed.Host = tenantSlug + "." + h.baseDomain
-				if port != "" {
-					parsed.Host = tenantSlug + "." + h.baseDomain + ":" + port
-				}
-				base = parsed.String()
-			}
-		}
-	}
-
-	params := url.Values{
-		"mcp_state": {stateKey},
-		"client_id": {clientID},
-	}
-	return base + "/auth/mcp-consent?" + params.Encode()
 }
 
 // resolveTenantID resolves a tenant slug to a tenant UUID via the tenant resolver.

--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -455,7 +455,8 @@ func (h *OIDCHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Capture requested OAuth scopes from the MCP client (space-delimited per RFC 6749).
-	requestedScopes := strings.Fields(strings.TrimSpace(q.Get("scope")))
+	// Only allow scopes with the "mcp:" prefix to prevent arbitrary scope injection.
+	requestedScopes := filterAllowedScopes(strings.Fields(strings.TrimSpace(q.Get("scope"))))
 	if len(requestedScopes) == 0 {
 		requestedScopes = []string{"mcp:default"}
 	}
@@ -764,4 +765,16 @@ func isAllowedRedirectURI(uri string) bool {
 		return host == "localhost" || host == "127.0.0.1" || host == "::1"
 	}
 	return false
+}
+
+// filterAllowedScopes returns only scopes with the "mcp:" prefix,
+// preventing clients from injecting arbitrary scope strings into signed JWTs.
+func filterAllowedScopes(scopes []string) []string {
+	var allowed []string
+	for _, s := range scopes {
+		if strings.HasPrefix(s, "mcp:") {
+			allowed = append(allowed, s)
+		}
+	}
+	return allowed
 }

--- a/services/mcp-server/internal/auth/oidc_consent.go
+++ b/services/mcp-server/internal/auth/oidc_consent.go
@@ -10,7 +10,10 @@ import (
 	"time"
 )
 
-var errConsentBaseNotConfigured = errors.New("consent redirect base is not configured")
+var (
+	errConsentBaseNotConfigured = errors.New("consent redirect base is not configured")
+	errConsentBaseURLInvalid    = errors.New("invalid consent redirect base URL: missing scheme or host")
+)
 
 // ConsentEntry holds the state stored alongside a consent code. This mirrors
 // the ConsentCodeEntry from api-gateway but avoids a direct import dependency
@@ -268,18 +271,19 @@ func (h *OIDCHandler) buildConsentPageURL(tenantSlug, stateKey, clientID string)
 		base = "https://" + h.baseDomain
 	}
 
+	parsed, err := url.Parse(base)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", errConsentBaseURLInvalid
+	}
+
 	// Insert tenant subdomain if base domain is configured.
 	if h.baseDomain != "" && tenantSlug != "" {
-		parsed, err := url.Parse(base)
-		if err == nil {
-			host := parsed.Hostname()
-			port := parsed.Port()
-			if host == h.baseDomain || strings.HasSuffix(host, "."+h.baseDomain) {
-				parsed.Host = tenantSlug + "." + h.baseDomain
-				if port != "" {
-					parsed.Host = tenantSlug + "." + h.baseDomain + ":" + port
-				}
-				base = parsed.String()
+		host := parsed.Hostname()
+		port := parsed.Port()
+		if host == h.baseDomain || strings.HasSuffix(host, "."+h.baseDomain) {
+			parsed.Host = tenantSlug + "." + h.baseDomain
+			if port != "" {
+				parsed.Host = tenantSlug + "." + h.baseDomain + ":" + port
 			}
 		}
 	}
@@ -288,5 +292,7 @@ func (h *OIDCHandler) buildConsentPageURL(tenantSlug, stateKey, clientID string)
 		"mcp_state": {stateKey},
 		"client_id": {clientID},
 	}
-	return base + "/auth/mcp-consent?" + params.Encode(), nil
+	parsed.Path = strings.TrimRight(parsed.Path, "/") + "/auth/mcp-consent"
+	parsed.RawQuery = params.Encode()
+	return parsed.String(), nil
 }

--- a/services/mcp-server/internal/auth/oidc_consent.go
+++ b/services/mcp-server/internal/auth/oidc_consent.go
@@ -2,12 +2,15 @@ package auth
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 )
+
+var errConsentBaseNotConfigured = errors.New("consent redirect base is not configured")
 
 // ConsentEntry holds the state stored alongside a consent code. This mirrors
 // the ConsentCodeEntry from api-gateway but avoids a direct import dependency
@@ -248,14 +251,20 @@ func (h *OIDCHandler) buildConsentRedirect(challenge, clientID, redirectURI, mcp
 		return "", fmt.Errorf("store state: %w", err)
 	}
 
-	consentURL := h.buildConsentPageURL(tenantSlug, stateKey, clientID)
+	consentURL, err := h.buildConsentPageURL(tenantSlug, stateKey, clientID)
+	if err != nil {
+		return "", fmt.Errorf("build consent URL: %w", err)
+	}
 	return consentURL, nil
 }
 
 // buildConsentPageURL constructs the UI consent page URL with tenant subdomain.
-func (h *OIDCHandler) buildConsentPageURL(tenantSlug, stateKey, clientID string) string {
+func (h *OIDCHandler) buildConsentPageURL(tenantSlug, stateKey, clientID string) (string, error) {
 	base := h.baseURL
 	if base == "" {
+		if h.baseDomain == "" {
+			return "", errConsentBaseNotConfigured
+		}
 		base = "https://" + h.baseDomain
 	}
 
@@ -279,5 +288,5 @@ func (h *OIDCHandler) buildConsentPageURL(tenantSlug, stateKey, clientID string)
 		"mcp_state": {stateKey},
 		"client_id": {clientID},
 	}
-	return base + "/auth/mcp-consent?" + params.Encode()
+	return base + "/auth/mcp-consent?" + params.Encode(), nil
 }

--- a/services/mcp-server/internal/auth/oidc_consent.go
+++ b/services/mcp-server/internal/auth/oidc_consent.go
@@ -241,6 +241,11 @@ func scopesSubset(approved, requested []string) bool {
 // session) and asks them to approve the requested scopes before redirecting
 // back to /oauth/callback with a consent code.
 func (h *OIDCHandler) buildConsentRedirect(challenge, clientID, redirectURI, mcpState, tenantSlug string, requestedScopes []string) (string, error) {
+	// Validate consent URL configuration before storing state to avoid orphaned entries.
+	if err := h.validateConsentBase(); err != nil {
+		return "", err
+	}
+
 	stateKey, err := h.stateStore.Store(OIDCFlowState{
 		MCPCodeChallenge: challenge,
 		MCPClientID:      clientID,
@@ -259,6 +264,23 @@ func (h *OIDCHandler) buildConsentRedirect(challenge, clientID, redirectURI, mcp
 		return "", fmt.Errorf("build consent URL: %w", err)
 	}
 	return consentURL, nil
+}
+
+// validateConsentBase checks that the handler has a valid base URL or domain
+// for constructing consent page redirects.
+func (h *OIDCHandler) validateConsentBase() error {
+	base := h.baseURL
+	if base == "" {
+		if h.baseDomain == "" {
+			return errConsentBaseNotConfigured
+		}
+		return nil // baseDomain will be used to construct a valid URL
+	}
+	parsed, err := url.Parse(base)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return errConsentBaseURLInvalid
+	}
+	return nil
 }
 
 // buildConsentPageURL constructs the UI consent page URL with tenant subdomain.

--- a/services/mcp-server/internal/auth/oidc_consent.go
+++ b/services/mcp-server/internal/auth/oidc_consent.go
@@ -129,6 +129,16 @@ func (h *OIDCHandler) handleConsentCallback(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// Defense-in-depth: approved scopes must be a subset of the originally
+	// requested scopes. Reject if the consent issuer returns broader access.
+	if !scopesSubset(consentEntry.ApprovedScopes, flowState.RequestedScopes) {
+		h.logger.Error("oidc: approved scopes exceed requested scopes",
+			"approved", consentEntry.ApprovedScopes,
+			"requested", flowState.RequestedScopes)
+		http.Error(w, "approved scopes exceed requested scopes", http.StatusBadRequest)
+		return
+	}
+
 	if !isAllowedRedirectURI(flowState.MCPRedirectURI) {
 		h.logger.Error("oidc: unsafe redirect URI scheme", "uri", flowState.MCPRedirectURI)
 		http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
@@ -204,6 +214,20 @@ func (h *OIDCHandler) handleDexCallback(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
+// scopesSubset returns true if every element of approved is contained in requested.
+func scopesSubset(approved, requested []string) bool {
+	allowed := make(map[string]struct{}, len(requested))
+	for _, s := range requested {
+		allowed[s] = struct{}{}
+	}
+	for _, s := range approved {
+		if _, ok := allowed[s]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // buildConsentRedirect stores OIDC flow state and returns the URL of the UI

--- a/services/mcp-server/internal/auth/oidc_consent.go
+++ b/services/mcp-server/internal/auth/oidc_consent.go
@@ -1,0 +1,259 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// ConsentEntry holds the state stored alongside a consent code. This mirrors
+// the ConsentCodeEntry from api-gateway but avoids a direct import dependency
+// on that package (which pulls in otel transitive dependencies).
+type ConsentEntry struct {
+	Email          string
+	TenantID       string
+	TenantSlug     string
+	MCPState       string
+	ClientID       string
+	ApprovedScopes []string
+}
+
+// ConsentCodeConsumer can consume a consent code exactly once. The canonical
+// implementation is gateway.ConsentCodeStore.
+type ConsentCodeConsumer interface {
+	// Consume atomically retrieves and deletes a consent code.
+	// Returns (entry, true) if the code exists and has not expired.
+	Consume(code string) (ConsentEntry, bool)
+}
+
+// ConsentCodeConsumerFunc is an adapter to use ordinary functions as
+// ConsentCodeConsumer implementations (see also: http.HandlerFunc pattern).
+type ConsentCodeConsumerFunc func(code string) (ConsentEntry, bool)
+
+// Consume calls f(code).
+func (f ConsentCodeConsumerFunc) Consume(code string) (ConsentEntry, bool) { return f(code) }
+
+// ConsentInfoResponse is the JSON response returned by HandleConsentInfo.
+type ConsentInfoResponse struct {
+	ClientID    string   `json:"client_id"`
+	ClientName  string   `json:"client_name"`
+	RedirectURI string   `json:"redirect_uri"`
+	Scopes      []string `json:"scopes"`
+	IsDynamic   bool     `json:"is_dynamic"`
+}
+
+// HandleConsentInfo handles GET /oauth/consent-info. It returns metadata about
+// the MCP client that initiated the authorization flow so the UI consent page
+// can display it to the user before they approve or deny.
+func (h *OIDCHandler) HandleConsentInfo(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	q := r.URL.Query()
+	clientID := q.Get("client_id")
+	mcpState := q.Get("mcp_state")
+	if clientID == "" || mcpState == "" {
+		http.Error(w, "client_id and mcp_state are required", http.StatusBadRequest)
+		return
+	}
+
+	stateClientID, redirectURI, scopes, ok := h.stateStore.PeekInfo(mcpState)
+	if !ok {
+		http.Error(w, "invalid or expired state", http.StatusBadRequest)
+		return
+	}
+
+	if stateClientID != clientID {
+		http.Error(w, "client_id mismatch", http.StatusBadRequest)
+		return
+	}
+
+	resp := ConsentInfoResponse{
+		ClientID:    clientID,
+		RedirectURI: redirectURI,
+		Scopes:      scopes,
+	}
+
+	// Resolve client name: static client gets a fixed name, dynamic clients
+	// use their registered client_name.
+	if clientID == h.oauthCfg.ClientID {
+		resp.ClientName = "Meridian CLI"
+		resp.IsDynamic = false
+	} else if h.registry != nil {
+		if client, found := h.registry.Lookup(clientID); found {
+			resp.IsDynamic = true
+			resp.ClientName = client.ClientName
+			if resp.ClientName == "" {
+				resp.ClientName = "Unknown Application"
+			}
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// handleConsentCallback processes the consent-code callback path. The BFF
+// issues a consent code after user approval; this method consumes it,
+// cross-validates bindings, and issues the MCP authorization code.
+func (h *OIDCHandler) handleConsentCallback(w http.ResponseWriter, r *http.Request, stateKey, code string) {
+	if stateKey == "" || code == "" {
+		http.Error(w, "missing state or code parameter", http.StatusBadRequest)
+		return
+	}
+
+	consentEntry, ok := h.consentStore.Consume(code)
+	if !ok {
+		http.Error(w, "invalid or expired consent code", http.StatusBadRequest)
+		return
+	}
+
+	flowState, ok := h.stateStore.Consume(stateKey)
+	if !ok {
+		http.Error(w, "invalid or expired state parameter", http.StatusBadRequest)
+		return
+	}
+
+	if consentEntry.MCPState != stateKey || consentEntry.ClientID != flowState.MCPClientID {
+		http.Error(w, "consent code binding mismatch", http.StatusBadRequest)
+		return
+	}
+
+	if consentEntry.TenantSlug != flowState.TenantSlug {
+		http.Error(w, "tenant mismatch", http.StatusBadRequest)
+		return
+	}
+
+	if !isAllowedRedirectURI(flowState.MCPRedirectURI) {
+		h.logger.Error("oidc: unsafe redirect URI scheme", "uri", flowState.MCPRedirectURI)
+		http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
+		return
+	}
+
+	redirectURL, err := h.issueCodeAndRedirect(
+		consentEntry.Email, consentEntry.TenantID, consentEntry.ApprovedScopes, flowState)
+	if err != nil {
+		h.logger.Error("oidc: failed to issue auth code", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
+// handleDexCallback processes the legacy Dex token-exchange callback path.
+func (h *OIDCHandler) handleDexCallback(w http.ResponseWriter, r *http.Request, stateKey, code string) {
+	ctx := r.Context()
+	q := r.URL.Query()
+
+	if errParam := q.Get("error"); errParam != "" {
+		desc := q.Get("error_description")
+		h.logger.Warn("oidc: Dex returned error",
+			"error", errParam, "description", desc)
+		http.Error(w, "authentication failed: "+errParam, http.StatusBadRequest)
+		return
+	}
+
+	if stateKey == "" || code == "" {
+		http.Error(w, "missing state or code parameter", http.StatusBadRequest)
+		return
+	}
+
+	flowState, ok := h.stateStore.Consume(stateKey)
+	if !ok {
+		http.Error(w, "invalid or expired state parameter", http.StatusBadRequest)
+		return
+	}
+
+	idToken, err := h.exchangeDexCode(ctx, code, flowState.DexCodeVerifier)
+	if err != nil {
+		h.logger.Error("oidc: Dex token exchange failed",
+			"tenant", flowState.TenantSlug, "error", err)
+		http.Error(w, "authentication token exchange failed", http.StatusBadGateway)
+		return
+	}
+
+	email, err := extractEmailFromJWT(idToken)
+	if err != nil {
+		h.logger.Error("oidc: failed to extract email from ID token",
+			"tenant", flowState.TenantSlug, "error", err)
+		http.Error(w, "failed to process identity", http.StatusBadGateway)
+		return
+	}
+
+	tenantID, err := h.resolveTenantID(ctx, flowState.TenantSlug)
+	if err != nil {
+		http.Error(w, errTenantResolutionFailed.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if !isAllowedRedirectURI(flowState.MCPRedirectURI) {
+		h.logger.Error("oidc: unsafe redirect URI scheme", "uri", flowState.MCPRedirectURI)
+		http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
+		return
+	}
+
+	redirectURL, err := h.issueCodeAndRedirect(email, tenantID, flowState.RequestedScopes, flowState)
+	if err != nil {
+		h.logger.Error("oidc: failed to issue auth code", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
+// buildConsentRedirect stores OIDC flow state and returns the URL of the UI
+// consent page. The consent page authenticates the user (via the existing BFF
+// session) and asks them to approve the requested scopes before redirecting
+// back to /oauth/callback with a consent code.
+func (h *OIDCHandler) buildConsentRedirect(challenge, clientID, redirectURI, mcpState, tenantSlug string, requestedScopes []string) (string, error) {
+	stateKey, err := h.stateStore.Store(OIDCFlowState{
+		MCPCodeChallenge: challenge,
+		MCPClientID:      clientID,
+		MCPRedirectURI:   redirectURI,
+		MCPState:         mcpState,
+		TenantSlug:       tenantSlug,
+		RequestedScopes:  requestedScopes,
+		IssuedAt:         time.Now(),
+	})
+	if err != nil {
+		return "", fmt.Errorf("store state: %w", err)
+	}
+
+	consentURL := h.buildConsentPageURL(tenantSlug, stateKey, clientID)
+	return consentURL, nil
+}
+
+// buildConsentPageURL constructs the UI consent page URL with tenant subdomain.
+func (h *OIDCHandler) buildConsentPageURL(tenantSlug, stateKey, clientID string) string {
+	base := h.baseURL
+	if base == "" {
+		base = "https://" + h.baseDomain
+	}
+
+	// Insert tenant subdomain if base domain is configured.
+	if h.baseDomain != "" && tenantSlug != "" {
+		parsed, err := url.Parse(base)
+		if err == nil {
+			host := parsed.Hostname()
+			port := parsed.Port()
+			if host == h.baseDomain || strings.HasSuffix(host, "."+h.baseDomain) {
+				parsed.Host = tenantSlug + "." + h.baseDomain
+				if port != "" {
+					parsed.Host = tenantSlug + "." + h.baseDomain + ":" + port
+				}
+				base = parsed.String()
+			}
+		}
+	}
+
+	params := url.Values{
+		"mcp_state": {stateKey},
+		"client_id": {clientID},
+	}
+	return base + "/auth/mcp-consent?" + params.Encode()
+}

--- a/services/mcp-server/internal/auth/oidc_test.go
+++ b/services/mcp-server/internal/auth/oidc_test.go
@@ -1620,6 +1620,40 @@ func TestOIDCHandler_HandleCallback_TenantMismatch(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "tenant mismatch")
 }
 
+func TestOIDCHandler_HandleCallback_ScopeEscalation(t *testing.T) {
+	consentStore := newFakeConsentStore()
+	handler, stateStore, _ := newConsentOIDCHandler(t, consentStore)
+
+	stateKey, err := stateStore.Store(auth.OIDCFlowState{
+		MCPClientID:     "meridian-mcp",
+		MCPRedirectURI:  "https://claude.ai/callback",
+		TenantSlug:      "acme",
+		RequestedScopes: []string{"mcp:default"},
+		IssuedAt:        time.Now(),
+	})
+	require.NoError(t, err)
+
+	// Consent code has broader scopes than originally requested
+	consentStore.Store("escalated-code", auth.ConsentEntry{
+		Email:          "admin@acme.com",
+		TenantID:       "tid",
+		TenantSlug:     "acme",
+		MCPState:       stateKey,
+		ClientID:       "meridian-mcp",
+		ApprovedScopes: []string{"mcp:default", "mcp:admin"}, // admin was not requested
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/callback?"+url.Values{
+		"code":  {"escalated-code"},
+		"state": {stateKey},
+	}.Encode(), nil)
+	w := httptest.NewRecorder()
+	handler.HandleCallback(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "approved scopes exceed requested scopes")
+}
+
 func TestOIDCHandler_HandleCallback_ScopesInJWT(t *testing.T) {
 	consentStore := newFakeConsentStore()
 	handler, stateStore, codeStore := newConsentOIDCHandler(t, consentStore)

--- a/services/mcp-server/internal/auth/oidc_test.go
+++ b/services/mcp-server/internal/auth/oidc_test.go
@@ -1300,3 +1300,513 @@ func TestOIDCStateStore_PeekInfo_NotFound(t *testing.T) {
 	assert.Empty(t, redirectURI)
 	assert.Nil(t, scopes)
 }
+
+// -----------------------------------------------------------------------
+// fakeConsentStore - test double for ConsentCodeConsumer
+// -----------------------------------------------------------------------
+
+type fakeConsentStore struct {
+	entries map[string]auth.ConsentEntry
+}
+
+func newFakeConsentStore() *fakeConsentStore {
+	return &fakeConsentStore{entries: make(map[string]auth.ConsentEntry)}
+}
+
+func (s *fakeConsentStore) Store(code string, entry auth.ConsentEntry) {
+	s.entries[code] = entry
+}
+
+func (s *fakeConsentStore) Consume(code string) (auth.ConsentEntry, bool) {
+	entry, ok := s.entries[code]
+	if !ok {
+		return auth.ConsentEntry{}, false
+	}
+	delete(s.entries, code)
+	return entry, true
+}
+
+// newConsentOIDCHandler creates an OIDCHandler with consent store wired for testing.
+func newConsentOIDCHandler(t *testing.T, consentStore auth.ConsentCodeConsumer) (*auth.OIDCHandler, *auth.OIDCStateStore, *auth.CodeStore) {
+	t.Helper()
+	dexSrv := fakeDexServer(t, "unused@test.com")
+	signer := newTestSigner(t)
+	codeStore := newTestStore(t)
+	stateStore := newTestOIDCStateStore(t)
+
+	handler, err := auth.NewOIDCHandler(auth.OIDCHandlerConfig{
+		OIDC: auth.OIDCConfig{
+			DexIssuerURL: dexSrv.URL + "/dex",
+			ClientID:     "meridian-service",
+			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
+		},
+		OAuth: auth.OAuthConfig{
+			ClientID:    "meridian-mcp",
+			RedirectURI: "https://claude.ai/callback",
+		},
+		ConsentStore:      consentStore,
+		StateStore:        stateStore,
+		CodeStore:         codeStore,
+		Signer:            signer,
+		BaseURL:           "https://demo.meridianhub.cloud",
+		BaseDomain:        "demo.meridianhub.cloud",
+		DefaultTenantSlug: "acme",
+		Logger:            slog.Default(),
+	})
+	require.NoError(t, err)
+	return handler, stateStore, codeStore
+}
+
+// -----------------------------------------------------------------------
+// Task 3: HandleConsentInfo
+// -----------------------------------------------------------------------
+
+func TestOIDCHandler_HandleConsentInfo_Success(t *testing.T) {
+	consentStore := newFakeConsentStore()
+	handler, stateStore, _ := newConsentOIDCHandler(t, consentStore)
+
+	stateKey, err := stateStore.Store(auth.OIDCFlowState{
+		MCPClientID:     "meridian-mcp",
+		MCPRedirectURI:  "https://claude.ai/callback",
+		RequestedScopes: []string{"mcp:default", "mcp:admin"},
+		IssuedAt:        time.Now(),
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/oauth/consent-info?client_id=meridian-mcp&mcp_state="+stateKey, nil)
+	w := httptest.NewRecorder()
+	handler.HandleConsentInfo(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp auth.ConsentInfoResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, "meridian-mcp", resp.ClientID)
+	assert.Equal(t, "Meridian CLI", resp.ClientName)
+	assert.Equal(t, "https://claude.ai/callback", resp.RedirectURI)
+	assert.Equal(t, []string{"mcp:default", "mcp:admin"}, resp.Scopes)
+	assert.False(t, resp.IsDynamic)
+}
+
+func TestOIDCHandler_HandleConsentInfo_InvalidState(t *testing.T) {
+	consentStore := newFakeConsentStore()
+	handler, _, _ := newConsentOIDCHandler(t, consentStore)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/oauth/consent-info?client_id=meridian-mcp&mcp_state=expired-key", nil)
+	w := httptest.NewRecorder()
+	handler.HandleConsentInfo(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "invalid or expired state")
+}
+
+func TestOIDCHandler_HandleConsentInfo_ClientMismatch(t *testing.T) {
+	consentStore := newFakeConsentStore()
+	handler, stateStore, _ := newConsentOIDCHandler(t, consentStore)
+
+	stateKey, err := stateStore.Store(auth.OIDCFlowState{
+		MCPClientID:    "meridian-mcp",
+		MCPRedirectURI: "https://claude.ai/callback",
+		IssuedAt:       time.Now(),
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/oauth/consent-info?client_id=wrong-client&mcp_state="+stateKey, nil)
+	w := httptest.NewRecorder()
+	handler.HandleConsentInfo(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "client_id mismatch")
+}
+
+func TestOIDCHandler_HandleConsentInfo_DynamicClient(t *testing.T) {
+	registry := newTestRegistry(t)
+	dexSrv := fakeDexServer(t, "unused@test.com")
+
+	client, err := registry.Register(auth.RegisteredClient{
+		ClientName:   "My Cool App",
+		RedirectURIs: []string{"https://myapp.com/callback"},
+	})
+	require.NoError(t, err)
+
+	consentStore := newFakeConsentStore()
+	stateStore := newTestOIDCStateStore(t)
+
+	handler, err := auth.NewOIDCHandler(auth.OIDCHandlerConfig{
+		OIDC: auth.OIDCConfig{
+			DexIssuerURL: dexSrv.URL + "/dex",
+			ClientID:     "meridian-service",
+			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
+		},
+		OAuth: auth.OAuthConfig{
+			ClientID:    "meridian-mcp",
+			RedirectURI: "https://claude.ai/callback",
+		},
+		ConsentStore: consentStore,
+		Registry:     registry,
+		StateStore:   stateStore,
+		CodeStore:    newTestStore(t),
+		Signer:       newTestSigner(t),
+		BaseURL:      "https://demo.meridianhub.cloud",
+		BaseDomain:   "demo.meridianhub.cloud",
+		Logger:       slog.Default(),
+	})
+	require.NoError(t, err)
+
+	stateKey, err := stateStore.Store(auth.OIDCFlowState{
+		MCPClientID:    client.ClientID,
+		MCPRedirectURI: "https://myapp.com/callback",
+		IssuedAt:       time.Now(),
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/oauth/consent-info?client_id="+client.ClientID+"&mcp_state="+stateKey, nil)
+	w := httptest.NewRecorder()
+	handler.HandleConsentInfo(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp auth.ConsentInfoResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, "My Cool App", resp.ClientName)
+	assert.True(t, resp.IsDynamic)
+}
+
+// -----------------------------------------------------------------------
+// Task 3: HandleCallback with consent code
+// -----------------------------------------------------------------------
+
+func TestOIDCHandler_HandleCallback_ConsentCode(t *testing.T) {
+	consentStore := newFakeConsentStore()
+	handler, stateStore, codeStore := newConsentOIDCHandler(t, consentStore)
+
+	_, challenge := generatePKCEPair(t)
+
+	stateKey, err := stateStore.Store(auth.OIDCFlowState{
+		MCPCodeChallenge: challenge,
+		MCPClientID:      "meridian-mcp",
+		MCPRedirectURI:   "https://claude.ai/callback",
+		MCPState:         "client-state-789",
+		TenantSlug:       "acme",
+		RequestedScopes:  []string{"mcp:default"},
+		IssuedAt:         time.Now(),
+	})
+	require.NoError(t, err)
+
+	consentStore.Store("consent-code-123", auth.ConsentEntry{
+		Email:          "admin@acme.com",
+		TenantID:       "550e8400-e29b-41d4-a716-446655440000",
+		TenantSlug:     "acme",
+		MCPState:       stateKey,
+		ClientID:       "meridian-mcp",
+		ApprovedScopes: []string{"mcp:default"},
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/callback?"+url.Values{
+		"code":  {"consent-code-123"},
+		"state": {stateKey},
+	}.Encode(), nil)
+	w := httptest.NewRecorder()
+	handler.HandleCallback(w, req)
+
+	resp := w.Result()
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+
+	location := resp.Header.Get("Location")
+	redirectURL, err := url.Parse(location)
+	require.NoError(t, err)
+
+	assert.Equal(t, "claude.ai", redirectURL.Host)
+	assert.NotEmpty(t, redirectURL.Query().Get("code"))
+	assert.Equal(t, "client-state-789", redirectURL.Query().Get("state"))
+
+	// Verify the MCP code is in the code store with correct JWT
+	mcpCode := redirectURL.Query().Get("code")
+	entry, ok := codeStore.Consume(mcpCode)
+	require.True(t, ok)
+	assert.NotEmpty(t, entry.Token)
+}
+
+func TestOIDCHandler_HandleCallback_ExpiredConsentCode(t *testing.T) {
+	consentStore := newFakeConsentStore()
+	handler, stateStore, _ := newConsentOIDCHandler(t, consentStore)
+
+	stateKey, err := stateStore.Store(auth.OIDCFlowState{
+		MCPClientID:    "meridian-mcp",
+		MCPRedirectURI: "https://claude.ai/callback",
+		TenantSlug:     "acme",
+		IssuedAt:       time.Now(),
+	})
+	require.NoError(t, err)
+
+	// Don't store a consent code - it should fail as "not found"
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/callback?"+url.Values{
+		"code":  {"nonexistent-consent-code"},
+		"state": {stateKey},
+	}.Encode(), nil)
+	w := httptest.NewRecorder()
+	handler.HandleCallback(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "invalid or expired consent code")
+}
+
+func TestOIDCHandler_HandleCallback_ConsentCodeMismatch(t *testing.T) {
+	consentStore := newFakeConsentStore()
+	handler, stateStore, _ := newConsentOIDCHandler(t, consentStore)
+
+	stateKey, err := stateStore.Store(auth.OIDCFlowState{
+		MCPClientID:    "meridian-mcp",
+		MCPRedirectURI: "https://claude.ai/callback",
+		TenantSlug:     "acme",
+		IssuedAt:       time.Now(),
+	})
+	require.NoError(t, err)
+
+	// Consent code has a different mcp_state
+	consentStore.Store("mismatched-code", auth.ConsentEntry{
+		Email:      "admin@acme.com",
+		TenantID:   "tid",
+		TenantSlug: "acme",
+		MCPState:   "different-state-key",
+		ClientID:   "meridian-mcp",
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/callback?"+url.Values{
+		"code":  {"mismatched-code"},
+		"state": {stateKey},
+	}.Encode(), nil)
+	w := httptest.NewRecorder()
+	handler.HandleCallback(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "consent code binding mismatch")
+}
+
+func TestOIDCHandler_HandleCallback_TenantMismatch(t *testing.T) {
+	consentStore := newFakeConsentStore()
+	handler, stateStore, _ := newConsentOIDCHandler(t, consentStore)
+
+	stateKey, err := stateStore.Store(auth.OIDCFlowState{
+		MCPClientID:    "meridian-mcp",
+		MCPRedirectURI: "https://claude.ai/callback",
+		TenantSlug:     "acme",
+		IssuedAt:       time.Now(),
+	})
+	require.NoError(t, err)
+
+	consentStore.Store("tenant-mismatch-code", auth.ConsentEntry{
+		Email:      "admin@evil.com",
+		TenantID:   "evil-tid",
+		TenantSlug: "evil-corp", // Does not match flowState.TenantSlug
+		MCPState:   stateKey,
+		ClientID:   "meridian-mcp",
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/callback?"+url.Values{
+		"code":  {"tenant-mismatch-code"},
+		"state": {stateKey},
+	}.Encode(), nil)
+	w := httptest.NewRecorder()
+	handler.HandleCallback(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "tenant mismatch")
+}
+
+func TestOIDCHandler_HandleCallback_ScopesInJWT(t *testing.T) {
+	consentStore := newFakeConsentStore()
+	handler, stateStore, codeStore := newConsentOIDCHandler(t, consentStore)
+
+	_, challenge := generatePKCEPair(t)
+
+	stateKey, err := stateStore.Store(auth.OIDCFlowState{
+		MCPCodeChallenge: challenge,
+		MCPClientID:      "meridian-mcp",
+		MCPRedirectURI:   "https://claude.ai/callback",
+		TenantSlug:       "acme",
+		RequestedScopes:  []string{"mcp:default", "mcp:admin"},
+		IssuedAt:         time.Now(),
+	})
+	require.NoError(t, err)
+
+	consentStore.Store("scoped-consent-code", auth.ConsentEntry{
+		Email:          "admin@acme.com",
+		TenantID:       "acme",
+		TenantSlug:     "acme",
+		MCPState:       stateKey,
+		ClientID:       "meridian-mcp",
+		ApprovedScopes: []string{"mcp:default", "mcp:admin"},
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/callback?"+url.Values{
+		"code":  {"scoped-consent-code"},
+		"state": {stateKey},
+	}.Encode(), nil)
+	w := httptest.NewRecorder()
+	handler.HandleCallback(w, req)
+
+	require.Equal(t, http.StatusFound, w.Code)
+
+	location := w.Header().Get("Location")
+	redirectURL, err := url.Parse(location)
+	require.NoError(t, err)
+
+	mcpCode := redirectURL.Query().Get("code")
+	entry, ok := codeStore.Consume(mcpCode)
+	require.True(t, ok)
+
+	// Parse JWT and verify scopes claim
+	signer := newTestSigner(t)
+	_ = signer // We need the signer that was used to create the handler
+	// Instead, decode the JWT payload directly (like extractEmailFromJWT)
+	parts := strings.Split(entry.Token, ".")
+	require.Len(t, parts, 3)
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+
+	var claims map[string]interface{}
+	require.NoError(t, json.Unmarshal(payload, &claims))
+
+	scopesClaim, ok := claims["scopes"].([]interface{})
+	require.True(t, ok, "scopes claim must be an array")
+	assert.Len(t, scopesClaim, 2)
+	assert.Equal(t, "mcp:default", scopesClaim[0])
+	assert.Equal(t, "mcp:admin", scopesClaim[1])
+}
+
+// -----------------------------------------------------------------------
+// Task 4: HandleAuthorize redirects to consent page
+// -----------------------------------------------------------------------
+
+func TestOIDCHandler_HandleAuthorize_RedirectsToConsent(t *testing.T) {
+	consentStore := newFakeConsentStore()
+	handler, _, _ := newConsentOIDCHandler(t, consentStore)
+
+	_, challenge := generatePKCEPair(t)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?"+url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"meridian-mcp"},
+		"redirect_uri":          {"https://claude.ai/callback"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {"client-state-abc"},
+	}.Encode(), nil)
+	req.Host = "acme.demo.meridianhub.cloud"
+	w := httptest.NewRecorder()
+	handler.HandleAuthorize(w, req)
+
+	resp := w.Result()
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+
+	location := resp.Header.Get("Location")
+	redirectURL, err := url.Parse(location)
+	require.NoError(t, err)
+
+	// Should redirect to consent page, NOT Dex
+	assert.Equal(t, "/auth/mcp-consent", redirectURL.Path)
+	assert.NotEmpty(t, redirectURL.Query().Get("mcp_state"))
+	assert.Equal(t, "meridian-mcp", redirectURL.Query().Get("client_id"))
+	// Should use tenant subdomain
+	assert.Equal(t, "acme.demo.meridianhub.cloud", redirectURL.Host)
+	assert.Equal(t, "https", redirectURL.Scheme)
+}
+
+func TestOIDCHandler_HandleAuthorize_StoresScopes(t *testing.T) {
+	consentStore := newFakeConsentStore()
+	handler, stateStore, _ := newConsentOIDCHandler(t, consentStore)
+
+	_, challenge := generatePKCEPair(t)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?"+url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"meridian-mcp"},
+		"redirect_uri":          {"https://claude.ai/callback"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"scope":                 {"mcp:read mcp:write"},
+	}.Encode(), nil)
+	req.Host = "acme.demo.meridianhub.cloud"
+	w := httptest.NewRecorder()
+	handler.HandleAuthorize(w, req)
+
+	require.Equal(t, http.StatusFound, w.Code)
+
+	location := w.Header().Get("Location")
+	redirectURL, err := url.Parse(location)
+	require.NoError(t, err)
+
+	mcpState := redirectURL.Query().Get("mcp_state")
+	require.NotEmpty(t, mcpState)
+
+	// PeekInfo to verify stored scopes
+	_, _, scopes, ok := stateStore.PeekInfo(mcpState)
+	require.True(t, ok)
+	assert.Equal(t, []string{"mcp:read", "mcp:write"}, scopes)
+}
+
+func TestOIDCHandler_HandleAuthorize_DefaultScopes(t *testing.T) {
+	consentStore := newFakeConsentStore()
+	handler, stateStore, _ := newConsentOIDCHandler(t, consentStore)
+
+	_, challenge := generatePKCEPair(t)
+
+	// No scope parameter - should default to ["mcp:default"]
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?"+url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"meridian-mcp"},
+		"redirect_uri":          {"https://claude.ai/callback"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+	}.Encode(), nil)
+	req.Host = "acme.demo.meridianhub.cloud"
+	w := httptest.NewRecorder()
+	handler.HandleAuthorize(w, req)
+
+	require.Equal(t, http.StatusFound, w.Code)
+
+	location := w.Header().Get("Location")
+	redirectURL, err := url.Parse(location)
+	require.NoError(t, err)
+
+	mcpState := redirectURL.Query().Get("mcp_state")
+	require.NotEmpty(t, mcpState)
+
+	_, _, scopes, ok := stateStore.PeekInfo(mcpState)
+	require.True(t, ok)
+	assert.Equal(t, []string{"mcp:default"}, scopes)
+}
+
+func TestOIDCHandler_HandleAuthorize_TenantScopedURL(t *testing.T) {
+	consentStore := newFakeConsentStore()
+	handler, _, _ := newConsentOIDCHandler(t, consentStore)
+
+	_, challenge := generatePKCEPair(t)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?"+url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"meridian-mcp"},
+		"redirect_uri":          {"https://claude.ai/callback"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+	}.Encode(), nil)
+	req.Host = "volterra.demo.meridianhub.cloud"
+	w := httptest.NewRecorder()
+	handler.HandleAuthorize(w, req)
+
+	require.Equal(t, http.StatusFound, w.Code)
+
+	location := w.Header().Get("Location")
+	redirectURL, err := url.Parse(location)
+	require.NoError(t, err)
+
+	assert.Equal(t, "volterra.demo.meridianhub.cloud", redirectURL.Host)
+	assert.Equal(t, "/auth/mcp-consent", redirectURL.Path)
+}


### PR DESCRIPTION
## Summary

- Add `HandleConsentInfo` endpoint (`GET /oauth/consent-info`) returning client metadata (name, redirect URI, scopes, is_dynamic) for the UI consent page
- Modify `HandleCallback` to consume consent codes from `ConsentCodeStore` (via `ConsentCodeConsumer` interface) instead of Dex authorization codes when configured
- Modify `HandleAuthorize` to redirect to `/auth/mcp-consent` on the tenant-scoped domain instead of Dex when consent store is configured
- Add `scopes` claim to issued JWTs
- Default scopes to `["mcp:default"]` when no scope parameter provided
- Preserve Dex legacy path when `ConsentStore` is nil (backwards compatible)

## Design decisions

- **`ConsentCodeConsumer` interface** instead of direct `gateway.ConsentCodeStore` import: the `api-gateway` package pulls in broken `otel/otlptrace` transitive dependencies. The interface decouples the auth package. A `ConsentCodeConsumerFunc` adapter is provided for wiring.
- **Consent entry type duplication**: `auth.ConsentEntry` mirrors `gateway.ConsentCodeEntry` fields. The wiring layer (main.go, Task 5/6) will provide an adapter.
- **Extracted `handleConsentCallback`/`handleDexCallback`**: split from `HandleCallback` to stay under golangci-lint cognitive complexity threshold.

## Test plan

- [x] `TestOIDCHandler_HandleConsentInfo_Success` - valid state returns client metadata
- [x] `TestOIDCHandler_HandleConsentInfo_InvalidState` - expired/missing state returns 400
- [x] `TestOIDCHandler_HandleConsentInfo_ClientMismatch` - client_id mismatch returns 400
- [x] `TestOIDCHandler_HandleConsentInfo_DynamicClient` - dynamic client returns name + is_dynamic
- [x] `TestOIDCHandler_HandleCallback_ConsentCode` - valid consent code issues MCP auth code
- [x] `TestOIDCHandler_HandleCallback_ExpiredConsentCode` - expired code returns 400
- [x] `TestOIDCHandler_HandleCallback_ConsentCodeMismatch` - mcp_state/client_id mismatch returns 400
- [x] `TestOIDCHandler_HandleCallback_TenantMismatch` - tenant slug mismatch returns 400
- [x] `TestOIDCHandler_HandleCallback_ScopesInJWT` - verify scopes claim in JWT
- [x] `TestOIDCHandler_HandleAuthorize_RedirectsToConsent` - verify redirect to consent page, not Dex
- [x] `TestOIDCHandler_HandleAuthorize_StoresScopes` - verify RequestedScopes stored in state
- [x] `TestOIDCHandler_HandleAuthorize_DefaultScopes` - default ["mcp:default"] when no scope param
- [x] `TestOIDCHandler_HandleAuthorize_TenantScopedURL` - redirect includes tenant subdomain
- [x] All existing tests pass (backwards compatible with Dex path)