### PR TITLE
chore(security): close remaining Dependabot/Trivy alerts after #2196 and #2199

### DIFF
--- a/.github/workflows/asyncapi.yml
+++ b/.github/workflows/asyncapi.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Set up Node.js

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -50,8 +50,8 @@ jobs:
             IMPORTANT: Today's date is ${{ steps.date.outputs.current_date }}.
 
             Key project facts:
-            - This project uses Go 1.26.2 (latest stable release)
-            - Go 1.26.2 is a valid version - do not question or flag it
+            - This project uses Go 1.26.3 (latest stable release)
+            - Go 1.26.3 is a valid version - do not question or flag it
             - Architecture: BIAN-compliant microservices
             - Stack: Go, Protocol Buffers, gRPC, Kubernetes
             - Security: All security scans must remain BLOCKING (never suggest making them non-blocking)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -68,7 +68,7 @@ jobs:
       if: matrix.language == 'go'
       uses: actions/setup-go@v6
       with:
-        go-version: '1.26.2'
+        go-version: '1.26.3'
         cache: true
 
     # Set up buf for protobuf generation (pinned version for reproducibility)

--- a/.github/workflows/control-plane-ci.yml
+++ b/.github/workflows/control-plane-ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Set up buf
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Set up buf
@@ -117,7 +117,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Set up buf
@@ -163,7 +163,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Set up buf
@@ -207,7 +207,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Install Atlas CLI
@@ -82,7 +82,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Install Atlas CLI

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Set up buf
@@ -101,7 +101,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.26.2'
+        go-version: '1.26.3'
         cache: true
 
     - name: Set up buf

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Set up buf
@@ -98,7 +98,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/saga-validation.yml
+++ b/.github/workflows/saga-validation.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Install protoc

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.26.2'
+        go-version: '1.26.3'
         cache: true
 
     - name: Set up buf
@@ -85,7 +85,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.26.2'
+        go-version: '1.26.3'
         cache: true
 
     - name: Set up buf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Set up buf
@@ -131,7 +131,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Set up buf

--- a/cmd/meridian/Dockerfile
+++ b/cmd/meridian/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by CGO_ENABLED=0 static binary
 
 # Build stage
-FROM golang:1.26.2-bookworm AS builder
+FROM golang:1.26.3-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4818,9 +4818,9 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5220,9 +5220,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5894,9 +5894,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7350,13 +7350,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -7420,9 +7420,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -7841,9 +7841,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7970,9 +7970,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8126,9 +8126,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8907,9 +8907,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },
@@ -9897,9 +9897,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -10563,9 +10563,9 @@
       }
     },
     "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -11240,9 +11240,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/meridianhub/meridian
 
