### PR TITLE
feat: Implement saga version pinning (063-saga-durability-parity.1)

### DIFF
--- a/services/control-plane/internal/applier/executor.go
+++ b/services/control-plane/internal/applier/executor.go
@@ -28,10 +28,11 @@ type PlannedResourceAction struct {
 // It loads the saga definition (with platform default fallback per ADR-0028),
 // constructs the saga input from the manifest, and executes via the saga engine.
 type ManifestExecutor struct {
-	pool    *pgxpool.Pool
-	runner  *saga.StarlarkSagaRunner
-	jobRepo *ApplyJobRepository
-	logger  *slog.Logger
+	pool        *pgxpool.Pool
+	runner      *saga.StarlarkSagaRunner
+	jobRepo     *ApplyJobRepository
+	sagaDefRepo *SagaDefinitionRepository
+	logger      *slog.Logger
 }
 
 // ManifestExecutorConfig contains configuration for creating a ManifestExecutor.
@@ -49,10 +50,11 @@ func NewManifestExecutor(cfg ManifestExecutorConfig) *ManifestExecutor {
 	}
 
 	return &ManifestExecutor{
-		pool:    cfg.Pool,
-		runner:  cfg.Runner,
-		jobRepo: NewApplyJobRepository(cfg.Pool),
-		logger:  logger.With("component", "manifest_executor"),
+		pool:        cfg.Pool,
+		runner:      cfg.Runner,
+		jobRepo:     NewApplyJobRepository(cfg.Pool),
+		sagaDefRepo: NewSagaDefinitionRepository(cfg.Pool),
+		logger:      logger.With("component", "manifest_executor"),
 	}
 }
 
@@ -346,7 +348,15 @@ func (e *ManifestExecutor) Apply(ctx context.Context, input *ApplyManifestInput)
 	return e.executeSagaAndFinalize(ctx, input, job, script, logger)
 }
 
-// prepareApplyJob creates the tracking job and resolves the saga script.
+// prepareApplyJob creates the tracking job, resolves the saga script, and pins
+// the resolved definition into the saga_definitions table so a future resume
+// path can re-execute the same script even if the platform default is later
+// updated.
+//
+// Pinning is best-effort: if the saga_definitions table is missing (e.g. in
+// older environments yet to apply the migration) or the pin fails for an
+// infrastructure reason, we log and continue with the resolved script - the
+// current saga still runs correctly, only durable-resume parity is lost.
 func (e *ManifestExecutor) prepareApplyJob(ctx context.Context, input *ApplyManifestInput) (*ApplyJob, string, error) {
 	versionInt := parseManifestVersion(input.ManifestVersion)
 	job, err := e.jobRepo.Create(ctx, versionInt)
@@ -354,13 +364,38 @@ func (e *ManifestExecutor) prepareApplyJob(ctx context.Context, input *ApplyMani
 		return nil, "", fmt.Errorf("create apply job: %w", err)
 	}
 
-	script, err := e.resolveSagaScript(ctx)
+	script, sagaVersion, err := e.resolveSagaScript(ctx)
 	if err != nil {
 		_ = e.jobRepo.MarkFailed(ctx, job.ID, err.Error())
 		return nil, "", fmt.Errorf("resolve saga script: %w", err)
 	}
 
+	e.pinSagaDefinition(ctx, "apply_manifest", sagaVersion, script)
+
 	return job, script, nil
+}
+
+// pinSagaDefinition writes the resolved saga definition into saga_definitions
+// via FindOrCreate. Errors are logged but not returned: a pinning failure must
+// not block the apply itself.
+func (e *ManifestExecutor) pinSagaDefinition(ctx context.Context, name, version, script string) {
+	if e.sagaDefRepo == nil {
+		return
+	}
+	def, err := e.sagaDefRepo.FindOrCreate(ctx, name, version, script, nil)
+	if err != nil {
+		e.logger.Warn("failed to pin saga definition",
+			"saga_name", name,
+			"saga_version", version,
+			"error", err,
+		)
+		return
+	}
+	e.logger.Debug("pinned saga definition",
+		"saga_name", name,
+		"saga_version", version,
+		"saga_definition_id", def.ID,
+	)
 }
 
 // executeSagaAndFinalize runs the saga, handles failure/success, and updates the job status.
@@ -426,15 +461,15 @@ func (e *ManifestExecutor) executeSagaAndFinalize(ctx context.Context, input *Ap
 	}, nil
 }
 
-// resolveSagaScript resolves the apply_manifest saga script from the platform default table.
+// resolveSagaScript resolves the apply_manifest saga script and its semver version
+// from the platform default table.
 // Per ADR-0028, the control plane uses the platform default directly from
 // public.platform_saga_definition. Tenant-specific saga overrides are resolved
 // by the Reference Data service's saga registry (GetActive), not here.
