### PR TITLE
fix: Align all coverage thresholds to 80%

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Check per-service coverage
         if: github.event_name == 'pull_request'
         run: |
-          chmod +x scripts/check-service-coverage.sh
+          chmod +x scripts/check-service-coverage.sh scripts/codecov-exclude-pattern.sh
           ./scripts/check-service-coverage.sh
 
       - name: Run tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -134,11 +134,11 @@ jobs:
           --jsonfile test-results.json \
           -- -race -coverprofile=coverage/coverage.out -covermode=atomic -timeout 15m ./...
 
-    - name: Filter generated files from coverage
+    - name: Filter excluded paths from coverage
       if: always()
       run: |
         if [ -f coverage/coverage.out ]; then
-          grep -v -E '\.pb\.go|\.pb\.validate\.go|_grpc\.pb\.go' coverage/coverage.out > coverage/coverage-filtered.out || true
+          grep -v -E '\.pb\.go|\.pb\.validate\.go|_grpc\.pb\.go|/cmd/|/mocks/|/testhelpers/' coverage/coverage.out > coverage/coverage-filtered.out || true
         fi
 
     - name: Upload coverage to Codecov

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -138,7 +138,8 @@ jobs:
       if: always()
       run: |
         if [ -f coverage/coverage.out ]; then
-          grep -v -E '\.pb\.go|\.pb\.validate\.go|_grpc\.pb\.go|/cmd/|/mocks/|/testhelpers/' coverage/coverage.out > coverage/coverage-filtered.out || true
+          exclude_pattern=$(./scripts/codecov-exclude-pattern.sh)
+          grep -v -E "$exclude_pattern" coverage/coverage.out > coverage/coverage-filtered.out || true
         fi
 
     - name: Upload coverage to Codecov

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -138,8 +138,12 @@ jobs:
       if: always()
       run: |
         if [ -f coverage/coverage.out ]; then
-          exclude_pattern=$(./scripts/codecov-exclude-pattern.sh)
-          grep -v -E "$exclude_pattern" coverage/coverage.out > coverage/coverage-filtered.out || true
+          exclude_pattern=$(./scripts/codecov-exclude-pattern.sh) || exclude_pattern=""
+          if [ -n "$exclude_pattern" ]; then
+            grep -v -E "$exclude_pattern" coverage/coverage.out > coverage/coverage-filtered.out || true
+          else
+            cp coverage/coverage.out coverage/coverage-filtered.out
+          fi
         fi
 
     - name: Upload coverage to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,8 +194,8 @@ jobs:
         run: |
           coverage=$(go tool cover -func=coverage/coverage-filtered.out | grep total | awk '{print $3}' | sed 's/%//')
           echo "Coverage (excluding generated proto files): ${coverage}%"
-          if (( $(echo "$coverage < 70.0" | bc -l) )); then
-            echo "❌ Coverage ${coverage}% is below 70% threshold"
+          if (( $(echo "$coverage < 80.0" | bc -l) )); then
+            echo "❌ Coverage ${coverage}% is below 80% threshold"
             exit 1
           fi
           echo "✅ Coverage ${coverage}% meets threshold"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,8 +168,12 @@ jobs:
           fi
           gocovmerge "${cov_files[@]}" > coverage/coverage.out
           echo "Filtering excluded paths from coverage (derived from codecov.yml)..."
-          exclude_pattern=$(./scripts/codecov-exclude-pattern.sh)
-          grep -v -E "$exclude_pattern" coverage/coverage.out > coverage/coverage-filtered.out || true
+          exclude_pattern=$(./scripts/codecov-exclude-pattern.sh) || exclude_pattern=""
+          if [ -n "$exclude_pattern" ]; then
+            grep -v -E "$exclude_pattern" coverage/coverage.out > coverage/coverage-filtered.out || true
+          else
+            cp coverage/coverage.out coverage/coverage-filtered.out
+          fi
 
       - name: Generate coverage report
         run: go tool cover -html=coverage/coverage.out -o coverage/coverage.html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,8 +167,8 @@ jobs:
             exit 0
           fi
           gocovmerge "${cov_files[@]}" > coverage/coverage.out
