### PR TITLE
ci: Pin Claude GitHub actions to latest Opus alias

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -62,8 +62,8 @@ jobs:
             - Go 1.25+ is the current stable release - don't flag version references
             - CI may still be running - check with `gh pr checks ${{ github.event.pull_request.number }}`
 
-          # Using Opus 4.6 for highest quality code reviews
-          claude_args: '--model claude-opus-4-6 --allowed-tools "Bash(gh api:*),Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          # Using the latest Opus for highest quality code reviews (alias tracks newest snapshot)
+          claude_args: '--model opus --allowed-tools "Bash(gh api:*),Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 
       - name: Report Final Status
         if: always()

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -78,7 +78,7 @@ jobs:
             - Service-specific README.md files for local conventions
 
           # Customize Claude's behavior
-          # Using Opus 4.5 for higher quality responses
+          # Using the latest Opus for higher quality responses (alias tracks newest snapshot)
           claude_args: |
             --max-input-tokens 50000
-            --model claude-opus-4-5-20251101
+            --model opus


### PR DESCRIPTION
## Summary

The Claude GitHub actions were pinned to fixed model identifiers, requiring a manual edit every time a newer Opus ships. This switches them to the moving `opus` alias, which always resolves to the latest Opus snapshot.

## Changes Made

| Workflow | Before | After |
|----------|--------|-------|
| `claude.yml` | `claude-opus-4-5-20251101` | `opus` |
| `claude-review.yml` | `claude-opus-4-6` | `opus` |

## Technical Details

The `--model opus` alias is resolved by claude-code-action to the newest available Opus model, so no further edits are needed on each model release.

## Risk Assessment

Low. CI-only change; affects which model the assistant/review actions invoke. Reversible by re-pinning a snapshot if a specific version is ever required.

## Testing

Config-only change. Workflows are exercised on the next `@claude` mention / PR review trigger.