### PR TITLE
docs: Backfill Reference/Registry and Identity service READMEs

### DIFF
--- a/services/identity/README.md
+++ b/services/identity/README.md
@@ -17,10 +17,10 @@ instructions: |
   at /dex/* without auth middleware. Connector type "meridian" bridges Dex to
   the identity domain via PasswordConnector.
 
-  Per-tenant isolation: identities live in org_<tenant_id> schemas. The
-  meridian_master tenant holds the platform admin. SeedDemoUsers reads
-  DEMO_OPERATOR_TENANT as a comma-separated list - each named tenant must
-  already be provisioned.
+  Per-tenant isolation: identities live in org_<tenant_id> schemas; the
+  meridian_master tenant follows the same pattern (org_meridian_master holds
+  the platform admin). SeedDemoUsers reads DEMO_OPERATOR_TENANT as a
+  comma-separated list - each named tenant must already be provisioned.
 
   Key invariant: account lockout (5 failed attempts) blocks Authenticate but
   not SetPassword or admin ReactivateIdentity.
@@ -42,7 +42,7 @@ of the Meridian architecture.
 | **BIAN Domain** | Infrastructure (non-BIAN) |
 | **Layer** | Identity |
 | **Port** | Shared gRPC port of the unified binary (default `50051`); Dex OIDC served at `/dex/*` via `api-gateway` HTTP port |
-| **Database** | CockroachDB (`meridian_identity` schema and per-tenant `org_<id>` schemas) |
+| **Database** | CockroachDB (per-tenant `org_<id>` schemas; platform admin in `org_meridian_master`) |
 | **Standalone** | No (embedded in `cmd/meridian`; requires `api-gateway` to expose OIDC endpoints) |
 
 ## API Surface
@@ -172,8 +172,8 @@ granted. This hierarchy is implemented in `domain/identity.go:CanGrant`.
 flowchart LR
     Client -- "POST /dex/token" --> APIGW["api-gateway"]
     APIGW -- "forward /dex/*" --> Dex["Embedded Dex (in-process)"]
-    Dex -- "PasswordConnector.Login" --> Connector["connector/connector.go"]
-    Connector -- "FindByEmail + bcrypt verify" --> Repo["identity domain/repository"]
+    Dex -- "PasswordConnector.Login" --> Connector["Connector"]
+    Connector -- "FindByEmail + bcrypt verify" --> Repo["Identity Repository"]
     Connector -- "FindRoleAssignments" --> Repo
     Dex -- "JWT with groups claim" --> APIGW
     APIGW -- "JWT" --> Client
@@ -191,12 +191,11 @@ identity repository directly (no gRPC hop) and maps role assignments to JWT `gro
 
 ## Dependents
 
-Grepped from the codebase for `IdentityService` callers and Dex JWKS consumers.
+Grepped from the codebase for `identityconnector` and `IdentityService` callers.
 
 | Service | Entry Point | Purpose |
 |---------|-------------|---------|
-| `api-gateway` | `services/api-gateway/auth/combined_middleware.go` | JWT validation via Dex JWKS; mounts `/dex/*` handler |
-| `tenant` | `services/tenant/provisioner/provisioner.go` | Post-provisioning hook to seed platform admin into new tenant schemas |
+| `api-gateway` | `services/api-gateway/cmd/main.go` | Wires `identityconnector` for SSO; mounts `/dex/*` handler and validates JWTs via Dex JWKS |
 
 ## Load-Bearing Files
 
@@ -223,7 +222,7 @@ Identity is embedded in the unified binary. Configuration is consumed at the
 
 | Variable | Required | Default | Purpose |
 |----------|----------|---------|---------|
-| `DATABASE_URL` | Yes | `postgres://root@localhost:26257/defaultdb?sslmode=disable` | CockroachDB base DSN (relative to `cmd/meridian` startup directory) |
+| `DATABASE_URL` | Yes | `postgres://root@localhost:26257/defaultdb?sslmode=disable` | CockroachDB base DSN |
 | `BASE_DOMAIN` | No | `app.meridianhub.cloud` | Base domain used to construct invitation accept links |
 | `PLATFORM_ADMIN_EMAIL` | No | - | Email for the bootstrapped platform admin (first-boot only) |
 | `PLATFORM_ADMIN_PASSWORD` | No | - | Password for the bootstrapped platform admin |

--- a/services/identity/README.md
+++ b/services/identity/README.md
@@ -1,82 +1,250 @@
 ---
 name: identity
-description: OIDC-based identity and authentication service for Meridian platform access
+description: Platform identity and access management - embedded Dex OIDC server, per-tenant user lifecycle, role assignment, and invitation flow
 triggers:
-  - Working on authentication and identity management
-  - Configuring OIDC providers and token validation
-  - Debugging authentication failures
-  - Managing user identity connectors
+  - Debugging authentication failures or OIDC token issues
+  - Adding or modifying user roles and permission checks
+  - Configuring the embedded Dex server or external OIDC connectors
+  - Implementing user invitation, email verification, or password reset
+  - Bootstrapping the platform admin on first boot
+  - Troubleshooting demo user seeding across tenants
 instructions: |
-  Identity service manages authentication and identity for the Meridian platform
-  using OIDC (OpenID Connect) providers.
+  Identity runs embedded inside the unified binary (cmd/meridian), not as a
+  standalone service. There is no dedicated gRPC port - IdentityService shares
+  the unified binary's gRPC port (default 50051).
 
-  Key concepts:
-  - OIDC provider integration (Dex, Keycloak, etc.)
-  - Token validation and JWKS endpoint management
-  - Identity connector configuration
-  - Bootstrap utilities for initial setup
+  Dex OIDC is an in-process library. The api-gateway mounts its HTTP handler
+  at /dex/* without auth middleware. Connector type "meridian" bridges Dex to
+  the identity domain via PasswordConnector.
 
-  Port: gRPC + HTTP
+  Per-tenant isolation: identities live in org_<tenant_id> schemas. The
+  meridian_master tenant holds the platform admin. SeedDemoUsers reads
+  DEMO_OPERATOR_TENANT as a comma-separated list - each named tenant must
+  already be provisioned.
+
+  Key invariant: account lockout (5 failed attempts) blocks Authenticate but
+  not SetPassword or admin ReactivateIdentity.
 ---
 
-# Identity
+# identity
 
-OIDC-based identity and authentication service for Meridian platform access.
+Platform identity and access management. Manages per-tenant user credentials, role
+assignments, invitation flows, email verification, and password reset. Hosts an
+embedded Dex OIDC server that issues JWTs consumed by the api-gateway.
+
+Sits on the [Identity layer](../../docs/architecture-layers.md#7-identity)
+of the Meridian architecture.
 
 ## Overview
 
 | Attribute | Value |
 |-----------|-------|
-| **Domain** | Identity & Access Management |
-| **Language** | Go |
-| **Database** | CockroachDB |
-| **Standalone** | No (embedded Dex OIDC server) |
+| **BIAN Domain** | Infrastructure (non-BIAN) |
+| **Layer** | Identity |
+| **Port** | Shared gRPC port of the unified binary (default `50051`); Dex OIDC served at `/dex/*` via `api-gateway` HTTP port |
+| **Database** | CockroachDB (`meridian_identity` schema and per-tenant `org_<id>` schemas) |
+| **Standalone** | No (embedded in `cmd/meridian`; requires `api-gateway` to expose OIDC endpoints) |
 
-## Purpose
+## API Surface
 
-The Identity service provides authentication for the Meridian platform by:
+### gRPC
 
-- Running an embedded Dex OIDC server within the unified binary
-- Bridging Dex authentication to Meridian's identity domain via a custom `PasswordConnector`
-- Managing users, credentials, and role assignments per tenant
-- Bootstrapping demo/operator users at startup
-- Serving OIDC endpoints at `/dex/*` (token, JWKS, discovery)
+| Service | RPC | Purpose |
+|---------|-----|---------|
+| `IdentityService` | `CreateIdentity` | Create a new user account in a tenant |
+| `IdentityService` | `RetrieveIdentity` | Fetch user by ID |
+| `IdentityService` | `UpdateIdentity` | Update display name or profile fields |
+| `IdentityService` | `ListIdentities` | List users within the caller's tenant |
+| `IdentityService` | `Authenticate` | Validate email and password; returns identity and roles |
+| `IdentityService` | `SetPassword` | Set password (admin operation, no current-password check) |
+| `IdentityService` | `ChangePassword` | Change password with current-password verification |
+| `IdentityService` | `RequestPasswordReset` | Issue a time-limited reset token and queue email |
+| `IdentityService` | `CompletePasswordReset` | Redeem reset token and set new password |
+| `IdentityService` | `GrantRole` | Assign a role to an identity (caller must outrank target) |
+| `IdentityService` | `RevokeRole` | Remove a role assignment |
+| `IdentityService` | `ListRoleAssignments` | List all active role assignments for an identity |
+| `IdentityService` | `InviteUser` | Create a pending identity and send invitation email |
+| `IdentityService` | `AcceptInvitation` | Redeem invitation token and activate account |
+| `IdentityService` | `SuspendIdentity` | Move identity to SUSPENDED status |
+| `IdentityService` | `ReactivateIdentity` | Restore SUSPENDED identity to ACTIVE |
 
-## Architecture
+Proto: [`api/proto/meridian/identity/v1/identity.proto`](../../api/proto/meridian/identity/v1/identity.proto).
 
-Dex runs as an embedded library within the Meridian binary rather than as a standalone container.
-The API gateway mounts Dex endpoints at `/dex/*` without auth middleware, since these endpoints
-are the authentication entry point. Tenant context is resolved from the request subdomain before
-reaching the connector.
+### OIDC (HTTP via api-gateway)
 
-```text
-Client -> Caddy (/dex/*) -> API Gateway -> Embedded Dex Server
-                                              |
-                                              v
-                                     MeridianConnector (PasswordConnector)
-                                              |
-                                     +--------+--------+
-                                     |        |        |
-                                  FindByEmail  Bcrypt  RoleAssignments
-                                  (identity   verify  (groups -> JWT
-                                   repo)              claims)
+Dex endpoints are mounted by the api-gateway at `/dex/*` without authentication middleware.
+All standard OIDC paths are served by the embedded Dex instance.
+
+| Path | Purpose |
+|------|---------|
+| `/dex/.well-known/openid-configuration` | OIDC discovery document |
+| `/dex/keys` | JWKS endpoint (public key rotation every 6 hours) |
+| `/dex/token` | Token endpoint (password grant, authorization code exchange) |
+| `/dex/auth` | Authorization endpoint |
+
+The connector ID is `meridian`. Token signing uses a local signer with 6-hour key
+rotation backed by Dex in-memory storage.
+
+## Domain Model
+
+```mermaid
+classDiagram
+    class Identity {
+        +UUID id
+        +TenantID tenantID
+        +string email
+        +IdentityStatus status
+        +string passwordHash
+        +int failedAttempts
+        +time lockedAt
+        +time activatedAt
+        +time createdAt
+    }
+
+    class RoleAssignment {
+        +UUID id
+        +TenantID tenantID
+        +UUID identityID
+        +UUID grantedByID
+        +Role role
+        +bool active
+        +time grantedAt
+        +time revokedAt
+    }
+
+    class Invitation {
+        +UUID id
+        +UUID inviteeID
+        +UUID inviterID
+        +string tokenHash
+        +InvitationStatus status
+        +time expiresAt
+        +time acceptedAt
+    }
+
+    class VerificationToken {
+        +UUID id
+        +UUID identityID
+        +string tokenHash
+        +time expiresAt
+        +time usedAt
+    }
+
+    class PasswordResetToken {
+        +UUID id
+        +UUID identityID
+        +string tokenHash
+        +time expiresAt
+        +time usedAt
+    }
+
+    class Role {
+        <<enumeration>>
+        OPERATOR
+        ADMIN
+        TENANT_OWNER
+        SUPER_ADMIN
+        PLATFORM_ADMIN
+    }
+
+    class IdentityStatus {
+        <<enumeration>>
+        PENDING_VERIFICATION
+        ACTIVE
+        SUSPENDED
+    }
+
+    Identity "1" --> "*" RoleAssignment : holds
+    Identity "1" --> "*" Invitation : receives
+    Identity "1" --> "*" PasswordResetToken : owns
+    Identity "1" --> "*" VerificationToken : owns
+    RoleAssignment --> Role
+    Identity --> IdentityStatus
 ```
 
-## Directory Structure
+Roles form a hierarchy: `PLATFORM_ADMIN > SUPER_ADMIN > TENANT_OWNER > ADMIN > OPERATOR`.
+`GrantRole` enforces that the caller's highest active role strictly outranks the role being
+granted. This hierarchy is implemented in `domain/identity.go:CanGrant`.
 
-```text
-services/identity/
-├── adapters/           # External adapters
-├── atlas/              # Atlas migration configuration
-├── bootstrap/          # Bootstrap utilities and demo user seeding
-├── connector/          # Meridian PasswordConnector bridging Dex to identity domain
-├── dex/                # Embedded Dex OIDC server package
-├── domain/             # Domain models (users, credentials, roles)
-├── migrations/         # CockroachDB migrations
-└── service/            # gRPC service implementation
+### Dex Integration
+
+```mermaid
+flowchart LR
+    Client -- "POST /dex/token" --> APIGW["api-gateway"]
+    APIGW -- "forward /dex/*" --> Dex["Embedded Dex (in-process)"]
+    Dex -- "PasswordConnector.Login" --> Connector["connector/connector.go"]
+    Connector -- "FindByEmail + bcrypt verify" --> Repo["identity domain/repository"]
+    Connector -- "FindRoleAssignments" --> Repo
+    Dex -- "JWT with groups claim" --> APIGW
+    APIGW -- "JWT" --> Client
 ```
+
+The `connector` package implements `dex/dexserver.PasswordConnector`. It calls the
+identity repository directly (no gRPC hop) and maps role assignments to JWT `groups` claims.
+
+## Dependencies
+
+| Service | Protocol | Purpose |
+|---------|----------|---------|
+| CockroachDB | SQL | User credentials, role assignments, invitations, verification tokens |
+| Email outbox (PostgreSQL) | SQL | Queue invitation, verification, and password-reset emails via `shared/pkg/email` |
+
+## Dependents
+
+Grepped from the codebase for `IdentityService` callers and Dex JWKS consumers.
+
+| Service | Entry Point | Purpose |
+|---------|-------------|---------|
+| `api-gateway` | `services/api-gateway/auth/combined_middleware.go` | JWT validation via Dex JWKS; mounts `/dex/*` handler |
+| `tenant` | `services/tenant/provisioner/provisioner.go` | Post-provisioning hook to seed platform admin into new tenant schemas |
+
+## Load-Bearing Files
+
+Paths are relative to `services/identity/`.
+
+| File | Why It Matters |
+|------|----------------|
+| `service/server.go` | gRPC service root; wires repository, email outbox, and base URL |
+| `service/grpc_identity_endpoints.go` | Identity CRUD and authentication RPCs including lockout enforcement |
+| `service/grpc_role_endpoints.go` | Role grant/revoke RPCs; enforces caller-outranks-target invariant |
+| `service/grpc_invitation_endpoints.go` | Invitation and acceptance flow; token generation and email queuing |
+| `dex/server.go` | Embedded Dex lifecycle; `StartServer` must be called before serving OIDC requests |
+| `dex/connector_adapter.go` | Bridges Dex `PasswordConnector` to Meridian identity domain |
+| `connector/connector.go` | Core authentication logic: `FindByEmail`, bcrypt verify, lockout check, role claims |
+| `domain/identity.go` | Identity aggregate: status machine, password hashing, lockout logic |
+| `domain/role_assignment.go` | RoleAssignment aggregate and `CanGrant` privilege hierarchy |
+| `bootstrap/bootstrap.go` | Platform admin bootstrap and demo user seeding on first boot |
+| `migrations/` | Atlas-managed schema; never edit applied files |
+
+## Configuration
+
+Identity is embedded in the unified binary. Configuration is consumed at the
+`cmd/meridian` level and passed to the identity service during wiring.
+
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `DATABASE_URL` | Yes | `postgres://root@localhost:26257/defaultdb?sslmode=disable` | CockroachDB base DSN (relative to `cmd/meridian` startup directory) |
+| `BASE_DOMAIN` | No | `app.meridianhub.cloud` | Base domain used to construct invitation accept links |
+| `PLATFORM_ADMIN_EMAIL` | No | - | Email for the bootstrapped platform admin (first-boot only) |
+| `PLATFORM_ADMIN_PASSWORD` | No | - | Password for the bootstrapped platform admin |
+| `DEMO_OPERATOR_EMAIL` | No | - | Email for demo operator users to seed at startup |
+| `DEMO_OPERATOR_PASSWORD` | No | - | Password for demo operator users |
+| `DEMO_OPERATOR_TENANT` | No | `volterra` | Comma-separated tenant IDs to seed the demo operator into |
+| `DEX_CONNECTORS` | No | - | JSON array of external OIDC connector definitions (Google, Azure AD) |
+| `DEX_REDIRECT_URIS` | No | - | Additional OAuth redirect URIs added to the Dex client at startup |
+
+## Security Considerations
+
+RBAC method permissions are declared in `rbac/method_permissions.go`. The
+`Authenticate` RPC enforces account lockout after 5 consecutive failed attempts.
+Invitation tokens, verification tokens, and password reset tokens are stored as
+bcrypt hashes - the plaintext is only returned at issuance. Dex key rotation
+occurs every 6 hours; the JWKS endpoint at `/dex/keys` always reflects the
+current keyset.
 
 ## References
 
-- [Service Architecture](../README.md)
-- [Dex Identity Migration Plan](../../deploy/demo/dex-identity-migration-plan.md)
+- [`docs/architecture-layers.md`](../../docs/architecture-layers.md) - Identity layer description
+- [`api/proto/meridian/identity/v1/`](../../api/proto/meridian/identity/v1/) - Proto definitions
+- [`cmd/meridian/wire_identity.go`](../../cmd/meridian/wire_identity.go) - Unified binary wiring
+- ADR-0002: Microservices per BIAN Domain

--- a/services/market-information/README.md
+++ b/services/market-information/README.md
@@ -1,206 +1,113 @@
 ---
-name: market-information-service
-description: BIAN Market Information Management for market data sets, price observations, and data sources with bi-temporal support
+name: market-information
+description: BIAN Market Information Management - bi-temporal price observations with the time-bound quality ladder for FX rates, energy prices, carbon prices, and other market data
 triggers:
-  - Managing market data feeds and price benchmarks
-  - Recording price observations with quality levels
-  - Implementing bi-temporal data patterns (knowledge time vs event time)
-  - Building CEL validation rules for market data
-  - Handling time-bound quality ladder patterns
-  - Working with interest rate curves and FX rates
+  - Recording price observations or market data feeds
+  - Implementing bi-temporal queries (event time vs knowledge time)
+  - Configuring the quality ladder (ESTIMATE to REVISED)
+  - Integrating ECB FX rate ingestion
+  - Forecasting service needing historical price data
+  - Control-plane manifest applying market data set definitions
 instructions: |
-  Market Information Management maintains market data sets, observations, and data sources
-  following BIAN v14.0 Market Information Management domain.
+  Market Information owns time-series observations, not instrument definitions.
+  Reference Data owns what can be observed; Market Information owns the observations.
 
-  Key concepts:
-  - DataSetDefinition: Reference data describing market data types with CEL validation
-  - MarketPriceObservation: Time-series observations with bi-temporal support
-  - DataSource: Provider registry with trust levels for conflict resolution
-  - Quality Ladder: ESTIMATE < PROVISIONAL < ACTUAL < REVISED
-  - Bi-temporal: Event time (observed_at) and knowledge time (created_at)
+  Quality ladder: ESTIMATE(1) < PROVISIONAL(2) < ACTUAL(3) < REVISED(4).
+  Higher quality supersedes lower. superseded_by links form an immutable chain.
 
-  Quality Ladder ordering:
-  - ESTIMATE (1): Preliminary estimate, subject to revision
-  - PROVISIONAL (2): Provisional value, pending verification
-  - ACTUAL (3): Verified, final value
-  - REVISED (4): Corrected value replacing previous observation
+  ECB worker runs as a background goroutine in the same process. Enable via
+  ECB_ENABLED=true. Default interval is 24h; dataset code ECB_FX.
 
-  CEL Validation:
-  - resolution_key_expression: Generates unique keys for observations
-  - validation_expression: Validates observation values
-  - error_message_expression: Custom error messages
-
-  Component Responsibilities:
-  - Market Information: OWNS market data observations and time-series data
-  - Reference Data: OWNS instrument definitions and asset metadata
-
-  Port: 50058 (gRPC)
+  Port: 50058 (gRPC). No outbound gRPC dependencies - leaf service.
 ---
 
-# Market Information Service
+# market-information
 
-BIAN-compliant market information management service for market data sets, price
-observations, and data sources with bi-temporal support.
+BIAN Market Information Management service. Stores bi-temporal price observations
+across data categories: FX rates, interest rates, energy prices, carbon prices,
+commodity prices, equity prices, and utilization benchmarks.
+
+Sits on the [Reference and Registry layer](../../docs/architecture-layers.md#6-reference-and-registry)
+of the Meridian architecture.
 
 ## Overview
 
 | Attribute | Value |
 |-----------|-------|
 | **BIAN Domain** | Market Information Management |
-| **Port** | 50058 (gRPC) |
-| **Language** | Go |
-| **Database** | PostgreSQL/CockroachDB |
-| **Standalone** | Yes |
+| **Layer** | Reference and Registry |
+| **Port** | 50058 (gRPC), 8082 (HTTP health/metrics) |
+| **Database** | CockroachDB (per-tenant schema) |
+| **Standalone** | No (requires CockroachDB) |
 
-## gRPC Methods
+## API Surface
 
-### Data Set Operations
+### gRPC
 
-| Method | HTTP | Purpose |
-|--------|------|---------|
-| `RegisterDataSet` | `POST /v1/market-information/datasets` | Create new data set definition |
-| `UpdateDataSet` | `PATCH /v1/market-information/datasets/{code}` | Modify DRAFT data set |
-| `ActivateDataSet` | `POST /v1/market-information/datasets/{code}/activate` | Transition to ACTIVE |
-| `DeprecateDataSet` | `POST /v1/market-information/datasets/{code}/deprecate` | Transition to DEPRECATED |
-| `RetrieveDataSet` | `GET /v1/market-information/datasets/{code}` | Get data set by code |
-| `ListDataSets` | `GET /v1/market-information/datasets` | List with filters |
+| Service | RPC | Purpose |
+|---------|-----|---------|
+| `MarketInformationService` | `RegisterDataSet` | Create a data set definition (DRAFT) |
+| `MarketInformationService` | `UpdateDataSet` | Modify a DRAFT data set |
+| `MarketInformationService` | `ActivateDataSet` | Transition DRAFT to ACTIVE |
+| `MarketInformationService` | `DeprecateDataSet` | Transition ACTIVE to DEPRECATED |
+| `MarketInformationService` | `RetrieveDataSet` | Fetch one data set by code |
+| `MarketInformationService` | `ListDataSets` | Paginated list with category and status filters |
+| `MarketInformationService` | `RegisterDataSource` | Register a data provider (ECB, Bloomberg, etc.) |
+| `MarketInformationService` | `UpdateDataSource` | Modify a data source |
+| `MarketInformationService` | `DeactivateDataSource` | Mark a source inactive |
+| `MarketInformationService` | `DeprecateDataSource` | Mark a source deprecated |
+| `MarketInformationService` | `ListDataSources` | List registered data sources |
+| `MarketInformationService` | `RecordObservation` | Record a single price observation |
+| `MarketInformationService` | `RecordObservationBatch` | Record up to 1000 observations atomically |
+| `MarketInformationService` | `RetrieveObservation` | Fetch an observation by ID; supports `knowledge_base_time` for bi-temporal lookup |
+| `MarketInformationService` | `ListObservations` | Time-range and quality-filtered observation queries |
 
-### Data Source Operations
+Proto: [`api/proto/meridian/market_information/v1/market_information.proto`](../../api/proto/meridian/market_information/v1/market_information.proto).
 
-| Method | HTTP | Purpose |
-|--------|------|---------|
-| `RegisterDataSource` | `POST /v1/market-information/sources` | Create new data source |
-| `UpdateDataSource` | `PATCH /v1/market-information/sources/{code}` | Modify data source |
-| `DeactivateDataSource` | `POST /v1/market-information/sources/{code}/deactivate` | Mark as inactive |
-| `ListDataSources` | `GET /v1/market-information/sources` | List with filters |
-
-### Observation Operations
-
-| Method | HTTP | Purpose |
-|--------|------|---------|
-| `RecordObservation` | `POST /v1/market-information/observations` | Record single observation |
-| `RecordObservationBatch` | `POST /v1/market-information/observations/batch` | Record batch (1-1000) |
-| `RetrieveObservation` | `GET /v1/market-information/observations/{observation_id}` | Get observation by ID |
-| `ListObservations` | `GET /v1/market-information/datasets/{dataset_code}/observations` | List with filters |
-
-## BIAN Alignment
-
-This service implements the **Market Information Management** service domain from BIAN v14.0, which provides:
-
-- Market data feed management and aggregation
-- Price observation capture with multiple data sources
-- Bi-temporal query support (knowledge time vs event time)
-- Quality ladder for data confidence levels
-- Data set versioning and lifecycle management
-
-**Market Information vs Reference Data:**
-
-| Responsibility | Service |
-|----------------|---------|
-| **Market data observations** (prices, rates) | Market Information |
-| **Instrument definitions** (currencies, assets) | Reference Data |
-| **Time-series data** (historical prices) | Market Information |
-| **Asset metadata** (decimal places, codes) | Reference Data |
-| **Quality levels** (ESTIMATE, ACTUAL) | Market Information |
-| **CEL validation rules** | Both (different contexts) |
-
-## Architecture
-
-```mermaid
-flowchart TB
-    subgraph External["External Data Sources"]
-        ECB["ECB<br/>(European Central Bank)"]
-        Bloomberg["Bloomberg"]
-        Reuters["Reuters"]
-    end
-
-    subgraph Service["Market Information Service :50058"]
-        Server["gRPC Server"]
-        Domain["Domain Logic"]
-        Repo["Repositories"]
-        ECBWorker["ECB Worker<br/>(Background)"]
-    end
-
-    subgraph Storage["Storage Layer"]
-        DB[("PostgreSQL<br/>market_information schema")]
-    end
-
-    ECB -->|"Daily FX Rates<br/>(XML Feed)"| ECBWorker
-    Bloomberg -.->|"Future: REST API"| Server
-    Reuters -.->|"Future: REST API"| Server
-
-    ECBWorker -->|"RecordObservation"| Server
-    Server --> Domain
-    Domain --> Repo
-    Repo --> DB
-
-    classDef external fill:#ff9800,stroke:#e65100,color:#fff
-    classDef service fill:#4a90d9,stroke:#2d5a87,color:#fff
-    classDef storage fill:#50c878,stroke:#2d7a4a,color:#fff
-
-    class ECB,Bloomberg,Reuters external
-    class Server,Domain,Repo,ECBWorker service
-    class DB storage
-```
-
-**Flow:**
-
-1. External data sources push/pull market data to service
-2. ECB Worker polls ECB daily for EUR FX rates (background job)
-3. gRPC API receives observations from clients or internal workers
-4. Domain layer validates against data set CEL expressions
-5. Repositories persist to PostgreSQL with bi-temporal tracking
-
-## Data Model
+## Domain Model
 
 ```mermaid
 classDiagram
     class DataSetDefinition {
-        +UUID ID
-        +string Code
-        +int Version
-        +DataCategory Category
-        +string Unit
-        +string ResolutionKeyExpression
-        +string ValidationExpression
-        +string ErrorMessageExpression
-        +JSON AttributeSchema
-        +DataSetStatus Status
-        +Time EffectiveFrom
-        +Time EffectiveTo
+        +UUID id
+        +string code
+        +int version
+        +DataCategory category
+        +string unit
+        +DataSetStatus status
+        +string resolutionKeyExpression
+        +string validationExpression
+        +string errorMessageExpression
+        +JSON attributeSchema
+        +time effectiveFrom
+        +time effectiveTo
+        +time activatedAt
+        +time deprecatedAt
     }
 
     class MarketPriceObservation {
-        +UUID ID
-        +string DatasetCode
-        +int DatasetVersion
-        +string ResolutionKeyValue
-        +Time ObservedAt
-        +Time ValidFrom
-        +Time ValidTo
-        +string Value
-        +QualityLevel Quality
-        +UUID SourceID
-        +Time CreatedAt
-        +Time SupersededAt
-        +UUID SupersededByID
-        +AttributeEntry[] Attributes
+        +UUID id
+        +string datasetCode
+        +int datasetVersion
+        +string resolutionKey
+        +time observedAt
+        +time validFrom
+        +time validTo
+        +time createdAt
+        +string value
+        +QualityLevel quality
+        +UUID sourceID
+        +UUID supersededBy
+        +time supersededAt
     }
 
     class DataSource {
-        +UUID ID
-        +string Code
-        +string Name
-        +int TrustLevel
-        +bool IsActive
-        +Time CreatedAt
-    }
-
-    class DataSetStatus {
-        <<enumeration>>
-        DRAFT
-        ACTIVE
-        DEPRECATED
+        +UUID id
+        +string code
+        +string name
+        +int trustLevel
+        +DataSourceStatus status
+        +time createdAt
     }
 
     class QualityLevel {
@@ -209,6 +116,13 @@ classDiagram
         PROVISIONAL
         ACTUAL
         REVISED
+    }
+
+    class DataSetStatus {
+        <<enumeration>>
+        DRAFT
+        ACTIVE
+        DEPRECATED
     }
 
     class DataCategory {
@@ -220,410 +134,100 @@ classDiagram
         ENERGY_PRICE
         CARBON_PRICE
         BENCHMARK_RATE
+        VOLATILITY
+        CREDIT_SPREAD
     }
 
     DataSetDefinition --> DataSetStatus
     DataSetDefinition --> DataCategory
     MarketPriceObservation --> QualityLevel
-    MarketPriceObservation --> DataSource
-    MarketPriceObservation --> DataSetDefinition : "validates against"
+    MarketPriceObservation --> DataSource : provided by
+    MarketPriceObservation --> DataSetDefinition : validated against
+    MarketPriceObservation --> MarketPriceObservation : supersededBy
 ```
 
-**Field Notes:**
+### Bi-Temporal Model
 
-- `ResolutionKeyExpression`: CEL expression to generate unique observation keys
-  - Example: `'spot'` for simple spot prices
-  - Example: `tenor + ':' + settlement_type` for rate curves
-- `ValidationExpression`: CEL expression to validate observation values
-  - Example: `value > 0 && value < 10000` for price bounds
-- `AttributeSchema`: JSON Schema defining valid attributes for observations
+Every observation carries two time dimensions:
 
-## Component Responsibilities
+| Dimension | Field | Meaning |
+|-----------|-------|---------|
+| Event time | `observed_at` | When the price occurred in the real world |
+| Knowledge time | `created_at` | When the system recorded the observation |
+| Valid time | `valid_from`, `valid_to` | When the value is valid (forward curves) |
 
-### Market Information Service
+`RetrieveObservation` accepts an optional `knowledge_base_time` to answer "what did the
+system know as of time T?" - the regulatory audit use case.
 
-**Owns:**
+### Quality Ladder
 
-- Market price observations (time-series data)
-- Data set definitions (what can be observed)
-- Data sources (who provides data)
-- Quality levels (confidence in observations)
-- Bi-temporal tracking (when observed, when known)
-
-**Examples:**
-
-- EUR/USD exchange rate at 1.0850 observed at 2026-01-20T10:00:00Z
-- LIBOR 3-month rate at 5.25% with quality ACTUAL
-- Brent crude oil price at $85.50/barrel from Reuters (trust level 90)
-
-### Reference Data Service
-
-**Owns:**
-
-- Instrument definitions (currencies, commodities, assets)
-- Validation rules for quantities
-- Fungibility rules for position aggregation
-- Asset metadata (decimal places, ISO codes)
-
-**Examples:**
-
-- EUR currency definition (ISO 4217, 2 decimal places)
-- GBP_PER_MWH energy unit definition
-- BRENT_CRUDE commodity instrument definition
-
-**Why the separation?**
-
-- **Market Information**: Dynamic time-series data that changes frequently
-- **Reference Data**: Static metadata that changes infrequently
-- **Market Information**: Multiple observations per second (high-frequency)
-- **Reference Data**: Version-controlled definitions (low-frequency)
-
-## Quality Ladder
-
-Market Information uses a **Time-Bound Quality Ladder** to handle evolving data quality:
-
-```mermaid
-stateDiagram-v2
-    direction LR
-    ESTIMATE --> PROVISIONAL: verification
-    PROVISIONAL --> ACTUAL: confirmation
-    ACTUAL --> REVISED: correction
-```
-
-| Quality Level | Value | Description | Supersedes |
-|--------------|-------|-------------|------------|
-| `ESTIMATE` | 1 | Preliminary estimate, subject to revision | None |
-| `PROVISIONAL` | 2 | Provisional value, pending final verification | ESTIMATE |
-| `ACTUAL` | 3 | Verified, final value | PROVISIONAL |
-| `REVISED` | 4 | Corrected value replacing previous observation | ACTUAL |
-
-**Ordering:** `ESTIMATE < PROVISIONAL < ACTUAL < REVISED`
-
-**Supersession Rules:**
-
-- Higher quality observations can supersede lower quality
-- `superseded_by_id` links to the newer observation
-- `superseded_at` records when supersession occurred
-- Original observations remain queryable (bi-temporal support)
-
-**Example Flow:**
+Higher-quality observations supersede lower-quality ones for the same dataset and
+`resolution_key`. Supersession is non-destructive: older observations remain queryable.
 
 ```text
-10:00 AM - ESTIMATE:  1.0800 (quick estimate)
-10:15 AM - PROVISIONAL: 1.0850 (supersedes ESTIMATE)
-11:00 AM - ACTUAL:     1.0855 (supersedes PROVISIONAL)
-12:00 PM - REVISED:    1.0860 (correction, supersedes ACTUAL)
+ESTIMATE(1) -> PROVISIONAL(2) -> ACTUAL(3) -> REVISED(4)
 ```
 
-## Bi-Temporal Support
+## Dependencies
 
-Market Information supports **bi-temporal queries** with two time dimensions:
+| Service | Protocol | Purpose |
+|---------|----------|---------|
+| CockroachDB | SQL | All observation and definition persistence |
+| ECB SDMX API | HTTP (background) | Daily EUR FX rate ingestion via ECB worker (when `ECB_ENABLED=true`) |
 
-| Time Dimension | Field | Meaning |
-|----------------|-------|---------|
-| **Event Time** | `observed_at` | When the observation occurred in the real world |
-| **Knowledge Time** | `created_at` | When the system learned about the observation |
-| **Valid Time** | `valid_from`, `valid_to` | When the observation value is valid (for forward curves) |
+Market Information has no outbound gRPC dependencies. It is a leaf service.
 
-**Use Cases:**
+## Dependents
 
-- **Historical Analysis:** "What was the EUR/USD rate at 10:00 AM on Jan 20?"
-  - Query: `observed_at = 2026-01-20T10:00:00Z`
+Grepped from `rg "market_information" services/` across the codebase.
 
-- **Regulatory Audit:** "What did we know about EUR/USD at 10:00 AM on Jan 20?"
-  - Query: `created_at <= 2026-01-20T10:00:00Z`
+| Service | Entry Point | Purpose |
+|---------|-------------|---------|
+| `forecasting` | `services/forecasting/adapters/mds/mds_adapter.go` | Fetch historical price observations for forward curve generation |
+| `event-router` | `services/event-router/adapters/mds/market_data_publisher.go` | Publish platform utilization measurements as observations |
+| `control-plane` | `services/control-plane/internal/applier/market_information_client.go` | Apply data set definitions from tenant manifests |
+| `api-gateway` | `services/api-gateway/cache/mds_source.go` | Cache market data for direct read endpoints |
+| `mcp-server` | `services/mcp-server/internal/clients/clients.go` | Expose market data query tools to LLM clients |
 
-- **Forward Curves:** "What is the 3-month LIBOR rate valid from March 1?"
-  - Query: `valid_from = 2026-03-01`
+## Load-Bearing Files
 
-**Supersession Tracking:**
+Paths are relative to `services/market-information/`.
 
-```text
-Event Time    Knowledge Time   Quality      Value    Superseded?
-2026-01-20    2026-01-20       ESTIMATE     1.0800   Yes (by observation 2)
-  10:00         10:05
-2026-01-20    2026-01-20       PROVISIONAL  1.0850   No
-  10:00         10:15
-```
-
-Query at `knowledge_base_time = 2026-01-20T10:10:00Z` returns ESTIMATE (1.0800).
-Query at `knowledge_base_time = 2026-01-20T10:20:00Z` returns PROVISIONAL (1.0850).
-
-## Database Schema
-
-**Schema**: `market_information`
-
-```mermaid
-erDiagram
-    dataset_definition {
-        uuid id PK
-        varchar(50) code
-        integer version
-        varchar(255) name
-        text description
-        varchar(50) data_category
-        text validation_expression "CEL expression"
-        text resolution_key_expression "CEL expression"
-        text error_message_expression "CEL expression"
-        jsonb attribute_schema "JSON Schema"
-        varchar(20) status "DRAFT, ACTIVE, DEPRECATED"
-        boolean is_shared "shared across tenants"
-        varchar(20) access_level "SYSTEM, TENANT"
-        timestamptz created_at
-        timestamptz updated_at
-        timestamptz activated_at
-        timestamptz deprecated_at
-    }
-
-    market_price_observation {
-        uuid id PK
-        uuid dataset_definition_id FK
-        uuid data_source_id FK
-        varchar(255) resolution_key
-        timestamptz observed_at "event time"
-        timestamptz valid_from "valid time start"
-        timestamptz valid_to "valid time end"
-        timestamptz created_at "knowledge time"
-        integer quality "1-4 (enum value)"
-        jsonb observation_context "attributes"
-        decimal numeric_value "precise decimal"
-        text text_value "for non-numeric"
-        uuid superseded_by FK
-        uuid causation_id "audit trail"
-    }
-
-    data_source {
-        uuid id PK
-        varchar(50) code UK
-        varchar(255) name
-        text description
-        integer trust_level "0-100"
-        timestamptz created_at
-        timestamptz updated_at
-        bigint version "optimistic lock"
-    }
-
-    dataset_definition ||--o{ market_price_observation : "validates"
-    data_source ||--o{ market_price_observation : "provides"
-    market_price_observation ||--o| market_price_observation : "supersedes"
-```
-
-**Constraints:**
-
-- `dataset_definition`:
-  - Unique: `(code, version)`
-  - Check: `status IN ('DRAFT', 'ACTIVE', 'DEPRECATED')`
-  - Check: Expression lengths <= 4096 chars
-  - Trigger: `enforce_dataset_lifecycle` (immutability rules)
-
-- `data_source`:
-  - Unique: `code`
-  - Check: `trust_level >= 0 AND trust_level <= 100`
-
-- `market_price_observation`:
-  - Index: `(dataset_definition_id, observed_at)` for time-series queries
-  - Index: `(dataset_definition_id, resolution_key, observed_at)`
-  - Check: `quality >= 1 AND quality <= 4`
-
-**Lifecycle Enforcement:**
-
-The `enforce_dataset_lifecycle` trigger ensures:
-
-1. **DRAFT → ACTIVE**: Sets `activated_at`, freezes validation rules
-2. **ACTIVE → DEPRECATED**: Sets `deprecated_at`, allows metadata updates
-3. **Immutability**: Cannot modify validation rules after activation
-
-## Usage Examples
-
-### Register Data Set
-
-```bash
-grpcurl -d '{
-  "code": "EUR_USD_FX",
-  "category": "DATA_CATEGORY_FX_RATE",
-  "unit": "EUR/USD",
-  "resolution_key_expression": "\"spot\"",
-  "validation_expression": "value > 0 && value < 10",
-  "error_message_expression": "\"Invalid FX rate: \" + string(value)",
-  "effective_from": "2026-01-01T00:00:00Z",
-  "display_name": "EUR/USD Spot Rate",
-  "description": "Euro to US Dollar exchange rate"
-}' \
-  -plaintext localhost:50058 \
-  meridian.market_information.v1.MarketInformationService/RegisterDataSet
-```
-
-### Record Observation
-
-```bash
-grpcurl -d '{
-  "dataset_code": "EUR_USD_FX",
-  "observed_at": "2026-01-20T10:00:00Z",
-  "valid_from": "2026-01-20T10:00:00Z",
-  "value": "1.0850",
-  "quality": "QUALITY_LEVEL_ACTUAL",
-  "source_code": "ECB"
-}' \
-  -plaintext localhost:50058 \
-  meridian.market_information.v1.MarketInformationService/RecordObservation
-```
-
-### Record Batch Observations
-
-```bash
-grpcurl -d '{
-  "observations": [
-    {
-      "dataset_code": "EUR_USD_FX",
-      "observed_at": "2026-01-20T10:00:00Z",
-      "valid_from": "2026-01-20T10:00:00Z",
-      "value": "1.0850",
-      "quality": "QUALITY_LEVEL_ACTUAL",
-      "source_code": "ECB",
-      "client_reference": "ref-001"
-    },
-    {
-      "dataset_code": "EUR_GBP_FX",
-      "observed_at": "2026-01-20T10:00:00Z",
-      "valid_from": "2026-01-20T10:00:00Z",
-      "value": "0.8520",
-      "quality": "QUALITY_LEVEL_ACTUAL",
-      "source_code": "ECB",
-      "client_reference": "ref-002"
-    }
-  ]
-}' \
-  -plaintext localhost:50058 \
-  meridian.market_information.v1.MarketInformationService/RecordObservationBatch
-```
-
-### List Observations with Filters
-
-```bash
-grpcurl -d '{
-  "dataset_code": "EUR_USD_FX",
-  "observed_from": "2026-01-20T00:00:00Z",
-  "observed_to": "2026-01-20T23:59:59Z",
-  "quality_filter": "QUALITY_LEVEL_ACTUAL",
-  "page_size": 100
-}' \
-  -plaintext localhost:50058 \
-  meridian.market_information.v1.MarketInformationService/ListObservations
-```
-
-### Retrieve Observation (Bi-Temporal)
-
-```bash
-# Current knowledge
-grpcurl -d '{
-  "observation_id": "123e4567-e89b-12d3-a456-426614174000"
-}' \
-  -plaintext localhost:50058 \
-  meridian.market_information.v1.MarketInformationService/RetrieveObservation
-
-# Historical knowledge (as-known-at 10:15 AM)
-grpcurl -d '{
-  "observation_id": "123e4567-e89b-12d3-a456-426614174000",
-  "knowledge_base_time": "2026-01-20T10:15:00Z"
-}' \
-  -plaintext localhost:50058 \
-  meridian.market_information.v1.MarketInformationService/RetrieveObservation
-```
+| File | Why It Matters |
+|------|----------------|
+| `cmd/main.go` | Wires gRPC server, ECB worker, and HTTP server; ECB worker lifecycle is managed here |
+| `service/server.go` | gRPC service implementation; all five operation groups are delegated from here |
+| `service/observation_service.go` | Observation recording with supersession logic and CEL validation |
+| `service/cel_validator.go` | CEL expression evaluation for dataset validation rules; compile-cache lives here |
+| `service/observation_query.go` | Bi-temporal query builder; `knowledge_base_time` filtering is implemented here |
+| `config/config.go` | All configuration loaded from environment variables (relative to `services/market-information/`) |
+| `migrations/` | Atlas-managed schema; never edit applied files |
 
 ## Configuration
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `GRPC_PORT` | 50058 | gRPC server port |
-| `METRICS_PORT` | 8082 | Prometheus metrics endpoint port |
-| `DATABASE_URL` | - | PostgreSQL connection string |
-| `DB_MAX_OPEN_CONNS` | 25 | Connection pool size |
-| `DB_MAX_IDLE_CONNS` | 5 | Idle connections |
-| `DB_CONN_MAX_LIFETIME` | 5m | Connection max age |
-| `LOG_LEVEL` | info | Logging level (debug, info, warn, error) |
+### Core
 
-### ECB Adapter Configuration
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `DATABASE_URL` | Yes | - | CockroachDB connection string (relative to service startup directory) |
+| `GRPC_PORT` | No | `50058` | gRPC listen port |
+| `METRICS_PORT` | No | `8082` | HTTP port for `/metrics`, `/health`, `/ready` endpoints |
+| `LOG_LEVEL` | No | `info` | Structured log level (`debug`, `info`, `warn`, `error`) |
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `ECB_ENABLED` | false | Enable ECB FX rate fetching |
-| `ECB_ENDPOINT` | `https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml` | ECB XML feed URL |
-| `ECB_INTERVAL` | 24h | Fetch interval |
-| `ECB_TIMEOUT` | 30s | HTTP request timeout |
-| `ECB_MAX_RETRIES` | 3 | Retry attempts on failure |
-| `ECB_DATASET_CODE` | `ECB_EUR_FX` | Data set code for ECB rates |
-| `ECB_SOURCE_CODE` | `ECB` | Data source code |
+### ECB Adapter
 
-**ECB Worker:**
-
-- Background worker polls ECB daily for EUR FX rates
-- Parses XML feed and records observations with quality ACTUAL
-- Automatically creates data source on first run
-- Logs errors and retries on transient failures
-
-## Observability
-
-### Metrics Endpoint
-
-The service exposes Prometheus metrics on port 8082:
-
-- **Endpoint**: `http://localhost:8082/metrics`
-- **Health Check**: `http://localhost:8082/health`
-- **Readiness Check**: `http://localhost:8082/ready`
-
-**Key Metrics:**
-
-| Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
-| `grpc_server_handled_total` | Counter | method, code | Total gRPC requests by method and status |
-| `grpc_server_handling_seconds` | Histogram | method | Request duration by method |
-| `market_information_observations_recorded_total` | Counter | dataset_code, quality | Total observations recorded |
-| `market_information_observations_superseded_total` | Counter | dataset_code | Total observations superseded |
-| `market_information_validation_errors_total` | Counter | dataset_code, error_type | CEL validation failures |
-
-### Distributed Tracing
-
-OpenTelemetry OTLP export to tracing backends:
-
-- Automatic trace context propagation via gRPC interceptors
-- Span annotations for CEL validation execution
-- Database query tracing with connection pool metrics
-
-## Testing
-
-### Running Tests
-
-```bash
-# Run all tests
-go test ./...
-
-# Run with coverage
-go test -cover ./...
-
-# Run specific test
-go test -run TestDataSetRepository_Create ./adapters/persistence
-```
-
-### Integration Tests
-
-Integration tests use Testcontainers for PostgreSQL:
-
-```bash
-# Requires Docker
-go test -tags=integration ./adapters/persistence/...
-```
-
-**Test Coverage:**
-
-- Unit tests: Domain logic, validation, mappers
-- Integration tests: Repository operations, database constraints
-- End-to-end tests: Full gRPC service workflows
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `ECB_ENABLED` | No | `false` | Enable background ECB FX rate worker |
+| `ECB_ENDPOINT` | No | ECB client default | ECB SDMX Web Service URL |
+| `ECB_SOURCE_CODE` | No | `ECB` | Data source code registered in Market Information |
+| `ECB_DATASET_CODE` | No | `ECB_FX` | Dataset code prefix for ECB FX rates |
+| `ECB_INTERVAL` | No | `24h` | Polling interval |
+| `ECB_TIMEOUT` | No | `30s` | HTTP request timeout |
+| `ECB_MAX_RETRIES` | No | `3` | Retry attempts on transient failure |
 
 ## References
 
-- [BIAN Market Information Management Specification](https://github.com/bian-official/public/blob/main/release14.0.0/semantic-apis/oas3%20/yamls/MarketInformationManagement.yaml)
-- [Service Architecture](../README.md)
-- [Proto Definitions](../../api/proto/meridian/market_information/v1/)
-- [ADR-0002: Microservices per BIAN Domain](../../docs/adr/0002-microservices-per-bian-domain.md)
-- [ADR-0020: Per-Service Audit Workers](../../docs/adr/0020-per-service-audit-workers.md)
-- [CEL Language Specification](https://github.com/google/cel-spec)
+- [`docs/architecture-layers.md`](../../docs/architecture-layers.md) - Reference and Registry layer description
+- [`api/proto/meridian/market_information/v1/`](../../api/proto/meridian/market_information/v1/) - Proto definitions
+- ADR-0002: Microservices per BIAN Domain

--- a/services/market-information/README.md
+++ b/services/market-information/README.md
@@ -209,7 +209,7 @@ Paths are relative to `services/market-information/`.
 
 | Variable | Required | Default | Purpose |
 |----------|----------|---------|---------|
-| `DATABASE_URL` | Yes | - | CockroachDB connection string (relative to service startup directory) |
+| `DATABASE_URL` | Yes | - | CockroachDB connection string |
 | `GRPC_PORT` | No | `50058` | gRPC listen port |
 | `METRICS_PORT` | No | `8082` | HTTP port for `/metrics`, `/health`, `/ready` endpoints |
 | `LOG_LEVEL` | No | `info` | Structured log level (`debug`, `info`, `warn`, `error`) |

--- a/services/party/README.md
+++ b/services/party/README.md
@@ -202,7 +202,7 @@ and type cannot be changed. Format validation is regex-only (no registry lookup)
 
 ## Dependents
 
-Grepped from `rg "party" services/` across the codebase.
+Grepped from `rg "party/v1|NewPartyClient|PartyServiceClient" services/ --exclude-dir services/party` across the codebase.
 
 | Service | Entry Point | Purpose |
 |---------|-------------|---------|
@@ -226,7 +226,7 @@ Paths are relative to `services/party/`.
 | `service/attribute_validator.go` | CEL-based attribute validation driven by PartyTypeDefinition |
 | `domain/party.go` | Party aggregate; status machine and optimistic locking invariants |
 | `verification/` | KYC provider abstraction (Onfido, Stripe); factory, provider interface, timeout handler |
-| `config/verification.go` | Verification provider configuration loaded from environment variables (relative to `services/party/`) |
+| `config/verification.go` | Verification provider configuration loaded from environment variables |
 | `migrations/` | Atlas-managed schema; never edit applied files |
 
 ## Configuration
@@ -235,7 +235,7 @@ Paths are relative to `services/party/`.
 
 | Variable | Required | Default | Purpose |
 |----------|----------|---------|---------|
-| `DATABASE_URL` | Yes | - | CockroachDB connection string (relative to service startup directory) |
+| `DATABASE_URL` | Yes | - | CockroachDB connection string |
 | `GRPC_PORT` | No | `50055` | gRPC listen port |
 | `LOG_LEVEL` | No | `info` | Structured log level (`debug`, `info`, `warn`, `error`) |
 | `ENVIRONMENT` | No | `development` | Runtime environment (`development`, `production`); affects verification config strictness |

--- a/services/party/README.md
+++ b/services/party/README.md
@@ -1,72 +1,148 @@
 ---
-name: party-service
-description: BIAN party reference data directory for customer and counterparty identity management
+name: party
+description: BIAN Party Reference Data Directory - INDIVIDUAL and ORGANIZATION lifecycle management with write-once external references, KYC verification, and payment method registration
 triggers:
-  - Implementing party registration
-  - Managing party lifecycle (status transitions)
-  - External reference validation (Companies House, LEI, Tax ID)
-  - Building gRPC party reference services
-  - Database schema design for party entities
-  - Optimistic locking patterns
+  - Registering customers or counterparties (individuals or organizations)
+  - Managing party lifecycle (ACTIVE, RESTRICTED, TERMINATED)
+  - Validating external references (Companies House, LEI, National ID, Tax ID)
+  - Configuring KYC/identity verification providers (Onfido, Stripe)
+  - Adding or removing payment methods on a party
+  - Debugging party association or demographic update failures
 instructions: |
-  Party service manages customer and counterparty identities with external reference validation.
+  Party is the BIAN Party Reference Data Directory. It stores legal identities
+  for customers and counterparties, not platform users. Platform users live in
+  the identity service.
 
-  Key patterns:
-  - PartyType: PERSON (individual) or ORGANIZATION (legal entity)
-  - PartyStatus: ACTIVE → RESTRICTED → TERMINATED (state machine)
-  - External references: Write-once, unique per type, format-validated
-  - Optimistic locking via version field
+  Party records are never hard-deleted. Status transitions to TERMINATED are
+  terminal; RESTRICTED can return to ACTIVE. External references (Companies
+  House, LEI, etc.) are write-once; format is validated by regex only.
 
-  External reference validation (regex):
-  - COMPANIES_HOUSE: ^[A-Z]{0,2}\d{6,8}$
-  - LEI: ^[A-Z0-9]{20}$
-  - NATIONAL_ID: ^[A-Z0-9]{5,20}$
-  - TAX_ID: ^[A-Z0-9]{5,20}$
+  Port: 50055 (gRPC). Optional HTTP on 8081 for KYC verification webhooks
+  (only started if VERIFICATION_PROVIDER is configured). Kafka outbox worker
+  starts only if KAFKA_BOOTSTRAP_SERVERS is set.
 
-  Port: 50055 (gRPC)
+  CEL-based attribute validation is driven by PartyTypeDefinition records.
+  Each party type can declare custom attribute schemas; AddPaymentMethod
+  enforces the party type's allowed payment method types.
 ---
 
-# Party Service
+# party
 
-BIAN-compliant party reference data directory for managing customer and counterparty identities.
+BIAN Party Reference Data Directory. Stores and manages the legal identities of
+customers and counterparties: individuals and organizations. Supports KYC verification
+via pluggable providers (Onfido, Stripe), party associations, demographics, bank
+relations, and payment methods.
+
+Sits on the [Identity layer](../../docs/architecture-layers.md#7-identity)
+of the Meridian architecture.
 
 ## Overview
 
 | Attribute | Value |
 |-----------|-------|
 | **BIAN Domain** | Party Reference Data Directory |
-| **Port** | 50055 (gRPC) |
-| **Language** | Go |
-| **Database** | PostgreSQL/CockroachDB |
-| **Standalone** | Yes |
+| **Layer** | Identity |
+| **Port** | 50055 (gRPC), 8081 (HTTP webhooks, when `VERIFICATION_PROVIDER` is configured) |
+| **Database** | CockroachDB (per-tenant schema) |
+| **Standalone** | No (requires CockroachDB; optional: Kafka for events, Onfido/Stripe for KYC) |
 
-## gRPC Methods
+## API Surface
 
-| Method | HTTP | Purpose |
+### gRPC
+
+| Service | RPC | Purpose |
+|---------|-----|---------|
+| `PartyService` | `RegisterParty` | Create a new party (INDIVIDUAL or ORGANIZATION) |
+| `PartyService` | `ListParties` | Paginated list with type and status filters |
+| `PartyService` | `RetrieveParty` | Fetch a party by ID |
+| `PartyService` | `UpdateParty` | Update mutable party fields (display name, attributes) |
+| `PartyService` | `ControlParty` | Transition party status (ACTIVE/RESTRICTED/TERMINATED) |
+| `PartyService` | `UpdateReference` | Set write-once external reference (Companies House, LEI, etc.) |
+| `PartyService` | `RetrieveReference` | Fetch external references for a party |
+| `PartyService` | `RegisterAssociations` | Create party-to-party associations (e.g., director/company) |
+| `PartyService` | `UpdateAssociations` | Modify existing associations |
+| `PartyService` | `RetrieveAssociations` | Fetch associations for a party |
+| `PartyService` | `ExchangeDemographics` | Upsert demographic records (address, contact details) |
+| `PartyService` | `UpdateDemographics` | Modify existing demographic records |
+| `PartyService` | `RetrieveDemographics` | Fetch demographics for a party |
+| `PartyService` | `UpdateBankRelations` | Upsert bank account relationships for a party |
+| `PartyService` | `RetrieveBankRelations` | Fetch bank relations |
+| `PartyService` | `ListParticipants` | List parties by association role |
+| `PartyService` | `GetStructuringData` | Return aggregated structuring data for a party |
+| `PartyService` | `AddPaymentMethod` | Add a payment method (card, bank account) to a party |
+| `PartyService` | `RemovePaymentMethod` | Remove a payment method |
+| `PartyService` | `SetDefaultPaymentMethod` | Set the default payment method |
+| `PartyService` | `ListPaymentMethods` | List all payment methods for a party |
+| `PartyService` | `GetDefaultPaymentMethod` | Fetch the default payment method |
+| `PartyService` | `RegisterPartyType` | Register a custom party type definition |
+| `PartyService` | `GetPartyType` | Fetch a party type by code |
+| `PartyService` | `ListPartyTypes` | List all party type definitions |
+| `PartyService` | `UpdatePartyType` | Modify a party type definition |
+
+Proto: [`api/proto/meridian/party/v1/party.proto`](../../api/proto/meridian/party/v1/party.proto).
+
+### HTTP
+
+Available only when `VERIFICATION_PROVIDER` is configured.
+
+| Method | Path | Purpose |
 |--------|------|---------|
-| `RegisterParty` | `POST /v1/parties` | Create new party |
-| `RetrieveParty` | `GET /v1/parties/{party_id}` | Get party details |
+| `POST` | `/webhooks/verification/` | Inbound KYC webhook receiver (HMAC-verified) |
+| `POST` | `/webhooks/verification/stripe` | Stripe-specific KYC webhook with Stripe signature verification |
+| `GET` | `/health` | Liveness probe with verification provider status |
 
 ## Domain Model
 
 ```mermaid
 classDiagram
     class Party {
-        +UUID ID
-        +PartyType PartyType
-        +string LegalName
-        +string DisplayName
-        +PartyStatus Status
-        +string ExternalReference
-        +ExternalReferenceType ExternalReferenceType
-        +int64 Version
-        +Time CreatedAt
-        +Time UpdatedAt
+        +UUID id
+        +PartyType partyType
+        +string legalName
+        +string displayName
+        +PartyStatus status
+        +int64 version
+        +time createdAt
+        +time updatedAt
+    }
+
+    class ExternalReference {
+        +UUID id
+        +UUID partyID
+        +ExternalReferenceType refType
+        +string value
+        +time createdAt
+    }
+
+    class PartyAssociation {
+        +UUID id
+        +UUID fromPartyID
+        +UUID toPartyID
+        +string roleType
+        +time effectiveFrom
+        +time effectiveTo
+    }
+
+    class PaymentMethod {
+        +UUID id
+        +UUID partyID
+        +string methodType
+        +string providerRef
+        +bool isDefault
+        +time createdAt
+    }
+
+    class PartyTypeDefinition {
+        +UUID id
+        +string code
+        +string validationExpression
+        +JSON attributeSchema
+        +time createdAt
     }
 
     class PartyType {
         <<enumeration>>
-        PERSON
+        INDIVIDUAL
         ORGANIZATION
     }
 
@@ -80,32 +156,21 @@ classDiagram
     class ExternalReferenceType {
         <<enumeration>>
         COMPANIES_HOUSE
-        NATIONAL_ID
         LEI
+        NATIONAL_ID
         TAX_ID
     }
 
     Party --> PartyType
     Party --> PartyStatus
-    Party --> ExternalReferenceType
+    Party "1" --> "*" ExternalReference : holds
+    Party "1" --> "*" PartyAssociation : member of
+    Party "1" --> "*" PaymentMethod : owns
+    Party --> PartyTypeDefinition : validated by
+    ExternalReference --> ExternalReferenceType
 ```
 
-**Party Types:**
-
-| Type | Description |
-|------|-------------|
-| `PERSON` | Natural person (individual) |
-| `ORGANIZATION` | Legal entity (company, partnership) |
-
-**Party Status:**
-
-| Status | Description |
-|--------|-------------|
-| `ACTIVE` | Can participate in banking operations |
-| `RESTRICTED` | Limited access (e.g., pending KYC) |
-| `TERMINATED` | Relationship ended (terminal) |
-
-**Status Transitions:**
+### Status Machine
 
 ```mermaid
 stateDiagram-v2
@@ -117,78 +182,90 @@ stateDiagram-v2
     TERMINATED --> [*]
 ```
 
-- TERMINATED is terminal (cannot be reactivated)
-- RESTRICTED can return to ACTIVE
+`TERMINATED` is terminal. External references are write-once: once set, the value
+and type cannot be changed. Format validation is regex-only (no registry lookup):
 
-## External Reference Validation
+| Type | Pattern |
+|------|---------|
+| `COMPANIES_HOUSE` | `^[A-Z]{0,2}\d{6,8}$` |
+| `LEI` | `^[A-Z0-9]{20}$` |
+| `NATIONAL_ID` | `^[A-Z0-9]{5,20}$` |
+| `TAX_ID` | `^[A-Z0-9]{5,20}$` |
 
-External references are write-once and unique per type:
+## Dependencies
 
-| Type | Pattern | Example |
-|------|---------|---------|
-| `COMPANIES_HOUSE` | `^[A-Z]{0,2}\d{6,8}$` | `12345678`, `GB12345678` |
-| `LEI` | `^[A-Z0-9]{20}$` | `5493001KJTIIGC8K1K12` |
-| `NATIONAL_ID` | `^[A-Z0-9]{5,20}$` | `AB12345` |
-| `TAX_ID` | `^[A-Z0-9]{5,20}$` | `TB123456789` |
+| Service | Protocol | Purpose |
+|---------|----------|---------|
+| CockroachDB | SQL | All party, association, demographic, and payment method persistence |
+| Kafka (optional) | TCP | Outbox worker publishes party domain events when `KAFKA_BOOTSTRAP_SERVERS` is set |
+| Onfido / Stripe (optional) | HTTP | KYC verification provider when `VERIFICATION_PROVIDER` is configured |
 
-**Note:** Validation is format-only (regex pattern matching). LEI checksum (ISO 17442 MOD 97-10)
-and Companies House registry lookups are not performed. External validation should be done
-upstream before registration if required.
+## Dependents
 
-## Database Schema
+Grepped from `rg "party" services/` across the codebase.
 
-**Schema**: `party`
+| Service | Entry Point | Purpose |
+|---------|-------------|---------|
+| `current-account` | `services/current-account/service/client_interfaces.go` | Validate party status before account operations |
+| `tenant` | `services/tenant/service/party_client_adapter.go` | Register organization party for the tenant on provisioning |
+| `payment-order` | `services/payment-order/service/payment_orchestrator.go` | Party lookup for billing and invoice generation |
+| `control-plane` | `services/control-plane/service/apply_manifest.go` | Party registration in manifest apply |
+| `internal-account` | `services/internal-account/client/starlark.go` | Starlark client exposes party lookup to saga scripts |
 
-```mermaid
-erDiagram
-    parties {
-        uuid id PK
-        varchar(20) party_type "PERSON, ORGANIZATION"
-        varchar(255) legal_name
-        varchar(255) display_name "nullable"
-        varchar(20) status "ACTIVE, RESTRICTED, TERMINATED"
-        varchar(100) external_reference "nullable, write-once"
-        varchar(30) external_reference_type "nullable"
-        bigint version "optimistic lock"
-        timestamptz created_at
-        timestamptz updated_at
-        timestamptz deleted_at "nullable, soft-delete"
-    }
-```
+## Load-Bearing Files
 
-**Indexes:**
+Paths are relative to `services/party/`.
 
-- `idx_parties_party_type`: Query by type
-- `idx_parties_status`: Query by status
-- `idx_party_external_ref`: Unique on (reference, type) where `deleted_at IS NULL`
-- `idx_party_parties_deleted_at`: Query active (non-deleted) records
+| File | Why It Matters |
+|------|----------------|
+| `cmd/main.go` | Wires gRPC server, optional HTTP server, Kafka outbox worker, and verification provider |
+| `service/server.go` | gRPC service root; all handler groups are registered here |
+| `service/party_handlers.go` | Core party CRUD and status transitions |
+| `service/reference_handlers.go` | Write-once external reference enforcement |
+| `service/association_handlers.go` | Party association lifecycle |
+| `service/attribute_validator.go` | CEL-based attribute validation driven by PartyTypeDefinition |
+| `domain/party.go` | Party aggregate; status machine and optimistic locking invariants |
+| `verification/` | KYC provider abstraction (Onfido, Stripe); factory, provider interface, timeout handler |
+| `config/verification.go` | Verification provider configuration loaded from environment variables (relative to `services/party/`) |
+| `migrations/` | Atlas-managed schema; never edit applied files |
 
 ## Configuration
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `GRPC_PORT` | 50055 | gRPC server port |
-| `DATABASE_URL` | - | PostgreSQL connection string |
-| `DB_MAX_OPEN_CONNS` | 25 | Connection pool size |
+### Core
 
-## Key Patterns
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `DATABASE_URL` | Yes | - | CockroachDB connection string (relative to service startup directory) |
+| `GRPC_PORT` | No | `50055` | gRPC listen port |
+| `LOG_LEVEL` | No | `info` | Structured log level (`debug`, `info`, `warn`, `error`) |
+| `ENVIRONMENT` | No | `development` | Runtime environment (`development`, `production`); affects verification config strictness |
+| `KAFKA_BOOTSTRAP_SERVERS` | No | - | Kafka broker addresses; outbox worker disabled if not set |
 
-### Registration Flow
+### Verification (KYC)
 
-1. Validate party_type (PERSON or ORGANIZATION)
-2. Create Party aggregate with ACTIVE status
-3. If external_reference provided:
-   - Check uniqueness
-   - Validate format against type-specific regex
-   - Set reference (write-once)
-4. Persist with version = 1
+Required only when `VERIFICATION_PROVIDER` is set. If absent in non-production environments,
+verification is disabled gracefully; in `ENVIRONMENT=production` the service refuses to start.
 
-### Optimistic Locking
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `VERIFICATION_PROVIDER` | No | - | KYC provider: `onfido` or `stripe` |
+| `VERIFICATION_API_KEY` | Conditional | - | Provider API key |
+| `VERIFICATION_API_SECRET` | Conditional | - | Provider API secret |
+| `VERIFICATION_BASE_URL` | No | - | Override provider API base URL |
+| `VERIFICATION_WEBHOOK_SECRET` | Conditional | - | HMAC secret for verifying inbound webhooks |
+| `VERIFICATION_WEBHOOK_URL` | No | - | Public URL for the webhook receiver (reported to provider) |
+| `STRIPE_WEBHOOK_SECRET` | Conditional | - | Stripe-specific webhook signing secret |
+| `HTTP_PORT` | No | `8081` | HTTP port for verification webhooks (only started when provider is configured) |
 
-Updates check `WHERE version = expected_version`. Returns conflict error on mismatch.
+## Security Considerations
+
+RBAC method permissions are declared in `rbac/method_permissions.go`. Inbound
+verification webhooks are HMAC-verified before processing - requests with invalid
+signatures return `401 Unauthorized` and are never processed. Stripe webhooks use
+Stripe's own signature scheme in addition to the inner HMAC check.
 
 ## References
 
-- [BIAN Party Reference Data Directory Specification](https://github.com/bian-official/public/blob/main/release14.0.0/semantic-apis/oas3%20/yamls/PartyReferenceDataDirectory.yaml)
-- [Service Architecture](../README.md)
-- [Proto Definitions](../../api/proto/meridian/party/v1/)
+- [`docs/architecture-layers.md`](../../docs/architecture-layers.md) - Identity layer description
+- [`api/proto/meridian/party/v1/`](../../api/proto/meridian/party/v1/) - Proto definitions
+- ADR-0002: Microservices per BIAN Domain

--- a/services/reference-data/README.md
+++ b/services/reference-data/README.md
@@ -1,228 +1,267 @@
 ---
-name: reference-data-service
-description: Instrument definitions with CEL validation and multi-tenant isolation
+name: reference-data
+description: Instrument definitions, saga definitions, account type registry, hierarchical node registry, and field mapping rules - the contract layer for all platform asset operations
 triggers:
-  - Instrument definitions and asset types
-  - CEL validation expressions
-  - Currency and measurement unit configuration
-  - System vs tenant instrument management
-  - Instrument lifecycle (DRAFT, ACTIVE, DEPRECATED)
+  - Defining or updating instrument types (GBP, KWH, TONNE_CO2E, GPU_HR)
+  - Writing or validating Starlark saga definitions
+  - Configuring account type definitions with CEL validation rules
+  - Working with the reference_data_node hierarchy
+  - Debugging CEL validation expression errors
+  - Platform provisioning of system instruments
 instructions: |
-  Reference Data manages instrument definitions for the ledger system.
-  System instruments are seeded during tenant provisioning (read-only via API).
-  Tenant instruments follow DRAFT → ACTIVE → DEPRECATED lifecycle.
-  CEL expressions validate quantities and generate fungibility bucket keys.
+  Reference Data is the contract layer. Everything it stores - instruments, sagas,
+  account types, mappings - is read by most other services. Break a definition
+  here and downstream services fail silently or loudly.
 
-  Port: 50054 (gRPC)
+  Five gRPC services on one binary: ReferenceDataService (instruments),
+  NodeService (hierarchy), AccountTypeRegistryService, SagaRegistryService,
+  MappingService.
+
+  Port: 50059 (gRPC). System instruments are seeded by the tenant provisioner,
+  not by migrations. Never delete or forcibly deprecate an instrument that has
+  live positions - position-keeping holds references by code, not FK.
 ---
 
-# Reference Data Service
+# reference-data
 
-The Reference Data service manages instrument definitions for the Meridian ledger system.
-It is aligned with the BIAN Reference Data Directory domain.
+Instrument definitions, saga definitions, account type registry, hierarchical node
+registry, and field mapping rules. The contract layer that every ledger and
+orchestration service reads to understand what it is operating on.
+
+Sits on the [Reference and Registry layer](../../docs/architecture-layers.md#6-reference-and-registry)
+of the Meridian architecture.
 
 ## Overview
 
-Instrument definitions describe measurement units, currencies, and asset types that can be
-tracked in the ledger. Each instrument specifies:
+| Attribute | Value |
+|-----------|-------|
+| **BIAN Domain** | Reference Data Directory |
+| **Layer** | Reference and Registry |
+| **Port** | 50059 (gRPC), 8082 (HTTP metrics) |
+| **Database** | CockroachDB (`meridian_reference_data` and per-tenant schemas) |
+| **Standalone** | No (requires CockroachDB) |
 
-- **Dimension**: What type of value it measures (MONETARY, ENERGY, QUANTITY, etc.)
-- **Precision**: Decimal places for amounts (0-18)
-- **Validation Rules**: CEL expressions for validating quantities
-- **Fungibility Rules**: CEL expressions for bucket key generation
+## API Surface
 
-## Architecture
+Five gRPC services are registered on the same binary.
 
-### System Instruments vs Tenant Instruments
+### ReferenceDataService
 
-The service supports two types of instruments:
+| RPC | Purpose |
+|-----|---------|
+| `RegisterInstrument` | Create a new instrument draft (`GBP`, `KWH`, `TONNE_CO2E`) |
+| `UpdateInstrument` | Modify a DRAFT instrument definition |
+| `ActivateInstrument` | Transition DRAFT to ACTIVE (immutable thereafter) |
+| `DeprecateInstrument` | Transition ACTIVE to DEPRECATED |
+| `RetrieveInstrument` | Fetch one instrument by code and version |
+| `ListInstruments` | Paginated list with status filter |
+| `EvaluateInstrument` | Run CEL validation against a quantity |
+| `GetAttributeSchema` | Return JSON Schema for instrument attributes |
 
-**System Instruments** (`is_system=true`):
+Proto: [`api/proto/meridian/reference_data/v1/instrument.proto`](../../api/proto/meridian/reference_data/v1/instrument.proto).
 
-- Pre-defined instruments like USD, EUR, GBP, KWH
-- **Seeded during tenant provisioning** by the tenant provisioner service
-- Read-only through the InstrumentRegistry API
-- Visible to all operations within a tenant's schema
+### NodeService
 
-**Tenant Instruments** (`is_system=false`):
+| RPC | Purpose |
+|-----|---------|
+| `CreateNode` | Create a node in the hierarchy |
+| `UpdateNode` | Modify node metadata |
+| `GetNode` | Fetch a single node |
+| `GetChildren` | Fetch direct children |
+| `GetAncestors` | Fetch ancestors to root |
+| `GetSubtree` | Fetch subtree rooted at node |
+| `GetNodeAsAt` | Bi-temporal point-in-time lookup |
+| `GetNodeHistory` | Full version history for a node |
+| `ImportNodes` | Bulk import from YAML/JSON |
 
-- Created by tenants through the InstrumentRegistry API
-- Full lifecycle management (DRAFT → ACTIVE → DEPRECATED)
-- Tenant-specific and isolated
+Proto: [`api/proto/meridian/reference_data/v1/node.proto`](../../api/proto/meridian/reference_data/v1/node.proto).
 
-### Multi-Tenant Isolation
+### AccountTypeRegistryService
 
-This service uses schema-per-tenant architecture:
+| RPC | Purpose |
+|-----|---------|
+| `CreateDraft` | Create a new account type definition draft |
+| `UpdateDefinition` | Modify a DRAFT account type |
+| `ActivateAccountType` | Transition DRAFT to ACTIVE |
+| `DeprecateAccountType` | Transition ACTIVE to DEPRECATED |
+| `GetDefinition` | Fetch by ID |
+| `GetActiveDefinition` | Fetch the current ACTIVE version by code |
+| `ListActive` | List all ACTIVE account type definitions |
+| `ListAll` | List all definitions regardless of status |
+| `ValidateProductDefinition` | Validate a CEL product definition against the registry |
 
-- Each tenant has an isolated PostgreSQL schema (`org_<tenant_id>`)
-- System instruments are COPIED into each tenant's schema during provisioning
-- No cross-schema queries or SystemTenantID constants needed
-- Tenant context extracted from ctx via `shared/platform/tenant`
+Proto: [`api/proto/meridian/reference_data/v1/account_type.proto`](../../api/proto/meridian/reference_data/v1/account_type.proto).
 
-## Component Responsibilities
+### SagaRegistryService
 
-### Reference-Data Service (This Service)
+| RPC | Purpose |
+|-----|---------|
+| `CreateSagaDraft` | Register a new Starlark saga draft |
+| `UpdateSagaDefinition` | Modify a DRAFT saga |
+| `ActivateSaga` | Compile and activate a saga |
+| `DeprecateSaga` | Transition ACTIVE to DEPRECATED |
+| `GetSaga` | Fetch by ID |
+| `GetActiveSaga` | Fetch current ACTIVE saga by name |
+| `ListSagas` | Paginated list |
+| `ValidateSagaDraft` | Validate Starlark without persisting |
+| `ValidateSaga` | Validate a persisted saga definition |
+| `AnalyzeDeprecationImpact` | Report callers affected before deprecation |
+| `DescribeHandlers` | List available handler names for Starlark authoring |
 
-- Enforces `is_system` read-only constraint
-- Manages tenant instrument lifecycle
-- Compiles and executes CEL validation rules
-- **Does NOT seed system instruments**
+Proto: [`api/proto/meridian/saga/v1/saga_registry.proto`](../../api/proto/meridian/saga/v1/saga_registry.proto).
 
-### Tenant Provisioner Service (services/tenant)
+### MappingService
 
-- Creates tenant schemas
-- Seeds system instruments with `is_system=true`
-- See: `services/tenant/provisioner/postgres_provisioner.go`
+| RPC | Purpose |
+|-----|---------|
+| `CreateMapping` | Create a CEL-based field mapping rule |
+| `GetMapping` | Fetch a mapping rule by ID |
+| `ListMappings` | Paginated list |
+| `UpdateMapping` | Modify a mapping rule |
+| `DeleteMapping` | Remove a mapping rule |
+| `DryRunMapping` | Execute a mapping without persisting output |
 
-## Instrument Lifecycle
+Proto: [`api/proto/meridian/mapping/v1/mapping.proto`](../../api/proto/meridian/mapping/v1/mapping.proto).
+
+## Domain Model
 
 ```mermaid
-stateDiagram-v2
-    DRAFT : DRAFT<br/>Editable
-    ACTIVE : ACTIVE<br/>Immutable
-    DEPRECATED : DEPRECATED<br/>Read-only
+classDiagram
+    class InstrumentDefinition {
+        +UUID id
+        +string code
+        +int version
+        +InstrumentDimension dimension
+        +int precision
+        +InstrumentStatus status
+        +bool isSystem
+        +string validationExpression
+        +string fungibilityKeyExpression
+        +time activatedAt
+        +time deprecatedAt
+    }
 
-    DRAFT --> ACTIVE : Activate
-    ACTIVE --> DEPRECATED : Deprecate
+    class SagaDefinition {
+        +UUID id
+        +string name
+        +int version
+        +SagaStatus status
+        +string starlarkSource
+        +string handlerVersion
+        +time activatedAt
+    }
+
+    class AccountTypeDefinition {
+        +UUID id
+        +string code
+        +int version
+        +AccountTypeStatus status
+        +string validationExpression
+        +string valuationMethodID
+        +time activatedAt
+    }
+
+    class ReferenceDataNode {
+        +UUID id
+        +string code
+        +string nodeType
+        +UUID parentID
+        +int depth
+        +time validFrom
+        +time validTo
+    }
+
+    class MappingDefinition {
+        +UUID id
+        +string name
+        +string sourceSchema
+        +string targetSchema
+        +string mappingExpression
+    }
+
+    class InstrumentStatus {
+        <<enumeration>>
+        DRAFT
+        ACTIVE
+        DEPRECATED
+    }
+
+    class SagaStatus {
+        <<enumeration>>
+        DRAFT
+        ACTIVE
+        DEPRECATED
+    }
+
+    InstrumentDefinition --> InstrumentStatus
+    SagaDefinition --> SagaStatus
+    AccountTypeDefinition --> InstrumentDefinition : valuation method links
+    ReferenceDataNode --> ReferenceDataNode : parent
 ```
 
-### Status Transitions
+Instruments cannot be hard-deleted. Positions in `position-keeping` reference
+instrument codes by value; deleting an instrument orphans those positions.
 
-| From | To | Allowed | Notes |
-|------|----|---------|-------|
-| DRAFT | ACTIVE | ✓ | Sets `activated_at` |
-| ACTIVE | DEPRECATED | ✓ | Sets `deprecated_at` |
-| DRAFT | DEPRECATED | ✗ | Must activate first |
-| ACTIVE | DRAFT | ✗ | Cannot revert activation |
-| DEPRECATED | * | ✗ | Terminal state |
+## Dependencies
 
-### System Instrument Protection
+| Service | Protocol | Purpose |
+|---------|----------|---------|
+| CockroachDB | SQL | All entity persistence (instruments, sagas, nodes, account types, mappings) |
 
-All modification operations reject system instruments:
+Reference Data has no outbound gRPC dependencies. It is a leaf node in the dependency graph.
 
-- `CreateDraft` - Cannot create with `is_system=true`
-- `UpdateDefinition` - Cannot update system instruments
-- `ActivateInstrument` - Cannot activate system instruments
-- `DeprecateInstrument` - Cannot deprecate system instruments
+## Dependents
 
-Read operations work normally for system instruments:
+Services that call this one. Grepped from `rg "reference_data" services/` across the codebase.
 
-- `GetDefinition` - Returns system instruments
-- `GetActiveDefinition` - Returns active system instruments
-- `ListActive` - Includes both system and tenant instruments
+| Service | Entry Point | Purpose |
+|---------|-------------|---------|
+| `position-keeping` | `services/position-keeping/app/container.go` | Resolve instrument definitions for position calculations |
+| `current-account` | `services/current-account/service/validators.go` | Validate instrument codes on account operations |
+| `control-plane` | `services/control-plane/internal/applier/reference_data_client.go` | Register and activate instruments/sagas during manifest apply |
+| `payment-order` | `services/payment-order/adapters/clients/reference_data_client.go` | Instrument lookups for payment validation |
+| `reconciliation` | `services/reconciliation/service/grpc_reference_data_provider.go` | Instrument metadata for materiality thresholds |
+| `forecasting` | `services/forecasting/validation/strategy_validator.go` | Validate dataset references in Starlark strategies |
+| `internal-account` | `services/internal-account/service/client_interfaces.go` | Instrument and account type lookups |
+| `mcp-server` | `services/mcp-server/internal/tools/refdata.go` | Expose instrument and saga tools to LLM clients |
+| `financial-accounting` | `services/financial-accounting/app/container.go` | Instrument dimension lookup for ledger posting |
 
-## CEL Validation
+## Load-Bearing Files
 
-Instrument definitions can include CEL expressions for validation.
+Paths are relative to `services/reference-data/`.
 
-### Available Variables
+| File | Why It Matters |
+|------|----------------|
+| `cmd/main.go` | Wires all five gRPC services; startup order affects which connections fail first |
+| `handler/grpc_handler.go` | ReferenceDataService gRPC contract; signature changes break all dependents |
+| `registry/` | Core instrument registry; owns the DRAFT/ACTIVE/DEPRECATED lifecycle and CEL compile |
+| `saga/registry.go` | SagaRegistry interface; controls which Starlark sagas are executable |
+| `saga/defaults/` | Platform-bundled default sagas (deposit, payment_execution, stripe_payment, etc.) |
+| `node/` | Reference data node hierarchy; bi-temporal queries depend on valid_from/valid_to columns |
+| `accounttype/` | AccountTypeRegistry; account type definitions link to valuation methods |
+| `mapping/` | MappingService; CEL-based field transformation rules |
+| `cel/` | CEL compiler and program cache; shared across instrument and mapping validation |
+| `migrations/` | Atlas-managed schema; never edit applied files |
 
-```cel
-attributes: map[string]string  // Key-value attributes from quantity
-amount: string                 // Decimal amount as string
-valid_from: timestamp          // Optional validity start
-valid_to: timestamp           // Optional validity end
-source: string                // Origin identifier
-```
+## Configuration
 
-### Example Expressions
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `DATABASE_URL` | Yes | `postgres://meridian_reference_data_user@localhost:26257/meridian_reference_data?sslmode=disable` | CockroachDB connection string (relative to service startup directory) |
+| `GRPC_PORT` | No | `50059` | gRPC listen port |
+| `METRICS_PORT` | No | `8082` | HTTP port for `/metrics`, `/health`, `/ready` endpoints |
+| `LOG_LEVEL` | No | `info` | Structured log level (`debug`, `info`, `warn`, `error`) |
 
-```cel
-// Validate positive amounts
-parse_int(amount) > 0
+## Security Considerations
 
-// Validate renewable energy source
-attributes["source_type"] == "renewable"
+All gRPC RPCs pass through the shared `bootstrap.AuthInterceptor`. RBAC method permissions
+are declared in `rbac/method_permissions.go`. System instruments (`is_system = true`) are
+write-protected at the handler layer - attempts to create, update, or deprecate them return
+`PERMISSION_DENIED`.
 
-// Validate time range
-valid_from < valid_to
+## References
 
-// Complex validation
-parse_int(amount) > 0 &&
-attributes.exists("batch_id") &&
-parse_iso_date(attributes["expiry"]) > now()
-```
-
-### CEL Compilation
-
-Expressions are compiled at creation time (fail-fast):
-
-- Invalid expressions reject the CreateDraft/UpdateDefinition call
-- Compiled programs are cached for performance
-- CEL cost limits prevent expensive expressions (max 10,000 cost units)
-
-## Database Schema
-
-### instrument_definition Table
-
-| Column | Type | Description |
-|--------|------|-------------|
-| id | UUID | Primary key |
-| code | VARCHAR(50) | Instrument code (e.g., "USD") |
-| version | INTEGER | Version number |
-| dimension | VARCHAR(20) | MONETARY, ENERGY, QUANTITY, etc. |
-| precision | INTEGER | Decimal places (0-18) |
-| status | VARCHAR(20) | DRAFT, ACTIVE, DEPRECATED |
-| is_system | BOOLEAN | True for system instruments |
-| validation_expression | TEXT | CEL validation rule |
-| fungibility_key_expression | TEXT | CEL bucket key rule |
-| error_message_expression | TEXT | CEL custom error message |
-| attribute_schema | JSONB | JSON schema for attributes |
-| display_name | VARCHAR(255) | Human-readable name |
-| description | TEXT | Additional context |
-| created_at | TIMESTAMPTZ | Creation timestamp |
-| updated_at | TIMESTAMPTZ | Last modification |
-| activated_at | TIMESTAMPTZ | When status became ACTIVE |
-| deprecated_at | TIMESTAMPTZ | When status became DEPRECATED |
-
-### Migrations
-
-Located in `migrations/`:
-
-- `20260104000001_initial.sql` - Initial schema and triggers
-- `20260105000001_add_is_system.sql` - Adds is_system column
-
-**Note**: System instruments are NOT seeded by migrations. They are seeded by the tenant provisioning service.
-
-## Usage Example
-
-```go
-// Create registry
-pool, _ := pgxpool.New(ctx, connStr)
-registry, _ := registry.NewPostgresRegistry(pool)
-
-// Create tenant instrument
-def := &registry.InstrumentDefinition{
-    Code:                 "CARBON_CREDIT",
-    Version:              1,
-    Dimension:            registry.DimensionQuantity,
-    Precision:            0,
-    ValidationExpression: `parse_int(amount) > 0 && attributes.exists("vintage_year")`,
-    DisplayName:          "Carbon Credit",
-}
-registry.CreateDraft(ctx, def)
-registry.ActivateInstrument(ctx, "CARBON_CREDIT", 1)
-
-// Validate a quantity
-result, _ := registry.ValidateAttributes(ctx, "CARBON_CREDIT", 1, registry.AttributeBag{
-    Amount:     "100",
-    Attributes: map[string]string{"vintage_year": "2024"},
-})
-// result.Valid == true
-```
-
-## Testing
-
-Integration tests use Testcontainers:
-
-```bash
-go test ./services/reference-data/... -v
-```
-
-Tests cover:
-
-- CRUD operations
-- Lifecycle transitions
-- System instrument protection
-- CEL validation
-- Tenant isolation
+- [`docs/architecture-layers.md`](../../docs/architecture-layers.md) - Reference and Registry layer description
+- [`api/proto/meridian/reference_data/v1/`](../../api/proto/meridian/reference_data/v1/) - Proto definitions
+- [`api/proto/meridian/saga/v1/`](../../api/proto/meridian/saga/v1/) - Saga registry proto
+- ADR-0002: Microservices per BIAN Domain

--- a/services/reference-data/README.md
+++ b/services/reference-data/README.md
@@ -247,7 +247,7 @@ Paths are relative to `services/reference-data/`.
 
 | Variable | Required | Default | Purpose |
 |----------|----------|---------|---------|
-| `DATABASE_URL` | Yes | `postgres://meridian_reference_data_user@localhost:26257/meridian_reference_data?sslmode=disable` | CockroachDB connection string (relative to service startup directory) |
+| `DATABASE_URL` | Yes | `postgres://meridian_reference_data_user@localhost:26257/meridian_reference_data?sslmode=disable` | CockroachDB connection string |
 | `GRPC_PORT` | No | `50059` | gRPC listen port |
 | `METRICS_PORT` | No | `8082` | HTTP port for `/metrics`, `/health`, `/ready` endpoints |
 | `LOG_LEVEL` | No | `info` | Structured log level (`debug`, `info`, `warn`, `error`) |


### PR DESCRIPTION
## Summary

- Apply `docs/service-readme-template.md` to `reference-data`, `market-information`, `identity`, and `party`
- Each README includes all required template sections: frontmatter, Overview table, API Surface, Domain Model (Mermaid classDiagram), Dependencies, Dependents, Load-Bearing Files, Configuration
- Layer names verified against `docs/architecture-layers.md` (Reference and Registry; Identity)
- Load-Bearing file paths verified to exist in the codebase
- Dependents populated by grepping for callers across the codebase

## Test Plan

- [x] All 4 READMEs include required template sections in order
- [x] Layers match architecture-layers.md (`Reference and Registry` for reference-data/market-information; `Identity` for identity/party)
- [x] Load-Bearing file paths exist and point to real files
- [x] Dependents grepped from codebase (`rg "reference_data" services/`, `rg "market_information" services/`, etc.)
- [x] `markdownlint-cli2` passes (0 errors)
- [x] Pre-commit hooks pass