### PR TITLE
docs: Backfill Lifecycle Orchestration service READMEs

### DIFF
--- a/services/control-plane/README.md
+++ b/services/control-plane/README.md
@@ -1,431 +1,216 @@
 ---
-name: control-plane-service
-description: Tenant configuration management with manifest-driven provisioning, causation tree visualization, and administrative operations
+name: control-plane
+description: Manifest-driven tenant configuration engine - validates, diffs, plans, and applies protobuf manifests as Starlark sagas across downstream services; hosts API key auth, Glass Box causation tree, balance sheet, and Stripe webhook integration
 triggers:
-  - Defining tenant business models (instruments, account types, sagas)
-  - Manifest validation (protobuf, CEL, Starlark)
-  - Manifest diff and apply workflow
-  - Causation tree tracing (Glass Box audit trail)
-  - Balance sheet aggregation and export
-  - Staff identity and API key management
-  - Stripe webhook processing for payment events
+  - Applying or debugging a tenant manifest (instruments, account types, sagas, valuation rules)
+  - Tracing a position, transaction, or event to its originating saga (Glass Box)
+  - Adding or modifying the manifest validation or diff pipeline
+  - Extending staff identity or API key management
+  - Investigating Stripe webhook signature failures or Kafka event publishing
+  - Triggering sagas programmatically from event-router or mcp-server
+  - Generating a manifest from a natural language description (EconomyGeneratorService)
 instructions: |
-  Control Plane manages tenant configuration through declarative manifests and provides
-  administrative operations for audit, balance sheet, and staff identity management.
+  Control Plane manages tenant configuration through declarative manifests and
+  provides administrative operations for audit, balance sheet, and staff identity.
 
-  Key patterns:
-  - Manifest-driven: Tenants declare instruments, account types, valuation rules, and sagas in a single JSON manifest
-  - Kubernetes-style apply: Diff last-applied manifest vs new, plan phased gRPC calls, execute as saga
-  - Glass Box: Trace any position, transaction, or event back to its originating saga causation tree
-  - Staff identity: Tenant-scoped staff users (admin/operator/auditor) with API key authentication
-  - Stripe webhooks: Verify signatures, extract metadata, publish payment events to Kafka
+  Manifest apply pipeline (apply_manifest Starlark saga, bootstrapped to
+  public.platform_saga_definition on startup):
+  1. Validate - protobuf constraints, CEL type-check, Starlark compile,
+     cross-references, immutability rules
+  2. Diff - Kubernetes-style CREATE/UPDATE/DELETE/NO_CHANGE against last-applied
+  3. Plan - map diff actions to five dependency-ordered phases targeting
+     reference-data, internal-account, market-information, party, operational-gateway
+  4. Execute - StarlarkSagaRunner with automatic compensation on failure
 
-  Manifest apply pipeline:
-  1. Validate (protobuf constraints, CEL type-check, Starlark compile, cross-references, immutability)
-  2. Diff (compare last-applied vs new, detect drift, safety-check deletions)
-  3. Plan (map actions to phased gRPC calls with dependency ordering)
-  4. Execute (run apply_manifest Starlark saga with automatic compensation)
+  Glass Box pattern: GetCausationTreeForPosition traces
+  position_log -> transaction_log_entry -> idempotency_key -> saga_instance
+  up the parent_saga_id chain to the root.
 
-  gRPC services: CausationVisualizerService, BalanceSheetService, ManifestHistoryService, AuthService
+  AuthService.ValidateAPIKey is called by api-gateway on every request. Key format:
+  pk_{tenant_slug}_{entropy}. Hash is SHA-256; prefix enables O(1) tenant routing.
+
+  gRPC port 50062. Stripe webhook handling runs in the unified binary's HTTP server.
+  Kafka required for Stripe payment event publishing (KAFKA_BOOTSTRAP_SERVERS).
 ---
 
-# Control Plane Service
+# control-plane
 
-Tenant configuration management service with manifest-driven provisioning, causation tree
-visualization, balance sheet aggregation, and staff identity management.
+Manifest-driven tenant configuration engine with Glass Box causation tracing, balance
+sheet aggregation, staff identity management, and AI-assisted economy generation.
 
 ## Overview
 
 | Attribute | Value |
 |-----------|-------|
-| **Type** | Infrastructure (not BIAN) |
-| **Language** | Go |
-| **Database** | PostgreSQL/CockroachDB |
-| **Standalone** | No (requires Position Keeping, Reference Data, Internal Account) |
+| **BIAN Domain** | Infrastructure (non-BIAN) |
+| **Layer** | Lifecycle Orchestration |
+| **Port** | 50062 (gRPC) |
+| **Database** | CockroachDB platform schema; per-tenant `org_{tenant_id}` for staff users, API keys, manifest versions |
+| **Standalone** | No - requires `reference-data`, `internal-account`, `operational-gateway`, `party`, `market-information`, and `position-keeping` at runtime |
 
-## Architecture
+## API Surface
 
-The control plane provides four distinct capabilities:
+### gRPC
 
-1. **Manifest Management** -- Validate, diff, plan, and apply tenant configuration manifests
-2. **Causation Visualization** -- Trace positions, transactions, and events to originating sagas
-3. **Balance Sheet** -- Aggregate positions into classified financial statements with drill-down
-4. **Staff Identity** -- Manage staff users and API keys per tenant schema
+| Service | RPC | Purpose |
+|---------|-----|---------|
+| `ApplyManifestService` | `ApplyManifest` | Validate, diff, plan, and apply a full tenant manifest |
+| `ApplyManifestService` | `ApplyResource` | Apply a single-resource mutation against the live manifest |
+| `ManifestHistoryService` | `GetCurrentManifest` | Retrieve the most recently applied manifest version |
+| `ManifestHistoryService` | `GetManifestVersion` | Retrieve a specific manifest version by version string |
+| `ManifestHistoryService` | `ListManifestVersions` | Paginated manifest version history (most recent first) |
+| `ManifestHistoryService` | `DiffManifestVersions` | Compare two manifest versions by sequence number |
+| `ManifestHistoryService` | `ExportManifest` | Reconstruct a manifest from live service state |
+| `ManifestHistoryService` | `ReconcileManifest` | Detect drift between stored manifest and live state |
+| `ManifestHistoryService` | `RollbackManifest` | Revert to a previous version (creates a new forward-only record) |
+| `SagaExecutionService` | `ExecuteSaga` | Trigger a named saga instance with idempotency key |
+| `CausationVisualizerService` | `GetCausationTreeForPosition` | Trace a position log to its originating saga (Glass Box) |
+| `CausationVisualizerService` | `GetCausationTreeForTransaction` | Trace a transaction to its originating saga |
+| `CausationVisualizerService` | `GetCausationTreeForEvent` | Trace an event via causation_id to its originating saga |
+| `BalanceSheetService` | `GetBalanceSheet` | Multi-asset balance sheet grouped by ASSETS/LIABILITIES/EQUITY |
+| `BalanceSheetService` | `GetPositionDetails` | Drill into individual positions for an account type and instrument |
+| `BalanceSheetService` | `ExportBalanceSheetCSV` | CSV export with metadata headers |
+| `AuthService` | `ValidateAPIKey` | Verify API key prefix and hash against tenant schema (called by api-gateway) |
+| `EconomyGeneratorService` | `GenerateManifest` | Generate a tenant manifest from a natural language description |
+| `EconomyGeneratorService` | `GetGenerationContext` | Return pattern-matching context for a description without generating |
 
