### PR TITLE
feat: add TenantScheduleProvider for cross-tenant schedule discovery

### DIFF
--- a/services/control-plane/internal/scheduling/provider.go
+++ b/services/control-plane/internal/scheduling/provider.go
@@ -2,6 +2,7 @@ package scheduling
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -9,6 +10,9 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/scheduler"
 	"gorm.io/gorm"
 )
+
+// ErrAllSchemaQueriesFailed is returned when every tenant schema query fails.
+var ErrAllSchemaQueriesFailed = errors.New("all tenant schema queries failed")
 
 // TenantScheduleRepository queries enabled schedules from tenant schemas.
 type TenantScheduleRepository interface {
@@ -104,6 +108,7 @@ func (r *GormTenantScheduleRepository) ListEnabledSchedules(ctx context.Context)
 	}
 
 	var allSchedules []TenantSchedule
+	var failedSchemas int
 	for _, schema := range schemas {
 		tenantID := schemaToTenantID(schema)
 
@@ -115,6 +120,7 @@ func (r *GormTenantScheduleRepository) ListEnabledSchedules(ctx context.Context)
 		if err != nil {
 			r.logger.Error("failed to query tenant schedules",
 				"schema", schema, "error", err)
+			failedSchemas++
 			continue
 		}
 
@@ -127,6 +133,14 @@ func (r *GormTenantScheduleRepository) ListEnabledSchedules(ctx context.Context)
 				Metadata:     e.Metadata,
 			})
 		}
+	}
+
+	if failedSchemas > 0 && failedSchemas == len(schemas) {
+		return nil, fmt.Errorf("%w: %d schemas queried", ErrAllSchemaQueriesFailed, failedSchemas)
+	}
+	if failedSchemas > 0 {
+		r.logger.Warn("some tenant schema queries failed",
+			"failed", failedSchemas, "total", len(schemas))
 	}
 
 	return allSchedules, nil

