### PR TITLE
feat: wire shared MCP OAuth stores in unified binary

### DIFF
--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -329,6 +329,12 @@ func setupAndStartGateway(ctx context.Context, infra *unifiedInfra, grpcPort, ht
 	bffSigner, bffAuthOpts := wireBFFAuth(infra.conns.gormDB("identity"), logger)
 	extraGWOpts = append(extraGWOpts, bffAuthOpts...)
 
+	mcpOAuthOpts, mcpOAuthCleanup := wireMCPOAuth(bffSigner, logger)
+	extraGWOpts = append(extraGWOpts, mcpOAuthOpts...)
+	if mcpOAuthCleanup != nil {
+		defer mcpOAuthCleanup()
+	}
+
 	baseDomain := env.GetEnvOrDefault("BASE_DOMAIN", "localhost")
 	identityEmailOutboxRepo := email.NewPostgresOutboxRepository(infra.conns.gormDB("identity"))
 	if regOpt := wireRegistration(infra.conns.gormDB("identity"), infra.conns.gormDB("tenant"), infra.loopback.rawConn, baseDomain, identityEmailOutboxRepo, logger); regOpt != nil {

--- a/cmd/meridian/mcp_oauth_wiring_test.go
+++ b/cmd/meridian/mcp_oauth_wiring_test.go
@@ -1,0 +1,464 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	gateway "github.com/meridianhub/meridian/services/api-gateway"
+	gwauth "github.com/meridianhub/meridian/services/api-gateway/auth"
+	"github.com/meridianhub/meridian/services/mcp-server/oauthwiring"
+	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testSigner creates a JWT signer with an auto-generated RSA key for testing.
+func testSigner(t *testing.T) *platformauth.JWTSigner {
+	t.Helper()
+	signer, err := platformauth.NewJWTSigner(platformauth.JWTSignerConfig{
+		KeyID:  "test-key-1",
+		Issuer: "meridian-test",
+	})
+	require.NoError(t, err)
+	return signer
+}
+
+// buildTestGateway creates a gateway server wired with MCP OAuth endpoints
+// and a BFF consent handler sharing the same stores.
+func buildTestGateway(t *testing.T, signer *platformauth.JWTSigner, baseDomain string) (*gateway.Server, func()) {
+	t.Helper()
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	consentStore := gateway.NewConsentCodeStore()
+	consentConsumer := &consentStoreAdapter{store: consentStore}
+
+	endpoints, mcpCleanup, err := oauthwiring.Wire(oauthwiring.Config{
+		Signer:            signer,
+		BaseDomain:        baseDomain,
+		BaseURL:           "http://localhost:8090",
+		ClientID:          "test-mcp-client",
+		RedirectURI:       "http://localhost:8090/oauth/callback",
+		TokenTTL:          time.Hour,
+		DefaultTenantSlug: "test-tenant",
+		Logger:            logger,
+	}, consentConsumer)
+	require.NoError(t, err)
+
+	oidcPeeker := &oidcStatePeekerAdapter{store: endpoints.StateStore}
+	consentHandler := gateway.NewMCPConsentHandler(gateway.MCPConsentHandlerConfig{
+		ConsentStore:   consentStore,
+		OIDCStateStore: oidcPeeker,
+		Logger:         logger,
+	})
+
+	config := &gateway.Config{
+		Port:       0,
+		BaseDomain: baseDomain,
+	}
+
+	srv := gateway.NewServer(config, logger, nil,
+		gateway.WithMCPConsentHandler(consentHandler),
+		gateway.WithMCPOAuthEndpoints(&gateway.MCPOAuthEndpoints{
+			Authorize:   endpoints.Authorize,
+			Callback:    endpoints.Callback,
+			Token:       endpoints.Token,
+			ConsentInfo: endpoints.ConsentInfo,
+			Metadata:    endpoints.Metadata,
+			Register:    endpoints.Register,
+		}),
+	)
+
+	cleanup := func() {
+		consentStore.Close()
+		if mcpCleanup != nil {
+			mcpCleanup()
+		}
+	}
+
+	return srv, cleanup
+}
+
+func pkceChallenge(verifier string) string {
+	h := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(h[:])
+}
+
+// withAuthClaims injects JWT claims and tenant slug into the request context,
+// simulating what the gateway auth middleware chain does.
+func withAuthClaims(ctx context.Context, email, tenantID, tenantSlug string) context.Context {
+	claims := &platformauth.Claims{
+		Email:    email,
+		TenantID: tenantID,
+	}
+	ctx = context.WithValue(ctx, gwauth.ClaimsContextKey, claims)
+	ctx = tenant.WithSlug(ctx, tenantSlug)
+	return ctx
+}
+
+// doGet performs an HTTP GET with context.
+func doGet(ctx context.Context, client *http.Client, url string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return client.Do(req)
+}
+
+// doPostForm performs an HTTP POST with form values and context.
+func doPostForm(ctx context.Context, client *http.Client, url string, data url.Values) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return client.Do(req)
+}
+
+// doPostJSON performs an HTTP POST with JSON body and context.
+func doPostJSON(ctx context.Context, client *http.Client, url, body string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return client.Do(req)
+}
+
+// TestMCPOAuthFullApproveFlow tests the complete consent-based OAuth flow:
+// authorize -> consent-info -> approve -> callback -> token exchange.
+func TestMCPOAuthFullApproveFlow(t *testing.T) {
+	ctx := context.Background()
+	signer := testSigner(t)
+	srv, cleanup := buildTestGateway(t, signer, "localhost")
+	defer cleanup()
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	challenge := pkceChallenge(verifier)
+
+	// Step 1: GET /oauth/authorize - should redirect to consent page.
+	noRedirect := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	resp, err := doGet(ctx, noRedirect, ts.URL+"/oauth/authorize?"+url.Values{
+		"client_id":             {"test-mcp-client"},
+		"response_type":         {"code"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"redirect_uri":          {"http://localhost:8090/oauth/callback"},
+		"state":                 {"mcp-client-state"},
+		"scope":                 {"mcp:default"},
+	}.Encode())
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusFound, resp.StatusCode, "authorize should redirect to consent page")
+
+	redirectLocation := resp.Header.Get("Location")
+	require.Contains(t, redirectLocation, "/auth/mcp-consent", "should redirect to consent page")
+
+	// Parse the mcp_state from the redirect URL.
+	redirectURL, err := url.Parse(redirectLocation)
+	require.NoError(t, err)
+	mcpState := redirectURL.Query().Get("mcp_state")
+	require.NotEmpty(t, mcpState, "mcp_state should be in redirect")
+
+	// Step 2: GET /oauth/consent-info - verify flow metadata.
+	infoResp, err := doGet(ctx, http.DefaultClient, ts.URL+"/oauth/consent-info?"+url.Values{
+		"client_id": {"test-mcp-client"},
+		"mcp_state": {mcpState},
+	}.Encode())
+	require.NoError(t, err)
+	defer infoResp.Body.Close()
+	require.Equal(t, http.StatusOK, infoResp.StatusCode)
+
+	var infoBody map[string]interface{}
+	require.NoError(t, json.NewDecoder(infoResp.Body).Decode(&infoBody))
+	assert.Equal(t, "test-mcp-client", infoBody["client_id"])
+
+	// Step 3: POST /api/auth/mcp-consent (approve).
+	// The consent handler is behind auth middleware in production, but in this
+	// test there is no auth middleware. The handler reads claims from context,
+	// so we call it directly via the mux with injected context.
+	consentBody := `{"mcp_state":"` + mcpState + `","client_id":"test-mcp-client","action":"approve"}`
+	req := httptest.NewRequest("POST", "/api/auth/mcp-consent", strings.NewReader(consentBody))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(withAuthClaims(req.Context(), "test@example.com", "tenant-123", "test-tenant"))
+
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "consent approve should succeed")
+
+	var consentResp map[string]string
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&consentResp))
+	consentRedirect := consentResp["redirect_url"]
+	require.Contains(t, consentRedirect, "/oauth/callback", "should redirect to callback")
+	require.Contains(t, consentRedirect, "code=", "should include consent code")
+	require.Contains(t, consentRedirect, "state="+url.QueryEscape(mcpState), "should include state")
+
+	// Step 4: GET /oauth/callback - exchange consent code for auth code.
+	callbackResp, err := doGet(ctx, noRedirect, ts.URL+consentRedirect)
+	require.NoError(t, err)
+	defer callbackResp.Body.Close()
+	require.Equal(t, http.StatusFound, callbackResp.StatusCode, "callback should redirect to MCP client")
+
+	callbackLocation := callbackResp.Header.Get("Location")
+	require.Contains(t, callbackLocation, "code=", "callback redirect should include auth code")
+	require.Contains(t, callbackLocation, "state=mcp-client-state", "should forward MCP client state")
+
+	// Extract the authorization code from the redirect.
+	callbackRedirectURL, err := url.Parse(callbackLocation)
+	require.NoError(t, err)
+	authCode := callbackRedirectURL.Query().Get("code")
+	require.NotEmpty(t, authCode)
+
+	// Step 5: POST /oauth/token - exchange auth code + PKCE verifier for JWT.
+	tokenResp, err := doPostForm(ctx, http.DefaultClient, ts.URL+"/oauth/token", url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {authCode},
+		"code_verifier": {verifier},
+		"client_id":     {"test-mcp-client"},
+		"redirect_uri":  {"http://localhost:8090/oauth/callback"},
+	})
+	require.NoError(t, err)
+	defer tokenResp.Body.Close()
+	require.Equal(t, http.StatusOK, tokenResp.StatusCode)
+
+	var tokenBody map[string]interface{}
+	require.NoError(t, json.NewDecoder(tokenResp.Body).Decode(&tokenBody))
+	accessToken, ok := tokenBody["access_token"].(string)
+	require.True(t, ok, "response should include access_token")
+	require.NotEmpty(t, accessToken, "access_token should not be empty")
+	assert.Equal(t, "Bearer", tokenBody["token_type"])
+}
+
+// TestMCPOAuthDenyFlow tests that denying consent returns an error redirect.
+func TestMCPOAuthDenyFlow(t *testing.T) {
+	ctx := context.Background()
+	signer := testSigner(t)
+	srv, cleanup := buildTestGateway(t, signer, "localhost")
+	defer cleanup()
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	challenge := pkceChallenge(verifier)
+
+	noRedirect := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	resp, err := doGet(ctx, noRedirect, ts.URL+"/oauth/authorize?"+url.Values{
+		"client_id":             {"test-mcp-client"},
+		"response_type":         {"code"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"redirect_uri":          {"http://localhost:8090/oauth/callback"},
+		"state":                 {"mcp-deny-state"},
+		"scope":                 {"mcp:default"},
+	}.Encode())
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	redirectURL, err := url.Parse(resp.Header.Get("Location"))
+	require.NoError(t, err)
+	mcpState := redirectURL.Query().Get("mcp_state")
+
+	// Deny consent.
+	consentBody := `{"mcp_state":"` + mcpState + `","client_id":"test-mcp-client","action":"deny"}`
+	req := httptest.NewRequest("POST", "/api/auth/mcp-consent", strings.NewReader(consentBody))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(withAuthClaims(req.Context(), "test@example.com", "tenant-123", "test-tenant"))
+
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var denyResp map[string]string
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&denyResp))
+	denyRedirect := denyResp["redirect_url"]
+	require.Contains(t, denyRedirect, "error=access_denied", "deny should return access_denied error")
+	require.Contains(t, denyRedirect, "state=mcp-deny-state", "should include original MCP client state")
+}
+
+// TestMCPOAuthPKCEIntegrity ensures that a wrong PKCE verifier is rejected at token exchange.
+func TestMCPOAuthPKCEIntegrity(t *testing.T) {
+	ctx := context.Background()
+	signer := testSigner(t)
+	srv, cleanup := buildTestGateway(t, signer, "localhost")
+	defer cleanup()
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	verifier := "correct-verifier-for-pkce-test"
+	challenge := pkceChallenge(verifier)
+
+	noRedirect := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+
+	// Authorize
+	resp, err := doGet(ctx, noRedirect, ts.URL+"/oauth/authorize?"+url.Values{
+		"client_id":             {"test-mcp-client"},
+		"response_type":         {"code"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"redirect_uri":          {"http://localhost:8090/oauth/callback"},
+		"scope":                 {"mcp:default"},
+	}.Encode())
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	redirectURL, err := url.Parse(resp.Header.Get("Location"))
+	require.NoError(t, err)
+	mcpState := redirectURL.Query().Get("mcp_state")
+
+	// Approve consent
+	consentBody := `{"mcp_state":"` + mcpState + `","client_id":"test-mcp-client","action":"approve"}`
+	req := httptest.NewRequest("POST", "/api/auth/mcp-consent", strings.NewReader(consentBody))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(withAuthClaims(req.Context(), "test@example.com", "tenant-123", "test-tenant"))
+
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var consentResp map[string]string
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&consentResp))
+
+	// Callback
+	callbackResp, err := doGet(ctx, noRedirect, ts.URL+consentResp["redirect_url"])
+	require.NoError(t, err)
+	defer callbackResp.Body.Close()
+
+	callbackURL, err := url.Parse(callbackResp.Header.Get("Location"))
+	require.NoError(t, err)
+	authCode := callbackURL.Query().Get("code")
+
+	// Token exchange with WRONG verifier
+	tokenResp, err := doPostForm(ctx, http.DefaultClient, ts.URL+"/oauth/token", url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {authCode},
+		"code_verifier": {"wrong-verifier-should-fail"},
+		"client_id":     {"test-mcp-client"},
+	})
+	require.NoError(t, err)
+	defer tokenResp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, tokenResp.StatusCode, "wrong PKCE verifier should fail")
+
+	body, _ := io.ReadAll(tokenResp.Body)
+	assert.Contains(t, string(body), "PKCE", "error should mention PKCE")
+}
+
+// TestMCPOAuthTenantIsolation verifies that cross-tenant consent is rejected.
+func TestMCPOAuthTenantIsolation(t *testing.T) {
+	ctx := context.Background()
+	signer := testSigner(t)
+	srv, cleanup := buildTestGateway(t, signer, "example.com")
+	defer cleanup()
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	verifier := "tenant-isolation-verifier"
+	challenge := pkceChallenge(verifier)
+
+	noRedirect := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+
+	// Authorize - uses default tenant slug "test-tenant" since no subdomain.
+	resp, err := doGet(ctx, noRedirect, ts.URL+"/oauth/authorize?"+url.Values{
+		"client_id":             {"test-mcp-client"},
+		"response_type":         {"code"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"redirect_uri":          {"http://localhost:8090/oauth/callback"},
+		"scope":                 {"mcp:default"},
+	}.Encode())
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	redirectURL, err := url.Parse(resp.Header.Get("Location"))
+	require.NoError(t, err)
+	mcpState := redirectURL.Query().Get("mcp_state")
+	require.NotEmpty(t, mcpState)
+
+	// Attempt consent with a DIFFERENT tenant slug.
+	consentBody := `{"mcp_state":"` + mcpState + `","client_id":"test-mcp-client","action":"approve"}`
+	req := httptest.NewRequest("POST", "/api/auth/mcp-consent", strings.NewReader(consentBody))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(withAuthClaims(req.Context(), "attacker@example.com", "different-tenant-id", "different-tenant"))
+
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	require.Equal(t, http.StatusForbidden, w.Code, "cross-tenant consent should be rejected")
+
+	var errResp map[string]string
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&errResp))
+	assert.Equal(t, "tenant_mismatch", errResp["error"])
+}
+
+// TestMCPOAuthMetadataEndpoint verifies the OAuth authorization server metadata.
+func TestMCPOAuthMetadataEndpoint(t *testing.T) {
+	ctx := context.Background()
+	signer := testSigner(t)
+	srv, cleanup := buildTestGateway(t, signer, "localhost")
+	defer cleanup()
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp, err := doGet(ctx, http.DefaultClient, ts.URL+"/.well-known/oauth-authorization-server")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var meta map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&meta))
+	assert.Contains(t, meta["authorization_endpoint"], "/oauth/authorize")
+	assert.Contains(t, meta["token_endpoint"], "/oauth/token")
+	assert.Contains(t, meta["registration_endpoint"], "/oauth/register")
+}
+
+// TestMCPOAuthDynamicClientRegistration verifies dynamic client registration works.
+func TestMCPOAuthDynamicClientRegistration(t *testing.T) {
+	ctx := context.Background()
+	signer := testSigner(t)
+	srv, cleanup := buildTestGateway(t, signer, "localhost")
+	defer cleanup()
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	regBody := `{
+		"client_name": "Test MCP Client",
+		"redirect_uris": ["https://example.com/callback"],
+		"grant_types": ["authorization_code"],
+		"response_types": ["code"],
+		"token_endpoint_auth_method": "none"
+	}`
+	resp, err := doPostJSON(ctx, http.DefaultClient, ts.URL+"/oauth/register", regBody)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	var regResp map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&regResp))
+	assert.NotEmpty(t, regResp["client_id"])
+	assert.Equal(t, "Test MCP Client", regResp["client_name"])
+}