-```mermaid
-flowchart TB
-    subgraph "Manifest Pipeline"
-        M[Manifest JSON] --> V[Validator]
-        V --> D[Differ]
-        D --> P[Planner]
-        P --> E[Executor]
-    end
+Proto files: `api/proto/meridian/control_plane/v1/` (relative to repo root).
 
-    subgraph "Downstream Services"
-        E -->|Phase 1| RD[Reference Data]
-        E -->|Phase 2| IBA[Internal Account]
-        E -->|Phase 3| RD
-        E -->|Phase 4| SR[Saga Registry]
-    end
+### HTTP endpoints
 
-    subgraph "Admin Services"
-        CV[Causation Visualizer]
-        BS[Balance Sheet]
-        SI[Staff Identity]
-        SW[Stripe Webhooks]
-    end
+Stripe webhook handling runs in the unified binary's shared HTTP server, not in the
+standalone control-plane binary.
 
-    CV -->|query| PK[Position Keeping]
-    BS -->|aggregate| PK
-    SW -->|publish| K[Kafka]
-```
-
-## gRPC Services
-
-### CausationVisualizerService
-
-Traces financial entities back to their originating saga, enabling the "Glass Box" audit pattern.
-
-| Method | HTTP | Purpose |
+| Method | Path | Purpose |
 |--------|------|---------|
-| `GetCausationTreeForPosition` | `GET /admin/causation-tree/position/{position_id}` | Trace position to saga tree |
-| `GetCausationTreeForTransaction` | `GET /admin/causation-tree/transaction/{transaction_id}` | Trace transaction to saga tree |
-| `GetCausationTreeForEvent` | `GET /admin/causation-tree/event/{event_id}` | Trace event to saga tree |
+| `POST` | `/stripe/webhook` | Stripe webhook: HMAC-SHA256 verified, publishes payment events to Kafka |
 
-### BalanceSheetService
-
-Aggregates positions into classified balance sheets with drill-down to individual positions.
-
-| Method | HTTP | Purpose |
-|--------|------|---------|
-| `GetBalanceSheet` | `GET /admin/balance-sheet/{tenant_id}` | Multi-asset balance sheet |
-| `GetPositionDetails` | `GET /admin/balance-sheet/{tenant_id}/details/{account_type}/{instrument}` | Drill into positions |
-| `ExportBalanceSheetCSV` | `GET /admin/balance-sheet/{tenant_id}/export` | CSV export with metadata |
-
-### ManifestHistoryService
-
-Version history and rollback for tenant manifests with forward-only audit trail.
-
-| Method | Purpose |
-|--------|---------|
-| `GetCurrentManifest` | Latest applied manifest |
-| `GetManifestVersion` | Specific version by version string |
-| `ListManifestVersions` | Paginated version history |
-
-### AuthService
-
-API key validation for the Gateway service.
-
-| Method | Purpose |
-|--------|---------|
-| `ValidateAPIKey` | Verify API key prefix and hash against tenant schema |
-
-## Manifest Pipeline
-
-### Manifest Structure
-
-A manifest declares the complete business model for a tenant:
-
-```json
-{
-  "version": "1.0",
-  "metadata": { "name": "Acme Energy", "industry": "energy" },
-  "instruments": [
-    {
-      "code": "GBP", "name": "British Pound",
-      "type": "INSTRUMENT_TYPE_FIAT",
-      "dimensions": { "unit": "GBP", "precision": 2 }
-    },
-    {
-      "code": "KWH", "name": "Kilowatt Hour",
-      "type": "INSTRUMENT_TYPE_COMMODITY",
-      "dimensions": { "unit": "kWh", "precision": 3 }
-    }
-  ],
-  "account_types": [
-    {
-      "code": "CURRENT", "name": "Current Account",
-      "normal_balance": "NORMAL_BALANCE_DEBIT",
-      "allowed_instruments": ["GBP"]
-    }
-  ],
-  "valuation_rules": [
-    {
-      "from_instrument": "KWH", "to_instrument": "GBP",
-      "method": "VALUATION_METHOD_SPOT_RATE",
-      "source": "nordpool_spot"
-    }
-  ],
-  "sagas": [
-    { "name": "process_deposit", "trigger": "api:/v1/deposits", "script": "..." }
-  ],
-  "payment_rails": [
-    { "provider": "stripe_connect", "mode": "CONNECT_MODE_STANDARD", "account_id": "acct_..." }
-  ]
-}
-```
-
-### Validation
-
-The manifest validator performs seven checks:
-
-| Check | Error Code | Description |
-|-------|-----------|-------------|
-| Structural | `PROTO_VALIDATION` | Protobuf field constraints (min/max length, patterns, required fields) |
-| Duplicates | `DUPLICATE_CODE` | No duplicate instrument codes, account type codes, or saga names |
-| CEL expressions | `CEL_COMPILATION_ERROR` | Type-check account type policy and bucketing expressions |
-| Starlark scripts | `STARLARK_COMPILATION_ERROR` | Compile saga scripts with service binding stubs |
-| Cross-references | `UNDEFINED_INSTRUMENT_REFERENCE` | All instrument references resolve within the manifest |
-| Payment rails | `INVALID_PAYMENT_PROVIDER` | Provider, account ID format, and method validation |
-| Immutability | `IMMUTABLE_FIELD_CHANGED` | Instrument and account type codes cannot change between versions |
-
-Errors include structured location paths, "Did you mean?" suggestions via Levenshtein distance,
-and available field lists for AI-friendly feedback loops.
-
-### Diff Engine
-
-Compares last-applied manifest against new manifest following Kubernetes apply semantics:
-
-- Resources present in new but not last-applied: **CREATE**
-- Resources present in both with field changes: **UPDATE**
-- Resources present in last-applied but not in new: **DELETE** (with safety checks)
-- Identical resources: **NO_CHANGE**
-
-Safety checks query downstream services before allowing deletions (e.g., non-zero balances
-block account type deletion, running sagas block saga deletion).
-
-### Execution Planner
-
-Maps diff actions to dependency-ordered gRPC calls in five phases:
-
-| Phase | Resources | Target Service |
-|-------|-----------|---------------|
-| 1 | Instruments | Reference Data |
-| 2 | Account Types | Internal Account |
-| 3 | Valuation Rules | Reference Data |
-| 4 | Saga Definitions | Saga Registry |
-| 5 | Seed Data | Various |
-
-Phases execute sequentially; calls within a phase may execute in parallel.
-Each call includes a deterministic SHA-256 idempotency key for safe retry.
-
-### Manifest Executor
-
-Orchestrates the apply as a Starlark saga with automatic compensation:
-
-1. Creates tracking job (PENDING)
-2. Resolves apply_manifest saga script from platform defaults (ADR-0028)
-3. Executes saga via StarlarkSagaRunner
-4. Marks job APPLIED or FAILED
-
-The apply_manifest saga definition is embedded in the binary and bootstrapped to
-`public.platform_saga_definition` on startup.
-
-## Causation Tree Visualization
-
-Enables the "Glass Box" pattern: click a balance sheet line item, see every saga step
-that produced it.
-
-**Tracing paths:**
-
-- Position: `position_log` -> `transaction_log_entry` -> `idempotency_key` -> `saga_instance`
-- Transaction: `transaction_id` -> `saga_step_results` (correlation_id) -> `saga_instance`
-- Event: `event_id` -> `event_outbox` (causation_id) -> `saga_step_results` -> `saga_instance`
-
-All paths walk up the `parent_saga_id` chain to find the root saga, then retrieve
-the full causation tree via `CausationTreeRepository`.
-
-**Export formats:** JSON (preserves tree structure) and CSV (flattened for spreadsheet audit).
-
-## Balance Sheet
-
-Aggregates positions from Position Keeping into a classified balance sheet:
-
-| Section | Normal Balance | Account Type Examples |
-|---------|---------------|---------------------|
-| ASSETS | Debit | STRIPE_NOSTRO, ENERGY_INVENTORY |
-| LIABILITIES | Credit | CUSTOMER_DEPOSIT, PAYABLE |
-| EQUITY | Credit | RETAINED_EARNINGS, OWNER_EQUITY |
-
-Features:
-
-- Multi-instrument support (each section has totals per instrument)
-- Point-in-time queries via `as_of` parameter
-- Drill-down to individual positions with causation tree links
-- CSV export with metadata headers and injection protection
-
-## Staff Identity
-
-Tenant-scoped staff user management for the Admin Console, stored in `org_{tenant_id}` schemas.
-
-### Staff User Lifecycle
+## Domain Model
 
 ```mermaid
-stateDiagram-v2
-    [*] --> invited
-    invited --> active : ActivateStaff
-    active --> suspended : SuspendStaff
-    suspended --> [*]
-```
-
-**Roles:**
-
-| Role | Description |
-|------|-------------|
-| `admin` | Full access to all operations |
-| `operator` | Operational access |
-| `auditor` | Read-only access |
-
-### API Key Management
-
-- Key format: `pk_{tenant_slug}_{entropy}` (prefix enables O(1) tenant routing)
-- Storage: SHA-256 hash (high-entropy keys do not need argon2id)
-- Validation: Constant-time hash comparison, expiry check, staff status check
-- Scoping: Per-key permission scopes and rate limits (default 100 RPS)
-
-## Stripe Webhook Integration
-
-Receives Stripe webhook events via HTTP, verifies signatures, and publishes payment events
-to Kafka for downstream saga processing.
-
-**Handled event types:**
-
-| Stripe Event | Action |
-|-------------|--------|
-| `payment_intent.succeeded` | Extract metadata, publish payment event to Kafka |
-| `payment_intent.payment_failed` | Log failure (no saga triggered) |
-| `charge.refunded` | Extract metadata, publish refund event to Kafka |
-
-**Required metadata** on PaymentIntent: `tenant_id`, `party_id`
-
-Idempotency keys are deterministic SHA-256 hashes of `event_id + event_type`.
-Unknown event types are acknowledged (HTTP 200) to prevent Stripe retries.
-
-## CLI Tools
-
-### Manifest Validator
-
-```bash
-# Validate manifest files against schema
-go run ./services/control-plane/cmd/validate -manifest='examples/manifests/*.json'
-
-# JSON output for CI pipelines
-go run ./services/control-plane/cmd/validate -manifest='manifests/*.json' -json
-```
-
-## Database Schema
-
-Tables are created in tenant schemas (`org_{tenant_id}`) using the schema-per-tenant pattern.
-
-### staff_user
-
-```mermaid
-erDiagram
-    staff_user {
-        uuid id PK
-        varchar(255) email UK "lowercase, trimmed"
-        varchar(255) name "nullable"
-        varchar(50) role "admin, operator, auditor"
-        varchar(20) status "invited, active, suspended"
-        varchar(255) auth_provider_id "nullable, external IdP"
-        timestamptz created_at
-        timestamptz updated_at
-    }
-```
-
-### api_key
-
-```mermaid
-erDiagram
-    api_key {
-        uuid id PK
-        uuid staff_user_id FK
-        varchar(100) key_prefix UK "pk_{slug}_{first8}, unique where not revoked"
-        bytea key_hash "SHA-256"
-        varchar(255) name "nullable"
-        text_array scopes "nullable"
-        integer rate_limit_rps "default 100"
-        timestamptz last_used_at "nullable"
-        timestamptz expires_at "nullable"
-        timestamptz created_at
-        timestamptz revoked_at "nullable"
+classDiagram
+    class ManifestVersion {
+        +UUID ID
+        +string Version
+        +Manifest ManifestJSON
+        +time AppliedAt
+        +string AppliedBy
+        +ApplyStatus ApplyStatus
+        +string DiffSummary
+        +int64 SequenceNumber
+        +string Checksum
+        +map PhaseStatus
     }
 
-    staff_user ||--o{ api_key : "has"
-```
-
-### manifest_versions
-
-```mermaid
-erDiagram
-    manifest_versions {
-        uuid id PK
-        varchar(50) version "schema version e.g. 1.0"
-        jsonb manifest_json "protobuf JSON snapshot"
-        timestamptz applied_at
-        varchar(255) applied_by "staff identity or system"
-        varchar(20) apply_status "APPLIED, FAILED, ROLLED_BACK"
-        uuid apply_job_id "nullable"
-        text diff_summary "nullable, human-readable"
-        timestamptz created_at
+    class ManifestApplyJob {
+        +UUID ID
+        +int ManifestVersion
+        +UUID SagaExecutionID
+        +string Status
+        +string Error
+        +time CreatedAt
+        +time CompletedAt
     }
-```
 