-func (e *ManifestExecutor) resolveSagaScript(ctx context.Context) (string, error) {
+func (e *ManifestExecutor) resolveSagaScript(ctx context.Context) (script, version string, err error) {
 	// Query platform default (applies to all tenants including those with 0 local saga definitions)
-	var script string
-	err := e.pool.QueryRow(ctx,
-		`SELECT script FROM public.platform_saga_definition
+	err = e.pool.QueryRow(ctx,
+		`SELECT script, version FROM public.platform_saga_definition
 		 WHERE name = $1 AND status = 'ACTIVE'
 		 ORDER BY
 			COALESCE(NULLIF(split_part(version, '.', 1), '')::int, 0) DESC,
@@ -442,15 +477,15 @@ func (e *ManifestExecutor) resolveSagaScript(ctx context.Context) (string, error
 			COALESCE(NULLIF(split_part(version, '.', 3), '')::int, 0) DESC
 		 LIMIT 1`,
 		"apply_manifest",
-	).Scan(&script)
+	).Scan(&script, &version)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return "", ErrSagaNotFound
+			return "", "", ErrSagaNotFound
 		}
-		return "", fmt.Errorf("query platform saga definition: %w", err)
+		return "", "", fmt.Errorf("query platform saga definition: %w", err)
 	}
 
-	return script, nil
+	return script, version, nil
 }
 
 // buildSagaInput converts the structured input into the map[string]interface{}

--- a/services/control-plane/internal/applier/executor_pinning_test.go
+++ b/services/control-plane/internal/applier/executor_pinning_test.go
@@ -1,0 +1,86 @@
+package applier
+
+import (
+	"context"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestManifestExecutor_PinSagaDefinition verifies that the executor writes a
+// saga_definitions row when it pins the resolved apply_manifest script. This is
+// the durable-resume parity guarantee: future calls to FindByID can return the
+// exact script that was used to start the apply.
+func TestManifestExecutor_PinSagaDefinition(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool := testdb.NewTestPool(t, testdb.WithMigrations("control-plane"))
+	ctx := context.Background()
+
+	executor := NewManifestExecutor(ManifestExecutorConfig{Pool: pool})
+
+	const (
+		name    = "apply_manifest"
+		version = "1.5.0"
+		script  = "def main(): return {'ok': True}"
+	)
+
+	executor.pinSagaDefinition(ctx, name, version, script)
+
+	// Subsequent FindByID must return the exact pinned row.
+	repo := NewSagaDefinitionRepository(pool)
+
+	// Locate by (name, version) since pinSagaDefinition doesn't return the ID.
+	stored, err := repo.FindOrCreate(ctx, name, version, script, nil)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Equal(t, name, stored.Name)
+	assert.Equal(t, version, stored.Version)
+	assert.Equal(t, script, stored.Script)
+	assert.Equal(t, saga.ComputeSagaDefinitionScriptHash(script), stored.ScriptHash)
+}
+
+// TestManifestExecutor_PinSagaDefinition_Idempotent verifies that pinning the
+// same (name, version, script) twice does not create duplicate rows or error.
+func TestManifestExecutor_PinSagaDefinition_Idempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool := testdb.NewTestPool(t, testdb.WithMigrations("control-plane"))
+	ctx := context.Background()
+
+	executor := NewManifestExecutor(ManifestExecutorConfig{Pool: pool})
+
+	const (
+		name    = "apply_manifest"
+		version = "2.0.0"
+		script  = "def main(): return None"
+	)
+
+	executor.pinSagaDefinition(ctx, name, version, script)
+	executor.pinSagaDefinition(ctx, name, version, script)
+
+	// Count rows for (name, version) - must be exactly one.
+	var count int
+	err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM saga_definitions WHERE name = $1 AND version = $2`,
+		name, version,
+	).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+// TestManifestExecutor_PinSagaDefinition_NilRepoIsNoOp confirms that an executor
+// constructed without a pgxpool (e.g. unit tests) skips pinning silently rather
+// than panicking.
+func TestManifestExecutor_PinSagaDefinition_NilRepoIsNoOp(_ *testing.T) {
+	executor := NewManifestExecutor(ManifestExecutorConfig{})
+	// sagaDefRepo is nil when Pool is nil; pinSagaDefinition must tolerate this.
+	executor.pinSagaDefinition(context.Background(), "any", "1.0.0", "def main(): pass")
+}

--- a/services/control-plane/internal/applier/executor_pinning_test.go
+++ b/services/control-plane/internal/applier/executor_pinning_test.go
@@ -32,17 +32,20 @@ func TestManifestExecutor_PinSagaDefinition(t *testing.T) {
 
 	executor.pinSagaDefinition(ctx, name, version, script)
 
-	// Subsequent FindByID must return the exact pinned row.
-	repo := NewSagaDefinitionRepository(pool)
-
-	// Locate by (name, version) since pinSagaDefinition doesn't return the ID.
-	stored, err := repo.FindOrCreate(ctx, name, version, script, nil)
-	require.NoError(t, err)
-	require.NotNil(t, stored)
-	assert.Equal(t, name, stored.Name)
-	assert.Equal(t, version, stored.Version)
-	assert.Equal(t, script, stored.Script)
-	assert.Equal(t, saga.ComputeSagaDefinitionScriptHash(script), stored.ScriptHash)
+	// Verify the row exists by reading directly from the DB. Using FindOrCreate
+	// here would mask a pinning regression: it would insert the row itself if
+	// pinSagaDefinition had failed, and the assertions would still pass.
+	var (
+		storedScript     string
+		storedScriptHash string
+	)
+	err := pool.QueryRow(ctx,
+		`SELECT script, script_hash FROM saga_definitions WHERE name = $1 AND version = $2`,
+		name, version,
+	).Scan(&storedScript, &storedScriptHash)
+	require.NoError(t, err, "pinSagaDefinition must have written a saga_definitions row")
+	assert.Equal(t, script, storedScript)
+	assert.Equal(t, saga.ComputeSagaDefinitionScriptHash(script), storedScriptHash)
 }
 
 // TestManifestExecutor_PinSagaDefinition_Idempotent verifies that pinning the

--- a/services/control-plane/internal/applier/saga_definition_repository.go
+++ b/services/control-plane/internal/applier/saga_definition_repository.go
@@ -81,16 +81,26 @@ func (r *SagaDefinitionRepository) FindOrCreate(
 	existing, err := r.findByNameVersion(ctx, name, version)
 	switch {
 	case err == nil:
-		if existing.ScriptHash != hash {
-			return nil, fmt.Errorf("%w: name=%s version=%s (stored=%s incoming=%s)",
-				saga.ErrSagaDefinitionHashMismatch, name, version, existing.ScriptHash, hash)
-		}
-		return existing, nil
+		return verifyExistingHashMatch(existing, hash, name, version)
 	case !errors.Is(err, saga.ErrSagaDefinitionNotFound):
 		return nil, err
 	}
 
-	// Serialize params_schema. Empty payloads stored as NULL.
+	def, insertErr := r.insertSagaDefinition(ctx, name, version, script, paramsSchema, hash)
+	if insertErr == nil {
+		return def, nil
+	}
+	return r.resolveInsertRace(ctx, insertErr, name, version, hash)
+}
+
+// insertSagaDefinition inserts a new row and returns the in-memory entity on
+// success. Callers handle insertErr to detect race losses on the unique index.
+func (r *SagaDefinitionRepository) insertSagaDefinition(
+	ctx context.Context,
+	name, version, script string,
+	paramsSchema saga.JSONB,
+	hash string,
+) (*saga.SagaDefinition, error) {
 	var paramsBytes []byte
 	if paramsSchema != nil {
 		b, marshalErr := json.Marshal(paramsSchema)
@@ -102,38 +112,51 @@ func (r *SagaDefinitionRepository) FindOrCreate(
 
 	id := uuid.New()
 	createdAt := time.Now().UTC()
-	_, insertErr := r.pool.Exec(ctx,
+	if _, err := r.pool.Exec(ctx,
 		`INSERT INTO saga_definitions
 			(id, name, version, script, params_schema, script_hash, created_at)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
 		id, name, version, script, paramsBytes, hash, createdAt,
-	)
-	if insertErr == nil {
-		return &saga.SagaDefinition{
-			ID:           id,
-			Name:         name,
-			Version:      version,
-			Script:       script,
-			ParamsSchema: paramsSchema,
-			ScriptHash:   hash,
-			CreatedAt:    createdAt,
-		}, nil
+	); err != nil {
+		return nil, err
 	}
+	return &saga.SagaDefinition{
+		ID:           id,
+		Name:         name,
+		Version:      version,
+		Script:       script,
+		ParamsSchema: paramsSchema,
+		ScriptHash:   hash,
+		CreatedAt:    createdAt,
+	}, nil
+}
 
-	// Treat any insert failure as a possible race on the unique (name, version)
-	// index: re-read and validate the winner's hash.
-	raceWinner, lookupErr := r.findByNameVersion(ctx, name, version)
+// resolveInsertRace handles the case where the INSERT failed: typically the
+// unique (name, version) index lost a race with a concurrent caller. Re-read
+// the winning row and validate its hash matches.
+func (r *SagaDefinitionRepository) resolveInsertRace(
+	ctx context.Context,
+	insertErr error,
+	name, version, hash string,
+) (*saga.SagaDefinition, error) {
+	winner, lookupErr := r.findByNameVersion(ctx, name, version)
 	if lookupErr != nil {
 		if errors.Is(lookupErr, saga.ErrSagaDefinitionNotFound) {
 			return nil, fmt.Errorf("insert saga definition: %w", insertErr)
 		}
 		return nil, fmt.Errorf("insert saga definition (%w) and re-read failed: %w", insertErr, lookupErr)
 	}
-	if raceWinner.ScriptHash != hash {
+	return verifyExistingHashMatch(winner, hash, name, version)
+}
+
+// verifyExistingHashMatch returns the existing row when its script_hash matches
+// the incoming script's hash, or ErrSagaDefinitionHashMismatch otherwise.
+func verifyExistingHashMatch(existing *saga.SagaDefinition, hash, name, version string) (*saga.SagaDefinition, error) {
+	if existing.ScriptHash != hash {
 		return nil, fmt.Errorf("%w: name=%s version=%s (stored=%s incoming=%s)",
-			saga.ErrSagaDefinitionHashMismatch, name, version, raceWinner.ScriptHash, hash)
+			saga.ErrSagaDefinitionHashMismatch, name, version, existing.ScriptHash, hash)
 	}
-	return raceWinner, nil
+	return existing, nil
 }
 
 func (r *SagaDefinitionRepository) findByNameVersion(

--- a/services/control-plane/internal/applier/saga_definition_repository.go
+++ b/services/control-plane/internal/applier/saga_definition_repository.go
@@ -1,0 +1,170 @@
+package applier
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+)
+
+// SagaDefinitionRepository pins resolved saga definitions in the control-plane
+// database so the resume path can load the exact script that ran originally,
+// rather than re-resolving the (potentially updated) manifest state.
+//
+// This is a pgx-based implementation that operates on the same saga_definitions
+// schema as the GORM-managed shared/pkg/saga.GormSagaDefinitionRepository.
+type SagaDefinitionRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewSagaDefinitionRepository creates a SagaDefinitionRepository backed by the
+// given pgxpool. Returns nil if the pool is nil.
+func NewSagaDefinitionRepository(pool *pgxpool.Pool) *SagaDefinitionRepository {
+	if pool == nil {
+		return nil
+	}
+	return &SagaDefinitionRepository{pool: pool}
+}
+
+// FindByID retrieves a saga definition by its immutable ID.
+// Returns saga.ErrSagaDefinitionNotFound when no row exists.
+func (r *SagaDefinitionRepository) FindByID(ctx context.Context, id uuid.UUID) (*saga.SagaDefinition, error) {
+	if id == uuid.Nil {
+		return nil, saga.ErrSagaDefinitionNotFound
+	}
+
+	def := &saga.SagaDefinition{}
+	var paramsRaw []byte
+
+	err := r.pool.QueryRow(ctx,
+		`SELECT id, name, version, script, params_schema, script_hash, created_at
+		 FROM saga_definitions WHERE id = $1`,
+		id,
+	).Scan(&def.ID, &def.Name, &def.Version, &def.Script, &paramsRaw, &def.ScriptHash, &def.CreatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, saga.ErrSagaDefinitionNotFound
+		}
+		return nil, fmt.Errorf("query saga definition by id: %w", err)
+	}
+
+	if len(paramsRaw) > 0 {
+		var schema saga.JSONB
+		if unmarshalErr := json.Unmarshal(paramsRaw, &schema); unmarshalErr != nil {
+			return nil, fmt.Errorf("decode saga definition params_schema: %w", unmarshalErr)
+		}
+		def.ParamsSchema = schema
+	}
+
+	return def, nil
+}
+
+// FindOrCreate returns an existing row matching (name, version, script hash),
+// or inserts a new row if no (name, version) entry exists. Same contract as
+// the shared/pkg/saga repository.
+//
+// Returns saga.ErrSagaDefinitionHashMismatch when (name, version) is present
+// but the stored script hash differs from the incoming script.
+func (r *SagaDefinitionRepository) FindOrCreate(
+	ctx context.Context,
+	name, version, script string,
+	paramsSchema saga.JSONB,
+) (*saga.SagaDefinition, error) {
+	hash := saga.ComputeSagaDefinitionScriptHash(script)
+
+	existing, err := r.findByNameVersion(ctx, name, version)
+	switch {
+	case err == nil:
+		if existing.ScriptHash != hash {
+			return nil, fmt.Errorf("%w: name=%s version=%s (stored=%s incoming=%s)",
+				saga.ErrSagaDefinitionHashMismatch, name, version, existing.ScriptHash, hash)
+		}
+		return existing, nil
+	case !errors.Is(err, saga.ErrSagaDefinitionNotFound):
+		return nil, err
+	}
+
+	// Serialize params_schema. Empty payloads stored as NULL.
+	var paramsBytes []byte
+	if paramsSchema != nil {
+		b, marshalErr := json.Marshal(paramsSchema)
+		if marshalErr != nil {
+			return nil, fmt.Errorf("encode params_schema: %w", marshalErr)
+		}
+		paramsBytes = b
+	}
+
+	id := uuid.New()
+	createdAt := time.Now().UTC()
+	_, insertErr := r.pool.Exec(ctx,
+		`INSERT INTO saga_definitions
+			(id, name, version, script, params_schema, script_hash, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		id, name, version, script, paramsBytes, hash, createdAt,
+	)
+	if insertErr == nil {
+		return &saga.SagaDefinition{
+			ID:           id,
+			Name:         name,
+			Version:      version,
+			Script:       script,
+			ParamsSchema: paramsSchema,
+			ScriptHash:   hash,
+			CreatedAt:    createdAt,
+		}, nil
+	}
+
+	// Treat any insert failure as a possible race on the unique (name, version)
+	// index: re-read and validate the winner's hash.
+	raceWinner, lookupErr := r.findByNameVersion(ctx, name, version)
+	if lookupErr != nil {
+		if errors.Is(lookupErr, saga.ErrSagaDefinitionNotFound) {
+			return nil, fmt.Errorf("insert saga definition: %w", insertErr)
+		}
+		return nil, fmt.Errorf("insert saga definition (%w) and re-read failed: %w", insertErr, lookupErr)
+	}
+	if raceWinner.ScriptHash != hash {
+		return nil, fmt.Errorf("%w: name=%s version=%s (stored=%s incoming=%s)",
+			saga.ErrSagaDefinitionHashMismatch, name, version, raceWinner.ScriptHash, hash)
+	}
+	return raceWinner, nil
+}
+
+func (r *SagaDefinitionRepository) findByNameVersion(
+	ctx context.Context,
+	name, version string,
+) (*saga.SagaDefinition, error) {
+	def := &saga.SagaDefinition{}
+	var paramsRaw []byte
+
+	err := r.pool.QueryRow(ctx,
+		`SELECT id, name, version, script, params_schema, script_hash, created_at
+		 FROM saga_definitions WHERE name = $1 AND version = $2`,
+		name, version,
+	).Scan(&def.ID, &def.Name, &def.Version, &def.Script, &paramsRaw, &def.ScriptHash, &def.CreatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, saga.ErrSagaDefinitionNotFound
+		}
+		return nil, fmt.Errorf("lookup saga definition by name+version: %w", err)
+	}
+
+	if len(paramsRaw) > 0 {
+		var schema saga.JSONB
+		if unmarshalErr := json.Unmarshal(paramsRaw, &schema); unmarshalErr != nil {
+			return nil, fmt.Errorf("decode saga definition params_schema: %w", unmarshalErr)
+		}
+		def.ParamsSchema = schema
+	}
+
+	return def, nil
+}
+
+// Compile-time check that we satisfy the shared interface.
+var _ saga.SagaDefinitionRepository = (*SagaDefinitionRepository)(nil)

--- a/services/control-plane/internal/applier/saga_definition_repository_test.go
+++ b/services/control-plane/internal/applier/saga_definition_repository_test.go
@@ -1,0 +1,100 @@
+package applier
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSagaDefinitionRepository_PgxIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool := testdb.NewTestPool(t, testdb.WithMigrations("control-plane"))
+	repo := NewSagaDefinitionRepository(pool)
+	ctx := context.Background()
+
+	t.Run("FindOrCreate_NewRow", func(t *testing.T) {
+		script := "def main(): return {'ok': True}"
+		def, err := repo.FindOrCreate(ctx, "test_saga_new", "1.0.0", script, nil)
+		require.NoError(t, err)
+		require.NotNil(t, def)
+
+		assert.NotEqual(t, uuid.Nil, def.ID)
+		assert.Equal(t, "test_saga_new", def.Name)
+		assert.Equal(t, "1.0.0", def.Version)
+		assert.Equal(t, script, def.Script)
+		assert.Equal(t, saga.ComputeSagaDefinitionScriptHash(script), def.ScriptHash)
+		assert.False(t, def.CreatedAt.IsZero())
+	})
+
+	t.Run("FindOrCreate_Idempotent", func(t *testing.T) {
+		script := "def main(): return None"
+
+		first, err := repo.FindOrCreate(ctx, "saga_dup_pgx", "1.0.0", script, nil)
+		require.NoError(t, err)
+
+		second, err := repo.FindOrCreate(ctx, "saga_dup_pgx", "1.0.0", script, nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, first.ID, second.ID, "same (name, version, script) must return same row")
+	})
+
+	t.Run("FindOrCreate_HashMismatchRejected", func(t *testing.T) {
+		_, err := repo.FindOrCreate(ctx, "immutable_pgx", "2.0.0", "def v1(): pass", nil)
+		require.NoError(t, err)
+
+		_, err = repo.FindOrCreate(ctx, "immutable_pgx", "2.0.0", "def v1_TAMPERED(): pass", nil)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, saga.ErrSagaDefinitionHashMismatch),
+			"expected ErrSagaDefinitionHashMismatch, got %v", err)
+	})
+
+	t.Run("FindOrCreate_PersistsParamsSchema", func(t *testing.T) {
+		params := saga.JSONB{"amount": map[string]any{"type": "Decimal", "required": true}}
+		def, err := repo.FindOrCreate(ctx, "schema_pgx", "1.0.0", "def main(): pass", params)
+		require.NoError(t, err)
+		require.NotNil(t, def.ParamsSchema)
+
+		loaded, err := repo.FindByID(ctx, def.ID)
+		require.NoError(t, err)
+		require.NotNil(t, loaded.ParamsSchema)
+		assert.Contains(t, loaded.ParamsSchema, "amount")
+	})
+
+	t.Run("FindByID_Success", func(t *testing.T) {
+		created, err := repo.FindOrCreate(ctx, "lookup_pgx", "1.0.0", "def main(): pass", nil)
+		require.NoError(t, err)
+
+		loaded, err := repo.FindByID(ctx, created.ID)
+		require.NoError(t, err)
+		require.NotNil(t, loaded)
+
+		assert.Equal(t, created.ID, loaded.ID)
+		assert.Equal(t, created.Script, loaded.Script)
+		assert.Equal(t, created.ScriptHash, loaded.ScriptHash)
+	})
+
+	t.Run("FindByID_NotFound", func(t *testing.T) {
+		_, err := repo.FindByID(ctx, uuid.New())
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, saga.ErrSagaDefinitionNotFound))
+	})
+
+	t.Run("FindByID_NilUUIDReturnsNotFound", func(t *testing.T) {
+		_, err := repo.FindByID(ctx, uuid.Nil)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, saga.ErrSagaDefinitionNotFound))
+	})
+
+	t.Run("Constructor_NilPoolReturnsNil", func(t *testing.T) {
+		assert.Nil(t, NewSagaDefinitionRepository(nil))
+	})
+}

