### PR TITLE
fix: Bump Go toolchain to 1.26.4 to patch stdlib CVEs on develop

### DIFF
--- a/.github/workflows/asyncapi.yml
+++ b/.github/workflows/asyncapi.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Set up Node.js

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -50,8 +50,8 @@ jobs:
             IMPORTANT: Today's date is ${{ steps.date.outputs.current_date }}.
 
             Key project facts:
-            - This project uses Go 1.26.3 (latest stable release)
-            - Go 1.26.3 is a valid version - do not question or flag it
+            - This project uses Go 1.26.4 (latest stable release)
+            - Go 1.26.4 is a valid version - do not question or flag it
             - Architecture: BIAN-compliant microservices
             - Stack: Go, Protocol Buffers, gRPC, Kubernetes
             - Security: All security scans must remain BLOCKING (never suggest making them non-blocking)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -68,7 +68,7 @@ jobs:
       if: matrix.language == 'go'
       uses: actions/setup-go@v6
       with:
-        go-version: '1.26.3'
+        go-version: '1.26.4'
         cache: true
 
     # Set up buf for protobuf generation (pinned version for reproducibility)

--- a/.github/workflows/control-plane-ci.yml
+++ b/.github/workflows/control-plane-ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Set up buf
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Set up buf
@@ -117,7 +117,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Set up buf
@@ -163,7 +163,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Set up buf
@@ -207,7 +207,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Install Atlas CLI
@@ -82,7 +82,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Install Atlas CLI

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Set up buf
@@ -101,7 +101,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.26.3'
+        go-version: '1.26.4'
         cache: true
 
     - name: Set up buf

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Set up buf
@@ -98,7 +98,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Set up buf
@@ -128,7 +128,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/saga-validation.yml
+++ b/.github/workflows/saga-validation.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Install protoc

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.26.3'
+        go-version: '1.26.4'
         cache: true
 
     - name: Set up buf
@@ -85,7 +85,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.26.3'
+        go-version: '1.26.4'
         cache: true
 
     - name: Set up buf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Set up buf
@@ -131,7 +131,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Set up buf

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,7 @@
 # audit-worker - Development Dockerfile for Tilt Live Update
 # Uses Debian bookworm for CGO support (required by confluent-kafka-go/librdkafka)
 
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 # Install build dependencies for CGO (librdkafka)
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/cmd/meridian/Dockerfile
+++ b/cmd/meridian/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by CGO_ENABLED=0 static binary
 
 # Build stage
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/meridianhub/meridian
 
-go 1.26.3
+go 1.26.4
 
 require (
 	ariga.io/atlas-provider-gorm v0.6.0

--- a/services/api-gateway/cmd/Dockerfile
+++ b/services/api-gateway/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/control-plane/cmd/Dockerfile
+++ b/services/control-plane/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go dependencies
 
 # Build stage
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/current-account/cmd/Dockerfile
+++ b/services/current-account/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/event-router/cmd/Dockerfile
+++ b/services/event-router/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/financial-accounting/cmd/Dockerfile
+++ b/services/financial-accounting/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/financial-gateway/cmd/Dockerfile
+++ b/services/financial-gateway/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image for minimal attack surface
 
 # Build stage
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/forecasting/cmd/Dockerfile
+++ b/services/forecasting/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go dependencies
 
 # Build stage
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/internal-account/cmd/Dockerfile
+++ b/services/internal-account/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/market-information/cmd/Dockerfile
+++ b/services/market-information/cmd/Dockerfile
@@ -4,7 +4,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go dependencies
 
 # Build stage
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/mcp-server/cmd/Dockerfile
+++ b/services/mcp-server/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image for minimal attack surface
 
 # Build stage
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/party/cmd/Dockerfile
+++ b/services/party/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/payment-order/cmd/Dockerfile
+++ b/services/payment-order/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/position-keeping/cmd/Dockerfile
+++ b/services/position-keeping/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/reconciliation/cmd/Dockerfile
+++ b/services/reconciliation/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go dependencies
 
 # Build stage
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/reference-data/cmd/Dockerfile
+++ b/services/reference-data/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go dependencies
 
 # Build stage
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/tenant/cmd/Dockerfile
+++ b/services/tenant/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary

The **Go Vulnerability Check** security gate is failing on `develop`. `govulncheck` flags two non-allowlisted **Go standard library** vulnerabilities:

- `GO-2026-5039` (`net/textproto`) - fixed in go1.26.4
- `GO-2026-5037` (`crypto/x509`) - fixed in go1.26.4

Both are resolved by the Go toolchain patch release. This PR bumps the pinned Go version `1.26.3 -> 1.26.4` so the patched standard library is used at build and scan time.

Allowlisting the CVEs was rejected as the wrong fix - it would suppress real vulnerabilities rather than patch them. The toolchain bump fixes the root cause.

## Changes Made

- `go.mod`: `go 1.26.3 -> 1.26.4`
- 15 CI workflow `setup-go` pins: `1.26.3 -> 1.26.4` (incl. `security.yml`, which drives the govulncheck gate)
- 19 service Dockerfile build stages: `golang:1.26.3-bookworm -> golang:1.26.4-bookworm` (so shipped binaries contain the patched stdlib)
- `claude.yml` guidance lines updated to reference 1.26.4

36 files changed, all a mechanical version-string bump (no false-positive matches).

## Testing

Verified locally on go1.26.4 by running `govulncheck ./...` exactly as `security.yml` does:

- `GO-2026-5039` and `GO-2026-5037` - **cleared**
- Only remaining finding: `GO-2024-2476` (embedded Dex), already allowlisted per ADR-0036
- CI allowlist filter simulated against the output - **gate passes**
- `go build ./services/api-gateway/...` - clean

## Risk Assessment

Low. Patch-level Go release (1.26.3 -> 1.26.4); no language or API changes. Affects build/CI tooling versions only, not application code.

## Evidence

- Failing run: https://github.com/meridianhub/meridian/actions/runs/26868774414
- Error: `Non-allowlisted vulnerabilities detected: GO-2026-5037 GO-2026-5039`

## Out of Scope (triaged, not fixed here)

- **Dependabot go_modules update** failure - Dependabot's own update job hit a transitive resolution conflict (`otel/semconv v1.41.0` unresolvable when bumping `otlptracegrpc`). Not develop CI; separate concern.
- **Nightly Slow Integration Tests** (Jun 1) - one-off flake; nightlies on Jun 2 and Jun 3 both passed.