-### manifest_apply_job
-
-```mermaid
-erDiagram
-    manifest_apply_job {
-        uuid id PK
-        integer manifest_version
-        uuid saga_execution_id "nullable"
-        varchar(32) status "PENDING, APPLYING, APPLIED, FAILED"
-        text error "nullable"
-        timestamptz created_at
-        timestamptz completed_at "nullable"
+    class StaffUser {
+        +UUID ID
+        +string Email
+        +string Name
+        +StaffRole Role
+        +StaffStatus Status
+        +string AuthProviderID
+        +time CreatedAt
     }
+
+    class ApiKey {
+        +UUID ID
+        +UUID StaffUserID
+        +string KeyPrefix
+        +bytes KeyHash
+        +string Name
+        +[]string Scopes
+        +int RateLimitRPS
+        +time ExpiresAt
+        +time RevokedAt
+    }
+
+    class ApplyStatus {
+        <<enumeration>>
+        APPLIED
+        FAILED
+        ROLLED_BACK
+        PARTIAL
+    }
+
+    class StaffRole {
+        <<enumeration>>
+        admin
+        operator
+        auditor
+    }
+
+    ManifestVersion --> ApplyStatus
+    ManifestVersion --> ManifestApplyJob : tracked by
+    StaffUser --> StaffRole
+    StaffUser "1" --> "*" ApiKey : owns
 ```
 
-## Service Dependencies
+Apply pipeline state: `PENDING -> APPLYING -> APPLIED | FAILED | PARTIAL`.
+Rollback creates a new `ManifestVersion` record with the target version's content
+(forward-only audit trail; rollback does not overwrite existing records).
 