--- a/services/control-plane/migrations/20260516000001_saga_definitions.sql
+++ b/services/control-plane/migrations/20260516000001_saga_definitions.sql
@@ -1,0 +1,29 @@
+-- Saga Definitions table for version-pinned saga execution.
+--
+-- Each row captures the script that an in-flight saga instance was started with,
+-- so the resume path can re-execute that exact script even after the underlying
+-- manifest or reference-data registry has been updated.
+--
+-- Immutability invariant:
+--   * (name, version) is unique.
+--   * The script for an existing (name, version) pair is frozen; FindOrCreate
+--     rejects mismatched script hashes at the application layer.
+--
+-- This table mirrors the GORM-managed shared/pkg/saga.SagaDefinition model so
+-- services that run sagas (control-plane, current-account, payment-order, ...)
+-- all share one schema definition.
+
+CREATE TABLE IF NOT EXISTS "saga_definitions" (
+  "id"            uuid NOT NULL DEFAULT gen_random_uuid(),
+  "name"          varchar(64) NOT NULL,
+  "version"       varchar(32) NOT NULL,
+  "script"        text NOT NULL,
+  "params_schema" jsonb,
+  "script_hash"   varchar(64) NOT NULL,
+  "created_at"    timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY ("id")
+);
+
+-- Unique constraint on (name, version) enforces immutable per-version rows.
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_saga_definitions_name_version"
+  ON "saga_definitions" ("name", "version");

--- a/services/control-plane/migrations/atlas.sum
+++ b/services/control-plane/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:KbyhuEXJILRR48NzKoX/qDGV7Vy5t98dLYHIMzulk7w=
+h1:ZKxMh7LQrjyguvHMaOpiQcNT0ouHSjVUwfiVaKmYdlc=
 20260209000001_staff_identity.sql h1:OR9Cq4l2MfrW7It8jLDt0Kzg/z1th9KJdSlZEVpOhqA=
 20260209000002_create_manifest_versions.sql h1:+HzLzVoK1e/nPNN9wb56hb1yxxC9K2I53CpwAks6nCE=
 20260209000004_manifest_apply_jobs.sql h1:nq4MOflgbXAfdltITMKqKWHg9RuUXVs0mrIa2CDkIig=
@@ -14,3 +14,4 @@ h1:KbyhuEXJILRR48NzKoX/qDGV7Vy5t98dLYHIMzulk7w=
 20260401000002_migrate_version_to_varchar.sql h1:A+WRTgqwZfgeU8VfQqmYUeXkzb27ArcAplSIMqmO0xs=
 20260401000003_rename_version_column.sql h1:1JEVT+cGxBeMuVImnP3/B5RN0YkUoIvN2147VgBydwk=
 20260406000001_create_tenant_schedule.sql h1:w88vPDnJfitk+GRwtFHh1XV9iQf688+NvHVENMDu2gg=
+20260516000001_saga_definitions.sql h1:m+5F3nsd0IcXgG85oZ2kBGlsCPXuZnT9K7yW/VvuzLw=

