### PR TITLE
fix: relax NATIONAL_ID regex to accept short codes like DCC

### DIFF
--- a/services/party/domain/party.go
+++ b/services/party/domain/party.go
@@ -607,8 +607,8 @@ var (
 	// LEI: 20 alphanumeric characters
 	leiRegex = regexp.MustCompile(`^[A-Z0-9]{20}$`)
 
-	// National ID: varies by country, using a general alphanumeric pattern
-	nationalIDRegex = regexp.MustCompile(`^[A-Z0-9]{5,20}$`)
+	// National ID: varies by country, using a general alphanumeric pattern (min 2 for short codes like DCC)
+	nationalIDRegex = regexp.MustCompile(`^[A-Z0-9]{2,20}$`)
 
 	// Tax ID: varies by country, using a general alphanumeric pattern
 	taxIDRegex = regexp.MustCompile(`^[A-Z0-9]{5,20}$`)

--- a/services/party/domain/party_test.go
+++ b/services/party/domain/party_test.go
@@ -357,7 +357,7 @@ func TestParty_SetExternalReference_NationalID(t *testing.T) {
 		},
 		{
 			name:      "minimum length",
-			reference: "AB123",
+			reference: "AB",
 			wantErr:   false,
 		},
 		{
@@ -367,7 +367,7 @@ func TestParty_SetExternalReference_NationalID(t *testing.T) {
 		},
 		{
 			name:      "too short",
-			reference: "AB12",
+			reference: "A",
 			wantErr:   true,
 		},
 		{

--- a/services/party/domain/party_test.go
+++ b/services/party/domain/party_test.go
@@ -518,6 +518,12 @@ func TestValidateExternalReference(t *testing.T) {
 			wantErr:   false,
 		},
 		{
+			name:      "valid short national ID",
+			reference: "DCC",
+			refType:   ExternalReferenceTypeNationalID,
+			wantErr:   false,
+		},
+		{
 			name:      "valid tax ID",
 			reference: "GB123456789",
 			refType:   ExternalReferenceTypeTaxID,


### PR DESCRIPTION
## Summary

- Lowered the NATIONAL_ID external reference regex minimum from 5 to 2 characters
- Short codes like `DCC` (3 chars), `GETW` (4 chars), and `SEPD` (4 chars) are legitimate UK energy industry identifiers used in the PAYG energy manifest
- This has been causing the nightly Demo Reset workflow to fail on every run since the PAYG tenant was added (#1963)

## Test plan

- [x] Added test case for short national ID (`DCC`) - passes
- [x] Existing `TestValidateExternalReference` suite passes
- [ ] CI green
- [ ] Demo Reset workflow succeeds after merge and redeploy