### PR TITLE
feat(auth): differentiate provisioning-pending login errors and verify admin hook failure semantics

### DIFF
--- a/services/api-gateway/auth_handler.go
+++ b/services/api-gateway/auth_handler.go
@@ -120,6 +120,16 @@ func (h *AuthHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Reject login attempts against tenants that are not yet operational. The
+	// tenant resolver middleware allows /api/auth/login through during async
+	// provisioning so this handler can return a JSON status-aware error
+	// instead of HTML, distinguishing "still being set up" from "wrong
+	// password" (which would otherwise confuse self-registered users).
+	if status, ok := tenant.StatusFromContext(ctx); ok && status != "" && status != tenantStatusActive {
+		h.handleNonActiveTenant(ctx, w, tenantID, status)
+		return
+	}
+
 	// Validate credentials and sign JWT.
 	tokenStr, identity, err := h.authenticateAndSign(ctx, tenantID, req)
 	if err != nil {
@@ -165,6 +175,44 @@ func (h *AuthHandler) authenticateAndSign(ctx context.Context, tenantID tenant.T
 
 // errInvalidCredentials is a sentinel for invalid email/password.
 var errInvalidCredentials = errors.New("invalid credentials")
+
+// Tenant lifecycle status string constants matching services/tenant/domain.Status.
+// Duplicated here as untyped strings to avoid importing the tenant domain package
+// into the API gateway (which would invert the existing dependency direction).
+const (
+	tenantStatusActive              = "active"
+	tenantStatusProvisioningPending = "provisioning_pending"
+	tenantStatusProvisioning        = "provisioning"
+	tenantStatusProvisioningFailed  = "provisioning_failed"
+)
+
+// handleNonActiveTenant responds to login attempts against tenants that are not
+// yet (or no longer) operational, returning a status-specific JSON message so
+// the SPA can render an actionable error to the user.
+func (h *AuthHandler) handleNonActiveTenant(ctx context.Context, w http.ResponseWriter, tenantID tenant.TenantID, status string) {
+	h.logger.InfoContext(ctx, "auth: login rejected - tenant not active",
+		"tenant_id", tenantID,
+		"tenant_status", status)
+
+	switch status {
+	case tenantStatusProvisioningPending, tenantStatusProvisioning:
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "Your tenant is still being set up. Please wait a moment and try again.",
+			"status": status,
+		})
+	case tenantStatusProvisioningFailed:
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "Tenant provisioning failed. Please contact support.",
+			"status": status,
+		})
+	default:
+		// suspended, deprovisioned, or any future non-active status.
+		writeJSON(w, http.StatusForbidden, map[string]string{
+			"error":  "This tenant is not currently available.",
+			"status": status,
+		})
+	}
+}
 
 // handleLoginError maps authenticateAndSign errors to HTTP responses.
 func (h *AuthHandler) handleLoginError(ctx context.Context, w http.ResponseWriter, tenantID tenant.TenantID, err error) {

--- a/services/api-gateway/auth_handler_test.go
+++ b/services/api-gateway/auth_handler_test.go
@@ -229,6 +229,142 @@ func TestAuthHandler_MethodNotAllowed(t *testing.T) {
 	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
 }
 
+func TestAuthHandler_TenantProvisioning_Returns503(t *testing.T) {
+	signer := newTestSigner(t)
+
+	connectorCalled := false
+	conn := &stubConnector{
+		loginFn: func(_ context.Context, _ []string, _, _ string) (connector.Identity, bool, error) {
+			connectorCalled = true
+			return connector.Identity{}, false, nil
+		},
+	}
+
+	handler, err := gateway.NewAuthHandler(gateway.AuthHandlerConfig{
+		Connector: conn,
+		Signer:    signer,
+		Logger:    slog.Default(),
+	})
+	require.NoError(t, err)
+
+	statuses := []string{"provisioning_pending", "provisioning"}
+	for _, status := range statuses {
+		t.Run(status, func(t *testing.T) {
+			connectorCalled = false
+
+			body, _ := json.Marshal(map[string]string{
+				"email":    "user@example.com",
+				"password": "correct",
+			})
+			req := httptest.NewRequest(http.MethodPost, "/api/auth/login", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			tid, _ := tenant.NewTenantID("acme")
+			ctx := tenant.WithTenant(req.Context(), tid)
+			ctx = tenant.WithStatus(ctx, status)
+			req = req.WithContext(ctx)
+
+			rec := httptest.NewRecorder()
+			handler.HandleLogin(rec, req)
+
+			assert.Equal(t, http.StatusServiceUnavailable, rec.Code,
+				"login during %s must return 503, not 401", status)
+			assert.False(t, connectorCalled,
+				"connector must not be called when tenant is %s", status)
+
+			var resp map[string]string
+			err := json.NewDecoder(rec.Body).Decode(&resp)
+			require.NoError(t, err)
+			assert.Contains(t, resp["error"], "still being set up",
+				"error message should mention provisioning, got %q", resp["error"])
+			assert.Equal(t, status, resp["status"], "status field should reflect tenant lifecycle")
+		})
+	}
+}
+
+func TestAuthHandler_TenantProvisioningFailed_Returns503(t *testing.T) {
+	signer := newTestSigner(t)
+
+	connectorCalled := false
+	conn := &stubConnector{
+		loginFn: func(_ context.Context, _ []string, _, _ string) (connector.Identity, bool, error) {
+			connectorCalled = true
+			return connector.Identity{}, true, nil
+		},
+	}
+
+	handler, err := gateway.NewAuthHandler(gateway.AuthHandlerConfig{
+		Connector: conn,
+		Signer:    signer,
+		Logger:    slog.Default(),
+	})
+	require.NoError(t, err)
+
+	body, _ := json.Marshal(map[string]string{
+		"email":    "user@example.com",
+		"password": "anything",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	tid, _ := tenant.NewTenantID("acme")
+	ctx := tenant.WithTenant(req.Context(), tid)
+	ctx = tenant.WithStatus(ctx, "provisioning_failed")
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	handler.HandleLogin(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.False(t, connectorCalled,
+		"connector must not be called when tenant provisioning failed")
+
+	var resp map[string]string
+	err = json.NewDecoder(rec.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Contains(t, resp["error"], "provisioning failed",
+		"error message should explain provisioning failure, got %q", resp["error"])
+	assert.Equal(t, "provisioning_failed", resp["status"])
+}
+
+func TestAuthHandler_TenantActive_ProceedsToAuth(t *testing.T) {
+	signer := newTestSigner(t)
+
+	conn := &stubConnector{
+		loginFn: func(_ context.Context, _ []string, username, password string) (connector.Identity, bool, error) {
+			if username == "user@example.com" && password == "correct" {
+				return connector.Identity{
+					UserID: "user-123",
+					Email:  "user@example.com",
+				}, true, nil
+			}
+			return connector.Identity{}, false, nil
+		},
+	}
+
+	handler, err := gateway.NewAuthHandler(gateway.AuthHandlerConfig{
+		Connector: conn,
+		Signer:    signer,
+		Logger:    slog.Default(),
+	})
+	require.NoError(t, err)
+
+	body, _ := json.Marshal(map[string]string{
+		"email":    "user@example.com",
+		"password": "correct",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	tid, _ := tenant.NewTenantID("acme")
+	ctx := tenant.WithTenant(req.Context(), tid)
+	ctx = tenant.WithStatus(ctx, "active")
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	handler.HandleLogin(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code,
+		"active tenant must proceed to authentication and succeed")
+}
+
 func TestAuthHandler_EmailNotVerified_Returns403(t *testing.T) {
 	signer := newTestSigner(t)
 

--- a/services/identity/bootstrap/demo_users_test.go
+++ b/services/identity/bootstrap/demo_users_test.go
@@ -23,6 +23,11 @@ type fakeRepo struct {
 	// schemaNotProvisioned makes FindByEmail return ErrTenantSchemaNotProvisioned
 	// for any email lookup, simulating a missing tenant schema.
 	schemaNotProvisioned bool
+
+	// Error injection fields for failure-path tests. When non-nil, the matching
+	// method returns the configured error instead of its normal result.
+	findByEmailErr   error
+	saveWithRolesErr error
 }
 
 func newFakeRepo() *fakeRepo {
@@ -47,6 +52,9 @@ func (f *fakeRepo) FindByID(_ context.Context, id uuid.UUID) (*domain.Identity, 
 }
 
 func (f *fakeRepo) FindByEmail(_ context.Context, email string) (*domain.Identity, error) {
+	if f.findByEmailErr != nil {
+		return nil, f.findByEmailErr
+	}
 	if f.schemaNotProvisioned {
 		return nil, db.ErrTenantSchemaNotProvisioned
 	}
@@ -80,6 +88,9 @@ func (f *fakeRepo) SaveIdentityWithInvitation(_ context.Context, identity *domai
 
 func (f *fakeRepo) SaveIdentityWithRoles(_ context.Context, identity *domain.Identity, roles []*domain.RoleAssignment) error {
 	f.saveWithRolesCalled = true
+	if f.saveWithRolesErr != nil {
+		return f.saveWithRolesErr
+	}
 	f.identities[identity.Email()] = identity
 	f.roles[identity.ID()] = append(f.roles[identity.ID()], roles...)
 	return nil

--- a/services/identity/bootstrap/self_registered_admin.go
+++ b/services/identity/bootstrap/self_registered_admin.go
@@ -84,6 +84,14 @@ func (h *SelfRegisteredAdminHook) AsPostProvisioningHook() func(ctx context.Cont
 // Provision creates the self-registered admin identity from tenant metadata.
 // If no registration metadata is present (e.g., tenant was created via API, not
 // self-registration), this is a no-op.
+//
+// Fail-hard semantics: every infrastructure or domain failure surfaces as a
+// non-nil error. The provisioning worker treats a non-nil hook error as fatal
+// (services/tenant/worker.executePostProvisioningHooks): tenant status stays
+// in provisioning and the worker transitions it to provisioning_failed instead
+// of active. This prevents an apparently-active tenant whose admin identity
+// was never created (which would surface to the user as a misleading "invalid
+// email or password" 401 on the very first login attempt).
 func (h *SelfRegisteredAdminHook) Provision(ctx context.Context, tenantID tenant.TenantID) error {
 	// Read tenant metadata to check for registration credentials.
 	metadata, err := h.tenantStore.GetMetadata(ctx, tenantID)

--- a/services/identity/bootstrap/self_registered_admin_test.go
+++ b/services/identity/bootstrap/self_registered_admin_test.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/meridianhub/meridian/services/identity/domain"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // mockIdentityRepo satisfies domain.Repository for testing.
@@ -25,6 +27,46 @@ func (m *mockTenantMetadataStore) GetMetadata(_ context.Context, _ tenant.Tenant
 
 func (m *mockTenantMetadataStore) UpdateMetadata(_ context.Context, _ tenant.TenantID, _ map[string]interface{}) error {
 	return nil
+}
+
+// errorInjectingMetadataStore is a TenantMetadataStore that returns
+// configurable metadata and can simulate read/write failures, used to verify
+// the fail-hard semantics of SelfRegisteredAdminHook.Provision.
+type errorInjectingMetadataStore struct {
+	metadata     map[string]interface{}
+	getErr       error
+	updateErr    error
+	updateCalled bool
+}
+
+func (m *errorInjectingMetadataStore) GetMetadata(_ context.Context, _ tenant.TenantID) (map[string]interface{}, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	// Return a copy so callers cannot mutate the test fixture.
+	if m.metadata == nil {
+		return nil, nil
+	}
+	out := make(map[string]interface{}, len(m.metadata))
+	for k, v := range m.metadata {
+		out[k] = v
+	}
+	return out, nil
+}
+
+func (m *errorInjectingMetadataStore) UpdateMetadata(_ context.Context, _ tenant.TenantID, _ map[string]interface{}) error {
+	m.updateCalled = true
+	return m.updateErr
+}
+
+// validRegistrationMetadata returns a metadata map that would satisfy the
+// hook's validation, suitable for tests that exercise downstream failure
+// paths.
+func validRegistrationMetadata() map[string]interface{} {
+	return map[string]interface{}{
+		MetaKeyRegistrationEmail:        "owner@example.com",
+		MetaKeyRegistrationPasswordHash: "$2a$12$dummyhashdummyhashdummyhashdummyhashdummyhashdummyhash",
+	}
 }
 
 func TestNewSelfRegisteredAdminHook_NilIdentityRepo(t *testing.T) {
@@ -55,4 +97,189 @@ func TestSelfRegisteredAdminHook_AsPostProvisioningHook(t *testing.T) {
 
 	// Verify RoleTenantOwner is the correct role for self-registered admins.
 	assert.Equal(t, domain.Role("TENANT_OWNER"), domain.RoleTenantOwner)
+}
+
+// --- Failure-path tests for fail-hard semantics ---
+//
+// The provisioning worker treats any non-nil error from a post-provisioning
+// hook as fatal: the tenant is marked provisioning_failed instead of active
+// (services/tenant/worker/provisioning_worker.go:executePostProvisioningHooks
+// + markTenantAsActive). These tests pin the hook's contract: every
+// infrastructure or domain failure surfaces as a non-nil error so the
+// worker's failure handling actually fires.
+
+func TestProvision_NoMetadata_NoOp(t *testing.T) {
+	tid := tenant.MustNewTenantID("acme")
+
+	repo := newFakeRepo()
+	store := &errorInjectingMetadataStore{} // no metadata at all
+
+	hook, err := NewSelfRegisteredAdminHook(repo, store, slog.Default())
+	require.NoError(t, err)
+
+	err = hook.Provision(context.Background(), tid)
+	require.NoError(t, err, "tenants without registration metadata should be a no-op, not an error")
+	assert.False(t, repo.saveWithRolesCalled, "no identity should be saved when metadata is absent")
+	assert.False(t, store.updateCalled, "metadata should not be cleared when nothing was set")
+}
+
+func TestProvision_GetMetadataFails_ReturnsError(t *testing.T) {
+	tid := tenant.MustNewTenantID("acme")
+
+	repo := newFakeRepo()
+	store := &errorInjectingMetadataStore{
+		getErr: errors.New("connection refused"),
+	}
+
+	hook, err := NewSelfRegisteredAdminHook(repo, store, slog.Default())
+	require.NoError(t, err)
+
+	err = hook.Provision(context.Background(), tid)
+	require.Error(t, err, "GetMetadata failure must surface so the worker marks the tenant provisioning_failed")
+	assert.Contains(t, err.Error(), "reading tenant metadata")
+	assert.False(t, repo.saveWithRolesCalled)
+}
+
+func TestProvision_MissingEmail_ReturnsInvalidMetadataError(t *testing.T) {
+	tid := tenant.MustNewTenantID("acme")
+
+	repo := newFakeRepo()
+	store := &errorInjectingMetadataStore{
+		metadata: map[string]interface{}{
+			MetaKeyRegistrationPasswordHash: "$2a$12$dummyhash",
+			// email key intentionally missing - partial metadata is invalid.
+		},
+	}
+
+	hook, err := NewSelfRegisteredAdminHook(repo, store, slog.Default())
+	require.NoError(t, err)
+
+	err = hook.Provision(context.Background(), tid)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidRegistrationMetadata,
+		"partial metadata (hash without email) must surface as ErrInvalidRegistrationMetadata")
+	assert.False(t, repo.saveWithRolesCalled)
+}
+
+func TestProvision_MissingPasswordHash_ReturnsInvalidMetadataError(t *testing.T) {
+	tid := tenant.MustNewTenantID("acme")
+
+	repo := newFakeRepo()
+	store := &errorInjectingMetadataStore{
+		metadata: map[string]interface{}{
+			MetaKeyRegistrationEmail: "owner@example.com",
+			// hash key intentionally missing - partial metadata is invalid.
+		},
+	}
+
+	hook, err := NewSelfRegisteredAdminHook(repo, store, slog.Default())
+	require.NoError(t, err)
+
+	err = hook.Provision(context.Background(), tid)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidRegistrationMetadata,
+		"partial metadata (email without hash) must surface as ErrInvalidRegistrationMetadata")
+	assert.False(t, repo.saveWithRolesCalled)
+}
+
+func TestProvision_SaveIdentityWithRolesFails_ReturnsError(t *testing.T) {
+	// This is the core fail-hard test: when the identity write fails (DB
+	// down, constraint violation, etc.) the hook MUST return an error so the
+	// provisioning worker does not flip the tenant to active. Otherwise the
+	// user would land on an "active" tenant with no admin identity and see a
+	// misleading "invalid email or password" 401 on first login.
+	tid := tenant.MustNewTenantID("acme")
+
+	dbErr := errors.New("database connection failed")
+	repo := newFakeRepo()
+	repo.saveWithRolesErr = dbErr
+
+	store := &errorInjectingMetadataStore{
+		metadata: validRegistrationMetadata(),
+	}
+
+	hook, err := NewSelfRegisteredAdminHook(repo, store, slog.Default())
+	require.NoError(t, err)
+
+	err = hook.Provision(context.Background(), tid)
+	require.Error(t, err, "SaveIdentityWithRoles failure must surface so the tenant is marked provisioning_failed")
+	assert.ErrorIs(t, err, dbErr, "underlying error must be wrapped, not swallowed")
+	assert.Contains(t, err.Error(), "saving identity with roles")
+	assert.True(t, repo.saveWithRolesCalled, "the failure should occur at SaveIdentityWithRoles, not earlier")
+	assert.False(t, store.updateCalled,
+		"registration metadata must NOT be cleared when identity creation fails - retries need it intact")
+}
+
+func TestProvision_UpdateMetadataFails_ReturnsError(t *testing.T) {
+	// Clearing the bcrypt hash from metadata is fatal-by-design: leaving it
+	// behind violates minimal credential retention. If the clear fails the
+	// hook must surface an error so the worker treats the tenant as failed
+	// and operators investigate.
+	tid := tenant.MustNewTenantID("acme")
+
+	repo := newFakeRepo()
+	store := &errorInjectingMetadataStore{
+		metadata:  validRegistrationMetadata(),
+		updateErr: errors.New("update conflict"),
+	}
+
+	hook, err := NewSelfRegisteredAdminHook(repo, store, slog.Default())
+	require.NoError(t, err)
+
+	err = hook.Provision(context.Background(), tid)
+	require.Error(t, err, "UpdateMetadata failure must surface to abort tenant activation")
+	assert.Contains(t, err.Error(), "clearing registration metadata")
+	assert.True(t, repo.saveWithRolesCalled, "identity should have been saved before clear was attempted")
+}
+
+func TestProvision_HappyPath_ClearsMetadataAndSavesIdentity(t *testing.T) {
+	// Sanity check that the success path still works end-to-end: identity is
+	// saved with TENANT_OWNER role and registration credentials are cleared.
+	tid := tenant.MustNewTenantID("acme")
+
+	repo := newFakeRepo()
+	store := &errorInjectingMetadataStore{
+		metadata: validRegistrationMetadata(),
+	}
+
+	hook, err := NewSelfRegisteredAdminHook(repo, store, slog.Default())
+	require.NoError(t, err)
+
+	err = hook.Provision(context.Background(), tid)
+	require.NoError(t, err)
+
+	assert.True(t, repo.saveWithRolesCalled, "identity should be saved")
+	assert.True(t, store.updateCalled, "registration metadata should be cleared")
+
+	identity, ok := repo.identities["owner@example.com"]
+	require.True(t, ok, "identity should exist after provisioning")
+	roles := repo.roles[identity.ID()]
+	require.Len(t, roles, 1)
+	assert.Equal(t, domain.RoleTenantOwner, roles[0].Role(),
+		"self-registered admin must have TENANT_OWNER role")
+}
+
+func TestProvision_IdempotentWhenIdentityAlreadyExists(t *testing.T) {
+	// If the hook is re-run (e.g. after a transient failure), and the
+	// identity already exists in the tenant schema, it should skip creation
+	// silently rather than error out.
+	tid := tenant.MustNewTenantID("acme")
+
+	existing, err := domain.NewIdentity(tid, "owner@example.com")
+	require.NoError(t, err)
+
+	repo := newFakeRepo()
+	repo.identities["owner@example.com"] = existing
+
+	store := &errorInjectingMetadataStore{
+		metadata: validRegistrationMetadata(),
+	}
+
+	hook, err := NewSelfRegisteredAdminHook(repo, store, slog.Default())
+	require.NoError(t, err)
+
+	err = hook.Provision(context.Background(), tid)
+	require.NoError(t, err, "re-running the hook against an existing admin must succeed")
+	assert.False(t, repo.saveWithRolesCalled, "must not attempt to recreate an existing identity")
+	assert.True(t, store.updateCalled, "metadata should still be cleared on the idempotent path")
 }

--- a/shared/platform/gateway/tenant_resolver.go
+++ b/shared/platform/gateway/tenant_resolver.go
@@ -56,6 +56,32 @@ func isProvisioningAllowedPath(path string) bool {
 	return false
 }
 
+// statusAwarePassThroughPaths are URL paths that must reach their downstream
+// handler even when the tenant is in a non-active provisioning state. The
+// handler is expected to check the status from context (via
+// tenant.StatusFromContext) and return an appropriate JSON response.
+//
+// This exists because the BFF login endpoint receives JSON requests and
+// needs to return JSON errors. Without this allow-list the tenant resolver
+// would intercept the request and serve the HTML provisioning page, which
+// the SPA cannot parse, leaving the user with a misleading "invalid email
+// or password" message.
+var statusAwarePassThroughPaths = []string{
+	"/api/auth/login",
+}
+
+// isStatusAwarePassThroughPath returns true if the request path is one whose
+// handler must run even for non-active tenants (with status injected into
+// context so it can return a status-specific response).
+func isStatusAwarePassThroughPath(path string) bool {
+	for _, p := range statusAwarePassThroughPaths {
+		if path == p {
+			return true
+		}
+	}
+	return false
+}
+
 // ErrTenantNotFound is returned when a tenant cannot be found by slug.
 var ErrTenantNotFound = errors.New("tenant not found")
 
@@ -287,11 +313,7 @@ func (m *TenantResolverMiddleware) HandlerOptionalTenant(next http.Handler) http
 		)
 
 		r.Header.Set(tenant.TenantIDKey, string(resolved.ID))
-		ctx = tenant.WithTenant(ctx, resolved.ID)
-		ctx = tenant.WithSlug(ctx, slug)
-		if resolved.DisplayName != "" {
-			ctx = tenant.WithDisplayName(ctx, resolved.DisplayName)
-		}
+		ctx = m.injectTenantContext(ctx, resolved, slug)
 		r = r.WithContext(ctx)
 
 		next.ServeHTTP(w, r)
@@ -338,6 +360,17 @@ func (m *TenantResolverMiddleware) Handler(next http.Handler) http.Handler {
 				slog.Int64("resolution_time_ms", resolutionTimeMs),
 			)
 
+			// Status-aware pass-through paths (e.g., /api/auth/login) need to
+			// reach their handler so it can return a JSON status-specific error
+			// instead of HTML. Inject tenant ID, slug, display name, and status
+			// into context, then forward to the downstream handler.
+			if isStatusAwarePassThroughPath(r.URL.Path) {
+				ctx = m.injectTenantContext(ctx, resolved, slug)
+				r = r.WithContext(ctx)
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			// For provisioning states, serve a progress page instead of a bare 503.
 			// Allow the provisioning status polling endpoint through so the page
 			// can fetch updates.
@@ -363,12 +396,8 @@ func (m *TenantResolverMiddleware) Handler(next http.Handler) http.Handler {
 		// Step 5: Inject tenant ID into request header
 		r.Header.Set(tenant.TenantIDKey, string(resolved.ID))
 
-		// Step 6: Add tenant ID, slug, and display name to context
-		ctx = tenant.WithTenant(ctx, resolved.ID)
-		ctx = tenant.WithSlug(ctx, slug)
-		if resolved.DisplayName != "" {
-			ctx = tenant.WithDisplayName(ctx, resolved.DisplayName)
-		}
+		// Step 6: Add tenant ID, slug, display name, and status to context
+		ctx = m.injectTenantContext(ctx, resolved, slug)
 
 		// Step 7: Update request with new context
 		r = r.WithContext(ctx)
@@ -376,6 +405,23 @@ func (m *TenantResolverMiddleware) Handler(next http.Handler) http.Handler {
 		// Step 8: Call next handler
 		next.ServeHTTP(w, r)
 	})
+}
+
+// injectTenantContext attaches the resolved tenant ID, slug, display name, and
+// lifecycle status to the context. The status is always set so downstream
+// handlers can return status-aware responses (for example, an HTTP 503 with a
+// "still provisioning" message when the BFF login handler is reached during
+// async provisioning).
+func (m *TenantResolverMiddleware) injectTenantContext(ctx context.Context, resolved resolvedTenant, slug string) context.Context {
+	ctx = tenant.WithTenant(ctx, resolved.ID)
+	ctx = tenant.WithSlug(ctx, slug)
+	if resolved.DisplayName != "" {
+		ctx = tenant.WithDisplayName(ctx, resolved.DisplayName)
+	}
+	if resolved.Status != "" {
+		ctx = tenant.WithStatus(ctx, string(resolved.Status))
+	}
+	return ctx
 }
 
 // serveProvisioningPage renders the provisioning progress page for tenants

--- a/shared/platform/gateway/tenant_resolver_test.go
+++ b/shared/platform/gateway/tenant_resolver_test.go
@@ -1206,8 +1206,12 @@ func TestServeHTTP(t *testing.T) {
 		rec := httptest.NewRecorder()
 
 		nextCalled := false
-		next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		capturedStatus := ""
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			nextCalled = true
+			if s, ok := tenant.StatusFromContext(r.Context()); ok {
+				capturedStatus = s
+			}
 			w.WriteHeader(http.StatusOK)
 		})
 
@@ -1216,6 +1220,155 @@ func TestServeHTTP(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, rec.Code, "should return 200 for active tenant")
 		assert.True(t, nextCalled, "next handler should be called")
+		assert.Equal(t, "active", capturedStatus,
+			"tenant resolver should inject status into context for downstream handlers")
+
+		mockCache.AssertExpectations(t)
+		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("login path passes through during provisioning_pending with status in context", func(t *testing.T) {
+		mockCache := new(MockSlugCache)
+		mockRepo := new(MockTenantRepository)
+		logger := slog.Default()
+
+		pendingTenant := &domain.Tenant{
+			ID:          testTenantID,
+			DisplayName: "Acme Corp",
+			Slug:        testSlug,
+			Status:      domain.StatusProvisioningPending,
+		}
+
+		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), "", nil)
+		mockRepo.On("GetBySlug", ctx, testSlug).Return(pendingTenant, nil)
+		mockCache.On("Set", ctx, testSlug, testTenantID, "provisioning_pending").Return(nil)
+
+		middleware := &TenantResolverMiddleware{
+			slugCache:  mockCache,
+			tenantRepo: mockRepo,
+			baseDomain: baseDomain,
+			logger:     logger,
+		}
+
+		req := httptest.NewRequest(http.MethodPost, "http://"+testHost+"/api/auth/login", nil)
+		req = req.WithContext(ctx)
+		rec := httptest.NewRecorder()
+
+		nextCalled := false
+		capturedStatus := ""
+		capturedTenantID := tenant.TenantID("")
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			nextCalled = true
+			if s, ok := tenant.StatusFromContext(r.Context()); ok {
+				capturedStatus = s
+			}
+			if tid, ok := tenant.FromContext(r.Context()); ok {
+				capturedTenantID = tid
+			}
+			w.WriteHeader(http.StatusOK)
+		})
+
+		handler := middleware.Handler(next)
+		handler.ServeHTTP(rec, req)
+
+		assert.True(t, nextCalled,
+			"login handler must be reached during provisioning so it can return JSON status-aware error")
+		assert.Equal(t, "provisioning_pending", capturedStatus,
+			"status should be injected into context for the login handler")
+		assert.Equal(t, testTenantID, capturedTenantID,
+			"tenant ID should be injected into context")
+
+		mockCache.AssertExpectations(t)
+		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("login path passes through during provisioning_failed with status in context", func(t *testing.T) {
+		mockCache := new(MockSlugCache)
+		mockRepo := new(MockTenantRepository)
+		logger := slog.Default()
+
+		failedTenant := &domain.Tenant{
+			ID:          testTenantID,
+			DisplayName: "Acme Corp",
+			Slug:        testSlug,
+			Status:      domain.StatusProvisioningFailed,
+		}
+
+		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), "", nil)
+		mockRepo.On("GetBySlug", ctx, testSlug).Return(failedTenant, nil)
+		mockCache.On("Set", ctx, testSlug, testTenantID, "provisioning_failed").Return(nil)
+
+		middleware := &TenantResolverMiddleware{
+			slugCache:  mockCache,
+			tenantRepo: mockRepo,
+			baseDomain: baseDomain,
+			logger:     logger,
+		}
+
+		req := httptest.NewRequest(http.MethodPost, "http://"+testHost+"/api/auth/login", nil)
+		req = req.WithContext(ctx)
+		rec := httptest.NewRecorder()
+
+		nextCalled := false
+		capturedStatus := ""
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			nextCalled = true
+			if s, ok := tenant.StatusFromContext(r.Context()); ok {
+				capturedStatus = s
+			}
+			w.WriteHeader(http.StatusOK)
+		})
+
+		handler := middleware.Handler(next)
+		handler.ServeHTTP(rec, req)
+
+		assert.True(t, nextCalled,
+			"login handler must be reached for provisioning_failed so it can return JSON error")
+		assert.Equal(t, "provisioning_failed", capturedStatus)
+
+		mockCache.AssertExpectations(t)
+		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("non-login paths still serve provisioning page during provisioning", func(t *testing.T) {
+		mockCache := new(MockSlugCache)
+		mockRepo := new(MockTenantRepository)
+		logger := slog.Default()
+
+		pendingTenant := &domain.Tenant{
+			ID:          testTenantID,
+			DisplayName: "Acme Corp",
+			Slug:        testSlug,
+			Status:      domain.StatusProvisioning,
+		}
+
+		mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), "", nil)
+		mockRepo.On("GetBySlug", ctx, testSlug).Return(pendingTenant, nil)
+		mockCache.On("Set", ctx, testSlug, testTenantID, "provisioning").Return(nil)
+
+		middleware := &TenantResolverMiddleware{
+			slugCache:  mockCache,
+			tenantRepo: mockRepo,
+			baseDomain: baseDomain,
+			logger:     logger,
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "http://"+testHost+"/api/transactions", nil)
+		req = req.WithContext(ctx)
+		rec := httptest.NewRecorder()
+
+		nextCalled := false
+		next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			nextCalled = true
+		})
+
+		handler := middleware.Handler(next)
+		handler.ServeHTTP(rec, req)
+
+		assert.False(t, nextCalled,
+			"non-login paths must still be intercepted by the provisioning page during provisioning")
+		assert.Contains(t, rec.Header().Get("Content-Type"), "text/html",
+			"non-login paths should receive HTML provisioning page")
 
 		mockCache.AssertExpectations(t)
 		mockRepo.AssertExpectations(t)

--- a/shared/platform/tenant/context.go
+++ b/shared/platform/tenant/context.go
@@ -14,6 +14,9 @@ const slugContextKey contextKey = TenantSlugKey
 // displayNameContextKey is the context key for the tenant display name.
 const displayNameContextKey contextKey = TenantDisplayNameKey
 
+// statusContextKey is the context key for the tenant lifecycle status.
+const statusContextKey contextKey = TenantStatusKey
+
 // WithTenant returns a new context with the tenant ID attached.
 func WithTenant(ctx context.Context, tenantID TenantID) context.Context {
 	return context.WithValue(ctx, tenantContextKey, tenantID)
@@ -29,6 +32,15 @@ func WithDisplayName(ctx context.Context, displayName string) context.Context {
 	return context.WithValue(ctx, displayNameContextKey, displayName)
 }
 
+// WithStatus returns a new context with the tenant lifecycle status attached.
+// The value is the string form of services/tenant/domain.Status (for example
+// "active", "provisioning", "provisioning_pending", "provisioning_failed").
+// We carry it as an untyped string to avoid importing the tenant domain
+// package here (which would create a dependency cycle).
+func WithStatus(ctx context.Context, status string) context.Context {
+	return context.WithValue(ctx, statusContextKey, status)
+}
+
 // DisplayNameFromContext extracts the tenant display name from the context.
 // Returns the display name and true if present, or empty string and false if not.
 func DisplayNameFromContext(ctx context.Context) (string, bool) {
@@ -36,6 +48,17 @@ func DisplayNameFromContext(ctx context.Context) (string, bool) {
 		return "", false
 	}
 	s, ok := ctx.Value(displayNameContextKey).(string)
+	return s, ok
+}
+
+// StatusFromContext extracts the tenant lifecycle status from the context.
+// Returns the status and true if present, or empty string and false if not.
+// The status is the string form of services/tenant/domain.Status.
+func StatusFromContext(ctx context.Context) (string, bool) {
+	if ctx == nil {
+		return "", false
+	}
+	s, ok := ctx.Value(statusContextKey).(string)
 	return s, ok
 }
 
@@ -117,6 +140,9 @@ func PropagateToBackground(parent context.Context) context.Context {
 	}
 	if displayName, ok := DisplayNameFromContext(parent); ok {
 		asyncCtx = WithDisplayName(asyncCtx, displayName)
+	}
+	if status, ok := StatusFromContext(parent); ok {
+		asyncCtx = WithStatus(asyncCtx, status)
 	}
 	return asyncCtx
 }

--- a/shared/platform/tenant/context_test.go
+++ b/shared/platform/tenant/context_test.go
@@ -72,6 +72,27 @@ func TestDisplayNameFromContext_nil_context(t *testing.T) {
 	assert.Equal(t, "", name)
 }
 
+func TestWithStatus_and_StatusFromContext(t *testing.T) {
+	ctx := WithStatus(context.Background(), "provisioning")
+
+	status, ok := StatusFromContext(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, "provisioning", status)
+}
+
+func TestStatusFromContext_missing(t *testing.T) {
+	status, ok := StatusFromContext(context.Background())
+	assert.False(t, ok)
+	assert.Equal(t, "", status)
+}
+
+func TestStatusFromContext_nil_context(t *testing.T) {
+	//nolint:staticcheck // SA1012: intentionally testing nil context handling
+	status, ok := StatusFromContext(nil)
+	assert.False(t, ok)
+	assert.Equal(t, "", status)
+}
+
 func TestMustFromContext_success(t *testing.T) {
 	tid := TenantID("acme_corp")
 	ctx := WithTenant(context.Background(), tid)
@@ -105,6 +126,7 @@ func TestPropagateToBackground_with_tenant(t *testing.T) {
 	parent := WithTenant(context.Background(), tid)
 	parent = WithSlug(parent, "acme-corp")
 	parent = WithDisplayName(parent, "Acme Corp")
+	parent = WithStatus(parent, "active")
 
 	asyncCtx := PropagateToBackground(parent)
 
@@ -122,6 +144,11 @@ func TestPropagateToBackground_with_tenant(t *testing.T) {
 	name, ok := DisplayNameFromContext(asyncCtx)
 	assert.True(t, ok)
 	assert.Equal(t, "Acme Corp", name)
+
+	// Status propagated
+	status, ok := StatusFromContext(asyncCtx)
+	assert.True(t, ok)
+	assert.Equal(t, "active", status)
 
 	// No deadline from parent
 	_, hasDeadline := asyncCtx.Deadline()

--- a/shared/platform/tenant/keys.go
+++ b/shared/platform/tenant/keys.go
@@ -15,3 +15,10 @@ const TenantSlugKey = "x-tenant-slug"
 // TenantDisplayNameKey is the key for the tenant display name (human-readable label).
 // Used in JWT claims so frontends can show the tenant name without an extra API call.
 const TenantDisplayNameKey = "x-tenant-display-name"
+
+// TenantStatusKey is the key for the tenant lifecycle status (e.g. "active",
+// "provisioning", "provisioning_pending", "provisioning_failed"). It is set by
+// the tenant resolver middleware so downstream handlers can return status-aware
+// responses (for example, the BFF login handler returns a descriptive 503 when
+// a tenant is still being provisioned, instead of a misleading 401).
+const TenantStatusKey = "x-tenant-status"


### PR DESCRIPTION
## Summary

Self-registered users hitting POST /api/auth/login during async tenant provisioning previously received the HTML provisioning page (intercepted by the tenant resolver middleware), which the SPA could not parse and which surfaced as "invalid email or password" - misleading the user about both their credentials and the tenant state. Combined fix:

- **Task 5 (UX fix)**: login handler now returns a JSON 503 with descriptive copy and the lifecycle status, distinguishing "still being set up" from "wrong password" and "provisioning failed".
- **Task 6 (safety net)**: pin the fail-hard contract of the self-registered admin post-provisioning hook so the failure path that task 5 surfaces actually fires correctly - if the hook fails, the worker marks the tenant `provisioning_failed`, never `active`.

## Changes Made

### Task 5 - login error differentiation
- `shared/platform/tenant/keys.go`, `shared/platform/tenant/context.go`: add `TenantStatusKey`, `WithStatus`, `StatusFromContext`. `PropagateToBackground` now forwards status.
- `shared/platform/gateway/tenant_resolver.go`: inject status into context for all resolved tenants. New status-aware pass-through allow-list (`/api/auth/login`) lets the auth handler run during non-active states so it can return JSON instead of HTML. Non-login paths still receive the HTML provisioning page.
- `services/api-gateway/auth_handler.go`: short-circuit before calling the connector when context status is non-active. Returns JSON 503 with status string for `provisioning_pending` / `provisioning` / `provisioning_failed`, and 403 for `suspended` / `deprovisioned`.

### Task 6 - admin hook fail-hard verification
- `services/identity/bootstrap/self_registered_admin.go`: document the fail-hard contract on `Provision`, naming the worker function that depends on it and the user-visible failure (the misleading 401) the contract prevents. No behavior change - the hook already returned errors at every failure point.
- `services/identity/bootstrap/self_registered_admin_test.go`: add 8 tests covering every failure path: GetMetadata error, missing email, missing password hash, SaveIdentityWithRoles error (the core scenario), UpdateMetadata error when clearing credentials, plus happy-path and idempotency assertions. The SaveIdentityWithRoles test also verifies registration metadata is NOT cleared on failure so retries can succeed.
- `services/identity/bootstrap/demo_users_test.go`: extend `fakeRepo` with `findByEmailErr` / `saveWithRolesErr` injection fields.

## Technical Details

### How the pieces fit
1. Tenant in `provisioning_pending` / `provisioning` -> tenant resolver previously served HTML for all paths. Now `/api/auth/login` is allowed through with status in context.
2. Auth handler reads status via `tenant.StatusFromContext` and returns a JSON 503 with descriptive copy and `status` field.
3. Once the post-provisioning hook completes, tenant flips to `active` and login proceeds normally.
4. If the hook fails, the worker (already correct) marks the tenant `provisioning_failed` - the auth handler returns a different 503 ("provisioning failed, please contact support"). The new tests pin this contract.

### Why a string in context
Status is carried as an untyped string to avoid importing `services/tenant/domain` from `shared/platform/tenant`, which would invert the existing dependency direction. The api-gateway handler defines its own const block of the same string values for the same reason.

## Testing

- `go test ./shared/platform/tenant/... ./shared/platform/gateway/... ./services/api-gateway/... ./services/identity/bootstrap/...` - all passing.
- New unit tests:
  - `TestAuthHandler_TenantProvisioning_Returns503` (provisioning_pending and provisioning subtests, asserts connector never called)
  - `TestAuthHandler_TenantProvisioningFailed_Returns503`
  - `TestAuthHandler_TenantActive_ProceedsToAuth`
  - Tenant resolver subtests for login pass-through during provisioning_pending and provisioning_failed, plus "non-login paths still serve HTML"
  - 8 `TestProvision_*` tests covering hook failure paths and invariants
  - `TestWithStatus_and_StatusFromContext`, `TestStatusFromContext_missing`, `TestStatusFromContext_nil_context`

## Risk Assessment

Low. New context key and helpers are additive. The tenant resolver behavior change is scoped to a single explicit allow-list (`/api/auth/login`); all other paths follow the existing flow. The auth handler short-circuit only fires when status is present and non-active; with no status (legacy behavior), the existing flow runs unchanged. Task 6 is purely a documentation + test addition - no production code semantics change.

## Deployment Notes

No migrations. No config changes. No new env vars.