### PR TITLE
docs: Backfill Core Ledger service READMEs

### DIFF
--- a/services/current-account/README.md
+++ b/services/current-account/README.md
@@ -1,128 +1,112 @@
 ---
-name: current-account-service
-description: BIAN current account facility with lien-based fund reservations for payment processing
+name: current-account
+description: BIAN Current Account service that manages customer deposit accounts, lien-based fund reservations, and deposit and withdrawal sagas
 triggers:
-  - Creating or modifying current account operations
-  - Implementing fund reservations (liens) for payments
-  - Handling account lifecycle (freeze, close, activate)
-  - Overdraft facility management
-  - Integration with payment order saga patterns
-  - Transaction logging and position keeping
-  - Financial accounting and ledger posting
-  - Account balance queries (delegated to Position Keeping)
+  - Creating or managing customer current accounts
+  - Fund reservation (lien) for in-flight payments
+  - Account lifecycle transitions (freeze, close, activate)
+  - Deposit or withdrawal saga execution
+  - Balance queries for customer accounts (delegated to position-keeping)
+  - Multi-asset account support and valuation features
+  - Payment order lien initiation or execution
 instructions: |
-  CurrentAccount orchestrates customer-facing banking operations with three upstream dependencies:
-  - Party (validate customer exists and is active)
-  - PositionKeeping (balance queries and transaction audit trail)
-  - FinancialAccounting (double-entry ledger posting)
+  current-account manages customer-facing deposit account facilities. It is the
+  customer facade in the Core Ledger layer. All balance data is delegated to
+  position-keeping per ADR-0023 - current-account holds NO balance columns.
 
   Key patterns:
-  - Balance delegation: All balance queries use Position Keeping service (not stored locally)
-  - Lien-based fund reservation for payment processing (ACTIVE → EXECUTED or TERMINATED)
-  - Account lifecycle: ACTIVE → FROZEN → CLOSED (state machine)
-  - Optimistic locking via version field for concurrent updates
+  - Lien lifecycle: ACTIVE -> EXECUTED (ExecuteLien) or TERMINATED (TerminateLien)
+  - Account lifecycle: ACTIVE -> FROZEN -> CLOSED (irreversible close)
+  - Deposit and withdrawal sagas are fetched at runtime from reference-data
+    (defaults/deposit/v1.0.0.star, defaults/withdrawal/v1.0.0.star)
+  - Cross-service clients (party, position-keeping, financial-accounting,
+    internal-account) are wired at the Starlark saga layer via K8S_NAMESPACE
+    service discovery, not at container init time
+  - Idempotency keys on InitiateLien / ExecuteDeposit / ExecuteWithdrawal prevent
+    double-charges on retry
 
-  Balance Query Pattern:
-  ```go
-  // Query all balance types from Position Keeping
-  balances, err := positionKeepingClient.GetAccountBalances(ctx, accountID)
-  // Returns: OPENING, CLOSING, CURRENT, AVAILABLE, LEDGER, RESERVE, FREE
-  ```
+  Port: 50051 (gRPC)
 
-  Port: 50057 (gRPC)
+  current-account has instability I=1.00 - it is the customer-facing orchestration
+  facade. High instability is architecturally correct here.
 ---
 
-# CurrentAccount Service
+# current-account
 
