### PR TITLE
docs: Refresh load-bearing ADR hubs and fix ADR-index contradictions (tasks 6 + 13)

### DIFF
--- a/docs/adr/0002-microservices-per-bian-domain.md
+++ b/docs/adr/0002-microservices-per-bian-domain.md
@@ -9,9 +9,11 @@ triggers:
   - Discussing BIAN domain implementation
 
 instructions: |
-  Create one service per BIAN domain (FinancialAccounting, PositionKeeping, CurrentAccount).
-  Each service independently deployable with own database. Use gRPC for sync communication,
-  Kafka for async events. Services are "lego blocks" for composability.
+  Create one service per BIAN domain (the codebase has grown to ~19 services such as
+  FinancialAccounting, PositionKeeping, CurrentAccount, PaymentOrder, ReferenceData, Tenant).
+  Each service owns its database/schema. Use gRPC for sync communication, Kafka for async
+  events. Services are "lego blocks" but ship today as one unified binary (cmd/meridian)
+  wired in dependency-tier order. See ADR-0015 for the canonical service directory layout.
 ---
 
 # 2. Microservices Architecture with One Service per BIAN Domain
@@ -26,12 +28,20 @@ Amended: 2025-11-19 - Added saga orchestration pattern and service coupling enfo
 
 ## Context
 
-Meridian implements multiple BIAN (Banking Industry Architecture Network) service domains: FinancialAccounting,
-PositionKeeping, and CurrentAccount. We need to decide whether to build a modular monolith with all domains in one
-deployable or separate microservices with one service per BIAN domain.
+Meridian implements multiple BIAN (Banking Industry Architecture Network) service domains. We need to decide whether
+to build a modular monolith with all domains in one deployable or separate microservices with one service per BIAN
+domain.
 
 BIAN service domains already define clear bounded contexts with well-defined interfaces, making them natural candidates
 for service boundaries.
+
+> **2026 status note:** This decision still holds, and the codebase has grown well beyond the original three domains.
+> There are now ~19 service packages under `services/` (current-account, financial-accounting, position-keeping,
+> payment-order, party, internal-account, market-information, reconciliation, reference-data, tenant, control-plane,
+> identity, forecasting, plus gateway/worker/router services). Each owns its own database/schema and exposes a gRPC
+> surface, but they are compiled and deployed as a **single unified binary** (`cmd/meridian`) rather than as separately
+> deployed pods today. The bounded-context boundaries described here are enforced at the package/coupling level (see the
+> Service Coupling Enforcement amendment) even though deployment is currently unified.
 
 ## Decision Drivers
 
@@ -70,7 +80,7 @@ Chosen option: "Microservices - One service per BIAN domain", because:
 
 ### Negative Consequences
 
-* Increased operational complexity (6+ services to deploy and monitor)
+* Increased architectural complexity (~19 service packages to reason about; mitigated by shipping them as one unified binary today)
 * Distributed transactions require Saga pattern or 2PC where needed
 * Network latency between services (though all communication is gRPC)
 * Service mesh or API gateway required for cross-cutting concerns
@@ -129,37 +139,48 @@ Core domains (FinancialAccounting, PositionKeeping) in monolith, customer-facing
 
 ### Service Structure
 
-Each BIAN domain service will follow this structure:
+> The original draft of this section proposed a per-service `internal/{domain,repository,grpc,kafka}` layout, per-service
+> `go.mod` files, and Flyway migrations. The implemented layout differs and is documented canonically in
+> [ADR-0015](0015-standard-service-directory-structure.md). The actual structure is:
 
 ```text
 services/
-├── financial-accounting-service/
-│   ├── cmd/server/main.go
-│   ├── internal/
-│   │   ├── domain/          # BIAN domain model
-│   │   ├── repository/      # Database persistence
-│   │   ├── grpc/           # gRPC service implementation
-│   │   └── kafka/          # Event publishing
-│   ├── migrations/          # Flyway database migrations
-│   ├── Dockerfile
-│   └── go.mod
-├── position-keeping-service/
+├── financial-accounting/
+│   ├── cmd/main.go              # service entry point (also wired into cmd/meridian unified binary)
+│   ├── domain/                  # BIAN domain model (pure, no infrastructure tags)
+│   ├── adapters/
+│   │   ├── persistence/         # GORM entities + repository adapters
+│   │   └── messaging/           # Kafka event publishers (outbox-backed)
+│   ├── service/                 # gRPC handlers (server.go + grpc_*_endpoints.go)
+│   ├── atlas/atlas.hcl          # Atlas migration config (NOT Flyway)
+│   └── migrations/              # Atlas SQL migrations
+├── position-keeping/
 │   └── ...
-└── current-account-service/
+└── current-account/
     └── ...
 ```
 
+Notes vs the original draft:
+
+- Migrations use **Atlas**, not Flyway (see [ADR-0003](0003-database-schema-migrations.md)).
+- There is a **single Go module** (`github.com/meridianhub/meridian`), not per-service `go.mod` files.
+- Service directories are not `-service`-suffixed.
+- gRPC handlers live in `service/`; event publishers in `adapters/messaging/`; persistence in `adapters/persistence/`.
+
 ### Shared Platform Services
 
-Common platform services (database, Kafka, auth, observability) will be in:
+Common platform utilities (database, Kafka, auth, observability, idempotency) live under `shared/`:
 
 ```text
-platform/
-├── database/        # Connection pooling, transaction management
-├── kafka/           # Producer/consumer utilities with protobuf serialization
-├── auth/            # JWT validation, authorization
-├── observability/   # OpenTelemetry, logging, metrics
-└── idempotency/     # Redis-based idempotency keys
+shared/
+├── platform/
+│   ├── db/              # Connection pooling, tenant search_path scoping
+│   ├── kafka/           # Producer/consumer utilities with protobuf serialization
+│   ├── events/          # Transactional outbox + Kafka publisher/worker
+│   └── observability/   # OpenTelemetry, logging, metrics
+└── pkg/
+    ├── idempotency/     # Redis or Postgres-backed idempotency keys
+    └── saga/            # Starlark saga runner (see ADR-0028)
 ```
 
 ### Inter-Service Communication
@@ -177,6 +198,15 @@ platform/
 * Re-evaluate if distributed transaction complexity becomes unmanageable
 
 ## Amendment: Saga Orchestration Pattern (2025-11-19)
+
+> **Superseded by [ADR-0028](0028-starlark-saga-cel-valuation.md) (2026-01).** The hand-written Go orchestrator pattern
+> described below was the implementation as of 2025-11. It has since been replaced by **Starlark saga orchestration**:
+> saga step sequences and LIFO compensation are now defined as Starlark scripts (stored as saga definitions in the
+> reference-data service) and executed by `shared/pkg/saga.StarlarkSagaRunner`. For example, current-account's
+> `ExecuteDeposit` still exists but delegates to a `DepositOrchestrator` that resolves and runs a Starlark deposit saga
+> rather than calling downstream services inline. The orchestration *principle* (an orchestrator owns the sequence and
+> compensation; gRPC for sync steps) still holds; the *mechanism* moved from Go code to Starlark. The Go example below
+> is retained for historical context.
 
 ### Context
 
@@ -377,40 +407,45 @@ import "github.com/meridianhub/meridian/api/proto/financial_accounting/v1"
 **Forbidden:**
 
 ```go
-import "github.com/meridianhub/meridian/internal/financial-accounting/domain"
+import "github.com/meridianhub/meridian/services/financial-accounting/domain"
 ```
 
 **Enforcement:**
 
-* Linter: Custom rule to detect `internal/<other-service>/` imports
+* Linter: Custom rule to detect cross-service `services/<other-service>/` imports
 * CI: Automated coupling analysis (see `scripts/analyze-coupling.sh`)
 * Code review: Reject PRs with cross-service internal imports
 
 **Rationale:** Proto contracts are the public API. Internal packages can change without breaking other services.
 
-#### Rule 2: Platform Code in pkg/, Not internal/
+#### Rule 2: Shared Platform Code in shared/, Not Inside a Service
 
-**Rule:** Shared platform utilities (observability, Kafka, database) MUST be in `pkg/platform/`, not `internal/platform/`.
+**Rule:** Shared platform utilities (observability, Kafka, database, events) MUST live under `shared/` (`shared/platform/`
+and `shared/pkg/`), not inside any individual service package.
 
 **Allowed:**
 
 ```go
-import "github.com/meridianhub/meridian/pkg/platform/observability"
+import "github.com/meridianhub/meridian/shared/platform/observability"
 ```
 
 **Forbidden:**
 
 ```go
-import "github.com/meridianhub/meridian/internal/platform/observability"
+import "github.com/meridianhub/meridian/services/current-account/observability" // service-private, do not share
 ```
 
 **Enforcement:**
 
-* Migration: Move `internal/platform/` → `pkg/platform/` (see [Boundary Migration Plan](../architecture/boundary-migration-plan.md))
-* Linter: Warn on `internal/platform/` imports from services
-* CI: Track platform coupling metrics
+* Linter: warn when one service imports another service's package (see Rule 1)
+* CI: track platform coupling metrics
 
-**Rationale:** `internal/` signals "private to this service." Platform code shared across services must be in `pkg/`.
+**Rationale:** Code shared across services belongs in `shared/`; a service package signals "private to this service."
+
+> **Note (2026):** The original draft of this rule proposed a `pkg/platform/` → migrated-from-`internal/platform/`
+> location. Neither path exists in the current tree. Shared platform code settled at `shared/platform/` (e.g.
+> `shared/platform/observability`, `shared/platform/events`) and `shared/pkg/` (e.g. `shared/pkg/idempotency`,
+> `shared/pkg/saga`).
 
 #### Rule 3: Own Your Domain Entities
 
@@ -426,7 +461,7 @@ import "github.com/meridianhub/meridian/internal/platform/observability"
 
 ```go
 // In FinancialAccounting service
-import "github.com/meridianhub/meridian/internal/current-account/domain"
+import "github.com/meridianhub/meridian/services/current-account/domain"
 
 func PostToLedger(account *domain.Account) { ... } // ❌ Using another service's domain model
 ```
@@ -587,7 +622,10 @@ ADR-002 specified database-per-service in Rule 4, but didn't detail the actual d
 
 Each microservice has its own CockroachDB database with tenant isolation via schemas:
 
-**Database naming:**
+**Database naming (representative - the table below lists the original six; more service databases have since been
+added, e.g. `meridian_control_plane`, `meridian_reference_data`, `meridian_market_information`,
+`meridian_reconciliation`, `meridian_internal_account`, `meridian_identity`). See
+[data-model.md](../architecture/data-model.md) for the current, authoritative topology.):**
 
 | Service | Database |
 |---------|----------|