-| Service | Purpose |
-|---------|---------|
-| Position Keeping | Balance sheet aggregation, causation tree tracing |
-| Reference Data | Instrument, account type, valuation rule, and saga registration |
-| Internal Account | Account provisioning during manifest apply |
-| Kafka | Stripe payment event publishing |
+`ManifestVersion.SequenceNumber` is an optimistic lock. Callers must echo it back as
+`expected_sequence_number` in subsequent applies to prevent concurrent overwrites.
+
+## Dependencies
+
+| Service | Protocol | Purpose |
+|---------|----------|---------|
+| `reference-data` | gRPC | Instrument, valuation rule, and saga definition registration during manifest apply phases 1, 3, 4 |
+| `internal-account` | gRPC | Internal account type provisioning during manifest apply phase 2 |
+| `operational-gateway` | gRPC | Provider connection and instruction route registration during manifest apply |
+| `party` | gRPC | Party type definition registration during manifest apply |
+| `market-information` | gRPC | Market data source and set registration during manifest apply |
+| `position-keeping` | gRPC | Balance aggregation for `BalanceSheetService`; causation chain traversal for Glass Box |
+
+## Dependents
+
+| Service | Entry Point | Purpose |
+|---------|-------------|---------|
+| `api-gateway` | `services/api-gateway/auth/rpc_apikey_validator.go` | `ValidateAPIKey` on every authenticated request |
+| `event-router` | `services/event-router/adapters/grpc/saga_trigger_client.go` | `ExecuteSaga` on domain events from Kafka |
+| `mcp-server` | `services/mcp-server/internal/clients/clients.go` | Manifest apply, history, and economy generation from LLM clients |
+| `financial-gateway` | `services/financial-gateway/cmd/main.go` | Manifest tenant config lookup for Stripe rail connection details |
+| `payment-order` | `services/payment-order/adapters/gateway/stripe/manifest_tenant_config.go` | Manifest tenant config lookup for Stripe payment gateway |
+
+## Load-Bearing Files
+
+Paths are relative to `services/control-plane/`.
+
+| File | Why It Matters |
+|------|----------------|
+| `cmd/main.go` | Wires gRPC server with auth and RBAC interceptors; controls startup order and shutdown |
+| `service/apply_manifest.go` | Entry point for validate/diff/plan/execute pipeline; `RegisterApplyManifestService` |
+| `internal/applier/apply_job.go` | Apply job lifecycle tracking (`PENDING -> APPLIED/FAILED`); idempotency boundary |
+| `internal/applier/executor.go` | Starlark saga runner for manifest apply; calls `StarlarkSagaRunner` with `apply_manifest` |
+| `internal/validator/manifest_validator.go` | Seven-stage validation pipeline; changes here affect every manifest operation |
+| `internal/differ/manifest_differ.go` | Kubernetes-style diff engine (`CREATE/UPDATE/DELETE/NO_CHANGE`); safety-checks deletions |
+| `internal/planner/manifest_planner.go` | Maps diff actions to dependency-ordered phased gRPC calls with idempotency keys |
+| `internal/admin/handler.go` | `CausationVisualizerService` and `BalanceSheetService` gRPC implementations |
+| `internal/stripe/webhook.go` | HMAC-SHA256 signature verification and Kafka payment event publishing; 5-minute replay guard |
+| `rbac/method_permissions.go` | RBAC method-to-permission mapping; all RPC authorization rules live here |
 
 ## Configuration
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `DATABASE_URL` | - | PostgreSQL/CockroachDB connection string |
-| `STRIPE_WEBHOOK_SECRET` | - | Stripe webhook signing secret (whsec_...) |
-| `DB_MAX_OPEN_CONNS` | 25 | Connection pool size |
-
-## Key Patterns
-
-### Manifest Version History
-
-All manifest changes are stored as immutable snapshots. Rollbacks create new version records
-with the target version's content, maintaining a forward-only audit trail. Diff summaries
-are auto-generated by comparing against the previous applied version.
-
-### Platform Default Saga Bootstrap
-
-On startup, the control plane upserts the embedded `apply_manifest` Starlark saga into
-`public.platform_saga_definition`. This ensures the saga is available for all tenants
-via ADR-0028 platform default fallback resolution. The bootstrap is idempotent and handles
-concurrent startup race conditions.
-
-### Tenant Schema Isolation
-
-Staff users, API keys, manifest versions, and apply jobs are stored in tenant schemas
-(`org_{tenant_id}`). The service uses `search_path` or GORM tenant transactions to route
-queries to the correct schema based on tenant context from request metadata.
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `DATABASE_URL` | Yes | - | CockroachDB connection string |
+| `GRPC_PORT` | No | `50062` | gRPC listen port |
+| `LOG_LEVEL` | No | `info` | Log verbosity: `debug`, `info`, `warn`, `error` |
 
 ## References
 
-- [Service Architecture](../README.md)
-- [Proto Definitions](../../api/proto/meridian/control_plane/v1/)
-- [Example Manifests](../../api/proto/meridian/control_plane/v1/examples/)
+- [`docs/architecture-layers.md`](../../docs/architecture-layers.md) - Lifecycle Orchestration layer (section 5)
+- [`docs/architecture/starlark-saga-architecture.md`](../../docs/architecture/starlark-saga-architecture.md) - Saga execution
+- [`api/proto/meridian/control_plane/v1/`](../../api/proto/meridian/control_plane/v1/) - Proto definitions
+- [`api/proto/meridian/control_plane/v1/examples/`](../../api/proto/meridian/control_plane/v1/examples/) - Example manifests

--- a/services/payment-order/README.md
+++ b/services/payment-order/README.md
@@ -1,89 +1,70 @@
 ---
-name: payment-order-service
-description: BIAN payment order saga orchestrator for fund reservation, gateway execution, and settlement
+name: payment-order
+description: BIAN Payment Order saga orchestrator - coordinates fund reservation, external gateway dispatch, and ledger settlement across current-account, financial-accounting, and financial-gateway
 triggers:
-  - Implementing payment order workflows
-  - Designing saga patterns for distributed transactions
-  - Adding payment processing to services
-  - Handling external payment gateway callbacks
-  - Managing fund reservations and settlements
-  - Webhook signature validation (HMAC-SHA256)
+  - Implementing or debugging a payment flow from initiation to settlement
+  - Adding a new payment gateway provider or webhook handler
+  - Tracing a failed payment through the saga state machine
+  - Extending billing or dunning worker behaviour
+  - Handling lien lifecycle (reserve, execute, terminate)
 instructions: |
-  PaymentOrder orchestrates money movement as a saga:
+  PaymentOrder orchestrates money movement as a saga across three services:
+  current-account (liens), financial-accounting (ledger postings), and
+  financial-gateway or Stripe (external dispatch).
 
-  State Machine: INITIATED → RESERVED → EXECUTING → COMPLETED
-                        ↘ FAILED (with compensation)
-                        ↘ CANCELLED (before EXECUTING)
-  COMPLETED → REVERSED (post-completion compensation)
+  State machine: INITIATED -> RESERVED -> EXECUTING -> COMPLETED
+  Failures trigger LIFO compensation (lien release, reversal posting).
+  Cancellation is allowed before EXECUTING; reversal after COMPLETED.
 
-  Key flows:
-  1. InitiatePaymentOrder: Creates order, validates amount/IBAN
-  2. Async worker reserves funds via CurrentAccount.InitiateLien
-  3. Async worker sends to gateway, transitions to EXECUTING
-  4. Gateway webhook calls UpdatePaymentOrder (HMAC-protected)
-  5. On settlement: COMPLETED, async ExecuteLien with retry (max 5)
-  6. On rejection: FAILED, releases lien (automatic compensation)
+  Webhooks arrive over HTTP at port 8080 and are HMAC-SHA256 verified
+  before being forwarded to UpdatePaymentOrder. gRPC listens on port 50054.
 
-  Cancellation only allowed before EXECUTING
-  Reversal only allowed for COMPLETED orders
+  Payment orders are currency-only: non-fiat instruments (kWh, GPU_HOUR,
+  TONNE_CO2E) are rejected at the boundary by ValidateCurrencyDimension()
+  in domain/quantity.go.
 
-  Ports: 50054 (gRPC), 8080 (HTTP webhooks)
+  Starlark saga orchestration (USE_SAGA_ORCHESTRATION=true) is optional;
+  the default path uses the Go-native orchestrator in
+  service/payment_orchestrator.go.
 ---
 
-# PaymentOrder Service
+# payment-order
 
-BIAN-compliant payment order service with saga orchestration for distributed transactions.
+BIAN Payment Order saga orchestrator for fund reservation, external gateway dispatch,
+and ledger settlement.
 
 ## Overview
 
 | Attribute | Value |
 |-----------|-------|
 | **BIAN Domain** | Payment Order |
-| **Port** | 50054 (gRPC), 8080 (HTTP) |
-| **Language** | Go |
-| **Database** | PostgreSQL/CockroachDB |
-| **Standalone** | No (requires CurrentAccount) |
+| **Layer** | Lifecycle Orchestration |
+| **Port** | 50054 (gRPC), 8080 (HTTP webhooks) |
+| **Database** | CockroachDB tenant schema (`org_{tenant_id}`) |
+| **Standalone** | No - requires `current-account`, `financial-accounting`, and a payment gateway at runtime |
 
-## gRPC Methods
+## API Surface
 
-| Method | HTTP | Purpose |
+### gRPC
+
+| Service | RPC | Purpose |
+|---------|-----|---------|
+| `PaymentOrderService` | `InitiatePaymentOrder` | Create a payment order and begin the saga |
+| `PaymentOrderService` | `RetrievePaymentOrder` | Get order details by ID |
+| `PaymentOrderService` | `UpdatePaymentOrder` | Handle async gateway callback (status update) |
+| `PaymentOrderService` | `CancelPaymentOrder` | Cancel before EXECUTING; releases lien if RESERVED |
+| `PaymentOrderService` | `ListPaymentOrders` | Paginated list with status and date filters |
+| `PaymentOrderService` | `ReversePaymentOrder` | Post-completion compensation (COMPLETED -> REVERSED) |
+| `BillingService` | `ListBillingRuns` | List billing run history (available when `BILLING_ENABLED=true`) |
+
+Proto: `api/proto/meridian/payment_order/v1/payment_order.proto` (relative to repo root).
+
+### HTTP endpoints
+
+| Method | Path | Purpose |
 |--------|------|---------|
