### PR TITLE
fix: Route MCP traffic to unified binary for PRD-061 consent flow

### DIFF
--- a/deploy/demo/.env.demo.example
+++ b/deploy/demo/.env.demo.example
@@ -167,55 +167,38 @@ DEPOSIT_CLEARING_ACCOUNT_ID=CLEARING-GBP-001
 #OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
 
 # ---------------------------------------------------------------------------
-# MCP Server (AI Integration)
+# MCP OAuth 2.1 (AI Integration)
 # ---------------------------------------------------------------------------
+# MCP OAuth runs inside the unified binary, sharing in-memory consent stores
+# with the BFF (PRD-061). No separate mcp-server container needed.
 
 # [REQUIRED] Public base URL for MCP OAuth callbacks.
 MCP_BASE_URL=https://demo.meridianhub.cloud
 
-# [REQUIRED] API key for MCP server to authenticate with Meridian gRPC API.
-# Must match an entry in API_KEYS above (format: "key:identity").
-MERIDIAN_API_KEY=changeme
-
-# [OPTIONAL] Enable OAuth 2.1 for MCP clients (Claude.ai, etc.).
-# When true, MCP clients must complete an OAuth flow to get a JWT.
-MCP_OAUTH_ENABLED=false
+# [OPTIONAL] Enable OAuth 2.1 for MCP clients (Claude Code, etc.).
+# When true, MCP clients complete an OAuth consent flow via the Meridian UI.
+MCP_OAUTH_ENABLED=true
 
 # [OPTIONAL] OAuth client ID that MCP clients use to authenticate.
 #MCP_OAUTH_CLIENT_ID=meridian-mcp
-
-# [OPTIONAL] Base domain for subdomain-based tenant resolution on MCP requests.
-#MCP_BASE_DOMAIN=demo.meridianhub.cloud
 
 # [OPTIONAL] Default tenant slug for single-tenant deployments.
 # When set, bare-domain OAuth requests (no tenant subdomain) use this tenant.
 # When empty in multi-tenant mode, bare-domain requests fail closed with HTTP 400.
 #MCP_DEFAULT_TENANT_SLUG=volterra
 
-# [REQUIRED when MCP_OAUTH_ENABLED=true] Dex OIDC issuer URL (internal).
-# The MCP server acts as an OIDC client of Dex for delegated authentication.
-#MCP_DEX_ISSUER_URL=http://dex:5556/dex
-
-# [OPTIONAL] Dex static client ID for the MCP server's OIDC integration.
-#MCP_DEX_CLIENT_ID=meridian-service
-
-# [REQUIRED when MCP_OAUTH_ENABLED=true] MCP server's OIDC callback URL (must be registered in dex.yaml).
-#MCP_DEX_CALLBACK_URL=https://demo.meridianhub.cloud/oauth/callback
-
-# [REQUIRED when MCP_OAUTH_ENABLED=true] JWKS URL for validating bearer tokens on MCP requests.
-# Points to the BFF's JWKS endpoint so BFF-issued tokens are accepted.
-#MCP_JWKS_URL=https://demo.meridianhub.cloud/api/auth/jwks
-
-# [REQUIRED when MCP_OAUTH_ENABLED=true] RSA private key for JWT signing.
-# Must be the same key used by the BFF for cross-subdomain session sharing.
+# ---------------------------------------------------------------------------
+# JWT Signing Key
+# ---------------------------------------------------------------------------
+# Used by both BFF auth and MCP OAuth for token signing/validation.
 #
-# Preferred approach — mount the key as a file (keeps it out of `docker inspect`):
+# Preferred approach - mount the key as a file (keeps it out of `docker inspect`):
 #   1. Generate a key:  openssl genrsa -out /opt/meridian/secrets/jwt-signing-key.pem 2048
 #   2. Lock it down:    chmod 600 /opt/meridian/secrets/jwt-signing-key.pem
 #   3. Set the path:    JWT_SIGNING_KEY_FILE=/run/secrets/jwt-signing-key.pem
-#      (The docker-compose.yml mounts /opt/meridian/secrets → /run/secrets inside the containers.)
+#      (The docker-compose.yml mounts /opt/meridian/secrets -> /run/secrets inside the containers.)
 #