-BIAN-compliant current account facility microservice with lien-based payment reservations.
+BIAN Current Account service - customer-facing account facility in the Core Ledger
+layer. Part of the [Core Ledger layer](../../docs/architecture-layers.md#4-core-ledger).
 
 ## Overview
 
 | Attribute | Value |
 |-----------|-------|
 | **BIAN Domain** | Current Account |
-| **Port** | 50057 (gRPC) |
-| **Language** | Go |
-| **Database** | PostgreSQL/CockroachDB |
-| **Standalone** | No (requires Party, PositionKeeping, FinancialAccounting) |
+| **Layer** | Core Ledger |
+| **Port** | 50051 (gRPC) |
+| **Database** | CockroachDB (`current_account` schema) |
+| **Standalone** | No (requires party, position-keeping, financial-accounting, internal-account via saga layer) |
 
-## gRPC Methods
+## API Surface
 
-### Account Operations
+| Service | RPC | Purpose |
+|---------|-----|---------|
+| `CurrentAccountService` | `InitiateCurrentAccount` | Create a new customer account facility |
+| `CurrentAccountService` | `ListCurrentAccounts` | Paginated list with status, IBAN, and party filters |
+| `CurrentAccountService` | `RetrieveCurrentAccount` | Get account details including delegated balance |
+| `CurrentAccountService` | `UpdateCurrentAccount` | Update overdraft settings or account configuration |
+| `CurrentAccountService` | `ControlCurrentAccount` | FREEZE / UNFREEZE / CLOSE lifecycle action (BIAN CoCR) |
+| `CurrentAccountService` | `ExecuteDeposit` | Execute a deposit saga (position-keeping + financial-accounting) |
+| `CurrentAccountService` | `InitiateWithdrawal` | Create a pending withdrawal for later execution |
+| `CurrentAccountService` | `ExecuteWithdrawal` | Commit a pending or direct withdrawal via saga |
+| `CurrentAccountService` | `UpdateWithdrawal` | Modify a pending withdrawal before execution |
+| `CurrentAccountService` | `RetrieveWithdrawal` | Get withdrawal by ID or list withdrawals by account |
+| `CurrentAccountService` | `InitiateLien` | Reserve funds for a payment order |
+| `CurrentAccountService` | `ExecuteLien` | Convert reservation to actual debit (terminal) |
+| `CurrentAccountService` | `TerminateLien` | Release reservation without execution (terminal) |
+| `CurrentAccountService` | `RetrieveLien` | Get lien details by ID |
+| `CurrentAccountService` | `GetActiveAmountBlocks` | Active liens for position-keeping balance computation |
+| `CurrentAccountService` | `CreateValuationFeature` | Add a valuation method mapping for multi-asset accounts |
+| `CurrentAccountService` | `UpdateValuationFeature` | Lifecycle transitions on a valuation feature |
+| `CurrentAccountService` | `GetValuationFeature` | Retrieve valuation feature by ID or bi-temporal query |
+| `CurrentAccountService` | `ListValuationFeatures` | List valuation features for an account |
+| `CurrentAccountService` | `EvaluateAssetValuation` | Non-binding valuation inquiry (same logic as InitiateLien) |
 
-| Method | HTTP | Purpose |
-|--------|------|---------|
-| `InitiateCurrentAccount` | `POST /v1/current-accounts` | Create new account |
-| `ExecuteDeposit` | `POST /v1/current-accounts/{id}/deposits` | Deposit funds |
-| `RetrieveCurrentAccount` | `GET /v1/current-accounts/{id}` | Get account details |
-
-### Withdrawal Operations
-
-| Method | HTTP | Purpose |
-|--------|------|---------|
-| `InitiateWithdrawal` | `POST /v1/current-accounts/{id}/withdrawals:initiate` | Validate and create pending withdrawal |
-| `ExecuteWithdrawal` | `POST /v1/current-accounts/{id}/withdrawals:execute` | Execute pending or direct withdrawal |
-| `UpdateWithdrawal` | `PATCH /v1/withdrawals/{id}` | Retrieve and validate pending withdrawal |
-| `RetrieveWithdrawal` | `GET /v1/withdrawals/{id}` or `GET /v1/current-accounts/{id}/withdrawals` | Get withdrawal or list by account |
-
-### Lien Operations (Fund Reservation)
-
-| Method | HTTP | Purpose |
-|--------|------|---------|
-| `InitiateLien` | `POST /v1/current-accounts/{id}/liens` | Reserve funds |
-| `ExecuteLien` | `POST /v1/current-account-liens/{id}/execute` | Debit reserved funds |
-| `TerminateLien` | `POST /v1/current-account-liens/{id}/terminate` | Release reservation |
-| `RetrieveLien` | `GET /v1/current-account-liens/{id}` | Get lien details |
-
-## Saga Definitions
-
-Deposit and withdrawal sagas are **NOT** stored locally. They are fetched at runtime from the
-reference-data service via `GetSaga()` RPC.
-
-**Canonical source:** `services/reference-data/saga/defaults/`
-
-- deposit: `defaults/deposit/v1.0.0.star`
-- withdrawal: `defaults/withdrawal/v1.0.0.star`
-
-To modify these sagas, update the files in reference-data service and run
-`PlatformSync.SyncPlatformDefaults()`.
+Proto: [`api/proto/meridian/current_account/v1/current_account.proto`](../../api/proto/meridian/current_account/v1/current_account.proto)
 
 ## Domain Model
 
 ```mermaid
 classDiagram
-    class CurrentAccount {
-        +UUID ID
+    class CurrentAccountFacility {
         +string AccountID
-        +string AccountIdentification
-        +UUID PartyID
-        +AccountStatus Status
-        +Money OverdraftLimit
-        +bool OverdraftEnabled
-        +int64 Version
+        +string ExternalIdentifier
+        +AccountStatus AccountStatus
+        +string InstrumentCode
+        +string ProductTypeCode
+        +string BehaviorClass
+        +string PartyID
+        +string OrgPartyID
+        +int32 Version
+        +time CreatedAt
+        +time UpdatedAt
     }
 
     class Lien {
-        +UUID ID
-        +UUID AccountID
-        +Money Amount
+        +string LienID
+        +string AccountID
+        +MoneyAmount Amount
         +LienStatus Status
         +string PaymentOrderReference
-        +Time ExpiresAt
-        +int Version
-    }
-
-    class AccountStatus {
-        <<enumeration>>
-        ACTIVE
-        FROZEN
-        CLOSED
+        +InstrumentAmount ReservedQuantity
+        +InstrumentAmount ValuedAmount
+        +string BucketID
+        +time ExpiresAt
     }
 
     class Withdrawal {
-        +UUID ID
-        +UUID AccountID
-        +Money Amount
+        +string WithdrawalID
+        +string AccountID
+        +MoneyAmount Amount
         +WithdrawalStatus Status
         +string Reference
         +int Version
@@ -145,511 +129,110 @@ classDiagram
         CANCELLED
     }
 
-    CurrentAccount "1" --> "*" Lien : has
-    CurrentAccount "1" --> "*" Withdrawal : has
-    CurrentAccount --> AccountStatus
+    class AccountStatus {
+        <<enumeration>>
+        ACTIVE
+        FROZEN
+        CLOSED
+    }
+
+    CurrentAccountFacility "1" --> "*" Lien : has
+    CurrentAccountFacility "1" --> "*" Withdrawal : has
+    CurrentAccountFacility --> AccountStatus
     Lien --> LienStatus
     Withdrawal --> WithdrawalStatus
 ```
 
-**Field Notes:**
+Balance is not stored on `CurrentAccountFacility`; it is computed by `position-keeping`
+per ADR-0023. `GetActiveAmountBlocks` exposes active liens so `position-keeping` can
+subtract in-flight reservations from the available balance. Lien lifecycle is
+ACTIVE -> EXECUTED (funds debited) or TERMINATED (reservation released); both are
+terminal. Withdrawal lifecycle is PENDING -> COMPLETED / FAILED / CANCELLED.
 
-- `AccountID`: Business ID format `ACC-{uuid[:8]}`
-- `AccountIdentification`: IBAN format
-- `PaymentOrderReference`: Idempotency key for payment orders
-- **Balance fields removed**: Balance is computed by Position Keeping service (see
-  [Balance Query Delegation](#balance-query-delegation))
+## Dependencies
 
-## Lien Lifecycle
+| Service | Protocol | Purpose |
+|---------|----------|---------|
+| `reference-data` | gRPC | Instrument lookup at account creation; saga definition retrieval (deposit/withdrawal Starlark scripts) |
+| `position-keeping` | gRPC | Balance computation delegation per ADR-0023 (saga layer) |
+| `financial-accounting` | gRPC | Double-entry ledger posting for deposits and withdrawals (saga layer) |
+| `internal-account` | gRPC | Internal account resolution for payment routing (saga layer) |
+| `party` | gRPC | Party validation at account creation (saga layer) |
+| Redis | TCP | Idempotency store for deposit and withdrawal operations (required in production) |
+| Kafka | TCP | Account lifecycle event publishing via transactional outbox (optional; enables outbox worker when set) |
 
-```mermaid
-stateDiagram-v2
-    ACTIVE : ACTIVE (reservation)
-    EXECUTED : EXECUTED (funds debited)
-    TERMINATED : TERMINATED (released)
+## Dependents
 
-    ACTIVE --> EXECUTED : Execute lien
-    ACTIVE --> TERMINATED : Cancel/timeout
-```
+| Service | Entry Point | Purpose |
+|---------|-------------|---------|
+| `payment-order` | `service/payment_orchestrator_lien.go`, `service/saga_handler_lien.go` | Lien initiation, execution, and termination during payment settlement |
+| `position-keeping` | `service/account_validator.go`, `app/container.go` | Account validation for balance queries; active amount block (lien) reads |
+| `reconciliation` | `app/container.go`, `service/account_party_resolver.go` | Account and party resolution for reconciliation workflows |
 
-- **ACTIVE**: Funds reserved, reduces AvailableBalance
-- **EXECUTED**: Terminal state, funds withdrawn from Balance
-- **TERMINATED**: Terminal state, AvailableBalance restored
+## Load-Bearing Files
 
-## Withdrawal Operations
-
-The service supports a two-phase withdrawal pattern as well as direct withdrawals.
-
-### InitiateWithdrawal
-
-Creates a pending withdrawal in PENDING status. Validates the account is active, currency
-matches, and amount is positive. Warns (but does not reject) if the requested amount exceeds
-the current available balance, since balance may change before execution.
-
-A `reference` can be provided for idempotency. If omitted, one is auto-generated in the
-format `WTH-{uuid[:8]}`.
-
-### ExecuteWithdrawal
-
-Supports two modes:
-
-**1. Execute pending withdrawal** -- provide `withdrawal_id`:
-
-Looks up a previously initiated withdrawal, verifies it is in PENDING status, and executes
-the withdrawal saga. On success, the withdrawal transitions to COMPLETED via the transactional
-outbox pattern (atomically updating status and publishing a `WithdrawalStatusUpdated` event).
-
-**2. Direct withdrawal** -- provide `account_id` and `amount`:
-
-Executes a withdrawal immediately without prior initiation. Requires both fields.
-
-Both modes:
-
-- Validate the account is ACTIVE (rejects FROZEN or CLOSED)
-- Validate currency matches the account currency
-- Check sufficient funds via `PrepareForDebit` (considers overdraft if enabled)
-- Execute the withdrawal saga (Position Keeping DEBIT, Financial Accounting double-entry,
-  account metadata save)
-- Support Redis-based idempotency via `idempotency_key`
-
-### UpdateWithdrawal
-
-Retrieves a pending withdrawal and performs validation. Field updates (amount, description,
-reference) are not yet supported -- the domain model treats these as immutable after creation.
-If update fields are provided, the response includes warning messages indicating the fields
-were not modified.
-
-Only withdrawals in PENDING status can be queried via this method. Attempting to update
-a non-pending withdrawal returns `FailedPrecondition`.
-
-### RetrieveWithdrawal
-
-Supports two query modes:
-
-**1. Single lookup** -- provide `withdrawal_id`:
-
-Returns the withdrawal matching the given ID. Internally, `withdrawal_id` maps to the
-withdrawal's `reference` field for lookup.
-
-**2. List by account** -- provide `account_id`:
-
-Returns a paginated list of withdrawals for the account (default page size: 50). Uses
-offset-based pagination via `page_token` (the token is the numeric offset). Results are
-ordered by `created_at DESC`.
-
-At least one of `withdrawal_id` or `account_id` is required.
-
-### Withdrawal Lifecycle
-
-```mermaid
-stateDiagram-v2
-    PENDING : PENDING (initiated)
-    COMPLETED : COMPLETED (executed)
-    FAILED : FAILED (error)
-    CANCELLED : CANCELLED (aborted)
-
-    PENDING --> COMPLETED : ExecuteWithdrawal succeeds
-    PENDING --> FAILED : ExecuteWithdrawal fails
-    PENDING --> CANCELLED : Cancellation
-```
-
-- **PENDING**: Withdrawal initiated, awaiting execution
-- **COMPLETED**: Terminal state, funds withdrawn via saga
-- **FAILED**: Terminal state, saga or validation failure
-- **CANCELLED**: Terminal state, withdrawal aborted before execution
-
-All terminal transitions are idempotent (calling `Complete()` on an already-completed
-withdrawal is a no-op).
-
-### Withdrawal Saga
-
-The withdrawal saga executes three steps sequentially via Starlark:
-
-1. **log_position**: DEBIT entry in Position Keeping (source of truth for balance)
-2. **post_ledger**: Booking log and dual ledger postings in Financial Accounting
-   (customer account DEBIT, clearing account CREDIT)
-3. **save_account**: Persist account metadata (status, version)
-
-Compensation runs in LIFO order on failure. The saga definition is fetched at runtime from
-the reference-data service (`defaults/withdrawal/v1.0.0.star`).
-
-### Withdrawal Events
-
-When a pending withdrawal is executed successfully, a `WithdrawalStatusUpdated` event is
-published via the transactional outbox pattern:
-
-| Event | Kafka Topic | Trigger |
-|-------|-------------|---------|
-| WithdrawalStatusUpdated | `current-account.withdrawal.status` | Pending withdrawal executed |
-
-The outbox write happens atomically with the withdrawal status update in a single database
-transaction, providing at-least-once delivery guarantees. If the outbox write fails, the
-service falls back to a direct status update without event publication.
-
-## Service Dependencies
-
-| Service | Port | Purpose |
-|---------|------|---------|
-| Party | 50055 | Validate party exists and is active |
-| PositionKeeping | 50053 | Transaction audit trail logging |
-| FinancialAccounting | 50052 | Double-entry ledger posting |
-
-All clients use circuit breaker with exponential backoff retry (3 retries).
-
-## Database Schema
-
-**Schema**: `current_account`
-
-```mermaid
-erDiagram
-    accounts {
-        uuid id PK
-        varchar(100) account_id UK "ACC-xxxxxxxx"
-        varchar(34) account_identification UK "IBAN"
-        uuid party_id FK
-        varchar(20) status "ACTIVE, FROZEN, CLOSED"
-        bigint overdraft_limit "cents"
-        bigint version "optimistic lock"
-    }
-
-    liens {
-        uuid id PK
-        uuid account_id FK
-        bigint amount_cents
-        varchar(20) status "ACTIVE, EXECUTED, TERMINATED"
-        varchar(255) payment_order_reference UK "idempotency key"
-        timestamptz expires_at "nullable"
-    }
-
-    withdrawal {
-        uuid id PK
-        uuid account_id FK
-        bigint amount_cents "positive (CHECK)"
-        varchar(3) currency
-        varchar(20) status "PENDING, COMPLETED, FAILED, CANCELLED"
-        varchar(255) reference UK "idempotency key"
-        bigint version "optimistic lock, default 1"
-        timestamptz created_at
-        timestamptz updated_at
-    }
-
-    accounts ||--o{ liens : "has"
-    accounts ||--o{ withdrawal : "has"
-```
-
-> **Note:** Balance columns (`balance`, `available_balance`, `balance_updated_at`) were removed
-> in migration `20260108000001_remove_balance_columns.sql`. Balance is now computed by Position
-> Keeping service.
-
-The `withdrawal` table was added in migration `20251231000002_create_withdrawal_table.sql`.
-Key design decisions:
-
-- **Optimistic locking**: `version` column incremented on each update, prevents concurrent
-  modification
-- **Idempotency**: `reference` column has a unique index, preventing duplicate withdrawals
-  with the same reference
-- **Tenant isolation**: Uses schema-per-tenant pattern (table exists within the tenant's
-  database schema)
-- **Indexes**: Composite `(account_id, status)` for filtered queries, `created_at DESC` for
-  time-ordered listing, unique `reference` for idempotency lookups
+| File | Why It Matters |
+|------|----------------|
+| `cmd/main.go` | Process wiring; initialises container, gRPC server, and outbox worker |
+| `app/container.go` | Dependency injection; wires DB, Redis, Kafka; cross-service clients explicitly delegated to saga layer |
+| `service/grpc_account_endpoints.go` | Account CRUD and lifecycle RPC handlers; account status state machine |
+| `service/grpc_control_endpoints.go` | ControlCurrentAccount (FREEZE / UNFREEZE / CLOSE) with outbox-backed event publishing |
+| `service/lien_lifecycle.go` | Lien state machine; ACTIVE -> EXECUTED / TERMINATED transitions with optimistic locking |
+| `service/lien_service.go` | Lien reservation service; idempotency via PaymentOrderReference unique constraint |
+| `service/grpc_withdrawal_execute.go` | ExecuteWithdrawal RPC handler; two-phase and direct withdrawal modes |
+| `service/grpc_withdrawal_manage.go` | InitiateWithdrawal / UpdateWithdrawal / RetrieveWithdrawal RPC handlers |
+| `service/saga_handler_financial_accounting.go` | Deposit and withdrawal saga; Starlark execution with LIFO compensation |
+| `domain/account.go` | CurrentAccountFacility entity; overdraft rules and account status invariants |
+| `domain/lien.go` | Lien entity; immutability rules after terminal transition |
+| `domain/withdrawal.go` | Withdrawal entity; PENDING -> COMPLETED / FAILED / CANCELLED state machine |
+| `config/accounts.go` | Clearing account configuration; enables double-entry when DEPOSIT_CLEARING_ACCOUNT_ID is set |
 
 ## Configuration
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `GRPC_PORT` | 50057 | gRPC server port |
-| `DATABASE_URL` | - | PostgreSQL connection string |
-| `K8S_NAMESPACE` | default | Kubernetes namespace for service discovery |
-| `DB_MAX_OPEN_CONNS` | 25 | Connection pool size |
-
-## Key Patterns
-
-### Retry Idempotency
-
-**Safe to Retry (Idempotent):**
-
-| Method | Idempotency Key | Behavior |
-|--------|-----------------|----------|
-| `InitiateLien` | `PaymentOrderReference` | Returns existing lien if key matches |
-| `ExecuteLien` | Lien ID (path param) | No-op if already EXECUTED |
-| `TerminateLien` | Lien ID (path param) | No-op if already TERMINATED |
-| `ExecuteDeposit` | `IdempotencyKey` header | Returns existing result if key matches |
-| `InitiateWithdrawal` | `reference` field | Returns existing withdrawal if reference matches |
-| `ExecuteWithdrawal` | `idempotency_key` field | Returns cached result from Redis if key matches |
-
-**Retry Guidance:**
-
-- Always include `idempotency_key` for `ExecuteDeposit` to prevent duplicate credits
-- Always include `idempotency_key` for `ExecuteWithdrawal` to prevent duplicate debits
-- `InitiateWithdrawal` uses `reference` as natural idempotency key (unique constraint in DB)
-- `InitiateLien` uses `PaymentOrderReference` as natural idempotency key (unique per payment)
-- Terminal state transitions (EXECUTED, TERMINATED) are no-ops on retry
-- Use exponential backoff: 100ms → 200ms → 400ms (max 3 retries)
-
-**Non-Idempotent Operations:**
-
-- `InitiateCurrentAccount`: Creating duplicate accounts requires unique party/IBAN
-
-### Balance Query Delegation
-
-Balance is computed by Position Keeping service, not stored locally. Current Account queries
-Position Keeping for all balance operations.
-
-**Balance Types (BIAN-compliant):**
-
-| Type | Description |
-|------|-------------|
-| `OPENING` | Balance at start of accounting period |
-| `CLOSING` | Balance at end of accounting period |
-| `CURRENT` | Real-time balance including all posted transactions |
-| `AVAILABLE` | Balance available for withdrawal (considers holds/liens) |
-| `LEDGER` | Balance on the books (may differ from current due to holds) |
-| `RESERVE` | Amount held in reserve (not available for use) |
-| `FREE` | Unencumbered balance (current minus holds and reserves) |
-
-**Query Pattern:**
-
-```go
-import pk "meridian/position_keeping/v1"
-
-// Query single balance type
-resp, err := pkClient.GetAccountBalance(ctx, &pk.GetAccountBalanceRequest{
-    AccountId:   accountID,
-    BalanceType: pk.BALANCE_TYPE_AVAILABLE,
-})
-
-// Query all balance types
-resp, err := pkClient.GetAccountBalances(ctx, &pk.GetAccountBalancesRequest{
-    AccountId: accountID,
-})
-for _, balance := range resp.Balances {
-    log.Printf("%s: %v", balance.BalanceType, balance.Amount)
-}
-```
-
-**Sequence Diagram:**
-
-```mermaid
-sequenceDiagram
-    participant Client
-    participant CA as CurrentAccount
-    participant PK as PositionKeeping
-
-    Client->>CA: RetrieveCurrentAccount(accountID)
-    CA->>PK: GetAccountBalances(accountID)
-    PK-->>CA: BalanceEntry[] (7 types)
-    CA-->>Client: CurrentAccountFacility with balances
-```
-
-### Overdraft Facility
-
-Overdraft configuration is stored in Current Account. When calculating available balance,
-Position Keeping considers the overdraft limit.
-
-```text
-AvailableBalance = CurrentBalance + (OverdraftEnabled ? OverdraftLimit : 0) - ActiveLiens
-```
-
-Allows withdrawals beyond zero balance up to the configured limit.
-
-### Payment Order Saga Integration
-
-1. `InitiateLien` - Reserve funds (updates AvailableBalance)
-2. External payment processing
-3. `ExecuteLien` (success) or `TerminateLien` (failure/cancellation)
-
-### Optimistic Locking
-
-All mutations check `WHERE version = expected_version`. Returns conflict error on mismatch.
-
-## Account Lifecycle Events
-
-The service publishes events to Kafka for account lifecycle state transitions.
-Events use fire-and-forget semantics - publishing failures are logged but do not fail
-the business operation.
-
-### Event Topics
-
-| Event | Kafka Topic | Trigger |
-|-------|-------------|---------|
-| AccountFrozen | `current-account.account-frozen.v1` | Account transitions to FROZEN status |
-| AccountUnfrozen | `current-account.account-unfrozen.v1` | Account transitions from FROZEN to ACTIVE |
-| AccountClosed | `current-account.account-closed.v1` | Account transitions to CLOSED status |
-
-### Event Schemas
-
-Events are serialized as Protocol Buffers.
-See `api/proto/meridian/events/v1/current_account_events.proto` for full schema definitions.
-
-**AccountFrozenEvent:**
-
-```json
-{
-  "event_id": "uuid",
-  "account_id": "ACC-xxxxxxxx",
-  "reason": "Suspicious activity detected",
-  "frozen_at": "2024-01-15T10:30:00Z",
-  "frozen_by": "compliance-officer",
-  "correlation_id": "uuid",
-  "causation_id": "uuid",
-  "timestamp": "2024-01-15T10:30:00Z",
-  "version": 5,
-  "metadata": {}
-}
-```
-
-**AccountUnfrozenEvent:**
-
-```json
-{
-  "event_id": "uuid",
-  "account_id": "ACC-xxxxxxxx",
-  "unfrozen_at": "2024-01-16T14:00:00Z",
-  "unfrozen_by": "compliance-officer",
-  "correlation_id": "uuid",
-  "causation_id": "uuid",
-  "timestamp": "2024-01-16T14:00:00Z",
-  "version": 6,
-  "metadata": {}
-}
-```
-
-**AccountClosedEvent:**
-
-```json
-{
-  "event_id": "uuid",
-  "account_id": "ACC-xxxxxxxx",
-  "closing_balance": {"units": 0, "nanos": 0, "currency_code": "GBP"},
-  "closure_reason": "Customer requested closure",
-  "closed_by": "customer-service",
-  "closure_date": "2024-01-20T09:00:00Z",
-  "correlation_id": "uuid",
-  "causation_id": "uuid",
-  "timestamp": "2024-01-20T09:00:00Z",
-  "version": 7,
-  "metadata": {}
-}
-```
-
-### Event Publishing Guarantees
-
-- **Fire-and-forget**: Event publishing errors do not fail the business operation
-- **At-most-once delivery**: Events may be lost if Kafka is unavailable
-- **Idempotent consumers**: Consumers should handle duplicate events gracefully using `event_id`
-- **Ordering**: Events are keyed by `account_id` for partition-level ordering
-
-## Webhook Notifications
-
-For regulatory compliance, account freeze and closure events trigger webhook notifications to tenant-configured HTTP endpoints.
-
-### Supported Events
-
-| Event Type | Trigger | Use Case |
-|------------|---------|----------|
-| `account.frozen` | Account frozen | Compliance reporting, customer notification |
-| `account.closed` | Account closed | Regulatory reporting, audit trail |
-
-### Webhook Configuration
-
-Webhooks are configured per-tenant in the Tenant service. The webhook URL is retrieved via gRPC call to the Tenant service.
-
-| Environment Variable | Default | Description |
-|---------------------|---------|-------------|
-| `WEBHOOK_REQUEST_TIMEOUT` | `5s` | HTTP request timeout per attempt |
-| `WEBHOOK_MAX_RETRIES` | `3` | Maximum retry attempts |
-
-### Retry Policy
-
-Webhooks use exponential backoff with the following default delays:
-
-| Attempt | Delay |
-|---------|-------|
-| 1st retry | 1 second |
-| 2nd retry | 2 seconds |
-| 3rd retry | 4 seconds |
-
-After all retries are exhausted, the delivery is marked as failed in the audit table.
-
-### Webhook Payload Format
-
-```json
-{
-  "event_id": "550e8400-e29b-41d4-a716-446655440000",
-  "event_type": "account.frozen",
-  "timestamp": "2024-01-15T10:30:00Z",
-  "account_id": "ACC-12345678",
-  "tenant_id": "tenant-001",
-  "reason": "Suspicious activity detected",
-  "final_balance": {
-    "amount": 150000,
-    "currency_code": "GBP"
-  }
-}
-```
-
-**Field Notes:**
-
-- `final_balance` is only included for `account.closed` events
-- `amount` is in minor units (e.g., pence for GBP, cents for USD)
-- `reason` is optional and included when provided in the control action request
-
-### Webhook Delivery Audit
-
-All webhook delivery attempts are recorded in the `webhook_deliveries` table for audit trail:
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | UUID | Delivery record ID |
-| `event_id` | VARCHAR | Event ID that triggered delivery |
-| `event_type` | VARCHAR | Event type (account.frozen, account.closed) |
-| `tenant_id` | VARCHAR | Tenant that owns the account |
-| `account_id` | VARCHAR | Affected account ID |
-| `webhook_url` | VARCHAR | Target webhook URL |
-| `status` | VARCHAR | pending, success, or failed |
-| `attempts` | INT | Number of delivery attempts |
-| `last_attempt_at` | BIGINT | Unix timestamp of last attempt |
-| `last_error` | VARCHAR | Error message from last failure |
-| `response_code` | INT | HTTP status code from last attempt |
-| `created_at` | BIGINT | Unix timestamp when queued |
-| `completed_at` | BIGINT | Unix timestamp when completed/failed |
-
-### Webhook Security
-
-- Webhooks are sent via HTTPS (HTTP URLs in configuration are rejected)
-- `User-Agent: Meridian-Webhook/1.0` header is included
-- `Content-Type: application/json` header is set
-- Tenants should validate the `tenant_id` matches their expected value
-
-## Instrument Resolution (Account Creation)
-
-Account creation resolves instrument properties (dimension, precision) from Reference Data
-at the gRPC layer. The domain trusts caller-provided instrument properties. Downstream
-operations (deposits, withdrawals, balance queries) use the instrument properties stored
-at account creation time.
-
-**Resolution flow:**
-
-1. `InitiateCurrentAccount` receives `instrument_code` (e.g., `"GBP"`, `"KWH"`)
-2. gRPC layer calls `instrumentGetter.GetInstrument(ctx, code, version)` to resolve dimension and precision
-3. Domain constructor `NewCurrentAccountWithDimension()` uses `quantity.NewInstrument()` directly (no local registry lookup)
-4. If Reference Data is unavailable, account creation fails closed (`codes.FailedPrecondition`)
-
-**Error handling for instrument lookup:**
-
-| Error | gRPC Code | Behavior |
-|-------|-----------|----------|
-| Instrument not found | `InvalidArgument` | Unknown instrument code |
-| Context canceled | `Canceled` | Client canceled the request |
-| Context deadline exceeded | `DeadlineExceeded` | Lookup timed out |
-| Reference Data unavailable | `FailedPrecondition` | Service not configured |
-| Other errors | `Unavailable` | Transient failure, client should retry |
-
-See [ADR-0035: Multi-Asset Purity](../../docs/adr/0035-multi-asset-purity.md) for the architectural decision.
+### Core
+
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `DATABASE_URL` | Yes | - | CockroachDB connection string |
+| `GRPC_PORT` | No | `50051` | gRPC listen port |
+| `LOG_LEVEL` | No | `info` | Structured log level (`debug`, `info`, `warn`, `error`) |
+| `ENVIRONMENT` | No | - | Deployment environment; `production` makes Redis required |
+| `K8S_NAMESPACE` | No | `default` | Kubernetes namespace for saga-layer service DNS discovery |
+
+### Authentication
+
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `AUTH_ENABLED` | No | `true` | Enable JWT bearer authentication on all gRPC calls |
+| `AUTH_JWKS_URL` | No | - | JWKS endpoint URL; required when `AUTH_ENABLED=true` |
+
+### Messaging
+
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `KAFKA_BOOTSTRAP_SERVERS` | No | - | Kafka broker list; enables outbox worker and account lifecycle events when set |
+
+### Idempotency Store (Redis)
+
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `REDIS_URL` | No* | `redis://localhost:6379` | Redis connection URL; *required in production (`ENVIRONMENT=production`) |
+| `REDIS_PASSWORD` | No | - | Redis authentication password |
+| `REDIS_DB` | No | `0` | Redis database index |
+
+### Clearing Accounts
+
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `DEPOSIT_CLEARING_ACCOUNT_ID` | No | - | Clearing account for deposit double-entry; omit to operate in single-entry mode |
+| `WITHDRAWAL_CLEARING_ACCOUNT_ID` | No | - | Clearing account for withdrawal double-entry |
+| `NOSTRO_ACCOUNT_ID` | No | - | Nostro account for cross-currency settlement |
 
 ## References
 
-- [BIAN Current Account Specification](https://github.com/bian-official/public/blob/main/release14.0.0/semantic-apis/oas3%20/yamls/CurrentAccount.yaml)
-- [Service Architecture](../README.md)
-- [Proto Definitions](../../api/proto/meridian/current_account/v1/)
-- [Event Proto Definitions](../../api/proto/meridian/events/v1/current_account_events.proto)
+- [ADR-0023: Balance Delegation to Position Keeping](../../docs/adr/0023-balance-delegation-to-position-keeping.md)
+- [ADR-0035: Multi-Asset Purity](../../docs/adr/0035-multi-asset-purity.md)
+- [Architecture Layers - Core Ledger](../../docs/architecture-layers.md#4-core-ledger)
+- [Service Coupling Analysis](../../docs/architecture/service-coupling-analysis.md)
+- [BIAN Current Account specification](https://github.com/bian-official/public/blob/main/release14.0.0/semantic-apis/oas3%20/yamls/CurrentAccount.yaml)
+

--- a/services/financial-accounting/README.md
+++ b/services/financial-accounting/README.md
@@ -118,11 +118,14 @@ equals the sum of all `CREDIT` postings (double-entry invariant enforced at serv
 `PostingAmount` uses `InstrumentAmount` for multi-asset support: currencies, energy (kWh),
 carbon credits, and compute hours are all valid posting units.
 
-`POSTED`, `CANCELLED`, and `REVERSED` are terminal states - the domain's `IsFinal()` method
-returns true for all three and the control actions block further transitions. `FAILED` is a
-suspended state used by the `SUSPEND` control action; it is resumable via `RESUME` and is NOT
-a true terminal state. `REVERSED` is reserved for future offsetting-entry support and is not
-yet produceable via `ControlFinancialBookingLog`.
+`POSTED`, `CANCELLED`, and `REVERSED` are behaviorally terminal: control actions block
+further transitions on them. `FAILED` is the suspended state produced by the `SUSPEND` control
+action and is resumable via `RESUME` (FAILED -> PENDING); it is not a true terminal from a
+user-workflow perspective. Note: `TransactionStatus.IsFinal()` returns true for FAILED as well
+(to prevent double-SUSPEND), while `FinancialBookingLog.IsTerminal()` returns true for
+POSTED/FAILED/CANCELLED - the distinction is a code-level guard, not a state-machine
+boundary. `REVERSED` is reserved for future offsetting-entry support and is not yet
+produceable via `ControlFinancialBookingLog`.
 
 ## Dependencies
 

--- a/services/financial-accounting/README.md
+++ b/services/financial-accounting/README.md
@@ -17,7 +17,12 @@ instructions: |
   Key invariants:
   - Posting amounts are always positive; direction (DEBIT/CREDIT) carries sign
   - Cross-instrument postings within a single booking log are rejected
-  - POSTED and CANCELLED are terminal states; no further mutations allowed
+  - POSTED, CANCELLED, and REVERSED are terminal states (IsFinal() = true);
+    no further control actions or mutations are allowed on these logs
+  - FAILED is used as a suspended (resumable) state by ControlLog SUSPEND;
+    it is NOT a final terminal state - RESUME returns it to PENDING
+  - REVERSED exists in the domain for offsetting-entry support; it is not
+    yet produceable via the ControlFinancialBookingLog CoCR actions
   - All mutations require an idempotency_key for exactly-once guarantees
 
   Port: 50052 (gRPC), 8082 (metrics)
@@ -113,6 +118,12 @@ equals the sum of all `CREDIT` postings (double-entry invariant enforced at serv
 `PostingAmount` uses `InstrumentAmount` for multi-asset support: currencies, energy (kWh),
 carbon credits, and compute hours are all valid posting units.
 
+`POSTED`, `CANCELLED`, and `REVERSED` are terminal states - the domain's `IsFinal()` method
+returns true for all three and the control actions block further transitions. `FAILED` is a
+suspended state used by the `SUSPEND` control action; it is resumable via `RESUME` and is NOT
+a true terminal state. `REVERSED` is reserved for future offsetting-entry support and is not
+yet produceable via `ControlFinancialBookingLog`.
+
 ## Dependencies
 
 | Service | Protocol | Purpose |
@@ -150,10 +161,11 @@ carbon credits, and compute hours are all valid posting units.
 | Variable | Required | Default | Purpose |
 |----------|----------|---------|---------|
 | `DATABASE_URL` | Yes | - | CockroachDB connection string |
+| `BANK_CASH_ACCOUNT_ID` | Yes | - | Bank cash account ID for the clearing side of double-entry; service fails to start without it |
 | `GRPC_PORT` | No | `50052` | gRPC listen port |
 | `METRICS_PORT` | No | `8082` | Prometheus metrics listen port |
 | `LOG_LEVEL` | No | `info` | Structured log level (`debug`, `info`, `warn`, `error`) |
-| `BANK_CASH_ACCOUNT_ID` | No | - | Well-known bank cash account ID for clearing side of double-entry |
+| `ENVIRONMENT` | No | - | Deployment environment; `production` makes Kafka and Redis required |
 | `REFERENCE_DATA_SERVICE_URL` | No | - | reference-data gRPC address; enables instrument validation when set |
 
 ### Authentication
@@ -174,7 +186,7 @@ carbon credits, and compute hours are all valid posting units.
 
 | Variable | Required | Default | Purpose |
 |----------|----------|---------|---------|
-| `REDIS_URL` | No | `redis://localhost:6379` | Redis connection URL for idempotency store |
+| `REDIS_URL` | No* | `redis://localhost:6379` | Redis connection URL for idempotency store; *required in production (`ENVIRONMENT=production`) |
 | `REDIS_PASSWORD` | No | - | Redis authentication password |
 | `REDIS_DB` | No | `0` | Redis database index |
 | `IDEMPOTENCY_CLEANUP_ENABLED` | No | `true` | Enable background cleanup of stale idempotency keys |

--- a/services/financial-accounting/README.md
+++ b/services/financial-accounting/README.md
@@ -1,91 +1,92 @@
 ---
-name: financial-accounting-service
-description: BIAN-compliant double-entry bookkeeping and general ledger service
+name: financial-accounting
+description: BIAN-compliant double-entry general ledger service that owns booking logs and ledger postings for all asset classes
 triggers:
-  - Financial accounting operations
-  - Double-entry bookkeeping patterns
-  - Ledger posting validation
-  - Booking log lifecycle management
-  - Money and currency handling
-  - Idempotent gRPC operations
-  - Kafka event consumption (deposits)
+  - Double-entry bookkeeping for deposits, withdrawals, or payment settlement
+  - Ledger posting validation or booking log lifecycle management
+  - Multi-asset posting (currency, energy, carbon, compute)
+  - Understanding the accounting nucleus of the Core Ledger layer
+  - Idempotent ledger operations and exactly-once posting guarantees
+  - CaptureLedgerPosting or InitiateFinancialBookingLog usage
 instructions: |
-  FinancialAccounting implements double-entry bookkeeping where debits always equal credits.
+  financial-accounting implements BIAN Financial Accounting. Every financial
+  operation results in a FinancialBookingLog (the BIAN control record) plus one
+  or more LedgerPostings (the individual debit/credit lines). Debits must equal
+  credits within a booking log before it can transition to POSTED.
 
-  Key concepts:
-  - BookingLog: BIAN control record aggregating related postings
-  - LedgerPosting: Individual debit/credit line item
-  - PostingDirection: DEBIT (asset/expense increase) or CREDIT (liability/income increase)
-
-  Core operation (ProcessDeposit) - from bank's general ledger perspective:
-    Debit Entry:  Cash/Reserves (bank's asset ↑)
-    Credit Entry: Customer Deposit Account (bank's liability ↑)
-    Balance Check: Debits = Credits
+  Key invariants:
+  - Posting amounts are always positive; direction (DEBIT/CREDIT) carries sign
+  - Cross-instrument postings within a single booking log are rejected
+  - POSTED and CANCELLED are terminal states; no further mutations allowed
+  - All mutations require an idempotency_key for exactly-once guarantees
 
   Port: 50052 (gRPC), 8082 (metrics)
+
+  financial-accounting has instability I=0.00 per the coupling analysis - it is
+  the most stable Core Ledger service. Treat its proto contract as load-bearing;
+  breaking changes require an ADR.
 ---
 
-# FinancialAccounting Service
+# financial-accounting
 
-BIAN-compliant financial accounting microservice for double-entry bookkeeping.
+BIAN Financial Accounting service - the general ledger nucleus of the Core Ledger
+layer. Part of the [Core Ledger layer](../../docs/architecture-layers.md#4-core-ledger).
 
 ## Overview
 
 | Attribute | Value |
 |-----------|-------|
-| **BIAN Domain** | Financial Standard Management |
+| **BIAN Domain** | Financial Accounting |
+| **Layer** | Core Ledger |
 | **Port** | 50052 (gRPC), 8082 (metrics) |
-| **Language** | Go |
-| **Database** | PostgreSQL/CockroachDB |
-| **Standalone** | Yes |
+| **Database** | CockroachDB (`financial_accounting` schema) |
+| **Standalone** | Yes (no required Meridian service dependencies at startup) |
 
-## gRPC Methods
+## API Surface
 
-### Booking Log Operations
+| Service | RPC | Purpose |
+|---------|-----|---------|
+| `FinancialAccountingService` | `InitiateFinancialBookingLog` | Create a new booking log (BIAN control record) |
+| `FinancialAccountingService` | `UpdateFinancialBookingLog` | Update booking log status or chart-of-accounts rules |
+| `FinancialAccountingService` | `RetrieveFinancialBookingLog` | Get booking log with all associated postings |
+| `FinancialAccountingService` | `ListFinancialBookingLogs` | Paginated list with status and business-unit filters |
+| `FinancialAccountingService` | `CaptureLedgerPosting` | Create a single debit or credit posting |
+| `FinancialAccountingService` | `UpdateLedgerPosting` | Update posting status or result field |
+| `FinancialAccountingService` | `RetrieveLedgerPosting` | Get a posting by ID |
+| `FinancialAccountingService` | `ListLedgerPostings` | Paginated list with account, direction, date, and instrument filters |
+| `FinancialAccountingService` | `ControlFinancialBookingLog` | SUSPEND / RESUME / TERMINATE lifecycle action (BIAN CoCR) |
 
-| Method | HTTP | Purpose |
-|--------|------|---------|
-| `InitiateFinancialBookingLog` | `POST /v1/booking-logs` | Create booking log |
-| `UpdateFinancialBookingLog` | `PUT /v1/booking-logs/{id}` | Update status/rules |
-| `RetrieveFinancialBookingLog` | `GET /v1/booking-logs/{id}` | Get with postings |
-| `ListFinancialBookingLogs` | `GET /v1/booking-logs` | List with filters |
-
-### Ledger Posting Operations
-
-| Method | HTTP | Purpose |
-|--------|------|---------|
-| `CaptureLedgerPosting` | `POST /v1/booking-logs/{id}/postings` | Create posting |
-| `UpdateLedgerPosting` | `PUT /v1/postings/{id}` | Update status |
-| `RetrieveLedgerPosting` | `GET /v1/postings/{id}` | Get posting |
-| `ListLedgerPostings` | `GET /v1/postings` | List with filters |
+Proto: [`api/proto/meridian/financial_accounting/v1/financial_accounting.proto`](../../api/proto/meridian/financial_accounting/v1/financial_accounting.proto)
 
 ## Domain Model
 
 ```mermaid
 classDiagram
     class FinancialBookingLog {
-        +UUID ID
+        +string ID
         +string FinancialAccountType
         +string ProductServiceReference
         +string BusinessUnitReference
         +string ChartOfAccountsRules
-        +string BaseCurrency
-        +BookingLogStatus Status
-        +int64 Version
+        +string BaseInstrumentCode
+        +TransactionStatus Status
+        +time CreatedAt
+        +time UpdatedAt
     }
 
     class LedgerPosting {
-        +UUID ID
-        +UUID FinancialBookingLogID
+        +string ID
+        +string FinancialBookingLogID
         +PostingDirection Direction
-        +Money Amount
+        +InstrumentAmount PostingAmount
         +string AccountID
-        +Time ValueDate
-        +PostingStatus Status
-        +string CorrelationID
+        +AccountServiceDomain AccountServiceDomain
+        +time ValueDate
+        +string PostingResult
+        +TransactionStatus Status
     }
 
-    class BookingLogStatus {
+    class TransactionStatus {
         <<enumeration>>
         PENDING
         POSTED
@@ -100,129 +101,91 @@ classDiagram
         CREDIT
     }
 
-    class PostingStatus {
-        <<enumeration>>
-        PENDING
-        POSTED
-        FAILED
-    }
-
     FinancialBookingLog "1" --> "*" LedgerPosting : contains
-    FinancialBookingLog --> BookingLogStatus
+    FinancialBookingLog --> TransactionStatus
     LedgerPosting --> PostingDirection
-    LedgerPosting --> PostingStatus
+    LedgerPosting --> TransactionStatus
 ```
 
-**Field Notes:**
+Every financial transaction creates at least one debit and one credit posting.
+The booking log transitions to `POSTED` only when the sum of all `DEBIT` postings
+equals the sum of all `CREDIT` postings (double-entry invariant enforced at service layer).
+`PostingAmount` uses `InstrumentAmount` for multi-asset support: currencies, energy (kWh),
+carbon credits, and compute hours are all valid posting units.
 
-- `BaseCurrency`: ISO 4217 currency code (GBP, USD, EUR, etc.)
-- `CorrelationID`: Trace ID for distributed tracing
+## Dependencies
 
-## Double-Entry Bookkeeping
+| Service | Protocol | Purpose |
+|---------|----------|---------|
+| `reference-data` | gRPC | Instrument validation for multi-asset postings (optional; enabled when `REFERENCE_DATA_SERVICE_URL` is set) |
+| `internal-account` | gRPC | Account metadata resolution for posting routing (optional; account resolver) |
+| Redis | TCP | Idempotency store for exactly-once posting guarantees |
 
-Every financial transaction creates balanced postings:
+## Dependents
 
-```text
-Deposit £500.00 (from bank's general ledger perspective):
-  DEBIT   Cash/Reserves (bank's asset ↑)          = £500.00
-  CREDIT  Customer Deposit Account (liability ↑)  = £500.00
-  ──────────────────────────────────────────────────────────
-  Balance Check: Debits (£500.00) = Credits (£500.00) ✓
-```
+| Service | Entry Point | Purpose |
+|---------|-------------|---------|
+| `current-account` | `service/saga_handler_financial_accounting.go` | Deposit and withdrawal saga - posts double-entry to the ledger |
+| `payment-order` | `service/payment_orchestrator_ledger.go` | Settlement ledger posting after external payment confirms |
+| `mcp-server` | `internal/clients/clients.go` | Read-side inspection of booking logs and postings |
 
-**Note:** Customer deposits are liabilities on the bank's balance sheet
-(money owed back to customers). The debit increases the bank's cash assets,
-while the credit increases the liability to the customer.
+## Load-Bearing Files
 
-**Validation Rules:**
-
-- Amounts must be positive (reversals use opposite direction)
-- Debits must equal credits within a booking log
-- Terminal states (POSTED, FAILED) prevent further transitions
-
-## Kafka Integration
-
-**Consumer**: DepositEvent
-
-Consumes deposit events and creates balanced debit/credit postings automatically.
-
-**Idempotency Handling:**
-
-| Source Field | Maps To | Purpose |
-|--------------|---------|---------|
-| `event_id` | `idempotency_key` | Dedupe on consumer restart/redelivery |
-| `correlation_id` | `correlation_id` | Distributed tracing |
-
-- Duplicate events (same `event_id`) are skipped with logged warning
-- Partial failures: If booking log exists but posting missing, retry completes the posting
-- Consumer commits offset after successful DB transaction (at-least-once delivery)
-
-**Supported Currencies**: GBP, USD, EUR, JPY, CHF, CAD, AUD
-
-## Database Schema
-
-**Schema**: `financial_accounting`
-
-```mermaid
-erDiagram
-    financial_booking_logs {
-        uuid id PK
-        varchar(50) financial_account_type
-        varchar(100) product_service_reference
-        varchar(100) business_unit_reference
-        varchar(255) chart_of_accounts_rules
-        varchar(3) base_currency "ISO 4217"
-        varchar(50) status "PENDING, POSTED, FAILED, etc."
-        varchar(255) idempotency_key UK
-        bigint version "optimistic lock"
-    }
-
-    ledger_postings {
-        uuid id PK
-        uuid financial_booking_log_id FK
-        varchar(10) posting_direction "DEBIT, CREDIT"
-        bigint amount_cents
-        varchar(3) currency "ISO 4217"
-        varchar(255) account_id
-        timestamptz value_date
-        varchar(50) status "PENDING, POSTED, FAILED"
-        varchar(255) correlation_id "trace ID"
-    }
-
-    financial_booking_logs ||--o{ ledger_postings : "contains"
-```
+| File | Why It Matters |
+|------|----------------|
+| `cmd/main.go` | Process wiring; initialises container, gRPC server, and metrics server |
+| `app/container.go` | Dependency injection; wires database, Redis, Kafka, and optional service clients |
+| `service/server.go` | gRPC service registration; changes here affect the public contract |
+| `service/posting_service.go` | Core double-entry validation; enforces debits-equal-credits invariant |
+| `service/grpc_booking_endpoints.go` | Booking log RPC handlers; booking log lifecycle state machine |
+| `service/grpc_ledger_endpoints.go` | Ledger posting RPC handlers; idempotency enforcement per posting |
+| `domain/financial_booking_log.go` | FinancialBookingLog entity; status transition rules and aggregate invariants |
+| `domain/ledger_posting.go` | LedgerPosting entity; direction semantics and immutability rules after capture |
+| `config/config.go` | Idempotency cleanup worker configuration; Redis key TTL and batch parameters |
 
 ## Configuration
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `GRPC_PORT` | 50052 | gRPC server port |
-| `METRICS_PORT` | 8082 | Prometheus metrics |
-| `DATABASE_URL` | - | PostgreSQL connection string |
-| `BANK_CASH_ACCOUNT_ID` | - | Well-known bank account |
+### Core
 
-## Prometheus Metrics
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `DATABASE_URL` | Yes | - | CockroachDB connection string |
+| `GRPC_PORT` | No | `50052` | gRPC listen port |
+| `METRICS_PORT` | No | `8082` | Prometheus metrics listen port |
+| `LOG_LEVEL` | No | `info` | Structured log level (`debug`, `info`, `warn`, `error`) |
+| `BANK_CASH_ACCOUNT_ID` | No | - | Well-known bank cash account ID for clearing side of double-entry |
+| `REFERENCE_DATA_SERVICE_URL` | No | - | reference-data gRPC address; enables instrument validation when set |
 
-| Metric | Type | Purpose |
-|--------|------|---------|
-| `financial_accounting_operation_duration_seconds` | Histogram | Operation latency |
-| `financial_accounting_postings_total` | Counter | Postings by direction/currency |
-| `financial_accounting_double_entry_validations_total` | Counter | Balance checks |
-| `financial_accounting_errors_total` | Counter | Errors by category |
+### Authentication
 
-## Instrument Resolution
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `AUTH_ENABLED` | No | `true` | Enable JWT bearer authentication on all gRPC calls |
+| `AUTH_JWKS_URL` | No | - | JWKS endpoint URL; required when `AUTH_ENABLED=true` |
 
-Ledger posting validation uses `InstrumentResolver` from Reference Data to verify instrument
-properties at the API boundary. The domain layer trusts caller-provided instrument properties.
+### Messaging
 
-The service validates that debit and credit entries within a booking log use matching
-instruments (cross-instrument postings are rejected). The database schema stores
-`instrument_code` as `VARCHAR(32)` to accommodate non-currency instrument codes.
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `KAFKA_BOOTSTRAP_SERVERS` | No | - | Kafka broker list; enables audit event publishing when set |
+| `KAFKA_AUDIT_TOPIC` | No | `audit.events.*` | Audit event topic name override |
 
-See [ADR-0035: Multi-Asset Purity](../../docs/adr/0035-multi-asset-purity.md) for the architectural decision.
+### Idempotency Store (Redis)
+
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `REDIS_URL` | No | `redis://localhost:6379` | Redis connection URL for idempotency store |
+| `REDIS_PASSWORD` | No | - | Redis authentication password |
+| `REDIS_DB` | No | `0` | Redis database index |
+| `IDEMPOTENCY_CLEANUP_ENABLED` | No | `true` | Enable background cleanup of stale idempotency keys |
+| `IDEMPOTENCY_CLEANUP_STALE_THRESHOLD` | No | `15m` | Duration before a `PENDING` key is considered stale |
+| `IDEMPOTENCY_CLEANUP_RUN_INTERVAL` | No | `5m` | How often the cleanup worker polls for stale keys |
+| `IDEMPOTENCY_CLEANUP_BATCH_SIZE` | No | `100` | Maximum stale keys processed per cleanup iteration |
 
 ## References
 
-- [BIAN Financial Accounting Specification](https://github.com/bian-official/public/blob/main/release14.0.0/semantic-apis/oas3%20/yamls/FinancialAccounting.yaml)
-- [Service Architecture](../README.md)
-- [Proto Definitions](../../api/proto/meridian/financial_accounting/v1/)
+- [ADR-0023: Balance Delegation to Position Keeping](../../docs/adr/0023-balance-delegation-to-position-keeping.md)
+- [ADR-0035: Multi-Asset Purity](../../docs/adr/0035-multi-asset-purity.md)
+- [Architecture Layers - Core Ledger](../../docs/architecture-layers.md#4-core-ledger)
+- [Service Coupling Analysis](../../docs/architecture/service-coupling-analysis.md)
+- [BIAN Financial Accounting specification](https://github.com/bian-official/public/blob/main/release14.0.0/semantic-apis/oas3%20/yamls/FinancialAccounting.yaml)

--- a/services/internal-account/README.md
+++ b/services/internal-account/README.md
@@ -1,188 +1,70 @@
 ---
-name: internal-account-service
-description: BIAN-compliant internal account registry for managing counterparty and operational accounts with multi-asset support
+name: internal-account
+description: BIAN Internal Account service that manages counterparty and operational accounts (clearing, nostro, vostro, inventory) with multi-asset support and lien-based fund reservation
 triggers:
-  - Creating or modifying internal accounts
-  - Counterparty account management (nostro/vostro)
-  - Operational account tracking (clearing, suspense, holding)
-  - Multi-asset account support (currency, energy, compute, carbon)
-  - Internal ledger account references
-  - Account lifecycle management (suspend, activate, close)
-  - Balance queries for internal accounts
+  - Creating or managing internal counterparty or operational accounts
+  - Nostro, vostro, clearing, suspense, holding, revenue, expense, or inventory accounts
+  - Account lifecycle transitions (suspend, activate, close)
+  - Lien reservation on an internal account for in-flight payment settlement
+  - Balance queries for internal accounts (delegated to position-keeping)
+  - Valuation feature configuration for multi-asset account pricing
+  - Account resolution for payment routing or double-entry bookkeeping
 instructions: |
-  InternalAccount manages non-customer accounts used for internal accounting purposes:
-  - Counterparty accounts (nostro/vostro for counterparty banking)
-  - Operational accounts (clearing, suspense, holding, revenue, expense)
-  - Multi-asset support (fiat, energy, carbon credits, compute hours)
+  internal-account manages non-customer accounts used for internal accounting
+  and counterparty banking. It is the internal counterpart to current-account in
+  the Core Ledger layer.
 
   Key patterns:
-  - Account lifecycle: ACTIVE -> SUSPENDED -> CLOSED (no PENDING state)
+  - Account lifecycle: ACTIVE -> SUSPENDED -> CLOSED (no PENDING state; CLOSED is terminal)
   - Account types: CLEARING, NOSTRO, VOSTRO, HOLDING, SUSPENSE, REVENUE, EXPENSE, INVENTORY
-  - Balance is NOT stored locally - delegated to Position Keeping service
-  - No DELETE operations - accounts managed through status transitions
-  - No RecordPosting RPC - postings flow through Financial Accounting -> Position Keeping
+  - NOSTRO and VOSTRO accounts require CounterpartyDetails; other types must not include them
+  - CLEARING accounts carry a ClearingPurpose (DEPOSIT / WITHDRAWAL / SETTLEMENT / GENERAL)
+  - Balance is NOT stored locally - delegated to position-keeping per ADR-0023
+  - GetBalance proxies to position-keeping; the client is not yet wired in container,
+    so GetBalance returns Unimplemented until position-keeping is connected
+  - Lien lifecycle: ACTIVE -> EXECUTED (ExecuteLien) or TERMINATED (TerminateLien)
+  - No DELETE operations; accounts managed through status transitions only
+  - Postings do NOT flow through internal-account; they go Financial Accounting -> Position Keeping
 
-  Port: 50057 (gRPC)
+  Port: 50057 (gRPC), 8082 (metrics)
 ---
 
-# InternalAccount Service
+# internal-account
 
-BIAN-compliant internal account registry microservice for managing counterparty and operational accounts.
+BIAN Internal Account service - counterparty and operational account registry in the Core Ledger
+layer. Part of the [Core Ledger layer](../../docs/architecture-layers.md#4-core-ledger).
 
 ## Overview
 
 | Attribute | Value |
 |-----------|-------|
 | **BIAN Domain** | Internal Account |
-| **Port** | 50057 (gRPC) |
-| **Language** | Go |
-| **Database** | PostgreSQL/CockroachDB |
-| **Standalone** | Yes (balance delegated to Position Keeping) |
+| **Layer** | Core Ledger |
+| **Port** | 50057 (gRPC), 8082 (metrics) |
+| **Database** | CockroachDB (`internal_account` schema) |
+| **Standalone** | Yes (no required Meridian service dependencies at startup) |
 
-## Purpose
+## API Surface
 
-The Internal Account service manages accounts that are not customer-facing but are essential
-for internal accounting and counterparty banking operations:
+| Service | RPC | Purpose |
+|---------|-----|---------|
+| `InternalAccountService` | `InitiateInternalAccount` | Create a new internal account facility |
+| `InternalAccountService` | `UpdateInternalAccount` | Update account name, description, or counterparty details |
+| `InternalAccountService` | `ControlInternalAccount` | SUSPEND / ACTIVATE / CLOSE lifecycle action (BIAN CoCR) |
+| `InternalAccountService` | `RetrieveInternalAccount` | Get account details by ID or account code |
+| `InternalAccountService` | `ListInternalAccounts` | Paginated list with type, status, and clearing-purpose filters |
+| `InternalAccountService` | `GetBalance` | Query current balance (proxied to position-keeping) |
+| `InternalAccountService` | `CreateValuationFeature` | Add a valuation method mapping for multi-asset accounts |
+| `InternalAccountService` | `UpdateValuationFeature` | Lifecycle transitions on a valuation feature |
+| `InternalAccountService` | `GetValuationFeature` | Retrieve valuation feature by ID or bi-temporal query |
+| `InternalAccountService` | `ListValuationFeatures` | List valuation features for an account |
+| `InternalAccountService` | `EvaluateAssetValuation` | Non-binding valuation inquiry |
+| `InternalAccountService` | `InitiateLien` | Reserve funds on an internal account |
+| `InternalAccountService` | `ExecuteLien` | Convert reservation to actual debit (terminal) |
+| `InternalAccountService` | `TerminateLien` | Release reservation without execution (terminal) |
+| `InternalAccountService` | `RetrieveLien` | Get lien details by ID |
 
-- **Clearing Accounts**: Settlement and clearing operations during transaction processing
-- **Nostro Accounts**: "Our account at your bank" - accounts held at counterparty banks
-- **Vostro Accounts**: "Your account at our bank" - accounts held by counterparty banks at us
-- **Holding Accounts**: Temporary holding of funds during multi-step processes
-- **Suspense Accounts**: Unidentified or pending transactions awaiting resolution
-- **Revenue Accounts**: Income and revenue tracking for GL integration
-- **Expense Accounts**: Cost and expense tracking for GL integration
-- **Inventory Accounts**: Non-cash asset tracking (energy, commodities, compute resources)
-
-## gRPC Methods
-
-### Account Operations
-
-| Method | HTTP | Purpose |
-|--------|------|---------|
-| `InitiateInternalAccount` | `POST /v1/internal-accounts` | Create new internal account |
-| `UpdateInternalAccount` | `PATCH /v1/internal-accounts/{account_id}` | Modify account settings |
-| `ControlInternalAccount` | `POST /v1/internal-accounts/{account_id}/control` | Lifecycle transitions |
-| `RetrieveInternalAccount` | `GET /v1/internal-accounts/{account_id}` | Get account details |
-| `ListInternalAccounts` | `GET /v1/internal-accounts` | List with filters |
-| `GetBalance` | `GET /v1/internal-accounts/{account_id}/balance` | Query balance (from Position Keeping) |
-
-### Method Details
-
-#### InitiateInternalAccount
-
-Creates a new internal account in ACTIVE status.
-
-```go
-req := &iba.InitiateInternalAccountRequest{
-    AccountCode:    "NOSTRO-USD-HSBC",
-    Name:           "USD Nostro at HSBC London",
-    AccountType:    iba.INTERNAL_ACCOUNT_TYPE_NOSTRO,
-    InstrumentCode: "USD",
-    CounterpartyDetails: &iba.CounterpartyDetails{
-        CounterpartyId:          "hsbc-london",
-        CounterpartyName:        "HSBC London",
-        CounterpartyExternalRef: "GB12HSBC12345678901234",
-        CounterpartyType:        iba.COUNTERPARTY_TYPE_NOSTRO,
-    },
-    Description:    "Primary USD clearing account at HSBC London",
-    IdempotencyKey: &common.IdempotencyKey{Key: "create-nostro-001"},
-}
-
-resp, err := client.InitiateInternalAccount(ctx, req)
-// resp.AccountId = "2rPxMVkj3tNmqPwT5Wk8Lc4M9xZ"
-// resp.Facility contains full account details
-```
-
-#### ControlInternalAccount
-
-Performs lifecycle state transitions with audit trail.
-
-```go
-req := &iba.ControlInternalAccountRequest{
-    AccountId:     "2rPxMVkj3tNmqPwT5Wk8Lc4M9xZ",
-    ControlAction: iba.CONTROL_ACTION_SUSPEND,
-    Reason:        "Quarterly compliance review - temporary suspension pending audit completion",
-}
-
-resp, err := client.ControlInternalAccount(ctx, req)
-// resp.Facility.AccountStatus = INTERNAL_ACCOUNT_STATUS_SUSPENDED
-// resp.ActionTimestamp = time of state change
-```
-
-#### GetBalance
-
-Queries the current balance for an internal account by proxying to the
-Position Keeping service, which is the single source of truth for all
-balance data.
-
-```go
-req := &iba.GetBalanceRequest{
-    AccountId: "2rPxMVkj3tNmqPwT5Wk8Lc4M9xZ",
-}
-
-resp, err := client.GetBalance(ctx, req)
-// resp.CurrentBalance.Amount = "1500000.00"
-// resp.CurrentBalance.InstrumentCode = "USD"
-// resp.AsOf = timestamp from Position Keeping
-```
-
-**Prerequisites:**
-
-- Position Keeping service must be deployed and reachable
-- Account must be in `ACTIVE` status (suspended/closed accounts return `FailedPrecondition`)
-- A position record must exist in Position Keeping for the account/instrument combination
-
-**Behavior:**
-
-- Returns `BALANCE_TYPE_CURRENT` from the Position Keeping response
-- O(1) query: Position Keeping maintains pre-computed running balance totals
-- 5-second timeout on the Position Keeping call (`context.WithTimeout`)
-- Response includes `as_of` timestamp from Position Keeping (falls back to current time if absent)
-
-**Error Scenarios:**
-
-| gRPC Code | Condition | Description |
-|-----------|-----------|-------------|
-| `Unimplemented` | Position Keeping client not configured | Service constructed without PK client (e.g., `NewService` instead of `NewServiceWithClients`) |
-| `FailedPrecondition` | Account not active | Account is suspended or closed |
-| `NotFound` | Account does not exist | Account ID/code not found in local database |
-| `Internal` | Position not found in PK | PK returned NotFound (position record missing) |
-| `Unavailable` | PK service unreachable | PK unavailable, deadline exceeded, or resource exhausted |
-| `Internal` | PK invalid argument | Request to PK was malformed (indicates a code defect) |
-| `InvalidArgument` | Empty account_id | Request missing required `account_id` field |
-
-**Monitoring:**
-
-| Metric | Description |
-|--------|-------------|
-| `internal_account_operation_duration_seconds{operation="get_balance"}` | Total GetBalance RPC duration |
-| `internal_account_balance_query_duration_seconds{status}` | Duration of the PK call specifically (target p99 < 50ms) |
-| `internal_account_errors_total{category="position_keeping"}` | PK-related error counter |
-
-The health check endpoint (`grpc.health.v1.Health/Check`) reports PK
-connectivity as a degraded (not critical) dependency. The service
-continues serving non-balance operations even when PK is unreachable.
-
-**Local Development (grpcurl):**
-
-```bash
-# Query balance for an account
-grpcurl -plaintext -d '{"account_id": "<account-id>"}' \
-  localhost:50057 meridian.internal_account.v1.InternalAccountService/GetBalance
-
-# Check health (includes PK connectivity status)
-grpcurl -plaintext -d '{"service": "internal-account"}' \
-  localhost:50057 grpc.health.v1.Health/Check
-```
-
-**Production Deployment:**
-
-| Attribute | Value |
-|-----------|-------|
-| Service name | `internal-account` |
-| gRPC port | `50057` |
-| Health endpoint | `grpc.health.v1.Health/Check` (service: `internal-account`) |
-| PK dependency | `position-keeping:50053` |
+Proto: [`api/proto/meridian/internal_account/v1/internal_account.proto`](../../api/proto/meridian/internal_account/v1/internal_account.proto)
 
 ## Domain Model
 
@@ -199,16 +81,32 @@ classDiagram
         +CounterpartyDetails CounterpartyDetails
         +string Description
         +int32 Version
-        +Timestamp CreatedAt
-        +Timestamp UpdatedAt
+        +time CreatedAt
+        +time UpdatedAt
     }
 
     class CounterpartyDetails {
         +string CounterpartyID
         +string CounterpartyName
         +string CounterpartyExternalRef
-        +map Attributes
         +CounterpartyType CounterpartyType
+    }
+
+    class Lien {
+        +string LienID
+        +string AccountID
+        +InstrumentAmount Amount
+        +LienStatus Status
+        +string PaymentOrderReference
+        +time ExpiresAt
+    }
+
+    class ValuationFeature {
+        +string FeatureID
+        +string AccountID
+        +string SourceInstrumentCode
+        +string TargetInstrumentCode
+        +string ValuationMethod
     }
 
     class InternalAccountType {
@@ -239,11 +137,11 @@ classDiagram
         CLOSED
     }
 
-    class ControlAction {
+    class LienStatus {
         <<enumeration>>
-        SUSPEND
-        ACTIVATE
-        CLOSE
+        ACTIVE
+        EXECUTED
+        TERMINATED
     }
 
     class CounterpartyType {
@@ -255,502 +153,82 @@ classDiagram
     InternalAccountFacility --> InternalAccountType
     InternalAccountFacility --> ClearingPurpose
     InternalAccountFacility --> InternalAccountStatus
-    InternalAccountFacility --> CounterpartyDetails
+    InternalAccountFacility "1" --> "0..1" CounterpartyDetails : required for NOSTRO/VOSTRO
+    InternalAccountFacility "1" --> "*" Lien : has
+    InternalAccountFacility "1" --> "*" ValuationFeature : has
     CounterpartyDetails --> CounterpartyType
+    Lien --> LienStatus
 ```
 
-**Field Notes:**
+Balance is not stored on `InternalAccountFacility`; it is computed by `position-keeping`
+per ADR-0023. `NOSTRO` and `VOSTRO` accounts require `CounterpartyDetails`; all other
+account types must omit it. `CLEARING` accounts carry a `ClearingPurpose` to allow
+downstream callers to distinguish deposit, withdrawal, and settlement clearing lanes.
+Lien lifecycle mirrors `current-account`: ACTIVE -> EXECUTED (terminal) or TERMINATED (terminal).
 
-- `AccountID`: System-generated KSUID (e.g., `2rPxMVkj3tNmqPwT5Wk8Lc4M9xZ`)
-- `AccountCode`: Business-friendly code (e.g., `NOSTRO-USD-HSBC`, `CLR-001`)
-- `InstrumentCode`: References instrument from Reference Data service (e.g., `USD`, `KWH`, `GPU_HOUR`)
-- `CounterpartyDetails`: Required for NOSTRO/VOSTRO accounts, null for others
+## Dependencies
 
-## Account Types
+| Service | Protocol | Purpose |
+|---------|----------|---------|
+| `position-keeping` | gRPC | Balance computation for `GetBalance` (client not yet wired at startup; `GetBalance` returns `Unimplemented` until connected) |
+| Kafka | TCP | Account lifecycle event publishing via transactional outbox (optional; enables outbox worker when `KAFKA_BOOTSTRAP_SERVERS` is set) |
 
-| Type | Description | Typical Use |
-|------|-------------|-------------|
-| `CLEARING` | Settlement and clearing operations | Interbank settlement, payment clearing |
-| `NOSTRO` | Our account at another bank | Foreign currency holdings, counterparty banking |
-| `VOSTRO` | Their account at our bank | Counterparty accounts for partner banks |
-| `HOLDING` | Temporary fund holding | Escrow, pending transfers, batch processing |
-| `SUSPENSE` | Unmatched/pending transactions | Reconciliation, error correction |
-| `REVENUE` | Income tracking | Fee collection, interest income |
-| `EXPENSE` | Cost tracking | Operating expenses, fee payments |
-| `INVENTORY` | Non-cash assets | Energy inventory, carbon credits, compute allocation |
+## Dependents
 
-## Clearing Account Purposes
+| Service | Entry Point | Purpose |
+|---------|-------------|---------|
+| `payment-order` | `service/account_resolver.go` | Internal account resolution for payment routing |
+| `control-plane` | `internal/applier/internal_account_client.go`, `internal/applier/handlers.go` | Account provisioning from tenant manifest (declarative account creation) |
+| `position-keeping` | `service/account_validator.go`, `app/container.go` | Account validation for position and balance operations |
+| `financial-accounting` | `service/account_resolver.go`, `service/client_interfaces.go` | Internal account resolution for double-entry routing |
+| `current-account` | `service/account_resolver.go`, `service/client_interfaces.go` | Internal account resolution in deposit and withdrawal sagas |
 
-Clearing accounts can be specialized for specific purposes using the `clearing_purpose` field:
+## Load-Bearing Files
 
-| Purpose | Enum Value | Use Case |
-|---------|------------|----------|
-| Deposit | `CLEARING_PURPOSE_DEPOSIT` | Clearing accounts for deposit operations |
-| Withdrawal | `CLEARING_PURPOSE_WITHDRAWAL` | Clearing accounts for withdrawal operations |
-| Settlement | `CLEARING_PURPOSE_SETTLEMENT` | Clearing accounts for settlement operations |
-| General | `CLEARING_PURPOSE_GENERAL` | General-purpose clearing accounts |
-
-**Important**: The `clearing_purpose` field is only applicable when `account_type` is
-`INTERNAL_ACCOUNT_TYPE_CLEARING`. For all other account types, the value must be
-`CLEARING_PURPOSE_UNSPECIFIED`.
-
-### Example: Creating Purpose-Specific Clearing Accounts
-
-```go
-// Deposit clearing account
-req := &iba.InitiateInternalAccountRequest{
-    AccountCode:     "CLR-GBP-DEPOSIT",
-    Name:            "GBP Deposit Clearing",
-    AccountType:     iba.INTERNAL_ACCOUNT_TYPE_CLEARING,
-    ClearingPurpose: iba.CLEARING_PURPOSE_DEPOSIT,
-    InstrumentCode:  "GBP",
-}
-
-// Withdrawal clearing account
-req := &iba.InitiateInternalAccountRequest{
-    AccountCode:     "CLR-USD-WITHDRAW",
-    Name:            "USD Withdrawal Clearing",
-    AccountType:     iba.INTERNAL_ACCOUNT_TYPE_CLEARING,
-    ClearingPurpose: iba.CLEARING_PURPOSE_WITHDRAWAL,
-    InstrumentCode:  "USD",
-}
-
-// Settlement clearing account
-req := &iba.InitiateInternalAccountRequest{
-    AccountCode:     "CLR-EUR-SETTLE",
-    Name:            "EUR Settlement Clearing",
-    AccountType:     iba.INTERNAL_ACCOUNT_TYPE_CLEARING,
-    ClearingPurpose: iba.CLEARING_PURPOSE_SETTLEMENT,
-    InstrumentCode:  "EUR",
-}
-```
-
-### Querying by Clearing Purpose
-
-Use the `clearing_purpose_filter` in `ListInternalAccounts`:
-
-```bash
-# List all deposit clearing accounts
-grpcurl -plaintext -d '{
-  "account_type_filter": "INTERNAL_ACCOUNT_TYPE_CLEARING",
-  "clearing_purpose_filter": "CLEARING_PURPOSE_DEPOSIT"
-}' localhost:50057 meridian.internal_account.v1.InternalAccountService/ListInternalAccounts
-```
-
-### Default Clearing Accounts
-
-Each tenant is provisioned with purpose-specific clearing accounts per instrument:
-
-| Account Code | Purpose | Instrument | Usage |
-|--------------|---------|------------|-------|
-| `CLR-GBP-DEPOSIT` | DEPOSIT | GBP | Customer deposits |
-| `CLR-GBP-WITHDRAW` | WITHDRAWAL | GBP | Customer withdrawals |
-| `CLR-USD-DEPOSIT` | DEPOSIT | USD | Customer deposits |
-| `CLR-USD-WITHDRAW` | WITHDRAWAL | USD | Customer withdrawals |
-| `CLR-EUR-DEPOSIT` | DEPOSIT | EUR | Customer deposits |
-| `CLR-EUR-WITHDRAW` | WITHDRAWAL | EUR | Customer withdrawals |
-
-## Account Lifecycle State Machine
-
-```mermaid
-stateDiagram-v2
-    [*] --> ACTIVE: InitiateInternalAccount
-    ACTIVE --> SUSPENDED: SUSPEND action
-    SUSPENDED --> ACTIVE: ACTIVATE action
-    ACTIVE --> CLOSED: CLOSE action
-    SUSPENDED --> CLOSED: CLOSE action
-    CLOSED --> [*]
-```
-
-### State Transitions
-
-| From | To | Action | Description |
-|------|-----|--------|-------------|
-| - | ACTIVE | Create | New accounts start as ACTIVE |
-| ACTIVE | SUSPENDED | SUSPEND | Temporary freeze, reversible |
-| SUSPENDED | ACTIVE | ACTIVATE | Resume normal operations |
-| ACTIVE | CLOSED | CLOSE | Permanent closure (terminal) |
-| SUSPENDED | CLOSED | CLOSE | Close suspended account (terminal) |
-
-### State Descriptions
-
-- **ACTIVE**: Account is operational and can participate in transactions
-- **SUSPENDED**: Temporarily frozen; cannot process new transactions but maintains audit trail
-- **CLOSED**: Terminal state; no further operations allowed (immutable)
-
-## Multi-Asset Support
-
-Internal accounts support the full range of Meridian instrument dimensions through the Reference Data service:
-
-### Instrument Dimensions
-
-| Dimension | Examples | Use Case |
-|-----------|----------|----------|
-| `CURRENCY` | USD, EUR, GBP, BTC | Traditional fiat and crypto currencies |
-| `ENERGY` | KWH, MWH, THERM | Energy trading, utility accounts |
-| `MASS` | KG, TON, LB | Commodity inventory |
-| `VOLUME` | LITRE, GALLON, BARREL | Liquid commodities (oil, gas) |
-| `TIME` | HOUR, DAY | Time-based billing, subscriptions |
-| `COMPUTE` | GPU_HOUR, CPU_SECOND | Cloud compute resource allocation |
-| `CARBON` | TONNE_CO2E | Carbon credits, emissions tracking |
-| `DATA` | GB, TB | Data transfer, storage allocation |
-| `COUNT` | UNIT, TOKEN, VOUCHER | Digital assets, vouchers, countable items |
-
-### Multi-Asset Examples
-
-#### Energy Inventory Account (kWh)
-
-```go
-req := &iba.InitiateInternalAccountRequest{
-    AccountCode:    "INV-ENERGY-GRID1",
-    Name:           "Grid 1 Energy Inventory",
-    AccountType:    iba.INTERNAL_ACCOUNT_TYPE_INVENTORY,
-    InstrumentCode: "KWH",  // Energy in kilowatt-hours
-    Description:    "Energy inventory for Grid Region 1 - aggregated generation",
-}
-```
-
-#### GPU Compute Allocation Account
-
-```go
-req := &iba.InitiateInternalAccountRequest{
-    AccountCode:    "INV-GPU-POOL-A",
-    Name:           "GPU Pool A Allocation",
-    AccountType:    iba.INTERNAL_ACCOUNT_TYPE_INVENTORY,
-    InstrumentCode: "GPU_HOUR",  // GPU compute hours
-    Description:    "Allocated GPU compute for AI training cluster A",
-}
-```
-
-#### Carbon Credit Suspense Account
-
-```go
-req := &iba.InitiateInternalAccountRequest{
-    AccountCode:    "SUS-CARBON-UNMATCHED",
-    Name:           "Carbon Credit Suspense",
-    AccountType:    iba.INTERNAL_ACCOUNT_TYPE_SUSPENSE,
-    InstrumentCode: "TONNE_CO2E",  // Carbon credits
-    Description:    "Unmatched carbon credits pending verification",
-}
-```
-
-See [ADR-0035: Multi-Asset Purity](../../docs/adr/0035-multi-asset-purity.md) for the architectural decision.
-
-## Balance Delegation to Position Keeping
-
-**Critical Design Decision**: Internal Account does NOT store balance locally.
-
-```mermaid
-sequenceDiagram
-    participant Client
-    participant IBA as InternalAccount
-    participant PK as PositionKeeping
-    participant DB as PositionKeeping DB
-
-    Client->>IBA: GetBalance(account_id)
-    IBA->>PK: GetAccountBalance(account_id)
-    PK->>DB: Query POSTED transactions
-    DB-->>PK: Transaction entries
-    PK->>PK: Compute balance
-    PK-->>IBA: BalanceResponse
-    IBA-->>Client: GetBalanceResponse
-```
-
-### Why Position Keeping Owns Balance
-
-1. **Single Source of Truth**: Position Keeping maintains the immutable transaction log
-2. **Balance Types**: Computes all 7 BIAN balance types (Opening, Closing, Current, Available, Ledger, Reserve, Free)
-3. **Audit Trail**: Balance derived from auditable transaction history
-4. **Consistency**: Same balance computation logic for all account types (customer and internal)
-
-### Transaction Flow
-
-Postings flow through Financial Accounting, not directly through Internal Account:
-
-```mermaid
-sequenceDiagram
-    participant CA as CurrentAccount
-    participant FA as FinancialAccounting
-    participant PK as PositionKeeping
-    participant IBA as InternalAccount
-
-    Note over CA,IBA: Example: Customer Deposit
-    CA->>FA: RecordPosting(customer_credit, internal_debit)
-    FA->>PK: InitiateFinancialPositionLog (both legs)
-    PK-->>FA: Position logs created
-    FA-->>CA: Posting confirmed
-
-    Note over CA,IBA: Later: Balance Query
-    IBA->>PK: GetAccountBalance(internal_account_id)
-    PK-->>IBA: Computed balance from transaction log
-```
-
-## Error Codes
-
-| gRPC Code | Condition | Recovery |
-|-----------|-----------|----------|
-| `NOT_FOUND` | Account ID does not exist | Verify account ID, check tenant context |
-| `ALREADY_EXISTS` | Duplicate account_code | Use different code or retrieve existing |
-| `INVALID_ARGUMENT` | Validation failed (missing fields, invalid patterns) | Check request against proto validation rules |
-| `FAILED_PRECONDITION` | Invalid state transition (e.g., close already closed) | Check account status before operation |
-| `ABORTED` | Optimistic lock conflict (version mismatch) | Re-read account, retry with current version |
-| `PERMISSION_DENIED` | Insufficient permissions for operation | Check auth token and tenant access |
-| `UNAVAILABLE` | Position Keeping unavailable (for balance queries) | Retry with backoff |
-
-### Validation Errors
-
-| Field | Validation | Error |
-|-------|------------|-------|
-| `account_code` | Pattern: `^[A-Z0-9_-]+$`, max 50 chars | "account_code must match pattern" |
-| `name` | Required, max 255 chars | "name is required" |
-| `account_type` | Must not be UNSPECIFIED | "account_type must be specified" |
-| `instrument_code` | Pattern: `^[A-Z][A-Z0-9_]*$`, max 32 chars | "instrument_code must match pattern" |
-| `control_action.reason` | Min 10 chars for audit completeness | "reason must be at least 10 characters" |
-| `counterparty_details` | Required for NOSTRO/VOSTRO types | "counterparty details required for nostro/vostro" |
-
-## Database Schema
-
-**Schema**: `internal_account`
-
-```mermaid
-erDiagram
-    internal_account {
-        uuid id PK "KSUID"
-        string account_code UK "Business code"
-        string name "Display name"
-        string account_type "CLEARING|NOSTRO|VOSTRO|..."
-        string status "ACTIVE|SUSPENDED|CLOSED"
-        string instrument_code "USD|KWH|GPU_HOUR|..."
-        string description "nullable"
-        bigint version "Optimistic lock"
-        timestamp created_at
-        timestamp updated_at
-    }
-
-    counterparty_details {
-        string counterparty_id "nullable"
-        string counterparty_name "nullable"
-        string counterparty_external_ref "nullable"
-        string counterparty_type "NOSTRO|VOSTRO"
-    }
-
-    internal_account ||--o| counterparty_details : "has (nostro/vostro only)"
-```
-
-## Service Dependencies
-
-| Service | Port | Purpose |
-|---------|------|---------|
-| Position Keeping | 50053 | Balance computation (required for GetBalance) |
-| Reference Data | 50055 | Instrument validation (validates instrument_code) |
-| Financial Accounting | 50052 | Posting entry point (transactions flow through FA) |
-
-```mermaid
-graph TD
-    IBA[Internal Account<br>:50057] --> PK[Position Keeping<br>:50053]
-    IBA --> RD[Reference Data<br>:50055]
-    FA[Financial Accounting<br>:50052] --> PK
-    FA --> IBA
-
-    subgraph "Balance Computation"
-        PK
-    end
-
-    subgraph "Reference Data"
-        RD
-    end
-
-    subgraph "Transaction Processing"
-        FA
-    end
-```
+| File | Why It Matters |
+|------|----------------|
+| `cmd/main.go` | Process wiring; initialises container, gRPC server, outbox worker, and metrics server |
+| `app/container.go` | Dependency injection; wires DB and Kafka; position-keeping and reference-data explicitly not yet wired |
+| `service/server.go` | gRPC service registration; changes here affect the public contract |
+| `service/grpc_account_endpoints.go` | Account CRUD RPC handlers; account status state machine and counterparty-details validation |
+| `service/grpc_balance_endpoints.go` | `GetBalance` RPC; delegates to position-keeping with 5-second timeout |
+| `service/lien_service.go` | Lien reservation service; ACTIVE->EXECUTED/TERMINATED state machine |
+| `service/valuation_feature_service.go` | Valuation feature CRUD and lifecycle transitions |
+| `service/valuation_engine.go` | `EvaluateAssetValuation` computation logic |
+| `domain/internal_account.go` | InternalAccountFacility entity; account type invariants and status transition rules |
+| `domain/lien.go` | Lien entity; immutability rules after terminal transition |
+| `domain/valuation_feature.go` | ValuationFeature entity; instrument dimension mapping rules |
+| `domain/account_type.go` | AccountType enum and counterparty-details requirement enforcement |
+| `domain/clearing_purpose.go` | ClearingPurpose enum; valid purpose-to-type combinations |
 
 ## Configuration
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `LOG_LEVEL` | `info` | Logging level (debug, info, warn, error) |
-| `LOG_FORMAT` | `json` | Log format (json, text) |
-| `GRPC_PORT` | `50057` | gRPC server port |
-| `DATABASE_URL` | - | PostgreSQL connection string |
-| `DB_MAX_OPEN_CONNS` | `25` | Max open database connections |
-| `DB_MAX_IDLE_CONNS` | `5` | Max idle database connections |
-| `POSITION_KEEPING_ADDR` | `position-keeping:50053` | Position Keeping service address |
-| `REFERENCE_DATA_ADDR` | `reference-data:50055` | Reference Data service address |
-| `OTEL_SERVICE_NAME` | `internal-account-service` | OpenTelemetry service name |
+### Core
 
-## Key Patterns
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `DATABASE_URL` | Yes | - | CockroachDB connection string |
+| `GRPC_PORT` | No | `50057` | gRPC listen port |
+| `METRICS_PORT` | No | `8082` | Prometheus metrics listen port |
+| `LOG_LEVEL` | No | `info` | Structured log level (`debug`, `info`, `warn`, `error`) |
 
-### Idempotency
+### Authentication
 
-Create operations accept an `idempotency_key` for exactly-once semantics:
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `AUTH_ENABLED` | No | `true` | Enable JWT bearer authentication on all gRPC calls |
+| `AUTH_JWKS_URL` | No | - | JWKS endpoint URL; required when `AUTH_ENABLED=true` |
 
-```go
-req := &iba.InitiateInternalAccountRequest{
-    // ... fields ...
-    IdempotencyKey: &common.IdempotencyKey{
-        Key: "create-nostro-hsbc-usd-20240115",  // Client-generated unique key
-    },
-}
-```
+### Messaging
 
-If the same idempotency key is reused:
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `KAFKA_BOOTSTRAP_SERVERS` | No | - | Kafka broker list; enables outbox worker and account lifecycle events when set |
 
-- Within TTL: Returns the original response (effectively-once)
-- After TTL: Creates a new account (key expired)
+## References
 
-### Optimistic Locking
-
-Update operations use version-based optimistic locking:
-
-```go
-// Read current state
-account, _ := client.RetrieveInternalAccount(ctx, &iba.RetrieveInternalAccountRequest{
-    AccountId: "2rPxMVkj3tNmqPwT5Wk8Lc4M9xZ",
-})
-
-// Update with expected version
-_, err := client.UpdateInternalAccount(ctx, &iba.UpdateInternalAccountRequest{
-    AccountId:       "2rPxMVkj3tNmqPwT5Wk8Lc4M9xZ",
-    Name:            "Updated Account Name",
-    ExpectedVersion: account.Facility.Version,  // Must match current
-})
-
-if status.Code(err) == codes.Aborted {
-    // Version conflict - re-read and retry
-}
-```
-
-### No DELETE Operations
-
-Accounts are never deleted. Lifecycle is managed through status transitions:
-
-```go
-// WRONG: No delete endpoint exists
-// client.DeleteInternalAccount(...)  // Does not exist!
-
-// CORRECT: Close the account
-client.ControlInternalAccount(ctx, &iba.ControlInternalAccountRequest{
-    AccountId:     "2rPxMVkj3tNmqPwT5Wk8Lc4M9xZ",
-    ControlAction: iba.CONTROL_ACTION_CLOSE,
-    Reason:        "Account consolidated into CLR-002 per finance directive FIN-2024-042",
-})
-```
-
-### Counterparty Banking
-
-Nostro and vostro accounts require counterparty details:
-
-```go
-// Nostro: Our account at their bank
-nostro := &iba.InitiateInternalAccountRequest{
-    AccountCode: "NOSTRO-EUR-DEUTSCHE",
-    AccountType: iba.INTERNAL_ACCOUNT_TYPE_NOSTRO,
-    InstrumentCode: "EUR",
-    CounterpartyDetails: &iba.CounterpartyDetails{
-        CounterpartyId:          "deutsche-frankfurt",
-        CounterpartyName:        "Deutsche Bank Frankfurt",
-        CounterpartyExternalRef: "DE89370400440532013000",
-        CounterpartyType:        iba.COUNTERPARTY_TYPE_NOSTRO,
-    },
-}
-
-// Vostro: Their account at our bank
-vostro := &iba.InitiateInternalAccountRequest{
-    AccountCode: "VOSTRO-JPY-MUFG",
-    AccountType: iba.INTERNAL_ACCOUNT_TYPE_VOSTRO,
-    InstrumentCode: "JPY",
-    CounterpartyDetails: &iba.CounterpartyDetails{
-        CounterpartyId:          "mufg-tokyo",
-        CounterpartyName:        "MUFG Bank Tokyo",
-        CounterpartyExternalRef: "VOSTRO-MUFG-001",
-        CounterpartyType:        iba.COUNTERPARTY_TYPE_VOSTRO,
-    },
-}
-```
-
-## Performance Characteristics
-
-| Operation | Complexity | Notes |
-|-----------|------------|-------|
-| `InitiateInternalAccount` | O(1) | Single insert with idempotency check |
-| `RetrieveInternalAccount` | O(1) | Primary key lookup |
-| `UpdateInternalAccount` | O(1) | Single update with version check |
-| `ControlInternalAccount` | O(1) | Status update with audit entry |
-| `ListInternalAccounts` | O(n) | Filtered query, paginated |
-| `GetBalance` | O(m) | Delegated to Position Keeping (m = transactions) |
-
-**Notes:**
-
-- Account operations are fast (local database)
-- Balance queries depend on Position Keeping performance
-- Consider caching for high-traffic balance queries
-
-## Development
-
-### Building
-
-```bash
-# Build binary
-go build -o internal-account ./services/internal-account/cmd
-
-# Build Docker image
-docker build -t internal-account:latest \
-  -f services/internal-account/cmd/Dockerfile .
-```
-
-### Running Locally
-
-```bash
-# Set required environment variables
-export DATABASE_URL="postgres://user:pass@localhost:5432/meridian?search_path=internal_account"
-export POSITION_KEEPING_ADDR="localhost:50053"
-export REFERENCE_DATA_ADDR="localhost:50055"
-export LOG_LEVEL=debug
-
-# Run the service
-./internal-account
-```
-
-### Running Migrations
-
-```bash
-# Generate migration from schema changes
-atlas migrate diff --env local
-
-# Apply migrations
-atlas migrate apply --env local
-```
-
-### Testing with grpcurl
-
-```bash
-# Create an account
-grpcurl -plaintext -d '{
-  "account_code": "CLR-TEST-001",
-  "name": "Test Clearing Account",
-  "account_type": "INTERNAL_ACCOUNT_TYPE_CLEARING",
-  "instrument_code": "GBP",
-  "description": "Test clearing account for development"
-}' localhost:50057 meridian.internal_account.v1.InternalAccountService/InitiateInternalAccount
-
-# List accounts
-grpcurl -plaintext localhost:50057 meridian.internal_account.v1.InternalAccountService/ListInternalAccounts
-
-# Get balance
-grpcurl -plaintext -d '{"account_id": "2rPxMVkj3tNmqPwT5Wk8Lc4M9xZ"}' \
-  localhost:50057 meridian.internal_account.v1.InternalAccountService/GetBalance
-```
-
-## Related Documentation
-
-- [ADR-0002: Microservices per BIAN Domain](../../docs/adr/0002-microservices-per-bian-domain.md)
-- [ADR-0003: Database Schema Migrations](../../docs/adr/0003-database-schema-migrations.md)
-- [ADR-0013: Generic Asset Quantity Types](../../docs/adr/0013-generic-asset-quantity-types.md)
-- [ADR-0015: Standard Service Directory Structure](../../docs/adr/0015-standard-service-directory-structure.md)
 - [ADR-0023: Balance Delegation to Position Keeping](../../docs/adr/0023-balance-delegation-to-position-keeping.md)
-- [ADR-0024: Internal Bank Account Service](../../docs/adr/0024-internal-bank-account-service.md)
-- [ADR-0025: Clearing Purpose Specialization](../../docs/adr/0025-clearing-purpose-specialization.md)
-- [Proto Definitions](../../api/proto/meridian/internal_account/v1/)
-- [Position Keeping Service](../position-keeping/README.md)
-- [Reference Data Service](../reference-data/README.md)
+- [ADR-0035: Multi-Asset Purity](../../docs/adr/0035-multi-asset-purity.md)
+- [Architecture Layers - Core Ledger](../../docs/architecture-layers.md#4-core-ledger)
+- [Service Coupling Analysis](../../docs/architecture/service-coupling-analysis.md)
+- [BIAN Internal Account specification](https://github.com/bian-official/public/blob/main/release14.0.0/semantic-apis/oas3%20/yamls/InternalAccount.yaml)


### PR DESCRIPTION
## Summary

Rewrites READMEs for all three Core Ledger services to comply with the service README template introduced in #2193.

- `services/financial-accounting/README.md` - BIAN general ledger nucleus
- `services/current-account/README.md` - Customer deposit account facade
- `services/internal-account/README.md` - Counterparty and operational account registry

All three now have the 8 required template sections in order: frontmatter, overview, API surface, domain model, dependencies, dependents, load-bearing files, configuration.

## Key corrections over previous READMEs

- **financial-accounting**: BIAN domain corrected from "Financial Standard Management" to "Financial Accounting"; `Layer: Core Ledger` added
- **current-account**: gRPC port corrected from 50057 to 50051 (was using internal-account's port); `Layer: Core Ledger` added; cross-service clients documented as saga-layer delegation (not wired at container init); clearing account env vars (`DEPOSIT_CLEARING_ACCOUNT_ID`, `WITHDRAWAL_CLEARING_ACCOUNT_ID`, `NOSTRO_ACCOUNT_ID`) documented
- **internal-account**: False `POSITION_KEEPING_ADDR` and `REFERENCE_DATA_ADDR` env vars removed (both clients are nil at startup per `container.go`); `Layer: Core Ledger` added; `GetBalance` noted as returning `Unimplemented` until position-keeping client is wired

## Codebase context

- Port authority: `shared/platform/ports/ports.go` (CurrentAccount=50051, InternalAccount=50057)
- Balance delegation: ADR-0023 - current-account and internal-account hold no balance columns
- Multi-asset: ADR-0035 - InstrumentAmount used in lien and posting amounts across all three services