### PR TITLE
fix: Increase seed-dev timeout to 5m in deploy workflows

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -352,6 +352,7 @@ jobs:
               --subdomain=volterra.demo.meridianhub.cloud \
               --manifest=/app/examples/manifests/energy.json \
               --force \
+              --timeout=5m \
               --with-fixtures
 
       - name: Verify deployment health

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -363,6 +363,7 @@ jobs:
               --display-name='Volterra Energy' \
               --subdomain=volterra-energy.develop.meridianhub.cloud \
               --manifest=/app/examples/manifests/energy.json \
+              --timeout=5m \
               --with-fixtures
 
       - name: Verify deployment health


### PR DESCRIPTION
## Summary

Deploy Develop has been failing intermittently with `DeadlineExceeded` errors mid-seed. The latest failure on develop ([run 25858645007](https://github.com/meridianhub/meridian/actions/runs/25858645007)) timed out on customer 7 (Andrew Patel), day 13 of fixture seeding.

## Root Cause

`seed-dev` defaults to a 2-minute overall timeout (`cmd/seed-dev/cmd/root.go:112`), but `--with-fixtures` performs 600 sequential RPC calls:

- 10 customers
- 30 days of history per customer
- 2 deposits per day (GBP billing + kWh meter read)

Observed runtime is ~12-15s per customer, so fixture seeding alone is ~120-150s, plus tenant provisioning and manifest apply on top.

## Fix

Pass `--timeout=5m` explicitly in `deploy-develop.yml` and `deploy-demo.yml`. The same fragility exists in both workflows; demo has been hitting it less frequently but the headroom is the same.

## Alternatives Considered

- **Raise the seed-dev default**: Would mask the issue for `--skip-manifest` callers where 2m is appropriate. Surgical override at the call site is preferable.
- **Parallelise fixture deposits**: Larger change; idempotency/ordering invariants in the deposit orchestrator need review. Worth doing eventually but out of scope for unblocking deploys today.

## Test Plan

- [ ] Deploy Develop workflow run succeeds end-to-end (manifest apply + fixtures + health check)
- [ ] Deploy Demo workflow run succeeds end-to-end
- [ ] Verify total seed-dev runtime is well under 5m in CI logs