### PR TITLE
fix: Pass --timeout=5m to seed-dev in reset scripts

### DIFF
--- a/scripts/reset-demo.sh
+++ b/scripts/reset-demo.sh
@@ -132,6 +132,7 @@ ssh "${DEMO_HOST}" "docker exec ${APP_CONTAINER} /seed-dev \
   --display-name='Volterra Energy' \
   --subdomain=volterra-energy.demo.meridianhub.cloud \
   --manifest=/app/examples/manifests/volterra-energy-demo.json \
+  --timeout=5m \
   --with-fixtures"
 
 echo ""
@@ -144,6 +145,7 @@ ssh "${DEMO_HOST}" "docker exec ${APP_CONTAINER} /seed-dev \
   --display-name='PAYG Energy' \
   --subdomain=payg-energy.demo.meridianhub.cloud \
   --manifest=/app/examples/manifests/payg-energy.manifest.json \
+  --timeout=5m \
   --with-fixtures"
 
 echo ""

--- a/scripts/reset-develop.sh
+++ b/scripts/reset-develop.sh
@@ -135,6 +135,7 @@ ssh "${DEVELOP_HOST}" "docker exec ${APP_CONTAINER} /seed-dev \
   --display-name='Volterra Energy' \
   --subdomain=volterra-energy.develop.meridianhub.cloud \
   --manifest=/app/examples/manifests/volterra-energy-demo.json \
+  --timeout=5m \
   --with-fixtures"
 
 echo ""
@@ -147,6 +148,7 @@ ssh "${DEVELOP_HOST}" "docker exec ${APP_CONTAINER} /seed-dev \
   --display-name='PAYG Energy' \
   --subdomain=payg-energy.develop.meridianhub.cloud \
   --manifest=/app/examples/manifests/payg-energy.manifest.json \
+  --timeout=5m \
   --with-fixtures"
 
 echo ""


### PR DESCRIPTION
## Summary

Follow-up to #2205. After dropping the obsolete \`mcp-server\` references, the next Demo Reset run (manual dispatch, [25971427957](https://github.com/meridianhub/meridian/actions/runs/25971427957)) reached the seed step and then hit the same \`seed-dev\` 2-minute timeout that PR #2203 fixed in the deploy workflows.

\`\`\`
Error: seed fixtures: seed balances: deposit KWH for Charlotte Davies day 13:
  rpc error: code = DeadlineExceeded desc = context deadline exceeded
\`\`\`

## Root Cause

\`reset-demo.sh\` and \`reset-develop.sh\` each invoke \`seed-dev\` twice (\`volterra_energy\` + \`payg_energy\` tenants) without \`--timeout\`, inheriting the 2-minute default. Each \`--with-fixtures\` run performs ~600 sequential RPC calls (10 customers x 30 days x 2 deposits) and consistently takes 3+ minutes.

## Fix

Pass \`--timeout=5m\` to all four \`seed-dev\` invocations, matching the headroom set in \`deploy-develop.yml\` / \`deploy-demo.yml\` by #2203.

## Test Plan

- [ ] Trigger \`Demo Reset\` via \`workflow_dispatch\` and confirm it completes end-to-end through the health check