### PR TITLE
fix: return AlreadyExists gRPC code for duplicate account creation

### DIFF
--- a/services/current-account/service/grpc_account_endpoints.go
+++ b/services/current-account/service/grpc_account_endpoints.go
@@ -98,7 +98,7 @@ func (s *Service) InitiateCurrentAccount(ctx context.Context, req *pb.InitiateCu
 	// Save to database (context carries audit user info for created_by/updated_by fields)
 	if err := s.repo.Save(ctx, account); err != nil {
 		operationStatus = opStatusSaveFailed
-		if errors.Is(err, persistence.ErrAccountExists) {
+		if errors.Is(err, persistence.ErrAccountExists) || errors.Is(err, persistence.ErrVersionConflict) {
 			return nil, status.Errorf(codes.AlreadyExists, "account already exists: %v", err)
 		}
 		return nil, status.Errorf(codes.Internal, "failed to create account: %v", err)

--- a/services/current-account/service/grpc_account_endpoints.go
+++ b/services/current-account/service/grpc_account_endpoints.go
@@ -98,6 +98,9 @@ func (s *Service) InitiateCurrentAccount(ctx context.Context, req *pb.InitiateCu
 	// Save to database (context carries audit user info for created_by/updated_by fields)
 	if err := s.repo.Save(ctx, account); err != nil {
 		operationStatus = opStatusSaveFailed
+		if errors.Is(err, persistence.ErrAccountExists) {
+			return nil, status.Errorf(codes.AlreadyExists, "account already exists: %v", err)
+		}
 		return nil, status.Errorf(codes.Internal, "failed to create account: %v", err)
 	}
 

--- a/services/current-account/service/grpc_service_test.go
+++ b/services/current-account/service/grpc_service_test.go
@@ -382,6 +382,31 @@ func TestInitiateCurrentAccount(t *testing.T) {
 	}
 }
 
+func TestInitiateCurrentAccount_DuplicateReturnsAlreadyExists(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	svc := mustNewService(t, repo, nil)
+
+	req := &pb.InitiateCurrentAccountRequest{
+		ExternalIdentifier: "GB82WEST12345698765432",
+		PartyId:            uuid.New().String(),
+		InstrumentCode:     "GBP",
+	}
+
+	_, err := svc.InitiateCurrentAccount(ctx, req)
+	require.NoError(t, err)
+
+	// Second call with same external identifier should return AlreadyExists.
+	_, err = svc.InitiateCurrentAccount(ctx, req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.AlreadyExists, st.Code(), "duplicate account should return AlreadyExists, got %v: %s", st.Code(), st.Message())
+}
+
 func TestExecuteDeposit(t *testing.T) {
 	db, ctx, cleanup := setupTestDB(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

- The `InitiateCurrentAccount` endpoint returned `codes.Internal` when `repo.Save` hit a duplicate account (`ErrAccountExists`). The seed-dev fixture seeder's `createAccountIdempotent` checks for `codes.AlreadyExists` to skip existing accounts, so the wrong status code caused the nightly demo reset to fail on re-runs.
- Now checks for `persistence.ErrAccountExists` and returns `codes.AlreadyExists`, making the seeder's idempotent retry logic work correctly.

## Test plan

- [ ] Existing current-account tests pass (no behavior change for non-duplicate paths)
- [ ] Nightly demo reset succeeds on re-run without "account already exists" failures