### PR TITLE
fix(deps): Override qs to 6.15.2 (DoS GHSA-q8mj-m7cp-5q26)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4570,6 +4570,70 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.0.tgz",
@@ -10073,9 +10137,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,7 +57,8 @@
   "overrides": {
     "hono": "^4.12.12",
     "@hono/node-server": "^1.19.13",
-    "flatted": "^3.4.2"
+    "flatted": "^3.4.2",
+    "qs": "^6.15.2"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.65.0",


### PR DESCRIPTION
## Summary

Resolves open Dependabot alert [#62](https://github.com/meridianhub/meridian/security/dependabot/62): `qs` remotely triggerable DoS ([GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26), medium).

## Changes Made

- Added `"qs": "^6.15.2"` to `frontend/package.json` `overrides`.
- Regenerated `frontend/package-lock.json` (qs 6.15.0 → 6.15.2).

## Technical Details

`qs@6.15.0` was pulled transitively (dev scope):

```
shadcn -> @modelcontextprotocol/sdk -> express -> qs
```

Vulnerable range is `>= 6.11.1, <= 6.15.1`; `qs.stringify` crashes with a `TypeError` on null/undefined entries in comma-format arrays when `encodeValuesOnly` is set. Patched in 6.15.2. The bump is a semver patch within express's `^6.x` constraint.

## Testing

- `npm install` resolves cleanly; `npm ls qs` confirms a single `qs@6.15.2` (overridden).
- `npm audit` no longer reports the qs advisory.

## Risk Assessment

Low. Dev-scope transitive dependency, patch-level version bump, no source changes.

## Deployment Notes

None. Frontend lockfile only.