### PR TITLE
fix: Correct CSV import resume off-by-one duplicating ledger positions

### DIFF
--- a/cmd/position-tool/cmd/import.go
+++ b/cmd/position-tool/cmd/import.go
@@ -343,8 +343,8 @@ type importProcessor struct {
 // processRow handles validation and insertion of a single CSV row.
 // Returns an error only for fatal errors that should stop processing.
 func (p *importProcessor) processRow(ctx context.Context, csvRow *csvadapter.ImportRow) error {
-	// Skip rows before the resume point
-	if p.cp.ProcessedRows > 0 && csvRow.LineNumber <= p.cp.LastProcessedLine {
+	// Skip rows already committed in a prior run when resuming.
+	if p.cp.ShouldSkipResumedLine(csvRow.LineNumber) {
 		return nil
 	}
 

--- a/cmd/position-tool/cmd/import_resume_integration_test.go
+++ b/cmd/position-tool/cmd/import_resume_integration_test.go
@@ -36,13 +36,18 @@ const (
 // setupResumeTestPool returns a pgx pool on a CockroachDB testcontainer with a
 // minimal position table.
 //
-// It uses testdb.NewCockroachTestPool for production parity: the BatchInserter
-// requires a *pgxpool.Pool, so SetupCockroachDB (which returns a *gorm.DB) does
-// not fit, and NewTestPool is Postgres-backed. Migrations are applied manually
-// rather than via WithMigrations because the production position-keeping
-// migrations include plpgsql triggers, which CockroachDB does not support; this
-// test only INSERTs (never UPDATEs) positions, so the append-only trigger and
-// the rest of the schema are unnecessary.
+// It uses testdb.NewCockroachTestPool (which wraps the shared
+// StartCockroachContainer + CockroachDSN helpers for production parity) rather
+// than testdb.SetupCockroachDB because the position-tool is pgx-based, not gorm:
+// the BatchInserter and tenant helpers operate on a *pgxpool.Pool, whereas
+// SetupCockroachDB returns a *gorm.DB and cannot satisfy them. This mirrors the
+// established pgxpool pattern in cmd/position-tool/integration_test.go.
+//
+// Migrations are applied manually rather than via WithMigrations because the
+// production position-keeping migrations include plpgsql triggers, which
+// CockroachDB does not support; this test only INSERTs (never UPDATEs)
+// positions, so the append-only trigger and the rest of the schema are
+// unnecessary.
 func setupResumeTestPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 

--- a/cmd/position-tool/cmd/import_resume_integration_test.go
+++ b/cmd/position-tool/cmd/import_resume_integration_test.go
@@ -33,22 +33,23 @@ const (
 	resumeTestFungibilityExpr = `attributes["registry"]`
 )
 
-// setupResumeTestPool starts a CockroachDB container and returns a connection
-// pool with a minimal position table. The append-only plpgsql trigger from the
-// production migration is intentionally omitted: CockroachDB does not support
-// plpgsql triggers, and these tests only INSERT (never UPDATE) positions.
+// setupResumeTestPool returns a pgx pool on a CockroachDB testcontainer with a
+// minimal position table.
+//
+// It uses testdb.NewCockroachTestPool for production parity: the BatchInserter
+// requires a *pgxpool.Pool, so SetupCockroachDB (which returns a *gorm.DB) does
+// not fit, and NewTestPool is Postgres-backed. Migrations are applied manually
+// rather than via WithMigrations because the production position-keeping
+// migrations include plpgsql triggers, which CockroachDB does not support; this
+// test only INSERTs (never UPDATEs) positions, so the append-only trigger and
+// the rest of the schema are unnecessary.
 func setupResumeTestPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 
-	container, _ := testdb.StartCockroachContainer(t, "test_position_tool")
-	dsn := testdb.CockroachDSN(t, container)
+	pool := testdb.NewCockroachTestPool(t)
 
 	ctx := context.Background()
-	pool, err := pgxpool.New(ctx, dsn)
-	require.NoError(t, err, "failed to create connection pool")
-	t.Cleanup(pool.Close)
-
-	_, err = pool.Exec(ctx, `
+	_, err := pool.Exec(ctx, `
 		CREATE TABLE "position" (
 			"id" uuid NOT NULL DEFAULT gen_random_uuid(),
 			"created_at" timestamptz NOT NULL DEFAULT now(),

--- a/cmd/position-tool/cmd/import_resume_integration_test.go
+++ b/cmd/position-tool/cmd/import_resume_integration_test.go
@@ -1,0 +1,231 @@
+// Integration tests for the CSV import resume guard.
+//
+// These tests drive the real importProcessor.processRow path against a live
+// CockroachDB container to prove the resume off-by-one fix end to end:
+// a data row already committed before an interruption must not be reprocessed
+// (and thus duplicated as a ledger position) when the import resumes and
+// re-reads the source file from the top.
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	csvadapter "github.com/meridianhub/meridian/cmd/position-tool/internal/adapters/csv"
+	"github.com/meridianhub/meridian/cmd/position-tool/internal/checkpoint"
+	"github.com/meridianhub/meridian/cmd/position-tool/internal/infra"
+	"github.com/meridianhub/meridian/cmd/position-tool/internal/validation"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+)
+
+const (
+	resumeTestInstrument = "CARBON_CREDIT"
+	resumeTestTenant     = "resume-test-tenant"
+	// fungibilityExpr yields a non-empty bucket key from row attributes so
+	// domain.NewPosition (which rejects empty bucket keys) succeeds.
+	resumeTestFungibilityExpr = `attributes["registry"]`
+)
+
+// setupResumeTestPool starts a CockroachDB container and returns a connection
+// pool with a minimal position table. The append-only plpgsql trigger from the
+// production migration is intentionally omitted: CockroachDB does not support
+// plpgsql triggers, and these tests only INSERT (never UPDATE) positions.
+func setupResumeTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	container, _ := testdb.StartCockroachContainer(t, "test_position_tool")
+	dsn := testdb.CockroachDSN(t, container)
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	require.NoError(t, err, "failed to create connection pool")
+	t.Cleanup(pool.Close)
+
+	_, err = pool.Exec(ctx, `
+		CREATE TABLE "position" (
+			"id" uuid NOT NULL DEFAULT gen_random_uuid(),
+			"created_at" timestamptz NOT NULL DEFAULT now(),
+			"created_by" character varying(100) NOT NULL,
+			"deleted_at" timestamptz NULL,
+			"account_id" character varying(34) NOT NULL,
+			"instrument_code" character varying(32) NOT NULL,
+			"bucket_key" character varying(256) NOT NULL,
+			"amount" decimal(38, 18) NOT NULL,
+			"dimension" character varying(32) NOT NULL DEFAULT 'Monetary',
+			"attributes" jsonb NULL,
+			"reference_id" uuid NULL,
+			PRIMARY KEY ("id")
+		)
+	`)
+	require.NoError(t, err, "failed to create position table")
+
+	return pool
+}
+
+// buildResumeTestRows builds n data rows mirroring a CSV layout: the header
+// occupies line 1, so the first data row is line 2 and the nth is line n+1.
+func buildResumeTestRows(n int) []csvadapter.ImportRow {
+	rows := make([]csvadapter.ImportRow, 0, n)
+	for i := 1; i <= n; i++ {
+		rows = append(rows, csvadapter.ImportRow{
+			LineNumber:     i + 1, // line 1 is the header
+			AccountID:      fmt.Sprintf("ACC-%03d", i),
+			InstrumentCode: resumeTestInstrument,
+			Amount:         fmt.Sprintf("%d", 100+i),
+			Timestamp:      time.Now().UTC(),
+			Attributes:     map[string]string{"registry": "VERRA", "vintage_year": "2024"},
+		})
+	}
+	return rows
+}
+
+// newResumeTestProcessor builds an importProcessor wired to the live pool but
+// with a stubbed instrument checker so no reference-data gRPC service is needed.
+// Each call models a fresh process invocation (its own batch inserter) while the
+// caller carries a single checkpoint across phases, exactly as resume does.
+func newResumeTestProcessor(t *testing.T, pool *pgxpool.Pool, cp *checkpoint.Checkpoint) *importProcessor {
+	t.Helper()
+
+	celEval, err := infra.NewCELEvaluatorDefault()
+	require.NoError(t, err, "failed to create CEL evaluator")
+
+	pipeline, err := validation.NewPipeline(validation.PipelineConfig{
+		DuplicateChecker: validation.NewDuplicateChecker(
+			validation.DefaultBloomFilterConfig(),
+			createDuplicateLookup(pool),
+		),
+		InstrumentChecker: &validation.MockInstrumentChecker{
+			CheckFunc: func(_ context.Context, _ string, _ int) (*validation.InstrumentCheckResult, error) {
+				return &validation.InstrumentCheckResult{Exists: true, IsActive: true}, nil
+			},
+		},
+		Logger: slog.Default(),
+	})
+	require.NoError(t, err, "failed to create validation pipeline")
+
+	batchInserter, err := infra.NewBatchInserter(infra.BatchInserterConfig{
+		Pool:      pool,
+		BatchSize: 100,
+	})
+	require.NoError(t, err, "failed to create batch inserter")
+
+	return &importProcessor{
+		cfg:           &importConfig{TenantID: resumeTestTenant, BatchSize: 100},
+		cp:            cp,
+		result:        &importResult{},
+		celEval:       celEval,
+		pipeline:      pipeline,
+		batchInserter: batchInserter,
+		logger:        slog.Default(),
+		// Pre-populated so processRow never calls the (nil) concrete instrument
+		// checker for the fungibility-key lookup.
+		fungibilityExprs: map[string]string{resumeTestInstrument: resumeTestFungibilityExpr},
+	}
+}
+
+// runImportPass processes every supplied row through a fresh processor and
+// flushes the batch, returning positions to the database. The shared checkpoint
+// is mutated in place so a subsequent pass observes prior progress.
+func runImportPass(ctx context.Context, t *testing.T, pool *pgxpool.Pool, cp *checkpoint.Checkpoint, rows []csvadapter.ImportRow) {
+	t.Helper()
+	proc := newResumeTestProcessor(t, pool, cp)
+	for i := range rows {
+		require.NoError(t, proc.processRow(ctx, &rows[i]))
+	}
+	require.NoError(t, proc.batchInserter.Flush(ctx))
+}
+
+func countAllResumePositions(ctx context.Context, t *testing.T, pool *pgxpool.Pool) int64 {
+	t.Helper()
+	var count int64
+	require.NoError(t, pool.QueryRow(ctx, `SELECT COUNT(*) FROM "position"`).Scan(&count))
+	return count
+}
+
+func countResumePositionsForAccount(ctx context.Context, t *testing.T, pool *pgxpool.Pool, accountID string) int64 {
+	t.Helper()
+	var count int64
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM "position" WHERE account_id = $1`, accountID).Scan(&count))
+	return count
+}
+
+// TestIntegration_ImportResumeGuard exercises the resume guard at its boundaries.
+//
+// A source file has a header on line 1 and 10 data rows on lines 2..11. M
+// processed data rows therefore occupy lines 2..M+1. On resume the import
+// re-reads the whole file; the guard must skip exactly the already-committed
+// lines and process the rest once.
+func TestIntegration_ImportResumeGuard(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	const totalDataRows = 10
+	ctx := context.Background()
+	pool := setupResumeTestPool(t)
+	rows := buildResumeTestRows(totalDataRows)
+
+	t.Run("boundary row is not reprocessed on resume", func(t *testing.T) {
+		const committed = 5
+		// Fresh state for this subtest.
+		_, err := pool.Exec(ctx, `DELETE FROM "position"`)
+		require.NoError(t, err)
+
+		cp := &checkpoint.Checkpoint{TenantID: resumeTestTenant, Status: checkpoint.StatusRunning}
+
+		// Phase 1: commit the first 5 data rows (lines 2..6), then interrupt.
+		runImportPass(ctx, t, pool, cp, rows[:committed])
+		require.Equal(t, committed, cp.ProcessedRows, "five data rows committed before interruption")
+		require.Equal(t, int64(committed), countAllResumePositions(ctx, t, pool))
+
+		// Phase 2: resume - re-read the whole file (all 10 rows). The guard must
+		// skip lines 2..6 and process lines 7..11 exactly once. The boundary is
+		// line 6 (the 5th, last-committed data row -> ACC-005): the pre-fix guard
+		// (<= ProcessedRows) would reprocess it and duplicate its position.
+		runImportPass(ctx, t, pool, cp, rows)
+
+		assert.Equal(t, int64(totalDataRows), countAllResumePositions(ctx, t, pool),
+			"resume must not duplicate any committed row")
+		for i := 1; i <= totalDataRows; i++ {
+			acct := fmt.Sprintf("ACC-%03d", i)
+			assert.Equal(t, int64(1), countResumePositionsForAccount(ctx, t, pool, acct),
+				"account %s must have exactly one position", acct)
+		}
+	})
+
+	t.Run("resume after zero rows processes all", func(t *testing.T) {
+		_, err := pool.Exec(ctx, `DELETE FROM "position"`)
+		require.NoError(t, err)
+
+		cp := &checkpoint.Checkpoint{TenantID: resumeTestTenant, Status: checkpoint.StatusRunning}
+		runImportPass(ctx, t, pool, cp, rows)
+
+		assert.Equal(t, totalDataRows, cp.ProcessedRows)
+		assert.Equal(t, int64(totalDataRows), countAllResumePositions(ctx, t, pool),
+			"a fresh import (ProcessedRows=0) must process every row")
+	})
+
+	t.Run("resume after all rows processes none", func(t *testing.T) {
+		_, err := pool.Exec(ctx, `DELETE FROM "position"`)
+		require.NoError(t, err)
+
+		cp := &checkpoint.Checkpoint{TenantID: resumeTestTenant, Status: checkpoint.StatusRunning}
+		// Commit all 10 rows.
+		runImportPass(ctx, t, pool, cp, rows)
+		require.Equal(t, totalDataRows, cp.ProcessedRows)
+		require.Equal(t, int64(totalDataRows), countAllResumePositions(ctx, t, pool))
+
+		// Resume after a completed pass: re-reading the file must add nothing.
+		runImportPass(ctx, t, pool, cp, rows)
+		assert.Equal(t, int64(totalDataRows), countAllResumePositions(ctx, t, pool),
+			"resuming a fully-processed file must not insert duplicates")
+	})
+}

--- a/cmd/position-tool/internal/checkpoint/doc.go
+++ b/cmd/position-tool/internal/checkpoint/doc.go
@@ -72,8 +72,9 @@
 //	    return err
 //	}
 //
-//	// Skip already-processed lines
-//	startLine := cp.LastProcessedLine + 1
+//	// Skip already-processed lines (header on line 1, so M processed
+//	// data rows occupy lines 2..M+1; the next line to process is M+2).
+//	startLine := cp.ProcessedRows + 2
 //
 // # Rollback
 //

--- a/cmd/position-tool/internal/checkpoint/manager.go
+++ b/cmd/position-tool/internal/checkpoint/manager.go
@@ -97,10 +97,6 @@ type Checkpoint struct {
 	// Status is the current status of the import.
 	Status Status
 
-	// LastProcessedLine is the last line number processed (1-indexed, for resume).
-	// This allows resumption from the exact line where import was interrupted.
-	LastProcessedLine int
-
 	// RollbackSQL contains SQL statements to undo the import (for partial rollback).
 	// Typically DELETE statements with the IDs of imported records.
 	RollbackSQL []string

--- a/cmd/position-tool/internal/checkpoint/manager_helpers.go
+++ b/cmd/position-tool/internal/checkpoint/manager_helpers.go
@@ -69,7 +69,6 @@ func (m *PostgresManager) scanCheckpoint(ctx context.Context, query string, args
 
 	cp.Status = Status(statusStr)
 	cp.RollbackSQL = decodeRollbackSQL(rollbackSQL)
-	cp.LastProcessedLine = cp.ProcessedRows // Use processed_rows as last line marker
 
 	return &cp, nil
 }
@@ -100,7 +99,6 @@ func scanCheckpointRow(rows pgx.Rows) (*Checkpoint, error) {
 
 	cp.Status = Status(statusStr)
 	cp.RollbackSQL = decodeRollbackSQL(rollbackSQL)
-	cp.LastProcessedLine = cp.ProcessedRows
 
 	return &cp, nil
 }
@@ -162,14 +160,25 @@ func (c *Checkpoint) AddRollbackStatement(sql string) {
 func (c *Checkpoint) IncrementSuccess(count int) {
 	c.SuccessCount += count
 	c.ProcessedRows += count
-	c.LastProcessedLine = c.ProcessedRows
 }
 
 // IncrementFailure increments the failure count and processed rows.
 func (c *Checkpoint) IncrementFailure(count int) {
 	c.FailureCount += count
 	c.ProcessedRows += count
-	c.LastProcessedLine = c.ProcessedRows
+}
+
+// ShouldSkipResumedLine reports whether a row at the given 1-indexed source
+// CSV line number was already processed in a prior run and must be skipped
+// when resuming an interrupted import.
+//
+// ProcessedRows counts data rows only. The source file carries a header on
+// line 1, so the first data row is line 2 and M processed data rows occupy
+// lines 2..M+1. The resume guard therefore skips up to and including line
+// ProcessedRows+1; using ProcessedRows alone would reprocess the last
+// committed data row and duplicate its ledger position.
+func (c *Checkpoint) ShouldSkipResumedLine(lineNumber int) bool {
+	return c.ProcessedRows > 0 && lineNumber <= c.ProcessedRows+1
 }
 
 // SetTotalRows sets the total row count (usually after file parsing).

--- a/cmd/position-tool/internal/checkpoint/manager_test.go
+++ b/cmd/position-tool/internal/checkpoint/manager_test.go
@@ -62,12 +62,10 @@ func TestCheckpoint_IncrementSuccess(t *testing.T) {
 	cp.IncrementSuccess(5)
 	assert.Equal(t, 5, cp.SuccessCount)
 	assert.Equal(t, 5, cp.ProcessedRows)
-	assert.Equal(t, 5, cp.LastProcessedLine)
 
 	cp.IncrementSuccess(3)
 	assert.Equal(t, 8, cp.SuccessCount)
 	assert.Equal(t, 8, cp.ProcessedRows)
-	assert.Equal(t, 8, cp.LastProcessedLine)
 }
 
 func TestCheckpoint_IncrementFailure(t *testing.T) {
@@ -76,12 +74,48 @@ func TestCheckpoint_IncrementFailure(t *testing.T) {
 	cp.IncrementFailure(2)
 	assert.Equal(t, 2, cp.FailureCount)
 	assert.Equal(t, 2, cp.ProcessedRows)
-	assert.Equal(t, 2, cp.LastProcessedLine)
 
 	cp.IncrementFailure(1)
 	assert.Equal(t, 3, cp.FailureCount)
 	assert.Equal(t, 3, cp.ProcessedRows)
-	assert.Equal(t, 3, cp.LastProcessedLine)
+}
+
+// TestCheckpoint_ShouldSkipResumedLine pins the resume off-by-one boundary.
+//
+// ProcessedRows counts data rows; the source CSV has a header on line 1, so M
+// processed data rows occupy lines 2..M+1. On resume the guard must skip
+// exactly those lines and no more. The boundary case (M processed, line M+1)
+// is the last committed data row: a guard of `<= ProcessedRows` would NOT skip
+// it, reprocessing it and duplicating its ledger position.
+func TestCheckpoint_ShouldSkipResumedLine(t *testing.T) {
+	tests := []struct {
+		name          string
+		processedRows int
+		lineNumber    int
+		wantSkip      bool
+	}{
+		// Fresh import (nothing processed): never skip, even the header-adjacent line.
+		{name: "no rows processed, first data row", processedRows: 0, lineNumber: 2, wantSkip: false},
+		{name: "no rows processed, header line", processedRows: 0, lineNumber: 1, wantSkip: false},
+
+		// 5 data rows processed -> they occupy lines 2..6.
+		{name: "5 processed, header line skipped", processedRows: 5, lineNumber: 1, wantSkip: true},
+		{name: "5 processed, first committed data row", processedRows: 5, lineNumber: 2, wantSkip: true},
+		{name: "5 processed, boundary last committed data row", processedRows: 5, lineNumber: 6, wantSkip: true},
+		{name: "5 processed, first new data row", processedRows: 5, lineNumber: 7, wantSkip: false},
+		{name: "5 processed, later new data row", processedRows: 5, lineNumber: 11, wantSkip: false},
+
+		// 1 data row processed -> it occupies line 2.
+		{name: "1 processed, committed data row", processedRows: 1, lineNumber: 2, wantSkip: true},
+		{name: "1 processed, next data row", processedRows: 1, lineNumber: 3, wantSkip: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cp := &Checkpoint{ProcessedRows: tt.processedRows}
+			assert.Equal(t, tt.wantSkip, cp.ShouldSkipResumedLine(tt.lineNumber))
+		})
+	}
 }
 
 func TestCheckpoint_SetTotalRows(t *testing.T) {
@@ -174,7 +208,6 @@ func TestCheckpoint_MixedIncrements(t *testing.T) {
 	assert.Equal(t, 15, cp.SuccessCount)
 	assert.Equal(t, 3, cp.FailureCount)
 	assert.Equal(t, 18, cp.ProcessedRows)
-	assert.Equal(t, 18, cp.LastProcessedLine)
 }
 
 func TestCalculateFileChecksum(t *testing.T) {
@@ -393,7 +426,6 @@ func TestCheckpoint_InitialState(t *testing.T) {
 	assert.Equal(t, 0, cp.SuccessCount)
 	assert.Equal(t, 0, cp.FailureCount)
 	assert.Equal(t, Status(""), cp.Status)
-	assert.Equal(t, 0, cp.LastProcessedLine)
 	assert.Nil(t, cp.RollbackSQL)
 	assert.Empty(t, cp.ErrorMessage)
 	assert.True(t, cp.CreatedAt.IsZero())

--- a/shared/platform/testdb/cockroachdb.go
+++ b/shared/platform/testdb/cockroachdb.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/cockroachdb"
 	gormpg "gorm.io/driver/postgres"
@@ -103,6 +104,44 @@ func CockroachDSN(t *testing.T, container *cockroachdb.CockroachDBContainer) str
 
 	return fmt.Sprintf("postgres://%s@%s:%d/%s?sslmode=disable",
 		connConfig.User, connConfig.Host, connConfig.Port, connConfig.Database)
+}
+
+// NewCockroachTestPool starts a CockroachDB testcontainer and returns a
+// pgxpool.Pool connected to it, for pgx-based repositories that need
+// CockroachDB production parity.
+//
+// Use this instead of NewTestPool (which is Postgres-backed) when the code
+// under test talks to CockroachDB, and instead of SetupCockroachDB (which
+// returns a *gorm.DB) when the code under test requires a *pgxpool.Pool.
+//
+// The pool and container are cleaned up automatically via t.Cleanup. The
+// optional WithMigrations option applies a service's SQL migrations; omit it
+// to manage schema setup directly in the test.
+func NewCockroachTestPool(t *testing.T, opts ...PoolOption) *pgxpool.Pool {
+	t.Helper()
+
+	cfg := &poolConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	container, _ := StartCockroachContainer(t, "test_db")
+	dsn := CockroachDSN(t, container)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("Failed to create CockroachDB connection pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	if cfg.migrations != "" {
+		applyMigrationsWithPgx(t, pool, cfg.migrations)
+	}
+
+	return pool
 }
 
 // SetupCockroachDB creates a CockroachDB testcontainer for integration testing.


### PR DESCRIPTION
## Summary

Fixes an off-by-one in the `position-tool` CSV import resume logic that caused the last data row committed before an interruption to be reprocessed on resume, creating a **duplicate financial position**.

The resume guard compared `csvRow.LineNumber` (1-indexed, header on line 1) against `ProcessedRows` (counts data rows only). After M committed data rows - which occupy `LineNumber` 2..M+1 - the guard skipped only `LineNumber <= M`, leaving the Mth data row (`LineNumber = M+1`) unguarded and reprocessed.

## Changes Made

- **`internal/checkpoint/manager.go`**: Removed the redundant `LastProcessedLine` field from the `Checkpoint` struct.
- **`internal/checkpoint/manager_helpers.go`**: Removed the four assignments that mirrored `ProcessedRows` into `LastProcessedLine`; added `Checkpoint.ShouldSkipResumedLine(lineNumber)`, a self-documenting predicate that accounts for the header offset.
- **`cmd/import.go`**: Resume guard now calls `cp.ShouldSkipResumedLine(csvRow.LineNumber)`.
- **`internal/checkpoint/doc.go`**: Updated the resume example (`startLine := cp.ProcessedRows + 2`).
- **`internal/checkpoint/manager_test.go`**: Removed `LastProcessedLine` assertions; added a table-driven boundary unit test for `ShouldSkipResumedLine`.
- **`cmd/import_resume_integration_test.go`** (new): CockroachDB integration test driving the real `processRow` path through a process/resume cycle.

## Technical Details

**Fix chosen: Option A (remove the redundant field).**

Investigation (Chesterton's Fence) confirmed `LastProcessedLine` was **never a database column** - the `import_manifest` migration has no such column, and both scan sites set it unconditionally to `ProcessedRows`. It was a struct-only mirror with zero independent meaning, so removing it carries no persistence risk. The round-trip (`scanCheckpoint`/`scanCheckpointRow`) is unaffected because they only ever derived it from `processed_rows`.

The corrected guard skips up to and including line `ProcessedRows + 1`:

```go
func (c *Checkpoint) ShouldSkipResumedLine(lineNumber int) bool {
    return c.ProcessedRows > 0 && lineNumber <= c.ProcessedRows+1
}
```

Note on the boundary: the duplicated row is **line M+1 (the last committed data row)** - e.g. with 5 committed rows the boundary is line 6 / `ACC-005`, not line 7. The task description's "line 7" label was off; the guard fix itself matches the task's recommendation.

## Testing

- **Unit** (`ShouldSkipResumedLine`, no DB): covers 0 processed (process all), the boundary at line M+1 (skip), the first new row at M+2 (process), and the header line. Confirmed **red** on the pre-fix predicate (`<= ProcessedRows`).
- **Integration** (CockroachDB testcontainer, drives real `processRow` + `BatchInserter`): header + 10 data rows; commit 5, resume re-reading the whole file, assert total = 10 positions with each `ACC-00x` appearing exactly once. Also covers resume-after-0 (all process) and resume-after-all (none process). Confirmed **red** on the pre-fix predicate (`ACC-005` duplicated → 2 positions, total 11).
- `go build ./...` green; `gofumpt` and `golangci-lint` clean (pre-commit hook).

The integration test uses a CockroachDB container per project convention; it creates a minimal `position` table without the append-only plpgsql trigger (unsupported on CockroachDB and unnecessary since the path only INSERTs).

## Risk Assessment

Low. The change narrows the resume skip window by exactly one line to match data-row semantics; the removed field had no persisted state and no external consumers. No migration or API changes. Behavior for fresh imports (`ProcessedRows = 0`) is unchanged.