--- a/cmd/meridian/wire_gateway.go
+++ b/cmd/meridian/wire_gateway.go
@@ -11,6 +11,7 @@ import (
 	identitypersistence "github.com/meridianhub/meridian/services/identity/adapters/persistence"
 	identityconnector "github.com/meridianhub/meridian/services/identity/connector"
 	identitydex "github.com/meridianhub/meridian/services/identity/dex"
+	"github.com/meridianhub/meridian/services/mcp-server/oauthwiring"
 	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/env"
 
@@ -108,4 +109,141 @@ func wireBFFAuth(identityDB *gorm.DB, logger *slog.Logger) (*platformauth.JWTSig
 		"token_ttl", tokenTTL)
 
 	return signer, []gateway.ServerOption{gateway.WithAuthHandler(handler)}
+}
+
+// wireMCPOAuth creates shared in-memory stores and wires the consent-based OAuth
+// 2.1 flow for the unified binary. The BFF consent handler and the MCP OIDC handler
+// share the same ConsentCodeStore and OIDCStateStore, enabling the full flow:
+//
+//	MCP client -> /oauth/authorize -> consent page -> POST /api/auth/mcp-consent
+//	           -> /oauth/callback -> /oauth/token -> MCP client has JWT
+//
+// Returns gateway ServerOptions to mount both the consent handler and OAuth endpoints,
+// plus a cleanup function to stop background goroutines.
+// Returns (nil, noop) when MCP OAuth is not enabled or the signer is unavailable.
+func wireMCPOAuth(signer *platformauth.JWTSigner, logger *slog.Logger) ([]gateway.ServerOption, func()) {
+	noop := func() {}
+
+	if signer == nil {
+		logger.Info("MCP OAuth disabled: no JWT signer available")
+		return nil, noop
+	}
+
+	if env.GetEnvOrDefault("MCP_OAUTH_ENABLED", "false") != "true" {
+		logger.Info("MCP OAuth disabled: MCP_OAUTH_ENABLED not set")
+		return nil, noop
+	}
+
+	baseDomain := env.GetEnvOrDefault("BASE_DOMAIN", "localhost")
+	baseURL := env.GetEnvOrDefault("MCP_BASE_URL", "")
+	clientID := env.GetEnvOrDefault("MCP_OAUTH_CLIENT_ID", "meridian-mcp")
+	redirectURI := env.GetEnvOrDefault("MCP_OAUTH_REDIRECT_URI", baseURL+"/oauth/callback")
+	tokenTTL := env.GetEnvAsDuration("JWT_TOKEN_TTL", time.Hour)
+
+	// Create the BFF-side consent code store.
+	consentStore := gateway.NewConsentCodeStore()
+
+	// Adapter: gateway.ConsentCodeStore -> oauthwiring.ConsentCodeConsumer
+	consentConsumer := &consentStoreAdapter{store: consentStore}
+
+	// Wire MCP OAuth endpoints via the public oauthwiring package.
+	endpoints, mcpCleanup, err := oauthwiring.Wire(oauthwiring.Config{
+		Signer:            signer,
+		BaseDomain:        baseDomain,
+		BaseURL:           baseURL,
+		ClientID:          clientID,
+		RedirectURI:       redirectURI,
+		TokenTTL:          tokenTTL,
+		DefaultTenantSlug: env.GetEnvOrDefault("MCP_DEFAULT_TENANT_SLUG", ""),
+		Logger:            logger.With("component", "mcp-oauth"),
+	}, consentConsumer)
+	if err != nil {
+		logger.Error("failed to wire MCP OAuth, MCP OAuth disabled", "error", err)
+		consentStore.Close()
+		return nil, noop
+	}
+
+	// Adapter: oauthwiring.OIDCStateStore -> gateway.OIDCStatePeeker
+	oidcPeeker := &oidcStatePeekerAdapter{store: endpoints.StateStore}
+
+	consentHandler := gateway.NewMCPConsentHandler(gateway.MCPConsentHandlerConfig{
+		ConsentStore:   consentStore,
+		OIDCStateStore: oidcPeeker,
+		Logger:         logger.With("component", "mcp-consent"),
+	})
+
+	cleanup := func() {
+		consentStore.Close()
+		if mcpCleanup != nil {
+			mcpCleanup()
+		}
+	}
+
+	opts := []gateway.ServerOption{
+		gateway.WithMCPConsentHandler(consentHandler),
+		gateway.WithMCPOAuthEndpoints(&gateway.MCPOAuthEndpoints{
+			Authorize:   endpoints.Authorize,
+			Callback:    endpoints.Callback,
+			Token:       endpoints.Token,
+			ConsentInfo: endpoints.ConsentInfo,
+			Metadata:    endpoints.Metadata,
+			Register:    endpoints.Register,
+		}),
+	}
+
+	logger.Info("MCP OAuth wired with shared stores",
+		"base_domain", baseDomain,
+		"base_url", baseURL,
+		"client_id", clientID)
+
+	return opts, cleanup
+}
+
+// ─── MCP OAuth Adapters ─────────────────────────────────────────────────────
+
+// consentStoreAdapter adapts gateway.ConsentCodeStore to oauthwiring.ConsentCodeConsumer.
+// The BFF writes consent codes via the gateway store; the MCP OIDC handler consumes
+// them via this adapter.
+type consentStoreAdapter struct {
+	store *gateway.ConsentCodeStore
+}
+
+func (a *consentStoreAdapter) Consume(code string) (oauthwiring.ConsentEntry, bool) {
+	entry, ok := a.store.Consume(code)
+	if !ok {
+		return oauthwiring.ConsentEntry{}, false
+	}
+	return oauthwiring.ConsentEntry{
+		Email:          entry.Email,
+		TenantID:       entry.TenantID,
+		TenantSlug:     entry.TenantSlug,
+		MCPState:       entry.MCPState,
+		ClientID:       entry.ClientID,
+		ApprovedScopes: entry.ApprovedScopes,
+	}, true
+}
+
+// oidcStatePeekerAdapter adapts oauthwiring.OIDCStateStore to gateway.OIDCStatePeeker.
+// The MCP OIDC handler stores flow state; the BFF consent handler peeks and deletes
+// entries via this adapter.
+type oidcStatePeekerAdapter struct {
+	store *oauthwiring.OIDCStateStore
+}
+
+func (a *oidcStatePeekerAdapter) PeekInfo(key string) (gateway.OIDCStatePeekResult, bool) {
+	info, ok := a.store.PeekInfo(key)
+	if !ok {
+		return gateway.OIDCStatePeekResult{}, false
+	}
+	return gateway.OIDCStatePeekResult{
+		ClientID:    info.ClientID,
+		RedirectURI: info.RedirectURI,
+		Scopes:      info.Scopes,
+		MCPState:    info.MCPState,
+		TenantSlug:  info.TenantSlug,
+	}, true
+}
+
+func (a *oidcStatePeekerAdapter) Delete(key string) {
+	a.store.Delete(key)
 }