-| `InitiatePaymentOrder` | `POST /v1/payment-orders` | Create payment |
-| `RetrievePaymentOrder` | `GET /v1/payment-orders/{id}` | Get order details |
-| `UpdatePaymentOrder` | `PATCH /v1/payment-orders/{id}` | Handle webhook callback |
-| `CancelPaymentOrder` | `POST /v1/payment-orders/{id}/cancel` | Cancel before execution |
-| `ReversePaymentOrder` | `POST /v1/payment-orders/{id}/reverse` | Reverse completed payment |
-| `ListPaymentOrders` | `GET /v1/payment-orders` | List with filters |
-
-## HTTP Endpoints
-
-| Endpoint | Method | Purpose |
-|----------|--------|---------|
-| `/webhook/payment-gateway` | POST | External gateway callbacks |
-| `/health` | GET | Health check |
-
-## Saga Definitions
-
-Payment execution saga is **NOT** stored locally. It is fetched at runtime from the
-reference-data service via `GetSaga()` RPC.
-
-**Canonical source:** `services/reference-data/saga/defaults/payment_execution/v1.0.0.star`
-
-To modify this saga, update the file in reference-data service and run
-`PlatformSync.SyncPlatformDefaults()`.
-
-## Currency-Only Constraint
-
-Payment Order is **intentionally restricted to CURRENCY dimension instruments**. This is a permanent business rule:
-
-- Payment orders model fiat money movements (bank transfers, direct debits, SEPA/SWIFT settlements)
-- These real-world payment rails only carry ISO 4217 currencies
-- The database stores currency as `CHAR(3)` for ISO 4217 codes
-- Non-currency assets (energy kWh, compute GPU_HOUR, carbon credits) belong in
-  the **position-keeping** service
-
-The `ValidateCurrencyDimension()` helper in `domain/quantity.go` enforces this
-at the service boundary by rejecting instruments outside the CURRENCY dimension.
+| `POST` | `/webhook/payment-gateway` | External gateway callback, HMAC-SHA256 verified |
+| `GET` | `/health` | Health check |
 
 ## Domain Model
 
@@ -94,9 +75,10 @@ classDiagram
         +string DebtorAccountID
         +string CreditorReference
         +Money Amount
-        +PaymentStatus Status
+        +PaymentOrderStatus Status
         +string LienID
         +string GatewayReferenceID
+        +string LedgerBookingID
         +string IdempotencyKey
         +string FailureReason
         +LienExecutionStatus LienExecutionStatus
@@ -104,7 +86,7 @@ classDiagram
         +int Version
     }
 
