### PR TITLE
fix: Patch 9 frontend security vulnerabilities (hono, vite)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -69,7 +69,7 @@
         "tw-animate-css": "^1.4.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
-        "vite": "^7.3.1",
+        "vite": "^7.3.2",
         "vitest": "^3.2.4",
         "vitest-axe": "^0.1.0"
       },
@@ -1925,9 +1925,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7970,9 +7970,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
-      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11710,9 +11710,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,8 +55,8 @@
     "zustand": "^5.0.11"
   },
   "overrides": {
-    "hono": "^4.12.4",
-    "@hono/node-server": "^1.19.10",
+    "hono": "^4.12.12",
+    "@hono/node-server": "^1.19.13",
     "flatted": "^3.4.2"
   },
   "devDependencies": {
@@ -87,7 +87,7 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
-    "vite": "^7.3.1",
+    "vite": "^7.3.2",
     "vitest": "^3.2.4",
     "vitest-axe": "^0.1.0"
   }


### PR DESCRIPTION
## Summary

- Bump `hono` override from 4.12.4 to 4.12.12 (5 medium CVEs - cookie bypass, IP matching, path traversal, middleware bypass)
- Bump `@hono/node-server` override from 1.19.10 to 1.19.13 (1 medium CVE - middleware bypass via repeated slashes)
- Bump `vite` from 7.3.1 to 7.3.2 (2 high + 1 medium CVE - path traversal, fs.deny bypass, WebSocket arbitrary file read)

Resolves Dependabot alerts #40-#48.

## Test plan

- [ ] CI passes (frontend build, lint, tests)
- [ ] Dependabot alerts auto-close after merge