### PR TITLE
docs: Backfill Observability and Routing service READMEs

### DIFF
--- a/services/audit-worker/README.md
+++ b/services/audit-worker/README.md
@@ -40,7 +40,7 @@ Kafka consumer and fallback outbox poller for the Meridian audit trail. Part of 
 | **Layer** | Observability and Routing |
 | **Port** | 8080 (HTTP, health checks and metrics); AuditService gRPC served through the unified Meridian binary (no dedicated standalone gRPC port) |
 | **Database** | All tenant schemas - reads `audit_outbox`, writes `audit_log` |
-| **Standalone** | No (requires CockroachDB and Kafka) |
+| **Standalone** | No (requires CockroachDB; Kafka required for the Kafka consumer path - the outbox-only binary needs only CockroachDB) |
 
 ## API Surface
 

--- a/services/audit-worker/README.md
+++ b/services/audit-worker/README.md
@@ -1,113 +1,187 @@
 ---
-name: audit-worker-service
-description: Fallback audit logging worker for Kafka outage recovery
+name: audit-worker
+description: Kafka consumer and outbox fallback poller that maintains the per-tenant audit_log; provides the ListAuditEntries gRPC read API via the unified binary
 triggers:
-  - Audit log processing and outbox draining
-  - Kafka unavailability and fallback mode
-  - Audit metrics and monitoring
-  - Audit event retention and recovery
+  - Investigating audit trail gaps or missing entries
+  - Debugging audit_outbox backlog or high outbox depth
+  - Understanding the dual-path audit pipeline (Kafka primary, outbox fallback)
+  - Adding auditable entities to a service
+  - Reading audit history via ListAuditEntries
 instructions: |
-  The audit-worker processes audit_outbox entries when Kafka is unavailable.
-  It polls the outbox table every 5 seconds and moves entries to audit_log.
-  Monitor via Prometheus metrics: meridian_audit_worker_outbox_depth (alert if > 1000).
+  audit-worker has two delivery paths, both converging on audit_log:
+  - Primary (Kafka): domain services publish AuditEvent to
+    audit.events.<service>.v1; the AuditConsumer in this service writes the
+    event to the tenant-scoped audit_log (identified via x-tenant-id header).
+  - Fallback (outbox): when Kafka is unavailable, GORM hooks write an
+    audit_outbox row in the same DB transaction as the business write. The
+    audit.Worker polls audit_outbox every 5 s (adaptive) and drains to
+    audit_log. Alert threshold: meridian_audit_worker_outbox_depth > 1000.
 
-  Port: 8080 (HTTP for health/metrics)
+  The standalone binary (cmd/main.go) runs the outbox Worker only.
+  The AuditService gRPC (ListAuditEntries) is implemented in service/server.go
+  and registered in the unified Meridian binary (cmd/meridian/wire_grpc.go:415).
+  Both paths use ON CONFLICT (event_id) DO NOTHING so duplicate delivery is safe.
+
+  SERVICE_NAME identifies which source service's audit events this instance
+  processes. AUDIT_SCHEMA identifies the schema the outbox Worker polls.
+  Tenant context comes from the x-tenant-id Kafka header, set by ProtoConsumer.
 ---
 
 # audit-worker
 