--- a/services/api-gateway/mcp_consent_handler.go
+++ b/services/api-gateway/mcp_consent_handler.go
@@ -188,3 +188,25 @@ func WithMCPConsentHandler(handler *MCPConsentHandler) ServerOption {
 		s.mcpConsentHandler = handler
 	}
 }
+
+// MCPOAuthEndpoints bundles the HTTP handlers for MCP OAuth 2.1 endpoints
+// that are mounted on the gateway when running in unified binary mode.
+// This allows the gateway to serve both BFF consent and MCP OAuth endpoints
+// in the same process, sharing in-memory stores.
+type MCPOAuthEndpoints struct {
+	Authorize   http.Handler     // GET /oauth/authorize
+	Callback    http.Handler     // GET /oauth/callback
+	Token       http.Handler     // POST /oauth/token
+	ConsentInfo http.Handler     // GET /oauth/consent-info
+	Metadata    http.HandlerFunc // GET /.well-known/oauth-authorization-server
+	Register    http.Handler     // POST /oauth/register
+}
+
+// WithMCPOAuthEndpoints mounts MCP OAuth 2.1 endpoints on the gateway.
+// These endpoints do NOT go through the gateway auth middleware chain since
+// they implement their own OAuth flow authentication.
+func WithMCPOAuthEndpoints(endpoints *MCPOAuthEndpoints) ServerOption {
+	return func(s *Server) {
+		s.mcpOAuthEndpoints = endpoints
+	}
+}

