### PR TITLE
feat: Implement exponential backoff on transient saga retries (063-saga-durability-parity.2)

### DIFF
--- a/shared/pkg/saga/backoff.go
+++ b/shared/pkg/saga/backoff.go
@@ -74,8 +74,13 @@ func CalculateBackoffDelay(replayCount int, baseDelay, maxDelay time.Duration) t
 	multiplier := int64(1) << uint(count)
 
 	// Overflow check on the multiplication itself.
+	// maxDelay/baseDelay is integer division: if multiplier exceeds that
+	// quotient, multiplier*baseDelay strictly exceeds maxDelay so we saturate.
+	// (We dropped the +1 slop term that previously appeared here - it could
+	// overflow int64 at extreme maxDelay values and is unnecessary because
+	// equality already produces a delay <= maxDelay after the cap below.)
 	if multiplier > 0 && int64(baseDelay) > 0 &&
-		multiplier > int64(maxDelay)/int64(baseDelay)+1 {
+		multiplier > int64(maxDelay)/int64(baseDelay) {
 		// Even without jitter we'd exceed maxDelay - saturate.
 		return maxDelay
 	}

--- a/shared/pkg/saga/backoff.go
+++ b/shared/pkg/saga/backoff.go
@@ -1,0 +1,83 @@
+// Package saga provides saga orchestration runtime and persistence for durable execution.
+package saga
+
+import (
+	"math/rand/v2"
+	"time"
+)
+
+// DefaultRetryBaseDelay is the default base delay for exponential backoff.
+// Used when neither the global ClaimConfig nor a per-handler retry policy overrides it.
+const DefaultRetryBaseDelay = 1 * time.Second
+
+// DefaultRetryMaxDelay is the default upper bound on backoff delay.
+// Used when neither the global ClaimConfig nor a per-handler retry policy overrides it.
+const DefaultRetryMaxDelay = 5 * time.Minute
+
+// CalculateBackoffDelay computes the wall-clock duration a saga should wait before
+// it is eligible for another reclaim attempt after a transient failure.
+//
+// Formula: min(baseDelay * 2^replayCount + jitter, maxDelay)
+// where jitter is a uniform random value in [0, baseDelay).
+//
+// Bounds:
+//   - replayCount is clamped to a non-negative value; negative inputs return baseDelay + jitter.
+//   - baseDelay <= 0 falls back to DefaultRetryBaseDelay so callers cannot accidentally
+//     produce a zero-base sequence (which would yield zero growth and a thundering herd).
+//   - maxDelay <= 0 falls back to DefaultRetryMaxDelay.
+//   - High replayCount values that would overflow int64 are saturated to maxDelay,
+//     so this function is safe for unexpectedly large counts (e.g., after MaxReplays
+//     races) without panicking.
+//
+// Jitter is essential to prevent thundering herd: if N sagas hit the same outage at
+// the same moment, deterministic backoff would have them all retry simultaneously.
+// Adding [0, baseDelay) of random spread breaks the synchronization.
+func CalculateBackoffDelay(replayCount int, baseDelay, maxDelay time.Duration) time.Duration {
+	if baseDelay <= 0 {
+		baseDelay = DefaultRetryBaseDelay
+	}
+	if maxDelay <= 0 {
+		maxDelay = DefaultRetryMaxDelay
+	}
+	// If max <= base, the cap immediately applies once jitter is added.
+	// Treat that as the legitimate "max" floor rather than an error.
+
+	count := replayCount
+	if count < 0 {
+		count = 0
+	}
+
+	// Overflow guard: 2^63 wraps to a negative or zero shift. Anything beyond 62
+	// already exceeds any sane maxDelay, so saturate.
+	const maxShift = 62
+	if count > maxShift {
+		return maxDelay
+	}
+
+	// Exponential component: baseDelay * 2^count.
+	// We compute the multiplier first to detect overflow before applying to baseDelay.
+	multiplier := int64(1) << uint(count)
+
+	// Overflow check on the multiplication itself.
+	if multiplier > 0 && int64(baseDelay) > 0 &&
+		multiplier > int64(maxDelay)/int64(baseDelay)+1 {
+		// Even without jitter we'd exceed maxDelay - saturate.
+		return maxDelay
+	}
+
+	delay := baseDelay * time.Duration(multiplier)
+	if delay < 0 || delay > maxDelay {
+		// Defensive: if anything overflowed past the cap (or wrapped negative), saturate.
+		return maxDelay
+	}
+
+	// Add jitter in [0, baseDelay). rand.Int64N requires n > 0; we already
+	// normalised baseDelay > 0 above.
+	jitter := time.Duration(rand.Int64N(int64(baseDelay)))
+	delay += jitter
+
+	if delay > maxDelay || delay < 0 {
+		return maxDelay
+	}
+	return delay
+}

--- a/shared/pkg/saga/backoff.go
+++ b/shared/pkg/saga/backoff.go
@@ -14,6 +14,21 @@ const DefaultRetryBaseDelay = 1 * time.Second
 // Used when neither the global ClaimConfig nor a per-handler retry policy overrides it.
 const DefaultRetryMaxDelay = 5 * time.Minute
 
+// RetryPolicy defines per-handler exponential backoff parameters at the runtime
+// (registry-side) layer. It mirrors schema.RetryPolicy which is the YAML-parsed
+// counterpart - services that register handlers with custom retry behavior copy
+// values from the schema into HandlerMetadata.RetryPolicy.
+//
+// Either or both fields may be zero, in which case the corresponding global
+// ClaimConfig default applies.
+type RetryPolicy struct {
+	// BaseDelay overrides ClaimConfig.RetryBaseDelay for this handler.
+	BaseDelay time.Duration
+
+	// MaxDelay overrides ClaimConfig.RetryMaxDelay for this handler.
+	MaxDelay time.Duration
+}
+
 // CalculateBackoffDelay computes the wall-clock duration a saga should wait before
 // it is eligible for another reclaim attempt after a transient failure.
 //

--- a/shared/pkg/saga/backoff_integration_test.go
+++ b/shared/pkg/saga/backoff_integration_test.go
@@ -48,6 +48,66 @@ func TestUpdateNextRetryAt_PersistsValue(t *testing.T) {
 		"persisted next_retry_at should round-trip within DB precision")
 }
 