--- a/docs/adr/0002-microservices-per-bian-domain.md
+++ b/docs/adr/0002-microservices-per-bian-domain.md
@@ -131,7 +131,7 @@ Core domains (FinancialAccounting, PositionKeeping) in monolith, customer-facing
 ## Links
 
 * [BIAN Service Landscape](https://bian.org/servicelandscape/)
-* [BIAN Semantic APIs](../../../bian/bian-public-main/release14.0.0/semantic-apis/)
+* [BIAN Semantic APIs (v14.0.0)](https://github.com/bian-official/public/tree/main/release14.0.0/semantic-apis)
 * [GitHub Issue #1: Infrastructure](https://github.com/meridianhub/meridian/issues/1)
 * [GitHub Issue #3: Platform Services](https://github.com/meridianhub/meridian/issues/3)
 

--- a/docs/adr/0003-database-schema-migrations.md
+++ b/docs/adr/0003-database-schema-migrations.md
@@ -9,9 +9,11 @@ triggers:
   - Handling schema drift
 
 instructions: |
-  Use Atlas for declarative schema migrations. Each service has own migrations directory.
-  Migrations run automatically on service startup. Atlas generates SQL from desired state,
-  ensuring safe schema evolution without manual SQL.
+  Use Atlas for declarative schema migrations. Each service has its own
+  services/<service>/migrations/ directory and services/<service>/atlas/atlas.hcl config.
+  Migrations do NOT run automatically on startup - apply them explicitly via the unified
+  binary's `--migrate` flag (or `atlas migrate apply` in CI). Atlas generates SQL by diffing
+  the GORM models loaded through utilities/atlas-loader against the live schema.
 ---
 
 # 3. Database Schema Migrations with Atlas
@@ -210,7 +212,7 @@ project-root/
 
 ### Database Entity as Source of Truth for Persistence
 
-**internal/adapters/persistence/booking_log_entity.go:**
+**services/financial-accounting/adapters/persistence/booking_log_entity.go:**
 
 ```go
 package persistence
@@ -254,7 +256,7 @@ func (BookingLogEntity) TableName() string {
 }
 ```
 
-**Corresponding domain model (internal/domain/booking_log.go) - NO persistence tags:**
+**Corresponding domain model (services/financial-accounting/domain/booking_log.go) - NO persistence tags:**
 
 ```go
 package domain
@@ -300,10 +302,11 @@ func (b *FinancialBookingLog) Post() error {
 
 ### Atlas Configuration
 
-Configuration files are located in the `atlas/` directory, organized by schema. Each service domain has its own
-subdirectory with an `atlas.hcl` configuration file (e.g., `atlas/financial_accounting/atlas.hcl`):
+Each service owns its Atlas config at `services/<service>/atlas/atlas.hcl`, and its migrations at
+`services/<service>/migrations/`. The config invokes the shared GORM loader at `utilities/atlas-loader` to derive the
+desired schema:
 
-**atlas/financial_accounting/atlas.hcl:**
+**services/financial-accounting/atlas/atlas.hcl:**
 
 ```hcl
 data "external_schema" "gorm" {
@@ -311,14 +314,14 @@ data "external_schema" "gorm" {
     "go",
     "run",
     "-mod=mod",
-    "./cmd/atlas-loader",
+    "./utilities/atlas-loader",
     "--schema=financial_accounting"
   ]
 }
 
 env "local" {
   migration {
-    dir = "file://migrations/financial_accounting"
+    dir = "file://services/financial-accounting/migrations"
   }
 
   dev = "docker://postgres/16/dev"
@@ -340,7 +343,7 @@ env "local" {
 
 env "ci" {
   migration {
-    dir = "file://migrations/financial_accounting"
+    dir = "file://services/financial-accounting/migrations"
   }
 
   dev = "docker://postgres/16/dev"
@@ -379,7 +382,7 @@ type BookingLogEntity struct {
 # Atlas inspects database entities and generates migration
 atlas migrate diff add_narrative \
   --env local \
-  --config atlas/financial_accounting/atlas.hcl
+  --config file://services/financial-accounting/atlas/atlas.hcl
 ```
 
 **Generated migration (services/financial-accounting/migrations/20250125120000_add_narrative.sql):**
@@ -399,7 +402,7 @@ ALTER TABLE "financial_booking_log"
 # Catch dangerous changes before deployment
 atlas migrate lint \
   --env local \
-  --config atlas/financial_accounting/atlas.hcl \
+  --config file://services/financial-accounting/atlas/atlas.hcl \
   --latest 1
 ```
 
@@ -409,7 +412,7 @@ atlas migrate lint \
 # Verify migration checksums
 atlas migrate hash \
   --env local \
-  --config atlas/financial_accounting/atlas.hcl
+  --config file://services/financial-accounting/atlas/atlas.hcl
 ```
 
 **5. Apply Migration:**
@@ -418,9 +421,13 @@ atlas migrate hash \
 # Deploy to target environment
 atlas migrate apply \
   --env local \
-  --config atlas/financial_accounting/atlas.hcl \
+  --config file://services/financial-accounting/atlas/atlas.hcl \
   --url "$DATABASE_URL"
 ```
+
+> **Runtime note:** Meridian does **not** auto-run migrations on service startup. In production/demo, migrations are
+> applied by the unified binary's `--migrate` flag (`cmd/meridian/main.go`, which applies the embedded SQL and exits),
+> and in CI via `atlas migrate apply`. There is no implicit migration-on-boot.
 
 ### CI/CD Integration
 
@@ -430,18 +437,20 @@ See `.github/workflows/migrations.yml` for the actual implementation. Key path t
 on:
   pull_request:
     paths:
-      - 'migrations/**'
-      - 'atlas/**'
-      - 'cmd/atlas-loader/**'
-      - 'internal/domain/models/**'
+      - 'services/*/migrations/**'
+      - 'services/*/atlas/**'
+      - 'shared/atlas/**'
+      - 'utilities/atlas-loader/**'
+      - 'shared/domain/models/**'
+      - 'scripts/migrate-all-orgs.sh'
 ```
 
-Migration verification uses the schema-specific configs:
+Migration verification uses the per-service configs:
 
 ```bash
-# Verify checksums for each schema
-atlas migrate hash --env ci --config file://atlas/current_account/atlas.hcl
-atlas migrate hash --env ci --config file://atlas/position_keeping/atlas.hcl
+# Verify checksums for each service
+atlas migrate hash --env ci --config file://services/current-account/atlas/atlas.hcl
+atlas migrate hash --env ci --config file://services/position-keeping/atlas/atlas.hcl
 ```
 
 ### Immutability Principle
@@ -461,7 +470,8 @@ For complex changes, write SQL manually:
 
 # Create empty migration file
 
-atlas migrate new complex_data_migration --env gorm
+atlas migrate new complex_data_migration \
+  --config file://services/financial-accounting/atlas/atlas.hcl --env local
 ```
 
 Edit the generated file with custom SQL, then Atlas manages it like any other migration.

--- a/docs/adr/0004-event-schema-evolution.md
+++ b/docs/adr/0004-event-schema-evolution.md
@@ -75,7 +75,7 @@ Use **protobuf's native versioning** with **BIAN-aligned semantic event types** 
 For minor additions that don't change semantic meaning:
 
 ```protobuf
-// api/proto/events/current_account/v1/events.proto
+// api/proto/meridian/events/v1/current_account_events.proto
 
 // Before
 message AccountUpdated {
@@ -105,7 +105,7 @@ message AccountUpdated {
 For new BIAN operations with distinct semantics:
 
 ```protobuf
-// api/proto/events/current_account/v1/events.proto
+// api/proto/meridian/events/v1/current_account_events.proto
 
 // Existing event
 message AccountUpdated {
@@ -133,8 +133,14 @@ to distinct event types rather than overloading a single event schema.
 
 ### Topic Naming Strategy
 
-- **One topic per event type:** `account-updated`, `account-suspended`, `booking-created`
-- **No version suffixes:** Use semantic names, not `account-updated-v2`
+> **Superseded by the 2025-11-19 amendment below.** The flat, unversioned names in this original section
+> (`account-updated`, `account-suspended`) are NOT what the code uses. The implemented convention is
+> **`<service>.<event-name>.<version>`** with an explicit `.v1` suffix on every topic, e.g.
+> `current-account.account-frozen.v1`, `position-keeping.transaction-captured.v1`, `audit.events.v1`. The canonical
+> topic constants live in `shared/platform/events/topics/topics.go` (with a `topics.yaml` registry and
+> `topics_test.go` enforcing the convention). See the "Event Topic Naming Convention" amendment for rationale.
+
+- **One topic per event type** (illustrative names only; see the amendment for the real `.v1` convention)
 - **BIAN alignment:** Topic names reflect BIAN behavior qualifiers
 - **Retention policy:** 7 days (events are coordination, not system of record)
 
@@ -144,7 +150,7 @@ to distinct event types rather than overloading a single event schema.
 
 ```yaml
 
-# .github/workflows/proto-validation.yml
+# .github/workflows/proto.yml
 
 - name: Lint protobuf schemas
 
@@ -152,7 +158,7 @@ to distinct event types rather than overloading a single event schema.
 
 - name: Check for breaking changes
 
-  run: buf breaking --against '.git#branch=main'
+  run: buf breaking --against '.git#branch=develop'
 ```
 
 **Breaking changes fail the build**, forcing developers to either:
@@ -187,7 +193,7 @@ Question: Is "Suspend" semantically different from "Update"?
 ### Step 2: Define New Event
 
 ```protobuf
-// api/proto/events/current_account/v1/events.proto
+// api/proto/meridian/events/v1/current_account_events.proto
 
 message AccountSuspended {
   // Event metadata
@@ -214,7 +220,7 @@ buf generate
 
 ```bash
 buf lint
-buf breaking --against main
+buf breaking --against '.git#branch=develop'
 
 # ✅ No breaking changes - new file, no modifications to existing schemas
 
@@ -448,7 +454,7 @@ Maintain a living document of all event types:
 ### AccountUpdated
 
 - **Topic:** account-updated
-- **Schema:** api/proto/events/current_account/v1/events.proto
+- **Schema:** api/proto/meridian/events/v1/current_account_events.proto
 - **Producers:** current-account-service
 - **Consumers:** position-keeping-service, financial-accounting-service
 - **BIAN Qualifier:** Update
@@ -456,7 +462,7 @@ Maintain a living document of all event types:
 ### AccountSuspended
 
 - **Topic:** account-suspended
-- **Schema:** api/proto/events/current_account/v1/events.proto
+- **Schema:** api/proto/meridian/events/v1/current_account_events.proto
 - **Producers:** current-account-service
 - **Consumers:** position-keeping-service, risk-management-service
 - **BIAN Qualifier:** Control (Suspend)
@@ -664,21 +670,28 @@ Use **transactional outbox pattern** for at-least-once event delivery guarantees
 3. Mark event as published after successful Kafka acknowledgment
 4. Consumers use idempotency keys to handle duplicates
 
-**Implementation:**
+**Implementation:** The real outbox lives at `shared/platform/events/` (`outbox.go`, `outbox_pgx.go`, `worker.go`,
+`publisher.go`); the schema is in `shared/platform/events/schema.sql`. The table is named **`event_outbox`** and tracks
+state with a **`status`** column (`pending`/`processing`/`completed`/`failed`) rather than a nullable `published_at`.
+This deliberately avoids the partial-index-on-`published_at IS NULL` pattern, which is awkward on CockroachDB; instead
+a plain compound index on `(status, service_name, created_at)` drives polling. The payload is stored as `BYTEA`
+(serialized protobuf), not JSONB.
 
 ```sql
--- Outbox table (per service database)
-CREATE TABLE outbox (
-    id UUID PRIMARY KEY,
-    aggregate_type VARCHAR(100) NOT NULL,
-    aggregate_id VARCHAR(100) NOT NULL,
-    event_type VARCHAR(100) NOT NULL,
-    event_payload JSONB NOT NULL,
-    topic_name VARCHAR(255) NOT NULL,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    published_at TIMESTAMP,
-    retry_count INT NOT NULL DEFAULT 0,
-    INDEX idx_unpublished (published_at, created_at) WHERE published_at IS NULL
+-- shared/platform/events/schema.sql (simplified)
+CREATE TABLE event_outbox (
+    id              UUID PRIMARY KEY,
+    aggregate_type  VARCHAR(100) NOT NULL,
+    aggregate_id    VARCHAR(100) NOT NULL,
+    event_type      VARCHAR(100) NOT NULL,
+    event_payload   BYTEA NOT NULL,          -- serialized protobuf
+    topic_name      VARCHAR(255) NOT NULL,
+    service_name    VARCHAR(100) NOT NULL,
+    status          VARCHAR(20) NOT NULL DEFAULT 'pending', -- pending|processing|completed|failed
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    processed_at    TIMESTAMPTZ,
+    retry_count     INT NOT NULL DEFAULT 0,
+    INDEX idx_event_outbox_polling (status, service_name, created_at)
 );
 ```
 
@@ -712,7 +725,8 @@ func (s *AccountService) CreateAccount(ctx context.Context, req *pb.CreateAccoun
 
 ```go
 func (p *OutboxPublisher) Run(ctx context.Context) {
-    ticker := time.NewTicker(100 * time.Millisecond)
+    // Real default poll interval is 5s (worker.go), configurable via PollInterval.
+    ticker := time.NewTicker(5 * time.Second)
     for {
         select {
         case <-ticker.C:
@@ -790,7 +804,7 @@ func (p *OutboxPublisher) Run(ctx context.Context) {
 
 **Polling strategy:**
 
-- Frequency: 100ms (10 events/sec per service minimum)
+- Frequency: 5s default poll interval (configurable via `PollInterval`)
 - Batch size: 100 events per poll
 - Retry: Exponential backoff (1s, 2s, 4s, 8s, max 60s)
 - Dead letter: Move to DLQ after 10 retries
@@ -819,13 +833,13 @@ func (p *OutboxPublisher) Run(ctx context.Context) {
 **Negative:**
 
 - ❌ Additional table: Outbox table adds storage overhead
-- ❌ Latency: 100ms delay before event published (vs direct publish)
+- ❌ Latency: up to one poll interval (5s default) before event published (vs direct publish)
 - ❌ Duplicates: Consumers must handle at-least-once semantics
 
 **Mitigations:**
 
 - **Storage**: Outbox cleanup after 7 days (auto-vacuuming)
-- **Latency**: 100ms acceptable for event-driven coordination
+- **Latency**: a few-second poll interval is acceptable for event-driven coordination (tune `PollInterval` if lower latency is required)
 - **Duplicates**: Idempotency pattern (see next amendment)
 
 ### References
@@ -860,18 +874,25 @@ func HandleAccountCreated(event *events.AccountCreatedEvent) {
 
 Implement **event_id-based idempotency** for all event consumers using Redis or database deduplication.
 
+> **Implementation note:** This is implemented generically in `shared/pkg/idempotency/` with two interchangeable
+> backends - `redis_service.go` (preferred; keys are `idempotency:result:<key>` plus a lock key) and
+> `postgres_service.go` (a single `_idempotency_keys` table indexed on `expires_at`, used when Redis is unavailable).
+> A noop backend exists for dev, with `ErrRedisRequiredInProduction` guarding production. TTL is **per-operation and
+> configurable** (the executor default is 1h), not a fixed 7 days. The key strings (`event:processed:*`) and table
+> (`processed_events`) shown below are illustrative only - the real key/table names are as stated above.
+
 **Pattern:**
 
-1. Check if `event_id` already processed before handling event
-2. Process event only if `event_id` not seen
-3. Store `event_id` with TTL matching event retention (7 days)
+1. Check if the operation key (derived from `event_id`) was already processed before handling the event
+2. Process event only if the key has not been seen
+3. Store the key with a configurable TTL
 
 **Implementation (Redis):**
 
 ```go
 func (c *EventConsumer) HandleAccountCreated(ctx context.Context, event *events.AccountCreatedEvent) error {
-    // Step 1: Check if already processed
-    key := fmt.Sprintf("event:processed:%s", event.EventId)
+    // Step 1: Check if already processed (real keys: idempotency:result:<key>)
+    key := fmt.Sprintf("idempotency:result:%s", event.EventId)
     exists, err := c.redis.Exists(ctx, key).Result()
     if err != nil {
         return fmt.Errorf("redis check failed: %w", err)
@@ -886,8 +907,8 @@ func (c *EventConsumer) HandleAccountCreated(ctx context.Context, event *events.
         return fmt.Errorf("failed to create account: %w", err)
     }
 
-    // Step 3: Mark as processed (TTL = 7 days)
-    if err := c.redis.Set(ctx, key, "1", 7*24*time.Hour).Err(); err != nil {
+    // Step 3: Mark as processed (configurable TTL; executor default 1h)
+    if err := c.redis.Set(ctx, key, "1", time.Hour).Err(); err != nil {
         return fmt.Errorf("failed to mark processed: %w", err)
     }
 
@@ -895,18 +916,20 @@ func (c *EventConsumer) HandleAccountCreated(ctx context.Context, event *events.
 }
 ```
 
-**Implementation (Database):**
+**Implementation (Database):** the real Postgres backend uses a single `_idempotency_keys` table (serving both
+dedup and locking) indexed on `expires_at`; rows expire by their stored TTL. The illustrative shape:
 
 ```sql
-CREATE TABLE processed_events (
-    event_id UUID PRIMARY KEY,
-    event_type VARCHAR(100) NOT NULL,
-    processed_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    INDEX idx_processed_at (processed_at)
+-- Real table: _idempotency_keys (shared/pkg/idempotency/postgres_service.go)
+CREATE TABLE _idempotency_keys (
+    key         VARCHAR PRIMARY KEY,
+    result      BYTEA,
+    expires_at  TIMESTAMPTZ NOT NULL,
+    INDEX idx_idempotency_expires_at (expires_at)
 );
 
--- Cleanup old events (daily cron)
-DELETE FROM processed_events WHERE processed_at < NOW() - INTERVAL '7 days';
+-- Cleanup expired keys
+DELETE FROM _idempotency_keys WHERE expires_at < NOW();
 ```
 
 ### Alternatives Considered
@@ -972,8 +995,10 @@ DELETE FROM processed_events WHERE processed_at < NOW() - INTERVAL '7 days';
 
 **TTL strategy:**
 
-- Match Kafka retention: 7 days
-- Rationale: Event won't be replayed after 7 days (purged from Kafka)
+- Per-operation and configurable (executor default 1h). Set it at least as long as the window in which a duplicate
+  could plausibly be redelivered for that operation.
+- For long-lived dedup, size the TTL toward Kafka retention (7 days); for short-lived request idempotency the 1h
+  default is typical.
 
 **Error handling:**
 

--- a/docs/adr/0005-adapter-pattern-layer-translation.md
+++ b/docs/adr/0005-adapter-pattern-layer-translation.md
@@ -81,12 +81,29 @@ prevent drift.
 
 ## Implementation
 
+> **Path/package note (refreshed 2026):** The adapter pattern below is still the live architecture, but the code no
+> longer lives under `internal/`. The current layout per service is:
+>
+> | Concern | Current location | Package |
+> |---------|------------------|---------|
+> | Domain models + ports | `services/<svc>/domain/` | `domain` |
+> | Persistence adapters | `services/<svc>/adapters/persistence/` | `persistence` |
+> | Event publishers | `services/<svc>/adapters/messaging/` | `messaging` |
+> | gRPC handlers | `services/<svc>/service/` | `service` |
+>
+> The single Go module is `github.com/meridianhub/meridian`, so imports are
+> `github.com/meridianhub/meridian/services/<svc>/domain`, etc. The `toEntity`/`toDomain` translators are typically
+> package-level functions (e.g. `toBookingLogEntity`/`toBookingLogDomain`) rather than repository methods. Event
+> publishing goes through the **transactional outbox** (`shared/platform/events`) rather than a direct
+> `producer.Publish(...)`; see [ADR-0004](0004-event-schema-evolution.md). The code samples below are illustrative of
+> the pattern; field lists are simplified and may not match current structs exactly.
+
 ### Repository Port (Domain Interface)
 
 The domain defines what it needs, not how it's implemented:
 
 ```go
-// internal/domain/booking_log_repository.go
+// services/financial-accounting/domain/booking_log_repository.go
 package domain
 
 import (
@@ -122,12 +139,12 @@ func (s *BookingLogService) CreateBooking(ctx context.Context, booking *Financia
 The adapter implements the port and handles translation:
 
 ```go
-// internal/adapters/persistence/booking_log_repository.go
+// services/financial-accounting/adapters/persistence/booking_log_repository.go
 package persistence
 
 import (
     "context"
-    "github.com/meridianhub/meridian/internal/domain"
+    "github.com/meridianhub/meridian/services/financial-accounting/domain"
     "github.com/google/uuid"
     "gorm.io/gorm"
 )
@@ -216,13 +233,13 @@ func (r *BookingLogRepository) toDomain(e *BookingLogEntity) *domain.FinancialBo
 ### Event Publisher Adapter
 
 ```go
-// internal/adapters/events/booking_log_publisher.go
-package events
+// services/financial-accounting/adapters/messaging/booking_log_publisher.go
+package messaging
 
 import (
     "context"
-    "github.com/meridianhub/meridian/internal/domain"
-    eventspb "github.com/meridianhub/meridian/api/proto/events/financial_accounting/v1"
+    "github.com/meridianhub/meridian/services/financial-accounting/domain"
+    eventspb "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
     "github.com/google/uuid"
     "google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -281,13 +298,13 @@ func getCausationID(ctx context.Context) string {
 ### gRPC Service Adapter
 
 ```go
-// internal/adapters/grpc/booking_log_service.go
-package grpc
+// services/financial-accounting/service/booking_log_service.go
+package service
 
 import (
     "context"
-    "github.com/meridianhub/meridian/internal/domain"
-    pb "github.com/meridianhub/meridian/api/proto/financial_accounting/v1"
+    "github.com/meridianhub/meridian/services/financial-accounting/domain"
+    pb "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
     "google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -355,7 +372,9 @@ changes.
 #### Step 1: Update domain model (business logic)
 
 ```go
-// internal/domain/current_account.go
+// services/current-account/domain/current_account.go
+// (Illustrative BIAN-evolution example. The real current-account domain models a "Frozen"
+//  status rather than "Suspended"; the mechanics are identical.)
 
 // Updated for BIAN 15.0
 type CurrentAccount struct {
@@ -394,7 +413,7 @@ func (a *CurrentAccount) Suspend(reason string, until time.Time, by string) erro
 #### Step 2: Update persistence adapter (database mapping)
 
 ```go
-// internal/adapters/persistence/current_account_repository.go
+// services/current-account/adapters/persistence/current_account_repository.go
 
 // Add new fields to entity
 type CurrentAccountEntity struct {
@@ -449,7 +468,7 @@ func (r *CurrentAccountRepository) toDomain(e *CurrentAccountEntity) *domain.Cur
 #### Step 3: Update event adapter (new event type per ADR-0004)
 
 ```go
-// internal/adapters/events/current_account_publisher.go
+// services/current-account/adapters/messaging/current_account_publisher.go
 
 // New method for BIAN 15.0 behavior qualifier
 func (p *CurrentAccountPublisher) PublishSuspended(
@@ -514,7 +533,7 @@ disruption.
 Ensure adapters don't lose data:
 
 ```go
-// internal/adapters/persistence/booking_log_repository_test.go
+// services/financial-accounting/adapters/persistence/booking_log_repository_test.go
 package persistence_test
 
 import (
@@ -522,8 +541,8 @@ import (
     "testing"
     "time"
 
-    "github.com/meridianhub/meridian/internal/adapters/persistence"
-    "github.com/meridianhub/meridian/internal/domain"
+    "github.com/meridianhub/meridian/services/financial-accounting/adapters/persistence"
+    "github.com/meridianhub/meridian/services/financial-accounting/domain"
     "github.com/google/uuid"
     "github.com/stretchr/testify/assert"
 )

--- a/docs/adr/0012-lien-based-fund-reservation.md
+++ b/docs/adr/0012-lien-based-fund-reservation.md
@@ -21,6 +21,12 @@ Date: 2025-11-25
 
 Accepted
 
+> **Orchestration mechanism superseded by [ADR-0028](0028-starlark-saga-cel-valuation.md) (2026-01).** The lien-based
+> fund-reservation *decision* (reserve funds via a lien, then confirm or compensate) still holds. The Go-coded
+> `PaymentOrderSaga.Execute` shown below is no longer the orchestration mechanism: saga step sequencing and LIFO
+> compensation are now expressed as Starlark saga definitions executed by `shared/pkg/saga.StarlarkSagaRunner`. Read the
+> Go saga below for the lien/compensation semantics, not as the current control flow.
+
 ## Context
 
 The Payment Order service domain orchestrates multi-step payment flows that involve:

--- a/docs/adr/0013-generic-asset-quantity-types.md
+++ b/docs/adr/0013-generic-asset-quantity-types.md
@@ -19,7 +19,7 @@ Date: 2025-12-03
 
 ## Status
 
-Proposed
+Accepted (Implemented)
 
 ## Context
 

--- a/docs/adr/0014-financial-instrument-reference-data.md
+++ b/docs/adr/0014-financial-instrument-reference-data.md
@@ -14,11 +14,41 @@ instructions: |
 
 # 14. Financial Instrument Reference Data
 
-Date: 2025-12-04
+Date: 2025-12-04 (Revised: 2026-05 to match shipped implementation)
 
 ## Status
 
-Proposed
+Accepted (Implemented)
+
+The `reference-data` service is shipped (`services/reference-data/`), with the instrument registry, CEL compiler,
+per-tenant caching, and gRPC API all live. The core decision below - a BIAN Financial Instrument Reference Data
+service using CEL for validation and fungibility - holds. Several specifics evolved during implementation; the
+revision note captures the deltas.
+
+> **Implementation drift (what shipped vs the original 2025-12-04 draft):**
+>
+> - **Table is `instrument_definition` (singular), with no `tenant_id` column.** Multi-tenancy is schema-per-tenant
+>   (each tenant's `org_<id>` schema holds its own `instrument_definition` table), so the unique key is
+>   `UNIQUE(code, version)`, not `UNIQUE(tenant_id, code, version)`. Migration:
+>   `services/reference-data/migrations/20260104000001_initial.sql`.
+> - **Fungibility is a bucket-key model, not a pairwise boolean.** The column is `fungibility_key_expression` and the
+>   CEL returns a **string** bucket key for a single position; two positions are fungible iff they produce the same
+>   key. There is no dual-input `a`/`b` `a == b` comparison. CEL validation env variable is `attributes`, not `attrs`.
+> - **Instruments have a DRAFT → ACTIVE → DEPRECATED lifecycle.** The draft's "no `deprecated_at`, versions immutable"
+>   decision did not ship; `status`, `activated_at`, `deprecated_at`, and `successor_id` columns exist, and the API has
+>   `UpdateInstrument`, `ActivateInstrument`, and `DeprecateInstrument`. (Published versions are still treated as
+>   immutable in spirit; lifecycle transitions are how change is managed.)
+> - **CEL and JSON Schema coexist.** `attribute_schema` (JSON Schema, JSONB) was retained alongside the CEL
+>   expressions rather than replaced by them.
+> - **No `SystemTenantID` constant or cross-tenant fallback.** Platform instruments (GBP/USD/EUR) are seeded into each
+>   tenant's own schema via `registry/seeder.go` with an `is_system = true` flag.
+> - **CEL compiler is shared** at `shared/pkg/cel/` (the `services/reference-data/cel` package re-exports it); it
+>   manages bucket-key / eligibility / event-filter environments.
+> - **Caching is a per-tenant map of LRU caches** (`cache/instrument_cache.go`), still using `hashicorp/golang-lru/v2`.
+> - The service is `ReferenceDataService`; proto at `api/proto/meridian/reference_data/v1/instrument.proto`. Domain
+>   type lives in `services/reference-data/registry/` (there is no `domain/` package).
+>
+> The sections below have been updated to reflect the above. Older illustrative snippets are marked where retained.
 
 ## Context
 
@@ -103,82 +133,112 @@ Chosen option: **BIAN Financial Instrument Reference Data Management Service**.
 
 ### Directory Entry Schema
 
+The shipped DDL (`services/reference-data/migrations/20260104000001_initial.sql`, plus later migrations that add
+`is_system` and `successor_id`). Note: the table lives in each tenant's `org_<id>` schema, so there is no `tenant_id`
+column.
+
 ```sql
--- BIAN: FinancialInstrumentDirectoryEntry
-CREATE TABLE instrument_definitions (
+-- BIAN: FinancialInstrumentDirectoryEntry (created in each tenant's org_<id> schema)
+CREATE TABLE instrument_definition (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    tenant_id UUID NOT NULL,
 
     -- BIAN: FinancialInstrumentIdentification
-    code VARCHAR(32) NOT NULL,
+    code VARCHAR(50) NOT NULL,
     version INTEGER NOT NULL DEFAULT 1,
 
     -- Dimension (derived from instrument_type in ADR-0013)
-    dimension VARCHAR(32) NOT NULL,         -- "Monetary" or "Commodity"
+    dimension VARCHAR(32) NOT NULL,
 
     -- Instrument Properties
     precision INTEGER NOT NULL,             -- Decimal places (2, 4, 8)
 
-    -- CEL Expressions (replaces JSON Schema)
-    validation_expression TEXT NOT NULL DEFAULT 'true',     -- Ingestion gatekeeper
-    fungibility_expression TEXT NOT NULL DEFAULT 'a == b',  -- Position merge arbiter
+    -- CEL Expressions
+    validation_expression       TEXT,                       -- Ingestion gatekeeper (nullable)
+    fungibility_key_expression  TEXT NOT NULL DEFAULT '',    -- Returns a STRING bucket key
+    error_message_expression    TEXT,                        -- Optional custom validation error
+
+    -- JSON Schema (retained alongside CEL)
+    attribute_schema            JSONB,
 
     -- BIAN: FinancialInstrumentName
     display_name VARCHAR(128),
-    description TEXT,
+    description  TEXT,
 
-    -- Lifecycle
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- Lifecycle (DRAFT -> ACTIVE -> DEPRECATED)
+    status        VARCHAR(20) NOT NULL DEFAULT 'DRAFT',
+    is_system     BOOLEAN NOT NULL DEFAULT FALSE,           -- platform-seeded instrument
+    successor_id  UUID,                                     -- lineage to replacement version
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    activated_at  TIMESTAMPTZ,
+    deprecated_at TIMESTAMPTZ,
 
-    UNIQUE(tenant_id, code, version),
+    UNIQUE(code, version),
     CHECK (precision >= 0 AND precision <= 18),
-    CHECK (dimension IN ('Monetary', 'Commodity')),
-    CHECK (validation_expression <> ''),
-    CHECK (fungibility_expression <> '')
+    CHECK (dimension IN ('MONETARY','ENERGY','QUANTITY','COMPUTE','TIME','MASS','VOLUME'))
 );
 
-CREATE INDEX idx_instrument_definitions_lookup
-    ON instrument_definitions(tenant_id, code, version);
+CREATE INDEX idx_instrument_definition_lookup
+    ON instrument_definition(code, version);
 ```
 
 **Key design decisions:**
 
-1. **CEL instead of JSON Schema**: `validation_expression` and `fungibility_expression`
-   replace the JSONB schema field. CEL compiles to bytecode (~100ns) vs JSON Schema (~1ms).
+1. **CEL alongside JSON Schema**: `validation_expression` and `fungibility_key_expression` carry the CEL logic. The
+   `attribute_schema` JSON Schema column was retained (not replaced) for structural validation and tooling. CEL
+   compiles to bytecode (~100ns) for hot-path checks.
 
-2. **No `deprecated_at`**: Simplified lifecycle - versions are immutable once created.
-   New requirements = new version.
+2. **Bucket-key fungibility**: `fungibility_key_expression` is a single-input CEL that returns a **string** bucket key
+   for one position. Two positions are fungible iff their keys match - no pairwise `a == b` comparison. Default `''`
+   means "all positions of this instrument share one bucket" (fully fungible).
 
-3. **Dimension stored explicitly**: Required for `ParseQuantity()` factory
-   (see ADR-0013 Generic Bridge section).
+3. **Lifecycle, not pure immutability**: instruments move DRAFT → ACTIVE → DEPRECATED (`status`), with
+   `activated_at`/`deprecated_at` timestamps and `successor_id` lineage. Published versions are not edited in place;
+   change is managed via new versions and deprecation (see ADR-0022 for successor lineage).
+
+4. **Dimension stored explicitly** using the `MONETARY/ENERGY/QUANTITY/COMPUTE/TIME/MASS/VOLUME` enum, required for the
+   `ParseQuantity()` factory (see ADR-0013 Generic Bridge section).
+
+5. **Schema-per-tenant**: no `tenant_id` column; isolation is by the tenant's `org_<id>` schema. Platform instruments
+   are seeded per tenant with `is_system = true`.
 
 ### Domain Types
 
 ```go
-// InstrumentDefinition is the domain type for instrument reference data.
-// Maps to BIAN FinancialInstrumentDirectoryEntry.
+// InstrumentDefinition is the domain type for instrument reference data
+// (package: services/reference-data/registry). Maps to BIAN
+// FinancialInstrumentDirectoryEntry. No TenantID field - tenancy is the schema.
 type InstrumentDefinition struct {
-    ID        uuid.UUID
-    TenantID  uuid.UUID
+    ID uuid.UUID
 
     // Identification
     Code      string  // "USD", "KWH", "RICE-VOUCHER"
     Version   uint32  // Schema version (1, 2, 3...)
-    Dimension string  // "Monetary" or "Commodity"
+    Dimension string  // "MONETARY", "ENERGY", "QUANTITY", "COMPUTE", "TIME", "MASS", "VOLUME"
 
     // Properties
     Precision int     // Decimal places
 
     // CEL Expressions (compiled at load time)
-    ValidationExpression  string  // Ingestion gatekeeper
-    FungibilityExpression string  // Position merge arbiter
+    ValidationExpression     string  // Ingestion gatekeeper (single input: attributes)
+    FungibilityKeyExpression string  // Returns a string bucket key for one position
+    ErrorMessageExpression   string  // Optional custom validation-failure message
+
+    // JSON Schema (retained alongside CEL)
+    AttributeSchema []byte
 
     // Display
     DisplayName string
     Description string
 
     // Lifecycle
-    CreatedAt time.Time
+    Status       string     // DRAFT | ACTIVE | DEPRECATED
+    IsSystem     bool       // platform-seeded instrument
+    SuccessorID  *uuid.UUID // lineage to replacement version (ADR-0022)
+    CreatedAt    time.Time
+    UpdatedAt    time.Time
+    ActivatedAt  *time.Time
+    DeprecatedAt *time.Time
 }
 
 // ToFinancialInstrument converts to the ADR-0013 domain type.
@@ -194,91 +254,78 @@ func (d InstrumentDefinition) ToFinancialInstrument() FinancialInstrument {
 
 ### CEL Expression Definitions
 
-Each instrument defines two CEL expressions:
+Each instrument defines two CEL expressions. Both take a **single** position's attributes (variable named
+`attributes`); the validation env also exposes `amount`, `valid_from`, `valid_to`, and `source`.
 
-**1. Validation Expression** - Ingestion gatekeeper (single input: `attrs`)
+**1. Validation Expression** - Ingestion gatekeeper. Returns a bool (single input: `attributes`)
 
 ```cel
 // Simple: require expiry_date exists
-has(attrs.expiry_date)
+has(attributes.expiry_date)
 
 // With type validation
-has(attrs.expiry_date) && has(attrs.quality_grade) &&
-  attrs.quality_grade in ["A", "B", "C"]
+has(attributes.expiry_date) && has(attributes.quality_grade) &&
+  attributes.quality_grade in ["A", "B", "C"]
 
 // Temporal: expiry must be in the future
-has(attrs.expiry_date) &&
-  timestamp(attrs.expiry_date) > now()
+has(attributes.expiry_date) &&
+  timestamp(attributes.expiry_date) > now()
 
 // Energy with time-of-use period
-has(attrs.tou_period) &&
-  int(attrs.tou_period) >= 0 && int(attrs.tou_period) <= 47
+has(attributes.tou_period) &&
+  int(attributes.tou_period) >= 0 && int(attributes.tou_period) <= 47
 ```
 
-**2. Fungibility Expression** - Position merge arbiter (two inputs: `a`, `b`)
+**2. Fungibility Key Expression** - Position bucketing. Returns a **string** key (single input: `attributes`).
+Two positions are fungible iff they evaluate to the same key. There is no pairwise `a`/`b` comparison.
 
 ```cel
-// Simple equality (default)
-a == b
+// Default ('' empty expression): all positions of this instrument share one bucket (fully fungible)
 
-// Same expiry date required for merge
-a.expiry_date == b.expiry_date
+// Bucket by expiry date
+attributes.expiry_date
 
-// Same day and quality grade
-a.expiry_date == b.expiry_date && a.quality_grade == b.quality_grade
+// Bucket by expiry date AND quality grade
+attributes.expiry_date + "|" + attributes.quality_grade
 
-// Time-bound: same period required
-a.tou_period == b.tou_period
+// Energy: bucket by time-of-use period and tariff zone
+attributes.tou_period + "|" + attributes.tariff_zone
 ```
 
 ### CEL Compiler
 
-The service pre-compiles CEL expressions at load time for ~100ns validation:
+The shared compiler at `shared/pkg/cel/compiler.go` pre-compiles CEL expressions at load time for ~100ns evaluation.
+The `services/reference-data/cel` package is a thin re-export shim over it. The compiler maintains several
+single-input environments (the variable is `attributes`, a `map<string,string>`), notably:
+
+- a **validation** env (`attributes` plus `amount`, `valid_from`, `valid_to`, `source`) - the program returns a bool
+- a **bucket-key** env (`attributes`) - the program must return a **string**; a non-string result is an error
+  (`ErrBucketKeyNotString`)
+- additional envs for eligibility and event-filter expressions used elsewhere in the platform
 
 ```go
-import (
-    "github.com/google/cel-go/cel"
-    lru "github.com/hashicorp/golang-lru/v2"
-)
+import "github.com/google/cel-go/cel"
 
-// CELCompiler manages two CEL environments for different expression types.
-type CELCompiler struct {
-    validationEnv  *cel.Env  // Single input: attrs map
-    fungibilityEnv *cel.Env  // Two inputs: a, b maps
+// Bucket-key environment: single attributes map, expression MUST return a string.
+func createBucketKeyEnv() (*cel.Env, error) {
+    return cel.NewEnv(
+        cel.Variable("attributes", cel.MapType(cel.StringType, cel.StringType)),
+    )
 }
 
-// NewCELCompiler creates a compiler with pre-configured environments.
-func NewCELCompiler() (*CELCompiler, error) {
-    // Validation: single attrs map
-    valEnv, err := cel.NewEnv(
-        cel.Variable("attrs", cel.MapType(cel.StringType, cel.StringType)),
+// Validation environment: attributes + position metadata, expression returns a bool.
+func createValidationEnv() (*cel.Env, error) {
+    return cel.NewEnv(
+        cel.Variable("attributes", cel.MapType(cel.StringType, cel.StringType)),
+        cel.Variable("amount", cel.StringType),
+        cel.Variable("valid_from", cel.TimestampType),
+        cel.Variable("valid_to", cel.TimestampType),
+        cel.Variable("source", cel.StringType),
     )
-    if err != nil {
-        return nil, err
-    }
-
-    // Fungibility: two attribute maps (a and b)
-    fungEnv, err := cel.NewEnv(
-        cel.Variable("a", cel.MapType(cel.StringType, cel.StringType)),
-        cel.Variable("b", cel.MapType(cel.StringType, cel.StringType)),
-    )
-    if err != nil {
-        return nil, err
-    }
-
-    return &CELCompiler{
-        validationEnv:  valEnv,
-        fungibilityEnv: fungEnv,
-    }, nil
-}
-
-// CompiledInstrument holds pre-compiled CEL programs for an instrument.
-type CompiledInstrument struct {
-    Definition          InstrumentDefinition
-    ValidationProgram   cel.Program
-    FungibilityProgram  cel.Program
 }
 ```
+
+There is no dual-input `a`/`b` fungibility environment; fungibility is the single-input bucket-key program above.
 
 ### Schema-on-Write Validation
 
@@ -306,67 +353,61 @@ flowchart LR
 
 ### Service Interface (BIAN Operations)
 
+The registry interface is tenant-scoped by the request's `org_<id>` schema (resolved from context), so lookups take no
+`tenantID` parameter. Validation returns a bool; fungibility returns a bucket-key string.
+
 ```go
-// InstrumentReferenceDataService implements BIAN service operations.
-type InstrumentReferenceDataService interface {
-    // Register creates a new instrument definition (BIAN: Register)
+// Registry implements BIAN Financial Instrument Reference Data operations.
+// (services/reference-data/registry)
+type Registry interface {
+    // Register creates a new instrument definition (status DRAFT).
     // Validates CEL expressions compile before persisting.
     Register(ctx context.Context, def InstrumentDefinition) error
 
-    // Retrieve loads an instrument by code and version (BIAN: Retrieve)
-    // Pass version=0 to retrieve the latest version.
-    // Returns compiled CEL programs alongside the definition.
-    Retrieve(ctx context.Context, tenantID uuid.UUID, code string, version uint32) (CompiledInstrument, error)
+    // Retrieve loads an instrument by code and version. version=0 => latest.
+    Retrieve(ctx context.Context, code string, version uint32) (CachedInstrument, error)
 
-    // RetrieveLatest loads the latest version (convenience wrapper)
-    RetrieveLatest(ctx context.Context, tenantID uuid.UUID, code string) (CompiledInstrument, error)
+    // RetrieveLatest loads the latest version (convenience wrapper).
+    RetrieveLatest(ctx context.Context, code string) (CachedInstrument, error)
 
-    // ValidateAttributes executes the validation CEL program
-    ValidateAttributes(ctx context.Context, inst CompiledInstrument, attrs map[string]string) error
+    // Lifecycle transitions.
+    Activate(ctx context.Context, code string, version uint32) error
+    Deprecate(ctx context.Context, code string, version uint32, successorID *uuid.UUID) error
 
-    // AreFungible executes the fungibility CEL program
-    AreFungible(ctx context.Context, inst CompiledInstrument, a, b map[string]string) (bool, error)
+    // ValidateAttributes runs the compiled validation program (returns nil if valid).
+    ValidateAttributes(ctx context.Context, inst CachedInstrument, attributes map[string]string) error
+
+    // FungibilityKey runs the compiled bucket-key program for one position.
+    // Two positions are fungible iff their keys are equal.
+    FungibilityKey(ctx context.Context, inst CachedInstrument, attributes map[string]string) (string, error)
 }
 ```
 
-### System Tenant Inheritance
+### Platform Instruments (per-tenant seeding)
 
-Platform-wide instruments (USD, EUR, GBP) use the System Tenant ID:
-
-```go
-const SystemTenantID = "00000000-0000-0000-0000-000000000000"
-```
-
-**Lookup falls back to System Tenant:**
+There is no system-tenant UUID or cross-tenant fallback. Platform-wide instruments (GBP, USD, EUR) are seeded into
+**each tenant's own schema** at provisioning time via `registry/seeder.go`, flagged `is_system = true`:
 
 ```go
-func (s *service) Retrieve(
-    ctx context.Context,
-    tenantID uuid.UUID,
-    code string,
-    version uint32,
-) (CompiledInstrument, error) {
-    // 1. Try tenant-specific instrument first
-    inst, err := s.cache.Get(tenantID, code, version)
-    if err == nil {
-        return inst, nil
+// services/reference-data/registry/seeder.go (sketch)
+func (s *Seeder) SeedTenant(ctx context.Context, tenantID tenant.TenantID) error {
+    for _, def := range systemInstruments() { // GBP, USD, EUR ...
+        def.IsSystem = true
+        if err := s.registry.Register(ctx, def); err != nil { // writes into the tenant's org_<id> schema
+            return err
+        }
     }
-    if !errors.Is(err, ErrNotFound) {
-        return CompiledInstrument{}, err
-    }
-
-    // 2. Fall back to System Tenant
-    inst, err = s.cache.Get(SystemTenantID, code, version)
-    if err != nil {
-        return CompiledInstrument{}, fmt.Errorf("instrument %s (v%d) not found", code, version)
-    }
-    return inst, nil
+    return nil
 }
 ```
+
+Tenants can register their own instruments alongside the seeded `is_system` ones; lookups resolve within the tenant's
+schema, so no fallback chain is needed.
 
 ### Version Lifecycle
 
-Instrument versions are **immutable once created**. New requirements = new version:
+Published instrument versions are not edited in place; change is managed by registering new versions and using the
+DRAFT → ACTIVE → DEPRECATED lifecycle (with `successor_id` lineage). Old positions keep their version:
 
 ```mermaid
 stateDiagram-v2
@@ -387,65 +428,42 @@ stateDiagram-v2
 
 ### Caching Strategy
 
-Instrument definitions are read frequently, written rarely. Use **bounded LRU cache**
-to prevent memory leaks from temporary or abandoned instruments:
+Instrument definitions are read frequently, written rarely. The cache (`cache/instrument_cache.go`) uses bounded LRU
+(`hashicorp/golang-lru/v2`) but is structured as a **per-tenant map of LRU caches** - one LRU per tenant, lazily
+created - so a busy tenant cannot evict another tenant's hot entries. The per-tenant key is a struct of `{code,
+version}` and the value is a `*CachedInstrument` (definition + compiled CEL programs):
 
 ```go
 import lru "github.com/hashicorp/golang-lru/v2"
 
-type CachedReferenceData struct {
-    db       *sql.DB
-    cache    *lru.Cache[string, CompiledInstrument]  // Bounded LRU
-    compiler *CELCompiler
+type InstrumentCache struct {
+    mu           sync.RWMutex
+    tenantCaches map[tenant.TenantID]*lru.Cache[Key, *CachedInstrument] // one LRU per tenant
+    maxPerTenant int
+    compiler     *cel.Compiler
 }
 
-func NewCachedReferenceData(db *sql.DB, maxEntries int) (*CachedReferenceData, error) {
-    cache, err := lru.New[string, CompiledInstrument](maxEntries)
-    if err != nil {
-        return nil, err
-    }
-    compiler, err := NewCELCompiler()
-    if err != nil {
-        return nil, err
-    }
-    return &CachedReferenceData{
-        db:       db,
-        cache:    cache,
-        compiler: compiler,
-    }, nil
+type Key struct {
+    Code    string
+    Version uint32
 }
 
-func (r *CachedReferenceData) Get(
-    tenantID uuid.UUID,
-    code string,
-    version uint32,
-) (CompiledInstrument, error) {
-    key := fmt.Sprintf("%s:%s:%d", tenantID, code, version)
-
-    if cached, ok := r.cache.Get(key); ok {
-        return cached, nil
+func (c *InstrumentCache) tenantCache(t tenant.TenantID) *lru.Cache[Key, *CachedInstrument] {
+    c.mu.Lock()
+    defer c.mu.Unlock()
+    cache, ok := c.tenantCaches[t]
+    if !ok {
+        cache, _ = lru.New[Key, *CachedInstrument](c.maxPerTenant) // created on first use
+        c.tenantCaches[t] = cache
     }
-
-    // Load from DB and compile CEL expressions
-    def, err := r.loadFromDB(tenantID, code, version)
-    if err != nil {
-        return CompiledInstrument{}, err
-    }
-
-    compiled, err := r.compiler.Compile(def)
-    if err != nil {
-        return CompiledInstrument{}, fmt.Errorf("compile CEL: %w", err)
-    }
-
-    r.cache.Add(key, compiled)  // LRU evicts oldest if full
-    return compiled, nil
+    return cache
 }
 ```
 
-**Why bounded LRU:**
-- `sync.Map` grows unbounded → memory leak risk with temporary instruments
-- LRU evicts least-recently-used when capacity reached
-- Recommended capacity: 10,000 entries (typical: ~100 active instruments per tenant)
+**Why per-tenant bounded LRU:**
+- A single flat cache lets one noisy tenant evict others' entries; per-tenant LRUs isolate eviction.
+- `sync.Map` grows unbounded → memory leak risk with temporary instruments.
+- LRU evicts least-recently-used when a tenant's cache reaches capacity.
 
 ## Positive Consequences
 
@@ -453,9 +471,9 @@ func (r *CachedReferenceData) Get(
 * **Tenant autonomy**: New instruments via configuration, no code deployment
 * **CEL performance**: ~100ns validation vs ~1ms JSON Schema
 * **Fungibility rules**: Tenant-defined position merge logic without code changes
-* **Version clarity**: Different versions are explicitly distinct, immutable
-* **Cache-friendly**: Compiled CEL programs cached in bounded LRU
-* **System Tenant**: Platform instruments (USD, EUR) inherited by all tenants
+* **Version clarity**: Different versions are explicitly distinct, with a DRAFT/ACTIVE/DEPRECATED lifecycle
+* **Cache-friendly**: Compiled CEL programs cached in per-tenant bounded LRUs
+* **Platform instruments**: GBP/USD/EUR seeded per tenant (`is_system = true`) so every tenant has base currencies
 
 ## Negative Consequences
 
@@ -478,10 +496,11 @@ func (r *CachedReferenceData) Get(
 
 ### Tenant Isolation
 
-Instrument definitions are tenant-scoped. The `tenant_id` column ensures:
-- Tenants cannot see or use other tenants' custom instruments
-- Platform-wide instruments (USD, EUR) use a special system tenant ID
-- Queries always filter by tenant
+Instrument definitions are tenant-scoped **by schema** (each tenant's `org_<id>` schema has its own
+`instrument_definition` table); there is no `tenant_id` column:
+- Tenants cannot see or use other tenants' custom instruments (different schemas)
+- Platform-wide instruments (GBP, USD, EUR) are seeded into each tenant's schema with `is_system = true`
+- Queries run within the tenant's `search_path`; no per-row tenant filter is needed
 
 ### Instrument Type Mapping Guidance
 
@@ -516,26 +535,29 @@ instrument types.
 
 ### Built-in Instruments
 
-Platform provides standard instruments via System Tenant that all tenants inherit:
+The platform seeds standard currencies into **each tenant's schema** (via `registry/seeder.go`), flagged
+`is_system = true`. There is no system-tenant row. Conceptually, per tenant:
 
 ```sql
--- System tenant for platform-wide instruments
-INSERT INTO instrument_definitions
-    (tenant_id, code, version, dimension, precision,
-     validation_expression, fungibility_expression, display_name)
+-- Seeded into each tenant's org_<id> schema at provisioning time
+INSERT INTO instrument_definition
+    (code, version, dimension, precision,
+     validation_expression, fungibility_key_expression, display_name, status, is_system)
 VALUES
-    ('00000000-0000-0000-0000-000000000000', 'USD', 1, 'Monetary', 2,
-     'true', 'a == b', 'US Dollar'),
-    ('00000000-0000-0000-0000-000000000000', 'EUR', 1, 'Monetary', 2,
-     'true', 'a == b', 'Euro'),
-    ('00000000-0000-0000-0000-000000000000', 'GBP', 1, 'Monetary', 2,
-     'true', 'a == b', 'British Pound');
+    ('USD', 1, 'MONETARY', 2, NULL, '', 'US Dollar',     'ACTIVE', TRUE),
+    ('EUR', 1, 'MONETARY', 2, NULL, '', 'Euro',          'ACTIVE', TRUE),
+    ('GBP', 1, 'MONETARY', 2, NULL, '', 'British Pound', 'ACTIVE', TRUE);
 ```
 
-**Note**: Fiat currencies use `'true'` for validation (no attributes required) and
-`'a == b'` for fungibility (all positions of same currency are fungible).
+**Note**: Fiat currencies need no validation (NULL) and an empty `fungibility_key_expression` (`''`), meaning all
+positions of the same currency fall into one bucket (fully fungible).
 
 ### Multi-Asset Instrument Examples
+
+> **Note:** The example INSERTs below predate the bucket-key fungibility model and the singular table name. Read them
+> for the CEL validation logic. In current code: the table is `instrument_definition` (singular, no `tenant_id`); the
+> fungibility column is `fungibility_key_expression` and must return a **string** key for one position (e.g.
+> `attributes.tou_period + "|" + attributes.tariff_zone`) rather than a pairwise `a.x == b.x` boolean.
 
 The following examples demonstrate CEL expressions for real-world commodity instruments.
 See [ADR-0013](0013-generic-asset-quantity-types.md) for corresponding Go usage examples.
@@ -629,39 +651,33 @@ package ngo
 import (
     "context"
 
-    "github.com/google/uuid"
-    "meridian/services/reference-data/domain"
+    "github.com/meridianhub/meridian/services/reference-data/registry"
 )
 
 // RegisterRiceVoucher creates a custom instrument for an NGO food distribution program.
 // Vouchers are redeemable for 1kg of rice at distribution centers.
-func RegisterRiceVoucher(
-    ctx context.Context,
-    referenceData InstrumentReferenceDataService,
-    ngoTenantID uuid.UUID,
-) error {
-    def := domain.InstrumentDefinition{
-        TenantID:  ngoTenantID,
+// The tenant is resolved from ctx (org_<id> schema), so there is no TenantID field.
+func RegisterRiceVoucher(ctx context.Context, reg registry.Registry) error {
+    def := registry.InstrumentDefinition{
         Code:      "RICE-VOUCHER",
         Version:   1,
-        Dimension: "Commodity",
+        Dimension: "QUANTITY",
         Precision: 0, // Whole vouchers only
 
         // Validation: expiry must be in the future, quality grade must be valid
-        ValidationExpression: `has(attrs.expiry_date) &&
-            timestamp(attrs.expiry_date) > now() &&
-            has(attrs.quality_grade) &&
-            attrs.quality_grade in ["A", "B", "C"]`,
+        ValidationExpression: `has(attributes.expiry_date) &&
+            timestamp(attributes.expiry_date) > now() &&
+            has(attributes.quality_grade) &&
+            attributes.quality_grade in ["A", "B", "C"]`,
 
-        // Fungibility: same expiry date AND quality grade can merge
-        FungibilityExpression: `a.expiry_date == b.expiry_date &&
-            a.quality_grade == b.quality_grade`,
+        // Fungibility key: bucket by expiry date + quality grade (same key => fungible)
+        FungibilityKeyExpression: `attributes.expiry_date + "|" + attributes.quality_grade`,
 
         DisplayName: "Rice Voucher",
         Description: "Redeemable voucher for 1kg of rice at distribution centers",
     }
 
-    return referenceData.Register(ctx, def)
+    return reg.Register(ctx, def)
 }
 ```
 
@@ -745,35 +761,43 @@ newPosition := Position{
 
 ### gRPC API (BIAN Operations)
 
+The real service is `ReferenceDataService` (`api/proto/meridian/reference_data/v1/instrument.proto`). It exposes the
+full lifecycle, and carries **both** the CEL expressions and the JSON Schema (`attribute_schema`) - they coexist.
+
 ```protobuf
-service FinancialInstrumentReferenceDataManagement {
-    // BIAN: Register
-    rpc Register(RegisterInstrumentRequest) returns (FinancialInstrumentDirectoryEntry);
-
-    // BIAN: Retrieve
-    rpc Retrieve(RetrieveInstrumentRequest) returns (FinancialInstrumentDirectoryEntry);
-
-    // BIAN: Retrieve (list)
-    rpc List(ListInstrumentsRequest) returns (ListInstrumentsResponse);
-
-    // BIAN: Update (deprecate)
-    rpc Deprecate(DeprecateInstrumentRequest) returns (FinancialInstrumentDirectoryEntry);
+service ReferenceDataService {
+    rpc RegisterInstrument(RegisterInstrumentRequest) returns (Instrument);
+    rpc RetrieveInstrument(RetrieveInstrumentRequest) returns (Instrument);
+    rpc ListInstruments(ListInstrumentsRequest) returns (ListInstrumentsResponse);
+    rpc UpdateInstrument(UpdateInstrumentRequest) returns (Instrument);   // DRAFT edits
+    rpc ActivateInstrument(ActivateInstrumentRequest) returns (Instrument);
+    rpc DeprecateInstrument(DeprecateInstrumentRequest) returns (Instrument);
+    rpc EvaluateInstrument(EvaluateInstrumentRequest) returns (EvaluateInstrumentResponse); // CEL playground
+    rpc GetAttributeSchema(GetAttributeSchemaRequest) returns (GetAttributeSchemaResponse);
+    // (plus account-type and node RPCs on the same service)
 }
 
 message RegisterInstrumentRequest {
-    string instrument_code = 1;
-    string instrument_type = 2;     // Currency, Debt, Equity, Derivative, Commodity
-    string instrument_name = 3;
-    int32 precision = 4;
-    string attribute_schema = 5;    // JSON Schema as string
-    string description = 6;
+    string instrument_code            = 1;
+    string instrument_type            = 2;  // maps to dimension
+    string instrument_name            = 3;
+    int32  precision                  = 4;
+    string validation_expression      = 5;  // CEL (bool)
+    string fungibility_key_expression = 6;  // CEL (returns string bucket key)
+    string error_message_expression   = 7;  // CEL (optional)
+    string attribute_schema           = 8;  // JSON Schema (coexists with CEL)
+    string description                = 9;
 }
 
 message RetrieveInstrumentRequest {
     string instrument_code = 1;
-    uint32 version = 2;             // 0 = latest non-deprecated
+    uint32 version         = 2;  // 0 = latest
 }
 ```
+
+> Note: the field numbers above mirror the proto's mix of CEL and JSON-Schema fields; consult the proto for the exact
+> wire numbers. The point is that lifecycle RPCs (`Update`/`Activate`/`Deprecate`) and JSON Schema both exist - the
+> earlier draft's "no deprecate, CEL replaces JSON Schema" framing did not ship.
 
 ### Consumer Guidance: Partition Routing
 
@@ -781,7 +805,7 @@ Consumers of this service (e.g., Position Keeping, Ledger) may partition storage
 dimension for regulatory segregation. The dimension is derived from `instrument_type`:
 
 ```go
-dimension := instrument.InstrumentType.Dimension()  // "Monetary" or "Commodity"
+dimension := instrument.Dimension  // "MONETARY", "ENERGY", "QUANTITY", "COMPUTE", "TIME", "MASS", "VOLUME"
 ```
 
 This keeps the Reference Data service focused on its BIAN responsibility (instrument

--- a/docs/adr/0017-temporal-quality-ladder.md
+++ b/docs/adr/0017-temporal-quality-ladder.md
@@ -20,7 +20,7 @@ Date: 2025-12-14
 
 ## Status
 
-Proposed
+Accepted (Implemented)
 
 ## Context
 

--- a/docs/adr/0018-settlement-reconciliation.md
+++ b/docs/adr/0018-settlement-reconciliation.md
@@ -19,7 +19,7 @@ Date: 2025-12-14
 
 ## Status
 
-Proposed
+Accepted (Implemented)
 
 ## Context
 

--- a/docs/adr/0020-per-service-audit-workers.md
+++ b/docs/adr/0020-per-service-audit-workers.md
@@ -34,7 +34,7 @@ Deprecate Centralized) are all CANCELLED in favor of the Kafka-based dual-path a
 
 ## Context
 
-ADR-0009 established the transactional outbox pattern for application-level audit logging. The current implementation (`services/audit-worker/main.go`) deploys a centralized audit-worker service that connects to a single database and processes audit_outbox entries.
+ADR-0009 established the transactional outbox pattern for application-level audit logging. The current implementation (`services/audit-worker/cmd/main.go`) deploys a centralized audit-worker service that connects to a single database and processes audit_outbox entries.
 
 As the platform grows to 6 services with separate database schemas (current-account, position-keeping, financial-accounting, party, payment-order, tenant), we must decide how to scale audit processing:
 

--- a/docs/adr/0022-instrument-successor-lineage.md
+++ b/docs/adr/0022-instrument-successor-lineage.md
@@ -26,7 +26,7 @@ Date: 2026-01-05
 
 ## Status
 
-Proposed
+Accepted (Implemented)
 
 ## Context
 

--- a/docs/adr/0028-starlark-saga-cel-valuation.md
+++ b/docs/adr/0028-starlark-saga-cel-valuation.md
@@ -15,11 +15,17 @@ instructions: |
 
 # 28. Starlark Saga Orchestration with CEL Valuation
 
-Date: 2025-01-20
+Date: 2026-01-20
 
 ## Status
 
 Accepted (PRD approved for baseline)
+
+Supersedes the hand-written Go saga orchestration approach in
+[ADR-0002](0002-microservices-per-bian-domain.md#amendment-saga-orchestration-pattern-2025-11-19) and
+[ADR-0012](0012-lien-based-fund-reservation.md): saga step sequencing and LIFO compensation are now defined as
+Starlark scripts (stored as saga definitions in reference-data) and executed by `shared/pkg/saga.StarlarkSagaRunner`,
+rather than hardcoded in each service's Go domain layer.
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,23 +48,23 @@ Architectural Decision Records) format.
 | [ADR-0007](0007-raw-yaml-over-helm-for-initial-development.md) | Raw YAML over Helm for Initial Development | Accepted | 2025-10-25 |
 <!-- markdownlint-enable MD013 -->
 | [ADR-0008](0008-defensive-testing-standards.md) | Defensive Testing Standards | Accepted | 2025-10-25 |
-| [ADR-0009](0009-application-level-audit-logging.md) | Application-Level Audit Logging | Proposed | 2025-11-04 |
+| [ADR-0009](0009-application-level-audit-logging.md) | Application-Level Audit Logging | Accepted | 2025-11-04 |
 <!-- markdownlint-disable-next-line MD013 -->
 | [ADR-0010](0010-grpc-client-side-load-balancing.md) | gRPC Client-Side Load Balancing with Headless Services | Accepted | 2025-11-14 |
 | [ADR-0011](0011-iso-20022-compliance-via-adapter-layer.md) | ISO 20022 Compliance via Adapter Layer | Accepted | 2025-11-14 |
 | [ADR-0012](0012-lien-based-fund-reservation.md) | Lien-Based Fund Reservation for Payment Order Saga | Accepted | 2025-11-25 |
-| [ADR-0013](0013-generic-asset-quantity-types.md) | Universal Quantity Type System | Proposed | 2025-12-03 |
-| [ADR-0014](0014-financial-instrument-reference-data.md) | Financial Instrument Reference Data | Proposed | 2025-12-04 |
+| [ADR-0013](0013-generic-asset-quantity-types.md) | Universal Quantity Type System | Accepted | 2025-12-03 |
+| [ADR-0014](0014-financial-instrument-reference-data.md) | Financial Instrument Reference Data | Accepted | 2025-12-04 |
 | [ADR-0015](0015-standard-service-directory-structure.md) | Standard Service Directory Structure | Accepted | 2025-12-06 |
 | [ADR-0016](0016-tenant-id-naming-strategy.md) | Tenant ID Naming Strategy | Accepted | 2025-12-13 |
 <!-- markdownlint-disable-next-line MD013 -->
-| [ADR-0017](0017-temporal-quality-ladder.md) | Temporal Quality Ledger (Data Physics) | Proposed | 2025-12-14 |
-| [ADR-0018](0018-settlement-reconciliation.md) | Settlement & Reconciliation (Lifecycle) | Proposed | 2025-12-14 |
+| [ADR-0017](0017-temporal-quality-ladder.md) | Temporal Quality Ledger (Data Physics) | Accepted | 2025-12-14 |
+| [ADR-0018](0018-settlement-reconciliation.md) | Settlement & Reconciliation (Lifecycle) | Accepted | 2025-12-14 |
 | [ADR-0019](0019-resilient-client-patterns.md) | Resilient Client Patterns | Accepted | 2025-12-18 |
 | [ADR-0020](0020-per-service-audit-workers.md) | Per-Service Audit Workers | Accepted | 2025-12-20 |
 <!-- markdownlint-disable-next-line MD013 -->
 | [ADR-0021](0021-kyc-aml-verification-provider-architecture.md) | KYC/AML Verification Provider Architecture | Proposed | 2025-12-22 |
-| [ADR-0022](0022-instrument-successor-lineage.md) | Instrument Successor Lineage | Proposed | 2025-12-28 |
+| [ADR-0022](0022-instrument-successor-lineage.md) | Instrument Successor Lineage | Accepted | 2025-12-28 |
 <!-- markdownlint-disable-next-line MD013 -->
 | [ADR-0023](0023-balance-delegation-to-position-keeping.md) | Balance Delegation to Position Keeping | Accepted | 2026-01-08 |
 | [ADR-0024](0024-internal-bank-account-service.md) | Internal Account Service Domain | Accepted | 2026-01-15 |
@@ -75,17 +75,31 @@ Architectural Decision Records) format.
 <!-- markdownlint-disable-next-line MD013 -->
 | [ADR-0027](0027-market-information-management.md) | Market Information Management Service Architecture | Accepted | 2026-01-19 |
 <!-- markdownlint-disable-next-line MD013 -->
-| [ADR-0028](0028-starlark-saga-cel-valuation.md) | Starlark Saga Orchestration with CEL Valuation | Accepted | 2025-01-20 |
+| [ADR-0028](0028-starlark-saga-cel-valuation.md) | Starlark Saga Orchestration with CEL Valuation | Accepted | 2026-01-20 |
+<!-- markdownlint-disable-next-line MD013 -->
+| [ADR-0029](0029-settlement-scheduler-architecture.md) | Settlement Scheduler Architecture | Accepted | 2026-02-09 |
+<!-- markdownlint-disable-next-line MD013 -->
+| [ADR-0030](0030-kyc-aml-provider-selection.md) | KYC/AML Provider Selection | Accepted | 2026-02-12 |
 <!-- markdownlint-disable-next-line MD013 -->
 | [ADR-0031](0031-getbalance-nil-guard-retention.md) | Retain Nil Guard on PositionKeepingClient in GetBalance | Accepted | 2026-02-13 |
 <!-- markdownlint-disable-next-line MD013 -->
 | [ADR-0032](0032-vanguard-json-transcoding-gateway.md) | Vanguard HTTP/JSON Transcoding Gateway | Accepted | 2026-02-20 |
 <!-- markdownlint-disable-next-line MD013 -->
 | [ADR-0033](0033-event-triggered-sagas.md) | Event-Triggered Sagas | Accepted | 2026-03-04 |
+<!-- markdownlint-disable-next-line MD013 -->
+| [ADR-0034](0034-position-compaction-strategy.md) | Position Compaction Strategy | Accepted | 2026-03-06 |
+<!-- markdownlint-disable-next-line MD013 -->
+| [ADR-0035](0035-multi-asset-purity.md) | Multi-Asset Purity Enforcement | Accepted | 2026-03-07 |
+<!-- markdownlint-disable-next-line MD013 -->
+| [ADR-0036](0036-embedded-dex-identity.md) | Embed Dex OIDC Server in the Meridian Binary | Accepted | 2026-03-13 |
+<!-- markdownlint-disable-next-line MD013 -->
+| [ADR-0037](0037-scheduler-attribution-design.md) | Scheduler Attribution Design | Accepted | 2026-04-07 |
 
 ## Architecture Decision Relationships
 
-Key architectural decisions and their dependencies:
+Key **foundational** architectural decisions and their dependencies. This graph is intentionally scoped to the
+foundational set and does not depict every ADR; consult the full index table above for the complete list (including
+the saga set ADR-0028/0033 and later decisions ADR-0029 onward).
 
 ```mermaid
 graph LR


### PR DESCRIPTION
## Summary

Refreshes the highest-pagerank, load-bearing ADR hubs to match the current code, and fixes a set of ADR-index / cross-ADR contradictions surfaced by a documentation contradiction sweep. Markdown-only; no code changes. All edits are confined to `docs/adr/`.

Combines two assessment tasks:
- **Task 6** - refresh 5 stale ADR hubs against current code.
- **Task 13** - contradiction sweep across the doc tree (ADR contradictions folded in here; non-ADR contradictions reported below as a triage list for follow-up).

## Changes Made

### Task 6 - ADR hub refresh (verified against current code)

- **ADR-0002 (Microservices per BIAN Domain)** - ~19 services (not 3/6), shipped today as one unified binary (`cmd/meridian`); corrected the "Service Structure" block (`services/<svc>/{domain,adapters/persistence,adapters/messaging,service,migrations}`, Atlas not Flyway, single `go.mod`); shared platform code at `shared/` not `pkg/`; saga-orchestration amendment marked superseded by Starlark (ADR-0028); forbidden-import examples updated to `services/` paths.
- **ADR-0003 (Database Migrations with Atlas)** - migrations are explicit (`--migrate` / `atlas migrate apply`), not auto-on-startup; corrected to the real per-service layout `services/<svc>/atlas/atlas.hcl` + `services/<svc>/migrations/`; `utilities/atlas-loader` (not `cmd/atlas-loader`); real CI path triggers.
- **ADR-0004 (Event Schema Evolution)** - documented the real topic convention `<service>.<event>.v1` (`shared/platform/events/topics/topics.go`); corrected the outbox to table `event_outbox` with a `status` column + compound polling index (not `outbox` + `published_at` partial index), `BYTEA` payload, 5s default poll interval; idempotency via `shared/pkg/idempotency` (`idempotency:result:*` keys / `_idempotency_keys` table, configurable TTL); event protos at `api/proto/meridian/events/v1`; `buf breaking` targets `develop`.
- **ADR-0005 (Adapter Pattern)** - all paths moved from `internal/` to `services/<svc>/...`; `adapters/events`->`adapters/messaging`, `adapters/grpc`->`service`; outbox-backed publishing; corrected import prefixes. (Decision/pattern unchanged - still accurate.)
- **ADR-0014 (Financial Instrument Reference Data)** - largest drift; promoted Proposed->Accepted with a drift summary. Table `instrument_definition` (singular, no `tenant_id`, schema-per-tenant); fungibility is a single-input **bucket-key** CEL returning a string (`fungibility_key_expression`), not a pairwise `a==b` boolean; DRAFT->ACTIVE->DEPRECATED lifecycle with Update/Activate/Deprecate RPCs; CEL and JSON Schema coexist; platform instruments seeded per-tenant via `is_system=true` (no SystemTenantID/fallback); shared CEL compiler (`attributes` var); per-tenant LRU caches; service is `ReferenceDataService`. Removed the internal self-contradiction (the old gRPC block advertised `attribute_schema`/`Deprecate` while the decision claimed "CEL replaces JSON Schema, immutable, no deprecate").

### Task 13 - ADR-set contradictions folded in

- **README index**: added six ADRs that existed on disk but were missing from the index (0029, 0030, 0034-0037); reordered numerically; captioned the relationship graph as foundational-only.
- **Stale statuses**: promoted shipped ADRs Proposed->Accepted in both index and file headers (0009, 0013, 0014, 0017, 0018, 0022) to remove README-vs-file drift.
- **Saga supersession (highest-severity)**: ADR-0028 now records that it supersedes the hand-written Go saga orchestration in ADR-0002/0012; ADR-0012 carries a matching note (lien decision still holds, Go control flow superseded).
- **ADR-0028** date typo fixed (2025-01-20 -> 2026-01-20); **ADR-0020** path fixed (`audit-worker/main.go` -> `cmd/main.go`).

## Verification

- All internal `docs/adr/` relative `.md` links resolve (scripted check; the only two flags were a false positive on Go code and a pre-existing external BIAN-spec path I did not touch).
- `markdownlint` passes via pre-commit on every commit.
- Each ADR claim above was verified against the actual code (services layout, `topics.go`, `event_outbox` schema, `shared/pkg/idempotency`, reference-data migrations/proto/registry, control-plane Starlark saga runner) before editing.

## Risk Assessment

Documentation-only. No runtime, schema, or build impact.

---

## Task 13 triage - non-ADR contradictions (for follow-up; NOT fixed here)

These are outside `docs/adr/` (owned by the docs-links teammate / future tasks). Ranked by how confidently an agent following links from `README.md` would be misled. File:line refs are at the time of the sweep.

### HIGH
1. **`docs/architecture/data-model.md:112` (and `:62`)** - control-plane shown in DB `meridian_platform`/schema `public`; actually `meridian_control_plane` with tables in tenant `org_<id>` schemas (per `services/control-plane/migrations/20260209000001_staff_identity.sql:2-3`). Also contradicts `services/README.md:1156`.
2. **`services/README.md:707`** - tenant ER diagram labels DB `meridian_tenant`, which does not exist; tenant uses `meridian_platform` (`.env.example:31`). `data-model.md:128` has it right.
3. **Root `README.md:124-146`** - service tables list 15 services and omit `tenant` and `audit-worker`; there are 19 (`docs/architecture-layers.md:5,9`).

### MEDIUM
4. **`services/README.md:189,339`** - audit topics shown as per-service `audit.events.<service>`; code uses a single `audit.events.v1` (`shared/platform/events/topics/topics.go:13`).
5. **`docs/local-documentation.md:69-71,207-215`** - stale `internal/<service>/...` Go package paths and `go doc` examples; real path is `services/<service>/...`.
6. **`docs/runbooks/saga-failure-recovery.md:526-527`** - dead links to `internal/current-account/service/grpc_service.go` (path renamed to `services/...`, file no longer exists).

### LOW
7. **`docs/skills/schema-evolution.md:216,221,437`** - stale `internal/adapters/events/` path.
8. **`docs/coupling-visualization-example.md:20-24`** - references `internal/platform/...`; now `shared/platform/...`.
9. **`docs/architecture/event-driven-architecture.md:857`** - `buf breaking --against '.git#branch=main'`; should be `develop`.

Clean (verified, no action): `docs/patterns.md`, `docs/data-flows.md`, `docs/saga-handler-loading.md` (all sampled refs resolve); Flyway only appears in historical PRDs and "what not to do" tables; LISTEN/NOTIFY consistently described as unsupported on CockroachDB.
