### PR TITLE
fix: Align CI coverage thresholds, remove orphaned .taskmaster submodule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,8 +71,6 @@ jobs:
 
       - name: Check per-service coverage
         if: github.event_name == 'pull_request'
-        # continue-on-error: remove this once all services reach the 70% threshold
-        continue-on-error: true
         run: |
           chmod +x scripts/check-service-coverage.sh
           ./scripts/check-service-coverage.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,8 +194,8 @@ jobs:
         run: |
           coverage=$(go tool cover -func=coverage/coverage-filtered.out | grep total | awk '{print $3}' | sed 's/%//')
           echo "Coverage (excluding generated proto files): ${coverage}%"
-          if (( $(echo "$coverage < 50.0" | bc -l) )); then
-            echo "❌ Coverage ${coverage}% is below 50% threshold"
+          if (( $(echo "$coverage < 70.0" | bc -l) )); then
+            echo "❌ Coverage ${coverage}% is below 70% threshold"
             exit 1
           fi
           echo "✅ Coverage ${coverage}% meets threshold"


### PR DESCRIPTION
## Summary

- Remove orphaned .taskmaster gitlink that was causing CI checkout failures (`No url found for submodule path '.taskmaster' in .gitmodules`). The directory is already gitignored.
- Raise CI coverage threshold from 50% to 70%, aligning with the per-service script and moving toward the codecov project target of 75%.
- Enable per-service coverage enforcement in build.yml by removing `continue-on-error: true`.

## Context

Coverage configuration was misaligned across three layers:

| Config | Previous | Now |
|--------|----------|-----|
| CI threshold (test.yml) | 50% | 70% |
| Per-service script (build.yml) | 70% (non-blocking) | 70% (blocking) |
| Codecov project target | 75% | 75% (unchanged) |
| Codecov component target | 80% | 80% (unchanged) |

The 50% CI floor was too low to catch meaningful regressions. Per-service enforcement was disabled ("remove this once all services reach the 70% threshold") but never re-enabled.

## Test plan

- [ ] CI checkout succeeds without .taskmaster submodule error
- [ ] Coverage check runs at 70% threshold
- [ ] Per-service coverage check blocks on failure