### PR TITLE
docs: Add cookbook/README.md explaining pattern templates vs reference-data

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -1,0 +1,36 @@
+# Meridian Cookbook
+
+The cookbook is a registry of reference implementations for Meridian manifest patterns and UI
+components. Each pattern is a self-contained bundle of manifest primitives - instruments, account
+types, valuation rules, and Starlark sagas - that solves a specific business problem. Patterns are
+authored templates, not installed software: copying a pattern into your tenant configuration is the
+deployment step. The registry exists so AI assistants, the control plane UI, and human authors can
+discover available patterns, understand their dependencies, and compose them safely.
+
+## When to Use the Cookbook
+
+Use a pattern when starting a tenant configuration for a known domain and you want a vetted starting
+point rather than writing primitives from scratch. Energy billing tenants start from `energy-settlement`
+or `payg-energy`. Payment collection starts from `payment-gateway-stripe` or `default-stripe-payment`.
+Use the cookbook to understand how Meridian primitives compose - reading `saas-billing` shows how
+webhook triggers, event-driven sagas, and scheduled billing fit together in a single economy. Use
+patterns as debugging references: if a valuation rule or CEL filter behaves unexpectedly, compare
+your configuration against the canonical example.
+
+## Structure
+
+| Directory | Contents |
+|-----------|---------|
+| `patterns/` | Domain pattern bundles: `manifest-fragment.yaml`, Starlark `.star` saga files, and `pattern.json` metadata |
+| `schema/` | JSON Schema definitions for registry validation (`registry.json`, `registry-item.json`) |
+| `docs/` | Authoring guides for patterns (`authoring-patterns.md`) and UI components (`authoring-components.md`) |
+| `ui/` | UI component registry entries: `component.json` metadata pointing to frontend source files |
+
+## Relationship to Reference Data
+
+Cookbook patterns are templates, not runtime configuration. Copying a pattern's
+`manifest-fragment.yaml` into your tenant configuration and applying it via the control plane is
+what activates the instruments, account types, and sagas it declares. Nothing in the cookbook
+directory is loaded automatically. Canonical saga defaults that ship with the platform live in
+`services/reference-data/saga/defaults/` - these are the built-in behaviours Meridian applies
+before any tenant customisation. The cookbook contains composable extensions you layer on top.


### PR DESCRIPTION
## Summary

- Adds `cookbook/README.md` as the entry-point documentation for the cookbook directory
- Explains the cookbook's role as a registry of vetted manifest pattern templates (not runtime configuration)
- Covers when to use patterns, the four subdirectory purposes, and the critical distinction between cookbook templates and the canonical saga defaults in `services/reference-data/saga/defaults/`

## Task

Implements ai-navigability task 4.

## Test plan

- [ ] Markdownlint passes (verified by pre-commit hook)
- [ ] README accurately describes the actual directory structure (verified by reading cookbook before writing)
- [ ] Copy/apply distinction is clearly stated - cookbook patterns require explicit tenant configuration via control plane