-**Fallback service** that processes audit log entries from the outbox table when Kafka is unavailable.
+Kafka consumer and fallback outbox poller for the Meridian audit trail. Part of the
+[Observability and Routing layer](../../docs/architecture-layers.md#8-observability-and-routing).
 
-## Purpose
+## Overview
 
-The audit-worker implements the **fallback path** of the dual-path audit system described in
-[ADR-0009][adr-0009]. Under normal operation, audit events flow through Kafka to dedicated audit consumers.
-When Kafka is unavailable (network partition, broker outage), GORM hooks automatically write to the `audit_outbox`
-table instead, and this worker:
+| Attribute | Value |
+|-----------|-------|
+| **BIAN Domain** | Infrastructure (non-BIAN) |
+| **Layer** | Observability and Routing |
+| **Port** | 8080 (HTTP, health checks and metrics); AuditService gRPC served through the unified Meridian binary (no dedicated standalone gRPC port) |
+| **Database** | All tenant schemas - reads `audit_outbox`, writes `audit_log` |
+| **Standalone** | No (requires CockroachDB and Kafka) |
 
-[adr-0009]: ../../docs/adr/0009-application-level-audit-logging.md
+## API Surface
 
-**Note**: "Unavailable" refers to runtime detection of Kafka connectivity issues (5s timeout), not a configuration
-flag. There is no feature flag to enable/disable this worker - it is always running in production to process outbox
-entries written during Kafka outages.
+### gRPC (served via unified binary)
 
-1. Polls the `audit_outbox` table every 5 seconds (for entries written during Kafka outages)
-2. Processes records in batches of 100
-3. Moves entries to the `audit_log` table
-4. Implements retry logic (max 3 retries)
-5. Exposes Prometheus metrics for monitoring
+| Service | RPC | Purpose |
+|---------|-----|---------|
+| `AuditService` | `ListAuditEntries` | Paginated cursor query of the tenant-scoped `audit_log` |
 
-**Normal flow**: GORM hooks → Kafka → Audit Consumers → `audit_log`
-**Fallback flow**: GORM hooks → `audit_outbox` → audit-worker → `audit_log`
+Proto: [`api/proto/meridian/audit/v1/audit_service.proto`](../../api/proto/meridian/audit/v1/audit_service.proto).
 
-## Endpoints
+### HTTP
 
-| Endpoint | Port | Purpose |
-|----------|------|---------|
-| `/health/live` | 8080 | Kubernetes liveness probe |
-| `/health/ready` | 8080 | Kubernetes readiness probe |
-| `/health/startup` | 8080 | Kubernetes startup probe |
-| `/metrics` | 8080 | Prometheus metrics |
-| `/` | 8080 | Version info |
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/health/live` | Kubernetes liveness probe |
+| `GET` | `/health/ready` | Kubernetes readiness probe |
+| `GET` | `/health/startup` | Kubernetes startup probe |
+| `GET` | `/metrics` | Prometheus metrics endpoint |
 
-## Metrics
+## Domain Model
 
-**Worker-specific metrics:**
+audit-worker is a pipeline service; it does not own domain entities. It reads from
+`audit_outbox` rows written by domain services and writes `audit_log` rows. The
+`AuditLogEntry` returned by `ListAuditEntries` is the read projection of `audit_log`:
 
-- `meridian_audit_worker_outbox_depth` - Current number of entries in outbox (gauge)
-- `meridian_audit_worker_outbox_processed_total` - Total entries processed (counter)
-- `meridian_audit_worker_outbox_failed_total` - Total entries failed (counter)
-- `meridian_audit_worker_processing_duration_seconds` - Batch processing duration (histogram)
-- `meridian_audit_worker_entry_age_seconds` - Age of entries when processed (histogram)
+```mermaid
+classDiagram
+    class AuditOutbox {
+        +UUID eventId
+        +string tableName
+        +string operation
+        +string recordId
+        +JSON oldValues
+        +JSON newValues
+        +string status
+        +int retryCount
+        +time createdAt
+    }
+    class AuditLog {
+        +UUID id
+        +string tableName
+        +string operation
+        +string recordId
+        +JSON oldValues
+        +JSON newValues
+        +string changedBy
+        +string transactionId
+        +time createdAt
+    }
+    AuditOutbox --> AuditLog : drained by Worker or AuditConsumer
+```
 
-**System-wide metrics** (for overall audit health):
+`audit_outbox.status` lifecycle: `pending` -> `processing` -> `completed` (or `failed`
+after `maxRetries`). `ResetStuckEntries` reclaims rows stuck in `processing` longer than
+the configured threshold.
 
-- `meridian_audit_kafka_events_published_total` - Primary path usage (Kafka) (counter)
-- `meridian_audit_kafka_fallback_used_total` - Fallback path activations (counter)
-- `meridian_audit_kafka_events_consumed_total` - Consumer throughput (counter)
+## Dependencies
 
-**Alerting thresholds:**
+| Service | Protocol | Purpose |
+|---------|----------|---------|
+| CockroachDB (all tenant schemas) | SQL | Reads `audit_outbox`; writes `audit_log` |
+| Kafka (`audit.events.<service>.v1` topics) | Kafka consumer | Primary delivery path for audit events from domain services |
 
-- Alert if `meridian_audit_worker_outbox_depth` > 1000 for 5 minutes (indicates Kafka outage or worker lag)
-- Alert if `entry_age_seconds` p99 > 60s (indicates processing delays)
+## Dependents
 
-See [ADR-0009](../../docs/adr/0009-application-level-audit-logging.md) for complete Prometheus metrics
-reference and monitoring strategy.
+| Service | Entry Point | Purpose |
+|---------|-------------|---------|
+| `api-gateway` | `services/api-gateway/` (proxies `AuditService` gRPC) | Exposes `ListAuditEntries` to external callers |
+| `mcp-server` | `services/mcp-server/internal/tools/audit.go` | Surfaces audit history as an MCP tool for LLM clients |
+
+## Load-Bearing Files
+
+Paths are relative to `services/audit-worker/`.
+
+| File | Why It Matters |
+|------|----------------|
+| `cmd/main.go` | Entry point for the standalone binary; wires the outbox `audit.Worker` and HTTP server |
+| `app/container.go` | Dependency injection for the Kafka consumer path; wires `AuditConsumer` and health checker |
+| `app/config.go` | All configuration fields with defaults; the only source of env var names for the Kafka consumer path |
+| `adapters/kafka/consumer.go` | `AuditConsumer.handleAuditEvent` - writes `audit_log` from Kafka events; idempotency gate |
+| `adapters/persistence/tenant_audit_writer.go` | `TenantAuditWriter` - tenant-scoped `audit_log` insert with `ON CONFLICT DO NOTHING` |
+| `service/server.go` | `AuditService.ListAuditEntries` gRPC implementation; cursor-paginated read of `audit_log` |
 
 ## Configuration
 
-| Environment Variable | Default | Description |
-|---------------------|---------|-------------|
-| `PORT` | `8080` | HTTP server port |
-| `DATABASE_URL` | (local dev default) | PostgreSQL connection string |
+### Standalone binary (`cmd/main.go`)
 
-## Directory Structure
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `DATABASE_URL` | Yes | - | CockroachDB connection string |
+| `AUDIT_SCHEMA` | Yes | - | Tenant schema to poll (e.g., `org_<tenant_id>`) |
+| `PORT` | No | `8080` | HTTP listen port (health and metrics) |
+| `GRACEFUL_SHUTDOWN_TIMEOUT` | No | `30s` | Maximum wait on shutdown |
 
-```text
-services/audit-worker/
-├── cmd/                    # Entry point (main.go)
-├── domain/                 # Domain models (Measurement, AuditOperation, Transformer)
-├── adapters/
-│   ├── kafka/              # Kafka consumer adapter (AuditConsumer)
-│   └── persistence/        # Database adapter (TenantAuditWriter)
-├── app/                    # Configuration and dependency injection (Container)
-├── observability/          # Metrics and health checks
-└── README.md
+### Kafka consumer path (`app/container.go`)
+
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `DATABASE_URL` | Yes | - | CockroachDB connection string |
+| `KAFKA_BOOTSTRAP_SERVERS` | Yes | - | Comma-separated broker addresses |
+| `AUDIT_TOPIC` | Yes | - | Kafka topic to consume (e.g., `audit.events.current-account.v1`) |
+| `SERVICE_NAME` | Yes | - | Identifies which service's events this instance processes |
+| `KAFKA_GROUP_ID` | No | `audit-consumer-group` | Consumer group ID |
+| `KAFKA_CLIENT_ID` | No | `audit-consumer` | Client identifier for logs and metrics |
+| `KAFKA_HANDLER_TIMEOUT` | No | `30s` | Maximum duration per message |
+| `KAFKA_MAX_RETRIES` | No | `3` | Maximum retries before DLQ |
+| `PORT` | No | `8080` | HTTP listen port |
+| `DB_MAX_OPEN_CONNS` | No | `25` | Database connection pool maximum |
+| `DB_MAX_IDLE_CONNS` | No | `5` | Database idle connection pool size |
+| `DB_CONN_MAX_LIFETIME` | No | `5m` | Maximum connection reuse duration |
+| `DB_CONN_MAX_IDLE_TIME` | No | `10m` | Maximum idle connection duration |
+
+## Architecture
+
+The audit pipeline has two independent delivery paths from domain mutation to `audit_log`.
+See [`docs/data-flows.md`](../../docs/data-flows.md#2-audit-pipeline) for the full sequence
+diagram and invariant analysis.
+
+```mermaid
+flowchart TD
+    Hook[GORM Hook<br/>AfterCreate / AfterUpdate / AfterDelete] --> Decision{Kafka<br/>reachable?}
+    Decision -->|Primary| Kafka[Kafka topic<br/>audit.events.service.v1]
+    Decision -->|Fallback| Outbox[(audit_outbox<br/>same DB tx)]
+    Kafka --> Consumer[AuditConsumer<br/>in audit-worker]
+    Outbox --> Worker[audit.Worker<br/>polls every 5 s adaptive]
+    Consumer --> AuditLog[(audit_log<br/>tenant schema)]
+    Worker --> AuditLog
 ```
 
-## Development
+**Key invariants:**
 
-```bash
-# Run locally
-go run ./services/audit-worker/cmd
+- The `audit_outbox` write shares the business transaction - if the business write rolls back, no audit row is produced.
+- `event_id` uniqueness prevents duplicate delivery between the two paths.
+- The alert threshold `meridian_audit_worker_outbox_depth > 1000` indicates either a Kafka outage or worker
+  lag requiring operator attention.
 
-# Run tests
-go test ./services/audit-worker/...
-```
+## References
 
-## Deployment
-
-Deployed via Kubernetes manifests in `deployments/k8s/base/`.
-
-- **Replicas**: 3 (production)
-- **Resource limits**: 500m CPU, 512Mi memory
+- ADR-0009: Application-Level Audit Logging - [`docs/adr/0009-application-level-audit-logging.md`](../../docs/adr/0009-application-level-audit-logging.md)
+- ADR-0020: Per-Service Audit Workers - [`docs/adr/0020-per-service-audit-workers.md`](../../docs/adr/0020-per-service-audit-workers.md)
+- Audit pattern canonical location: [`shared/platform/audit/README.md`](../../shared/platform/audit/README.md)
+- Outbox pattern: [`docs/patterns.md`](../../docs/patterns.md#1-outbox-pattern)
+- Audit pipeline data flow: [`docs/data-flows.md`](../../docs/data-flows.md#2-audit-pipeline)

--- a/services/event-router/README.md
+++ b/services/event-router/README.md
@@ -47,7 +47,8 @@ Part of the [Observability and Routing layer](../../docs/architecture-layers.md#
 
 ## API Surface
 
-event-router exposes no gRPC or HTTP API. It is a pure consumer.
+event-router exposes no gRPC port and no business API endpoints. It is a pure consumer.
+HTTP endpoints below are for operational use only (health probes and metrics).
 
 ### HTTP
 

--- a/services/event-router/README.md
+++ b/services/event-router/README.md
@@ -1,183 +1,162 @@
 ---
 name: event-router
-description: CEL-filtered saga dispatcher that routes domain events from Kafka to saga workflows and platform billing handlers
+description: Kafka consumer that routes audit events to CEL-filtered saga triggers and transforms them into platform billing measurements via position-keeping
 triggers:
-  - Working on event-driven saga triggering
-  - Implementing CEL-based event filtering and routing
-  - Configuring platform billing and utilization metering
-  - Debugging event routing pipelines
-  - Understanding how domain events trigger saga workflows
+  - Debugging event-driven saga triggering
+  - Understanding how domain events reach control-plane workflows
+  - Configuring platform utilization metering for tenant-zero billing
+  - Investigating missing saga executions or billing measurements
+  - Adding a new event handler or routing rule
 instructions: |
-  Event Router is a Kafka consumer that routes domain events to registered handlers
-  using CEL filter expressions. Its primary responsibilities are saga triggering
-  and platform utilization metering.
+  event-router is a stateless Kafka consumer with no gRPC port of its own.
+  It consumes six audit topics (audit.events.*.v1) and dispatches each event
+  to registered EventHandler implementations:
 
-  Key concepts:
-  - Consumes domain events from multiple Kafka topics
-  - Routes events to handlers based on channel and event type
-  - Triggers saga workflows via the control-plane's SagaExecutionService
-  - Transforms audit events into utilization measurements for platform billing
-  - Idempotent saga triggering via idempotency keys
+  - SagaTrigger: triggers sagas via control-plane ExecuteSaga gRPC with an
+    idempotency key derived from the source event (prevents duplicate triggers
+    on Kafka redelivery).
+  - PlatformMeteringHandler: transforms audit events into utilization
+    measurements and calls position-keeping RecordMeasurement on tenant-zero
+    (the platform billing tenant). The MDS output (ENABLE_MDS_OUTPUT) buffers
+    measurements and flushes to market-information on a configurable interval.
 
-  Architecture patterns:
-  - Handler registry with pluggable EventHandler interface
-  - CEL expressions for event filtering
-  - Fire-and-forget event consumption (at-least-once semantics)
-  - Saga triggering via gRPC to control-plane
-  - Utilization metering via Position Keeping tenant-zero
+  Required env vars: KAFKA_BOOTSTRAP_SERVERS, POSITION_KEEPING_ENDPOINT,
+  TENANT_ZERO_ID. The consumer group is "event-router" by default.
 
-  Port: 8080 (HTTP - health checks and metrics)
+  Scale via HPA on Kafka consumer lag - do not run more than one instance per
+  topic partition to avoid duplicate saga triggering (idempotency keys mitigate
+  this but do not eliminate latency spikes).
+
+  Port: 8080 (HTTP - health checks and metrics only, no gRPC).
 ---
 
-# Event Router
+# event-router
 
-CEL-filtered saga dispatcher that routes domain events from Kafka to saga workflows and platform billing handlers.
+Kafka consumer that routes domain events to saga triggers and platform billing measurements.
+Part of the [Observability and Routing layer](../../docs/architecture-layers.md#8-observability-and-routing).
 
 ## Overview
 
 | Attribute | Value |
 |-----------|-------|
-| **Domain** | Infrastructure (Event Routing) |
-| **Port** | 8080 (HTTP) |
-| **Language** | Go |
+| **BIAN Domain** | Infrastructure (non-BIAN) |
+| **Layer** | Observability and Routing |
+| **Port** | 8080 (HTTP, health checks and metrics only; no gRPC port) |
 | **Database** | None (stateless consumer) |
-| **Standalone** | No (requires Kafka, Control Plane, Position Keeping) |
+| **Standalone** | No (requires Kafka, `position-keeping`, and `control-plane`) |
 
-## Purpose
+## API Surface
 
-The Event Router provides event-driven workflow orchestration by:
+event-router exposes no gRPC or HTTP API. It is a pure consumer.
 
-- Consuming domain events from Kafka audit topics
-- Routing events to registered handlers via the `EventHandler` interface
-- Triggering saga workflows through the control-plane's `SagaExecutionService`
-- Transforming audit events into utilization measurements for platform billing (tenant-zero)
+### HTTP
 
-## HTTP Endpoints
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/healthz` | Kubernetes liveness probe |
+| `GET` | `/ready` | Readiness probe (checks consumer initialization) |
+| `GET` | `/metrics` | Prometheus metrics endpoint |
 
-| Endpoint | Method | Purpose |
-|----------|--------|---------|
-| `/healthz` | GET | Liveness probe |
-| `/ready` | GET | Readiness probe (checks consumer initialization) |
-| `/metrics` | GET | Prometheus metrics endpoint |
+## Domain Model
 
-## Architecture
-
-### Handler Registry
-
-The Event Router uses a pluggable handler model:
-
-- **`EventHandler`** interface: `Handle(ctx, channel, event, metadata) error`
-- **`SagaTrigger`** interface: Triggers sagas via control-plane gRPC with idempotency keys
-- **`UtilizationPublisher`**: Transforms audit events into billing measurements
+event-router is a stateless routing adapter. It does not own persistent domain
+entities. The key interfaces are:
 
 ```mermaid
-flowchart LR
-    subgraph Kafka["Kafka Topics"]
-        T1["audit.events.*"]
-        T2["position-keeping<br/>.transaction-captured.v1"]
-    end
-
-    subgraph ER["Event Router"]
-        Consumer["Multi-Topic<br/>Consumer"]
-        Router["Handler<br/>Router"]
-        SH["Saga<br/>Handler"]
-        UH["Utilization<br/>Handler"]
-    end
-
-    subgraph Downstream["Downstream Services"]
-        CP["Control Plane<br/>(Saga Execution)"]
-        PK["Position Keeping<br/>(Tenant-Zero)"]
-    end
-
-    T1 --> Consumer
-    T2 --> Consumer
-    Consumer --> Router
-    Router --> SH
-    Router --> UH
-    SH -->|ExecuteSaga| CP
-    UH -->|RecordMeasurement| PK
-
-    classDef kafka fill:#50c878,stroke:#2d7a4a,color:#fff
-    classDef service fill:#4a90d9,stroke:#2d5a87,color:#fff
-    classDef downstream fill:#9c27b0,stroke:#6a1b9a,color:#fff
-    class T1,T2 kafka
-    class Consumer,Router,SH,UH service
-    class CP,PK downstream
+classDiagram
+    class EventHandler {
+        <<interface>>
+        +Handle(ctx, channel, event, metadata) error
+    }
+    class AuditConsumer {
+        +topics []string
+        +groupID string
+        +handlerRegistry map
+    }
+    class PlatformMeteringHandler {
+        +tenantZeroID UUID
+        +tenantAccountMapping map
+    }
+    class SagaTrigger {
+        <<interface>>
+        +TriggerSaga(ctx, channel, event, metadata) error
+    }
+    AuditConsumer --> EventHandler : dispatches to
+    PlatformMeteringHandler ..|> EventHandler
+    SagaTrigger ..|> EventHandler
 ```
 
-### Event Processing Pipeline
+Events consumed: protobuf `AuditEvent` messages from `audit.events.<service>.v1` topics.
+Measurements produced: gRPC `RecordMeasurement` calls to `position-keeping` on tenant-zero.
 
-1. **Consume**: Read event from Kafka topic
-2. **Deserialize**: Parse Protobuf event
-3. **Route**: Dispatch to registered handler(s) based on channel
-4. **Handle**: Handler processes event (trigger saga or record measurement)
-5. **Commit**: Commit Kafka offset (at-least-once semantics)
+## Dependencies
 
-## Service Dependencies
+| Service | Protocol | Purpose |
+|---------|----------|---------|
+| Kafka (`audit.events.*.v1` topics) | Kafka consumer | Source of all audit domain events |
+| `position-keeping` | gRPC | `RecordMeasurement` for platform billing (tenant-zero) |
+| `control-plane` | gRPC | `ExecuteSaga` for event-triggered saga workflows |
+| `market-information` | gRPC (optional) | MDS observation publishing when `ENABLE_MDS_OUTPUT=true` |
 
-| Service | Port | Purpose |
-|---------|------|---------|
-| Kafka | 9092 | Domain event streaming |
-| Control Plane | gRPC | Saga workflow triggering |
-| Position Keeping | 50053 | Utilization measurements (tenant-zero billing) |
+## Dependents
+
+event-router has no callers. It is an event consumer; all data flows outbound.
+
+## Load-Bearing Files
+
+Paths are relative to `services/event-router/`.
+
+| File | Why It Matters |
+|------|----------------|
+| `cmd/main.go` | Entry point; wires the consumer pipeline, HTTP server, and shutdown |
+| `app/config.go` | All configuration fields and defaults; the only source of required env var names |
+| `adapters/messaging/audit_consumer.go` | Multi-topic Kafka consumer; dispatches each event to the handler registry |
+| `adapters/messaging/platform_metering_handler.go` | Transforms audit events to utilization measurements; calls `RecordMeasurement` on tenant-zero |
+| `adapters/grpc/position_keeping_client.go` | gRPC client for `position-keeping` `RecordMeasurement` |
+| `domain/handler.go` | `EventHandler` interface contract; all new handlers must implement this |
+| `domain/tenant_mapping.go` | Tenant-to-account mapping used to resolve billing accounts from tenant IDs |
 
 ## Configuration
 
 | Variable | Required | Default | Purpose |
 |----------|----------|---------|---------|
-| `KAFKA_BOOTSTRAP_SERVERS` | Yes | `kafka:9092` | Kafka broker addresses |
-| `CONSUMER_GROUP_ID` | Yes | `event-router` | Consumer group identifier |
-| `AUDIT_TOPICS` | Yes | - | Comma-separated list of topics to consume |
-| `POSITION_KEEPING_ENDPOINT` | Yes | `position-keeping:50053` | Position Keeping gRPC endpoint |
-| `TENANT_ZERO_ID` | Yes | - | UUID of platform billing tenant |
-| `TENANT_ACCOUNT_MAPPING` | No | `{}` | JSON mapping of tenant IDs to billing accounts |
-| `HTTP_PORT` | No | `8080` | HTTP server port for health/metrics |
-| `CONTROL_PLANE_ENDPOINT` | Yes | - | Control Plane gRPC endpoint for saga triggering |
-| `MARKET_DATA_ENDPOINT` | No | - | Market Information gRPC endpoint |
+| `KAFKA_BOOTSTRAP_SERVERS` | Yes | - | Comma-separated Kafka broker addresses |
+| `POSITION_KEEPING_ENDPOINT` | Yes | - | gRPC address of `position-keeping` (e.g., `position-keeping:50053`) |
+| `TENANT_ZERO_ID` | Yes | - | UUID of the platform billing tenant for utilization metering |
+| `CONSUMER_GROUP_ID` | No | `event-router` | Kafka consumer group ID |
+| `TENANT_ACCOUNT_MAPPING` | No | - | JSON mapping of tenant UUIDs to billing account UUIDs |
+| `HTTP_PORT` | No | `8080` | HTTP listen port (health and metrics) |
+| `ENABLE_MDS_OUTPUT` | No | `true` | Enable MDS observation publishing to `market-information` |
+| `MDS_SERVICE_ADDR` | No | - | gRPC address of `market-information` (required when `ENABLE_MDS_OUTPUT=true`) |
+| `MDS_AGGREGATION_WINDOW` | No | `1h` | Measurement aggregation window before flush |
+| `MDS_FLUSH_INTERVAL` | No | `5m` | How often to flush buffered MDS observations |
 
-## Key Patterns
+The six default audit topics are hard-coded in `app/config.go`:
+`audit.events.current-account.v1`, `audit.events.financial-accounting.v1`,
+`audit.events.position-keeping.v1`, `audit.events.party.v1`,
+`audit.events.payment-order.v1`, `audit.events.tenant.v1`.
 
-### Idempotent Saga Triggering
+## Architecture
 
-Saga triggers include an idempotency key derived from the source event. Duplicate triggers
-(e.g., Kafka redelivery) return the existing saga ID without re-executing.
-
-### Stateless Consumer
-
-No local database. All state resides in downstream services (Control Plane for sagas,
-Position Keeping for billing). This enables horizontal scaling without data partitioning.
-
-### At-Least-Once Semantics
-
-Manual Kafka offset commits after successful processing. Duplicate events are handled
-by downstream idempotency.
-
-## Directory Structure
-
-```text
-services/event-router/
-├── cmd/                    # Entry point (main.go, Dockerfile)
-├── domain/                 # Domain models
-│   ├── handler.go          # EventHandler interface
-│   ├── saga_trigger.go     # SagaTrigger interface
-│   ├── measurement.go      # UtilizationMeasurement type
-│   ├── instruments.go      # Instrument code mapping
-│   ├── metrics.go          # Prometheus metrics
-│   └── tenant_mapping.go   # Tenant-to-account mapping
-├── adapters/               # External adapters
-│   ├── grpc/               # Control Plane saga trigger client
-│   ├── mds/                # Market Data Service client
-│   └── messaging/          # Kafka consumer
-├── app/                    # Application configuration
-│   └── config.go           # Config loading and validation
-├── internal/               # Internal implementation
-├── k8s/                    # Kubernetes manifests
-└── tests/                  # Integration tests
+```mermaid
+flowchart LR
+    Kafka["Kafka<br/>audit.events.*.v1"] --> Consumer[AuditConsumer]
+    Consumer --> Metering[PlatformMeteringHandler]
+    Consumer --> Saga[SagaTrigger]
+    Metering -->|RecordMeasurement| PK[position-keeping<br/>tenant-zero]
+    Saga -->|ExecuteSaga| CP[control-plane]
+    Metering -->|PublishObservation| MDS[market-information<br/>optional]
 ```
+
+**Key properties:**
+
+- At-least-once semantics: Kafka offsets commit only after successful handler dispatch.
+- Idempotent saga triggering: idempotency key derived from event ID prevents duplicate saga starts on
+  redelivery.
+- Scale via HPA on Kafka consumer lag. A single consumer group (`event-router`) ensures each event is
+  processed once per partition.
 
 ## References
 
-- [Service Architecture](../README.md)
-- [Kubernetes Deployment Guide](k8s/README.md)
-- [Position Keeping Service](../position-keeping/README.md)
-- [Control Plane Service](../control-plane/README.md)
+- Architecture layers: [`docs/architecture-layers.md`](../../docs/architecture-layers.md#8-observability-and-routing)
+- Event-driven architecture: [`docs/architecture/event-driven-architecture.md`](../../docs/architecture/event-driven-architecture.md)

--- a/services/forecasting/README.md
+++ b/services/forecasting/README.md
@@ -28,7 +28,7 @@ instructions: |
 
   Port: 50061 (gRPC, ports.Forecasting), 8082 (HTTP metrics and health).
   MDS_TARGET is the market-information gRPC endpoint (default market-information:50051).
-  REDIS_ADDR is required for distributed lease management.
+  REDIS_ADDR defaults to localhost:6379; set it explicitly in production for distributed lease management.
 ---
 
 # forecasting
@@ -45,7 +45,7 @@ Market Information Service observations on a cron schedule. Part of the
 | **Layer** | Observability and Routing |
 | **Port** | 50061 (gRPC), 8082 (HTTP metrics and health) |
 | **Database** | CockroachDB (tenant-scoped schemas) |
-| **Standalone** | No (requires `market-information` gRPC, Redis for scheduler lease management) |
+| **Standalone** | No (requires `market-information` gRPC; Redis for scheduler lease management, defaults to `localhost:6379`) |
 
 ## API Surface
 

--- a/services/forecasting/README.md
+++ b/services/forecasting/README.md
@@ -1,341 +1,165 @@
 ---
-name: forecasting-service
-description: Forward curve generation engine using tenant-defined Starlark strategies with cron-based scheduling
+name: forecasting
+description: Forward curve generation engine using tenant-defined Starlark strategies scheduled by cron against Market Information Service observations
 triggers:
-  - Implementing forecasting strategies for forward curves
-  - Starlark script execution and sandboxing
-  - Cron-based scheduled forecast execution
-  - Market data observation fetching and publishing
-  - Forward curve generation from historical data
-  - Strategy lifecycle management (DRAFT, ACTIVE, DEPRECATED)
+  - Implementing or debugging a forecasting strategy
+  - Understanding the Starlark sandbox used for forecasting scripts
+  - Configuring a cron-based forward curve schedule
+  - Investigating why a scheduled forecast did not run
+  - Tracing forecast output quality (ESTIMATE) back to market-information
 instructions: |
-  Forecasting service manages tenant-defined Starlark strategies that generate forward curves
-  from Market Data Service observations.
+  Forecasting executes tenant-defined Starlark scripts that read historical
+  observations from market-information and publish forward curve points back
+  as ESTIMATE quality observations.
 
-  Key patterns:
-  - Starlark sandbox: Guaranteed termination (no while loops, no recursion, no imports)
-  - Strategy lifecycle: DRAFT -> ACTIVE -> DEPRECATED (DEPRECATED is terminal)
-  - Cron scheduler: Polls for active strategies, acquires Redis leases to prevent duplicate execution
-  - MDS integration: Reads historical observations as input, publishes forecast points as ESTIMATE quality
-  - Optimistic locking via version field
-  - Immutable domain model (value types, defensive slice copies)
-  - Built-in templates: moving_average, seasonal_decomposition, capacity_pricing, external_blend
+  Strategy lifecycle: DRAFT -> ACTIVE -> DEPRECATED (DEPRECATED is terminal).
+  Only ACTIVE strategies are scheduled and can be executed via ComputeForwardCurve.
 
-  Port: 50061 (gRPC)
+  Starlark sandbox: ForecasterConfig (shared/platform/sandbox) - 10 s timeout,
+  1,000,000 max steps, 64 KB script size limit. No while loops, no recursion, no
+  load/import. The sandbox guarantees termination.
+
+  Cron scheduler: polls active strategies every SCHEDULER_REFRESH_INTERVAL (default 60 s),
+  acquires a Redis lease per strategy (TTL 5 min, renewed every 30 s) to prevent
+  duplicate execution across replicas.
+
+  Built-in templates: moving_average, seasonal_decomposition, capacity_pricing,
+  external_blend (see services/forecasting/templates/).
+
+  Port: 50061 (gRPC, ports.Forecasting), 8082 (HTTP metrics and health).
+  MDS_TARGET is the market-information gRPC endpoint (default market-information:50051).
+  REDIS_ADDR is required for distributed lease management.
 ---
 
-# Forecasting Service
+# forecasting
 
-Forward curve generation engine that executes tenant-defined Starlark strategies against Market Data Service observations.
+Forward curve generation engine that executes tenant-defined Starlark strategies against
+Market Information Service observations on a cron schedule. Part of the
+[Observability and Routing layer](../../docs/architecture-layers.md#8-observability-and-routing).
 
 ## Overview
 
 | Attribute | Value |
 |-----------|-------|
-| **Type** | Domain Service |
-| **Port** | 50061 (gRPC), 8082 (HTTP/metrics) |
-| **Language** | Go |
-| **Database** | CockroachDB (`meridian_forecasting`) |
-| **Standalone** | No (depends on Market Information Service) |
+| **BIAN Domain** | Market Information Management |
+| **Layer** | Observability and Routing |
+| **Port** | 50061 (gRPC), 8082 (HTTP metrics and health) |
+| **Database** | CockroachDB (tenant-scoped schemas) |
+| **Standalone** | No (requires `market-information` gRPC, Redis for scheduler lease management) |
 
-The Forecasting service allows tenants to define Starlark scripts that read historical market data observations,
-compute forward curve predictions, and publish the results back to the Market Data Service as ESTIMATE quality
-observations. Strategies are executed on cron schedules with distributed locking to prevent duplicate execution
-across replicas.
+## API Surface
 
-## Architecture
+### gRPC
 
-```mermaid
-graph LR
-    subgraph Forecasting Service
-        H[gRPC Handler]
-        S[Starlark Runner]
-        CR[Cron Scheduler]
-        LM[Lease Manager]
-    end
+| Service | RPC | Purpose |
+|---------|-----|---------|
+| `ForecastingService` | `ComputeForwardCurve` | Execute a forecasting strategy and publish output points to `market-information` as ESTIMATE quality |
 
-    MDS[Market Information Service]
-    DB[(CockroachDB)]
-    RD[(Redis)]
+Proto: [`api/proto/meridian/forecasting/v1/forecasting.proto`](../../api/proto/meridian/forecasting/v1/forecasting.proto).
 
-    H --> S
-    CR --> LM
-    CR --> H
-    LM --> RD
-    S -->|fetch observations| MDS
-    H -->|publish forecasts| MDS
-    H --> DB
-    CR --> DB
-```
+### HTTP
 
-**Execution flow:**
-
-1. Cron scheduler fires for an active strategy
-2. Lease manager acquires a Redis lock (prevents duplicate execution across pods)
-3. Handler fetches the strategy from the database
-4. Starlark runner fetches historical observations from MDS
-5. Starlark runner resolves reference data (if configured)
-6. Starlark script executes in a sandboxed environment (30s timeout)
-7. Output forecast points are validated (horizon, monotonicity, granularity alignment)
-8. Forecast points are published to MDS as ESTIMATE quality observations in batches of 1000
-
-## gRPC Methods
-
-| Method | Purpose |
-|--------|---------|
-| `ComputeForwardCurve` | Execute a forecasting strategy and publish results to MDS |
-
-The service currently exposes a single RPC. Strategy CRUD operations are planned but not yet implemented.
-
-## Starlark Sandbox
-
-Strategies are written in [Starlark](https://github.com/bazelbuild/starlark), a Python-like language that
-guarantees termination (no `while` loops, no recursion). Each script must define a `compute_forecast(ctx)` function.
-
-**Context fields available to scripts:**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `observations` | `dict[string, list[dict]]` | Historical observations keyed by dataset code |
-| `reference_data` | `dict` or `None` | Resolved reference data node attributes |
-| `horizon_seconds` | `int` | Total forecast window in seconds |
-| `granularity_seconds` | `int` | Spacing between forecast points in seconds |
-| `now` | `string` | Execution timestamp (RFC3339) |
-
-**Builtin functions:**
-
-| Category | Functions |
-|----------|-----------|
-| Statistical | `avg`, `sum`, `percentile` |
-| Observation | `filter_by_hour`, `group_by_hour` |
-| Time | `duration`, `add_seconds` |
-| Arithmetic | `Decimal` (arbitrary-precision) |
-| Stdlib (safe subset) | `len`, `str`, `int`, `float`, `bool`, `list`, `dict`, `tuple`, `range`, `enumerate`, `zip`, `sorted`, `reversed`, `min`, `max`, `abs`, `any`, `all`, `hasattr`, `getattr`, `dir`, `type`, `repr`, `hash`, `print` |
-
-**Forbidden operations:** `import`, `load` -- all required functionality is provided via builtins.
-
-**Script return format:** List of dicts with `timestamp` (RFC3339 string or unix int),
-`value` (Decimal, string, float, or int), and optional `metadata` (dict).
-
-### Built-in Templates
-
-| Template | Description |
-|----------|-------------|
-| `moving_average.star` | Simple/exponential moving average projection |
-| `seasonal_decomposition.star` | Hour-of-day seasonal pattern decomposition |
-| `capacity_pricing.star` | Capacity-based pricing with reference data attributes |
-| `external_blend.star` | Weighted blend of multiple input datasets |
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/health` | Kubernetes liveness probe |
+| `GET` | `/ready` | Kubernetes readiness probe |
+| `GET` | `/metrics` | Prometheus metrics endpoint |
 
 ## Domain Model
 
 ```mermaid
 classDiagram
     class ForecastingStrategy {
-        +UUID ID
-        +string TenantID
-        +string Name
-        +string Description
-        +string StarlarkCode
-        +int HorizonHours
-        +int GranularityHours
-        +string Schedule
-        +[]string InputDatasetCodes
-        +string OutputDatasetCode
-        +string ReferenceDataResolutionKey
-        +StrategyStatus Status
-        +int64 Version
-        +Time CreatedAt
-        +Time UpdatedAt
+        +UUID id
+        +string tenantId
+        +string name
+        +string starlarkCode
+        +int horizonHours
+        +int granularityHours
+        +string schedule
+        +string[] inputDatasetCodes
+        +string outputDatasetCode
+        +StrategyStatus status
+        +int64 version
     }
-
     class StrategyStatus {
         <<enumeration>>
         DRAFT
         ACTIVE
         DEPRECATED
     }
-
-    ForecastingStrategy --> StrategyStatus
+    ForecastingStrategy --> StrategyStatus : has
 ```
 
-**Field Notes:**
-
-- `HorizonHours`: 1-168 (max 7 days)
-- `GranularityHours`: 1 to HorizonHours
-- `Schedule`: Standard cron expression (e.g., `0 16 * * *`)
-- `InputDatasetCodes`: At least one MDS dataset code required
-- `ReferenceDataResolutionKey`: Optional hierarchy node context for the forecast
-
-### Strategy Status
-
-| Status | Description |
-|--------|-------------|
-| `DRAFT` | Strategy is being configured, not yet scheduled |
-| `ACTIVE` | Strategy is scheduled for cron execution |
-| `DEPRECATED` | Terminal state, strategy is retired |
-
-**Status Transitions:**
-
-```mermaid
-stateDiagram-v2
-    [*] --> DRAFT
-    DRAFT --> ACTIVE
-    DRAFT --> DEPRECATED
-    ACTIVE --> DEPRECATED
-    DEPRECATED --> [*]
-```
-
-- Only ACTIVE strategies can be executed via `ComputeForwardCurve`
-- DEPRECATED is terminal (cannot be reactivated)
-- Starlark code, description, and schedule can be updated while in DRAFT or ACTIVE
-
-## Cron Scheduler
-
-The scheduler polls the database every 60 seconds for active strategies and registers cron jobs for each.
-
-| Setting | Value |
-|---------|-------|
-| Poll interval | 60 seconds |
-| Shutdown timeout | 5 minutes |
-| Lease TTL | 5 minutes (Redis) |
-| Lease renewal | Every 30 seconds |
-| Execution timezone | UTC |
-
-**Distributed locking:** The `LeaseManager` uses Redis-based distributed locks to prevent multiple pods from
-executing the same strategy simultaneously. Locks are automatically renewed during execution and released
-on completion or during graceful shutdown.
-
-## Database Schema
-
-**Database**: `meridian_forecasting`
-
-```mermaid
-erDiagram
-    forecasting_strategy {
-        uuid id PK
-        text tenant_id "NOT NULL"
-        text name "NOT NULL"
-        text description "nullable"
-        text starlark_code "NOT NULL"
-        int horizon_hours "1-168"
-        int granularity_hours "1 to horizon_hours"
-        text schedule "cron expression"
-        text_array input_dataset_codes "NOT NULL"
-        text output_dataset_code "NOT NULL"
-        text reference_data_resolution_key "nullable"
-        text status "DRAFT, ACTIVE, DEPRECATED"
-        bigint version "optimistic lock"
-        timestamptz created_at
-        timestamptz updated_at
-    }
-```
-
-**Indexes:**
-
-- `idx_forecasting_strategy_unique_active`: Partial unique on (tenant_id, name) WHERE status = 'ACTIVE'
-- `idx_forecasting_strategy_tenant_status`: Covering index for tenant listing queries
-- `idx_forecasting_strategy_active`: Partial index for scheduler lookups WHERE status = 'ACTIVE'
-
-**Constraints:**
-
-- `chk_forecasting_strategy_status`: status IN ('DRAFT', 'ACTIVE', 'DEPRECATED')
-- `horizon_hours > 0 AND horizon_hours <= 168`
-- `granularity_hours > 0 AND granularity_hours <= horizon_hours`
-
-## Configuration
-
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `GRPC_PORT` | 50061 | gRPC server port |
-| `METRICS_PORT` | 8082 | HTTP metrics and health endpoint |
-| `DATABASE_URL` | - | CockroachDB connection string |
-| `DB_MAX_OPEN_CONNS` | 25 | Connection pool size |
-| `DB_MAX_IDLE_CONNS` | 5 | Idle connections |
-| `DB_CONN_MAX_LIFETIME` | 5m | Connection max age |
-| `DB_CONN_MAX_IDLE_TIME` | 10m | Idle connection max age |
-| `MDS_TARGET` | `market-information:50051` | Market Information Service gRPC target |
-| `LOG_LEVEL` | info | Log level (debug, info, warn, error) |
-| `LOG_FORMAT` | json | Log format |
-| `AUTH_ENABLED` | false | Enable gRPC auth interceptor |
-| `OTEL_SERVICE_NAME` | forecasting-service | OpenTelemetry service name |
-| `OTEL_SAMPLING_RATE` | 0.1 | Trace sampling rate |
-| `GRPC_MAX_CONCURRENT_STREAMS` | 100 | Max concurrent gRPC streams |
-
-## Observability
-
-### Metrics Endpoint
-
-The service exposes Prometheus metrics on port 8082:
-
-- **Endpoint**: `http://localhost:8082/metrics`
-- **Health Check**: `http://localhost:8082/health`
-- **Readiness Check**: `http://localhost:8082/ready`
-
-### Prometheus Metrics
-
-| Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
-| `meridian_forecasting_scheduled_executions_total` | Counter | tenant_id, strategy_id, status | Total scheduled forecast executions |
-| `meridian_forecasting_execution_duration_seconds` | Histogram | tenant_id, strategy_id | Duration of forecast execution |
-| `meridian_forecasting_lease_acquisition_failures_total` | Counter | reason | Lease acquisition failures |
-| `meridian_forecasting_active_strategies` | Gauge | - | Currently registered active strategies |
-| `meridian_forecasting_scheduler_reloads_total` | Counter | outcome | Strategy reload cycles |
-| `meridian_forecasting_scheduler_errors_total` | Counter | error_type | Scheduler errors |
-
-**Note**: `tenant_id` and `strategy_id` labels on execution metrics can produce high cardinality. Monitor in production.
+`ForecastingStrategy.status` lifecycle: `DRAFT` -> `ACTIVE` -> `DEPRECATED`.
+`DEPRECATED` is terminal - a deprecated strategy cannot be reactivated.
+Optimistic locking is enforced via the `version` field; updates must supply the current version.
 
 ## Dependencies
 
-| Service | Purpose |
-|---------|---------|
-| Market Information Service (50051) | Fetch historical observations; publish forecast points |
-| CockroachDB | Strategy persistence |
-| Redis | Distributed lease management for cron scheduler |
+| Service | Protocol | Purpose |
+|---------|----------|---------|
+| `market-information` | gRPC | Fetch historical observations as input; publish forward curve points as ESTIMATE quality |
+| CockroachDB | SQL | Persists forecasting strategies and scheduler execution records |
+| Redis | TCP | Distributed lease management per strategy to prevent duplicate cron execution |
 
-## Key Patterns
+## Dependents
 
-### Starlark Script Validation
+No Meridian services call `forecasting` directly. The service publishes its output to
+`market-information` as new ESTIMATE quality observations which other services may
+then query via `market-information`.
 
-The `validation` package performs static analysis before execution:
+## Load-Bearing Files
 
-1. Checks Starlark syntax
-2. Verifies `compute_forecast(ctx)` function exists with correct signature
-3. Rejects forbidden operations (`import`, `load`)
-4. Optionally performs dry-run execution with stub builtins
+Paths are relative to `services/forecasting/`.
 
-Validation results include AI-friendly suggestions for fixing issues (line, column, message, suggestion).
+| File | Why It Matters |
+|------|----------------|
+| `cmd/main.go` | Entry point; wires database pool, MDS client, Starlark runner, handler, scheduler, and both servers |
+| `config/config.go` | Configuration loading; the only source of env var names |
+| `handler/forecasting_handler.go` | gRPC handler and internal execution entry point; orchestrates the full compute-and-publish flow |
+| `starlark/runner.go` | `ForecastRunner` - applies sandbox, executes Starlark script, validates output, publishes to MDS |
+| `domain/forecasting_strategy.go` | Aggregate root; enforces status transitions and immutability invariants |
+| `scheduler/scheduler_adapters.go` | `ForecastScheduleProvider` and `ForecastScheduleExecutor` - plugs strategies into the shared cron scheduler |
+| `templates/templates.go` | Built-in Starlark strategy templates (moving_average, seasonal_decomposition, capacity_pricing, external_blend) |
 
-### Forecast Point Validation
+## Configuration
 
-After Starlark execution, returned points are validated:
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `DATABASE_URL` | Yes | - | CockroachDB connection string |
+| `MDS_TARGET` | No | `market-information:50051` | gRPC address of `market-information` |
+| `REDIS_ADDR` | No | `localhost:6379` | Redis address for distributed scheduler lease management |
+| `GRPC_PORT` | No | `50061` | gRPC listen port |
+| `METRICS_PORT` | No | `8082` | HTTP metrics and health listen port |
+| `SCHEDULER_REFRESH_INTERVAL` | No | `60s` | How often the cron scheduler reloads active strategies |
+| `LOG_LEVEL` | No | `info` | Log verbosity (`debug`, `info`, `warn`, `error`) |
 
-- Timestamps must be within `[now, now + horizon]`
-- Timestamps must be monotonically increasing
-- Timestamps must be aligned to the granularity interval
+## Architecture
 
-### MDS Publishing
+```mermaid
+flowchart LR
+    Scheduler[CronScheduler] -->|fires per strategy| Handler[ForecastingHandler]
+    Handler -->|fetch observations| MIS[market-information]
+    Handler -->|execute| Runner[StarlarkRunner]
+    Runner -->|sandbox.ForecasterConfig| Sandbox[Starlark sandbox]
+    Sandbox -->|compute_forecast ctx| Script[tenant Starlark script]
+    Script --> Points[forecast points]
+    Points -->|publish ESTIMATE quality| MIS
+```
 
-Forecast points are published to MDS as ESTIMATE quality observations in batches of 1000. Each observation
-includes a client reference in the format `forecast:{strategy_id}:v{version}:{timestamp}` for idempotency.
+**Starlark sandbox:** Uses `sandbox.ForecasterConfig` from `shared/platform/sandbox` - 10 s
+wall-clock timeout, 1,000,000 max execution steps, 64 KB script size cap. Because Starlark
+forbids `while` loops and recursion, every script is guaranteed to terminate. See
+[`docs/patterns.md`](../../docs/patterns.md#6-starlark-sandbox) for the full sandbox
+pattern reference.
 
-### Optimistic Locking
-
-Updates check `WHERE version = expected_version`. Returns conflict error on mismatch.
-
-## Kubernetes Deployment
-
-| Setting | Value |
-|---------|-------|
-| Replicas | 2 |
-| CPU | 50m-200m |
-| Memory | 64Mi-256Mi |
-| User | 65532 (non-root) |
-| Filesystem | Read-only |
-| Service Type | Headless (ClusterIP: None) |
-| Grace Period | 30 seconds |
+**Distributed execution safety:** The scheduler holds a per-strategy Redis lease (TTL 5 min)
+before executing. If a pod dies mid-execution, the lease expires and another pod picks up the
+next scheduled run. The lease renews every 30 seconds during execution.
 
 ## References
 
-- [Service Architecture](../README.md)
-- [Proto Definitions](../../api/proto/meridian/forecasting/v1/)
-- [Port Assignments](../../shared/platform/ports/ports.go)
+- Starlark sandbox pattern: [`docs/patterns.md`](../../docs/patterns.md#6-starlark-sandbox)
+- Architecture layers: [`docs/architecture-layers.md`](../../docs/architecture-layers.md#8-observability-and-routing)
+- Sandbox presets: [`shared/platform/sandbox/config.go`](../../shared/platform/sandbox/config.go)

--- a/services/position-keeping/README.md
+++ b/services/position-keeping/README.md
@@ -66,8 +66,8 @@ transaction history across all asset classes. Part of the
 | `PositionKeepingService` | `GetAccountBalance` | Query a single BIAN balance type for an account |
 | `PositionKeepingService` | `GetAccountBalances` | Query all 7 BIAN balance types for an account |
 | `PositionKeepingService` | `RecordMeasurement` | Record a utilization or billing measurement (used by event-router for platform billing) |
-| `PositionKeepingService` | `UpdatePosition` | Update a position record |
-| `PositionKeepingService` | `MergePositions` | Merge two position records (compaction support) |
+| `PositionKeepingService` | `UpdatePosition` | Update a position record (UNIMPLEMENTED stub) |
+| `PositionKeepingService` | `MergePositions` | Merge two position records - compaction support (UNIMPLEMENTED stub) |
 | `PositionKeepingService` | `RecordReservation` | Record a fund reservation against an account |
 | `PositionKeepingService` | `ReleaseReservation` | Release a previously recorded reservation |
 | `PositionKeepingService` | `GetProjectedBalance` | Compute projected balance including open reservations |

--- a/services/position-keeping/README.md
+++ b/services/position-keeping/README.md
@@ -205,7 +205,7 @@ Paths are relative to `services/position-keeping/`.
 
 ## References
 
-- ADR-0023: Balance Delegation to Position Keeping -
+- ADR-0023: Balance Delegation to Position Keeping:
   [`docs/adr/0023-balance-delegation-to-position-keeping.md`](../../docs/adr/0023-balance-delegation-to-position-keeping.md)
 - BIAN Position Keeping domain: [`docs/architecture/bian-service-boundaries.md`](../../docs/architecture/bian-service-boundaries.md)
 - Architecture layers: [`docs/architecture-layers.md`](../../docs/architecture-layers.md#8-observability-and-routing)

--- a/services/position-keeping/README.md
+++ b/services/position-keeping/README.md
@@ -1,449 +1,212 @@
 ---
-name: position-keeping-service
-description: BIAN transaction log for immutable financial transaction history, position tracking, and balance computation
+name: position-keeping
+description: BIAN Transaction Log - authoritative source for balance computation across all 7 BIAN balance types; immutable transaction history with parent-child lineage
 triggers:
-  - Designing transaction capture and position keeping systems
-  - Implementing financial audit trails and reconciliation workflows
-  - Working with BIAN Transaction Log domain patterns
-  - Building event-driven transaction systems
-  - Understanding capacity limits and state machines for financial data
-  - Handling optimistic concurrency control in transactional systems
-  - Querying account balances (7 BIAN balance types)
-  - Understanding balance computation responsibility
+  - Querying account balances or transaction history
+  - Debugging balance discrepancies across services
+  - Implementing a new transaction capture flow
+  - Understanding ADR-0023 (balance delegation)
+  - Adding a new balance type or measurement
+  - Diagnosing compaction or reservation issues
 instructions: |
-  PositionKeeping maintains immutable transaction history with comprehensive audit trails
-  and serves as the authoritative source for balance computation.
+  position-keeping is the read-side authority for balances. Per ADR-0023, all other
+  services (current-account, internal-account) delegate balance queries here.
+  Do not compute balances in any other service.
 
-  Key concepts:
-  - FinancialPositionLog: Aggregate root with 10,000 entry limit
-  - Transaction state machine: PENDING → RECONCILED → POSTED → REVERSED
-  - Parent-child lineage for reversals and amendments
-  - Kafka event publishing (fire-and-forget) for downstream consumers
-  - Balance ownership: Computes all 7 BIAN balance types (see Balance Calculation section)
+  FinancialPositionLog is the aggregate root. Each log is append-only and
+  enforces a hard limit of 10,000 entries. Transaction status machine:
+  PENDING -> RECONCILED -> POSTED -> REVERSED. POSTED is effectively immutable
+  (terminal for most mutations).
 
-  Balance Query APIs:
-  - GetAccountBalance: Query single balance type
-  - GetAccountBalances: Query all 7 balance types for an account
+  Parent-child lineage: reversals and amendments reference their parent log entry
+  via parent_log_id. This is how the audit chain for compensation is maintained.
 
-  Balance Types: OPENING, CLOSING, CURRENT, AVAILABLE, LEDGER, RESERVE, FREE
+  7 BIAN balance types: OPENING, CLOSING, CURRENT, AVAILABLE, LEDGER, RESERVE, FREE.
+  GetAccountBalance and GetAccountBalances are the two balance query RPCs; all other
+  services call these rather than computing balances themselves.
 
-  Capacity limits:
-  - MaxTransactionEntries: 10,000 per log
-  - MaxAuditEntries: 10,000 per log
+  Background compaction (COMPACTION_ENABLED, default true): merges fragmented bucket
+  rows into consolidated entries. Do not disable in production - high fragmentation
+  degrades query performance.
 
-  Immutability: POSTED logs cannot be modified (terminal state)
-
-  Port: 50053 (gRPC)
+  Port: 50053 (gRPC, ports.PositionKeeping), 9090 (HTTP metrics).
+  Instability I=0.00 - the most depended-on service in the platform; treat its proto
+  contract as load-bearing across the entire codebase.
 ---
 
-# PositionKeeping Service
+# position-keeping
 
-BIAN-compliant position keeping service for immutable financial transaction history and audit trails.
+BIAN Transaction Log service. Authoritative source for balance computation and immutable
+transaction history across all asset classes. Part of the
+[Observability and Routing layer](../../docs/architecture-layers.md#8-observability-and-routing).
 
 ## Overview
 
 | Attribute | Value |
 |-----------|-------|
 | **BIAN Domain** | Position Keeping |
-| **Port** | 50053 (gRPC) |
-| **Language** | Go |
-| **Database** | PostgreSQL/CockroachDB |
-| **Standalone** | Yes |
+| **Layer** | Observability and Routing |
+| **Port** | 50053 (gRPC), 9090 (HTTP metrics) |
+| **Database** | CockroachDB (tenant-scoped schemas) |
+| **Standalone** | No (requires `reference-data` for instrument resolution; optionally `current-account` and `internal-account` for account validation) |
 
-## gRPC Methods
+## API Surface
 
-### Position Log Operations
+### gRPC
 
-| Method | HTTP | Purpose |
-|--------|------|---------|
-| `InitiateFinancialPositionLog` | `POST /v1/position-logs` | Create log with initial transaction |
-| `RetrieveFinancialPositionLog` | `GET /v1/position-logs/{id}` | Get log details |
-| `ListFinancialPositionLogs` | `GET /v1/position-logs` | List with filters |
-| `UpdateFinancialPositionLog` | `PATCH /v1/position-logs/{id}` | State transitions |
-| `BulkImportTransactions` | `POST /v1/position-logs/bulk` | Batch import |
+| Service | RPC | Purpose |
+|---------|-----|---------|
+| `PositionKeepingService` | `InitiateFinancialPositionLog` | Create a new position log with an initial transaction entry |
+| `PositionKeepingService` | `InitiateFinancialPositionLogBatch` | Bulk create position log entries |
+| `PositionKeepingService` | `InitiateWithOpeningBalance` | Create a position log pre-loaded with an opening balance entry |
+| `PositionKeepingService` | `UpdateFinancialPositionLog` | Append a transaction entry and drive status transitions |
+| `PositionKeepingService` | `RetrieveFinancialPositionLog` | Fetch a position log by ID |
+| `PositionKeepingService` | `ListFinancialPositionLogs` | List position logs with filters |
+| `PositionKeepingService` | `BulkImportTransactions` | Batch import historical transactions |
+| `PositionKeepingService` | `GetAccountBalance` | Query a single BIAN balance type for an account |
+| `PositionKeepingService` | `GetAccountBalances` | Query all 7 BIAN balance types for an account |
+| `PositionKeepingService` | `RecordMeasurement` | Record a utilization or billing measurement (used by event-router for platform billing) |
+| `PositionKeepingService` | `UpdatePosition` | Update a position record |
+| `PositionKeepingService` | `MergePositions` | Merge two position records (compaction support) |
+| `PositionKeepingService` | `RecordReservation` | Record a fund reservation against an account |
+| `PositionKeepingService` | `ReleaseReservation` | Release a previously recorded reservation |
+| `PositionKeepingService` | `GetProjectedBalance` | Compute projected balance including open reservations |
 
-### Balance Query Operations
-
-| Method | HTTP | Purpose |
-|--------|------|---------|
-| `GetAccountBalance` | `GET /v1/accounts/{account_id}/balance/{balance_type}` | Query single balance type |
-| `GetAccountBalances` | `GET /v1/accounts/{account_id}/balances` | Query all balance types |
+Proto: [`api/proto/meridian/position_keeping/v1/position_keeping.proto`](../../api/proto/meridian/position_keeping/v1/position_keeping.proto).
 
 ## Domain Model
 
 ```mermaid
 classDiagram
     class FinancialPositionLog {
-        +UUID LogID
-        +string AccountID
-        +int64 Version
-        +TransactionStatus CurrentStatus
-        +TransactionStatus PreviousStatus
-        +ReconciliationStatus ReconciliationStatus
-        +string StatusReason
-        +string FailureReason
-        +TransactionLineage Lineage
+        +UUID logId
+        +string accountId
+        +string instrumentCode
+        +TransactionStatus status
+        +int64 version
+        +int entryCount
+        +time createdAt
     }
-
-    class TransactionLogEntry {
-        +UUID EntryID
-        +UUID TransactionID
-        +string AccountID
-        +Money Amount
-        +Direction Direction
-        +Time Timestamp
-        +string Description
-        +string Reference
-        +TransactionSource Source
+    class TransactionEntry {
+        +UUID entryId
+        +UUID logId
+        +UUID parentLogId
+        +decimal amount
+        +PostingDirection direction
+        +TransactionStatus status
+        +TransactionSource source
+        +time effectiveAt
     }
-
-    class AuditTrailEntry {
-        +UUID AuditID
-        +string UserID
-        +string Action
-        +string IPAddress
-        +JSON Details
-        +Time Timestamp
+    class Balance {
+        +BalanceType type
+        +decimal amount
+        +string instrumentCode
     }
-
-    class TransactionLineage {
-        +UUID TransactionID
-        +UUID ParentTransactionID
-        +UUID[] ChildTransactionIDs
-        +UUID[] RelatedTransactionIDs
-        +string TransactionType
+    class Measurement {
+        +UUID measurementId
+        +string accountId
+        +string metricCode
+        +decimal value
+        +time recordedAt
     }
-
-    class TransactionStatus {
-        <<enumeration>>
-        PENDING
-        RECONCILED
-        POSTED
-        AMENDED
-        FAILED
-        REJECTED
-        CANCELLED
-        REVERSED
+    class Reservation {
+        +UUID reservationId
+        +string accountId
+        +decimal amount
+        +ReservationStatus status
+        +time expiresAt
     }
-
-    class ReconciliationStatus {
-        <<enumeration>>
-        UNRECONCILED
-        MATCHED
-        MISMATCHED
-        RESOLVED
-    }
-
-    class TransactionSource {
-        <<enumeration>>
-        API
-        BATCH
-        MANUAL
-        SYSTEM
-        IMPORT
-        MIGRATION
-        CORRECTION
-    }
-
-    FinancialPositionLog "1" --> "*" TransactionLogEntry : entries
-    FinancialPositionLog "1" --> "*" AuditTrailEntry : auditTrail
-    FinancialPositionLog "1" --> "1" TransactionLineage : lineage
-    FinancialPositionLog --> TransactionStatus
-    FinancialPositionLog --> ReconciliationStatus
-    TransactionLogEntry --> TransactionSource
+    FinancialPositionLog "1" --> "*" TransactionEntry : contains (append-only)
+    TransactionEntry --> TransactionEntry : parent-child lineage (reversals)
+    FinancialPositionLog ..> Balance : computed from entries
 ```
 
-**Capacity Limits:**
+`TransactionEntry.status`: `PENDING` -> `RECONCILED` -> `POSTED` -> `REVERSED`.
+`POSTED` entries are immutable; reversals create a new child entry referencing the parent.
+Hard limit: 10,000 entries per `FinancialPositionLog`.
 
-- `Entries`: max 10,000 per log
-- `AuditTrail`: max 10,000 per log
+**7 BIAN Balance Types:**
 
-## Transaction Status State Machine
+| Type | Meaning |
+|------|---------|
+| `OPENING` | Balance at the start of the current period |
+| `CLOSING` | Balance at the end of the current period |
+| `CURRENT` | Real-time balance including all transactions |
+| `AVAILABLE` | Funds available for immediate use (CURRENT minus active reservations) |
+| `LEDGER` | Balance of posted transactions only |
+| `RESERVE` | Funds held or reserved |
+| `FREE` | Unencumbered funds with no restrictions |
 
-```mermaid
-stateDiagram-v2
-    [*] --> PENDING
-    PENDING --> RECONCILED
-    PENDING --> FAILED
-    PENDING --> REJECTED
-    PENDING --> CANCELLED
-    RECONCILED --> POSTED
-    RECONCILED --> AMENDED
-    POSTED --> REVERSED
-    POSTED --> [*]
-    FAILED --> [*]
-    REJECTED --> [*]
-    CANCELLED --> [*]
-    REVERSED --> [*]
-```
+## Dependencies
 
-### Reconciliation Status
+| Service | Protocol | Purpose |
+|---------|----------|---------|
+| `reference-data` | gRPC | Instrument definition lookup for position log creation |
+| `current-account` | gRPC (optional) | Account existence validation before creating a position log |
+| `internal-account` | gRPC (optional) | Internal account existence validation |
+| CockroachDB | SQL | Persists position logs, entries, measurements, and reservations |
+| Kafka | Producer | Publishes `position-keeping-events` topic for downstream consumers |
+| Redis (optional) | TCP | Idempotency key caching when `REDIS_ENABLED=true` |
 
-| Status | Description |
-|--------|-------------|
-| `UNRECONCILED` | Not yet matched |
-| `MATCHED` | Matched with external data |
-| `MISMATCHED` | Discrepancy found |
-| `RESOLVED` | Discrepancy resolved |
+## Dependents
 
-## Kafka Event Publishing
+| Service | Entry Point | Purpose |
+|---------|-------------|---------|
+| `current-account` | `services/current-account/service/client_interfaces.go` | Balance queries for lien checks and account balance reads |
+| `internal-account` | `services/internal-account/adapters/grpc/position_keeping_client.go` | Balance queries for internal account reads |
+| `reconciliation` | `services/reconciliation/service/grpc_pk_client.go` | Snapshot capture and balance assertions |
+| `event-router` | `services/event-router/adapters/grpc/position_keeping_client.go` | `RecordMeasurement` for platform billing (tenant-zero) |
+| `control-plane` | `services/control-plane/internal/admin/balance_sheet_handler.go` | Balance sheet queries across accounts |
+| `mcp-server` | `services/mcp-server/internal/clients/clients.go` | Balance and transaction history MCP tools |
+| `api-gateway` | `services/api-gateway/eventstream/` | Event stream subscriptions on position events |
 
-**Topics:**
+## Load-Bearing Files
 
-| Topic | Event |
-|-------|-------|
-| `position-keeping.transaction-captured.v1` | New transaction |
-| `position-keeping.transaction-amended.v1` | Post-capture modification |
-| `position-keeping.transaction-reconciled.v1` | External matching |
-| `position-keeping.transaction-posted.v1` | Final committed |
-| `position-keeping.transaction-rejected.v1` | Rejected |
-| `position-keeping.transaction-failed.v1` | Processing failed |
-| `position-keeping.transaction-cancelled.v1` | Cancelled |
-| `position-keeping.bulk-transaction-captured.v1` | Batch import |
+Paths are relative to `services/position-keeping/`.
 
-**Publishing Pattern:**
-
-- Fire-and-forget (doesn't block main operation)
-- Partition key = LogID (ensures ordering per aggregate)
-- Protobuf serialization
-
-**Fire-and-Forget Semantics:**
-
-Events are published asynchronously after the database transaction commits:
-
-- **Best-effort delivery**: Publish failures are logged but don't fail the request
-- **No transactional outbox**: Events may be lost if the service crashes after DB commit but before publish
-- **Trade-off**: Lower latency vs potential event loss during failures
-
-For use cases requiring guaranteed event delivery (e.g., regulatory audit),
-consider the [Audit Outbox Pattern](../README.md#audit-outbox-pattern) or
-implement a transactional outbox with a separate publisher worker.
-
-## Database Schema
-
-**Schema**: `position_keeping`
-
-```mermaid
-erDiagram
-    financial_position_logs {
-        uuid log_id PK
-        varchar(34) account_id
-        bigint version "optimistic lock"
-        varchar(20) current_status
-        varchar(20) previous_status
-        varchar(20) reconciliation_status
-        text status_reason
-        text failure_reason
-        timestamptz created_at
-        timestamptz updated_at
-    }
-
-    transaction_log_entries {
-        uuid entry_id PK
-        uuid financial_position_log_id FK
-        uuid transaction_id
-        bigint amount_cents
-        char(3) currency "ISO 4217"
-        varchar(10) direction "debit, credit"
-        varchar(20) source "API, BATCH, etc."
-        varchar(255) description
-        varchar(255) reference
-        timestamptz timestamp
-    }
-
-    audit_trail_entries {
-        uuid audit_id PK
-        uuid financial_position_log_id FK
-        varchar(100) user_id
-        varchar(100) action
-        varchar(45) ip_address
-        jsonb details
-        timestamptz timestamp
-    }
-
-    transaction_lineage {
-        uuid id PK
-        uuid financial_position_log_id FK
-        uuid transaction_id
-        uuid parent_transaction_id "nullable"
-        varchar(50) transaction_type
-    }
-
-    financial_position_logs ||--o{ transaction_log_entries : "entries"
-    financial_position_logs ||--o{ audit_trail_entries : "auditTrail"
-    financial_position_logs ||--o| transaction_lineage : "lineage"
-```
-
-## Capacity Limits
-
-| Limit | Value | Error |
-|-------|-------|-------|
-| Max Transaction Entries | 10,000 | `ErrTooManyEntries` |
-| Max Audit Entries | 10,000 | `ErrTooManyEntries` |
-
-## Instrument Resolution
-
-Position-keeping supports all instrument dimensions (CURRENCY, ENERGY, CARBON, COMPUTE, etc.).
-Instrument properties are resolved via `InstrumentResolver` from Reference Data.
-
-**Resolution flow:**
-
-1. Transaction recording receives `instrument_code` and resolves properties via `InstrumentResolver`
-2. Balance computation uses the resolved precision for decimal arithmetic
-3. Persistence reconstruction uses stored `instrument_code`, `dimension`, and `precision` columns
-   with `quantity.NewInstrument()` directly (no Reference Data call on read path)
-
-All instrument dimensions and precision values are defined in Reference Data. See
-[ADR-0035: Multi-Asset Purity](../../docs/adr/0035-multi-asset-purity.md) for the architectural decision.
+| File | Why It Matters |
+|------|----------------|
+| `app/config.go` | All configuration fields and defaults; the only source of env var names |
+| `service/server.go` | gRPC server construction; wires all handlers and interceptors |
+| `service/initiate.go` | `InitiateFinancialPositionLog` - creates the aggregate root and enforces capacity limits |
+| `service/balance.go` | `GetAccountBalance` / `GetAccountBalances` - balance computation from entries |
+| `domain/financial_position_log.go` | Aggregate root; enforces the 10,000 entry cap and append-only invariant |
+| `domain/balance_computer.go` | Computes all 7 BIAN balance types from position entries |
+| `domain/transaction_lineage.go` | Parent-child lineage for reversals and amendments |
+| `service/record_measurement.go` | `RecordMeasurement` - records billing measurements for tenant-zero |
+| `service/reservation.go` | `RecordReservation` / `ReleaseReservation` - fund reservation lifecycle |
 
 ## Configuration
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `GRPC_PORT` | 50053 | gRPC server port |
-| `DATABASE_URL` | - | PostgreSQL connection string |
-| `KAFKA_BROKERS` | kafka:9092 | Kafka broker addresses |
-| `REDIS_ENABLED` | false | Enable idempotency cache |
-| `REDIS_ADDRESS` | redis:6379 | Redis address |
-
-## Key Patterns
-
-### Idempotency
-
-- Redis-backed distributed locking (when enabled)
-- Idempotency keys for effectively-once processing (retries produce same result)
-- 5-minute TTL for pending operation locks
-- Fallback to in-memory cache when Redis unavailable
-
-### Optimistic Locking
-
-Version field required for all updates. Returns conflict error on mismatch.
-
-### Immutability
-
-POSTED logs cannot be modified. Returns `ErrAlreadyPosted`.
-
-## Balance Calculation Responsibility
-
-Position Keeping is the authoritative source for account balance computation. This design
-follows BIAN service domain principles where Position Keeping owns the transaction log and
-therefore has the data required to compute accurate balances.
-
-### Balance Types (BIAN-Compliant)
-
-Position Keeping computes 7 balance types per account:
-
-| Balance Type | Proto Enum | Computation |
-|--------------|------------|-------------|
-| **Opening** | `BALANCE_TYPE_OPENING` | Balance at start of accounting period |
-| **Closing** | `BALANCE_TYPE_CLOSING` | Balance at end of accounting period |
-| **Current** | `BALANCE_TYPE_CURRENT` | Sum of all POSTED transactions (real-time) |
-| **Available** | `BALANCE_TYPE_AVAILABLE` | Current minus holds, liens, and reserves |
-| **Ledger** | `BALANCE_TYPE_LEDGER` | Book balance (may differ from current due to holds) |
-| **Reserve** | `BALANCE_TYPE_RESERVE` | Amount held in reserve (not available for use) |
-| **Free** | `BALANCE_TYPE_FREE` | Unencumbered balance (current minus all encumbrances) |
-
-### Balance Calculation Formulas
-
-```text
-CURRENT   = Σ(POSTED transactions: credits - debits)
-AVAILABLE = CURRENT - RESERVE - ACTIVE_LIENS
-LEDGER    = CURRENT (excluding pending transactions)
-FREE      = CURRENT - RESERVE - HOLDS
-```
-
-### Balance Query APIs
-
-**GetAccountBalance** - Query a single balance type:
-
-```go
-// Request
-req := &pk.GetAccountBalanceRequest{
-    AccountId:   "ACC-12345678",
-    BalanceType: pk.BALANCE_TYPE_AVAILABLE,
-    Currency:    "GBP",  // Optional: filter by currency
-}
-
-// Response
-resp := &pk.GetAccountBalanceResponse{
-    AccountId:   "ACC-12345678",
-    BalanceType: pk.BALANCE_TYPE_AVAILABLE,
-    Amount:      &common.MoneyAmount{Units: 1500, Nanos: 0, CurrencyCode: "GBP"},
-    AsOf:        timestamppb.Now(),
-}
-```
-
-**GetAccountBalances** - Query all balance types:
-
-```go
-// Request
-req := &pk.GetAccountBalancesRequest{
-    AccountId: "ACC-12345678",
-    Currency:  "GBP",  // Optional
-}
-
-// Response contains all 7 balance types
-resp := &pk.GetAccountBalancesResponse{
-    AccountId: "ACC-12345678",
-    Balances: []*pk.BalanceEntry{
-        {BalanceType: pk.BALANCE_TYPE_OPENING, Amount: ...},
-        {BalanceType: pk.BALANCE_TYPE_CLOSING, Amount: ...},
-        {BalanceType: pk.BALANCE_TYPE_CURRENT, Amount: ...},
-        {BalanceType: pk.BALANCE_TYPE_AVAILABLE, Amount: ...},
-        {BalanceType: pk.BALANCE_TYPE_LEDGER, Amount: ...},
-        {BalanceType: pk.BALANCE_TYPE_RESERVE, Amount: ...},
-        {BalanceType: pk.BALANCE_TYPE_FREE, Amount: ...},
-    },
-    AsOf: timestamppb.Now(),
-}
-```
-
-### Balance Query Sequence
-
-```mermaid
-sequenceDiagram
-    participant CA as CurrentAccount
-    participant PK as PositionKeeping
-    participant DB as PositionKeeping DB
-
-    CA->>PK: GetAccountBalances(accountID)
-    PK->>DB: Query POSTED transactions
-    DB-->>PK: Transaction entries
-    PK->>PK: Compute balance types
-    PK-->>CA: BalanceEntry[] (7 types)
-```
-
-### Performance Characteristics
-
-| Operation | Complexity | Notes |
-|-----------|------------|-------|
-| `GetAccountBalance` | O(n) | Aggregates over POSTED transactions |
-| `GetAccountBalances` | O(n) | Single pass computes all types |
-
-**Optimization:** Balance snapshots may be cached or materialized for high-traffic accounts.
-
-### Opening Balance Support
-
-For account migration scenarios, Position Keeping supports initializing accounts with an
-opening balance:
-
-```go
-// InitiateWithOpeningBalance creates a position log with a synthetic
-// opening balance transaction for migration purposes
-req := &pk.InitiateFinancialPositionLogRequest{
-    AccountId: "ACC-12345678",
-    OpeningBalance: &common.MoneyAmount{
-        Units:        10000,
-        CurrencyCode: "GBP",
-    },
-}
-```
-
-This creates an initial transaction entry that establishes the account's starting position.
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `DATABASE_URL` | Yes | - | CockroachDB connection string |
+| `GRPC_PORT` | No | `50053` | gRPC listen port |
+| `METRICS_PORT` | No | `9090` | HTTP metrics endpoint port |
+| `KAFKA_BROKERS` | No | `kafka:9092` | Kafka broker addresses |
+| `KAFKA_TOPIC` | No | `position-keeping-events` | Kafka topic for position events |
+| `KAFKA_ENABLED` | No | `true` | Enable Kafka event publishing |
+| `REDIS_ENABLED` | No | `false` | Enable Redis-backed idempotency cache |
+| `REDIS_ADDRESS` | No | `redis:6379` | Redis address |
+| `REFERENCE_DATA_SERVICE_URL` | No | - | gRPC address of `reference-data` |
+| `CURRENT_ACCOUNT_SERVICE_URL` | No | - | gRPC address of `current-account` (for account validation) |
+| `INTERNAL_ACCOUNT_SERVICE_URL` | No | - | gRPC address of `internal-account` (for account validation) |
+| `ACCOUNT_VALIDATION_ENABLED` | No | `true` | Validate account existence before creating position logs |
+| `ACCOUNT_VALIDATION_CACHE_TTL` | No | `1m` | How long to cache account validation results |
+| `COMPACTION_ENABLED` | No | `true` | Enable background compaction worker |
+| `COMPACTION_RUN_INTERVAL` | No | `5m` | How often to run compaction |
+| `COMPACTION_FRAGMENT_THRESHOLD` | No | `100` | Minimum fragments in a bucket before compaction runs |
+| `COMPACTION_BATCH_SIZE` | No | `50` | Maximum buckets compacted per run |
+| `AUTH_ENABLED` | No | `true` | Enable JWT authentication interceptor |
+| `JWKS_URL` | No | - | JWKS endpoint URL for JWT validation |
+| `LOG_LEVEL` | No | `info` | Log verbosity |
+| `DB_MAX_OPEN_CONNS` | No | `25` | Database connection pool maximum |
+| `DB_MAX_IDLE_CONNS` | No | `5` | Database idle connection pool size |
 
 ## References
 
-- [BIAN Position Keeping Specification](https://github.com/bian-official/public/blob/main/release14.0.0/semantic-apis/oas3%20/yamls/PositionKeeping.yaml)
-- [Service Architecture](../README.md)
-- [Proto Definitions](../../api/proto/meridian/position_keeping/v1/)
-- [ADR-0023: Balance Delegation to Position Keeping](../../docs/adr/0023-balance-delegation-to-position-keeping.md)
+- ADR-0023: Balance Delegation to Position Keeping -
+  [`docs/adr/0023-balance-delegation-to-position-keeping.md`](../../docs/adr/0023-balance-delegation-to-position-keeping.md)
+- BIAN Position Keeping domain: [`docs/architecture/bian-service-boundaries.md`](../../docs/architecture/bian-service-boundaries.md)
+- Architecture layers: [`docs/architecture-layers.md`](../../docs/architecture-layers.md#8-observability-and-routing)
+- Service coupling analysis: [`docs/architecture/service-coupling-analysis.md`](../../docs/architecture/service-coupling-analysis.md)

--- a/services/reconciliation/README.md
+++ b/services/reconciliation/README.md
@@ -1,100 +1,185 @@
 ---
-name: reconciliation-service
-description: BIAN Account Reconciliation service for matching and reconciling positions across services
+name: reconciliation
+description: BIAN Account Reconciliation service that compares positions across position-keeping, financial-accounting, and current-account; tracks variances and disputes through their lifecycle
 triggers:
-  - Reconciling account positions between services
-  - Matching financial transactions across ledgers
-  - Settlement processing and scheduling
-  - Investigating reconciliation discrepancies
+  - Debugging balance discrepancies between services
+  - Initiating or inspecting a settlement run
+  - Investigating a variance or dispute
+  - Understanding how automated settlement scheduling works
+  - Adding a new reconciliation data source
 instructions: |
-  Reconciliation manages the matching and verification of account positions across
-  Position Keeping, Financial Accounting, and Current Account services.
+  Reconciliation runs a pipeline of four stages: snapshot capture, variance detection,
+  variance valuation, and dispute management.
 
-  Key concepts:
-  - Reconciliation runs compare positions across multiple sources
-  - Discrepancies are identified and tracked for resolution
-  - Settlement scheduler automates periodic reconciliation
+  Settlement run lifecycle: PENDING -> IN_PROGRESS -> COMPLETED (or FAILED).
+  Variance lifecycle: OPEN -> UNDER_REVIEW -> RESOLVED (or DISPUTED).
+  Dispute lifecycle: OPEN -> INVESTIGATING -> RESOLVED.
 
-  Port: 50060 (gRPC)
+  Port: 50060 (gRPC, ports.Reconciliation), 9090 (HTTP metrics).
+
+  Key wiring notes:
+  - POSITION_KEEPING_URL drives both snapshot capture (snapshot capturer) and
+    balance assertions (balance assertor). If unset, both are disabled.
+  - CURRENT_ACCOUNT_URL enables party resolution for variance valuation.
+  - REFERENCE_DATA_URL enables instrument lookup for variance valuation.
+  - SETTLEMENT_SCHEDULER_ENABLED=true + REDIS_URL enables automated scheduling
+    with Redis-based leader election (RedisLock).
+  - The scheduler self-loops via a gRPC client to localhost:<GRPC_PORT> -
+    ensure the gRPC server is started before the scheduler calls land.
+  - Outbox pattern (shared/platform/events) publishes reconciliation events to Kafka.
 ---
 
-# Reconciliation Service
+# reconciliation
 
-BIAN-compliant Account Reconciliation service for matching and reconciling positions across Meridian services.
+BIAN Account Reconciliation service that compares balance positions across services and
+manages variances and disputes through their resolution lifecycle. Part of the
+[Observability and Routing layer](../../docs/architecture-layers.md#8-observability-and-routing).
 
 ## Overview
 
 | Attribute | Value |
 |-----------|-------|
 | **BIAN Domain** | Account Reconciliation |
-| **Port** | 50060 (gRPC) |
-| **Language** | Go |
-| **Database** | CockroachDB |
-| **Standalone** | Yes |
+| **Layer** | Observability and Routing |
+| **Port** | 50060 (gRPC), 9090 (HTTP metrics and health) |
+| **Database** | CockroachDB (tenant-scoped schemas) |
+| **Standalone** | No (requires `position-keeping` gRPC for snapshot capture; `redis` for scheduler) |
 
-## Architecture
+## API Surface
 
-The Reconciliation service acts as a cross-cutting concern, comparing positions across
-multiple upstream services to verify consistency and identify discrepancies.
+### gRPC
 
-### Service Dependencies
+| Service | RPC | Purpose |
+|---------|-----|---------|
+| `AccountReconciliationService` | `InitiateAccountReconciliation` | Create and start a settlement run |
+| `AccountReconciliationService` | `ExecuteAccountReconciliation` | Trigger the reconciliation pipeline for an existing run |
+| `AccountReconciliationService` | `RetrieveAccountReconciliation` | Fetch a settlement run by ID |
+| `AccountReconciliationService` | `ListAccountReconciliations` | List settlement runs with optional filters |
+| `AccountReconciliationService` | `ControlAccountReconciliation` | Pause, resume, or cancel a settlement run |
+| `AccountReconciliationService` | `ListReconciliationResults` | List variances for a settlement run |
+| `AccountReconciliationService` | `AssertBalance` | Assert that an account's balance matches expectations |
+| `AccountReconciliationService` | `InitiateDispute` | Raise a dispute against a detected variance |
+| `AccountReconciliationService` | `ControlDispute` | Transition a dispute to investigating or resolved |
+| `AccountReconciliationService` | `RetrieveDispute` | Fetch a dispute by ID |
+| `AccountReconciliationService` | `ListDisputes` | List disputes with optional filters |
+| `AccountReconciliationService` | `UpdateDispute` | Update dispute reason or resolution notes |
+| `AccountReconciliationService` | `ListBalanceAssertions` | List balance assertions with optional filters |
 
-| Service | Purpose |
-|---------|---------|
-| Position Keeping | Source of transaction logs and balance positions |
-| Financial Accounting | Source of ledger entries and journal postings |
-| Current Account | Source of account state and balances |
-| Reference Data | Instrument definitions and validation rules |
-| Payment Order | Settlement execution for resolved discrepancies |
+Proto: [`api/proto/meridian/reconciliation/v1/reconciliation.proto`](../../api/proto/meridian/reconciliation/v1/reconciliation.proto).
+
+## Domain Model
+
+```mermaid
+classDiagram
+    class SettlementRun {
+        +UUID runId
+        +SettlementRunStatus status
+        +time startedAt
+        +time completedAt
+        +string triggeredBy
+    }
+    class SettlementSnapshot {
+        +UUID snapshotId
+        +UUID runId
+        +string accountId
+        +string instrumentCode
+        +decimal balance
+        +string source
+        +time capturedAt
+    }
+    class Variance {
+        +UUID varianceId
+        +UUID runId
+        +string accountId
+        +decimal amount
+        +VarianceReason reason
+        +VarianceStatus status
+    }
+    class Dispute {
+        +UUID disputeId
+        +UUID varianceId
+        +DisputeStatus status
+        +string reason
+        +string resolution
+        +string raisedBy
+    }
+    class BalanceAssertion {
+        +UUID assertionId
+        +string accountId
+        +string instrumentCode
+        +decimal expectedBalance
+        +AssertionStatus status
+    }
+    SettlementRun "1" --> "*" SettlementSnapshot : captures
+    SettlementRun "1" --> "*" Variance : detects
+    Variance "1" --> "0..1" Dispute : disputed via
+    SettlementRun "1" --> "*" BalanceAssertion : asserts
+```
+
+`SettlementRun.status`: `PENDING` -> `IN_PROGRESS` -> `COMPLETED` or `FAILED`.
+`Variance.status`: `OPEN` -> `UNDER_REVIEW` -> `RESOLVED` or `DISPUTED`.
+`Dispute.status`: `OPEN` -> `INVESTIGATING` -> `RESOLVED`.
+
+## Dependencies
+
+| Service | Protocol | Purpose |
+|---------|----------|---------|
+| `position-keeping` | gRPC | Snapshot capture (position balances) and balance assertions |
+| `current-account` | gRPC | Party resolution for variance valuation (optional) |
+| `reference-data` | gRPC | Instrument lookup for variance valuation (optional) |
+| CockroachDB | SQL | Persists settlement runs, snapshots, variances, disputes, assertions |
+| Redis | TCP | Distributed leader election for the settlement scheduler |
+| Kafka | Producer (outbox) | Publishes reconciliation events via the outbox pattern |
+
+## Dependents
+
+| Service | Entry Point | Purpose |
+|---------|-------------|---------|
+| `api-gateway` | proxies `AccountReconciliationService` gRPC | Exposes reconciliation RPCs to external callers |
+| `mcp-server` | `services/mcp-server/internal/clients/clients.go` | Surfaces reconciliation as an MCP tool |
+
+## Load-Bearing Files
+
+Paths are relative to `services/reconciliation/`.
+
+| File | Why It Matters |
+|------|----------------|
+| `config/config.go` | All configuration fields and defaults; the only source of env var names |
+| `app/container.go` | Dependency injection; wires snapshot capturer, balance assertor, variance components, scheduler, and Redis |
+| `service/server.go` | gRPC service implementation and pipeline coordination |
+| `service/grpc_settlement_endpoints.go` | `Initiate`, `Retrieve`, `List` handlers for settlement runs |
+| `service/grpc_pipeline_endpoints.go` | `Execute` and pipeline orchestration logic |
+| `adapters/persistence/settlement_run_repository.go` | Settlement run persistence; status transitions enforced here |
+| `adapters/persistence/variance_repository.go` | Variance storage and filtering |
+| `worker/settlement_executor.go` | Scheduler executor that calls `ExecuteAccountReconciliation` |
 
 ## Configuration
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `GRPC_PORT` | 50060 | gRPC server port |
-| `METRICS_PORT` | 9090 | HTTP metrics and health port |
-| `DATABASE_URL` | - | CockroachDB connection string |
-| `KAFKA_BROKERS` | - | Kafka broker addresses |
-| `REDIS_URL` | - | Redis connection URL |
-| `POSITION_KEEPING_URL` | - | Position Keeping gRPC address |
-| `FINANCIAL_ACCOUNTING_URL` | - | Financial Accounting gRPC address |
-| `CURRENT_ACCOUNT_URL` | - | Current Account gRPC address |
-| `REFERENCE_DATA_URL` | - | Reference Data gRPC address |
-| `PAYMENT_ORDER_URL` | - | Payment Order gRPC address |
-| `SETTLEMENT_SCHEDULER_ENABLED` | false | Enable automated settlement scheduling |
-
-## Local Development
-
-### Prerequisites
-
-- Go 1.25+
-- CockroachDB (via Docker or local install)
-- Protocol Buffers compiler (`buf`)
-
-### Running Locally
-
-```bash
-# Set required environment variables
-export DATABASE_URL="postgres://meridian_reconciliation_user@localhost:26257/meridian_reconciliation?sslmode=disable"
-
-# Run the service
-go run ./services/reconciliation/cmd
-
-# Run tests
-go test ./services/reconciliation/...
-```
-
-### Building
-
-```bash
-# Build binary
-go build -o reconciliation ./services/reconciliation/cmd
-
-# Build Docker image
-docker build -f services/reconciliation/cmd/Dockerfile -t reconciliation:latest .
-```
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `DATABASE_URL` | Yes | - | CockroachDB connection string |
+| `GRPC_PORT` | No | `50060` | gRPC listen port |
+| `METRICS_PORT` | No | `9090` | HTTP metrics and health port |
+| `POSITION_KEEPING_URL` | No | - | gRPC address of `position-keeping` (enables snapshot capture and balance assertions) |
+| `CURRENT_ACCOUNT_URL` | No | - | gRPC address of `current-account` (enables party resolution in variance valuation) |
+| `REFERENCE_DATA_URL` | No | - | gRPC address of `reference-data` (enables instrument lookup for valuation) |
+| `FINANCIAL_ACCOUNTING_URL` | No | - | gRPC address of `financial-accounting` (reserved for future source verification) |
+| `PAYMENT_ORDER_URL` | No | - | gRPC address of `payment-order` (reserved for future settlement execution) |
+| `REDIS_URL` | No | - | Redis connection URL (required when `SETTLEMENT_SCHEDULER_ENABLED=true`) |
+| `KAFKA_BROKERS` | No | - | Comma-separated broker addresses (enables outbox worker when set) |
+| `SETTLEMENT_SCHEDULER_ENABLED` | No | `false` | Enable cron-based automated settlement scheduling |
+| `SCHEDULER_POLL_INTERVAL` | No | `1h` | How often to refresh settlement schedules from reference data |
+| `SCHEDULER_SHUTDOWN_TIMEOUT` | No | `30s` | Maximum wait for in-flight jobs on shutdown |
+| `SCHEDULER_LEADER_LOCK_TTL` | No | `30s` | Redis leader election lock TTL |
+| `SCHEDULER_LEADER_RENEW_INTERVAL` | No | `10s` | Redis leader lock renewal interval |
+| `ENVIRONMENT` | No | `development` | Deployment environment label |
+| `LOG_LEVEL` | No | `info` | Log verbosity (`debug`, `info`, `warn`, `error`) |
+| `GRACEFUL_SHUTDOWN_TIMEOUT` | No | `30s` | Maximum wait on graceful shutdown |
+| `DB_MAX_OPEN_CONNS` | No | `25` | Database connection pool maximum |
+| `DB_MAX_IDLE_CONNS` | No | `5` | Database idle connection pool size |
 
 ## References
 
-- [BIAN Account Reconciliation](https://bian.org/semantic-apis/account-reconciliation/)
-- [Service Architecture](../README.md)
+- BIAN Account Reconciliation domain: [`docs/architecture/bian-service-boundaries.md`](../../docs/architecture/bian-service-boundaries.md)
+- Outbox pattern: [`docs/patterns.md`](../../docs/patterns.md#1-outbox-pattern)
+- Architecture layers: [`docs/architecture-layers.md`](../../docs/architecture-layers.md#8-observability-and-routing)

--- a/services/reconciliation/README.md
+++ b/services/reconciliation/README.md
@@ -43,7 +43,7 @@ manages variances and disputes through their resolution lifecycle. Part of the
 | **Layer** | Observability and Routing |
 | **Port** | 50060 (gRPC), 9090 (HTTP metrics and health) |
 | **Database** | CockroachDB (tenant-scoped schemas) |
-| **Standalone** | No (requires `position-keeping` gRPC for snapshot capture; `redis` for scheduler) |
+| **Standalone** | No (requires CockroachDB and `position-keeping` gRPC for snapshot capture; Redis required only when `SETTLEMENT_SCHEDULER_ENABLED=true`) |
 
 ## API Surface
 
@@ -151,7 +151,7 @@ Paths are relative to `services/reconciliation/`.
 | `service/grpc_pipeline_endpoints.go` | `Execute` and pipeline orchestration logic |
 | `adapters/persistence/settlement_run_repository.go` | Settlement run persistence; status transitions enforced here |
 | `adapters/persistence/variance_repository.go` | Variance storage and filtering |
-| `worker/settlement_executor.go` | Scheduler executor that calls `ExecuteAccountReconciliation` |
+| `worker/scheduler_adapters.go` | Scheduler executor that calls `ExecuteAccountReconciliation` via gRPC self-loop |
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Apply `docs/service-readme-template.md` to the five Observability and Routing
services that did not yet have template-compliant READMEs:

- `services/audit-worker/README.md`
- `services/reconciliation/README.md`
- `services/event-router/README.md`
- `services/forecasting/README.md`
- `services/position-keeping/README.md`

Each README now contains the eight required sections (frontmatter, overview table,
API surface, domain model, dependencies, dependents, load-bearing files,
configuration) with layer set to `Observability and Routing` per
`docs/architecture-layers.md`.

Notable additions per service:

- **audit-worker**: Documents the dual-path pipeline (Kafka primary / outbox
  fallback), clarifies that `AuditService` gRPC is registered in the unified
  binary (no standalone gRPC port), lists `api-gateway` and `mcp-server` as
  dependents.
- **reconciliation**: Settlement run / variance / dispute lifecycle class diagram,
  Redis-backed scheduler wiring notes, full env var table including all optional
  service URLs.
- **event-router**: Stateless routing adapter (no gRPC port), platform metering
  handler documentation, default audit topics enumerated.
- **forecasting**: Starlark sandbox preset (`ForecasterConfig`), strategy lifecycle
  (`DRAFT -> ACTIVE -> DEPRECATED`), built-in templates, Redis lease management.
- **position-keeping**: All 16 RPCs documented, 7 BIAN balance types table,
  compaction worker config, full dependents table (current-account, internal-account,
  reconciliation, event-router, control-plane, mcp-server, api-gateway).

## Test Plan

- [ ] All 5 READMEs include required template sections (frontmatter through configuration)
- [ ] Layer is `Observability and Routing` matching `docs/architecture-layers.md`
- [ ] Load-bearing file paths exist in the codebase
- [ ] Dependents verified by grep for proto imports across service directories
- [ ] `markdownlint` passes (enforced by pre-commit hook - 0 errors)