-# Fallback approach — inline PEM string (less secure, visible in `docker inspect`):
+# Fallback approach - inline PEM string (less secure, visible in `docker inspect`):
 #   Store as a single line with literal \n for newlines (docker-compose .env limitation).
 #   Generate: openssl genrsa 2048 | awk '{printf "%s\\n", $0}'
 #

--- a/deploy/demo/Caddyfile
+++ b/deploy/demo/Caddyfile
@@ -16,12 +16,14 @@ demo.meridianhub.cloud, *.demo.meridianhub.cloud {
 	}
 
 	# MCP Server: streamable HTTP transport + OAuth 2.1 endpoints
+	# Routed to the unified binary where MCP OAuth shares in-memory
+	# consent stores with the BFF (required by PRD-061).
 	# Also handles /.well-known/* for OAuth metadata discovery.
 	@mcp_transport {
 		path /mcp /mcp/* /oauth/* /.well-known/oauth-authorization-server
 	}
 	handle @mcp_transport {
-		reverse_proxy mcp-server:8090
+		reverse_proxy meridian:8090
 	}
 
 	# Dex OIDC endpoints (embedded in meridian binary)
@@ -64,11 +66,13 @@ develop.meridianhub.cloud, *.develop.meridianhub.cloud {
 	}
 
 	# MCP Server: streamable HTTP transport + OAuth 2.1 endpoints
+	# Routed to the unified binary where MCP OAuth shares in-memory
+	# consent stores with the BFF (required by PRD-061).
 	@mcp_transport {
 		path /mcp /mcp/* /oauth/* /.well-known/oauth-authorization-server
 	}
 	handle @mcp_transport {
-		reverse_proxy mcp-server-develop:8090
+		reverse_proxy meridian-develop:8090
 	}
 
 	# Dex OIDC endpoints (embedded in meridian binary)

--- a/deploy/demo/docker-compose.yml
+++ b/deploy/demo/docker-compose.yml
@@ -2,9 +2,11 @@
 #
 # Services:
 #   postgres    - PostgreSQL 16 (internal only, not exposed to host)
-#   meridian    - Unified binary with embedded Dex OIDC; starts after postgres is healthy
+#   meridian    - Unified binary with embedded Dex OIDC + MCP server; starts after postgres is healthy
 #   caddy       - Reverse proxy; exposes 80/443, terminates TLS via Cloudflare Origin Certificate
-#   mcp-server  - MCP server for AI integration (internal, proxied via Caddy)
+#
+# MCP OAuth runs inside the unified binary so the BFF and MCP share in-memory
+# consent/state stores (PRD-061). No separate mcp-server container needed.
 #
 # Usage:
 #   cp deploy/demo/.env.demo.example /opt/meridian/.env
@@ -116,6 +118,12 @@ services:
       DB_MAX_IDLE_CONNS: ${DB_MAX_IDLE_CONNS:-5}
       DB_CONN_MAX_LIFETIME: ${DB_CONN_MAX_LIFETIME:-5m}
       DB_CONN_MAX_IDLE_TIME: ${DB_CONN_MAX_IDLE_TIME:-10m}
+
+      # --- MCP OAuth 2.1 (runs inside unified binary, shares consent stores with BFF) ---
+      MCP_OAUTH_ENABLED: ${MCP_OAUTH_ENABLED:-false}
+      MCP_OAUTH_CLIENT_ID: ${MCP_OAUTH_CLIENT_ID:-meridian-mcp}
+      MCP_BASE_URL: ${MCP_BASE_URL:-}
+      MCP_DEFAULT_TENANT_SLUG: ${MCP_DEFAULT_TENANT_SLUG:-}
     volumes:
       # Mount the secrets directory read-only so JWT_SIGNING_KEY_FILE can reference
       # /run/secrets/jwt-signing-key.pem without the key appearing in docker inspect.
@@ -133,61 +141,6 @@ services:
     # the gRPC health check service on port 50051. Caddy uses service_started
     # and retries upstream connections itself during meridian startup.
     # Not exposed to host — accessed only by caddy on the internal network
-
-  mcp-server:
-    image: ${MERIDIAN_IMAGE:-ghcr.io/meridianhub/meridian:demo}
-    entrypoint: ["/mcp-server"]
-    restart: unless-stopped
-    depends_on:
-      meridian:
-        condition: service_started
-    environment:
-      # --- MCP Transport ---
-      MCP_TRANSPORT: http
-      MCP_PORT: "8090"
-      MCP_SERVER_NAME: ${MCP_SERVER_NAME:-meridian-mcp}
-      MCP_BASE_URL: ${MCP_BASE_URL:?MCP_BASE_URL must be set in the env file (e.g. https://your-domain)}
-
-      # --- Meridian API ---
-      MERIDIAN_API_URL: meridian:50051
-      MERIDIAN_API_KEY: ${MERIDIAN_API_KEY:?MERIDIAN_API_KEY must be set in the env file}
-
-      # --- Application ---
-      LOG_LEVEL: ${LOG_LEVEL:-info}
-
-      # --- OAuth 2.1 + OIDC (optional) ---
-      MCP_OAUTH_ENABLED: ${MCP_OAUTH_ENABLED:-false}
-      MCP_OAUTH_CLIENT_ID: ${MCP_OAUTH_CLIENT_ID:-meridian-mcp}
-      MCP_BASE_DOMAIN: ${BASE_DOMAIN:-}
-
-      # --- Tenant defaults (single-tenant demo mode) ---
-      MCP_DEFAULT_TENANT_SLUG: ${MCP_DEFAULT_TENANT_SLUG:-}       # e.g. "volterra" — used when no tenant subdomain is present
-
-      # --- Dex OIDC (delegates authentication to embedded Dex when MCP_OAUTH_ENABLED=true) ---
-      MCP_DEX_ISSUER_URL: ${MCP_DEX_ISSUER_URL:-}                 # e.g. https://demo.meridianhub.cloud/dex (Dex is embedded in meridian binary)
-      MCP_DEX_CLIENT_ID: ${MCP_DEX_CLIENT_ID:-meridian-service}   # Dex static client ID
-      MCP_DEX_CALLBACK_URL: ${MCP_DEX_CALLBACK_URL:-}             # e.g. https://demo.meridianhub.cloud/oauth/callback
-
-      # --- JWT signing (shared with BFF for session interoperability) ---
-      JWT_SIGNING_KEY_FILE: ${JWT_SIGNING_KEY_FILE:-}
-      JWT_SIGNING_KEY: ${JWT_SIGNING_KEY:-}
-      JWT_SIGNING_KEY_ID: ${JWT_SIGNING_KEY_ID:-meridian-1}
-      JWT_SIGNING_ISSUER: ${JWT_SIGNING_ISSUER:-meridian}
-
-      # --- Bearer token validation ---
-      MCP_JWKS_URL: ${MCP_JWKS_URL:-}                             # e.g. https://demo.meridianhub.cloud/api/auth/jwks
-    volumes:
-      - /opt/meridian/secrets:/run/secrets:ro
-    deploy:
-      resources:
-        limits:
-          cpus: '1'
-          memory: 512M
-        reservations:
-          cpus: '0.25'
-          memory: 128M
-    # Not exposed to host — accessed only by caddy on the internal network
-    # Caddy proxies /mcp to this container
 
   caddy:
     image: caddy:2-alpine

--- a/deploy/develop/.env.develop.template
+++ b/deploy/develop/.env.develop.template
@@ -118,26 +118,19 @@ JWT_SIGNING_KEY_ID=meridian-develop-1
 JWT_SIGNING_ISSUER=meridian-develop
 
 # ---------------------------------------------------------------------------
-# MCP Server (AI Integration)
+# MCP OAuth 2.1 (AI Integration)
 # ---------------------------------------------------------------------------
+# MCP OAuth runs inside the unified binary, sharing in-memory consent stores
+# with the BFF (PRD-061). No separate mcp-server container needed.
 
 # [REQUIRED] Public base URL for MCP OAuth callbacks.
 MCP_BASE_URL=https://develop.meridianhub.cloud
 
-# [REQUIRED] API key for MCP server to authenticate with Meridian gRPC API.
+# [REQUIRED] API key for service-to-service auth.
 MERIDIAN_API_KEY=
 
 # [OPTIONAL] Enable OAuth 2.1 for MCP clients.
-MCP_OAUTH_ENABLED=false
-
-# [OPTIONAL] MCP server name.
-MCP_SERVER_NAME=meridian-mcp-develop
+MCP_OAUTH_ENABLED=true
 
 # [OPTIONAL] Default tenant slug for single-tenant deployments.
 #MCP_DEFAULT_TENANT_SLUG=volterra
-
-# [REQUIRED when MCP_OAUTH_ENABLED=true] Dex OIDC issuer URL.
-#MCP_DEX_ISSUER_URL=http://meridian-develop:8090/dex
-#MCP_DEX_CLIENT_ID=meridian-service
-#MCP_DEX_CALLBACK_URL=https://develop.meridianhub.cloud/oauth/callback
-#MCP_JWKS_URL=https://develop.meridianhub.cloud/api/auth/jwks

--- a/deploy/develop/.env.develop.template
+++ b/deploy/develop/.env.develop.template
@@ -126,9 +126,6 @@ JWT_SIGNING_ISSUER=meridian-develop
 # [REQUIRED] Public base URL for MCP OAuth callbacks.
 MCP_BASE_URL=https://develop.meridianhub.cloud
 
-# [REQUIRED] API key for service-to-service auth.
-MERIDIAN_API_KEY=
-
 # [OPTIONAL] Enable OAuth 2.1 for MCP clients.
 MCP_OAUTH_ENABLED=true
 

--- a/deploy/develop/docker-compose.develop.yml
+++ b/deploy/develop/docker-compose.develop.yml
@@ -6,8 +6,7 @@
 #
 # Services:
 #   postgres-develop    - PostgreSQL 16 (isolated from demo, not exposed to host)
-#   meridian-develop    - Unified binary (develop branch build)
-#   mcp-server-develop  - MCP server for AI integration (develop branch build)
+#   meridian-develop    - Unified binary with MCP server (develop branch build)
 #
 # Usage:
 #   cp deploy/develop/.env.develop.template /opt/meridian-develop/.env
@@ -111,6 +110,12 @@ services:
       DB_MAX_IDLE_CONNS: ${DB_MAX_IDLE_CONNS:-5}
       DB_CONN_MAX_LIFETIME: ${DB_CONN_MAX_LIFETIME:-5m}
       DB_CONN_MAX_IDLE_TIME: ${DB_CONN_MAX_IDLE_TIME:-10m}
+
+      # --- MCP OAuth 2.1 (runs inside unified binary, shares consent stores with BFF) ---
+      MCP_OAUTH_ENABLED: ${MCP_OAUTH_ENABLED:-false}
+      MCP_OAUTH_CLIENT_ID: ${MCP_OAUTH_CLIENT_ID:-meridian-mcp}
+      MCP_BASE_URL: ${MCP_BASE_URL:-}
+      MCP_DEFAULT_TENANT_SLUG: ${MCP_DEFAULT_TENANT_SLUG:-}
     volumes:
       - /opt/meridian-develop/secrets:/run/secrets:ro
     networks:
@@ -124,62 +129,6 @@ services:
         reservations:
           cpus: '0.5'
           memory: 512M
-
-  mcp-server-develop:
-    image: ${MERIDIAN_IMAGE:-ghcr.io/meridianhub/meridian:develop}
-    container_name: mcp-server-develop
-    entrypoint: ["/mcp-server"]
-    restart: unless-stopped
-    depends_on:
-      meridian-develop:
-        condition: service_started
-    environment:
-      # --- MCP Transport ---
-      MCP_TRANSPORT: http
-      MCP_PORT: "8090"
-      MCP_SERVER_NAME: ${MCP_SERVER_NAME:-meridian-mcp-develop}
-      MCP_BASE_URL: ${MCP_BASE_URL:?MCP_BASE_URL must be set in the env file (e.g. https://develop.meridianhub.cloud)}
-
-      # --- Meridian API ---
-      MERIDIAN_API_URL: meridian-develop:50051
-      MERIDIAN_API_KEY: ${MERIDIAN_API_KEY:?MERIDIAN_API_KEY must be set in the env file}
-
-      # --- Application ---
-      LOG_LEVEL: ${LOG_LEVEL:-info}
-
-      # --- OAuth 2.1 + OIDC (optional) ---
-      MCP_OAUTH_ENABLED: ${MCP_OAUTH_ENABLED:-false}
-      MCP_OAUTH_CLIENT_ID: ${MCP_OAUTH_CLIENT_ID:-meridian-mcp}
-      MCP_BASE_DOMAIN: ${BASE_DOMAIN:-}
-
-      # --- Tenant defaults (single-tenant demo mode) ---
-      MCP_DEFAULT_TENANT_SLUG: ${MCP_DEFAULT_TENANT_SLUG:-}
-
-      # --- Dex OIDC ---
-      MCP_DEX_ISSUER_URL: ${MCP_DEX_ISSUER_URL:-}
-      MCP_DEX_CLIENT_ID: ${MCP_DEX_CLIENT_ID:-meridian-service}
-      MCP_DEX_CALLBACK_URL: ${MCP_DEX_CALLBACK_URL:-}
-
-      # --- JWT signing (SEPARATE from demo) ---
-      JWT_SIGNING_KEY_FILE: ${JWT_SIGNING_KEY_FILE:-}
-      JWT_SIGNING_KEY: ${JWT_SIGNING_KEY:-}
-      JWT_SIGNING_KEY_ID: ${JWT_SIGNING_KEY_ID:-meridian-develop-1}
-      JWT_SIGNING_ISSUER: ${JWT_SIGNING_ISSUER:-meridian-develop}
-
-      # --- Bearer token validation ---
-      MCP_JWKS_URL: ${MCP_JWKS_URL:-}
-    volumes:
-      - /opt/meridian-develop/secrets:/run/secrets:ro
-    networks:
-      - meridian
-    deploy:
-      resources:
-        limits:
-          cpus: '1'
-          memory: 512M
-        reservations:
-          cpus: '0.25'
-          memory: 128M
 
 volumes:
   postgres_develop_data:


### PR DESCRIPTION
## Summary

- Route MCP HTTP traffic (`/mcp`, `/oauth/*`, `/.well-known/*`) to the unified binary instead of the standalone `mcp-server` container in both demo and develop Caddyfile configs
- Add MCP OAuth env vars (`MCP_OAUTH_ENABLED`, `MCP_BASE_URL`, `MCP_OAUTH_CLIENT_ID`, `MCP_DEFAULT_TENANT_SLUG`) to the unified `meridian` service in both compose files
- Remove the standalone `mcp-server` / `mcp-server-develop` services from demo and develop compose files
- Remove obsolete Dex-specific MCP env vars (`MCP_DEX_ISSUER_URL`, `MCP_DEX_CLIENT_ID`, `MCP_DEX_CALLBACK_URL`, `MCP_JWKS_URL`) from `.env` templates
- Default `MCP_OAUTH_ENABLED=true` in env templates

## Context

PRD-061 (MCP OAuth Session Unification) replaced Dex-direct auth with a BFF consent flow that requires shared in-memory stores between the BFF and MCP OAuth handler. This only works when both run inside the unified binary (`cmd/meridian`). The code was merged (#2155-#2160) but the deploy configs still routed MCP traffic to a separate container, causing MCP OAuth to fail: the standalone container completed OAuth token issuance but Claude Code never established an MCP session because the consent stores weren't shared.

Symptoms: MCP server shows "Auth: authenticated" but "Status: needs authentication" in Claude Code.

## Deployment notes

After merging, the demo droplet needs:
1. Copy updated Caddyfile: `scp deploy/demo/Caddyfile root@68.183.40.239:/opt/meridian/Caddyfile`
2. Update `.env` on droplet: set `MCP_OAUTH_ENABLED=true`, remove `MCP_DEX_*` vars, remove `MERIDIAN_API_KEY` (no longer needed for MCP - it runs in-process)
3. Restart: `docker compose down && docker compose up -d` (removes the old `mcp-server` container)
4. Same for develop environment

## Test plan

- [ ] Verify demo MCP OAuth flow: Claude Code -> authorize -> consent page -> approve -> authenticated MCP session
- [ ] Verify develop environment starts without errors
- [ ] Verify `MCP OAuth wired with shared stores` log message appears in unified binary logs
- [ ] Verify old `mcp-server` container is no longer running