-    class PaymentStatus {
+    class PaymentOrderStatus {
         <<enumeration>>
         INITIATED
         RESERVED
@@ -122,158 +104,80 @@ classDiagram
         FAILED
     }
 
-    PaymentOrder --> PaymentStatus
+    class BillingRun {
+        +UUID ID
+        +string TenantID
+        +BillingRunStatus Status
+        +int DunningLevel
+        +time PeriodStart
+        +time PeriodEnd
+    }
+
+    PaymentOrder --> PaymentOrderStatus
     PaymentOrder --> LienExecutionStatus
 ```
 
-**Field Notes:**
+State machine: `INITIATED -> RESERVED -> EXECUTING -> COMPLETED` (happy path).
+Failed steps trigger LIFO compensation - lien release via
+`current-account.TerminateLien` and reversal posting via `financial-accounting`.
+Cancellation is allowed from INITIATED or RESERVED. Post-completion reversal
+transitions COMPLETED to REVERSED.
 
-- `CreditorReference`: IBAN format
-- `LienExecutionAttempts`: max 5 retries
+`CreditorReference` must be IBAN format. `LienExecutionAttempts` is capped at 5.
 
-## Payment Saga State Machine
+## Dependencies
 
-```mermaid
-stateDiagram-v2
-    [*] --> INITIATED
-    INITIATED --> RESERVED : InitiateLien success
-    INITIATED --> FAILED : reservation failed
-    RESERVED --> EXECUTING : sent to gateway
-    RESERVED --> CANCELLED : user cancelled
-    EXECUTING --> COMPLETED : gateway settled
-    EXECUTING --> FAILED : gateway rejected
-    COMPLETED --> REVERSED : post-completion reversal
-    CANCELLED --> [*]
-    FAILED --> [*]
-    COMPLETED --> [*]
-    REVERSED --> [*]
-```
+| Service | Protocol | Purpose |
+|---------|----------|---------|
+| `current-account` | gRPC | `InitiateLien`, `ExecuteLien`, `TerminateLien` for fund reservation |
+| `financial-accounting` | gRPC | Ledger posting on settlement via `InitiateFinancialBookingLog` and `CaptureLedgerPosting` |
+| `financial-gateway` | gRPC | External payment dispatch (Starlark handler registration) |
+| `position-keeping` | gRPC | Balance prefetch and position log updates (Starlark handler registration) |
+| `reference-data` | gRPC | Saga definition lookup when `USE_SAGA_ORCHESTRATION=true` |
+| `party` | gRPC | Starlark handler registration |
 
-## Saga Orchestration Flow
+## Dependents
 
-### Happy Path
+| Service | Entry Point | Purpose |
+|---------|-------------|---------|
+| `api-gateway` | `services/api-gateway/cmd/main.go` | Proxies payment order RPCs from external clients via Vanguard transcoder |
+| `financial-gateway` | `services/financial-gateway/service/server.go` | Publishes `payment-captured` and `payment-failed` Kafka events consumed by payment-order |
 
-1. **Initiation**: `InitiatePaymentOrder` creates order in INITIATED status
-2. **Reservation**: Async worker calls `CurrentAccount.InitiateLien` → RESERVED
-3. **Execution**: Async worker sends to payment gateway → EXECUTING
-4. **Settlement**: Gateway webhook confirms → COMPLETED
-5. **Lien Execution**: Async `ExecuteLien` converts reservation to debit (retries up to 5x)
+## Load-Bearing Files
 
-### Compensation
+Paths are relative to `services/payment-order/`.
 
-- **Gateway Rejection**: Automatically releases lien via `TerminateLien`
-- **Cancellation**: User cancels before EXECUTING, lien released
-- **Reversal**: Manual reversal of COMPLETED orders creates compensating entries
-
-## Webhook Security
-
-| Feature | Implementation |
-|---------|----------------|
-| Authentication | HMAC-SHA256 signature |
-| Header | `X-Webhook-Signature` |
-| Timestamp | Max 5 minutes age |
-| Rate Limiting | 100 req/sec per IP |
-
-**Idempotency Handling:**
-
-Webhooks are deduplicated using a deterministic idempotency key:
-
-```text
-idempotency_key = hash(gateway_reference_id + status + gateway_event_ts)
-```
-
-- `gateway_event_ts`: Timestamp from webhook payload (not receipt time)
-- Prefer gateway's `event_id` if provided (more reliable than timestamp)
-- Duplicate webhooks (same key) return 200 OK without re-processing
-
-**Rate Limiting with Reverse Proxy:**
-
-When behind a reverse proxy (nginx, AWS ALB, etc.), configure `X-Forwarded-For` handling:
-
-```text
-# Ensure the proxy sets X-Forwarded-For
-# PaymentOrder service uses client IP from:
-# 1. X-Forwarded-For header (first IP in chain)
-# 2. Direct connection IP if header absent
-
-# Trust only your proxy's IP to prevent spoofing
-TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12
-```
-
-Without proper proxy configuration, all requests may share the gateway's IP,
-causing legitimate traffic to be rate-limited.
-
-## Service Dependencies
-
-| Service | Port | Purpose |
-|---------|------|---------|
-| CurrentAccount | 50057 | Lien operations (reserve, execute, terminate) |
-
-## Database Schema
-
-**Schema**: `payment_order`
-
-```mermaid
-erDiagram
-    payment_orders {
-        uuid id PK
-        varchar(255) debtor_account_id
-        varchar(255) creditor_reference "IBAN"
-        bigint amount_cents
-        char(3) currency "ISO 4217"
-        varchar(20) status "saga state"
-        varchar(255) lien_id "CurrentAccount reservation"
-        varchar(255) gateway_reference_id "external txn ID"
-        varchar(255) idempotency_key UK
-        varchar(255) failure_reason
-        varchar(20) lien_execution_status "PENDING, SUCCEEDED, FAILED"
-        int lien_execution_attempts "max 5"
-        int version "optimistic lock"
-        timestamptz created_at
-        timestamptz updated_at
-    }
-```
-
-## Kafka Events
-
-| Topic | Purpose |
-|-------|---------|
-| `payment-order.initiated.v1` | Order created |
-| `payment-order.reserved.v1` | Funds reserved |
-| `payment-order.executing.v1` | Sent to gateway |
-| `payment-order.completed.v1` | Settlement confirmed |
-| `payment-order.failed.v1` | Processing failed |
-| `payment-order.cancelled.v1` | User cancelled |
-| `payment-order.reversed.v1` | Post-completion reversal |
+| File | Why It Matters |
+|------|----------------|
+| `cmd/main.go` | Wires every component; controls startup order and server lifecycle |
+| `service/server.go` | Registers gRPC service implementations; changes here break callers |
+| `domain/payment_order.go` | State machine and transition invariants; all status changes flow through here |
+| `service/payment_orchestrator.go` | Go-native saga orchestration (lien, gateway dispatch, ledger posting) |
+| `service/payment_orchestrator_lien.go` | Lien reservation and release logic; idempotency boundary for fund reservation |
+| `adapters/persistence/payment_order_entity.go` | GORM entity with audit hooks; `AuditID()` required by the audit pipeline |
+| `adapters/http/webhook_handler.go` | HMAC-SHA256 verification and webhook routing; rejects replays older than 5 minutes |
+| `config/service_config.go` | All env var defaults; authoritative source for service configuration |
 
 ## Configuration
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `GRPC_PORT` | 50054 | gRPC server port |
-| `HTTP_PORT` | 8080 | Webhook server port |
-| `WEBHOOK_HMAC_SECRET` | (required) | Signature validation secret |
-| `HTTP_RATE_LIMIT_PER_SECOND` | 100 | Rate limit |
-| `HTTP_RATE_LIMIT_BURST` | 200 | Burst allowance |
-
-**HMAC Secret Configuration:**
-
-- **Required:** Service will not start without a valid secret
-- **Minimum length:** 32 bytes recommended for security
-- **Generate:** `openssl rand -base64 32`
-- **Kubernetes:** Store in Secret, reference via `secretKeyRef`
-
-```bash
-# Generate secure secret
-openssl rand -base64 32
-
-# Example Kubernetes secret
-kubectl create secret generic payment-order-webhook \
-  --from-literal=hmac-secret="$(openssl rand -base64 32)"
-```
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `DATABASE_URL` | Yes | - | CockroachDB connection string |
+| `GRPC_PORT` | No | `50054` | gRPC listen port |
+| `HTTP_PORT` | No | `8080` | Webhook HTTP listen port |
+| `WEBHOOK_HMAC_SECRET` | Yes | - | HMAC-SHA256 secret for webhook signature verification |
+| `PAYMENT_GATEWAY_PROVIDER` | No | `mock` | Gateway mode: `stripe`, `financial-gateway`, or `mock` |
+| `STRIPE_API_KEY` | Conditional | - | Required when `PAYMENT_GATEWAY_PROVIDER=stripe` |
+| `STRIPE_WEBHOOK_SECRET` | Conditional | - | Required when `PAYMENT_GATEWAY_PROVIDER=stripe` |
+| `FINANCIAL_GATEWAY_ADDR` | Conditional | - | gRPC address, required when `PAYMENT_GATEWAY_PROVIDER=financial-gateway` |
+| `USE_SAGA_ORCHESTRATION` | No | `false` | Enable Starlark saga path (fetches saga script from `reference-data`) |
+| `BILLING_ENABLED` | No | `false` | Start billing cron scheduler and dunning worker |
+| `BILLING_CRON_SCHEDULE` | No | `0 0 * * *` | Cron expression for billing runs |
+| `BILLING_SHADOW_MODE` | No | `false` | Run billing as a dry run without posting charges |
+| `KAFKA_BOOTSTRAP_SERVERS` | No | - | Kafka bootstrap servers for event publishing and the payment event consumer |
 
 ## References
 
-- [BIAN Payment Order Specification](https://github.com/bian-official/public/blob/main/release14.0.0/semantic-apis/oas3%20/yamls/PaymentOrder.yaml)
-- [Service Architecture](../README.md)
-- [Proto Definitions](../../api/proto/meridian/payment_order/v1/)
+- [`docs/data-flows.md`](../../docs/data-flows.md) - Payment lifecycle sequence diagram (section 1)
+- [`docs/patterns.md`](../../docs/patterns.md) - Saga, idempotency, and outbox patterns
+- [`api/proto/meridian/payment_order/v1/payment_order.proto`](../../api/proto/meridian/payment_order/v1/payment_order.proto)

--- a/services/tenant/README.md
+++ b/services/tenant/README.md
@@ -1,67 +1,85 @@
 ---
-name: tenant-service
-description: Multi-tenant platform management with PostgreSQL schema-per-tenant isolation
+name: tenant
+description: Platform multi-tenancy registry - maintains tenant lifecycle state and drives schema-per-tenant provisioning across all CockroachDB service databases
 triggers:
-  - Implementing multi-tenancy patterns
-  - Managing tenant lifecycle (active, suspended, deprovisioned)
-  - Schema isolation for data segregation
-  - Building tenant registry services
-  - Platform infrastructure for shared clusters
+  - Creating or retrieving a tenant via InitiateTenant or RetrieveTenant
+  - Debugging provisioning failures (PROVISIONING_FAILED status or per-service errors)
+  - Running schema migrations against existing tenant databases (ReconcileMigrations)
+  - Tracing how a new tenant's org_{tenant_id} schema gets created across services
+  - Investigating slug routing or subdomain resolution
+  - Configuring PARTY_SERVICE_ENABLED or SCHEMA_PROVISIONING_ENABLED behaviour
 instructions: |
-  Tenant service manages platform multi-tenancy (NOT a BIAN component).
+  Tenant service manages platform multi-tenancy. It is NOT a BIAN component.
 
-  Key patterns:
-  - Schema isolation: Each tenant gets org_{tenant_id} PostgreSQL schema
-  - Status lifecycle: ACTIVE → SUSPENDED → DEPROVISIONED (terminal)
-  - Tenant ID: Alphanumeric + underscore, 1-50 chars
-  - Optimistic locking via version field
-  - Cached registry with async refresh (60s interval)
+  Lifecycle: PROVISIONING_PENDING -> PROVISIONING -> ACTIVE (happy path).
+  Failures land in PROVISIONING_FAILED and can be retried. DEPROVISIONED is
+  terminal - no operations can be performed after that transition.
 
-  Note: Distinct from BIAN Party.Organization which represents legal entities.
+  Schema provisioning: when SCHEMA_PROVISIONING_ENABLED=true the provisioner
+  opens connections to each service's CockroachDB database and runs
+  CREATE SCHEMA IF NOT EXISTS org_{tenant_id}, then applies all service migrations.
+  Services provisioned (in order): party, current-account, position-keeping,
+  financial-accounting, payment-order, market-information, reference-data,
+  internal-account, reconciliation, identity, control-plane.
 
-  Port: 50056 (gRPC)
+  Async provisioning: InitiateTenant returns PROVISIONING_PENDING immediately;
+  the ProvisioningWorker picks it up and drives it to ACTIVE. Poll
+  GetTenantProvisioningStatus for per-service progress.
+
+  Party registration: when PARTY_SERVICE_ENABLED=true (default), tenant creation
+  calls party.RegisterParty to create the corresponding BIAN Organization entity
+  and stores the returned party_id on the tenant record.
+
+  Port: 50056 (gRPC).
 ---
 
-# Tenant Service
+# tenant
 
-Platform infrastructure service for multi-tenant management with PostgreSQL schema isolation.
+Platform multi-tenancy registry and schema provisioner. Maintains tenant lifecycle
+state and creates `org_{tenant_id}` schemas across all CockroachDB service databases.
 
 ## Overview
 
 | Attribute | Value |
 |-----------|-------|
-| **Type** | Infrastructure (not BIAN) |
+| **BIAN Domain** | Infrastructure (non-BIAN) |
+| **Layer** | Lifecycle Orchestration |
 | **Port** | 50056 (gRPC) |
-| **Language** | Go |
-| **Database** | PostgreSQL/CockroachDB |
-| **Standalone** | Yes |
+| **Database** | CockroachDB platform schema (`platform`) for tenant registry; provisions `org_{tenant_id}` in all service databases |
+| **Standalone** | No - requires `party` at runtime when `PARTY_SERVICE_ENABLED=true`; requires per-service database URLs for schema provisioning |
 
-**Note**: This service is not part of the BIAN standard. It provides essential multi-tenancy
-infrastructure for shared-cluster deployments requiring data isolation between organizations.
+## API Surface
 
-## gRPC Methods
+### gRPC
 
-| Method | HTTP | Purpose |
-|--------|------|---------|
-| `InitiateTenant` | `POST /v1/tenants` | Create new tenant |
-| `RetrieveTenant` | `GET /v1/tenants/{tenant_id}` | Get tenant details |
-| `UpdateTenantStatus` | `PATCH /v1/tenants/{tenant_id}/status` | Change lifecycle status |
-| `ListTenants` | `GET /v1/tenants` | List with filters |
+| Service | RPC | Purpose |
+|---------|-----|---------|
+| `TenantService` | `InitiateTenant` | Register a new tenant; triggers async schema provisioning |
+| `TenantService` | `RetrieveTenant` | Get tenant details; used to poll provisioning status |
+| `TenantService` | `UpdateTenantStatus` | Lifecycle transitions (active, suspended, deprovisioned) with optimistic locking |
+| `TenantService` | `ListTenants` | Paginated list with optional status filter |
+| `TenantService` | `ReconcileMigrations` | Apply new service migrations to existing tenant schemas |
+| `TenantService` | `GetTenantProvisioningStatus` | Per-service provisioning progress with migration versions and error details |
+
+Proto: `api/proto/meridian/tenant/v1/tenant.proto` (relative to repo root).
 
 ## Domain Model
 
 ```mermaid
 classDiagram
     class Tenant {
-        +string ID
+        +string TenantID
         +string DisplayName
         +string SettlementAsset
         +string Subdomain
+        +string Slug
         +TenantStatus Status
-        +Time CreatedAt
-        +Time DeprovisionedAt
+        +string PartyID
         +JSON Metadata
         +int Version
+        +string ErrorMessage
+        +time CreatedAt
+        +time DeprovisionedAt
     }
 
     class TenantStatus {
@@ -69,181 +87,128 @@ classDiagram
         ACTIVE
         SUSPENDED
         DEPROVISIONED
+        PROVISIONING
+        PROVISIONING_FAILED
+        PROVISIONING_PENDING
+    }
+
+    class ServiceProvisioningStatus {
+        +string ServiceName
+        +ProvisioningState Status
+        +string MigrationVersion
+        +string ErrorMessage
+        +time StartedAt
+        +time CompletedAt
+    }
+
+    class ProvisioningState {
+        <<enumeration>>
+        PENDING
+        IN_PROGRESS
+        COMPLETED
+        FAILED
     }
 
     Tenant --> TenantStatus
+    Tenant "1" --> "*" ServiceProvisioningStatus : tracked per service
+    ServiceProvisioningStatus --> ProvisioningState
 ```
 
-**Field Notes:**
+Tenant ID is alphanumeric plus underscore (1-50 chars) and is used directly as
+the schema name suffix (`org_{tenant_id}`). Slug is a DNS label (lowercase
+alphanumeric with hyphens, 3-63 chars) used for subdomain routing.
 
-- `ID`: Alphanumeric + underscore, 1-50 chars (used for schema name `org_{id}`)
-- `SettlementAsset`: e.g., GBP, USD, GPU-HOUR
+Status transitions: `PROVISIONING_PENDING -> PROVISIONING -> ACTIVE` (happy path).
+`PROVISIONING_FAILED` is retryable (transitions back to `PROVISIONING`).
+`DEPROVISIONED` is terminal. Tenants are never hard-deleted.
 
-### Tenant Status
+`Version` field enables optimistic locking. `UpdateTenantStatus` returns `ABORTED`
+on version mismatch; callers should retry with a fresh `RetrieveTenant`.
 
-| Status | Description |
-|--------|-------------|
-| `ACTIVE` | Tenant is operational |
-| `SUSPENDED` | Temporarily disabled (recoverable) |
-| `DEPROVISIONED` | Terminal state (no operations) |
+## Dependencies
 
-**Note:** API enum uses uppercase (ACTIVE), DB stores lowercase (active).
+| Service | Protocol | Purpose |
+|---------|----------|---------|
+| `party` | gRPC | Registers the organization as a BIAN Party on tenant creation and stores the returned `party_id` (requires `PARTY_SERVICE_ENABLED=true`) |
+| All service CockroachDB databases | Direct SQL | Creates `org_{tenant_id}` schema and applies service migrations during provisioning |
 
-**Status Transitions:**
+Services whose databases receive schemas during provisioning: `party`, `current-account`,
+`position-keeping`, `financial-accounting`, `payment-order`, `market-information`,
+`reference-data`, `internal-account`, `reconciliation`, `identity`, `control-plane`.
 
-```mermaid
-stateDiagram-v2
-    [*] --> ACTIVE
-    ACTIVE --> SUSPENDED
-    ACTIVE --> DEPROVISIONED
-    SUSPENDED --> ACTIVE
-    SUSPENDED --> DEPROVISIONED
-    DEPROVISIONED --> [*]
-```
+## Dependents
 
-- DEPROVISIONED is terminal (cannot be reactivated)
-- SUSPENDED can return to ACTIVE
+| Service | Entry Point | Purpose |
+|---------|-------------|---------|
+| `api-gateway` | `services/api-gateway/registration_handler.go` | Tenant creation during user self-registration flow |
+| `identity` | `services/identity/bootstrap/self_registered_admin.go` | Tenant domain types for operator admin bootstrap |
 
-## Schema Isolation
+## Load-Bearing Files
 
-Each tenant's data is isolated in a dedicated PostgreSQL schema:
+Paths are relative to `services/tenant/`.
 
-```text
-org_{tenant_id}
-```
-
-Example: Tenant `acme_bank` → Schema `org_acme_bank`
-
-The tenant registry itself is stored in the shared `platform` schema.
-
-## Database Schema
-
-**Schema**: `platform`
-
-```mermaid
-erDiagram
-    tenants {
-        varchar(50) id PK "alphanumeric + underscore"
-        varchar(255) display_name
-        varchar(20) settlement_asset
-        varchar(255) subdomain UK "nullable"
-        varchar(20) status "active, suspended, deprovisioned"
-        timestamptz created_at
-        timestamptz deprovisioned_at "nullable"
-        jsonb metadata "flexible config"
-        integer version "optimistic lock"
-    }
-```
-
-**Constraints:**
-
-- `valid_status`: status IN ('active', 'suspended', 'deprovisioned')
-- `valid_org_id`: id matches `^[a-zA-Z0-9_]{1,50}$`
-- Subdomain unique when not null
-
-## Cached Registry
-
-In-memory tenant cache for validation middleware:
-
-| Setting | Value |
-|---------|-------|
-| Refresh interval | 60 seconds |
-| Per-refresh timeout | 30 seconds |
-| Strategy | Fail-open (uses stale cache if refresh fails) |
-
-**Fail-open guardrails:**
-
-- Only allows previously-seen tenants (cached entries)
-- Never accepts unknown tenant IDs during refresh failures
-- Emits metrics/alerts when operating in stale-cache mode
-- Cache populated on startup before accepting traffic
+| File | Why It Matters |
+|------|----------------|
+| `cmd/main.go` | Wires gRPC server with platform admin interceptor; loads worker config and controls startup order |
+| `app/container.go` | Dependency injection container; initialization order and worker lifecycle; controls which features are enabled based on env vars |
+| `service/server.go` | gRPC `TenantService` implementation; delegates to repository and provisioner |
+| `service/grpc_provisioning_endpoints.go` | `ReconcileMigrations` and `GetTenantProvisioningStatus` gRPC handlers |
+| `provisioner/provisioner.go` | Orchestrates multi-service schema provisioning; `DefaultConfig` enumerates all provisioned services |
+| `provisioner/postgres_provisioner.go` | Creates `org_{tenant_id}` schemas and runs migrations per service database; circuit breaker per service |
+| `domain/tenant.go` | Tenant entity and status transition invariants; all status changes validated here |
+| `adapters/persistence/repository.go` | CockroachDB GORM repository; GORM hooks for audit trail |
 
 ## Configuration
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `GRPC_PORT` | 50056 | gRPC server port |
-| `METRICS_PORT` | 9090 | Prometheus metrics endpoint port |
-| `DATABASE_URL` | - | PostgreSQL connection string |
-| `DB_MAX_OPEN_CONNS` | 25 | Connection pool size |
-| `DB_MAX_IDLE_CONNS` | 5 | Idle connections |
-| `DB_CONN_MAX_LIFETIME` | 5m | Connection max age |
+### Core
 
-## Observability
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `DATABASE_URL` | Yes | - | CockroachDB connection string (platform schema) |
+| `GRPC_PORT` | No | `50056` | gRPC listen port |
+| `LOG_LEVEL` | No | `info` | Log verbosity: `debug`, `info`, `warn`, `error` |
 
-### Metrics Endpoint
+### Schema Provisioning
 
-The service exposes Prometheus metrics on port 9090:
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `SCHEMA_PROVISIONING_ENABLED` | No | `false` | Enable per-tenant schema creation and migration on `InitiateTenant` |
+| `MIGRATIONS_BASE_PATH` | No | `/migrations` | Base path for service migration directories, relative to container root |
+| `PARTY_DATABASE_URL` | Conditional | derived from `DATABASE_URL` | CockroachDB URL for `party` service schema provisioning |
+| `CURRENT_ACCOUNT_DATABASE_URL` | Conditional | derived | CockroachDB URL for `current-account` schema provisioning |
+| `POSITION_KEEPING_DATABASE_URL` | Conditional | derived | CockroachDB URL for `position-keeping` schema provisioning |
+| `FINANCIAL_ACCOUNTING_DATABASE_URL` | Conditional | derived | CockroachDB URL for `financial-accounting` schema provisioning |
+| `PAYMENT_ORDER_DATABASE_URL` | Conditional | derived | CockroachDB URL for `payment-order` schema provisioning |
 
-- **Endpoint**: `http://localhost:9090/metrics`
-- **Health Check**: `http://localhost:9090/healthz`
+Per-service database URLs are derived from `DATABASE_URL` by substituting the database
+name if a specific `{SERVICE}_DATABASE_URL` variable is not set.
 
-**Provisioning Metrics:**
+### Party Client
 
-| Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
-| `tenant_provisioning_duration_seconds` | Histogram | status | Duration of tenant provisioning operations |
-| `tenant_provisioning_queue_depth` | Gauge | - | Number of tenants in PROVISIONING_PENDING status awaiting provisioning |
-| `tenant_service_provisioning_failures_total` | Counter | service_name | Service-specific provisioning failures |
-| `tenant_provisioning_retries_total` | Counter | - | Provisioning retry attempts across all tenants |
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `PARTY_SERVICE_ENABLED` | No | `true` | Register BIAN party on tenant creation |
+| `K8S_NAMESPACE` | No | `default` | Kubernetes namespace for party service discovery |
 
-**Prometheus Scrape Configuration:**
+### Provisioning Worker
 
-```yaml
-scrape_configs:
-  - job_name: 'tenant-service'
-    kubernetes_sd_configs:
-      - role: endpoints
-    relabel_configs:
-      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
-        action: keep
-        regex: true
-      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_port]
-        action: replace
-        target_label: __address__
-        regex: ([^:]+)(?::\d+)?;(\d+)
-        replacement: $1:$2
-      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
-        action: replace
-        target_label: __metrics_path__
-        regex: (.+)
-```
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `PROVISIONING_WORKER_POLL_INTERVAL` | No | `10s` | Polling interval for `PROVISIONING_PENDING` jobs |
+| `PROVISIONING_MAX_RETRIES` | No | `5` | Maximum retry attempts per provisioning job |
+| `PROVISIONING_RETRY_BASE_DELAY` | No | `2s` | Initial retry backoff delay |
+| `PROVISIONING_RETRY_MAX_DELAY` | No | `30s` | Maximum retry backoff delay |
+| `PROVISIONING_MAX_CONCURRENT` | No | `5` | Maximum concurrent provisioning jobs |
 
-## Key Patterns
+### Alerting
 
-### Tenant ID Validation
-
-Must match: `^[a-zA-Z0-9_]{1,50}$`
-
-Used for:
-
-- PostgreSQL schema routing (`org_{id}`)
-- API subdomain routing
-
-### No Delete Operations
-
-Tenants are managed through status transitions, not deletion:
-
-- Audit compliance (full history preserved)
-- Recoverable: suspended can be reactivated
-- Data integrity: no cascade delete complexities
-
-### Optimistic Locking
-
-Updates check `WHERE version = expected_version`. Returns conflict error on mismatch.
-
-## Kubernetes Deployment
-
-| Setting | Value |
-|---------|-------|
-| Replicas | 2 |
-| CPU | 50m-200m |
-| Memory | 64Mi-256Mi |
-| User | 65532 (non-root) |
-| Filesystem | Read-only |
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `PAGERDUTY_ENABLED` | No | `false` | Enable PagerDuty alerting on provisioning failure |
+| `PAGERDUTY_ROUTING_KEY` | Conditional | - | PagerDuty routing key (required when `PAGERDUTY_ENABLED=true`) |
+| `SLACK_WEBHOOK_URL` | No | - | Slack webhook URL for provisioning failure notifications |
 
 ## References
 
-- [Service Architecture](../README.md)
-- [Proto Definitions](../../api/proto/meridian/tenant/v1/)
-- [ADR-0002: Microservices per BIAN Domain](../../docs/adr/0002-microservices-per-bian-domain.md)
+- [`docs/architecture-layers.md`](../../docs/architecture-layers.md) - Lifecycle Orchestration layer (section 5)
+- [`api/proto/meridian/tenant/v1/tenant.proto`](../../api/proto/meridian/tenant/v1/tenant.proto)


### PR DESCRIPTION
## Summary

- Apply `docs/service-readme-template.md` to all three Lifecycle Orchestration services
- `payment-order` was completed in a prior commit (977e46ab)
- This PR adds `control-plane` and `tenant`
- All three cite Layer: Lifecycle Orchestration matching `docs/architecture-layers.md`

## Test Plan

- [ ] All 3 READMEs include the 8 required template sections in order (Frontmatter, Overview, API Surface, Domain Model, Dependencies, Dependents, Load-Bearing Files, Configuration)
- [ ] Layer row reads "Lifecycle Orchestration" in every Overview table
- [ ] Load-Bearing file paths verified to exist in the service directories
- [ ] Dependents grepped from codebase (controlplanev1, tenantv1, services/tenant imports)
- [ ] markdownlint passes (enforced by pre-commit hook)