### PR TITLE
chore: Update dot-directory references to .claude/skills after skill relocation

### DIFF
--- a/.claude/skills/generate-llm-blueprint/SKILL.md
+++ b/.claude/skills/generate-llm-blueprint/SKILL.md
@@ -24,7 +24,7 @@ Run from the `meridian-main` directory:
 ```bash
 repomix --style markdown \
   --include "docs/prd/**/*.md,docs/adr/**/*.md,docs/architecture/**/*.md,docs/guides/**/*.md,api/proto/**/*.proto,**/atlas.hcl,**/openapi.json,go.mod,CLAUDE.md,CONTRIBUTING.md,README.md" \
-  --ignore "node_modules/**,**/CHANGELOG.md,docs/architecture/api-contracts/**,docs/skills/**,services/**/*.md" \
+  --ignore "node_modules/**,**/CHANGELOG.md,docs/architecture/api-contracts/**,.claude/skills/**,services/**/*.md" \
   --remove-empty-lines \
   -o ../meridian-blueprint.md
 ```

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -34,7 +34,7 @@ Runs before each commit to ensure code quality:
 
 If any check fails, the commit will be blocked. Fix the issues and try again.
 
-**Proto Evolution**: For guidance on safe schema changes, see `docs/skills/schema-evolution.md`
+**Proto Evolution**: For guidance on safe schema changes, see `.claude/skills/schema-evolution/SKILL.md`
 
 ## Automatic Tool Installation
 
@@ -104,4 +104,4 @@ When modifying proto files, the hook will:
 3. Block commit if breaking changes detected
 4. Provide helpful tips for safe evolution patterns
 
-For detailed guidance, see `docs/skills/schema-evolution.md`
+For detailed guidance, see `.claude/skills/schema-evolution/SKILL.md`

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -76,7 +76,7 @@ if [ -n "$STAGED_PROTO_FILES" ]; then
     else
         echo -e "${RED}✗${NC} buf lint failed"
         echo -e "${RED}Please fix proto style issues above before committing${NC}"
-        echo -e "${YELLOW}Tip:${NC} See docs/skills/schema-evolution.md for proto guidelines"
+        echo -e "${YELLOW}Tip:${NC} See .claude/skills/schema-evolution/SKILL.md for proto guidelines"
         exit 1
     fi
 
@@ -89,7 +89,7 @@ if [ -n "$STAGED_PROTO_FILES" ]; then
         else
             echo -e "${RED}✗${NC} Breaking proto changes detected"
             echo -e "${RED}Please review proto compatibility issues above${NC}"
-            echo -e "${YELLOW}Tip:${NC} See docs/skills/schema-evolution.md for safe evolution patterns"
+            echo -e "${YELLOW}Tip:${NC} See .claude/skills/schema-evolution/SKILL.md for safe evolution patterns"
             echo -e "${YELLOW}Tip:${NC} Consider adding optional fields or creating new event types"
             exit 1
         fi

--- a/.github/claude-review-instructions.md
+++ b/.github/claude-review-instructions.md
@@ -742,7 +742,8 @@ local correctness.
 
 **Directories:**
 
-- `docs/skills/` - Operational guides (testing, starlark sagas, docker)
+- `.claude/skills/` - Operational guides (testing, starlark sagas, docker);
+  each skill is a subdirectory containing a `SKILL.md` entrypoint
 - `docs/adr/` - Architecture Decision Records (temporal quality ladder,
   asset types, saga orchestration)
 - `docs/prd/` - Product Requirements Documents (feature specs, BIAN
@@ -761,12 +762,15 @@ local correctness.
       "repos/{REPO}/contents/docs/prd?ref={HEAD_SHA}" \
       --jq '.[].name'
     gh api \
-      "repos/{REPO}/contents/docs/skills?ref={HEAD_SHA}" \
+      "repos/{REPO}/contents/.claude/skills?ref={HEAD_SHA}" \
       --jq '.[].name'
     gh api \
       "repos/{REPO}/contents/docs/runbooks?ref={HEAD_SHA}" \
       --jq '.[].name'
     ```
+
+    Note: `.claude/skills/` entries are directories - the doc to read is
+    `.claude/skills/{name}/SKILL.md` (the others are flat `.md` files).
 
 2. Pick the 1-3 files whose names relate to the PR's changed services
    or features. Read their YAML frontmatter (first 20 lines) to confirm

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -74,7 +74,7 @@ jobs:
             - CONTRIBUTING.md - development guidelines and conventions
             - docs/adr/ - Architecture Decision Records for design context
             - docs/prd/ - Product Requirements for feature context
-            - docs/skills/ - available automation skills
+            - .claude/skills/ - available automation skills
             - Service-specific README.md files for local conventions
 
           # Customize Claude's behavior


### PR DESCRIPTION
## Summary

Follow-up to #2226. That PR moved the operational skills to `.claude/skills/<name>/SKILL.md` and updated referrers, but the verification sweep used `ripgrep` without `--hidden`, so references inside **dot-directories** (`.github/`, `.githooks/`) were silently skipped. A reviewer flagged the AI-review harness's discovery step still pointing at `docs/skills/`. This corrects all remaining real references.

## Changes Made

- **`.github/claude-review-instructions.md`** - point the AI-review harness's documentation discovery at `.claude/skills`, and note that entries are `<name>/SKILL.md` directories (not flat `.md` files), so the frontmatter read path is `.claude/skills/{name}/SKILL.md`.
- **`.github/workflows/claude.yml`** - update the "available skills" location comment.
- **`.githooks/pre-commit`** and **`.githooks/README.md`** - update the schema-evolution guide path to `.claude/skills/schema-evolution/SKILL.md`.
- **`.claude/skills/generate-llm-blueprint/SKILL.md`** - update the repomix `--ignore` glob from `docs/skills/**` to `.claude/skills/**` (the content it excludes moved).

## Out of Scope (intentionally left)

Generated `/assess` artifacts under `.assess/` (`doc-graph.svg`, `assess-report.md`, `run-context.json`) still reference `docs/skills/` paths. These are point-in-time snapshots that regenerate on the next `/assess` run; hand-editing them would be pointless churn.

## Testing

- `rg --hidden "docs/skills"` (excluding `.git/` and generated `.assess/`) returns zero matches.
- Pre-commit hooks pass (Gitleaks: no secrets; markdownlint: 0 errors).

## Risk Assessment

Low. Documentation/config reference updates only; no code or runtime behavior changes.