-          echo "Filtering generated proto files from coverage..."
-          grep -v -E '\.pb\.go|\.pb\.validate\.go|_grpc\.pb\.go' coverage/coverage.out > coverage/coverage-filtered.out || true
+          echo "Filtering excluded paths from coverage (aligned with codecov.yml)..."
+          grep -v -E '\.pb\.go|\.pb\.validate\.go|_grpc\.pb\.go|/cmd/|/mocks/|/testhelpers/' coverage/coverage.out > coverage/coverage-filtered.out || true
 
       - name: Generate coverage report
         run: go tool cover -html=coverage/coverage.out -o coverage/coverage.html
@@ -193,7 +193,7 @@ jobs:
       - name: Check test coverage threshold
         run: |
           coverage=$(go tool cover -func=coverage/coverage-filtered.out | grep total | awk '{print $3}' | sed 's/%//')
-          echo "Coverage (excluding generated proto files): ${coverage}%"
+          echo "Coverage (excluding cmd, proto, mocks, testhelpers): ${coverage}%"
           if (( $(echo "$coverage < 80.0" | bc -l) )); then
             echo "❌ Coverage ${coverage}% is below 80% threshold"
             exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,8 +167,9 @@ jobs:
             exit 0
           fi
           gocovmerge "${cov_files[@]}" > coverage/coverage.out
-          echo "Filtering excluded paths from coverage (aligned with codecov.yml)..."
-          grep -v -E '\.pb\.go|\.pb\.validate\.go|_grpc\.pb\.go|/cmd/|/mocks/|/testhelpers/' coverage/coverage.out > coverage/coverage-filtered.out || true
+          echo "Filtering excluded paths from coverage (derived from codecov.yml)..."
+          exclude_pattern=$(./scripts/codecov-exclude-pattern.sh)
+          grep -v -E "$exclude_pattern" coverage/coverage.out > coverage/coverage-filtered.out || true
 
       - name: Generate coverage report
         run: go tool cover -html=coverage/coverage.out -o coverage/coverage.html
@@ -193,7 +194,7 @@ jobs:
       - name: Check test coverage threshold
         run: |
           coverage=$(go tool cover -func=coverage/coverage-filtered.out | grep total | awk '{print $3}' | sed 's/%//')
-          echo "Coverage (excluding cmd, proto, mocks, testhelpers): ${coverage}%"
+          echo "Coverage (excluding codecov.yml ignore paths): ${coverage}%"
           if (( $(echo "$coverage < 80.0" | bc -l) )); then
             echo "❌ Coverage ${coverage}% is below 80% threshold"
             exit 1

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,10 +16,9 @@ ignore:
   - "**/*_grpc.pb.go"
   - "**/mocks/**"
   - "**/testhelpers/**"
+  - "**/cmd/**"
   - "utilities/**"
   - "frontend/src/api/gen/**"
-  - "services/mcp-server/cmd/wire.go"
-  - "**/cmd/main.go"
 
 comment:
   layout: "condensed_header, condensed_files, components, condensed_footer"

--- a/scripts/check-service-coverage.sh
+++ b/scripts/check-service-coverage.sh
@@ -4,10 +4,9 @@
 # Runs unit tests (with -short to skip integration tests) for each Go service
 # and fails if any service falls below the minimum coverage threshold.
 #
-# Excluded from coverage (aligned with codecov.yml ignore rules):
-#   - cmd/ packages (bootstrap/wiring code)
-#   - generated protobuf files (*.pb.go, *_grpc.pb.go, *.pb.validate.go)
-#   - mocks/ and testhelpers/ directories
+# Exclusions are read from codecov.yml (single source of truth).
+# This script converts codecov glob patterns to grep filters applied to
+# Go coverprofiles, so both Codecov and this script enforce the same rules.
 #
 # Usage:
 #   ./scripts/check-service-coverage.sh