-go 1.26.2
+go 1.26.3
 
 require (
 	ariga.io/atlas-provider-gorm v0.6.0
@@ -61,7 +61,7 @@ require (
 
 require (
 	github.com/AppsFlyer/go-sundheit v0.6.0 // indirect
-	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
+	github.com/Azure/go-ntlmssp v0.1.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.3.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -653,8 +653,8 @@ github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.0.0 h1:D3occ
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.0.0/go.mod h1:bTSOgj05NGRuHHhQwAdPnYr9TOdNmKlZTgGLL6nyAdI=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
-github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 h1:mFRzDkZVAjdal+s7s0MwaRv9igoPqLRdzOLzw/8Xvq8=
-github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
+github.com/Azure/go-ntlmssp v0.1.1 h1:l+FM/EEMb0U9QZE7mKNEDw5Mu3mFiaa2GKOoTSsNDPw=
+github.com/Azure/go-ntlmssp v0.1.1/go.mod h1:NYqdhxd/8aAct/s4qSYZEerdPuH1liG2/X9DiVTbhpk=
 github.com/AzureAD/microsoft-authentication-library-for-go v0.5.1/go.mod h1:Vt9sXTKwMyGcOxSmLDMnGPgqsUg7m8pe215qMLrDXw4=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.1 h1:DzHpqpoJVaCgOUdVHxE8QB52S6NiVdDQvGlny1qvPqA=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.1/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=

--- a/services/api-gateway/cmd/Dockerfile
+++ b/services/api-gateway/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.26.2-bookworm AS builder
+FROM golang:1.26.3-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/control-plane/cmd/Dockerfile
+++ b/services/control-plane/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go dependencies
 
 # Build stage
-FROM golang:1.26.2-bookworm AS builder
+FROM golang:1.26.3-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/current-account/cmd/Dockerfile
+++ b/services/current-account/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.26.2-bookworm AS builder
+FROM golang:1.26.3-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/event-router/cmd/Dockerfile
+++ b/services/event-router/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.26.2-bookworm AS builder
+FROM golang:1.26.3-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/financial-accounting/cmd/Dockerfile
+++ b/services/financial-accounting/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.26.2-bookworm AS builder
+FROM golang:1.26.3-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/financial-gateway/cmd/Dockerfile
+++ b/services/financial-gateway/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image for minimal attack surface
 
 # Build stage
-FROM golang:1.26.2-bookworm AS builder
+FROM golang:1.26.3-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/forecasting/cmd/Dockerfile
+++ b/services/forecasting/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go dependencies
 
 # Build stage
-FROM golang:1.26.2-bookworm AS builder
+FROM golang:1.26.3-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/internal-account/cmd/Dockerfile
+++ b/services/internal-account/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.26.2-bookworm AS builder
+FROM golang:1.26.3-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/market-information/cmd/Dockerfile
+++ b/services/market-information/cmd/Dockerfile
@@ -4,7 +4,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go dependencies
 
 # Build stage
-FROM golang:1.26.2-bookworm AS builder
+FROM golang:1.26.3-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/mcp-server/cmd/Dockerfile
+++ b/services/mcp-server/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image for minimal attack surface
 
 # Build stage
-FROM golang:1.26.2-bookworm AS builder
+FROM golang:1.26.3-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/party/cmd/Dockerfile
+++ b/services/party/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.26.2-bookworm AS builder
+FROM golang:1.26.3-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/payment-order/cmd/Dockerfile
+++ b/services/payment-order/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.26.2-bookworm AS builder
+FROM golang:1.26.3-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/position-keeping/cmd/Dockerfile
+++ b/services/position-keeping/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.26.2-bookworm AS builder
+FROM golang:1.26.3-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/reconciliation/cmd/Dockerfile
+++ b/services/reconciliation/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go dependencies
 
 # Build stage
-FROM golang:1.26.2-bookworm AS builder
+FROM golang:1.26.3-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/reference-data/cmd/Dockerfile
+++ b/services/reference-data/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go dependencies
 
 # Build stage
-FROM golang:1.26.2-bookworm AS builder
+FROM golang:1.26.3-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/tenant/cmd/Dockerfile
+++ b/services/tenant/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.26.2-bookworm AS builder
+FROM golang:1.26.3-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary

Follow-up to Dependabot PRs #2196 (Go 1.26.2 -> 1.26.3 in top-level Dockerfile) and #2199 (Go deps group bump). Closes the remaining open security alerts that those PRs did not cover.

## Changes Made

### Code Scanning (Trivy) — alerts #273-#280

Bump `go-version` pin from `1.26.2` to `1.26.3` in:

- All 16 per-service Dockerfiles under `services/*/cmd/Dockerfile`
- `cmd/meridian/Dockerfile`
- All 16 GitHub Actions workflows that pin a Go version via `actions/setup-go`

Dependabot's #2196 only touched the top-level `Dockerfile`, `Dockerfile.dev`, and the `go` directive in `go.mod`. The per-service builder images and the `setup-go` pins in CI still resolved to 1.26.2, which means `govulncheck` continued to flag 8 stdlib advisories (CVE-2026-42499 and friends) on every PR. Bumping these here closes the alerts and unblocks `govulncheck` on subsequent PRs.

### Dependabot — alert #51

Upgrade `github.com/Azure/go-ntlmssp` from the 2022 pseudo-version `v0.0.0-20221128193559` to `v0.1.1`. Pulled in indirectly via `github.com/dexidp/dex` -> `github.com/go-ldap/ldap/v3`. Fixes GHSA-3xv4-7v32-pjjj (panic on malformed NTLM challenge payloads).

### Dependabot — alerts #49, #52, #53, #54, #56, #57, #58, #59, #60

`npm audit fix` in `frontend/`, picking up:

| Package | Before | After | Advisories closed |
|---------|--------|-------|-------------------|
| `hono` | 4.12.12 | 4.12.18 | #49, #54, #57, #58, #59 |
| `fast-uri` | 3.1.0 | 3.1.2 | #56, #60 |
| `postcss` | 8.5.6 | 8.5.14 | #53 |
| `ip-address` | 10.1.0 | 10.2.0 | #52 |

`npm audit` reports `found 0 vulnerabilities` after the bump.

## Technical Details

- `go.mod` / `go.sum` updated for the go-ntlmssp bump
- `package-lock.json` regenerated by `npm audit fix` (lockfile-only changes; no `package.json` modifications were necessary because all four packages were either transitive or already satisfied by a permissive caret range)
- The `go` directive in `go.mod` is also bumped to `1.26.3` (already done by #2196 but rebased here)

## Testing

- `go build ./...` (clean)
- `npm run typecheck` (clean)
- `npm audit` reports zero vulnerabilities

## Risk Assessment

Low. Patch-level bumps with no API surface changes. The Go stdlib bump is the recommended remediation per the Trivy advisories; go-ntlmssp 0.0.0 -> 0.1.1 only adds defensive parsing on NTLM challenge bytes; the npm bumps are all patch or minor releases on packages used internally by Hono/express middleware.

## Deployment Notes

After merge, the next image build will use Go 1.26.3, and the open Trivy code-scanning alerts plus the 9 referenced Dependabot alerts should close on the next scheduled scan.