--- a/services/api-gateway/server.go
+++ b/services/api-gateway/server.go
@@ -45,6 +45,7 @@ type Server struct {
 	resendWebhookHandler  *ResendWebhookHandler
 	adminHandler          *AdminHandler
 	mcpConsentHandler     *MCPConsentHandler
+	mcpOAuthEndpoints     *MCPOAuthEndpoints
 }
 
 // ServerOption is a functional option for configuring the server.
@@ -163,6 +164,44 @@ func (s *Server) registerAdminRoutes() {
 	s.mux.Handle("POST /api/v1/admin/identities/{identity_id}/verify", adminVerifyH)
 }
 
+// registerMCPOAuthRoutes registers MCP OAuth 2.1 endpoints when configured.
+// These endpoints are public (no gateway auth middleware) since they implement
+// their own OAuth authentication flow. Tenant resolution is applied to
+// /oauth/authorize and /oauth/callback so the OIDC handler can extract the
+// tenant slug from the subdomain.
+func (s *Server) registerMCPOAuthRoutes() {
+	ep := s.mcpOAuthEndpoints
+	if ep == nil {
+		return
+	}
+
+	// /oauth/authorize and /oauth/callback need tenant resolution for subdomain extraction.
+	if ep.Authorize != nil {
+		h := ep.Authorize
+		if s.tenantResolver != nil {
+			h = s.tenantResolver.HandlerOptionalTenant(h)
+		}
+		s.mux.Handle("GET /oauth/authorize", h)
+	}
+	if ep.Callback != nil {
+		s.mux.Handle("GET /oauth/callback", ep.Callback)
+	}
+	if ep.Token != nil {
+		s.mux.Handle("POST /oauth/token", ep.Token)
+	}
+	if ep.ConsentInfo != nil {
+		s.mux.Handle("GET /oauth/consent-info", ep.ConsentInfo)
+	}
+	if ep.Metadata != nil {
+		s.mux.HandleFunc("GET /.well-known/oauth-authorization-server", ep.Metadata)
+	}
+	if ep.Register != nil {
+		s.mux.Handle("POST /oauth/register", ep.Register)
+	}
+
+	s.logger.Info("MCP OAuth 2.1 endpoints registered on gateway")
+}
+
 // registerTenantInfoRoute registers the public tenant info endpoint if configured.
 // Rate limiting wraps the entire chain so abusive traffic is rejected before
 // tenant resolution performs cache/DB lookups.
