### PR TITLE
fix: Drop obsolete mcp-server references from reset scripts

### DIFF
--- a/scripts/reset-demo.sh
+++ b/scripts/reset-demo.sh
@@ -59,11 +59,11 @@ fi
 
 echo ""
 echo "=== Step 1: Pull latest demo image ==="
-ssh "${DEMO_HOST}" "cd ${DEMO_DIR} && docker compose pull meridian mcp-server"
+ssh "${DEMO_HOST}" "cd ${DEMO_DIR} && docker compose pull meridian"
 
 echo ""
-echo "=== Step 2: Stop meridian + mcp-server (keep postgres) ==="
-ssh "${DEMO_HOST}" "cd ${DEMO_DIR} && docker compose stop meridian mcp-server"
+echo "=== Step 2: Stop meridian (keep postgres) ==="
+ssh "${DEMO_HOST}" "cd ${DEMO_DIR} && docker compose stop meridian"
 
 echo ""
 echo "=== Step 3: Drop and recreate databases ==="
@@ -147,11 +147,7 @@ ssh "${DEMO_HOST}" "docker exec ${APP_CONTAINER} /seed-dev \
   --with-fixtures"
 
 echo ""
-echo "=== Step 8: Start mcp-server ==="
-ssh "${DEMO_HOST}" "cd ${DEMO_DIR} && docker compose up -d mcp-server"
-
-echo ""
-echo "=== Step 9: Health check ==="
+echo "=== Step 8: Health check ==="
 attempt=0
 until [ $attempt -ge 24 ]; do
   attempt=$((attempt + 1))

--- a/scripts/reset-develop.sh
+++ b/scripts/reset-develop.sh
@@ -3,14 +3,13 @@
 #
 # This script:
 #   1. Pulls the latest develop Docker image
-#   2. Stops the meridian-develop and mcp-server-develop containers (keeps postgres running)
+#   2. Stops the meridian-develop container (keeps postgres running)
 #   3. Drops and recreates all dev_ per-service databases
 #   4. Runs pre-migration scripts for PostgreSQL compatibility
 #   5. Starts meridian-develop and runs migrations
 #   6. Restarts meridian-develop post-migration
 #   7. Seeds the develop tenant with fixture data via gRPC
-#   8. Starts mcp-server-develop
-#   9. Verifies the environment is healthy
+#   8. Verifies the environment is healthy
 #
 # Usage:
 #   ./scripts/reset-develop.sh
@@ -62,11 +61,11 @@ fi
 
 echo ""
 echo "=== Step 1: Pull latest develop image ==="
-ssh "${DEVELOP_HOST}" "cd ${DEVELOP_DIR} && ${COMPOSE_CMD} pull meridian-develop mcp-server-develop"
+ssh "${DEVELOP_HOST}" "cd ${DEVELOP_DIR} && ${COMPOSE_CMD} pull meridian-develop"
 
 echo ""
-echo "=== Step 2: Stop meridian-develop + mcp-server-develop (keep postgres) ==="
-ssh "${DEVELOP_HOST}" "cd ${DEVELOP_DIR} && ${COMPOSE_CMD} stop meridian-develop mcp-server-develop"
+echo "=== Step 2: Stop meridian-develop (keep postgres) ==="
+ssh "${DEVELOP_HOST}" "cd ${DEVELOP_DIR} && ${COMPOSE_CMD} stop meridian-develop"
 
 echo ""
 echo "=== Step 3: Drop and recreate databases ==="
@@ -151,11 +150,7 @@ ssh "${DEVELOP_HOST}" "docker exec ${APP_CONTAINER} /seed-dev \
   --with-fixtures"
 
 echo ""
-echo "=== Step 8: Start mcp-server-develop ==="
-ssh "${DEVELOP_HOST}" "cd ${DEVELOP_DIR} && ${COMPOSE_CMD} up -d mcp-server-develop"
-
-echo ""
-echo "=== Step 9: Health check ==="
+echo "=== Step 8: Health check ==="
 attempt=0
 until [ $attempt -ge 24 ]; do
   attempt=$((attempt + 1))


### PR DESCRIPTION
## Summary

The nightly Demo Reset workflow has been failing every night since April 8 (most recent: [run 25951448994](https://github.com/meridianhub/meridian/actions/runs/25951448994)). It exits at Step 1 with:

```
no such service: mcp-server
```

## Root Cause

PR #2171 (2026-04-08, \"Route MCP traffic to unified binary for PRD-061 consent flow\") removed the standalone \`mcp-server\` / \`mcp-server-develop\` services from \`deploy/demo/docker-compose.yml\` and \`deploy/develop/docker-compose.develop.yml\`. MCP now runs inside the unified meridian binary so the BFF and MCP can share in-memory consent stores.

\`scripts/reset-demo.sh\` and \`scripts/reset-develop.sh\` were not updated and still call \`docker compose pull/stop/up\` on the deleted service.

## Fix

- Remove \`mcp-server\` from \`pull\` and \`stop\` commands in both scripts (steps 1 and 2)
- Delete the now-unused \"start mcp-server\" step (step 8 in both scripts)
- Renumber the trailing health-check step accordingly
- Update header comments to match

## Scope

- \`reset-demo.sh\`: exercised nightly via \`demo-reset.yml\` - actively broken in CI
- \`reset-develop.sh\`: not on a schedule (manual only), but has the same stale reference and would fail when run

## Test Plan

- [ ] Next nightly Demo Reset (\`schedule\`) succeeds end-to-end on demo droplet
- [ ] Manual run of \`reset-demo.sh\` against a clean demo droplet completes through health check