--- a/services/control-plane/internal/scheduling/provider.go
+++ b/services/control-plane/internal/scheduling/provider.go
@@ -1,0 +1,155 @@
+package scheduling
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/meridianhub/meridian/shared/platform/scheduler"
+	"gorm.io/gorm"
+)
+
+// TenantScheduleRepository queries enabled schedules from tenant schemas.
+type TenantScheduleRepository interface {
+	// ListEnabledSchedules returns all enabled tenant schedules across all tenant schemas.
+	// Each returned TenantSchedule includes the tenant ID derived from the schema name.
+	ListEnabledSchedules(ctx context.Context) ([]TenantSchedule, error)
+}
+
+// TenantSchedule is the domain representation of a row from tenant_schedule
+// augmented with the owning tenant ID.
+type TenantSchedule struct {
+	TenantID     string
+	ScheduleName string
+	SagaName     string
+	CronExpr     string
+	Metadata     *string
+}
+
+// TenantScheduleProvider implements scheduler.ScheduleProvider by querying
+// tenant_schedule tables across all tenant schemas.
+type TenantScheduleProvider struct {
+	repo   TenantScheduleRepository
+	logger *slog.Logger
+}
+
+// NewTenantScheduleProvider creates a new TenantScheduleProvider.
+func NewTenantScheduleProvider(repo TenantScheduleRepository, logger *slog.Logger) *TenantScheduleProvider {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &TenantScheduleProvider{
+		repo:   repo,
+		logger: logger.With("component", "tenant-schedule-provider"),
+	}
+}
+
+// ListSchedules implements scheduler.ScheduleProvider. It returns all enabled
+// schedules from all tenant schemas, with Schedule.ID formatted as "tenant_id:schedule_name".
+func (p *TenantScheduleProvider) ListSchedules(ctx context.Context) ([]scheduler.Schedule, error) {
+	tenantSchedules, err := p.repo.ListEnabledSchedules(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list enabled tenant schedules: %w", err)
+	}
+
+	schedules := make([]scheduler.Schedule, len(tenantSchedules))
+	for i, ts := range tenantSchedules {
+		var metadata any
+		if ts.Metadata != nil {
+			metadata = *ts.Metadata
+		}
+
+		schedules[i] = scheduler.Schedule{
+			ID:       ts.TenantID + ":" + ts.ScheduleName,
+			CronExpr: ts.CronExpr,
+			TenantID: ts.TenantID,
+			Metadata: metadata,
+		}
+	}
+
+	p.logger.Debug("loaded tenant schedules", "count", len(schedules))
+	return schedules, nil
+}
+
+// Compile-time check that TenantScheduleProvider implements ScheduleProvider.
+var _ scheduler.ScheduleProvider = (*TenantScheduleProvider)(nil)
+
+// GormTenantScheduleRepository implements TenantScheduleRepository using GORM.
+// It discovers tenant schemas and queries each for enabled schedules.
+type GormTenantScheduleRepository struct {
+	db            *gorm.DB
+	schemaPattern string
+	logger        *slog.Logger
+}
+
+// NewGormTenantScheduleRepository creates a new repository that queries tenant_schedule
+// tables across all tenant schemas matching the given pattern (default: "org_%").
+func NewGormTenantScheduleRepository(db *gorm.DB, logger *slog.Logger) *GormTenantScheduleRepository {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &GormTenantScheduleRepository{
+		db:            db,
+		schemaPattern: "org_%",
+		logger:        logger.With("component", "tenant-schedule-repository"),
+	}
+}
+
+// ListEnabledSchedules discovers tenant schemas and queries each for enabled schedules.
+func (r *GormTenantScheduleRepository) ListEnabledSchedules(ctx context.Context) ([]TenantSchedule, error) {
+	schemas, err := r.findTenantSchemas(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("discover tenant schemas: %w", err)
+	}
+
+	var allSchedules []TenantSchedule
+	for _, schema := range schemas {
+		tenantID := schemaToTenantID(schema)
+
+		var entities []TenantScheduleEntity
+		err := r.db.WithContext(ctx).
+			Table(fmt.Sprintf("%q.tenant_schedule", schema)).
+			Where("enabled = ?", true).
+			Find(&entities).Error
+		if err != nil {
+			r.logger.Error("failed to query tenant schedules",
+				"schema", schema, "error", err)
+			continue
+		}
+
+		for _, e := range entities {
+			allSchedules = append(allSchedules, TenantSchedule{
+				TenantID:     tenantID,
+				ScheduleName: e.ScheduleName,
+				SagaName:     e.SagaName,
+				CronExpr:     e.CronExpr,
+				Metadata:     e.Metadata,
+			})
+		}
+	}
+
+	return allSchedules, nil
+}
+
+// findTenantSchemas queries for schemas matching the pattern that contain a tenant_schedule table.
+func (r *GormTenantScheduleRepository) findTenantSchemas(ctx context.Context) ([]string, error) {
+	var schemas []string
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT DISTINCT s.schema_name
+		FROM information_schema.schemata s
+		JOIN information_schema.tables t
+		  ON t.table_schema = s.schema_name AND t.table_name = 'tenant_schedule'
+		WHERE s.schema_name LIKE ?
+		ORDER BY s.schema_name
+	`, r.schemaPattern).Scan(&schemas).Error
+	if err != nil {
+		return nil, fmt.Errorf("query tenant schemas: %w", err)
+	}
+	return schemas, nil
+}
+
+// schemaToTenantID converts an "org_xxx" schema name back to the tenant ID "xxx".
+func schemaToTenantID(schema string) string {
+	return strings.TrimPrefix(schema, "org_")
+}

--- a/services/control-plane/internal/scheduling/provider.go
+++ b/services/control-plane/internal/scheduling/provider.go
@@ -118,6 +118,9 @@ func (r *GormTenantScheduleRepository) ListEnabledSchedules(ctx context.Context)
 			Where("enabled = ?", true).
 			Find(&entities).Error
 		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil, fmt.Errorf("query tenant schedules for schema %q: %w", schema, err)
+			}
 			r.logger.Error("failed to query tenant schedules",
 				"schema", schema, "error", err)
 			failedSchemas++

--- a/services/control-plane/internal/scheduling/provider_test.go
+++ b/services/control-plane/internal/scheduling/provider_test.go
@@ -1,0 +1,207 @@
+package scheduling
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/platform/scheduler"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Unit tests for TenantScheduleProvider ---
+
+type mockTenantScheduleRepo struct {
+	schedules []TenantSchedule
+	err       error
+}
+
+func (m *mockTenantScheduleRepo) ListEnabledSchedules(_ context.Context) ([]TenantSchedule, error) {
+	return m.schedules, m.err
+}
+
+func TestTenantScheduleProvider_ListSchedules_ReturnsSchedules(t *testing.T) {
+	meta := `{"key":"value"}`
+	repo := &mockTenantScheduleRepo{
+		schedules: []TenantSchedule{
+			{TenantID: "acme", ScheduleName: "daily-billing", SagaName: "billing.run", CronExpr: "0 0 * * *", Metadata: &meta},
+			{TenantID: "beta", ScheduleName: "hourly-sync", SagaName: "sync.run", CronExpr: "0 * * * *"},
+		},
+	}
+
+	provider := NewTenantScheduleProvider(repo, nil)
+	schedules, err := provider.ListSchedules(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, schedules, 2)
+
+	assert.Equal(t, "acme:daily-billing", schedules[0].ID)
+	assert.Equal(t, "0 0 * * *", schedules[0].CronExpr)
+	assert.Equal(t, "acme", schedules[0].TenantID)
+	assert.Equal(t, meta, schedules[0].Metadata)
+
+	assert.Equal(t, "beta:hourly-sync", schedules[1].ID)
+	assert.Equal(t, "0 * * * *", schedules[1].CronExpr)
+	assert.Equal(t, "beta", schedules[1].TenantID)
+	assert.Nil(t, schedules[1].Metadata)
+}
+
+func TestTenantScheduleProvider_ListSchedules_EmptyResult(t *testing.T) {
+	repo := &mockTenantScheduleRepo{schedules: nil}
+	provider := NewTenantScheduleProvider(repo, nil)
+
+	schedules, err := provider.ListSchedules(context.Background())
+
+	require.NoError(t, err)
+	assert.Empty(t, schedules)
+}
+
+func TestTenantScheduleProvider_ListSchedules_PropagatesError(t *testing.T) {
+	repoErr := errors.New("db connection failed")
+	repo := &mockTenantScheduleRepo{err: repoErr}
+	provider := NewTenantScheduleProvider(repo, nil)
+
+	_, err := provider.ListSchedules(context.Background())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, repoErr)
+}
+
+func TestTenantScheduleProvider_ScheduleIDFormat(t *testing.T) {
+	repo := &mockTenantScheduleRepo{
+		schedules: []TenantSchedule{
+			{TenantID: "my_tenant", ScheduleName: "my-schedule", CronExpr: "0 0 * * *"},
+		},
+	}
+	provider := NewTenantScheduleProvider(repo, nil)
+
+	schedules, err := provider.ListSchedules(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "my_tenant:my-schedule", schedules[0].ID)
+}
+
+func TestTenantScheduleProvider_ImplementsScheduleProvider(_ *testing.T) {
+	var _ scheduler.ScheduleProvider = (*TenantScheduleProvider)(nil)
+}
+
+func TestSchemaToTenantID(t *testing.T) {
+	assert.Equal(t, "acme", schemaToTenantID("org_acme"))
+	assert.Equal(t, "beta_corp", schemaToTenantID("org_beta_corp"))
+	assert.Equal(t, "plain", schemaToTenantID("plain"))
+}
+
+// --- Integration tests for GormTenantScheduleRepository ---
+
+const tenantScheduleDDL = `CREATE TABLE IF NOT EXISTS %s.tenant_schedule (
+	id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+	schedule_name VARCHAR(128) NOT NULL,
+	saga_name VARCHAR(128) NOT NULL,
+	cron_expr VARCHAR(64) NOT NULL,
+	enabled BOOLEAN NOT NULL DEFAULT TRUE,
+	manifest_version_id UUID,
+	metadata JSONB,
+	created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+	updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+	CONSTRAINT uq_%s_tenant_schedule_name UNIQUE (schedule_name)
+)`
+
+func setupTestDB(t *testing.T) (*testdb.TenantTestContext, *testdb.TenantTestContext, func()) {
+	t.Helper()
+
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+
+	tc1 := testdb.SetupTenantSchema(t, db, "alpha")
+	testdb.CreateTable(t, tc1.DB, tc1.Tenant, fmt.Sprintf(tenantScheduleDDL, "%s", "alpha"))
+
+	tc2 := testdb.SetupTenantSchema(t, db, "beta")
+	testdb.CreateTable(t, tc2.DB, tc2.Tenant, fmt.Sprintf(tenantScheduleDDL, "%s", "beta"))
+
+	// Reset search_path so cross-schema queries work
+	db.Exec("SET search_path TO public")
+
+	return tc1, tc2, cleanup
+}
+
+func TestGormTenantScheduleRepository_ListEnabledSchedules_MultiTenant(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tc1, tc2, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Insert enabled schedule in alpha
+	tc1.DB.Exec(fmt.Sprintf(`INSERT INTO %q.tenant_schedule (schedule_name, saga_name, cron_expr, enabled) VALUES ('daily-billing', 'billing.run', '0 0 * * *', true)`, tc1.Tenant.SchemaName()))
+
+	// Insert enabled + disabled schedules in beta
+	tc2.DB.Exec(fmt.Sprintf(`INSERT INTO %q.tenant_schedule (schedule_name, saga_name, cron_expr, enabled) VALUES ('hourly-sync', 'sync.run', '0 * * * *', true)`, tc2.Tenant.SchemaName()))
+	tc2.DB.Exec(fmt.Sprintf(`INSERT INTO %q.tenant_schedule (schedule_name, saga_name, cron_expr, enabled) VALUES ('disabled-job', 'noop.run', '0 0 * * *', false)`, tc2.Tenant.SchemaName()))
+
+	repo := NewGormTenantScheduleRepository(tc1.DB, nil)
+	schedules, err := repo.ListEnabledSchedules(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, schedules, 2, "should return enabled schedules from both tenants")
+
+	// Verify tenant IDs and schedule names
+	byKey := make(map[string]TenantSchedule)
+	for _, s := range schedules {
+		byKey[s.TenantID+":"+s.ScheduleName] = s
+	}
+
+	alpha, ok := byKey["alpha:daily-billing"]
+	require.True(t, ok, "should contain alpha's daily-billing schedule")
+	assert.Equal(t, "billing.run", alpha.SagaName)
+	assert.Equal(t, "0 0 * * *", alpha.CronExpr)
+
+	beta, ok := byKey["beta:hourly-sync"]
+	require.True(t, ok, "should contain beta's hourly-sync schedule")
+	assert.Equal(t, "sync.run", beta.SagaName)
+	assert.Equal(t, "0 * * * *", beta.CronExpr)
+}
+
+func TestGormTenantScheduleRepository_ListEnabledSchedules_OnlyEnabled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tc1, _, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Insert one enabled and one disabled
+	tc1.DB.Exec(fmt.Sprintf(`INSERT INTO %q.tenant_schedule (schedule_name, saga_name, cron_expr, enabled) VALUES ('enabled-job', 'job.run', '0 0 * * *', true)`, tc1.Tenant.SchemaName()))
+	tc1.DB.Exec(fmt.Sprintf(`INSERT INTO %q.tenant_schedule (schedule_name, saga_name, cron_expr, enabled) VALUES ('disabled-job', 'noop.run', '0 0 * * *', false)`, tc1.Tenant.SchemaName()))
+
+	repo := NewGormTenantScheduleRepository(tc1.DB, nil)
+	schedules, err := repo.ListEnabledSchedules(context.Background())
+
+	require.NoError(t, err)
+
+	for _, s := range schedules {
+		if s.TenantID == "alpha" {
+			assert.Equal(t, "enabled-job", s.ScheduleName, "only enabled schedules should be returned")
+		}
+	}
+}
+
+func TestGormTenantScheduleRepository_ListEnabledSchedules_EmptyTenants(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	_, _, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// No schedules inserted - both tenants have empty tables
+	db, dbCleanup := testdb.SetupCockroachDB(t, nil)
+	defer dbCleanup()
+
+	repo := NewGormTenantScheduleRepository(db, nil)
+	schedules, err := repo.ListEnabledSchedules(context.Background())
+
+	require.NoError(t, err)
+	assert.Empty(t, schedules)
+}

--- a/services/control-plane/internal/scheduling/provider_test.go
+++ b/services/control-plane/internal/scheduling/provider_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/meridianhub/meridian/shared/platform/scheduler"
 	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -83,10 +82,6 @@ func TestTenantScheduleProvider_ScheduleIDFormat(t *testing.T) {
 	assert.Equal(t, "my_tenant:my-schedule", schedules[0].ID)
 }
 
-func TestTenantScheduleProvider_ImplementsScheduleProvider(_ *testing.T) {
-	var _ scheduler.ScheduleProvider = (*TenantScheduleProvider)(nil)
-}
-
 func TestSchemaToTenantID(t *testing.T) {
 	assert.Equal(t, "acme", schemaToTenantID("org_acme"))
 	assert.Equal(t, "beta_corp", schemaToTenantID("org_beta_corp"))
@@ -105,7 +100,7 @@ const tenantScheduleDDL = `CREATE TABLE IF NOT EXISTS %s.tenant_schedule (
 	metadata JSONB,
 	created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 	updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-	CONSTRAINT uq_%s_tenant_schedule_name UNIQUE (schedule_name)
+	UNIQUE (schedule_name)
 )`
 
 func setupTestDB(t *testing.T) (*testdb.TenantTestContext, *testdb.TenantTestContext, func()) {
@@ -114,13 +109,13 @@ func setupTestDB(t *testing.T) (*testdb.TenantTestContext, *testdb.TenantTestCon
 	db, cleanup := testdb.SetupCockroachDB(t, nil)
 
 	tc1 := testdb.SetupTenantSchema(t, db, "alpha")
-	testdb.CreateTable(t, tc1.DB, tc1.Tenant, fmt.Sprintf(tenantScheduleDDL, "%s", "alpha"))
+	testdb.CreateTable(t, tc1.DB, tc1.Tenant, tenantScheduleDDL)
 
 	tc2 := testdb.SetupTenantSchema(t, db, "beta")
-	testdb.CreateTable(t, tc2.DB, tc2.Tenant, fmt.Sprintf(tenantScheduleDDL, "%s", "beta"))
+	testdb.CreateTable(t, tc2.DB, tc2.Tenant, tenantScheduleDDL)
 
 	// Reset search_path so cross-schema queries work
-	db.Exec("SET search_path TO public")
+	require.NoError(t, db.Exec("SET search_path TO public").Error)
 
 	return tc1, tc2, cleanup
 }
@@ -134,11 +129,11 @@ func TestGormTenantScheduleRepository_ListEnabledSchedules_MultiTenant(t *testin
 	defer cleanup()
 
 	// Insert enabled schedule in alpha
-	tc1.DB.Exec(fmt.Sprintf(`INSERT INTO %q.tenant_schedule (schedule_name, saga_name, cron_expr, enabled) VALUES ('daily-billing', 'billing.run', '0 0 * * *', true)`, tc1.Tenant.SchemaName()))
+	require.NoError(t, tc1.DB.Exec(fmt.Sprintf(`INSERT INTO %q.tenant_schedule (schedule_name, saga_name, cron_expr, enabled) VALUES ('daily-billing', 'billing.run', '0 0 * * *', true)`, tc1.Tenant.SchemaName())).Error)
 
 	// Insert enabled + disabled schedules in beta
-	tc2.DB.Exec(fmt.Sprintf(`INSERT INTO %q.tenant_schedule (schedule_name, saga_name, cron_expr, enabled) VALUES ('hourly-sync', 'sync.run', '0 * * * *', true)`, tc2.Tenant.SchemaName()))
-	tc2.DB.Exec(fmt.Sprintf(`INSERT INTO %q.tenant_schedule (schedule_name, saga_name, cron_expr, enabled) VALUES ('disabled-job', 'noop.run', '0 0 * * *', false)`, tc2.Tenant.SchemaName()))
+	require.NoError(t, tc2.DB.Exec(fmt.Sprintf(`INSERT INTO %q.tenant_schedule (schedule_name, saga_name, cron_expr, enabled) VALUES ('hourly-sync', 'sync.run', '0 * * * *', true)`, tc2.Tenant.SchemaName())).Error)
+	require.NoError(t, tc2.DB.Exec(fmt.Sprintf(`INSERT INTO %q.tenant_schedule (schedule_name, saga_name, cron_expr, enabled) VALUES ('disabled-job', 'noop.run', '0 0 * * *', false)`, tc2.Tenant.SchemaName())).Error)
 
 	repo := NewGormTenantScheduleRepository(tc1.DB, nil)
 	schedules, err := repo.ListEnabledSchedules(context.Background())
@@ -172,19 +167,23 @@ func TestGormTenantScheduleRepository_ListEnabledSchedules_OnlyEnabled(t *testin
 	defer cleanup()
 
 	// Insert one enabled and one disabled
-	tc1.DB.Exec(fmt.Sprintf(`INSERT INTO %q.tenant_schedule (schedule_name, saga_name, cron_expr, enabled) VALUES ('enabled-job', 'job.run', '0 0 * * *', true)`, tc1.Tenant.SchemaName()))
-	tc1.DB.Exec(fmt.Sprintf(`INSERT INTO %q.tenant_schedule (schedule_name, saga_name, cron_expr, enabled) VALUES ('disabled-job', 'noop.run', '0 0 * * *', false)`, tc1.Tenant.SchemaName()))
+	require.NoError(t, tc1.DB.Exec(fmt.Sprintf(`INSERT INTO %q.tenant_schedule (schedule_name, saga_name, cron_expr, enabled) VALUES ('enabled-job', 'job.run', '0 0 * * *', true)`, tc1.Tenant.SchemaName())).Error)
+	require.NoError(t, tc1.DB.Exec(fmt.Sprintf(`INSERT INTO %q.tenant_schedule (schedule_name, saga_name, cron_expr, enabled) VALUES ('disabled-job', 'noop.run', '0 0 * * *', false)`, tc1.Tenant.SchemaName())).Error)
 
 	repo := NewGormTenantScheduleRepository(tc1.DB, nil)
 	schedules, err := repo.ListEnabledSchedules(context.Background())
 
 	require.NoError(t, err)
 
+	// Filter to alpha schedules and verify only enabled-job is returned
+	var alphaSchedules []TenantSchedule
 	for _, s := range schedules {
 		if s.TenantID == "alpha" {
-			assert.Equal(t, "enabled-job", s.ScheduleName, "only enabled schedules should be returned")
+			alphaSchedules = append(alphaSchedules, s)
 		}
 	}
+	require.Len(t, alphaSchedules, 1, "should return exactly one enabled schedule from alpha")
+	assert.Equal(t, "enabled-job", alphaSchedules[0].ScheduleName)
 }
 
 func TestGormTenantScheduleRepository_ListEnabledSchedules_EmptyTenants(t *testing.T) {
@@ -192,14 +191,11 @@ func TestGormTenantScheduleRepository_ListEnabledSchedules_EmptyTenants(t *testi
 		t.Skip("skipping integration test")
 	}
 
-	_, _, cleanup := setupTestDB(t)
+	tc1, _, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	// No schedules inserted - both tenants have empty tables
-	db, dbCleanup := testdb.SetupCockroachDB(t, nil)
-	defer dbCleanup()
-
-	repo := NewGormTenantScheduleRepository(db, nil)
+	// No schedules inserted - tenant tables exist but are empty
+	repo := NewGormTenantScheduleRepository(tc1.DB, nil)
 	schedules, err := repo.ListEnabledSchedules(context.Background())
 
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Implements `scheduler.ScheduleProvider` interface via `TenantScheduleProvider` that queries `tenant_schedule` tables across all `org_*` tenant schemas
- `GormTenantScheduleRepository` discovers tenant schemas using `information_schema` and queries each for enabled schedules
- Schedule IDs formatted as `tenant_id:schedule_name` for unique identification across tenants

## Changes

- `services/control-plane/internal/scheduling/provider.go` - Provider, repository interface, GORM implementation
- `services/control-plane/internal/scheduling/provider_test.go` - Unit tests (provider mapping, ID format, error propagation) and integration tests (multi-tenant CockroachDB)

## Test plan

- [x] Unit tests: provider mapping, Schedule.ID format, empty results, error propagation
- [x] Integration tests: multi-tenant queries, enabled-only filtering, empty tenants (CockroachDB testcontainers)
- [x] Compile-time interface check (`var _ scheduler.ScheduleProvider = ...`)