@@ -257,6 +296,9 @@ func (s *Server) registerRoutes() {
 		consentH := s.wrapWithAuthChain(http.HandlerFunc(s.mcpConsentHandler.HandleConsent))
 		s.mux.Handle("POST /api/auth/mcp-consent", consentH)
 	}
+
+	// MCP OAuth 2.1 endpoints - NO gateway auth middleware (they manage their own OAuth flow).
+	s.registerMCPOAuthRoutes()
 
 	// Admin identity management endpoints - full auth middleware chain.
 	s.registerAdminRoutes()
@@ -527,6 +569,12 @@ func (s *Server) handleAPI(w http.ResponseWriter, r *http.Request) {
 			"endpoint", r.URL.Path,
 			"remote_addr", r.RemoteAddr)
 	}
+}
+
+// Handler returns the server's HTTP handler for use in tests.
+// This allows integration tests to use httptest.NewServer(srv.Handler()).
+func (s *Server) Handler() http.Handler {
+	return s.mux
 }
 
 // Start starts the HTTP server and blocks until the server stops.

--- a/services/mcp-server/oauthwiring/wiring.go
+++ b/services/mcp-server/oauthwiring/wiring.go
@@ -1,0 +1,118 @@
+// Package oauthwiring provides a public factory for creating MCP OAuth 2.1
+// components needed by the unified binary. The internal auth package handles
+// the implementation details; this package exposes only the wiring surface.
+package oauthwiring
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	mcpauth "github.com/meridianhub/meridian/services/mcp-server/internal/auth"
+	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
+)
+
+// ConsentEntry holds the state stored alongside a consent code.
+// Matches the internal mcpauth.ConsentEntry type.
+type ConsentEntry = mcpauth.ConsentEntry
+
+// ConsentCodeConsumer can consume a consent code exactly once.
+type ConsentCodeConsumer = mcpauth.ConsentCodeConsumer
+
+// PeekInfoResult holds metadata about an in-flight OIDC authorization.
+type PeekInfoResult = mcpauth.PeekInfoResult
+
+// OIDCStateStore is the OIDC flow state store.
+type OIDCStateStore = mcpauth.OIDCStateStore
+
+// Config holds configuration for the MCP OAuth 2.1 wiring.
+type Config struct {
+	Signer            *platformauth.JWTSigner
+	BaseDomain        string
+	BaseURL           string
+	ClientID          string
+	RedirectURI       string
+	TokenTTL          time.Duration
+	DefaultTenantSlug string
+	Logger            *slog.Logger
+}
+
+// Endpoints holds the HTTP handlers and stores produced by wiring.
+type Endpoints struct {
+	// HTTP handlers for mounting on the gateway.
+	Authorize   http.Handler
+	Callback    http.Handler
+	Token       http.Handler
+	ConsentInfo http.Handler
+	Metadata    http.HandlerFunc
+	Register    http.Handler
+
+	// StateStore is the shared OIDCStateStore, exposed so the BFF consent
+	// handler can peek and delete entries via its OIDCStatePeeker interface.
+	StateStore *OIDCStateStore
+}
+
+// noopTokenIssuer is a fallback for the token endpoint. In the consent-based
+// OIDC flow, tokens are pre-signed via StoreWithToken.
+type noopTokenIssuer struct{}
+
+func (n *noopTokenIssuer) Issue(claims map[string]any) (string, error) {
+	return fmt.Sprintf("mcp-fallback-%v", claims["client_id"]), nil
+}
+
+// Wire creates shared stores and MCP OAuth 2.1 handlers.
+// The consentConsumer bridges the BFF-side consent store to the OIDC handler.
+// Returns Endpoints for mounting, a cleanup function, and any error.
+func Wire(cfg Config, consentConsumer ConsentCodeConsumer) (*Endpoints, func(), error) {
+	stateStore := mcpauth.NewOIDCStateStore()
+	codeStore := mcpauth.NewCodeStore()
+	clientRegistry := mcpauth.NewClientRegistry()
+
+	oauthCfg := mcpauth.OAuthConfig{
+		ClientID:         cfg.ClientID,
+		AuthorizationURL: cfg.BaseURL + "/oauth/authorize",
+		TokenURL:         cfg.BaseURL + "/oauth/token",
+		RedirectURI:      cfg.RedirectURI,
+	}
+
+	oidcHandler, err := mcpauth.NewOIDCHandler(mcpauth.OIDCHandlerConfig{
+		OAuth:             oauthCfg,
+		StateStore:        stateStore,
+		CodeStore:         codeStore,
+		Registry:          clientRegistry,
+		Signer:            cfg.Signer,
+		ConsentStore:      consentConsumer,
+		TokenTTL:          cfg.TokenTTL,
+		DefaultTenantSlug: cfg.DefaultTenantSlug,
+		BaseURL:           cfg.BaseURL,
+		BaseDomain:        cfg.BaseDomain,
+		Logger:            cfg.Logger,
+	})
+	if err != nil {
+		stateStore.Close()
+		codeStore.Close()
+		clientRegistry.Close()
+		return nil, nil, fmt.Errorf("create OIDC handler: %w", err)
+	}
+
+	tokenHandler := mcpauth.NewTokenHandler(oauthCfg, codeStore, &noopTokenIssuer{})
+	regHandler := mcpauth.NewRegistrationHandler(clientRegistry, cfg.Logger)
+	metadataHandler := mcpauth.NewMetadataHandler(cfg.BaseURL)
+
+	cleanup := func() {
+		stateStore.Close()
+		codeStore.Close()
+		clientRegistry.Close()
+	}
+
+	return &Endpoints{
+		Authorize:   http.HandlerFunc(oidcHandler.HandleAuthorize),
+		Callback:    http.HandlerFunc(oidcHandler.HandleCallback),
+		Token:       tokenHandler,
+		ConsentInfo: http.HandlerFunc(oidcHandler.HandleConsentInfo),
+		Metadata:    metadataHandler,
+		Register:    regHandler,
+		StateStore:  stateStore,
+	}, cleanup, nil
+}