+// TestBackoff_OrphanWatcherSkipsThenReclaims is the end-to-end safety net for
+// the backoff feature: after handleTransientFailure sets next_retry_at into the
+// future, the orphan watcher must skip the saga; after the backoff window
+// elapses the saga must become eligible again.
+//
+// We model "time elapsing" by directly rewriting next_retry_at to the past,
+// rather than sleeping for the real duration. This keeps the test fast.
+func TestBackoff_OrphanWatcherSkipsThenReclaims(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// 1. Insert an orphaned saga with no backoff in effect.
+	expiredLease := time.Now().Add(-10 * time.Minute)
+	repo := NewGormSagaInstanceRepository(db)
+	instance := &SagaInstance{
+		ID:               uuid.New(),
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		LeaseExpiresAt:   &expiredLease,
+	}
+	require.NoError(t, repo.Create(ctx, instance))
+
+	// 2. Simulate handleTransientFailure: set next_retry_at to 1 hour in the future.
+	future := time.Now().Add(1 * time.Hour)
+	require.NoError(t, repo.UpdateNextRetryAt(ctx, instance.ID, future))
+
+	claimService := NewClaimService(db, &ClaimConfig{
+		LeaseDuration:  5 * time.Minute,
+		BatchSize:      10,
+		MaxJitterMS:    0,
+		MaxReplays:     DefaultMaxReplays,
+		RetryBaseDelay: 1 * time.Second,
+		RetryMaxDelay:  5 * time.Minute,
+		PodID:          "test-pod",
+	})
+
+	// 3. Watcher should NOT reclaim - saga is mid-backoff.
+	claimed, err := claimService.ClaimOrphanedSagas(ctx)
+	require.NoError(t, err)
+	assert.NotContains(t, claimed, instance.ID,
+		"saga with future next_retry_at must be skipped by orphan watcher")
+
+	// 4. Simulate backoff window elapsing: rewrite next_retry_at to the past.
+	past := time.Now().Add(-1 * time.Minute)
+	require.NoError(t, repo.UpdateNextRetryAt(ctx, instance.ID, past))
+
+	// 5. Watcher reclaims now that the window has elapsed.
+	claimed, err = claimService.ClaimOrphanedSagas(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, claimed, instance.ID,
+		"saga should be reclaimable after next_retry_at elapses")
+}
+
 // TestResetReplayCountAndBackoff_ClearsBoth verifies the atomic reset method
 // clears replay_count AND next_retry_at in a single UPDATE.
 func TestResetReplayCountAndBackoff_ClearsBoth(t *testing.T) {

--- a/shared/pkg/saga/backoff_integration_test.go
+++ b/shared/pkg/saga/backoff_integration_test.go
@@ -1,0 +1,82 @@
+package saga
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateNextRetryAt_PersistsValue verifies the repository sets next_retry_at
+// and that subsequent reads observe the value.
+func TestUpdateNextRetryAt_PersistsValue(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	repo := NewGormSagaInstanceRepository(db)
+	ctx := context.Background()
+
+	instance := &SagaInstance{
+		ID:               uuid.New(),
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+	}
+	require.NoError(t, repo.Create(ctx, instance))
+
+	// next_retry_at starts NULL.
+	fetched, err := repo.FindByID(ctx, instance.ID)
+	require.NoError(t, err)
+	require.NotNil(t, fetched)
+	assert.Nil(t, fetched.NextRetryAt, "next_retry_at should default to NULL")
+
+	target := time.Now().Add(30 * time.Second).UTC().Truncate(time.Microsecond)
+	require.NoError(t, repo.UpdateNextRetryAt(ctx, instance.ID, target))
+
+	fetched, err = repo.FindByID(ctx, instance.ID)
+	require.NoError(t, err)
+	require.NotNil(t, fetched)
+	require.NotNil(t, fetched.NextRetryAt, "next_retry_at should be persisted")
+	assert.WithinDuration(t, target, *fetched.NextRetryAt, time.Second,
+		"persisted next_retry_at should round-trip within DB precision")
+}
+
+// TestResetReplayCountAndBackoff_ClearsBoth verifies the atomic reset method
+// clears replay_count AND next_retry_at in a single UPDATE.
+func TestResetReplayCountAndBackoff_ClearsBoth(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	repo := NewGormSagaInstanceRepository(db)
+	ctx := context.Background()
+
+	retry := time.Now().Add(1 * time.Minute)
+	instance := &SagaInstance{
+		ID:               uuid.New(),
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		ReplayCount:      3,
+		NextRetryAt:      &retry,
+	}
+	require.NoError(t, repo.Create(ctx, instance))
+
+	require.NoError(t, repo.ResetReplayCountAndBackoff(ctx, instance.ID))
+
+	fetched, err := repo.FindByID(ctx, instance.ID)
+	require.NoError(t, err)
+	require.NotNil(t, fetched)
+	assert.Equal(t, 0, fetched.ReplayCount, "replay_count must be reset to 0")
+	assert.Nil(t, fetched.NextRetryAt, "next_retry_at must be cleared to NULL")
+}

--- a/shared/pkg/saga/backoff_test.go
+++ b/shared/pkg/saga/backoff_test.go
@@ -1,0 +1,113 @@
+package saga
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCalculateBackoffDelay_ExponentialGrowth verifies the canonical doubling
+// sequence with a small base and large cap so jitter remains within range.
+func TestCalculateBackoffDelay_ExponentialGrowth(t *testing.T) {
+	baseDelay := 1 * time.Second
+	maxDelay := 1 * time.Hour
+
+	// replayCount=0: [1s, 2s)        (base + jitter in [0, base))
+	// replayCount=1: [2s, 3s)        (base*2 + jitter)
+	// replayCount=2: [4s, 5s)        (base*4 + jitter)
+	// replayCount=3: [8s, 9s)        (base*8 + jitter)
+	cases := []struct {
+		replayCount int
+		minExpected time.Duration
+		maxExpected time.Duration
+	}{
+		{0, 1 * time.Second, 2 * time.Second},
+		{1, 2 * time.Second, 3 * time.Second},
+		{2, 4 * time.Second, 5 * time.Second},
+		{3, 8 * time.Second, 9 * time.Second},
+		{4, 16 * time.Second, 17 * time.Second},
+	}
+
+	for _, c := range cases {
+		// Run several iterations so we sample the jitter distribution.
+		for i := 0; i < 20; i++ {
+			d := CalculateBackoffDelay(c.replayCount, baseDelay, maxDelay)
+			assert.GreaterOrEqual(t, d, c.minExpected,
+				"replayCount=%d: delay %s should be >= %s", c.replayCount, d, c.minExpected)
+			assert.Less(t, d, c.maxExpected,
+				"replayCount=%d: delay %s should be < %s", c.replayCount, d, c.maxExpected)
+		}
+	}
+}
+
+// TestCalculateBackoffDelay_CappedAtMaxDelay verifies that very large replay
+// counts saturate to maxDelay rather than overflowing.
+func TestCalculateBackoffDelay_CappedAtMaxDelay(t *testing.T) {
+	baseDelay := 1 * time.Second
+	maxDelay := 30 * time.Second
+
+	// replayCount=5 alone is 32s, exceeding 30s cap.
+	d := CalculateBackoffDelay(5, baseDelay, maxDelay)
+	assert.LessOrEqual(t, d, maxDelay, "replayCount=5 should be capped at maxDelay")
+
+	// replayCount=10 (1024s) is far above cap.
+	d = CalculateBackoffDelay(10, baseDelay, maxDelay)
+	assert.LessOrEqual(t, d, maxDelay, "replayCount=10 should be capped at maxDelay")
+}
+
+// TestCalculateBackoffDelay_HighReplayCountNoOverflow verifies the overflow guard
+// protects against absurdly large replay counts (defense in depth - MaxReplays
+// would normally prevent these).
+func TestCalculateBackoffDelay_HighReplayCountNoOverflow(t *testing.T) {
+	baseDelay := 1 * time.Second
+	maxDelay := 5 * time.Minute
+
+	// Test boundary near int64 shift overflow.
+	for _, replayCount := range []int{60, 62, 63, 64, 100, 1_000_000} {
+		d := CalculateBackoffDelay(replayCount, baseDelay, maxDelay)
+		assert.GreaterOrEqual(t, d, time.Duration(0),
+			"replayCount=%d: delay must not wrap to negative", replayCount)
+		assert.LessOrEqual(t, d, maxDelay,
+			"replayCount=%d: delay must respect maxDelay", replayCount)
+	}
+}
+
+// TestCalculateBackoffDelay_NegativeReplayCount treats negative input as zero
+// (defense against caller bugs).
+func TestCalculateBackoffDelay_NegativeReplayCount(t *testing.T) {
+	baseDelay := 2 * time.Second
+	maxDelay := 1 * time.Minute
+
+	d := CalculateBackoffDelay(-5, baseDelay, maxDelay)
+	assert.GreaterOrEqual(t, d, baseDelay, "negative replayCount should behave like 0")
+	assert.Less(t, d, baseDelay+baseDelay, "should be base + jitter range")
+}
+
+// TestCalculateBackoffDelay_FallsBackOnNonPositiveBase verifies that callers passing
+// zero or negative base/max do not get a zero-delay sequence (which would defeat backoff).
+func TestCalculateBackoffDelay_FallsBackOnNonPositiveBase(t *testing.T) {
+	// Both inputs zero - fall back to defaults.
+	d := CalculateBackoffDelay(0, 0, 0)
+	assert.GreaterOrEqual(t, d, DefaultRetryBaseDelay)
+	assert.LessOrEqual(t, d, DefaultRetryMaxDelay)
+
+	// Negative base - fall back.
+	d = CalculateBackoffDelay(0, -1*time.Second, 10*time.Second)
+	assert.GreaterOrEqual(t, d, DefaultRetryBaseDelay)
+}
+
+// TestCalculateBackoffDelay_JitterIsActuallyRandom verifies the jitter component
+// produces varied delays across calls with the same inputs (thundering herd prevention).
+func TestCalculateBackoffDelay_JitterIsActuallyRandom(t *testing.T) {
+	baseDelay := 1 * time.Second
+	maxDelay := 1 * time.Hour
+
+	seen := make(map[time.Duration]struct{})
+	for i := 0; i < 50; i++ {
+		seen[CalculateBackoffDelay(0, baseDelay, maxDelay)] = struct{}{}
+	}
+	// 50 calls with [0, 1s) jitter at nanosecond resolution should produce
+	// many distinct values; require at least 10 to flag a stuck RNG.
+	assert.GreaterOrEqual(t, len(seen), 10, "jitter should produce varied delays across calls")
+}

--- a/shared/pkg/saga/claiming.go
+++ b/shared/pkg/saga/claiming.go
@@ -63,16 +63,42 @@ type ClaimConfig struct {
 //   - SAGA_RETRY_BASE_DELAY: Base delay for exponential backoff. Default: 1s
 //   - SAGA_RETRY_MAX_DELAY: Max delay cap for exponential backoff. Default: 5m
 //   - HOSTNAME: Pod identifier (Kubernetes sets this). Fallback: generated UUID
+//
+// SAGA_RETRY_BASE_DELAY and SAGA_RETRY_MAX_DELAY are sanitized: negative
+// values or an inverted pair (base > max) fall back to the package defaults
+// rather than being silently accepted. Operator misconfiguration would
+// otherwise collapse or bypass backoff at runtime.
 func NewClaimConfig() *ClaimConfig {
+	baseDelay, maxDelay := loadRetryBounds()
 	return &ClaimConfig{
 		LeaseDuration:  env.GetEnvAsDuration("SAGA_LEASE_DURATION", 5*time.Minute),
 		BatchSize:      env.GetEnvAsInt("SAGA_CLAIM_BATCH_SIZE", 10),
 		MaxJitterMS:    env.GetEnvAsInt("SAGA_CLAIM_JITTER_MS", 500),
 		MaxReplays:     env.GetEnvAsInt("SAGA_MAX_REPLAYS", DefaultMaxReplays),
-		RetryBaseDelay: env.GetEnvAsDuration("SAGA_RETRY_BASE_DELAY", DefaultRetryBaseDelay),
-		RetryMaxDelay:  env.GetEnvAsDuration("SAGA_RETRY_MAX_DELAY", DefaultRetryMaxDelay),
+		RetryBaseDelay: baseDelay,
+		RetryMaxDelay:  maxDelay,
 		PodID:          GetPodID(),
 	}
+}
+
+// loadRetryBounds reads SAGA_RETRY_BASE_DELAY / SAGA_RETRY_MAX_DELAY and
+// returns sanitized values. A non-positive value or an inverted pair
+// (base > max) is rejected: both fields revert to the package defaults so
+// an operator typo cannot disable backoff in production.
+func loadRetryBounds() (time.Duration, time.Duration) {
+	baseDelay := env.GetEnvAsDuration("SAGA_RETRY_BASE_DELAY", DefaultRetryBaseDelay)
+	maxDelay := env.GetEnvAsDuration("SAGA_RETRY_MAX_DELAY", DefaultRetryMaxDelay)
+
+	if baseDelay <= 0 || maxDelay <= 0 || baseDelay > maxDelay {
+		slog.Default().Warn("invalid SAGA_RETRY_BASE_DELAY/SAGA_RETRY_MAX_DELAY - falling back to defaults",
+			"base_delay", baseDelay,
+			"max_delay", maxDelay,
+			"default_base", DefaultRetryBaseDelay,
+			"default_max", DefaultRetryMaxDelay,
+		)
+		return DefaultRetryBaseDelay, DefaultRetryMaxDelay
+	}
+	return baseDelay, maxDelay
 }
 
 // GetPodID returns the pod identifier from HOSTNAME env var or generates a UUID.

--- a/shared/pkg/saga/claiming.go
+++ b/shared/pkg/saga/claiming.go
@@ -42,6 +42,16 @@ type ClaimConfig struct {
 	// a zombie and transitions to FAILED_MANUAL_INTERVENTION.
 	// Default: 5 (SAGA_MAX_REPLAYS)
 	MaxReplays int
+
+	// RetryBaseDelay is the base delay for exponential backoff on transient failures.
+	// The actual delay for replay N is base*2^N + uniform[0, base) jitter, capped at MaxDelay.
+	// Default: 1s (SAGA_RETRY_BASE_DELAY)
+	RetryBaseDelay time.Duration
+
+	// RetryMaxDelay caps the computed backoff delay so a high replay_count cannot
+	// stretch a retry interval to hours or days.
+	// Default: 5m (SAGA_RETRY_MAX_DELAY)
+	RetryMaxDelay time.Duration
 }
 
 // NewClaimConfig creates a ClaimConfig populated from environment variables.
@@ -50,14 +60,18 @@ type ClaimConfig struct {
 //   - SAGA_CLAIM_BATCH_SIZE: Integer. Default: 10
 //   - SAGA_CLAIM_JITTER_MS: Integer milliseconds. Default: 500
 //   - SAGA_MAX_REPLAYS: Maximum replay attempts before zombie detection. Default: 5
+//   - SAGA_RETRY_BASE_DELAY: Base delay for exponential backoff. Default: 1s
+//   - SAGA_RETRY_MAX_DELAY: Max delay cap for exponential backoff. Default: 5m
 //   - HOSTNAME: Pod identifier (Kubernetes sets this). Fallback: generated UUID
 func NewClaimConfig() *ClaimConfig {
 	return &ClaimConfig{
-		LeaseDuration: env.GetEnvAsDuration("SAGA_LEASE_DURATION", 5*time.Minute),
-		BatchSize:     env.GetEnvAsInt("SAGA_CLAIM_BATCH_SIZE", 10),
-		MaxJitterMS:   env.GetEnvAsInt("SAGA_CLAIM_JITTER_MS", 500),
-		MaxReplays:    env.GetEnvAsInt("SAGA_MAX_REPLAYS", DefaultMaxReplays),
-		PodID:         GetPodID(),
+		LeaseDuration:  env.GetEnvAsDuration("SAGA_LEASE_DURATION", 5*time.Minute),
+		BatchSize:      env.GetEnvAsInt("SAGA_CLAIM_BATCH_SIZE", 10),
+		MaxJitterMS:    env.GetEnvAsInt("SAGA_CLAIM_JITTER_MS", 500),
+		MaxReplays:     env.GetEnvAsInt("SAGA_MAX_REPLAYS", DefaultMaxReplays),
+		RetryBaseDelay: env.GetEnvAsDuration("SAGA_RETRY_BASE_DELAY", DefaultRetryBaseDelay),
+		RetryMaxDelay:  env.GetEnvAsDuration("SAGA_RETRY_MAX_DELAY", DefaultRetryMaxDelay),
+		PodID:          GetPodID(),
 	}
 }
 
@@ -142,10 +156,17 @@ func (s *ClaimService) ClaimOrphanedSagas(ctx context.Context) ([]uuid.UUID, err
 		// CockroachDB's serializable isolation prevents concurrent claiming
 		// races at the transaction level, making SKIP LOCKED unnecessary.
 		// (CockroachDB does not support SKIP LOCKED under serializable isolation.)
+		//
+		// The next_retry_at predicate makes the watcher backoff-aware: sagas
+		// that hit a transient failure have next_retry_at set to a future
+		// timestamp and are skipped until that time elapses. NULL means no
+		// backoff in effect (fresh saga or successfully advanced to next step),
+		// so the watcher is free to reclaim it immediately.
 		var candidates []SagaInstance
 		result := tx.Model(&SagaInstance{}).
 			Where("status IN ?", []SagaStatus{SagaStatusPending, SagaStatusRunning, SagaStatusCompensating}).
 			Where("(lease_expires_at < ? OR claimed_by_pod IS NULL)", now).
+			Where("(next_retry_at IS NULL OR next_retry_at <= ?)", now).
 			Where("replay_count < ?", s.config.MaxReplays).
 			Clauses(clause.Locking{Strength: "UPDATE"}).
 			Select("id").
@@ -291,7 +312,15 @@ func (s *ClaimService) RenewLease(ctx context.Context, sagaID uuid.UUID) error {
 
 // ReleaseLease releases the lease on a saga, allowing other pods to claim it.
 // This should be called when a saga completes or when gracefully shutting down.
+//
+// Returns nil immediately if the service has no DB handle. This makes the call
+// safe inside the executor's handleTransientFailure path when constructing
+// test fixtures that supply a ClaimConfig (for retry-bound resolution) but no
+// database, and matches the existing nil-claimService guard at the call site.
 func (s *ClaimService) ReleaseLease(ctx context.Context, sagaID uuid.UUID) error {
+	if s.db == nil {
+		return nil
+	}
 	result := s.db.WithContext(ctx).Model(&SagaInstance{}).
 		Where("id = ? AND claimed_by_pod = ?", sagaID, s.config.PodID).
 		Updates(map[string]interface{}{

--- a/shared/pkg/saga/claiming_test.go
+++ b/shared/pkg/saga/claiming_test.go
@@ -20,6 +20,8 @@ func TestNewClaimConfig_Defaults(t *testing.T) {
 	os.Unsetenv("SAGA_LEASE_DURATION")
 	os.Unsetenv("SAGA_CLAIM_BATCH_SIZE")
 	os.Unsetenv("SAGA_CLAIM_JITTER_MS")
+	os.Unsetenv("SAGA_RETRY_BASE_DELAY")
+	os.Unsetenv("SAGA_RETRY_MAX_DELAY")
 	os.Unsetenv("HOSTNAME")
 
 	config := NewClaimConfig()
@@ -27,6 +29,8 @@ func TestNewClaimConfig_Defaults(t *testing.T) {
 	assert.Equal(t, 5*time.Minute, config.LeaseDuration, "Default lease duration should be 5 minutes")
 	assert.Equal(t, 10, config.BatchSize, "Default batch size should be 10")
 	assert.Equal(t, 500, config.MaxJitterMS, "Default max jitter should be 500ms")
+	assert.Equal(t, DefaultRetryBaseDelay, config.RetryBaseDelay, "Default retry base delay should be 1s")
+	assert.Equal(t, DefaultRetryMaxDelay, config.RetryMaxDelay, "Default retry max delay should be 5m")
 	assert.NotEmpty(t, config.PodID, "PodID should be generated via UUID fallback")
 }
 
@@ -36,6 +40,8 @@ func TestNewClaimConfig_FromEnv(t *testing.T) {
 	t.Setenv("SAGA_LEASE_DURATION", "10m")
 	t.Setenv("SAGA_CLAIM_BATCH_SIZE", "25")
 	t.Setenv("SAGA_CLAIM_JITTER_MS", "1000")
+	t.Setenv("SAGA_RETRY_BASE_DELAY", "3s")
+	t.Setenv("SAGA_RETRY_MAX_DELAY", "2m")
 	t.Setenv("HOSTNAME", "pod-abc-123")
 
 	config := NewClaimConfig()
@@ -43,6 +49,8 @@ func TestNewClaimConfig_FromEnv(t *testing.T) {
 	assert.Equal(t, 10*time.Minute, config.LeaseDuration, "Lease duration should be parsed from env")
 	assert.Equal(t, 25, config.BatchSize, "Batch size should be parsed from env")
 	assert.Equal(t, 1000, config.MaxJitterMS, "Max jitter should be parsed from env")
+	assert.Equal(t, 3*time.Second, config.RetryBaseDelay, "Retry base delay should be parsed from env")
+	assert.Equal(t, 2*time.Minute, config.RetryMaxDelay, "Retry max delay should be parsed from env")
 	assert.Equal(t, "pod-abc-123", config.PodID, "PodID should use HOSTNAME when set")
 }
 
@@ -154,6 +162,42 @@ func TestSagaClaimService_ClaimOrphanedSagas_Integration(t *testing.T) {
 		claimed, err := service.ClaimOrphanedSagas(context.Background())
 		require.NoError(t, err)
 		assert.NotContains(t, claimed, activeSaga.ID, "Sagas with active lease should not be claimed")
+	})
+
+	t.Run("skips sagas in backoff (next_retry_at in future)", func(t *testing.T) {
+		// Create an orphaned saga that is mid-backoff: lease expired, but
+		// next_retry_at is still in the future. The watcher must skip it.
+		expiredLease := time.Now().Add(-10 * time.Minute)
+		future := time.Now().Add(10 * time.Minute)
+		sagaInBackoff := createTestSagaWithRetry(t, db, SagaStatusRunning, &expiredLease, nil, &future)
+
+		claimed, err := service.ClaimOrphanedSagas(context.Background())
+		require.NoError(t, err)
+		assert.NotContains(t, claimed, sagaInBackoff.ID,
+			"sagas with future next_retry_at must be skipped by orphan watcher")
+	})
+
+	t.Run("claims sagas whose backoff has elapsed", func(t *testing.T) {
+		// next_retry_at in the past = backoff window has elapsed, saga is eligible.
+		expiredLease := time.Now().Add(-10 * time.Minute)
+		past := time.Now().Add(-1 * time.Minute)
+		readySaga := createTestSagaWithRetry(t, db, SagaStatusRunning, &expiredLease, nil, &past)
+
+		claimed, err := service.ClaimOrphanedSagas(context.Background())
+		require.NoError(t, err)
+		assert.Contains(t, claimed, readySaga.ID,
+			"sagas with past next_retry_at must be claimable again")
+	})
+
+	t.Run("claims sagas with NULL next_retry_at", func(t *testing.T) {
+		// Fresh saga (no backoff ever set) - NULL means immediately eligible.
+		expiredLease := time.Now().Add(-10 * time.Minute)
+		freshSaga := createTestSagaWithRetry(t, db, SagaStatusRunning, &expiredLease, nil, nil)
+
+		claimed, err := service.ClaimOrphanedSagas(context.Background())
+		require.NoError(t, err)
+		assert.Contains(t, claimed, freshSaga.ID,
+			"sagas with NULL next_retry_at must be claimable (no backoff in effect)")
 	})
 
 	t.Run("respects batch size limit", func(t *testing.T) {
@@ -341,6 +385,24 @@ func createTestSaga(t *testing.T, db *gorm.DB, status SagaStatus, leaseExpires *
 		CorrelationID:    uuid.New(),
 		LeaseExpiresAt:   leaseExpires,
 		ClaimedByPod:     claimedBy,
+	}
+	err := db.Create(saga).Error
+	require.NoError(t, err)
+	return saga
+}
+
+// createTestSagaWithRetry is like createTestSaga but also sets next_retry_at,
+// for tests that exercise the backoff-aware orphan-claim predicate.
+func createTestSagaWithRetry(t *testing.T, db *gorm.DB, status SagaStatus, leaseExpires *time.Time, claimedBy *string, nextRetryAt *time.Time) *SagaInstance {
+	t.Helper()
+	saga := &SagaInstance{
+		ID:               uuid.New(),
+		SagaDefinitionID: uuid.New(),
+		Status:           status,
+		CorrelationID:    uuid.New(),
+		LeaseExpiresAt:   leaseExpires,
+		ClaimedByPod:     claimedBy,
+		NextRetryAt:      nextRetryAt,
 	}
 	err := db.Create(saga).Error
 	require.NoError(t, err)

--- a/shared/pkg/saga/claiming_test.go
+++ b/shared/pkg/saga/claiming_test.go
@@ -70,6 +70,33 @@ func TestNewClaimConfig_InvalidEnv(t *testing.T) {
 	assert.Equal(t, 500, config.MaxJitterMS, "Invalid jitter should fallback to default")
 }
 
+// TestNewClaimConfig_RejectsNegativeRetryDelay verifies that a negative
+// SAGA_RETRY_BASE_DELAY or SAGA_RETRY_MAX_DELAY is sanitized to defaults,
+// preventing operator misconfiguration from disabling backoff in production.
+func TestNewClaimConfig_RejectsNegativeRetryDelay(t *testing.T) {
+	t.Setenv("SAGA_RETRY_BASE_DELAY", "-1s")
+	t.Setenv("SAGA_RETRY_MAX_DELAY", "5m")
+
+	config := NewClaimConfig()
+	assert.Equal(t, DefaultRetryBaseDelay, config.RetryBaseDelay,
+		"negative base delay should fall back to default")
+	assert.Equal(t, DefaultRetryMaxDelay, config.RetryMaxDelay,
+		"both bounds should reset when one is invalid - keeps the pair consistent")
+}
+
+// TestNewClaimConfig_RejectsInvertedRetryDelay verifies that base > max is
+// rejected (would force every retry to saturate to the smaller value).
+func TestNewClaimConfig_RejectsInvertedRetryDelay(t *testing.T) {
+	t.Setenv("SAGA_RETRY_BASE_DELAY", "1h")
+	t.Setenv("SAGA_RETRY_MAX_DELAY", "5s") // inverted - base > max
+
+	config := NewClaimConfig()
+	assert.Equal(t, DefaultRetryBaseDelay, config.RetryBaseDelay,
+		"inverted (base > max) should fall back to default")
+	assert.Equal(t, DefaultRetryMaxDelay, config.RetryMaxDelay,
+		"inverted (base > max) should fall back to default")
+}
+
 // TestGetPodID_HostnameFallback verifies pod ID generation.
 func TestGetPodID_HostnameFallback(t *testing.T) {
 	t.Run("uses HOSTNAME when set", func(t *testing.T) {

--- a/shared/pkg/saga/handlers.go
+++ b/shared/pkg/saga/handlers.go
@@ -501,6 +501,10 @@ func cloneHandlerMetadata(meta *HandlerMetadata) *HandlerMetadata {
 		return nil
 	}
 	clone := *meta
+	if meta.RetryPolicy != nil {
+		policyCopy := *meta.RetryPolicy
+		clone.RetryPolicy = &policyCopy
+	}
 	if meta.ProducesInstruments != nil {
 		clone.ProducesInstruments = make([]string, len(meta.ProducesInstruments))
 		copy(clone.ProducesInstruments, meta.ProducesInstruments)

--- a/shared/pkg/saga/linter.go
+++ b/shared/pkg/saga/linter.go
@@ -182,6 +182,11 @@ type HandlerMetadata struct {
 	// The value provides a migration message (e.g., "use handler_v2 instead").
 	// Empty string means the handler is not deprecated.
 	DeprecatedMessage string
+
+	// RetryPolicy overrides the global SAGA_RETRY_BASE_DELAY / SAGA_RETRY_MAX_DELAY
+	// for this specific handler. Used by saga_executor.resolveRetryBounds when
+	// computing next_retry_at on transient failures. Nil means "use global defaults".
+	RetryPolicy *RetryPolicy
 }
 
 // SemanticLinter performs AST-based semantic analysis on Starlark scripts.

--- a/shared/pkg/saga/migrations.go
+++ b/shared/pkg/saga/migrations.go
@@ -62,6 +62,23 @@ func RunSagaMigrations(db *gorm.DB) error {
 		return fmt.Errorf("failed to create partial index for orphan detection: %w", err)
 	}
 
+	// Add next_retry_at column for exponential backoff on transient failures.
+	// Idempotent via ADD COLUMN IF NOT EXISTS - safe to re-run on existing DBs.
+	//
+	// CRITICAL: This must execute as its own statement (separate transaction) from
+	// the partial index below. CockroachDB rejects partial indexes that reference a
+	// column added in the same transaction because the column is not yet "public".
+	// Each db.Exec runs in autocommit mode, satisfying that ordering requirement.
+	if err := addNextRetryAtColumn(db); err != nil {
+		return fmt.Errorf("failed to add next_retry_at column: %w", err)
+	}
+
+	// Create the partial index for backoff-aware orphan claiming.
+	// Only indexes rows where next_retry_at is set, keeping the index compact.
+	if err := createPartialIndexForNextRetryAt(db); err != nil {
+		return fmt.Errorf("failed to create partial index for next_retry_at: %w", err)
+	}
+
 	// Create composite unique constraint for (saga_instance_id, step_index)
 	// This prevents duplicate step results for the same saga step
 	if err := createCompositeUniqueConstraint(db); err != nil {
@@ -77,6 +94,48 @@ func createSagaDefinitionsNameVersionIndex(db *gorm.DB) error {
 	sql := `
 		CREATE UNIQUE INDEX IF NOT EXISTS idx_saga_definitions_name_version
 		ON saga_definitions (name, version)
+	`
+	return db.Exec(sql).Error
+}
+
+// addNextRetryAtColumn adds the next_retry_at column to saga_instances.
+//
+// The column is nullable: NULL means "no backoff in effect, immediately eligible
+// for reclaim by the orphan watcher". A non-NULL value is the earliest wall-clock
+// time at which the orphan watcher may reclaim the saga.
+//
+// Idempotent via ADD COLUMN IF NOT EXISTS - safe to re-run.
+//
+// This must run as its own statement before createPartialIndexForNextRetryAt,
+// because CockroachDB rejects partial indexes that reference a column added in
+// the same transaction (the column is not yet "public").
+func addNextRetryAtColumn(db *gorm.DB) error {
+	sql := `
+		ALTER TABLE saga_instances
+		ADD COLUMN IF NOT EXISTS next_retry_at TIMESTAMPTZ NULL
+	`
+	return db.Exec(sql).Error
+}
+
+// createPartialIndexForNextRetryAt creates the partial index used by the orphan
+// watcher to skip sagas that are still inside a backoff window.
+//
+// The orphan-claim query filters with:
+//
+//	WHERE (next_retry_at IS NULL OR next_retry_at <= NOW())
+//
+// A partial index over WHERE next_retry_at IS NOT NULL keeps the index small
+// (only sagas currently in backoff) and accelerates the next_retry_at <= NOW()
+// branch of the predicate. Sagas with next_retry_at IS NULL are served from the
+// existing idx_saga_instances_orphaned index.
+//
+// Must run AFTER addNextRetryAtColumn - CockroachDB rejects partial indexes
+// referencing a column added in the same transaction.
+func createPartialIndexForNextRetryAt(db *gorm.DB) error {
+	sql := `
+		CREATE INDEX IF NOT EXISTS idx_saga_instances_next_retry_at
+		ON saga_instances (next_retry_at)
+		WHERE next_retry_at IS NOT NULL
 	`
 	return db.Exec(sql).Error
 }

--- a/shared/pkg/saga/migrations.go
+++ b/shared/pkg/saga/migrations.go
@@ -62,21 +62,10 @@ func RunSagaMigrations(db *gorm.DB) error {
 		return fmt.Errorf("failed to create partial index for orphan detection: %w", err)
 	}
 
-	// Add next_retry_at column for exponential backoff on transient failures.
-	// Idempotent via ADD COLUMN IF NOT EXISTS - safe to re-run on existing DBs.
-	//
-	// CRITICAL: This must execute as its own statement (separate transaction) from
-	// the partial index below. CockroachDB rejects partial indexes that reference a
-	// column added in the same transaction because the column is not yet "public".
-	// Each db.Exec runs in autocommit mode, satisfying that ordering requirement.
-	if err := addNextRetryAtColumn(db); err != nil {
-		return fmt.Errorf("failed to add next_retry_at column: %w", err)
-	}
-
-	// Create the partial index for backoff-aware orphan claiming.
-	// Only indexes rows where next_retry_at is set, keeping the index compact.
-	if err := createPartialIndexForNextRetryAt(db); err != nil {
-		return fmt.Errorf("failed to create partial index for next_retry_at: %w", err)
+	// Add next_retry_at column + partial index for exponential backoff on transient
+	// failures (see migrateNextRetryAtBackoff for the CockroachDB ordering rule).
+	if err := migrateNextRetryAtBackoff(db); err != nil {
+		return err
 	}
 
 	// Create composite unique constraint for (saga_instance_id, step_index)
@@ -98,46 +87,40 @@ func createSagaDefinitionsNameVersionIndex(db *gorm.DB) error {
 	return db.Exec(sql).Error
 }
 
-// addNextRetryAtColumn adds the next_retry_at column to saga_instances.
+// migrateNextRetryAtBackoff adds the next_retry_at column AND its supporting
+// partial index for exponential-backoff orphan claiming.
 //
 // The column is nullable: NULL means "no backoff in effect, immediately eligible
 // for reclaim by the orphan watcher". A non-NULL value is the earliest wall-clock
 // time at which the orphan watcher may reclaim the saga.
 //
-// Idempotent via ADD COLUMN IF NOT EXISTS - safe to re-run.
+// CRITICAL CockroachDB ordering: the ALTER TABLE and the partial CREATE INDEX
+// MUST commit in separate transactions. Each db.Exec call here runs in
+// autocommit mode, so issuing them as two separate calls satisfies the rule.
+// Combining them inside a single Transaction(...) block would fail because the
+// new column is not yet "public" when the index references it.
 //
-// This must run as its own statement before createPartialIndexForNextRetryAt,
-// because CockroachDB rejects partial indexes that reference a column added in
-// the same transaction (the column is not yet "public").
-func addNextRetryAtColumn(db *gorm.DB) error {
-	sql := `
+// Both statements are idempotent (IF NOT EXISTS) and safe to re-run.
+func migrateNextRetryAtBackoff(db *gorm.DB) error {
+	if err := db.Exec(`
 		ALTER TABLE saga_instances
 		ADD COLUMN IF NOT EXISTS next_retry_at TIMESTAMPTZ NULL
-	`
-	return db.Exec(sql).Error
-}
+	`).Error; err != nil {
+		return fmt.Errorf("failed to add next_retry_at column: %w", err)
+	}
 
-// createPartialIndexForNextRetryAt creates the partial index used by the orphan
-// watcher to skip sagas that are still inside a backoff window.
-//
-// The orphan-claim query filters with:
-//
-//	WHERE (next_retry_at IS NULL OR next_retry_at <= NOW())
-//
-// A partial index over WHERE next_retry_at IS NOT NULL keeps the index small
-// (only sagas currently in backoff) and accelerates the next_retry_at <= NOW()
-// branch of the predicate. Sagas with next_retry_at IS NULL are served from the
-// existing idx_saga_instances_orphaned index.
-//
-// Must run AFTER addNextRetryAtColumn - CockroachDB rejects partial indexes
-// referencing a column added in the same transaction.
-func createPartialIndexForNextRetryAt(db *gorm.DB) error {
-	sql := `
+	// Partial index keeps the index compact: only sagas currently in backoff
+	// appear here. Sagas with next_retry_at IS NULL are served from the
+	// existing idx_saga_instances_orphaned index.
+	if err := db.Exec(`
 		CREATE INDEX IF NOT EXISTS idx_saga_instances_next_retry_at
 		ON saga_instances (next_retry_at)
 		WHERE next_retry_at IS NOT NULL
-	`
-	return db.Exec(sql).Error
+	`).Error; err != nil {
+		return fmt.Errorf("failed to create partial index for next_retry_at: %w", err)
+	}
+
+	return nil
 }
 
 // createPartialIndexForOrphanDetection creates the idx_saga_instances_orphaned partial index.

--- a/shared/pkg/saga/migrations_integration_test.go
+++ b/shared/pkg/saga/migrations_integration_test.go
@@ -245,6 +245,77 @@ func TestSagaMigrations_UniqueConstraints(t *testing.T) {
 	})
 }
 
+// TestSagaMigrations_NextRetryAtColumn verifies that the next_retry_at column
+// exists, is nullable, and is of the expected timestamp type.
+func TestSagaMigrations_NextRetryAtColumn(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	var col struct {
+		ColumnName string `gorm:"column:column_name"`
+		DataType   string `gorm:"column:data_type"`
+		IsNullable string `gorm:"column:is_nullable"`
+	}
+	err = db.Raw(`
+		SELECT column_name, data_type, is_nullable
+		FROM information_schema.columns
+		WHERE table_name = 'saga_instances'
+		  AND column_name = 'next_retry_at'
+	`).Scan(&col).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, "next_retry_at", col.ColumnName, "next_retry_at column should exist on saga_instances")
+	assert.Contains(t, col.DataType, "timestamp", "next_retry_at should be a timestamp type")
+	assert.Equal(t, "YES", col.IsNullable, "next_retry_at must be nullable (NULL means no backoff)")
+}
+
+// TestSagaMigrations_NextRetryAtPartialIndex verifies that the partial index
+// idx_saga_instances_next_retry_at is created and only covers rows with a value.
+func TestSagaMigrations_NextRetryAtPartialIndex(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	var idxCount int64
+	err = db.Raw(`
+		SELECT COUNT(DISTINCT index_name)
+		FROM information_schema.statistics
+		WHERE table_name = 'saga_instances'
+		  AND index_name = 'idx_saga_instances_next_retry_at'
+	`).Scan(&idxCount).Error
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), idxCount, "partial index idx_saga_instances_next_retry_at should exist")
+}
+
+// TestSagaMigrations_NextRetryAtIdempotent verifies that re-running migrations
+// is safe even after the column and index already exist.
+func TestSagaMigrations_NextRetryAtIdempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	// First run creates everything.
+	require.NoError(t, RunSagaMigrations(db))
+	// Second run must not error - all DDL is idempotent.
+	require.NoError(t, RunSagaMigrations(db))
+}
+
 // TestSagaMigrations_PartialIndex verifies the partial index for orphan queries.
 func TestSagaMigrations_PartialIndex(t *testing.T) {
 	if testing.Short() {

--- a/shared/pkg/saga/models.go
+++ b/shared/pkg/saga/models.go
@@ -122,6 +122,11 @@ type SagaInstance struct {
 	CurrentStepIndex int `gorm:"column:current_step_index;not null;default:0"`
 	// ReplayCount tracks how many times this saga has been replayed (for zombie detection)
 	ReplayCount int `gorm:"column:replay_count;not null;default:0"`
+	// NextRetryAt is the earliest wall-clock time this saga can be reclaimed after a
+	// transient failure. NULL means the saga is immediately eligible for reclaim
+	// (no exponential backoff in effect). Set by handleTransientFailure and cleared
+	// by ResetReplayCountAndBackoff on successful step completion.
+	NextRetryAt *time.Time `gorm:"column:next_retry_at"`
 	// Status is the current lifecycle state
 	Status SagaStatus `gorm:"column:status;type:varchar(32);not null;default:'PENDING';index"`
 

--- a/shared/pkg/saga/saga_executor.go
+++ b/shared/pkg/saga/saga_executor.go
@@ -247,12 +247,17 @@ func (e *SagaExecutor) handleTransientFailure(
 	// crashes, the orphan watcher still respects the backoff window. The
 	// alternative (release first, then set) opens a race where another pod
 	// reclaims immediately before the backoff is recorded.
+	//
+	// If this UPDATE fails we return an infrastructure error: silently
+	// continuing and releasing the lease would let the orphan watcher
+	// reclaim immediately, defeating the backoff guarantee and
+	// re-introducing the thundering-herd we are trying to prevent. The
+	// caller will retry; in the meantime our existing lease keeps other
+	// pods out, so we are not "stuck" - we are just deferring the release
+	// until the persistence layer recovers (or the lease expires naturally).
 	if updateErr := e.instanceRepo.UpdateNextRetryAt(ctx, result.SagaID, nextRetryAt); updateErr != nil {
-		e.logger.Error("failed to set next_retry_at - retry will not respect backoff",
-			"saga_id", result.SagaID,
-			"error", updateErr,
-		)
-		// Continue: a missed backoff is preferable to leaving the lease held.
+		return nil, fmt.Errorf("failed to persist next_retry_at for saga %s: %w",
+			result.SagaID, updateErr)
 	}
 
 	if e.claimService != nil {

--- a/shared/pkg/saga/saga_executor.go
+++ b/shared/pkg/saga/saga_executor.go
@@ -219,6 +219,11 @@ func (e *SagaExecutor) handleFatalFailure(
 
 // handleTransientFailure either retries (releasing the lease) or escalates to manual intervention
 // if max replays have been exceeded.
+//
+// Before releasing the lease, this method writes next_retry_at = now + backoff(replay_count)
+// to saga_instances. The orphan watcher's predicate (next_retry_at IS NULL OR <= now)
+// will then skip this saga until the backoff window elapses, preventing immediate
+// re-claim and breaking thundering herd when many sagas fail simultaneously.
 func (e *SagaExecutor) handleTransientFailure(
 	ctx context.Context,
 	result *StepFailureResult,
@@ -232,6 +237,24 @@ func (e *SagaExecutor) handleTransientFailure(
 
 	result.Action = FailureActionRetry
 
+	// Compute next_retry_at = now + backoff. Per-handler retry policy overrides
+	// global ClaimConfig defaults if present.
+	baseDelay, maxDelay := e.resolveRetryBounds(result.StepName)
+	delay := CalculateBackoffDelay(instance.ReplayCount, baseDelay, maxDelay)
+	nextRetryAt := time.Now().Add(delay)
+
+	// Set next_retry_at FIRST. If the subsequent lease release fails or the pod
+	// crashes, the orphan watcher still respects the backoff window. The
+	// alternative (release first, then set) opens a race where another pod
+	// reclaims immediately before the backoff is recorded.
+	if updateErr := e.instanceRepo.UpdateNextRetryAt(ctx, result.SagaID, nextRetryAt); updateErr != nil {
+		e.logger.Error("failed to set next_retry_at - retry will not respect backoff",
+			"saga_id", result.SagaID,
+			"error", updateErr,
+		)
+		// Continue: a missed backoff is preferable to leaving the lease held.
+	}
+
 	if e.claimService != nil {
 		if releaseErr := e.claimService.ReleaseLease(ctx, result.SagaID); releaseErr != nil {
 			e.logger.Error("failed to release lease for retry",
@@ -243,14 +266,55 @@ func (e *SagaExecutor) handleTransientFailure(
 
 	RecordStepFailure(result.StepName, string(result.ErrorCategory))
 
-	e.logger.Info("TRANSIENT error, releasing lease for retry",
+	e.logger.Info("TRANSIENT error, scheduled for retry with backoff",
 		"saga_id", result.SagaID,
 		"step_index", result.StepIndex,
 		"step_name", result.StepName,
 		"replay_count", instance.ReplayCount,
+		"backoff_delay", delay,
+		"next_retry_at", nextRetryAt,
 	)
 
 	return result, nil
+}
+
+// resolveRetryBounds returns the (baseDelay, maxDelay) pair to use for a given
+// step. Order of precedence:
+//  1. Per-handler retry policy declared in handlers.yaml (HandlerMetadata.RetryPolicy)
+//  2. Global ClaimConfig defaults (SAGA_RETRY_BASE_DELAY / SAGA_RETRY_MAX_DELAY)
+//  3. Package-level constants (DefaultRetryBaseDelay / DefaultRetryMaxDelay)
+//
+// This is forgiving by design: any layer is optional. If the executor has no
+// ClaimService wired in (some unit tests construct executors with nil), we fall
+// straight to the package defaults so behavior stays predictable.
+func (e *SagaExecutor) resolveRetryBounds(stepName string) (time.Duration, time.Duration) {
+	baseDelay := DefaultRetryBaseDelay
+	maxDelay := DefaultRetryMaxDelay
+
+	if e.claimService != nil && e.claimService.config != nil {
+		if e.claimService.config.RetryBaseDelay > 0 {
+			baseDelay = e.claimService.config.RetryBaseDelay
+		}
+		if e.claimService.config.RetryMaxDelay > 0 {
+			maxDelay = e.claimService.config.RetryMaxDelay
+		}
+	}
+
+	// Per-handler override via registry metadata (populated from handlers.yaml).
+	if e.handlerRegistry != nil && stepName != "" {
+		if _, meta, err := e.handlerRegistry.GetWithMetadata(stepName); err == nil && meta != nil {
+			if meta.RetryPolicy != nil {
+				if meta.RetryPolicy.BaseDelay > 0 {
+					baseDelay = meta.RetryPolicy.BaseDelay
+				}
+				if meta.RetryPolicy.MaxDelay > 0 {
+					maxDelay = meta.RetryPolicy.MaxDelay
+				}
+			}
+		}
+	}
+
+	return baseDelay, maxDelay
 }
 
 // handleZombieDetected transitions the saga to FAILED_MANUAL_INTERVENTION when max replays are exceeded.
@@ -357,9 +421,12 @@ func (e *SagaExecutor) ProcessStepResult(
 	maxReplays int,
 ) (*StepFailureResult, error) {
 	if err == nil {
-		// Success - reset replay count and move to next step
-		if resetErr := e.instanceRepo.ResetReplayCount(ctx, instance.ID); resetErr != nil {
-			return nil, fmt.Errorf("failed to reset replay count: %w", resetErr)
+		// Success - reset replay count AND clear any pending backoff atomically.
+		// Combining both columns in one UPDATE ensures the orphan watcher cannot
+		// observe a half-updated row (replay_count cleared but next_retry_at
+		// stale, or the inverse).
+		if resetErr := e.instanceRepo.ResetReplayCountAndBackoff(ctx, instance.ID); resetErr != nil {
+			return nil, fmt.Errorf("failed to reset replay count and backoff: %w", resetErr)
 		}
 		return nil, nil
 	}

--- a/shared/pkg/saga/saga_executor.go
+++ b/shared/pkg/saga/saga_executor.go
@@ -44,6 +44,17 @@ type SagaInstanceRepository interface {
 
 	// ResetReplayCount resets the replay count to 0 (used when moving to next step).
 	ResetReplayCount(ctx context.Context, id uuid.UUID) error
+
+	// UpdateNextRetryAt sets the earliest wall-clock time this saga can be reclaimed
+	// after a transient failure. Called from handleTransientFailure before releasing
+	// the lease. The orphan watcher filters on this column to skip sagas still in backoff.
+	UpdateNextRetryAt(ctx context.Context, id uuid.UUID, nextRetryAt time.Time) error
+
+	// ResetReplayCountAndBackoff atomically resets replay_count to 0 AND clears
+	// next_retry_at. Called when a step completes successfully so the saga starts the
+	// next step with a clean slate. Combining both columns in a single UPDATE avoids
+	// any window where the saga could be picked up with mismatched state.
+	ResetReplayCountAndBackoff(ctx context.Context, id uuid.UUID) error
 }
 
 // NewSagaExecutor creates a new SagaExecutor.

--- a/shared/pkg/saga/saga_executor_backoff_test.go
+++ b/shared/pkg/saga/saga_executor_backoff_test.go
@@ -230,6 +230,51 @@ func TestHandleTransientFailure_PerHandlerRetryPolicyOverridesGlobal(t *testing.
 		"per-handler base delay must override global 1s default")
 }
 
+// TestHandleTransientFailure_NextRetryAtPersistenceFails verifies that an
+// infrastructure error when writing next_retry_at propagates back to the
+// caller rather than being logged and ignored. Silently continuing would
+// release the lease without a recorded backoff window, allowing immediate
+// re-claim and defeating the backoff guarantee.
+func TestHandleTransientFailure_NextRetryAtPersistenceFails(t *testing.T) {
+	instanceRepo := &failingNextRetryAtRepo{
+		MockSagaInstanceRepositoryForExecutor: NewMockSagaInstanceRepositoryForExecutor(),
+		failErr:                               errors.New("transient db outage"),
+	}
+	sagaID := uuid.New()
+	instanceRepo.Add(&SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		ReplayCount:      0,
+	})
+
+	executor := NewSagaExecutor(instanceRepo, nil, nil, nil)
+
+	_, err := executor.HandleStepFailure(
+		context.Background(),
+		sagaID,
+		0,
+		"step",
+		errors.New("timeout"),
+		5,
+	)
+	require.Error(t, err, "infra error during UpdateNextRetryAt must propagate")
+	assert.Contains(t, err.Error(), "next_retry_at",
+		"error message should identify the failing operation")
+}
+
+// failingNextRetryAtRepo wraps the standard mock and forces UpdateNextRetryAt
+// to fail with a configurable error.
+type failingNextRetryAtRepo struct {
+	*MockSagaInstanceRepositoryForExecutor
+	failErr error
+}
+
+func (r *failingNextRetryAtRepo) UpdateNextRetryAt(_ context.Context, _ uuid.UUID, _ time.Time) error {
+	return r.failErr
+}
+
 // TestProcessStepResult_SuccessClearsBackoff verifies that completing a step
 // resets BOTH replay_count and next_retry_at in one operation.
 func TestProcessStepResult_SuccessClearsBackoff(t *testing.T) {

--- a/shared/pkg/saga/saga_executor_backoff_test.go
+++ b/shared/pkg/saga/saga_executor_backoff_test.go
@@ -1,0 +1,258 @@
+package saga
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleTransientFailure_SetsNextRetryAt verifies that a transient failure
+// records next_retry_at on the saga before releasing the lease.
+func TestHandleTransientFailure_SetsNextRetryAt(t *testing.T) {
+	instanceRepo := NewMockSagaInstanceRepositoryForExecutor()
+
+	sagaID := uuid.New()
+	instance := &SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		ReplayCount:      0,
+	}
+	instanceRepo.Add(instance)
+
+	executor := NewSagaExecutor(instanceRepo, nil, nil, nil)
+
+	before := time.Now()
+	transientErr := errors.New("connection timeout")
+	result, err := executor.HandleStepFailure(
+		context.Background(),
+		sagaID,
+		1,
+		"post_entries",
+		transientErr,
+		5,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, FailureActionRetry, result.Action)
+
+	// next_retry_at must be set to a future time.
+	updated, _ := instanceRepo.FindByID(context.Background(), sagaID)
+	require.NotNil(t, updated.NextRetryAt, "next_retry_at must be set after transient failure")
+	assert.True(t, updated.NextRetryAt.After(before),
+		"next_retry_at (%s) must be after request start (%s)", updated.NextRetryAt, before)
+}
+
+// TestHandleTransientFailure_UsesGlobalConfig verifies the executor reads
+// RetryBaseDelay / RetryMaxDelay from the ClaimService config when present.
+func TestHandleTransientFailure_UsesGlobalConfig(t *testing.T) {
+	instanceRepo := NewMockSagaInstanceRepositoryForExecutor()
+
+	sagaID := uuid.New()
+	instance := &SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		ReplayCount:      0,
+	}
+	instanceRepo.Add(instance)
+
+	// Build a ClaimService with custom retry bounds. The base delay floor is
+	// high enough that the smallest possible delay (base + 0 jitter) is well
+	// above any plausible test machine clock skew.
+	config := &ClaimConfig{
+		LeaseDuration:  5 * time.Minute,
+		BatchSize:      10,
+		MaxJitterMS:    0,
+		MaxReplays:     DefaultMaxReplays,
+		PodID:          "test-pod",
+		RetryBaseDelay: 10 * time.Second,
+		RetryMaxDelay:  1 * time.Hour,
+	}
+	// nil db is acceptable: handleTransientFailure only reads config off the service.
+	executor := NewSagaExecutor(instanceRepo, nil, nil, &ClaimService{config: config})
+
+	before := time.Now()
+	transientErr := errors.New("timeout")
+	_, err := executor.HandleStepFailure(
+		context.Background(),
+		sagaID,
+		0,
+		"flaky_step",
+		transientErr,
+		5,
+	)
+	require.NoError(t, err)
+
+	updated, _ := instanceRepo.FindByID(context.Background(), sagaID)
+	require.NotNil(t, updated.NextRetryAt)
+
+	// Replay count 0 with base=10s should give delay in [10s, 20s).
+	delay := updated.NextRetryAt.Sub(before)
+	assert.GreaterOrEqual(t, delay, 10*time.Second,
+		"backoff delay (%s) should be >= base 10s", delay)
+	assert.Less(t, delay, 21*time.Second,
+		"backoff delay (%s) should be < base*2 + tolerance", delay)
+}
+
+// TestHandleTransientFailure_DelayGrowsWithReplayCount verifies the exponential
+// component: a higher replay_count produces a longer backoff window.
+func TestHandleTransientFailure_DelayGrowsWithReplayCount(t *testing.T) {
+	makeExecutor := func(replayCount int) (*MockSagaInstanceRepositoryForExecutor, uuid.UUID, *SagaExecutor) {
+		repo := NewMockSagaInstanceRepositoryForExecutor()
+		id := uuid.New()
+		repo.Add(&SagaInstance{
+			ID:               id,
+			SagaDefinitionID: uuid.New(),
+			CorrelationID:    uuid.New(),
+			Status:           SagaStatusRunning,
+			ReplayCount:      replayCount,
+		})
+		config := &ClaimConfig{
+			RetryBaseDelay: 1 * time.Second,
+			RetryMaxDelay:  1 * time.Hour,
+			MaxReplays:     20,
+		}
+		return repo, id, NewSagaExecutor(repo, nil, nil, &ClaimService{config: config})
+	}
+
+	transientErr := errors.New("timeout")
+
+	repo0, id0, ex0 := makeExecutor(0)
+	before0 := time.Now()
+	_, err := ex0.HandleStepFailure(context.Background(), id0, 0, "step", transientErr, 20)
+	require.NoError(t, err)
+	delay0 := repo0.instances[id0].NextRetryAt.Sub(before0)
+
+	repo5, id5, ex5 := makeExecutor(5)
+	before5 := time.Now()
+	_, err = ex5.HandleStepFailure(context.Background(), id5, 0, "step", transientErr, 20)
+	require.NoError(t, err)
+	delay5 := repo5.instances[id5].NextRetryAt.Sub(before5)
+
+	// replay=0 -> 1-2s, replay=5 -> ~32-33s. The latter must be substantially larger.
+	assert.Greater(t, delay5, delay0*4,
+		"replay=5 delay (%s) should be substantially larger than replay=0 delay (%s)", delay5, delay0)
+}
+
+// TestHandleTransientFailure_AtMaxReplaysGoesToManualIntervention verifies the
+// existing zombie-detection path is still reached and that the success branch
+// (set next_retry_at) is NOT taken.
+func TestHandleTransientFailure_AtMaxReplaysGoesToManualIntervention(t *testing.T) {
+	instanceRepo := NewMockSagaInstanceRepositoryForExecutor()
+
+	sagaID := uuid.New()
+	instance := &SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		ReplayCount:      5, // at max
+	}
+	instanceRepo.Add(instance)
+
+	executor := NewSagaExecutor(instanceRepo, nil, nil, nil)
+
+	result, err := executor.HandleStepFailure(
+		context.Background(),
+		sagaID,
+		0,
+		"step",
+		errors.New("timeout"),
+		5,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, FailureActionManualIntervention, result.Action)
+
+	updated, _ := instanceRepo.FindByID(context.Background(), sagaID)
+	assert.Nil(t, updated.NextRetryAt,
+		"zombie path must not set next_retry_at - saga is going to FAILED_MANUAL_INTERVENTION")
+}
+
+// TestHandleTransientFailure_PerHandlerRetryPolicyOverridesGlobal verifies that
+// a handler-level retry policy registered on HandlerMetadata takes precedence
+// over the global ClaimConfig defaults.
+func TestHandleTransientFailure_PerHandlerRetryPolicyOverridesGlobal(t *testing.T) {
+	instanceRepo := NewMockSagaInstanceRepositoryForExecutor()
+
+	sagaID := uuid.New()
+	instance := &SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		ReplayCount:      0,
+	}
+	instanceRepo.Add(instance)
+
+	// Register a handler with a 30s base delay - much larger than the 1s global.
+	registry := NewHandlerRegistry()
+	require.NoError(t, registry.RegisterWithMetadata(
+		"external.slow_handler",
+		func(_ *StarlarkContext, _ map[string]any) (any, error) { return nil, nil },
+		&HandlerMetadata{
+			RetryPolicy: &RetryPolicy{
+				BaseDelay: 30 * time.Second,
+				MaxDelay:  1 * time.Hour,
+			},
+		},
+	))
+
+	config := &ClaimConfig{
+		RetryBaseDelay: 1 * time.Second, // small global default
+		RetryMaxDelay:  5 * time.Minute,
+	}
+	executor := NewSagaExecutor(instanceRepo, nil, registry, &ClaimService{config: config})
+
+	before := time.Now()
+	_, err := executor.HandleStepFailure(
+		context.Background(),
+		sagaID,
+		0,
+		"external.slow_handler",
+		errors.New("upstream timeout"),
+		5,
+	)
+	require.NoError(t, err)
+
+	updated, _ := instanceRepo.FindByID(context.Background(), sagaID)
+	require.NotNil(t, updated.NextRetryAt)
+	delay := updated.NextRetryAt.Sub(before)
+	// Per-handler base 30s, replay 0 -> delay in [30s, 60s).
+	assert.GreaterOrEqual(t, delay, 30*time.Second,
+		"per-handler base delay must override global 1s default")
+}
+
+// TestProcessStepResult_SuccessClearsBackoff verifies that completing a step
+// resets BOTH replay_count and next_retry_at in one operation.
+func TestProcessStepResult_SuccessClearsBackoff(t *testing.T) {
+	instanceRepo := NewMockSagaInstanceRepositoryForExecutor()
+
+	sagaID := uuid.New()
+	prevRetry := time.Now().Add(30 * time.Second)
+	instance := &SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		ReplayCount:      3,
+		NextRetryAt:      &prevRetry,
+	}
+	instanceRepo.Add(instance)
+
+	executor := NewSagaExecutor(instanceRepo, nil, nil, nil)
+
+	_, err := executor.ProcessStepResult(context.Background(), instance, 1, "step", nil, nil, 5)
+	require.NoError(t, err)
+
+	updated, _ := instanceRepo.FindByID(context.Background(), sagaID)
+	assert.Equal(t, 0, updated.ReplayCount, "replay_count must reset on step success")
+	assert.Nil(t, updated.NextRetryAt, "next_retry_at must clear on step success")
+}

--- a/shared/pkg/saga/saga_executor_test.go
+++ b/shared/pkg/saga/saga_executor_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -129,6 +130,22 @@ func (r *MockSagaInstanceRepositoryForExecutor) UpdateStatusWithError(_ context.
 func (r *MockSagaInstanceRepositoryForExecutor) ResetReplayCount(_ context.Context, id uuid.UUID) error {
 	if instance, exists := r.instances[id]; exists {
 		instance.ReplayCount = 0
+	}
+	return nil
+}
+
+func (r *MockSagaInstanceRepositoryForExecutor) UpdateNextRetryAt(_ context.Context, id uuid.UUID, nextRetryAt time.Time) error {
+	if instance, exists := r.instances[id]; exists {
+		t := nextRetryAt
+		instance.NextRetryAt = &t
+	}
+	return nil
+}
+
+func (r *MockSagaInstanceRepositoryForExecutor) ResetReplayCountAndBackoff(_ context.Context, id uuid.UUID) error {
+	if instance, exists := r.instances[id]; exists {
+		instance.ReplayCount = 0
+		instance.NextRetryAt = nil
 	}
 	return nil
 }

--- a/shared/pkg/saga/schema/derive.go
+++ b/shared/pkg/saga/schema/derive.go
@@ -87,6 +87,16 @@ func DeriveHandlerDef(_ string, meta *saga.HandlerMetadata) (*HandlerDef, error)
 		})
 	}
 
+	// Propagate per-handler retry policy if the registry declared one.
+	// The schema.RetryPolicy mirrors saga.RetryPolicy 1:1 so YAML-emitted
+	// schemas round-trip with what the registry holds.
+	if meta.RetryPolicy != nil {
+		hd.Retry = &RetryPolicy{
+			BaseDelay: meta.RetryPolicy.BaseDelay,
+			MaxDelay:  meta.RetryPolicy.MaxDelay,
+		}
+	}
+
 	return hd, nil
 }
 

--- a/shared/pkg/saga/schema/retry_policy_test.go
+++ b/shared/pkg/saga/schema/retry_policy_test.go
@@ -1,0 +1,99 @@
+package schema
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseRetryPolicy_HappyPath verifies that a retry block under a handler
+// parses into the typed RetryPolicy struct.
+func TestParseRetryPolicy_HappyPath(t *testing.T) {
+	yaml := `
+service: test
+version: "1.0"
+handlers:
+  external.flaky_call:
+    description: "External call with custom retry"
+    compensate: external.cancel_call
+    proto_ref:
+      proto_rpc: "test.v1.Service/Method"
+    retry:
+      base_delay: 2s
+      max_delay: 30s
+`
+
+	schema, err := Parse([]byte(yaml))
+	require.NoError(t, err)
+
+	h := schema.Handlers["external.flaky_call"]
+	require.NotNil(t, h)
+	require.NotNil(t, h.Retry, "retry block should parse into typed struct")
+	assert.Equal(t, 2*time.Second, h.Retry.BaseDelay)
+	assert.Equal(t, 30*time.Second, h.Retry.MaxDelay)
+}
+
+// TestParseRetryPolicy_Omitted verifies that handlers without a retry block
+// produce a nil RetryPolicy so callers fall back to global defaults.
+func TestParseRetryPolicy_Omitted(t *testing.T) {
+	yaml := `
+service: test
+version: "1.0"
+handlers:
+  internal.handler:
+    description: "Handler with no retry override"
+    compensate: internal.undo
+    proto_ref:
+      proto_rpc: "test.v1.Service/Method"
+`
+
+	schema, err := Parse([]byte(yaml))
+	require.NoError(t, err)
+	require.NotNil(t, schema.Handlers["internal.handler"])
+	assert.Nil(t, schema.Handlers["internal.handler"].Retry, "missing retry block should be nil")
+}
+
+// TestParseRetryPolicy_RejectsNegativeBaseDelay enforces the validator: a negative
+// base_delay would produce nonsense delays at runtime.
+func TestParseRetryPolicy_RejectsNegativeBaseDelay(t *testing.T) {
+	yaml := `
+service: test
+version: "1.0"
+handlers:
+  bad.handler:
+    description: "Bad retry config"
+    compensate: bad.undo
+    proto_ref:
+      proto_rpc: "test.v1.Service/Method"
+    retry:
+      base_delay: -1s
+      max_delay: 30s
+`
+
+	_, err := Parse([]byte(yaml))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidRetryPolicy)
+}
+
+// TestParseRetryPolicy_RejectsBaseDelayAboveMaxDelay catches the inversion error.
+func TestParseRetryPolicy_RejectsBaseDelayAboveMaxDelay(t *testing.T) {
+	yaml := `
+service: test
+version: "1.0"
+handlers:
+  bad.handler:
+    description: "Inverted retry config"
+    compensate: bad.undo
+    proto_ref:
+      proto_rpc: "test.v1.Service/Method"
+    retry:
+      base_delay: 60s
+      max_delay: 10s
+`
+
+	_, err := Parse([]byte(yaml))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidRetryPolicy)
+}

--- a/shared/pkg/saga/schema/schema.go
+++ b/shared/pkg/saga/schema/schema.go
@@ -185,13 +185,27 @@ type HandlerDef struct {
 
 // RetryPolicy defines per-handler exponential backoff parameters.
 // Values are parsed by yaml.v3 from Go duration strings (e.g. "2s", "30s", "1m").
+//
+// Field semantics (intentionally asymmetric with runtime loadRetryBounds):
+//   - Each field is independently optional. Zero (or unset) means "inherit the
+//     corresponding global ClaimConfig default" - so a YAML author can override
+//     just base_delay or just max_delay without restating the other.
+//   - Negative values are rejected by Validate.
+//   - To disable per-handler retry entirely, omit the whole retry: block.
+//
+// The runtime layer (loadRetryBounds in claiming.go) is stricter and rejects
+// zero, because there the values come from environment variables - an operator
+// who sets SAGA_RETRY_BASE_DELAY=0s almost certainly meant something else.
+// At the schema layer, zero is a legitimate "use global default" signal.
 type RetryPolicy struct {
 	// BaseDelay is the starting delay for replayCount=0. The actual delay grows
 	// exponentially: BaseDelay * 2^replayCount plus uniform [0, BaseDelay) jitter.
+	// Zero or unset means "inherit ClaimConfig.RetryBaseDelay".
 	BaseDelay time.Duration `yaml:"base_delay"`
 
 	// MaxDelay caps the computed delay. Replay counts that would produce a delay
 	// beyond MaxDelay (or that would overflow) are saturated to this value.
+	// Zero or unset means "inherit ClaimConfig.RetryMaxDelay".
 	MaxDelay time.Duration `yaml:"max_delay"`
 }
 
@@ -322,10 +336,10 @@ func (h *HandlerDef) Validate(handlerName string) error {
 }
 
 // validateRetryPolicy checks that any per-handler retry policy is well-formed.
-// Both fields are optional individually, but a non-positive duration is rejected
-// because it would either disable backoff entirely (base_delay=0 collapses to
-// pure jitter) or break the saturation logic (max_delay=0 falls back silently
-// at runtime, which is surprising for someone reading the YAML).
+// Per the field-level contract on RetryPolicy, zero means "inherit the global
+// ClaimConfig default", so zero is allowed. Negative values are rejected as
+// nonsense, and an inverted pair (base > max, both non-zero) is rejected
+// because it would force every retry to saturate to the smaller value.
 func (h *HandlerDef) validateRetryPolicy(handlerName string) error {
 	if h.Retry == nil {
 		return nil

--- a/shared/pkg/saga/schema/schema.go
+++ b/shared/pkg/saga/schema/schema.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -89,6 +90,7 @@ var (
 	ErrAliasCollision               = errors.New("param_alias target already exists as a field")
 	ErrDuplicateLeafName            = errors.New("duplicate leaf field name from exposed paths")
 	ErrCompositeWithProtoRef        = errors.New("composite handler must not set proto_ref")
+	ErrInvalidRetryPolicy           = errors.New("invalid retry policy")
 )
 
 // Schema represents a collection of handler definitions for a service.
@@ -173,6 +175,24 @@ type HandlerDef struct {
 
 	// Conversions defines rules for converting calls from previous handler versions.
 	Conversions []ConversionRule `yaml:"conversions,omitempty"`
+
+	// Retry overrides the saga runtime's global retry/backoff defaults for this
+	// handler. Useful for handlers that talk to slow external systems (longer
+	// base_delay) or that should fail fast (very short max_delay). When nil,
+	// the global SAGA_RETRY_BASE_DELAY / SAGA_RETRY_MAX_DELAY values apply.
+	Retry *RetryPolicy `yaml:"retry,omitempty"`
+}
+
+// RetryPolicy defines per-handler exponential backoff parameters.
+// Values are parsed by yaml.v3 from Go duration strings (e.g. "2s", "30s", "1m").
+type RetryPolicy struct {
+	// BaseDelay is the starting delay for replayCount=0. The actual delay grows
+	// exponentially: BaseDelay * 2^replayCount plus uniform [0, BaseDelay) jitter.
+	BaseDelay time.Duration `yaml:"base_delay"`
+
+	// MaxDelay caps the computed delay. Replay counts that would produce a delay
+	// beyond MaxDelay (or that would overflow) are saturated to this value.
+	MaxDelay time.Duration `yaml:"max_delay"`
 }
 
 // ConversionRule defines how to convert a call from a deprecated handler to the current version.
@@ -298,6 +318,30 @@ func (h *HandlerDef) Validate(handlerName string) error {
 		}
 	}
 
+	return h.validateRetryPolicy(handlerName)
+}
+
+// validateRetryPolicy checks that any per-handler retry policy is well-formed.
+// Both fields are optional individually, but a non-positive duration is rejected
+// because it would either disable backoff entirely (base_delay=0 collapses to
+// pure jitter) or break the saturation logic (max_delay=0 falls back silently
+// at runtime, which is surprising for someone reading the YAML).
+func (h *HandlerDef) validateRetryPolicy(handlerName string) error {
+	if h.Retry == nil {
+		return nil
+	}
+	if h.Retry.BaseDelay < 0 {
+		return fmt.Errorf("%w: handler %s: base_delay must be >= 0, got %s",
+			ErrInvalidRetryPolicy, handlerName, h.Retry.BaseDelay)
+	}
+	if h.Retry.MaxDelay < 0 {
+		return fmt.Errorf("%w: handler %s: max_delay must be >= 0, got %s",
+			ErrInvalidRetryPolicy, handlerName, h.Retry.MaxDelay)
+	}
+	if h.Retry.BaseDelay > 0 && h.Retry.MaxDelay > 0 && h.Retry.BaseDelay > h.Retry.MaxDelay {
+		return fmt.Errorf("%w: handler %s: base_delay (%s) must not exceed max_delay (%s)",
+			ErrInvalidRetryPolicy, handlerName, h.Retry.BaseDelay, h.Retry.MaxDelay)
+	}
 	return nil
 }
 

--- a/shared/pkg/saga/step_execution_integration_test.go
+++ b/shared/pkg/saga/step_execution_integration_test.go
@@ -77,6 +77,25 @@ func (r *GormSagaInstanceRepository) Create(ctx context.Context, instance *SagaI
 	return r.db.WithContext(ctx).Create(instance).Error
 }
 
+// UpdateNextRetryAt sets the next_retry_at column on the saga instance.
+func (r *GormSagaInstanceRepository) UpdateNextRetryAt(ctx context.Context, id uuid.UUID, nextRetryAt time.Time) error {
+	return r.db.WithContext(ctx).Model(&SagaInstance{}).
+		Where("id = ?", id).
+		Update("next_retry_at", nextRetryAt).Error
+}
+
+// ResetReplayCountAndBackoff atomically resets replay_count to 0 AND clears
+// next_retry_at in a single UPDATE so the orphan watcher cannot observe a
+// half-updated row.
+func (r *GormSagaInstanceRepository) ResetReplayCountAndBackoff(ctx context.Context, id uuid.UUID) error {
+	return r.db.WithContext(ctx).Model(&SagaInstance{}).
+		Where("id = ?", id).
+		Updates(map[string]interface{}{
+			"replay_count":  0,
+			"next_retry_at": nil,
+		}).Error
+}
+
 // GormTransactionalRepository implements TransactionalRepository using GORM.
 type GormTransactionalRepository struct {
 	db *gorm.DB


### PR DESCRIPTION
## Summary

Adds exponential backoff with jitter to the saga durable execution engine. Sagas that hit a transient failure now wait progressively longer between retries instead of being reclaimed at the very next orphan-watcher tick. This prevents thundering herd when many sagas fail simultaneously and stops a single bad step from burning through MaxReplays in seconds.

- Adds `next_retry_at TIMESTAMPTZ NULL` to `saga_instances` plus partial index `idx_saga_instances_next_retry_at`.
- `handleTransientFailure` sets `next_retry_at = now + backoff(replay_count)` before releasing the lease; orphan watcher predicate skips rows still inside their backoff window.
- Backoff formula: `min(base * 2^replay_count + jitter, max)` where jitter is uniform `[0, base)`. Overflow-safe for extreme replay counts.
- Bounds resolve in three layers: per-handler `retry:` in `handlers.yaml` -> global `SAGA_RETRY_BASE_DELAY` / `SAGA_RETRY_MAX_DELAY` (1s / 5m default) -> package constants.
- Success path uses `ResetReplayCountAndBackoff` so `replay_count` and `next_retry_at` clear atomically.

## Changes

### Schema (CockroachDB-safe)
- `addNextRetryAtColumn` and `createPartialIndexForNextRetryAt` run as separate `db.Exec` calls so each commits in its own implicit transaction. CockroachDB rejects partial indexes that reference a column added in the same transaction (column not yet `public`).

### Runtime
- `shared/pkg/saga/backoff.go`: `CalculateBackoffDelay(replayCount, base, max)` and `RetryPolicy` struct.
- `shared/pkg/saga/saga_executor.go`: `resolveRetryBounds` looks up per-handler policy via `HandlerRegistry.GetWithMetadata`; new `UpdateNextRetryAt` and `ResetReplayCountAndBackoff` calls in transient/success paths.
- `shared/pkg/saga/claiming.go`: predicate gains `(next_retry_at IS NULL OR next_retry_at <= now)`. `RetryBaseDelay` / `RetryMaxDelay` added to `ClaimConfig` with env-var loading. `ReleaseLease` now nil-DB-tolerant so the executor is unit-testable with a config-only `ClaimService`.

### Schema YAML
- `schema.HandlerDef.Retry` optional block, validated for non-negative durations and `base <= max`.
- `derive.DeriveHandlerDef` propagates `HandlerMetadata.RetryPolicy` into the materialised schema.

## Test plan

- [x] Unit: `CalculateBackoffDelay` exponential growth, max-delay cap, overflow guard at very high replay counts, negative input handling, jitter randomness across 50 calls.
- [x] Unit: `handleTransientFailure` sets `next_retry_at`; uses global `ClaimConfig`; respects per-handler policy override; zombie path does NOT set `next_retry_at`; `ProcessStepResult` success clears both columns.
- [x] Integration (CockroachDB testcontainer): migration adds column + partial index; idempotent re-run; repository round-trips `next_retry_at`; `ResetReplayCountAndBackoff` clears both columns; orphan watcher skips sagas with future `next_retry_at`, claims sagas with past or NULL `next_retry_at`; end-to-end "claim, backoff, skip, elapse, reclaim" sequence.
- [x] YAML parsing: happy-path, omitted block (nil policy), negative `base_delay` rejected, inverted `base > max` rejected.
- [x] `NewClaimConfig` reads `SAGA_RETRY_BASE_DELAY` / `SAGA_RETRY_MAX_DELAY` and falls back to package defaults.
- [x] Full `go test ./shared/pkg/saga/...` green locally.

## Risk Assessment

- **Migration**: `ADD COLUMN IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS`, both idempotent, no data movement, run online on CockroachDB.
- **Behavior change for existing sagas**: rows with `next_retry_at IS NULL` are treated as "no backoff in effect" - identical to pre-change behavior.
- **Default backoff (1s base, 5m max)** is conservative; operators can override via env or per-handler YAML.

## Deployment Notes

- No app-side migration coordination needed: column nullable, defaults work without code changes.
- Services pick up new env vars on next pod restart; absent vars use the documented defaults.