@@ -21,16 +20,32 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 THRESHOLD="${COVERAGE_THRESHOLD:-80}"
 TMPDIR="${TMPDIR:-/tmp}"
 
-# Validate THRESHOLD is a non-negative integer in range 0–100
+# Validate THRESHOLD is a non-negative integer in range 0-100
 if ! [[ "${THRESHOLD}" =~ ^[0-9]+$ ]] || [ "${THRESHOLD}" -gt 100 ]; then
     echo "ERROR: COVERAGE_THRESHOLD must be an integer between 0 and 100 (got: '${THRESHOLD}')" >&2
     exit 1
+fi
+
+# Build exclude pattern from codecov.yml (single source of truth for exclusions).
+# See scripts/codecov-exclude-pattern.sh for the glob-to-grep conversion logic.
+EXCLUDE_PATTERN=""
+exclude_script="${REPO_ROOT}/scripts/codecov-exclude-pattern.sh"
+if [ -x "${exclude_script}" ]; then
+    if exclude=$("${exclude_script}"); then
+        EXCLUDE_PATTERN="${exclude}"
+        echo "Exclude pattern (from codecov.yml): ${EXCLUDE_PATTERN}"
+    else
+        echo "WARNING: Failed to read exclusions from codecov.yml"
+    fi
+else
+    echo "WARNING: ${exclude_script} not found, running without exclusions"
 fi
 
 FAILED=0
 PASSED=0
 SKIPPED=0
 
+echo ""
 echo "Per-service Go coverage check (threshold: ${THRESHOLD}%)"
 echo "Using -short flag to skip integration tests"
 echo ""
@@ -75,29 +90,25 @@ for service_dir in "${REPO_ROOT}"/services/*/; do
         continue
     fi
 
-    # Filter coverprofile to exclude paths that codecov.yml also ignores:
-    #   - cmd/ packages (bootstrap/wiring code, not meaningfully unit-testable)
-    #   - generated protobuf files (*.pb.go, *_grpc.pb.go, *.pb.validate.go)
-    #   - mocks/ and testhelpers/ directories
-    filtered_file="${TMPDIR}/meridian_coverage_${service}_filtered.out"
-    head -1 "${coverage_file}" > "${filtered_file}"
-    tail -n +2 "${coverage_file}" \
-        | grep -v '/cmd/' \
-        | grep -v '\.pb\.go:' \
-        | grep -v '\.pb\.validate\.go:' \
-        | grep -v '_grpc\.pb\.go:' \
-        | grep -v '/mocks/' \
-        | grep -v '/testhelpers/' \
-        >> "${filtered_file}" || true
-    rm -f "${coverage_file}"
+    # Filter coverprofile using exclusions derived from codecov.yml
+    target_file="${coverage_file}"
+    if [ -n "${EXCLUDE_PATTERN}" ]; then
+        filtered_file="${TMPDIR}/meridian_coverage_${service}_filtered.out"
+        head -1 "${coverage_file}" > "${filtered_file}"
+        tail -n +2 "${coverage_file}" \
+            | grep -v -E "${EXCLUDE_PATTERN}" \
+            >> "${filtered_file}" || true
+        rm -f "${coverage_file}"
+        target_file="${filtered_file}"
+    fi
 
-    if ! coverage="$(go tool cover -func="${filtered_file}" | awk '/^total:/ { gsub(/%/, "", $3); print $3 }')"; then
+    if ! coverage="$(go tool cover -func="${target_file}" | awk '/^total:/ { gsub(/%/, "", $3); print $3 }')"; then
         echo "  SKIP ${service} (cover command failed)"
         SKIPPED=$((SKIPPED + 1))
-        rm -f "${filtered_file}"
+        rm -f "${target_file}"
         continue
     fi
-    rm -f "${filtered_file}"
+    rm -f "${target_file}"
 
     if [ -z "${coverage}" ]; then
         echo "  SKIP ${service} (could not parse coverage)"

--- a/scripts/check-service-coverage.sh
+++ b/scripts/check-service-coverage.sh
@@ -8,12 +8,12 @@
 #   ./scripts/check-service-coverage.sh
 #
 # Environment variables:
-#   COVERAGE_THRESHOLD  Minimum coverage % required per service (default: 70)
+#   COVERAGE_THRESHOLD  Minimum coverage % required per service (default: 80)
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-THRESHOLD="${COVERAGE_THRESHOLD:-70}"
+THRESHOLD="${COVERAGE_THRESHOLD:-80}"
 TMPDIR="${TMPDIR:-/tmp}"
 
 # Validate THRESHOLD is a non-negative integer in range 0–100

--- a/scripts/check-service-coverage.sh
+++ b/scripts/check-service-coverage.sh
@@ -4,6 +4,11 @@
 # Runs unit tests (with -short to skip integration tests) for each Go service
 # and fails if any service falls below the minimum coverage threshold.
 #
+# Excluded from coverage (aligned with codecov.yml ignore rules):
+#   - cmd/ packages (bootstrap/wiring code)
+#   - generated protobuf files (*.pb.go, *_grpc.pb.go, *.pb.validate.go)
+#   - mocks/ and testhelpers/ directories
+#
 # Usage:
 #   ./scripts/check-service-coverage.sh
 #
@@ -70,13 +75,29 @@ for service_dir in "${REPO_ROOT}"/services/*/; do
         continue
     fi
 