### PR DESCRIPTION
## Summary

- Wire shared ConsentCodeStore and OIDCStateStore between BFF consent handler and MCP OIDC handler in the unified binary, enabling the full consent-based OAuth 2.1 flow
- Add `oauthwiring` public factory package to bridge `services/mcp-server/internal/auth` types to `cmd/meridian` without violating Go's internal package boundary
- Add `MCPOAuthEndpoints` ServerOption to mount `/oauth/*`, `/.well-known/oauth-authorization-server`, and `/oauth/register` on the gateway
- Add 6 integration tests covering the full approve flow, deny flow, PKCE integrity, tenant isolation, metadata endpoint, and dynamic client registration

### Architecture

The unified binary creates shared in-memory stores at startup:
- `ConsentCodeStore` (BFF side) - stores consent codes after user approval
- `OIDCStateStore` (MCP side) - stores PKCE state during authorization flow
- `CodeStore` (MCP side) - stores authorization codes for token exchange

Adapter types bridge the two packages:
- `consentStoreAdapter`: gateway.ConsentCodeStore -> mcpauth.ConsentCodeConsumer
- `oidcStatePeekerAdapter`: mcpauth.OIDCStateStore -> gateway.OIDCStatePeeker

### Caddy Routing

Verified existing Caddy config correctly routes:
- `/auth/mcp-consent` -> SPA (catch-all file_server)
- `/api/auth/mcp-consent` -> meridian binary (BFF consent endpoint)
- `/oauth/*` -> mcp-server (OIDC endpoints)
- `/.well-known/oauth-authorization-server` -> mcp-server

No Caddy changes needed. In unified binary mode, all endpoints are served from the same process.

## Test plan

- [x] Full approve flow: authorize -> consent-info -> approve -> callback -> token
- [x] Deny flow: authorize -> consent -> deny -> error redirect with access_denied
- [x] PKCE integrity: wrong verifier rejected at token exchange
- [x] Tenant isolation: cross-tenant consent rejected with 403
- [x] OAuth metadata endpoint returns correct discovery document
- [x] Dynamic client registration (RFC 7591) creates valid client
- [x] Unified binary compiles: `go build ./cmd/meridian/...`
- [x] MCP server standalone compiles: `go build ./services/mcp-server/cmd/`
- [x] Existing gateway tests pass
- [x] Existing MCP server tests pass
- [x] golangci-lint clean