### PR TITLE
feat: Add OAuth MCP consent page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { TooltipProvider } from '@/components/ui/tooltip'
 import { Toaster } from 'sonner'
 import { CallbackPage } from '@/pages/callback'
 import { LoginPage } from '@/pages/login'
+import { OAuthConsentPage } from '@/pages/oauth-consent'
 import { RegisterPage } from '@/features/registration/pages/register-page'
 import { DashboardPage } from '@/features/dashboard'
 import { AccountDetailPage } from '@/features/accounts/pages/[accountId]'
@@ -355,6 +356,7 @@ function AuthenticatedApp() {
               <Route path="/login" element={<LoginPage />} />
               <Route path="/register" element={<RegisterPage />} />
               <Route path="/callback" element={<CallbackPage />} />
+              <Route path="/auth/mcp-consent" element={<OAuthConsentPage />} />
               <Route
                 path="/*"
                 element={

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -341,9 +341,7 @@ function DevTenantAutoSelector() {
   return null
 }
 
-/**
- * Inner app that has access to auth and tenant contexts for ApiClientProvider.
- */
+/** Inner app that has access to auth and tenant contexts for ApiClientProvider. */
 function AuthenticatedApp() {
   return (
     <TenantProvider>

--- a/frontend/src/components/consent-card.tsx
+++ b/frontend/src/components/consent-card.tsx
@@ -1,0 +1,76 @@
+interface ConsentInfo {
+  client_name: string
+  redirect_uri: string
+  scopes: string[]
+  is_dynamic_client: boolean
+}
+
+interface ConsentCardProps {
+  consentInfo: ConsentInfo
+  onApprove: () => void
+  onDeny: () => void
+  loading: boolean
+}
+
+export function ConsentCard({ consentInfo, onApprove, onDeny, loading }: ConsentCardProps) {
+  return (
+    <div className="w-full max-w-md rounded-lg border border-border bg-card p-6 shadow-sm space-y-5">
+      <div>
+        <h1 className="text-xl font-semibold">Authorize Access</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          An application is requesting access to your Meridian account.
+        </p>
+      </div>
+
+      <div className="rounded-md border border-border bg-muted/40 p-4 space-y-3 text-sm">
+        <div>
+          <span className="font-medium">Application</span>
+          <p className="text-muted-foreground mt-0.5">
+            {consentInfo.client_name}
+            {consentInfo.is_dynamic_client && (
+              <span className="ml-2 inline-flex items-center rounded-full bg-warning/20 px-2 py-0.5 text-xs font-medium text-warning-foreground">
+                Dynamic client
+              </span>
+            )}
+          </p>
+        </div>
+        <div>
+          <span className="font-medium">Redirect URI</span>
+          <p className="text-muted-foreground mt-0.5 break-all font-mono text-xs">
+            {consentInfo.redirect_uri}
+          </p>
+        </div>
+        {consentInfo.scopes.length > 0 && (
+          <div>
+            <span className="font-medium">Requested scopes</span>
+            <ul className="mt-1 space-y-1">
+              {consentInfo.scopes.map((scope) => (
+                <li key={scope} className="flex items-center gap-2 text-muted-foreground">
+                  <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/60 shrink-0" />
+                  <span className="font-mono text-xs">{scope}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+
+      <div className="flex gap-3">
+        <button
+          onClick={onApprove}
+          disabled={loading}
+          className="flex-1 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          {loading ? 'Processing...' : 'Approve'}
+        </button>
+        <button
+          onClick={onDeny}
+          disabled={loading}
+          className="flex-1 rounded-md border border-border bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-muted disabled:opacity-50"
+        >
+          Deny
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/consent-card.tsx
+++ b/frontend/src/components/consent-card.tsx
@@ -1,8 +1,8 @@
-interface ConsentInfo {
+export interface ConsentInfo {
   client_name: string
   redirect_uri: string
   scopes: string[]
-  is_dynamic_client: boolean
+  is_dynamic: boolean
 }
 
 interface ConsentCardProps {
@@ -27,7 +27,7 @@ export function ConsentCard({ consentInfo, onApprove, onDeny, loading }: Consent
           <span className="font-medium">Application</span>
           <p className="text-muted-foreground mt-0.5">
             {consentInfo.client_name}
-            {consentInfo.is_dynamic_client && (
+            {consentInfo.is_dynamic && (
               <span className="ml-2 inline-flex items-center rounded-full bg-warning/20 px-2 py-0.5 text-xs font-medium text-warning-foreground">
                 Dynamic client
               </span>

--- a/frontend/src/pages/oauth-consent.test.tsx
+++ b/frontend/src/pages/oauth-consent.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { AuthProvider } from '@/contexts/auth-context'
+import { TenantProvider } from '@/contexts/tenant-context'
+import { OAuthConsentPage } from '@/pages/oauth-consent'
+import { server } from '@/test/msw-handlers'
+import { createTestQueryClient } from '@/test/test-utils'
+import { createTenantUserToken } from '@/test/jwt-helpers'
+
+const CONSENT_PATH = '/auth/mcp-consent?mcp_state=state-abc&client_id=client-123'
+
+const MOCK_CONSENT_INFO = {
+  client_name: 'My MCP App',
+  redirect_uri: 'http://localhost:3000/callback',
+  scopes: ['read', 'write'],
+  is_dynamic_client: false,
+}
+
+function TestWrapper({
+  children,
+  initialToken,
+  initialPath = CONSENT_PATH,
+}: {
+  children: React.ReactNode
+  initialToken?: string
+  initialPath?: string
+}) {
+  const queryClient = createTestQueryClient()
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider initialToken={initialToken}>
+        <TenantProvider>
+          <MemoryRouter initialEntries={[initialPath]}>
+            <Routes>
+              <Route path="/login" element={<div data-testid="login-page">Login Page</div>} />
+              <Route path="/auth/mcp-consent" element={children} />
+            </Routes>
+          </MemoryRouter>
+        </TenantProvider>
+      </AuthProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('OAuthConsentPage', () => {
+  it('redirects unauthenticated user to /login with return_url', () => {
+    render(
+      <TestWrapper>
+        <OAuthConsentPage />
+      </TestWrapper>,
+    )
+
+    expect(screen.getByTestId('login-page')).toBeInTheDocument()
+    expect(screen.queryByText('Authorize Access')).not.toBeInTheDocument()
+  })
+
+  it('fetches consent-info when authenticated', async () => {
+    server.use(
+      http.get('/mcp/consent-info', () => {
+        return HttpResponse.json(MOCK_CONSENT_INFO)
+      }),
+    )
+
+    const token = createTenantUserToken()
+    render(
+      <TestWrapper initialToken={token}>
+        <OAuthConsentPage />
+      </TestWrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Authorize Access')).toBeInTheDocument()
+    })
+  })
+
+  it('displays client name from consent-info response', async () => {
+    server.use(
+      http.get('/mcp/consent-info', () => {
+        return HttpResponse.json(MOCK_CONSENT_INFO)
+      }),
+    )
+
+    const token = createTenantUserToken()
+    render(
+      <TestWrapper initialToken={token}>
+        <OAuthConsentPage />
+      </TestWrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('My MCP App')).toBeInTheDocument()
+    })
+  })
+
+  it('approve button sends correct POST with action approve', async () => {
+    const user = userEvent.setup()
+    let capturedBody: unknown = null
+
+    server.use(
+      http.get('/mcp/consent-info', () => {
+        return HttpResponse.json(MOCK_CONSENT_INFO)
+      }),
+      http.post('/api/auth/mcp-consent', async ({ request }) => {
+        capturedBody = await request.json()
+        // Return a redirect; jsdom will attempt assignment but we just verify the body
+        return HttpResponse.json({ redirect_url: 'http://localhost:3000/callback?code=xyz' })
+      }),
+    )
+
+    const token = createTenantUserToken()
+    render(
+      <TestWrapper initialToken={token}>
+        <OAuthConsentPage />
+      </TestWrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Approve')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('Approve'))
+
+    await waitFor(() => {
+      expect(capturedBody).toEqual({
+        mcp_state: 'state-abc',
+        client_id: 'client-123',
+        action: 'approve',
+      })
+    })
+  })
+
+  it('deny button sends correct POST with action deny', async () => {
+    const user = userEvent.setup()
+    let capturedBody: unknown = null
+
+    server.use(
+      http.get('/mcp/consent-info', () => {
+        return HttpResponse.json(MOCK_CONSENT_INFO)
+      }),
+      http.post('/api/auth/mcp-consent', async ({ request }) => {
+        capturedBody = await request.json()
+        return HttpResponse.json({ redirect_url: 'http://localhost:3000/callback?error=access_denied' })
+      }),
+    )
+
+    const token = createTenantUserToken()
+    render(
+      <TestWrapper initialToken={token}>
+        <OAuthConsentPage />
+      </TestWrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Deny')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('Deny'))
+
+    await waitFor(() => {
+      expect(capturedBody).toEqual({
+        mcp_state: 'state-abc',
+        client_id: 'client-123',
+        action: 'deny',
+      })
+    })
+  })
+})

--- a/frontend/src/pages/oauth-consent.test.tsx
+++ b/frontend/src/pages/oauth-consent.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { render } from '@testing-library/react'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { http, HttpResponse } from 'msw'
 import { AuthProvider } from '@/contexts/auth-context'
@@ -18,7 +18,13 @@ const MOCK_CONSENT_INFO = {
   client_name: 'My MCP App',
   redirect_uri: 'http://localhost:3000/callback',
   scopes: ['read', 'write'],
-  is_dynamic_client: false,
+  is_dynamic: false,
+}
+
+/** Captures the full location (pathname + search) for the rendered /login route */
+function LoginCapture() {
+  const location = useLocation()
+  return <div data-testid="login-page" data-location={location.pathname + location.search}>Login Page</div>
 }
 
 function TestWrapper({
@@ -37,7 +43,7 @@ function TestWrapper({
         <TenantProvider>
           <MemoryRouter initialEntries={[initialPath]}>
             <Routes>
-              <Route path="/login" element={<div data-testid="login-page">Login Page</div>} />
+              <Route path="/login" element={<LoginCapture />} />
               <Route path="/auth/mcp-consent" element={children} />
             </Routes>
           </MemoryRouter>
@@ -55,7 +61,12 @@ describe('OAuthConsentPage', () => {
       </TestWrapper>,
     )
 
-    expect(screen.getByTestId('login-page')).toBeInTheDocument()
+    const loginPage = screen.getByTestId('login-page')
+    expect(loginPage).toBeInTheDocument()
+    const location = loginPage.getAttribute('data-location') ?? ''
+    const decoded = decodeURIComponent(location)
+    expect(decoded).toContain('return_url')
+    expect(decoded).toContain('/auth/mcp-consent')
     expect(screen.queryByText('Authorize Access')).not.toBeInTheDocument()
   })
 

--- a/frontend/src/pages/oauth-consent.tsx
+++ b/frontend/src/pages/oauth-consent.tsx
@@ -1,14 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useAuth } from '@/contexts/auth-context'
-import { ConsentCard } from '@/components/consent-card'
-
-interface ConsentInfo {
-  client_name: string
-  redirect_uri: string
-  scopes: string[]
-  is_dynamic_client: boolean
-}
+import { ConsentCard, type ConsentInfo } from '@/components/consent-card'
 
 interface ConsentResponse {
   redirect_url: string
@@ -34,9 +27,9 @@ export function OAuthConsentPage() {
     }
   }, [isAuthenticated, navigate, mcpState, clientId])
 
-  // Fetch consent info once authenticated
+  // Fetch consent info once authenticated, with both params present
   useEffect(() => {
-    if (!isAuthenticated || !clientId) return
+    if (!isAuthenticated || !clientId || !mcpState) return
 
     const params = new URLSearchParams({ client_id: clientId, mcp_state: mcpState })
     fetch(`/mcp/consent-info?${params.toString()}`)
@@ -55,6 +48,8 @@ export function OAuthConsentPage() {
   }, [isAuthenticated, clientId, mcpState])
 
   const handleConsent = async (action: 'approve' | 'deny') => {
+    if (!accessToken || !mcpState || !clientId) return
+
     setLoading(true)
     try {
       const res = await fetch('/api/auth/mcp-consent', {
@@ -83,6 +78,18 @@ export function OAuthConsentPage() {
 
   if (!isAuthenticated) {
     return null
+  }
+
+  if (!mcpState || !clientId) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="w-full max-w-md space-y-4 px-4">
+          <p role="alert" className="rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            Missing required authorization parameters.
+          </p>
+        </div>
+      </div>
+    )
   }
 
   if (fetchError) {

--- a/frontend/src/pages/oauth-consent.tsx
+++ b/frontend/src/pages/oauth-consent.tsx
@@ -1,0 +1,118 @@
+import { useState, useEffect } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useAuth } from '@/contexts/auth-context'
+import { ConsentCard } from '@/components/consent-card'
+
+interface ConsentInfo {
+  client_name: string
+  redirect_uri: string
+  scopes: string[]
+  is_dynamic_client: boolean
+}
+
+interface ConsentResponse {
+  redirect_url: string
+}
+
+export function OAuthConsentPage() {
+  const { isAuthenticated, accessToken } = useAuth()
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+
+  const mcpState = searchParams.get('mcp_state') ?? ''
+  const clientId = searchParams.get('client_id') ?? ''
+
+  const [consentInfo, setConsentInfo] = useState<ConsentInfo | null>(null)
+  const [fetchError, setFetchError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  // Redirect to login if not authenticated
+  useEffect(() => {
+    if (!isAuthenticated) {
+      const returnUrl = `/auth/mcp-consent?mcp_state=${encodeURIComponent(mcpState)}&client_id=${encodeURIComponent(clientId)}`
+      navigate(`/login?return_url=${encodeURIComponent(returnUrl)}`, { replace: true })
+    }
+  }, [isAuthenticated, navigate, mcpState, clientId])
+
+  // Fetch consent info once authenticated
+  useEffect(() => {
+    if (!isAuthenticated || !clientId) return
+
+    const params = new URLSearchParams({ client_id: clientId, mcp_state: mcpState })
+    fetch(`/mcp/consent-info?${params.toString()}`)
+      .then(async (res) => {
+        if (!res.ok) {
+          const data = (await res.json().catch(() => null)) as { error?: string } | null
+          setFetchError(data?.error ?? 'Failed to load consent information')
+          return
+        }
+        const data = (await res.json()) as ConsentInfo
+        setConsentInfo(data)
+      })
+      .catch(() => {
+        setFetchError('Unable to reach the authorization service')
+      })
+  }, [isAuthenticated, clientId, mcpState])
+
+  const handleConsent = async (action: 'approve' | 'deny') => {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/auth/mcp-consent', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ mcp_state: mcpState, client_id: clientId, action }),
+      })
+
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null
+        setFetchError(data?.error ?? 'Authorization request failed')
+        return
+      }
+
+      const data = (await res.json()) as ConsentResponse
+      window.location.href = data.redirect_url
+    } catch {
+      setFetchError('Unable to reach the authorization service')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!isAuthenticated) {
+    return null
+  }
+
+  if (fetchError) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="w-full max-w-md space-y-4 px-4">
+          <p role="alert" className="rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            {fetchError}
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!consentInfo) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <ConsentCard
+        consentInfo={consentInfo}
+        onApprove={() => void handleConsent('approve')}
+        onDeny={() => void handleConsent('deny')}
+        loading={loading}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `/auth/mcp-consent` route outside `ProtectedRoute` (auth checked internally)
- `OAuthConsentPage` reads `mcp_state` and `client_id` from URL params, redirects to `/login` if unauthenticated, fetches `GET /mcp/consent-info` for client metadata, then renders a consent card
- On approve/deny: `POST /api/auth/mcp-consent` with JWT Bearer, redirects browser to `redirect_url` from response
- `ConsentCard` component follows existing LoginPage Tailwind styling patterns

## Test plan
- [ ] Unauthenticated user redirects to /login with return_url
- [ ] Authenticated user fetches consent-info
- [ ] Client name displayed from consent-info response
- [ ] Approve button sends correct POST with action: "approve"
- [ ] Deny button sends correct POST with action: "deny"
- All 5 tests pass locally