-    if ! coverage="$(go tool cover -func="${coverage_file}" | awk '/^total:/ { gsub(/%/, "", $3); print $3 }')"; then
+    # Filter coverprofile to exclude paths that codecov.yml also ignores:
+    #   - cmd/ packages (bootstrap/wiring code, not meaningfully unit-testable)
+    #   - generated protobuf files (*.pb.go, *_grpc.pb.go, *.pb.validate.go)
+    #   - mocks/ and testhelpers/ directories
+    filtered_file="${TMPDIR}/meridian_coverage_${service}_filtered.out"
+    head -1 "${coverage_file}" > "${filtered_file}"
+    tail -n +2 "${coverage_file}" \
+        | grep -v '/cmd/' \
+        | grep -v '\.pb\.go:' \
+        | grep -v '\.pb\.validate\.go:' \
+        | grep -v '_grpc\.pb\.go:' \
+        | grep -v '/mocks/' \
+        | grep -v '/testhelpers/' \
+        >> "${filtered_file}" || true
+    rm -f "${coverage_file}"
+
+    if ! coverage="$(go tool cover -func="${filtered_file}" | awk '/^total:/ { gsub(/%/, "", $3); print $3 }')"; then
         echo "  SKIP ${service} (cover command failed)"
         SKIPPED=$((SKIPPED + 1))
-        rm -f "${coverage_file}"
+        rm -f "${filtered_file}"
         continue
     fi
-    rm -f "${coverage_file}"
+    rm -f "${filtered_file}"
 
     if [ -z "${coverage}" ]; then
         echo "  SKIP ${service} (could not parse coverage)"