--- a/shared/pkg/saga/decimal.go
+++ b/shared/pkg/saga/decimal.go
@@ -94,7 +94,7 @@ func (d *DecimalValue) Hash() (uint32, error) {
 // CompareSameType compares two DecimalValue instances.
 // Returns -1 if d < other, 0 if equal, 1 if d > other.
 //
-//nolint:exhaustive // We only handle comparison operators; other tokens are invalid
+//nolint:exhaustive,nolintlint // We only handle comparison operators; other tokens are invalid
 func (d *DecimalValue) CompareSameType(op syntax.Token, y starlark.Value, _ int) (bool, error) {
 	other, ok := y.(*DecimalValue)
 	if !ok {
@@ -134,7 +134,7 @@ func (d *DecimalValue) Cmp(y starlark.Value, _ int) (int, error) {
 // Supports +, -, *, / operations.
 // The side parameter indicates whether d is on the left (Left) or right (Right) of the operator.
 //
-//nolint:exhaustive // We only handle arithmetic operators; other tokens are invalid
+//nolint:exhaustive,nolintlint // We only handle arithmetic operators; other tokens are invalid
 func (d *DecimalValue) Binary(op syntax.Token, y starlark.Value, side starlark.Side) (starlark.Value, error) {
 	// Only operate on Decimal types
 	other, ok := y.(*DecimalValue)

--- a/shared/pkg/saga/linter.go
+++ b/shared/pkg/saga/linter.go
@@ -488,7 +488,7 @@ func (v *lintVisitor) handleResolveCall(e *syntax.CallExpr) {
 
 // checkBinaryExpr checks binary operations for Decimal arithmetic.
 //
-//nolint:exhaustive // We only care about arithmetic operators
+//nolint:exhaustive,nolintlint // We only care about arithmetic operators
 func (v *lintVisitor) checkBinaryExpr(e *syntax.BinaryExpr) {
 	// Only check arithmetic operators
 	switch e.Op {

--- a/shared/pkg/saga/migrations.go
+++ b/shared/pkg/saga/migrations.go
@@ -30,10 +30,22 @@ func RunSagaMigrations(db *gorm.DB) error {
 	// The partial indexes and composite constraint below are already
 	// idempotent (IF NOT EXISTS / information_schema checks).
 	migrator := db.Migrator()
+	if !migrator.HasTable(&SagaDefinition{}) {
+		if err := db.AutoMigrate(&SagaDefinition{}); err != nil {
+			return fmt.Errorf("failed to auto-migrate saga_definitions: %w", err)
+		}
+	}
 	if !migrator.HasTable(&SagaInstance{}) || !migrator.HasTable(&SagaStepResult{}) {
 		if err := db.AutoMigrate(&SagaInstance{}, &SagaStepResult{}); err != nil {
 			return fmt.Errorf("failed to auto-migrate saga models: %w", err)
 		}
+	}
+
+	// Create the unique (name, version) constraint on saga_definitions.
+	// Two definitions with the same (name, version) are not allowed: per-version
+	// scripts are immutable, and FindOrCreate enforces hash match for reuse.
+	if err := createSagaDefinitionsNameVersionIndex(db); err != nil {
+		return fmt.Errorf("failed to create saga_definitions (name, version) index: %w", err)
 	}
 
 	// Create the partial index for orphan detection
@@ -57,6 +69,16 @@ func RunSagaMigrations(db *gorm.DB) error {
 	}
 
 	return nil
+}
+
+// createSagaDefinitionsNameVersionIndex creates a unique index on (name, version).
+// Each (name, version) combination resolves to exactly one immutable definition row.
+func createSagaDefinitionsNameVersionIndex(db *gorm.DB) error {
+	sql := `
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_saga_definitions_name_version
+		ON saga_definitions (name, version)
+	`
+	return db.Exec(sql).Error
 }
 
 // createPartialIndexForOrphanDetection creates the idx_saga_instances_orphaned partial index.
@@ -115,6 +137,9 @@ func DropSagaTables(db *gorm.DB) error {
 	}
 	if err := db.Migrator().DropTable(&SagaInstance{}); err != nil {
 		return fmt.Errorf("failed to drop saga_instances: %w", err)
+	}
+	if err := db.Migrator().DropTable(&SagaDefinition{}); err != nil {
+		return fmt.Errorf("failed to drop saga_definitions: %w", err)
 	}
 	return nil
 }

--- a/shared/pkg/saga/saga_definition.go
+++ b/shared/pkg/saga/saga_definition.go
@@ -27,8 +27,11 @@ type SagaDefinition struct {
 	// Name is the saga name (e.g., "apply_manifest", "current_account_deposit").
 	Name string `gorm:"column:name;type:varchar(64);not null"`
 
-	// Version is the saga version (integer; increments on script change).
-	Version int `gorm:"column:version;not null"`
+	// Version is the saga version. Stored as a string to accommodate both
+	// integer (reference-data tenant sagas: "1", "2") and semver
+	// (platform sagas: "1.0.0") versioning schemes. The (name, version) pair
+	// is unique; FindOrCreate enforces script immutability per version.
+	Version string `gorm:"column:version;type:varchar(32);not null"`
 
 	// Script is the Starlark source code for this definition.
 	Script string `gorm:"column:script;type:text;not null"`
@@ -82,7 +85,7 @@ type SagaDefinitionRepository interface {
 	// or inserts a new row if no (name, version) entry exists.
 	// Returns ErrSagaDefinitionHashMismatch when (name, version) exists but the
 	// stored script hash differs from ComputeSagaDefinitionScriptHash(script).
-	FindOrCreate(ctx context.Context, name string, version int, script string, paramsSchema JSONB) (*SagaDefinition, error)
+	FindOrCreate(ctx context.Context, name, version, script string, paramsSchema JSONB) (*SagaDefinition, error)
 }
 
 // ErrSagaDefinitionNotFound is returned when a saga definition cannot be located.

--- a/shared/pkg/saga/saga_definition.go
+++ b/shared/pkg/saga/saga_definition.go
@@ -1,0 +1,94 @@
+// Package saga provides saga orchestration runtime and persistence for durable execution.
+package saga
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// SagaDefinition represents an immutable, versioned saga definition pinned at the moment
+// a saga instance is started. Pinning prevents the resume path from picking up a different
+// script if the underlying definition is updated while an instance is still in-flight.
+//
+// Each row is immutable once written. New (name, version) combinations create new rows.
+// Re-applying the same (name, version, script) is idempotent: FindOrCreate returns the
+// existing row when the script hash matches.
+//
+//nolint:revive // SagaDefinition naming is intentional for GORM entity clarity
+type SagaDefinition struct {
+	// ID is the immutable identifier referenced by SagaInstance.SagaDefinitionID.
+	ID uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+
+	// Name is the saga name (e.g., "apply_manifest", "current_account_deposit").
+	Name string `gorm:"column:name;type:varchar(64);not null"`
+
+	// Version is the saga version (integer; increments on script change).
+	Version int `gorm:"column:version;not null"`
+
+	// Script is the Starlark source code for this definition.
+	Script string `gorm:"column:script;type:text;not null"`
+
+	// ParamsSchema captures the parameter schema for callers/UI (optional).
+	ParamsSchema JSONB `gorm:"column:params_schema;type:jsonb"`
+
+	// ScriptHash is the SHA-256 hex digest of the script content. Used for content
+	// addressing in FindOrCreate (same name+version+hash = reuse; mismatched hash for
+	// the same name+version is rejected as a tampering/immutability violation).
+	ScriptHash string `gorm:"column:script_hash;type:varchar(64);not null"`
+
+	// CreatedAt records when this definition was first persisted.
+	CreatedAt time.Time `gorm:"column:created_at;not null;default:now()"`
+}
+
+// TableName returns the table name for the SagaDefinition entity.
+func (SagaDefinition) TableName() string {
+	return "saga_definitions"
+}
+
+// ComputeSagaDefinitionScriptHash returns the SHA-256 hex digest of a script.
+// This is the canonical hash used for content addressing of saga definitions.
+func ComputeSagaDefinitionScriptHash(script string) string {
+	sum := sha256.Sum256([]byte(script))
+	return hex.EncodeToString(sum[:])
+}
+
+// SagaDefinitionRepository persists and retrieves pinned saga definitions.
+//
+// FindByID is used by the saga resume path: an in-flight instance carries the
+// SagaDefinitionID it was started with, and FindByID returns the exact script
+// that was pinned at start time. Resumed sagas must NEVER re-resolve the
+// definition from the live manifest or reference-data registry.
+//
+// FindOrCreate is used by the saga start path: callers resolve the active script
+// (from manifest applier or reference-data) and ask the repository to either
+// reuse an existing pinned row or insert a new one. Pinning rules:
+//   - Same (name, version, script hash): returns the existing row.
+//   - Same (name, version) but DIFFERENT script hash: returns
+//     ErrSagaDefinitionHashMismatch (immutable versions invariant).
+//   - New (name, version): inserts a new row.
+//
+//nolint:revive // SagaDefinitionRepository naming is intentional for clarity
+type SagaDefinitionRepository interface {
+	// FindByID retrieves a saga definition by its immutable ID.
+	// Returns ErrSagaDefinitionNotFound if no row exists.
+	FindByID(ctx context.Context, id uuid.UUID) (*SagaDefinition, error)
+
+	// FindOrCreate returns an existing row matching (name, version, script hash),
+	// or inserts a new row if no (name, version) entry exists.
+	// Returns ErrSagaDefinitionHashMismatch when (name, version) exists but the
+	// stored script hash differs from ComputeSagaDefinitionScriptHash(script).
+	FindOrCreate(ctx context.Context, name string, version int, script string, paramsSchema JSONB) (*SagaDefinition, error)
+}
+
+// ErrSagaDefinitionNotFound is returned when a saga definition cannot be located.
+var ErrSagaDefinitionNotFound = errors.New("saga definition not found")
+
+// ErrSagaDefinitionHashMismatch is returned when a caller attempts to register a
+// different script under an already-pinned (name, version). Saga definitions are
+// immutable per version; the caller must bump the version to publish a new script.
+var ErrSagaDefinitionHashMismatch = errors.New("saga definition script hash mismatch for existing (name, version)")

--- a/shared/pkg/saga/saga_definition_backfill.go
+++ b/shared/pkg/saga/saga_definition_backfill.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"gorm.io/gorm"
@@ -52,9 +53,7 @@ func BackfillSagaDefinitionIDs(ctx context.Context, db *gorm.DB) (BackfillResult
 		// resolve to a saga_definitions row.
 		var candidates []SagaInstance
 		findErr := tx.Model(&SagaInstance{}).
-			Where("status IN ?", []SagaStatus{
-				SagaStatusPending, SagaStatusRunning, SagaStatusCompensating,
-			}).
+			Where("status IN ?", nonTerminalSagaStatuses()).
 			Where("NOT EXISTS (SELECT 1 FROM saga_definitions sd WHERE sd.id = saga_instances.saga_definition_id)").
 			Find(&candidates).Error
 		if findErr != nil {
@@ -105,13 +104,32 @@ func BackfillSagaDefinitionIDs(ctx context.Context, db *gorm.DB) (BackfillResult
 	return result, nil
 }
 
+// nonTerminalSagaStatuses returns the set of statuses for in-flight sagas that
+// may eventually need to resume and therefore require a valid SagaDefinitionID.
+// Excludes COMPLETED, COMPENSATED, FAILED, and FAILED_MANUAL_INTERVENTION which
+// are terminal and never re-execute.
+func nonTerminalSagaStatuses() []SagaStatus {
+	return []SagaStatus{
+		SagaStatusPending,
+		SagaStatusRunning,
+		SagaStatusCompensating,
+		SagaStatusSuspended,
+		SagaStatusWaitingForEvent,
+	}
+}
+
 // findLocalDefinitionByNameVersion locates a saga_definitions row matching the
 // instance's (name, integer version). Returns nil when no row matches.
 //
 // The local saga_definitions.version column is a varchar (to accept both
 // integer reference-data versions and semver platform versions), but the
-// SagaInstance.SagaVersion is an int. We match by string-equality after
-// converting the int to its canonical decimal representation.
+// SagaInstance.SagaVersion field is an int. This backfill is therefore
+// scoped to services whose saga_definitions versions are integer-encoded; the
+// semver-versioned platform sagas live in control-plane's separate database
+// and never produce saga_instances rows that need backfilling.
+//
+// We match by string-equality after converting the int to its canonical
+// decimal representation.
 func findLocalDefinitionByNameVersion(tx *gorm.DB, name string, version int) (*SagaDefinition, error) {
 	if name == "" {
 		// Instances missing a saga_name cannot be looked up; treat as no match.
@@ -119,7 +137,7 @@ func findLocalDefinitionByNameVersion(tx *gorm.DB, name string, version int) (*S
 	}
 
 	var def SagaDefinition
-	versionStr := fmt.Sprintf("%d", version)
+	versionStr := strconv.Itoa(version)
 	err := tx.Where("name = ? AND version = ?", name, versionStr).First(&def).Error
 	if err != nil {
 		if isGormNotFound(err) {

--- a/shared/pkg/saga/saga_definition_backfill.go
+++ b/shared/pkg/saga/saga_definition_backfill.go
@@ -1,0 +1,136 @@
+package saga
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// BackfillResult summarizes the outcome of BackfillSagaDefinitionIDs.
+type BackfillResult struct {
+	// Linked is the number of in-flight saga instances that were successfully
+	// linked to a saga_definitions row matching their (saga_name, saga_version).
+	Linked int
+
+	// FlaggedManualIntervention is the number of in-flight instances that had no
+	// matching saga_definitions row and were transitioned to
+	// FAILED_MANUAL_INTERVENTION. These need operator review.
+	FlaggedManualIntervention int
+}
+
+// BackfillSagaDefinitionIDs reconciles existing in-flight saga instances with
+// the new saga_definitions pinning table.
+//
+// CockroachDB constraint: this MUST run as a separate operation from the
+// migration that adds the saga_definitions table itself. CockroachDB rejects
+// DML that references a column added in the same transaction. Callers should
+// invoke this once on service startup AFTER RunSagaMigrations has completed.
+//
+// Behavior:
+//
+//	For each instance whose status is PENDING / RUNNING / COMPENSATING and whose
+//	SagaDefinitionID points at a row that does NOT exist in saga_definitions:
+//	  1. Look up saga_definitions by (saga_name, saga_version).
+//	  2. If found: update SagaDefinitionID to the local pinning row.
+//	  3. If not found: transition the instance to FAILED_MANUAL_INTERVENTION
+//	     with an error message explaining the orphaned state.
+//
+// Instances that already point at a valid saga_definitions row are skipped.
+// The function is idempotent: repeated calls on the same data are no-ops.
+func BackfillSagaDefinitionIDs(ctx context.Context, db *gorm.DB) (BackfillResult, error) {
+	var result BackfillResult
+	now := time.Now().UTC()
+
+	// Single transaction so the backfill is atomic per call. CockroachDB's
+	// serializable isolation prevents another pod from claiming a saga we're
+	// rewriting underneath it.
+	err := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Find candidates: active instances whose SagaDefinitionID does NOT yet
+		// resolve to a saga_definitions row.
+		var candidates []SagaInstance
+		findErr := tx.Model(&SagaInstance{}).
+			Where("status IN ?", []SagaStatus{
+				SagaStatusPending, SagaStatusRunning, SagaStatusCompensating,
+			}).
+			Where("NOT EXISTS (SELECT 1 FROM saga_definitions sd WHERE sd.id = saga_instances.saga_definition_id)").
+			Find(&candidates).Error
+		if findErr != nil {
+			return fmt.Errorf("scan candidate instances: %w", findErr)
+		}
+
+		for i := range candidates {
+			inst := &candidates[i]
+			match, matchErr := findLocalDefinitionByNameVersion(tx, inst.SagaName, inst.SagaVersion)
+			if matchErr != nil {
+				return matchErr
+			}
+			if match != nil {
+				if err := tx.Model(&SagaInstance{}).
+					Where("id = ?", inst.ID).
+					Updates(map[string]interface{}{
+						"saga_definition_id": match.ID,
+						"updated_at":         now,
+					}).Error; err != nil {
+					return fmt.Errorf("link instance %s: %w", inst.ID, err)
+				}
+				result.Linked++
+				continue
+			}
+
+			// No matching local definition - flag for manual intervention.
+			errMsg := fmt.Sprintf(
+				"Backfill failed: no matching saga_definition found for (name=%q, version=%d)",
+				inst.SagaName, inst.SagaVersion,
+			)
+			if err := tx.Model(&SagaInstance{}).
+				Where("id = ?", inst.ID).
+				Updates(map[string]interface{}{
+					"status":        SagaStatusFailedManualIntervention,
+					"error_message": errMsg,
+					"updated_at":    now,
+				}).Error; err != nil {
+				return fmt.Errorf("flag instance %s: %w", inst.ID, err)
+			}
+			result.FlaggedManualIntervention++
+		}
+
+		return nil
+	})
+	if err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+// findLocalDefinitionByNameVersion locates a saga_definitions row matching the
+// instance's (name, integer version). Returns nil when no row matches.
+//
+// The local saga_definitions.version column is a varchar (to accept both
+// integer reference-data versions and semver platform versions), but the
+// SagaInstance.SagaVersion is an int. We match by string-equality after
+// converting the int to its canonical decimal representation.
+func findLocalDefinitionByNameVersion(tx *gorm.DB, name string, version int) (*SagaDefinition, error) {
+	if name == "" {
+		// Instances missing a saga_name cannot be looked up; treat as no match.
+		return nil, nil //nolint:nilnil // sentinel: caller flags as manual intervention
+	}
+
+	var def SagaDefinition
+	versionStr := fmt.Sprintf("%d", version)
+	err := tx.Where("name = ? AND version = ?", name, versionStr).First(&def).Error
+	if err != nil {
+		if isGormNotFound(err) {
+			return nil, nil //nolint:nilnil // sentinel: no match found
+		}
+		return nil, fmt.Errorf("lookup local saga definition: %w", err)
+	}
+	return &def, nil
+}
+
+// isGormNotFound returns true for the GORM "no rows" sentinel.
+func isGormNotFound(err error) bool {
+	return errors.Is(err, gorm.ErrRecordNotFound)
+}

--- a/shared/pkg/saga/saga_definition_backfill.go
+++ b/shared/pkg/saga/saga_definition_backfill.go
@@ -49,59 +49,72 @@ func BackfillSagaDefinitionIDs(ctx context.Context, db *gorm.DB) (BackfillResult
 	// serializable isolation prevents another pod from claiming a saga we're
 	// rewriting underneath it.
 	err := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		// Find candidates: active instances whose SagaDefinitionID does NOT yet
-		// resolve to a saga_definitions row.
-		var candidates []SagaInstance
-		findErr := tx.Model(&SagaInstance{}).
-			Where("status IN ?", nonTerminalSagaStatuses()).
-			Where("NOT EXISTS (SELECT 1 FROM saga_definitions sd WHERE sd.id = saga_instances.saga_definition_id)").
-			Find(&candidates).Error
-		if findErr != nil {
-			return fmt.Errorf("scan candidate instances: %w", findErr)
+		candidates, scanErr := scanBackfillCandidates(tx)
+		if scanErr != nil {
+			return scanErr
 		}
-
 		for i := range candidates {
-			inst := &candidates[i]
-			match, matchErr := findLocalDefinitionByNameVersion(tx, inst.SagaName, inst.SagaVersion)
-			if matchErr != nil {
-				return matchErr
+			if procErr := reconcileSagaInstance(tx, &candidates[i], now, &result); procErr != nil {
+				return procErr
 			}
-			if match != nil {
-				if err := tx.Model(&SagaInstance{}).
-					Where("id = ?", inst.ID).
-					Updates(map[string]interface{}{
-						"saga_definition_id": match.ID,
-						"updated_at":         now,
-					}).Error; err != nil {
-					return fmt.Errorf("link instance %s: %w", inst.ID, err)
-				}
-				result.Linked++
-				continue
-			}
-
-			// No matching local definition - flag for manual intervention.
-			errMsg := fmt.Sprintf(
-				"Backfill failed: no matching saga_definition found for (name=%q, version=%d)",
-				inst.SagaName, inst.SagaVersion,
-			)
-			if err := tx.Model(&SagaInstance{}).
-				Where("id = ?", inst.ID).
-				Updates(map[string]interface{}{
-					"status":        SagaStatusFailedManualIntervention,
-					"error_message": errMsg,
-					"updated_at":    now,
-				}).Error; err != nil {
-				return fmt.Errorf("flag instance %s: %w", inst.ID, err)
-			}
-			result.FlaggedManualIntervention++
 		}
-
 		return nil
 	})
 	if err != nil {
 		return result, err
 	}
 	return result, nil
+}
+
+// scanBackfillCandidates finds non-terminal instances whose SagaDefinitionID
+// does not resolve to a row in saga_definitions and therefore needs reconciling.
+func scanBackfillCandidates(tx *gorm.DB) ([]SagaInstance, error) {
+	var candidates []SagaInstance
+	err := tx.Model(&SagaInstance{}).
+		Where("status IN ?", nonTerminalSagaStatuses()).
+		Where("NOT EXISTS (SELECT 1 FROM saga_definitions sd WHERE sd.id = saga_instances.saga_definition_id)").
+		Find(&candidates).Error
+	if err != nil {
+		return nil, fmt.Errorf("scan candidate instances: %w", err)
+	}
+	return candidates, nil
+}
+
+// reconcileSagaInstance attempts to re-link the instance to a matching local
+// definition, or flags it FAILED_MANUAL_INTERVENTION when no match exists.
+// Counters on result are incremented in place.
+func reconcileSagaInstance(tx *gorm.DB, inst *SagaInstance, now time.Time, result *BackfillResult) error {
+	match, matchErr := findLocalDefinitionByNameVersion(tx, inst.SagaName, inst.SagaVersion)
+	if matchErr != nil {
+		return matchErr
+	}
+	if match != nil {
+		if err := tx.Model(&SagaInstance{}).
+			Where("id = ?", inst.ID).
+			Updates(map[string]interface{}{
+				"saga_definition_id": match.ID,
+				"updated_at":         now,
+			}).Error; err != nil {
+			return fmt.Errorf("link instance %s: %w", inst.ID, err)
+		}
+		result.Linked++
+		return nil
+	}
+	errMsg := fmt.Sprintf(
+		"Backfill failed: no matching saga_definition found for (name=%q, version=%d)",
+		inst.SagaName, inst.SagaVersion,
+	)
+	if err := tx.Model(&SagaInstance{}).
+		Where("id = ?", inst.ID).
+		Updates(map[string]interface{}{
+			"status":        SagaStatusFailedManualIntervention,
+			"error_message": errMsg,
+			"updated_at":    now,
+		}).Error; err != nil {
+		return fmt.Errorf("flag instance %s: %w", inst.ID, err)
+	}
+	result.FlaggedManualIntervention++
+	return nil
 }
 
 // nonTerminalSagaStatuses returns the set of statuses for in-flight sagas that

--- a/shared/pkg/saga/saga_definition_backfill_test.go
+++ b/shared/pkg/saga/saga_definition_backfill_test.go
@@ -105,6 +105,44 @@ func TestBackfillSagaDefinitionIDs_SkipsAlreadyLinkedInstance(t *testing.T) {
 	assert.Equal(t, 0, result.FlaggedManualIntervention)
 }
 
+// TestBackfillSagaDefinitionIDs_IncludesSuspendedAndWaitingForEvent verifies
+// that SUSPENDED and WAITING_FOR_EVENT instances are reconciled too. They are
+// non-terminal and will eventually resume, so they need a valid pinned
+// definition just like RUNNING instances.
+func TestBackfillSagaDefinitionIDs_IncludesSuspendedAndWaitingForEvent(t *testing.T) {
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	repo := NewSagaDefinitionRepository(db)
+	def, err := repo.FindOrCreate(ctx, "suspend_saga", "7", "def main(): pass", nil)
+	require.NoError(t, err)
+
+	statuses := []SagaStatus{SagaStatusSuspended, SagaStatusWaitingForEvent}
+	for _, status := range statuses {
+		instance := SagaInstance{
+			ID:               uuid.New(),
+			SagaDefinitionID: uuid.New(),
+			SagaName:         "suspend_saga",
+			SagaVersion:      7,
+			CorrelationID:    uuid.New(),
+			Status:           status,
+		}
+		require.NoError(t, db.Create(&instance).Error)
+	}
+
+	result, err := BackfillSagaDefinitionIDs(ctx, db)
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Linked, "must reconcile both SUSPENDED and WAITING_FOR_EVENT")
+
+	// Both instances should now point at the local definition.
+	var count int64
+	require.NoError(t, db.Model(&SagaInstance{}).
+		Where("saga_definition_id = ?", def.ID).
+		Count(&count).Error)
+	assert.Equal(t, int64(2), count)
+}
+
 // TestBackfillSagaDefinitionIDs_SkipsTerminalInstances verifies that the
 // backfill ignores COMPLETED/FAILED/etc. instances - only in-flight statuses
 // matter for resume correctness.

--- a/shared/pkg/saga/saga_definition_backfill_test.go
+++ b/shared/pkg/saga/saga_definition_backfill_test.go
@@ -1,0 +1,232 @@
+package saga
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// TestBackfillSagaDefinitionIDs_LinksInstanceToLocalDefinition is the happy
+// path: an in-flight instance whose saga_definition_id is stale gets relinked
+// to the matching (name, version) row in the local saga_definitions table.
+func TestBackfillSagaDefinitionIDs_LinksInstanceToLocalDefinition(t *testing.T) {
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Pre-create the local pinning row.
+	repo := NewSagaDefinitionRepository(db)
+	def, err := repo.FindOrCreate(ctx, "deposit", "1", "def main(): pass", nil)
+	require.NoError(t, err)
+
+	// Create an in-flight instance with a stale (random) saga_definition_id.
+	instance := SagaInstance{
+		ID:               uuid.New(),
+		SagaDefinitionID: uuid.New(), // stale - does NOT exist in saga_definitions
+		SagaName:         "deposit",
+		SagaVersion:      1,
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+	}
+	require.NoError(t, db.Create(&instance).Error)
+
+	result, err := BackfillSagaDefinitionIDs(ctx, db)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Linked)
+	assert.Equal(t, 0, result.FlaggedManualIntervention)
+
+	// Verify the instance now points at the local definition.
+	var reloaded SagaInstance
+	require.NoError(t, db.First(&reloaded, "id = ?", instance.ID).Error)
+	assert.Equal(t, def.ID, reloaded.SagaDefinitionID)
+	assert.Equal(t, SagaStatusRunning, reloaded.Status)
+}
+
+// TestBackfillSagaDefinitionIDs_FlagsOrphanedInstance verifies the failure
+// path: instances with no matching saga_definitions row are transitioned to
+// FAILED_MANUAL_INTERVENTION rather than left in an inconsistent state.
+func TestBackfillSagaDefinitionIDs_FlagsOrphanedInstance(t *testing.T) {
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// No saga_definitions row will exist for ("orphan_saga", 99).
+	instance := SagaInstance{
+		ID:               uuid.New(),
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "orphan_saga",
+		SagaVersion:      99,
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+	}
+	require.NoError(t, db.Create(&instance).Error)
+
+	result, err := BackfillSagaDefinitionIDs(ctx, db)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Linked)
+	assert.Equal(t, 1, result.FlaggedManualIntervention)
+
+	var reloaded SagaInstance
+	require.NoError(t, db.First(&reloaded, "id = ?", instance.ID).Error)
+	assert.Equal(t, SagaStatusFailedManualIntervention, reloaded.Status)
+	require.NotNil(t, reloaded.ErrorMessage)
+	assert.Contains(t, *reloaded.ErrorMessage, "orphan_saga")
+}
+
+// TestBackfillSagaDefinitionIDs_SkipsAlreadyLinkedInstance verifies that
+// instances whose saga_definition_id already resolves to a saga_definitions
+// row are left alone.
+func TestBackfillSagaDefinitionIDs_SkipsAlreadyLinkedInstance(t *testing.T) {
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	repo := NewSagaDefinitionRepository(db)
+	def, err := repo.FindOrCreate(ctx, "happy_saga", "1", "def main(): pass", nil)
+	require.NoError(t, err)
+
+	instance := SagaInstance{
+		ID:               uuid.New(),
+		SagaDefinitionID: def.ID, // already linked
+		SagaName:         "happy_saga",
+		SagaVersion:      1,
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+	}
+	require.NoError(t, db.Create(&instance).Error)
+
+	result, err := BackfillSagaDefinitionIDs(ctx, db)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Linked, "already-linked instance must not be re-linked")
+	assert.Equal(t, 0, result.FlaggedManualIntervention)
+}
+
+// TestBackfillSagaDefinitionIDs_SkipsTerminalInstances verifies that the
+// backfill ignores COMPLETED/FAILED/etc. instances - only in-flight statuses
+// matter for resume correctness.
+func TestBackfillSagaDefinitionIDs_SkipsTerminalInstances(t *testing.T) {
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	completed := SagaInstance{
+		ID:               uuid.New(),
+		SagaDefinitionID: uuid.New(), // stale; would normally be flagged
+		SagaName:         "old_saga",
+		SagaVersion:      1,
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusCompleted,
+	}
+	require.NoError(t, db.Create(&completed).Error)
+
+	result, err := BackfillSagaDefinitionIDs(ctx, db)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Linked)
+	assert.Equal(t, 0, result.FlaggedManualIntervention)
+
+	var reloaded SagaInstance
+	require.NoError(t, db.First(&reloaded, "id = ?", completed.ID).Error)
+	assert.Equal(t, SagaStatusCompleted, reloaded.Status, "terminal status must be preserved")
+}
+
+// TestBackfillSagaDefinitionIDs_Idempotent verifies that running the backfill
+// twice produces the same final state and zero additional work on the second
+// run.
+func TestBackfillSagaDefinitionIDs_Idempotent(t *testing.T) {
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	repo := NewSagaDefinitionRepository(db)
+	def, err := repo.FindOrCreate(ctx, "idem_saga", "1", "def main(): pass", nil)
+	require.NoError(t, err)
+
+	instance := SagaInstance{
+		ID:               uuid.New(),
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "idem_saga",
+		SagaVersion:      1,
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+	}
+	require.NoError(t, db.Create(&instance).Error)
+
+	first, err := BackfillSagaDefinitionIDs(ctx, db)
+	require.NoError(t, err)
+	assert.Equal(t, 1, first.Linked)
+
+	second, err := BackfillSagaDefinitionIDs(ctx, db)
+	require.NoError(t, err)
+	assert.Equal(t, 0, second.Linked, "second run must be a no-op")
+	assert.Equal(t, 0, second.FlaggedManualIntervention)
+
+	var reloaded SagaInstance
+	require.NoError(t, db.First(&reloaded, "id = ?", instance.ID).Error)
+	assert.Equal(t, def.ID, reloaded.SagaDefinitionID)
+}
+
+// TestBackfillSagaDefinitionIDs_HandlesEmptyTable confirms the backfill is
+// safe to call against a fresh database with no instances or definitions.
+func TestBackfillSagaDefinitionIDs_HandlesEmptyTable(t *testing.T) {
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	result, err := BackfillSagaDefinitionIDs(context.Background(), db)
+	require.NoError(t, err)
+	assert.Equal(t, BackfillResult{}, result)
+}
+
+// TestBackfillSagaDefinitionIDs_TransactionAtomicity verifies that all changes
+// happen inside one transaction by checking the SagaInstance row's updated_at
+// matches the saga_definition_id update.
+func TestBackfillSagaDefinitionIDs_TransactionAtomicity(t *testing.T) {
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	repo := NewSagaDefinitionRepository(db)
+	def, err := repo.FindOrCreate(ctx, "atomic_saga", "1", "def main(): pass", nil)
+	require.NoError(t, err)
+
+	matching := SagaInstance{
+		ID:               uuid.New(),
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "atomic_saga",
+		SagaVersion:      1,
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+	}
+	require.NoError(t, db.Create(&matching).Error)
+
+	orphan := SagaInstance{
+		ID:               uuid.New(),
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "orphan_atomic",
+		SagaVersion:      1,
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+	}
+	require.NoError(t, db.Create(&orphan).Error)
+
+	result, err := BackfillSagaDefinitionIDs(ctx, db)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Linked)
+	assert.Equal(t, 1, result.FlaggedManualIntervention)
+
+	var matchingReloaded, orphanReloaded SagaInstance
+	require.NoError(t, db.First(&matchingReloaded, "id = ?", matching.ID).Error)
+	require.NoError(t, db.First(&orphanReloaded, "id = ?", orphan.ID).Error)
+
+	assert.Equal(t, def.ID, matchingReloaded.SagaDefinitionID)
+	assert.Equal(t, SagaStatusFailedManualIntervention, orphanReloaded.Status)
+}
+
+// Compile-time check that the helper can be invoked with a transaction.
+var _ = func() {
+	var tx *gorm.DB
+	_, _ = findLocalDefinitionByNameVersion(tx, "name", 1)
+}

--- a/shared/pkg/saga/saga_definition_repository.go
+++ b/shared/pkg/saga/saga_definition_repository.go
@@ -1,0 +1,126 @@
+package saga
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// GormSagaDefinitionRepository persists pinned saga definitions using GORM.
+//
+// FindOrCreate enforces the immutability invariant: a given (name, version) pair
+// maps to exactly one immutable row, identified by the script's SHA-256 hash.
+// Concurrent FindOrCreate calls for the same (name, version, script) are safe
+// thanks to the unique index on (name, version) - the loser of a race retries
+// the lookup and returns the winner's row.
+type GormSagaDefinitionRepository struct {
+	db *gorm.DB
+}
+
+// NewSagaDefinitionRepository constructs a GORM-backed repository.
+func NewSagaDefinitionRepository(db *gorm.DB) *GormSagaDefinitionRepository {
+	return &GormSagaDefinitionRepository{db: db}
+}
+
+// Compile-time interface check.
+var _ SagaDefinitionRepository = (*GormSagaDefinitionRepository)(nil)
+
+// FindByID returns the definition with the given ID or ErrSagaDefinitionNotFound.
+func (r *GormSagaDefinitionRepository) FindByID(ctx context.Context, id uuid.UUID) (*SagaDefinition, error) {
+	if id == uuid.Nil {
+		return nil, ErrSagaDefinitionNotFound
+	}
+	var def SagaDefinition
+	if err := r.db.WithContext(ctx).Where("id = ?", id).First(&def).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrSagaDefinitionNotFound
+		}
+		return nil, fmt.Errorf("find saga definition by id: %w", err)
+	}
+	return &def, nil
+}
+
+// FindOrCreate returns an existing matching row or inserts a new one.
+//
+// Lookup order:
+//  1. Existing row with (name, version) AND matching script hash -> reuse.
+//  2. Existing row with (name, version) but DIFFERENT hash -> ErrSagaDefinitionHashMismatch.
+//  3. No row with (name, version) -> insert new row.
+//
+// Concurrency: the unique index on (name, version) ensures only one INSERT wins.
+// On a race the losing INSERT errors out; we then re-read the winning row and
+// validate its hash matches.
+func (r *GormSagaDefinitionRepository) FindOrCreate(
+	ctx context.Context,
+	name string,
+	version int,
+	script string,
+	paramsSchema JSONB,
+) (*SagaDefinition, error) {
+	hash := ComputeSagaDefinitionScriptHash(script)
+
+	// Step 1: lookup by (name, version).
+	existing, err := r.findByNameVersion(ctx, name, version)
+	switch {
+	case err == nil:
+		if existing.ScriptHash != hash {
+			return nil, fmt.Errorf("%w: name=%s version=%d (stored=%s incoming=%s)",
+				ErrSagaDefinitionHashMismatch, name, version, existing.ScriptHash, hash)
+		}
+		return existing, nil
+	case !errors.Is(err, ErrSagaDefinitionNotFound):
+		return nil, err
+	}
+
+	// Step 2: insert. If a concurrent caller wins the race, re-read and validate.
+	def := &SagaDefinition{
+		Name:         name,
+		Version:      version,
+		Script:       script,
+		ParamsSchema: paramsSchema,
+		ScriptHash:   hash,
+	}
+	createErr := r.db.WithContext(ctx).Create(def).Error
+	if createErr == nil {
+		return def, nil
+	}
+
+	// Treat any insert failure as a potential race: re-read and validate.
+	// (CockroachDB returns a unique-violation error class on the duplicate; we
+	// don't pattern-match on driver error codes to stay portable.)
+	raceWinner, lookupErr := r.findByNameVersion(ctx, name, version)
+	if lookupErr != nil {
+		if errors.Is(lookupErr, ErrSagaDefinitionNotFound) {
+			return nil, fmt.Errorf("insert saga definition: %w", createErr)
+		}
+		return nil, fmt.Errorf("insert saga definition (%w) and re-read failed: %w", createErr, lookupErr)
+	}
+	if raceWinner.ScriptHash != hash {
+		return nil, fmt.Errorf("%w: name=%s version=%d (stored=%s incoming=%s)",
+			ErrSagaDefinitionHashMismatch, name, version, raceWinner.ScriptHash, hash)
+	}
+	return raceWinner, nil
+}
+
+// findByNameVersion returns the row for (name, version) or
+// (nil, ErrSagaDefinitionNotFound) when no row exists.
+func (r *GormSagaDefinitionRepository) findByNameVersion(
+	ctx context.Context,
+	name string,
+	version int,
+) (*SagaDefinition, error) {
+	var def SagaDefinition
+	err := r.db.WithContext(ctx).
+		Where("name = ? AND version = ?", name, version).
+		First(&def).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrSagaDefinitionNotFound
+		}
+		return nil, fmt.Errorf("lookup saga definition by name+version: %w", err)
+	}
+	return &def, nil
+}

--- a/shared/pkg/saga/saga_definition_repository.go
+++ b/shared/pkg/saga/saga_definition_repository.go
@@ -55,9 +55,7 @@ func (r *GormSagaDefinitionRepository) FindByID(ctx context.Context, id uuid.UUI
 // validate its hash matches.
 func (r *GormSagaDefinitionRepository) FindOrCreate(
 	ctx context.Context,
-	name string,
-	version int,
-	script string,
+	name, version, script string,
 	paramsSchema JSONB,
 ) (*SagaDefinition, error) {
 	hash := ComputeSagaDefinitionScriptHash(script)
@@ -67,7 +65,7 @@ func (r *GormSagaDefinitionRepository) FindOrCreate(
 	switch {
 	case err == nil:
 		if existing.ScriptHash != hash {
-			return nil, fmt.Errorf("%w: name=%s version=%d (stored=%s incoming=%s)",
+			return nil, fmt.Errorf("%w: name=%s version=%s (stored=%s incoming=%s)",
 				ErrSagaDefinitionHashMismatch, name, version, existing.ScriptHash, hash)
 		}
 		return existing, nil
@@ -99,7 +97,7 @@ func (r *GormSagaDefinitionRepository) FindOrCreate(
 		return nil, fmt.Errorf("insert saga definition (%w) and re-read failed: %w", createErr, lookupErr)
 	}
 	if raceWinner.ScriptHash != hash {
-		return nil, fmt.Errorf("%w: name=%s version=%d (stored=%s incoming=%s)",
+		return nil, fmt.Errorf("%w: name=%s version=%s (stored=%s incoming=%s)",
 			ErrSagaDefinitionHashMismatch, name, version, raceWinner.ScriptHash, hash)
 	}
 	return raceWinner, nil
@@ -109,8 +107,7 @@ func (r *GormSagaDefinitionRepository) FindOrCreate(
 // (nil, ErrSagaDefinitionNotFound) when no row exists.
 func (r *GormSagaDefinitionRepository) findByNameVersion(
 	ctx context.Context,
-	name string,
-	version int,
+	name, version string,
 ) (*SagaDefinition, error) {
 	var def SagaDefinition
 	err := r.db.WithContext(ctx).

--- a/shared/pkg/saga/saga_definition_repository_test.go
+++ b/shared/pkg/saga/saga_definition_repository_test.go
@@ -1,0 +1,159 @@
+package saga
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSagaDefinitionRepository_FindOrCreate_NewRow(t *testing.T) {
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	repo := NewSagaDefinitionRepository(db)
+	ctx := context.Background()
+
+	script := "def main(): return {'ok': True}"
+	def, err := repo.FindOrCreate(ctx, "test_saga", 1, script, nil)
+	require.NoError(t, err)
+	require.NotNil(t, def)
+
+	assert.NotEqual(t, uuid.Nil, def.ID)
+	assert.Equal(t, "test_saga", def.Name)
+	assert.Equal(t, 1, def.Version)
+	assert.Equal(t, script, def.Script)
+	assert.Equal(t, ComputeSagaDefinitionScriptHash(script), def.ScriptHash)
+	assert.False(t, def.CreatedAt.IsZero())
+}
+
+func TestSagaDefinitionRepository_FindOrCreate_Idempotent(t *testing.T) {
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	repo := NewSagaDefinitionRepository(db)
+	ctx := context.Background()
+
+	script := "def main(): return None"
+
+	first, err := repo.FindOrCreate(ctx, "saga_dup", 1, script, nil)
+	require.NoError(t, err)
+
+	second, err := repo.FindOrCreate(ctx, "saga_dup", 1, script, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, first.ID, second.ID, "same (name, version, script) must return same row")
+	assert.Equal(t, first.CreatedAt.UnixNano(), second.CreatedAt.UnixNano())
+
+	// Verify only one row exists.
+	var count int64
+	require.NoError(t, db.Model(&SagaDefinition{}).Where("name = ? AND version = ?", "saga_dup", 1).Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+}
+
+func TestSagaDefinitionRepository_FindOrCreate_NewVersionCreatesNewRow(t *testing.T) {
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	repo := NewSagaDefinitionRepository(db)
+	ctx := context.Background()
+
+	v1, err := repo.FindOrCreate(ctx, "saga_versioned", 1, "def v1(): pass", nil)
+	require.NoError(t, err)
+
+	v2, err := repo.FindOrCreate(ctx, "saga_versioned", 2, "def v2(): pass", nil)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, v1.ID, v2.ID, "different versions must have different IDs")
+	assert.Equal(t, 1, v1.Version)
+	assert.Equal(t, 2, v2.Version)
+}
+
+func TestSagaDefinitionRepository_FindOrCreate_HashMismatchRejected(t *testing.T) {
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	repo := NewSagaDefinitionRepository(db)
+	ctx := context.Background()
+
+	_, err := repo.FindOrCreate(ctx, "immutable_saga", 1, "def v1(): pass", nil)
+	require.NoError(t, err)
+
+	// Same (name, version) but different script content must error out.
+	_, err = repo.FindOrCreate(ctx, "immutable_saga", 1, "def v1_TAMPERED(): pass", nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSagaDefinitionHashMismatch)
+
+	// Confirm no second row was created.
+	var count int64
+	require.NoError(t, db.Model(&SagaDefinition{}).Where("name = ?", "immutable_saga").Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+}
+
+func TestSagaDefinitionRepository_FindOrCreate_PersistsParamsSchema(t *testing.T) {
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	repo := NewSagaDefinitionRepository(db)
+	ctx := context.Background()
+
+	params := JSONB{"amount": map[string]any{"type": "Decimal", "required": true}}
+
+	def, err := repo.FindOrCreate(ctx, "schema_saga", 1, "def main(): pass", params)
+	require.NoError(t, err)
+	require.NotNil(t, def.ParamsSchema)
+
+	loaded, err := repo.FindByID(ctx, def.ID)
+	require.NoError(t, err)
+	require.NotNil(t, loaded.ParamsSchema)
+	assert.Contains(t, loaded.ParamsSchema, "amount")
+}
+
+func TestSagaDefinitionRepository_FindByID_Success(t *testing.T) {
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	repo := NewSagaDefinitionRepository(db)
+	ctx := context.Background()
+
+	created, err := repo.FindOrCreate(ctx, "lookup_saga", 1, "def main(): pass", nil)
+	require.NoError(t, err)
+
+	loaded, err := repo.FindByID(ctx, created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+
+	assert.Equal(t, created.ID, loaded.ID)
+	assert.Equal(t, created.Name, loaded.Name)
+	assert.Equal(t, created.Version, loaded.Version)
+	assert.Equal(t, created.Script, loaded.Script)
+	assert.Equal(t, created.ScriptHash, loaded.ScriptHash)
+}
+
+func TestSagaDefinitionRepository_FindByID_NotFound(t *testing.T) {
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	repo := NewSagaDefinitionRepository(db)
+	ctx := context.Background()
+
+	_, err := repo.FindByID(ctx, uuid.New())
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSagaDefinitionNotFound),
+		"expected ErrSagaDefinitionNotFound, got %v", err)
+}
+
+func TestSagaDefinitionRepository_FindByID_NilUUIDReturnsNotFound(t *testing.T) {
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	repo := NewSagaDefinitionRepository(db)
+	ctx := context.Background()
+
+	_, err := repo.FindByID(ctx, uuid.Nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSagaDefinitionNotFound)
+}

--- a/shared/pkg/saga/saga_definition_repository_test.go
+++ b/shared/pkg/saga/saga_definition_repository_test.go
@@ -18,13 +18,13 @@ func TestSagaDefinitionRepository_FindOrCreate_NewRow(t *testing.T) {
 	ctx := context.Background()
 
 	script := "def main(): return {'ok': True}"
-	def, err := repo.FindOrCreate(ctx, "test_saga", 1, script, nil)
+	def, err := repo.FindOrCreate(ctx, "test_saga", "1", script, nil)
 	require.NoError(t, err)
 	require.NotNil(t, def)
 
 	assert.NotEqual(t, uuid.Nil, def.ID)
 	assert.Equal(t, "test_saga", def.Name)
-	assert.Equal(t, 1, def.Version)
+	assert.Equal(t, "1", def.Version)
 	assert.Equal(t, script, def.Script)
 	assert.Equal(t, ComputeSagaDefinitionScriptHash(script), def.ScriptHash)
 	assert.False(t, def.CreatedAt.IsZero())
@@ -39,10 +39,10 @@ func TestSagaDefinitionRepository_FindOrCreate_Idempotent(t *testing.T) {
 
 	script := "def main(): return None"
 
-	first, err := repo.FindOrCreate(ctx, "saga_dup", 1, script, nil)
+	first, err := repo.FindOrCreate(ctx, "saga_dup", "1", script, nil)
 	require.NoError(t, err)
 
-	second, err := repo.FindOrCreate(ctx, "saga_dup", 1, script, nil)
+	second, err := repo.FindOrCreate(ctx, "saga_dup", "1", script, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, first.ID, second.ID, "same (name, version, script) must return same row")
@@ -50,7 +50,7 @@ func TestSagaDefinitionRepository_FindOrCreate_Idempotent(t *testing.T) {
 
 	// Verify only one row exists.
 	var count int64
-	require.NoError(t, db.Model(&SagaDefinition{}).Where("name = ? AND version = ?", "saga_dup", 1).Count(&count).Error)
+	require.NoError(t, db.Model(&SagaDefinition{}).Where("name = ? AND version = ?", "saga_dup", "1").Count(&count).Error)
 	assert.Equal(t, int64(1), count)
 }
 
@@ -61,15 +61,15 @@ func TestSagaDefinitionRepository_FindOrCreate_NewVersionCreatesNewRow(t *testin
 	repo := NewSagaDefinitionRepository(db)
 	ctx := context.Background()
 
-	v1, err := repo.FindOrCreate(ctx, "saga_versioned", 1, "def v1(): pass", nil)
+	v1, err := repo.FindOrCreate(ctx, "saga_versioned", "1", "def v1(): pass", nil)
 	require.NoError(t, err)
 
-	v2, err := repo.FindOrCreate(ctx, "saga_versioned", 2, "def v2(): pass", nil)
+	v2, err := repo.FindOrCreate(ctx, "saga_versioned", "2", "def v2(): pass", nil)
 	require.NoError(t, err)
 
 	assert.NotEqual(t, v1.ID, v2.ID, "different versions must have different IDs")
-	assert.Equal(t, 1, v1.Version)
-	assert.Equal(t, 2, v2.Version)
+	assert.Equal(t, "1", v1.Version)
+	assert.Equal(t, "2", v2.Version)
 }
 
 func TestSagaDefinitionRepository_FindOrCreate_HashMismatchRejected(t *testing.T) {
@@ -79,11 +79,11 @@ func TestSagaDefinitionRepository_FindOrCreate_HashMismatchRejected(t *testing.T
 	repo := NewSagaDefinitionRepository(db)
 	ctx := context.Background()
 
-	_, err := repo.FindOrCreate(ctx, "immutable_saga", 1, "def v1(): pass", nil)
+	_, err := repo.FindOrCreate(ctx, "immutable_saga", "1", "def v1(): pass", nil)
 	require.NoError(t, err)
 
 	// Same (name, version) but different script content must error out.
-	_, err = repo.FindOrCreate(ctx, "immutable_saga", 1, "def v1_TAMPERED(): pass", nil)
+	_, err = repo.FindOrCreate(ctx, "immutable_saga", "1", "def v1_TAMPERED(): pass", nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrSagaDefinitionHashMismatch)
 
@@ -102,7 +102,7 @@ func TestSagaDefinitionRepository_FindOrCreate_PersistsParamsSchema(t *testing.T
 
 	params := JSONB{"amount": map[string]any{"type": "Decimal", "required": true}}
 
-	def, err := repo.FindOrCreate(ctx, "schema_saga", 1, "def main(): pass", params)
+	def, err := repo.FindOrCreate(ctx, "schema_saga", "1", "def main(): pass", params)
 	require.NoError(t, err)
 	require.NotNil(t, def.ParamsSchema)
 
@@ -119,7 +119,7 @@ func TestSagaDefinitionRepository_FindByID_Success(t *testing.T) {
 	repo := NewSagaDefinitionRepository(db)
 	ctx := context.Background()
 
-	created, err := repo.FindOrCreate(ctx, "lookup_saga", 1, "def main(): pass", nil)
+	created, err := repo.FindOrCreate(ctx, "lookup_saga", "1", "def main(): pass", nil)
 	require.NoError(t, err)
 
 	loaded, err := repo.FindByID(ctx, created.ID)

--- a/shared/pkg/saga/saga_definition_test.go
+++ b/shared/pkg/saga/saga_definition_test.go
@@ -1,0 +1,54 @@
+package saga
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSagaDefinition_TableName(t *testing.T) {
+	assert.Equal(t, "saga_definitions", SagaDefinition{}.TableName())
+}
+
+func TestComputeSagaDefinitionScriptHash(t *testing.T) {
+	t.Run("returns 64-char hex digest", func(t *testing.T) {
+		hash := ComputeSagaDefinitionScriptHash("def main(): pass")
+		assert.Len(t, hash, 64)
+		// SHA-256 hex output should be lower-case hex
+		for _, c := range hash {
+			assert.True(t, (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'),
+				"hash should contain only lowercase hex chars, got %q", c)
+		}
+	})
+
+	t.Run("is deterministic", func(t *testing.T) {
+		script := "def main(): return {'ok': True}"
+		assert.Equal(t,
+			ComputeSagaDefinitionScriptHash(script),
+			ComputeSagaDefinitionScriptHash(script),
+		)
+	})
+
+	t.Run("differs for different scripts", func(t *testing.T) {
+		assert.NotEqual(t,
+			ComputeSagaDefinitionScriptHash("def a(): pass"),
+			ComputeSagaDefinitionScriptHash("def b(): pass"),
+		)
+	})
+
+	t.Run("differs for whitespace changes", func(t *testing.T) {
+		// Hashes pin exact byte content. Any whitespace edit must produce a
+		// different hash, otherwise version pinning would silently accept
+		// material script edits.
+		assert.NotEqual(t,
+			ComputeSagaDefinitionScriptHash("def main(): pass"),
+			ComputeSagaDefinitionScriptHash("def main():  pass"),
+		)
+	})
+
+	t.Run("empty script has stable hash", func(t *testing.T) {
+		// SHA-256 of the empty string is a well-known constant.
+		const sha256OfEmpty = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+		assert.Equal(t, sha256OfEmpty, ComputeSagaDefinitionScriptHash(""))
+	})
+}

--- a/shared/pkg/saga/saga_resume.go
+++ b/shared/pkg/saga/saga_resume.go
@@ -1,0 +1,69 @@
+package saga
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// ErrScriptHashCorruption is returned when a saga instance's recorded
+// ScriptHashAtStart does not match the script_hash on the SagaDefinition row
+// referenced by SagaDefinitionID. This indicates the pinned row was tampered
+// with (or the wrong instance was loaded) and the saga must be flagged for
+// manual intervention rather than resumed.
+var ErrScriptHashCorruption = errors.New("saga definition script hash does not match instance.ScriptHashAtStart")
+
+// ErrInstanceMissingDefinitionID is returned by LoadPinnedDefinition when the
+// supplied instance has SagaDefinitionID == uuid.Nil. Legacy instances created
+// before version pinning was wired in must be backfilled (see the backfill
+// migration) before they can resume.
+var ErrInstanceMissingDefinitionID = errors.New("saga instance has no saga_definition_id; backfill required before resume")
+
+// ErrNilSagaInstance is returned when LoadPinnedDefinition is called with a
+// nil instance pointer.
+var ErrNilSagaInstance = errors.New("saga instance is nil")
+
+// LoadPinnedDefinition returns the SagaDefinition that the given instance was
+// started with - NOT the current "active" definition for that saga name.
+//
+// This is the single entry point the resume path MUST use to obtain the script.
+// It enforces two invariants:
+//
+//  1. The instance carries a non-nil SagaDefinitionID (set at start time, kept
+//     immutable through the saga's lifetime).
+//  2. The script_hash recorded on the pinned definition matches the
+//     ScriptHashAtStart recorded on the instance. A mismatch means the pinned
+//     row was modified out of band; we refuse to resume.
+//
+// Re-resolving the definition from the live manifest or the reference-data
+// registry is explicitly disallowed: a definition that has since been
+// deprecated or replaced must continue to drive existing in-flight instances.
+func LoadPinnedDefinition(
+	ctx context.Context,
+	repo SagaDefinitionRepository,
+	instance *SagaInstance,
+) (*SagaDefinition, error) {
+	if instance == nil {
+		return nil, ErrNilSagaInstance
+	}
+	if instance.SagaDefinitionID == uuid.Nil {
+		return nil, ErrInstanceMissingDefinitionID
+	}
+
+	def, err := repo.FindByID(ctx, instance.SagaDefinitionID)
+	if err != nil {
+		return nil, fmt.Errorf("load pinned saga definition: %w", err)
+	}
+
+	// Verify the hash recorded on the instance matches the pinned definition.
+	// Empty ScriptHashAtStart is treated as "skip verification" so older instances
+	// created before this field was populated remain resumable.
+	if instance.ScriptHashAtStart != "" && def.ScriptHash != instance.ScriptHashAtStart {
+		return nil, fmt.Errorf("%w: instance=%s definition=%s",
+			ErrScriptHashCorruption, instance.ScriptHashAtStart, def.ScriptHash)
+	}
+
+	return def, nil
+}

--- a/shared/pkg/saga/saga_resume.go
+++ b/shared/pkg/saga/saga_resume.go
@@ -25,6 +25,10 @@ var ErrInstanceMissingDefinitionID = errors.New("saga instance has no saga_defin
 // nil instance pointer.
 var ErrNilSagaInstance = errors.New("saga instance is nil")
 
+// ErrNilSagaDefinitionRepository is returned when LoadPinnedDefinition is
+// called with a nil repository, preventing a nil-pointer panic on FindByID.
+var ErrNilSagaDefinitionRepository = errors.New("saga definition repository is nil")
+
 // LoadPinnedDefinition returns the SagaDefinition that the given instance was
 // started with - NOT the current "active" definition for that saga name.
 //
@@ -47,6 +51,9 @@ func LoadPinnedDefinition(
 ) (*SagaDefinition, error) {
 	if instance == nil {
 		return nil, ErrNilSagaInstance
+	}
+	if repo == nil {
+		return nil, ErrNilSagaDefinitionRepository
 	}
 	if instance.SagaDefinitionID == uuid.Nil {
 		return nil, ErrInstanceMissingDefinitionID

--- a/shared/pkg/saga/saga_resume_test.go
+++ b/shared/pkg/saga/saga_resume_test.go
@@ -56,6 +56,20 @@ func TestLoadPinnedDefinition_NilInstanceRejected(t *testing.T) {
 	repo := NewSagaDefinitionRepository(db)
 	_, err := LoadPinnedDefinition(context.Background(), repo, nil)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNilSagaInstance)
+}
+
+func TestLoadPinnedDefinition_NilRepoRejected(t *testing.T) {
+	// Guard against the easy footgun: passing a nil repo would otherwise panic
+	// when LoadPinnedDefinition calls FindByID. The error path keeps the caller
+	// in control of how to react.
+	instance := &SagaInstance{
+		SagaDefinitionID: uuid.New(),
+		Status:           SagaStatusRunning,
+	}
+	_, err := LoadPinnedDefinition(context.Background(), nil, instance)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNilSagaDefinitionRepository)
 }
 
 func TestLoadPinnedDefinition_MissingDefinitionIDRejected(t *testing.T) {

--- a/shared/pkg/saga/saga_resume_test.go
+++ b/shared/pkg/saga/saga_resume_test.go
@@ -1,0 +1,136 @@
+package saga
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadPinnedDefinition_ReturnsPinnedDefinition is the central invariant:
+// when a definition with the same name is replaced by a NEW row (simulating a
+// manifest update mid-flight), LoadPinnedDefinition still returns the original
+// row referenced by instance.SagaDefinitionID - never the new row.
+func TestLoadPinnedDefinition_ReturnsPinnedDefinition(t *testing.T) {
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	repo := NewSagaDefinitionRepository(db)
+	ctx := context.Background()
+
+	// Pin v1 of the saga and create an instance referencing it.
+	v1Script := "def v1(): return 'old'"
+	v1, err := repo.FindOrCreate(ctx, "drift_test", "1", v1Script, nil)
+	require.NoError(t, err)
+
+	instance := &SagaInstance{
+		SagaDefinitionID:  v1.ID,
+		SagaName:          "drift_test",
+		SagaVersion:       1,
+		ScriptHashAtStart: v1.ScriptHash,
+		Status:            SagaStatusRunning,
+	}
+
+	// Simulate a manifest update: v2 is created with new script, but v1 stays around.
+	v2Script := "def v2(): return 'new'"
+	v2, err := repo.FindOrCreate(ctx, "drift_test", "2", v2Script, nil)
+	require.NoError(t, err)
+	require.NotEqual(t, v1.ID, v2.ID)
+
+	// The resume path MUST return v1, even though v2 exists.
+	loaded, err := LoadPinnedDefinition(ctx, repo, instance)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+
+	assert.Equal(t, v1.ID, loaded.ID, "must return the pinned definition, not the latest")
+	assert.Equal(t, v1Script, loaded.Script, "must return the pinned script, not v2")
+}
+
+func TestLoadPinnedDefinition_NilInstanceRejected(t *testing.T) {
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	repo := NewSagaDefinitionRepository(db)
+	_, err := LoadPinnedDefinition(context.Background(), repo, nil)
+	require.Error(t, err)
+}
+
+func TestLoadPinnedDefinition_MissingDefinitionIDRejected(t *testing.T) {
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	repo := NewSagaDefinitionRepository(db)
+	instance := &SagaInstance{
+		SagaDefinitionID: uuid.Nil,
+		Status:           SagaStatusRunning,
+	}
+
+	_, err := LoadPinnedDefinition(context.Background(), repo, instance)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInstanceMissingDefinitionID)
+}
+
+func TestLoadPinnedDefinition_NotFoundReturnsWrappedError(t *testing.T) {
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	repo := NewSagaDefinitionRepository(db)
+	instance := &SagaInstance{
+		SagaDefinitionID: uuid.New(), // random; no matching row
+		Status:           SagaStatusRunning,
+	}
+
+	_, err := LoadPinnedDefinition(context.Background(), repo, instance)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSagaDefinitionNotFound),
+		"expected wrapped ErrSagaDefinitionNotFound, got %v", err)
+}
+
+func TestLoadPinnedDefinition_HashMismatchRejected(t *testing.T) {
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	repo := NewSagaDefinitionRepository(db)
+	ctx := context.Background()
+
+	v1Script := "def v1(): return 'pinned'"
+	v1, err := repo.FindOrCreate(ctx, "tamper_test", "1", v1Script, nil)
+	require.NoError(t, err)
+
+	// Build an instance with a stale/tampered hash recorded.
+	instance := &SagaInstance{
+		SagaDefinitionID:  v1.ID,
+		ScriptHashAtStart: "deadbeef" + v1.ScriptHash[8:], // mutated prefix
+		Status:            SagaStatusRunning,
+	}
+
+	_, err = LoadPinnedDefinition(ctx, repo, instance)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrScriptHashCorruption)
+}
+
+func TestLoadPinnedDefinition_EmptyHashSkipsVerification(t *testing.T) {
+	// Legacy instances created before ScriptHashAtStart was populated must still
+	// resume - we treat empty hash as "skip verification".
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	repo := NewSagaDefinitionRepository(db)
+	ctx := context.Background()
+
+	def, err := repo.FindOrCreate(ctx, "legacy_test", "1", "def main(): pass", nil)
+	require.NoError(t, err)
+
+	instance := &SagaInstance{
+		SagaDefinitionID:  def.ID,
+		ScriptHashAtStart: "", // legacy
+		Status:            SagaStatusRunning,
+	}
+
+	loaded, err := LoadPinnedDefinition(ctx, repo, instance)
+	require.NoError(t, err)
+	assert.Equal(t, def.ID, loaded.ID)
+}

--- a/shared/pkg/saga/test_helpers_test.go
+++ b/shared/pkg/saga/test_helpers_test.go
@@ -107,6 +107,9 @@ func setupTestPostgres(t *testing.T) (*gorm.DB, func()) {
 	if err := sharedDB.Exec("DELETE FROM saga_instances").Error; err != nil {
 		t.Fatalf("Failed to clean saga_instances: %v", err)
 	}
+	if err := sharedDB.Exec("DELETE FROM saga_definitions").Error; err != nil {
+		t.Fatalf("Failed to clean saga_definitions: %v", err)
+	}
 
 	return sharedDB, func() {
 		// No-op: container lifecycle managed by TestMain.


### PR DESCRIPTION
## Summary

Pins saga definitions at instance-start time so the resume path can re-execute the exact script the saga was started with, even if the underlying manifest or reference-data registry has been updated since.

This is task 1 of 063-saga-durability-parity, focused on the version-pinning correctness primitive that prevents in-flight sagas from silently switching scripts under their feet.

## Changes Made

**Schema**

- New \`saga_definitions\` table (immutable, content-addressed). Created via GORM AutoMigrate in shared/pkg/saga and via Atlas migration in control-plane.
  - Columns: \`id\`, \`name\`, \`version\` (varchar - accepts both int \`\"1\"\` and semver \`\"1.5.0\"\`), \`script\`, \`params_schema\`, \`script_hash\`, \`created_at\`.
  - Unique index on \`(name, version)\` enforces per-version immutability.

**shared/pkg/saga**

- \`SagaDefinition\` model + \`SagaDefinitionRepository\` interface.
- \`GormSagaDefinitionRepository.FindOrCreate\` returns existing row when \`(name, version, script hash)\` match; rejects with \`ErrSagaDefinitionHashMismatch\` when the same \`(name, version)\` is published with a different script.
- \`LoadPinnedDefinition\` is the entry point the resume path MUST use; verifies \`script_hash\` against \`SagaInstance.ScriptHashAtStart\` and refuses to resume on mismatch.
- \`BackfillSagaDefinitionIDs\` reconciles existing in-flight \`saga_instances\` rows whose \`saga_definition_id\` does not yet resolve to a local row. Matches on \`(saga_name, saga_version)\` or flags as \`FAILED_MANUAL_INTERVENTION\`. Idempotent.

**services/control-plane**

- Atlas migration \`20260516000001_saga_definitions.sql\` mirroring the GORM schema.
- pgx-based \`SagaDefinitionRepository\` satisfying the shared interface.
- \`ManifestExecutor.pinSagaDefinition\` writes the resolved \`apply_manifest\` script via FindOrCreate during \`prepareApplyJob\`. Pinning is best-effort: failures are logged but do not block the apply.

**Drive-by**

- Widened three \`//nolint:exhaustive\` directives in \`decimal.go\` and \`linter.go\` to \`exhaustive,nolintlint\` to work around a golangci-lint v2.11.4 regression where the two linters disagree on whether the suppression is needed.

## Technical Details

The pinning invariants enforced by the new API:

1. \`(name, version)\` is unique.
2. Same \`(name, version, script hash)\` is idempotent: FindOrCreate returns the existing row.
3. Different script under existing \`(name, version)\` is rejected as an immutability violation.
4. Resume MUST go through \`LoadPinnedDefinition\` and MUST NOT re-resolve from the live registry.

## Testing

- 16 new tests covering: hash determinism, FindOrCreate happy/mismatch/idempotency/concurrency-race paths, FindByID happy/not-found/nil-uuid, pinning during apply (happy + idempotent + nil-repo), resume drift safety (the central correctness test), and backfill happy/orphan/skip/atomicity/idempotency paths.
- Full \`shared/pkg/saga\` and \`services/control-plane/internal/applier\` test suites pass.

## Risk Assessment

Low. The new code is additive:
- \`saga_definitions\` is a new table; no existing reader queries it.
- Pinning in the manifest executor is best-effort; pinning failures fall through to the existing apply path.
- The resume API is built but not yet wired into any production resume path (forward-looking; consumed by the broader 063 effort).
- The backfill function is opt-in (services call it on startup once they adopt pinning); empty databases are a no-op.

## Deployment Notes

- Atlas migration runs on control-plane startup.
- GORM AutoMigrate runs on any service that calls \`saga.RunSagaMigrations\`.
- Optional: services with existing in-flight saga_instances can call \`BackfillSagaDefinitionIDs\` once after the migration applies.

## Known Conflicts with Queued Work

Task 2 (Exponential Backoff) will also touch \`shared/pkg/saga/models.go\` to add \`NextRetryAt\`. This PR does not modify \`models.go\` itself (the existing \`SagaDefinitionID\` field was sufficient), so there should be no merge conflicts.