--- a/scripts/codecov-exclude-pattern.sh
+++ b/scripts/codecov-exclude-pattern.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# codecov-exclude-pattern.sh
+#
+# Reads codecov.yml ignore globs and outputs a grep -E pattern for filtering
+# Go coverprofile lines. This is the bridge that keeps the per-service coverage
+# script and CI workflow filters aligned with codecov.yml (single source of truth).
+#
+# Usage:
+#   pattern=$(./scripts/codecov-exclude-pattern.sh)
+#   grep -v -E "$pattern" coverage.out > coverage-filtered.out
+#
+# Handles three glob categories:
+#   **/*.ext      -> file extension match (\.ext:)
+#   **/dir/**     -> directory match (/dir/)
+#   path/to/file  -> exact path match (path/to/file:)
+#
+# Non-Go patterns (frontend/*, utilities/*) are skipped.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CODECOV_YML="${1:-${REPO_ROOT}/codecov.yml}"
+
+if [ ! -f "${CODECOV_YML}" ]; then
+    echo "ERROR: codecov.yml not found at ${CODECOV_YML}" >&2
+    exit 1
+fi
+
+if ! command -v yq &>/dev/null; then
+    echo "ERROR: yq is required but not found" >&2
+    exit 1
+fi
+
+patterns=()
+
+while IFS= read -r glob; do
+    case "${glob}" in
+        # File extension: **/*.pb.go -> \.pb\.go:
+        \*\*/\**)
+            ext="${glob##*\*}"
+            patterns+=("$(echo "${ext}" | sed 's/\./\\./g'):")
+            ;;
+        # Directory: **/cmd/** -> /cmd/
+        \*\*/*\*\*)
+            dir="${glob#\*\*/}"
+            dir="${dir%/\*\*}"
+            patterns+=("/${dir}/")
+            ;;
+        # Skip non-Go paths
+        frontend/*|utilities/*) continue ;;
+        # Specific file: path/to/file.go -> path/to/file\.go:
+        *)
+            patterns+=("$(echo "${glob}" | sed 's/\./\\./g'):")
+            ;;
+    esac
+done < <(yq -r '.ignore[]' "${CODECOV_YML}" 2>/dev/null)
+
+if [ ${#patterns[@]} -eq 0 ]; then
+    echo "WARNING: No exclude patterns found in ${CODECOV_YML}" >&2
+    exit 1
+fi
+
+IFS='|'
+echo "${patterns[*]}"


### PR DESCRIPTION
## Summary

Follow-up to #2161. Aligns all coverage enforcement to 80% and eliminates drift between coverage systems.

**Key change**: `codecov.yml` is now the single source of truth for coverage exclusions. The per-service script and CI workflow filters derive their exclusion patterns from `codecov.yml` at runtime via `scripts/codecov-exclude-pattern.sh`, rather than hardcoding separate lists.

### Changes
- CI test.yml: 70% -> 80% threshold
- Per-service script default: 70% -> 80% threshold
- `codecov.yml`: consolidated cmd exclusions (`**/cmd/main.go` + `services/mcp-server/cmd/wire.go` -> `**/cmd/**`)
- New `scripts/codecov-exclude-pattern.sh`: converts codecov.yml ignore globs to grep patterns (uses `yq`)
- Per-service script, test.yml, nightly.yml all call the shared helper

### Why cmd/ is excluded
`cmd/` packages contain bootstrap/wiring code (main.go, DI factories, gRPC client creation). They connect to real infrastructure (databases, Kafka, gRPC) and are not meaningfully unit-testable with `-short`. Codecov already excluded `**/cmd/main.go`; this extends to all cmd files since they're the same category.

## Alignment after this PR

| Config | Target | Exclusion source |
|--------|--------|-----------------|
| Codecov project | 75% | codecov.yml ignore |
| Codecov components | 80% | codecov.yml ignore |
| CI test.yml threshold | 80% | codecov.yml via codecov-exclude-pattern.sh |
| Per-service script | 80% | codecov.yml via codecov-exclude-pattern.sh |
| Frontend | 80% | n/a |

## Test plan

- [x] `codecov-exclude-pattern.sh` generates correct pattern from codecov.yml
- [x] Per-service coverage passes locally for all 6 previously-failing services
- [x] Previous CI run passed with hardcoded equivalent patterns
- [ ] CI passes with yq-derived patterns