### PR TITLE
docs: Wire orphan docs into the graph and add missing cross-references (assess-2026-06-04.6)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,6 +214,9 @@ make proto
 make test
 ```
 
+The git hooks installed by `.githooks/install.sh` run secret scanning and markdown linting on every commit;
+see [.githooks/README.md](.githooks/README.md) for what each hook enforces and how to skip them when needed.
+
 ## Development Workflow
 
 ### Standard Workflow
@@ -1152,6 +1155,10 @@ Closes #123
 3. Address feedback
 4. Approval and merge
 
+Pull requests are also reviewed by an automated Claude reviewer. The conventions it follows -
+what it checks for and how it comments - are documented in
+[.github/claude-review-instructions.md](.github/claude-review-instructions.md).
+
 ## Architecture Decisions
 
 ### When to Create an ADR
@@ -1216,7 +1223,7 @@ Place ADRs in `docs/adr/` with numbering:
 ## Code of Conduct
 
 Be respectful, professional, and collaborative. We value diverse perspectives and view questions and feedback as
-opportunities for continuous improvement.
+opportunities for continuous improvement. See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for the full policy.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Browse the full technical documentation index at [docs/README.md](docs/README.md
 covering architecture, developer guides, runbooks, integrations, API reference,
 product requirements, and architecture decision records.
 
+Release history and notable changes are recorded in [CHANGELOG.md](CHANGELOG.md).
+
 ## Technology
 
 | Layer | Stack |

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -23,7 +23,7 @@ your configuration against the canonical example.
 |-----------|---------|
 | `patterns/` | Domain pattern bundles: `manifest-fragment.yaml`, Starlark `.star` saga files, and `pattern.json` metadata |
 | `schema/` | JSON Schema definitions for registry validation (`registry.json`, `registry-item.json`) |
-| `docs/` | Authoring guides for patterns (`authoring-patterns.md`) and UI components (`authoring-components.md`) |
+| `docs/` | Authoring guides for patterns ([`authoring-patterns.md`](docs/authoring-patterns.md)) and UI components ([`authoring-components.md`](docs/authoring-components.md)) |
 | `ui/` | UI component registry entries: `component.json` metadata pointing to frontend source files |
 
 ## Relationship to Reference Data

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,22 @@
+# Deployment Configurations
+
+Environment-specific deployment configuration for Meridian. Each subdirectory holds the
+Docker Compose files, database bootstrap SQL, and supporting config for one environment.
+
+## Environments
+
+| Directory | Purpose |
+|-----------|---------|
+| `dev/` | Local developer Docker Compose stack. |
+| `develop/` | The shared `develop` integration environment (auto-deployed on merge). |
+| `demo/` | The public demo environment on the DigitalOcean droplet. |
+
+## Demo Environment
+
+The demo environment runs the Backend-For-Frontend auth architecture behind Caddy with Dex OIDC.
+Its configuration and operational runbooks live in `demo/`:
+
+- [Demo Auth Architecture](demo/README.md) - BFF authentication design and request flows
+- [Cloudflare Setup Checklist](demo/cloudflare-setup-checklist.md) - origin certificate and DNS setup
+- [Dex Identity Migration Plan](demo/dex-identity-migration-plan.md) - migrating identity onto embedded Dex
+- [Postgres Migration Compatibility Report](demo/pg-migration-compatibility-report.md) - schema compatibility findings

--- a/deployments/k8s/README.md
+++ b/deployments/k8s/README.md
@@ -1,0 +1,19 @@
+# Kubernetes Deployments
+
+Kustomize-based Kubernetes manifests for deploying Meridian and its supporting workloads.
+
+## Layout
+
+| Directory | Purpose |
+|-----------|---------|
+| `base/` | Base Kustomize manifests shared across environments |
+| `overlays/` | Environment-specific overlays layered on top of `base/` |
+| `local/` | Local-cluster manifests for development |
+| `observability/` | Tracing, metrics, and logging stack manifests |
+| `audit-consumer/` | Per-service audit consumer deployments |
+| `policies/` | OPA Gatekeeper policies and their tests |
+
+## Component Docs
+
+- [Audit Consumer Deployments](audit-consumer/README.md) - Kustomize deployments for the per-service audit consumer
+- [OPA Gatekeeper Policy Tests](policies/tests/README.md) - tests for the `BlockDevModeInProduction` admission policy

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,14 @@ documentation.
 - [Saga Handler Loading](saga-handler-loading.md)
 - [Saga Service Catalog](saga-service-catalog.md)
 
+## Source Tree Guides
+
+Entry-point READMEs for the major code subtrees outside `services/`:
+
+- [Frontend](../frontend/README.md) - the operations console (React/TypeScript UI)
+- [Scripts](../scripts/README.md) - demo, doctor, and developer tooling scripts
+- [Shared Packages](../shared/README.md) - cross-service domain, platform, and infrastructure packages
+
 ## Developer Guides
 
 - [Developer Guides Index](guides/README.md) - conventions, value types, Starlark, proto, and testing guides
@@ -49,6 +57,11 @@ documentation.
 - [Audit System Monitoring](operations/audit-monitoring.md)
 - [Secrets Management](secrets-management.md)
 - [Tilt Fast Startup Mode](tilt-fast-startup.md)
+
+### Deployment Configuration
+
+- [Deployment Configurations](../deploy/README.md) - per-environment Docker Compose stacks (dev, develop, demo)
+- [Kubernetes Deployments](../deployments/k8s/README.md) - Kustomize manifests, overlays, and admission policies
 
 ## Integrations
 
@@ -79,6 +92,7 @@ documentation.
 
 ## Testing
 
+- [Cross-Service Tests](../tests/README.md) - end-to-end, integration, contract, and load test suites
 - [Chaos Testing Strategy](testing/CHAOS_TESTING.md)
 - [Test Coverage Analysis](testing/COVERAGE_ANALYSIS.md)
 

--- a/docs/adr/0015-standard-service-directory-structure.md
+++ b/docs/adr/0015-standard-service-directory-structure.md
@@ -144,10 +144,10 @@ This follows industry practice for Go monorepos with interdependent services. Se
 | Document Type | Location | Example |
 |--------------|----------|---------|
 | Architecture decisions | `docs/adr/` | `0015-standard-service-directory-structure.md` |
-| Usage guides | `docs/guides/` | `circuit-breaker-usage.md` |
-| Operational runbooks | `docs/runbooks/` | `incident-response.md` |
-| Architecture diagrams | `docs/architecture/` | `service-coupling-analysis.md` |
-| Testing guides | `docs/testing/` | `COVERAGE_ANALYSIS.md` |
+| Usage guides | `docs/guides/` | [`circuit-breaker-usage.md`](../guides/circuit-breaker-usage.md) |
+| Operational runbooks | `docs/runbooks/` | [`incident-response.md`](../runbooks/incident-response.md) |
+| Architecture diagrams | `docs/architecture/` | [`service-coupling-analysis.md`](../architecture/service-coupling-analysis.md) |
+| Testing guides | `docs/testing/` | [`COVERAGE_ANALYSIS.md`](../testing/COVERAGE_ANALYSIS.md) |
 
 **Exceptions**: README.md files may exist at package roots to document package purpose (Go convention), but substantial documentation belongs in `docs/`.
 

--- a/docs/prd/049-codebase-consistency.md
+++ b/docs/prd/049-codebase-consistency.md
@@ -309,7 +309,7 @@ names without reading each service's `errors.go`.
 
 **Files Affected**:
 
-- `docs/guides/error-conventions.md` (new)
+- [`docs/guides/error-conventions.md`](../guides/error-conventions.md) (new)
 
 **Acceptance Criteria**:
 
@@ -329,7 +329,7 @@ names without reading each service's `errors.go`.
 
 **Files Affected**:
 
-- `docs/guides/repository-conventions.md` (new)
+- [`docs/guides/repository-conventions.md`](../guides/repository-conventions.md) (new)
 
 **Acceptance Criteria**:
 
@@ -349,7 +349,7 @@ names without reading each service's `errors.go`.
 
 **Files Affected**:
 
-- `docs/guides/value-types.md` (new)
+- [`docs/guides/value-types.md`](../guides/value-types.md) (new)
 
 **Acceptance Criteria**:
 
@@ -375,7 +375,7 @@ in this PRD and ADR-015.
 
 **Files Affected**:
 
-- `docs/guides/new-bian-service-checklist.md`
+- [`docs/guides/new-bian-service-checklist.md`](../guides/new-bian-service-checklist.md)
 
 **Acceptance Criteria**:
 

--- a/docs/prd/064-assess-2026-06-04-ai-readiness-closure.md
+++ b/docs/prd/064-assess-2026-06-04-ai-readiness-closure.md
@@ -1,0 +1,69 @@
+# AI-Readiness Closure (assess 2026-06-04)
+
+<!-- markdownlint-disable MD013 -->
+
+## Problem Statement
+
+The `/assess` run on 2026-06-04 (`.assess/assess-report.md`) scored Meridian **7.5 / 8 - AI-Native (Exemplary)**. Eight of nine layers are Present. The single half-point gap is **Layer 0 (Agent Instructions & Navigability)**, scored Partial: an agent's first hop into a subtree can land on a stale or unlinked map.
+
+The deterministic cross-layer scan surfaced three classes of concrete defect:
+
+- **Lying maps** - 10 README files describing service/module code that has churned underneath a comparatively static doc. A drifted README is the worst signal for an agent: it navigates fast to a stale conclusion.
+- **Orphan docs** - 26 module READMEs and platform docs reachable only by guessing a path; nothing links to them (reachability 88.7%, 20 disconnected islands).
+- **Unlinked prose cross-references** - 11 places where a doc names another doc without linking it.
+
+Three mid-tier architecture docs are also genuinely stale against their subject code. Separately, two Additional Opportunities harden the financial-correctness core beyond the score: mutation testing (Layer 6 truth-pressure is currently unverified) and an LLM contradiction sweep over `docs/`.
+
+## Technical Context
+
+- Source tree: `meridian-main/` (Go monorepo, module `github.com/meridianhub/meridian`).
+- Machine-readable inputs: `.assess/run-context.json` (orphan list, `missing_xrefs`, `stale_hubs`), `.assess/assess-report.md` (Top 3 Actions, cross-layer findings).
+- The prior `assess-2026-05-22` tag took reachability from 30% to 88.7%; this PRD closes the residual.
+- The assess gate (`.github/workflows/assess-gate.yml`) is already frozen into CI - reducing the orphan rate and refreshing the lying maps directly improves the gated snapshot.
+- Doc-graph wiring touches shared index files. To eliminate merge conflicts across parallel work, **one task owns all root-level entry/index edits**; subtree tasks own only files inside their own subtree.
+
+## Solution
+
+Reconcile every flagged README against its current code (refresh, not rewrite - characterize current behaviour rather than regenerate from intent), wire every orphan back into the doc graph, add the missing cross-references, refresh the three stale architecture docs, then harden Layer 6 with mutation testing and a contradiction sweep. Each README reconciliation must diff doc claims against the actual code and either refresh drifted sections or delete genuinely-superseded ones - default to refresh; these READMEs describe live subtrees.
+
+## Scope
+
+Ten independent work items. Hot-file ownership noted to keep them parallel and conflict-free.
+
+1. **Frontend wayfinding.** Reconcile `frontend/README.md` against `frontend/src/`; refresh drifted sections. Within the frontend subtree, link `frontend/docs/tenant-subdomain-routing.md` from `frontend/README.md`. (Owns: `frontend/README.md` and files under `frontend/`. Does NOT edit root index docs.)
+
+2. **Scripts wayfinding.** Reconcile `scripts/README.md` against the current `scripts/` directory (verify it still describes `demo.sh`, `doctor.sh`, and the other scripts that exist); refresh or delete superseded sections. Link `scripts/kafka-tests/README.md` from `scripts/README.md`. (Owns: files under `scripts/`.)
+
+3. **Shared subtree wayfinding.** Reconcile `shared/README.md` against `shared/` code. Add inbound links from `shared/README.md` to its orphan children: `shared/domain/money/PRECISION_GUARANTEES.md`, `shared/platform/bootstrap/README.md`, `shared/platform/observability/README.md`. (Owns: files under `shared/`.)
+
+4. **Core ledger service READMEs.** Reconcile each lying-map README against its service code, refreshing drifted sections: `services/control-plane/README.md`, `services/current-account/README.md`, `services/financial-accounting/README.md`, `services/internal-account/README.md`, `services/position-keeping/README.md`. (Owns: those five `services/*/README.md` files only.)
+
+5. **Identity and MCP-server wayfinding.** Reconcile `services/identity/README.md` and `services/mcp-server/README.md` against their code. Add inbound links from `services/mcp-server/README.md` to its orphan reference docs: `services/mcp-server/internal/resources/docs/cel-reference.md` and `services/mcp-server/internal/resources/docs/starlark-guide.md`. (Owns: files under `services/identity/` and `services/mcp-server/`.)
+
+6. **Central orphan wiring and missing cross-references (hot-file owner).** Sole editor of root-level entry/index docs (`README.md`, any top-level docs index). Also commit this PRD into the repo at `docs/prd/064-assess-2026-06-04-ai-readiness-closure.md`. Wire the remaining orphan docs into the graph with inbound links: `CHANGELOG.md`, `CODE_OF_CONDUCT.md`, `.githooks/README.md`, `.github/claude-review-instructions.md`, `deploy/demo/README.md`, `deploy/demo/cloudflare-setup-checklist.md`, `deploy/demo/dex-identity-migration-plan.md`, `deploy/demo/pg-migration-compatibility-report.md`, `deployments/k8s/policies/tests/README.md`, `services/event-router/k8s/README.md`, `services/internal-account/benchmarks/README.md`, `services/internal-account/examples/README.md`, `services/market-information/README.md`, `services/payment-order/service/HANDLER_ARCHITECTURE.md`, `tests/audit-e2e/README.md`, `cookbook/docs/authoring-patterns.md`, `cookbook/docs/authoring-components.md`. Add inbound links from `README.md`/docs index to the subtree roots rescued by items 1-5 (`frontend/README.md`, `scripts/README.md`, `shared/README.md`). Add the 11 missing prose cross-references (`missing_xrefs`): `cookbook/README.md` -> authoring-patterns + authoring-components; `docs/adr/0015-standard-service-directory-structure.md` -> circuit-breaker-usage, incident-response, service-coupling-analysis, COVERAGE_ANALYSIS; `docs/prd/049-codebase-consistency.md` -> new-bian-service-checklist, error-conventions, repository-conventions, value-types; `docs/prd/README.md` -> archive/panic-audit-inventory. Target reachability >= 97% and island count <= 3.
+
+7. **Refresh stale architecture docs.** Diff against current code and refresh: `docs/architecture/service-coupling-analysis.md` (153 days stale), `docs/architecture/event-driven-architecture.md` (95 days), `docs/architecture/bian-service-boundaries.md` (95 days). (Owns: those three files.)
+
+8. **Mutation testing on the financial-correctness core.** Add a mutation-testing harness (`go-mutesting` or a maintained Go-ecosystem equivalent) targeting `services/position-keeping` and the saga engine, where a surviving mutant means money moves wrong. Triage survivors, add tests to kill the high-value ones, and wire an opt-in CI job (non-blocking initially) plus a short runbook on running it. Converts Layer 6 from "covered" to "behaviour-pinned" for the core.
+
+9. **Confirm Go dead-code is clean.** Run `staticcheck -checks U1000 ./...` across the tree. Remove confirmed unreachable code; document any false positives (e.g. reflection/external consumers). Records the result so the Layer 1 caveat is closed.
+
+10. **LLM contradiction sweep over `docs/`.** Run an LLM pass over `docs/` to flag pages that contradict each other or the code (out of `/assess` deterministic scope). Fix clear contradictions inline; list anything ambiguous in the PR description for human judgement.
+
+## Out of Scope (manual follow-up, not agent tasks)
+
+- **Independent human review of `frontend/src/App.tsx`** (Top 3 Action #2) and **`scripts/doctor.sh`** - both flagged `self_referential_tests` (code and tests entered together). An agent cannot self-certify that its own tests assert observable behaviour rather than the author's mental model. These require a human reviewer and are tracked separately for Ben to action.
+
+## Success Criteria
+
+- All 10 lying-map READMEs reconciled against current code (refreshed or, where genuinely superseded, deleted).
+- Doc-graph reachability >= 97% (from 88.7%); island count <= 3 (from 20); all 26 orphans linked; all 11 missing cross-references added; 0 broken/dangling links.
+- The 3 stale architecture docs refreshed against current code.
+- Mutation-testing harness runs against `services/position-keeping` + saga engine; high-value survivors killed; opt-in CI job + runbook landed.
+- `staticcheck -checks U1000 ./...` result recorded; confirmed dead code removed.
+- Contradiction sweep completed; clear contradictions fixed, ambiguous ones surfaced.
+- A re-run of `/assess` would score Layer 0 Present (8 / 8).
+
+## Complexity Estimate
+
+10 tasks. Items 1-7, 9 are documentation/reconciliation (1-3 points each, mostly markdown - 1-approval PRs, high parallelism). Item 8 (mutation testing) is the one heavy task (5-8 points: new tooling, survivor triage, CI integration). Item 10 (contradiction sweep) is 3 points. No inter-task dependencies - all 10 are first-wave parallel; item 6 is the single hot-file owner so the others never touch root index docs.

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -109,6 +109,7 @@ stateDiagram-v2
 | [Per-Tenant Scheduled Execution](060-per-tenant-scheduled-execution.md) | Phased scheduling identity: attribution, manifest bridge, deferred JWT auth |
 | [MCP Auth Session Unification](061-mcp-auth-session-unification.md) | Unify MCP authentication and session handling across transports |
 | [Self-Service Onboarding Readiness](062-self-service-onboarding-readiness.md) | Readiness assessment for self-service tenant onboarding |
+| [AI-Readiness Closure (assess 2026-06-04)](064-assess-2026-06-04-ai-readiness-closure.md) | Close the Layer 0 navigability gap: reconcile lying maps, wire orphan docs, add cross-references |
 
 ### Task Master PRDs (`.taskmaster/docs/`)
 
@@ -173,7 +174,7 @@ These PRDs were implemented by appending tasks to existing tags rather than crea
 
 | File | Type |
 |------|------|
-| `panic-audit-inventory.md` | Audit inventory (reference doc, not a PRD) |
+| [`panic-audit-inventory.md`](../archive/panic-audit-inventory.md) | Audit inventory (reference doc, not a PRD) |
 
 ## What are PRDs?
 

--- a/services/README.md
+++ b/services/README.md
@@ -497,6 +497,20 @@ and Current Account services by matching positions and identifying discrepancies
 
 See [services/reconciliation/README.md](reconciliation/README.md) for full documentation.
 
+### Market Information Service
+
+The Market Information service records bi-temporal market observations and applies the quality
+ladder (Estimate -> Coefficient -> Actual -> Revised), supplying market data to forecasting,
+valuation, and settlement.
+
+**Responsibilities:**
+
+- **Bi-Temporal Observations**: Track what was known and when it was known
+- **Quality Ladder**: Promote observations from estimate through to revised actuals
+- **Delta Engine**: Wash-and-reload corrections without locking the database
+
+See [services/market-information/README.md](market-information/README.md) for full documentation.
+
 ### Forecasting Service
 
 The Forecasting service generates forward curves and forecasts using configurable Starlark-based

--- a/services/event-router/README.md
+++ b/services/event-router/README.md
@@ -161,3 +161,4 @@ flowchart LR
 
 - Architecture layers: [`docs/architecture-layers.md`](../../docs/architecture-layers.md#8-observability-and-routing)
 - Event-driven architecture: [`docs/architecture/event-driven-architecture.md`](../../docs/architecture/event-driven-architecture.md)
+- Kubernetes manifests: [`k8s/README.md`](k8s/README.md) - deployment, config, and network policy for this service

--- a/services/internal-account/README.md
+++ b/services/internal-account/README.md
@@ -232,3 +232,5 @@ Lien lifecycle mirrors `current-account`: ACTIVE -> EXECUTED (terminal) or TERMI
 - [Architecture Layers - Core Ledger](../../docs/architecture-layers.md#4-core-ledger)
 - [Service Coupling Analysis](../../docs/architecture/service-coupling-analysis.md)
 - [BIAN Internal Account specification](https://github.com/bian-official/public/blob/main/release14.0.0/semantic-apis/oas3%20/yamls/InternalAccount.yaml)
+- [Benchmarks](benchmarks/README.md) - performance benchmarks for this service
+- [Examples](examples/README.md) - runnable usage examples

--- a/services/payment-order/README.md
+++ b/services/payment-order/README.md
@@ -181,3 +181,4 @@ Paths are relative to `services/payment-order/`.
 - [`docs/data-flows.md`](../../docs/data-flows.md) - Payment lifecycle sequence diagram (section 1)
 - [`docs/patterns.md`](../../docs/patterns.md) - Saga, idempotency, and outbox patterns
 - [`api/proto/meridian/payment_order/v1/payment_order.proto`](../../api/proto/meridian/payment_order/v1/payment_order.proto)
+- [Handler Architecture](service/HANDLER_ARCHITECTURE.md) - how saga handlers are structured in this service

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,25 @@
+# Cross-Service Tests
+
+Suite of end-to-end, integration, contract, and load tests that exercise Meridian across
+multiple services. Per-package unit tests live next to the code they cover under `services/`;
+this directory holds the tests that span service boundaries.
+
+## Test Suites
+
+| Directory | Scope |
+|-----------|-------|
+| `audit-e2e/` | Audit system end-to-end flow across services - see [audit-e2e/README.md](audit-e2e/README.md) |
+| `clearinge2e/` | Clearing and settlement end-to-end flow |
+| `identity-e2e/` | Identity, SSO, and authentication end-to-end flow |
+| `reconciliation-e2e/` | Reconciliation run end-to-end flow |
+| `mapping-e2e/` | Mapping-layer transformation end-to-end flow |
+| `integration/` | Cross-service integration tests |
+| `contracts/` | Behavioural API contract tests |
+| `proto/` | Protobuf wire-compatibility tests |
+| `architecture/` | Architecture and dependency-boundary assertions |
+| `multi_tenant/` | Multi-tenant isolation tests |
+| `load/` | Load and performance tests |
+
+## Detailed Suite Docs
+
+- [Audit System End-to-End Tests](audit-e2e/README.md) - full audit flow from service operations to tenant `audit_log` tables


### PR DESCRIPTION
## Summary

Central orphan-wiring task for the `assess-2026-06-04` AI-readiness closure (unit `assess-2026-06-04.6`). This is the hot-file consolidation task: the sole editor of root-level entry/index docs. It commits the closure PRD, wires the remaining orphan docs into the documentation graph, and converts the 11 named-but-unlinked prose cross-references into real links.

Pure-markdown changes. No code touched.

## Changes Made

### PRD committed
- Added `docs/prd/064-assess-2026-06-04-ai-readiness-closure.md` and listed it in `docs/prd/README.md`.

### Orphan docs wired in (inbound links added)
- `README.md` -> `CHANGELOG.md`
- `CONTRIBUTING.md` -> `CODE_OF_CONDUCT.md`, `.githooks/README.md`, `.github/claude-review-instructions.md`
- New `deploy/README.md` indexing `deploy/demo/README.md`, `cloudflare-setup-checklist.md`, `dex-identity-migration-plan.md`, `pg-migration-compatibility-report.md`
- New `deployments/k8s/README.md` indexing `policies/tests/README.md` and `audit-consumer/README.md`
- `services/event-router/README.md` -> `k8s/README.md`
- `services/internal-account/README.md` -> `benchmarks/README.md`, `examples/README.md`
- `services/README.md` -> `services/market-information/README.md` (new Market Information Service subsection)
- `services/payment-order/README.md` -> `service/HANDLER_ARCHITECTURE.md`
- New `tests/README.md` indexing `tests/audit-e2e/README.md` and the other cross-service suites
- `cookbook/README.md` -> `docs/authoring-patterns.md`, `docs/authoring-components.md`

### Subtree-root links (in `docs/README.md`)
- New "Source Tree Guides" section linking `frontend/README.md`, `scripts/README.md`, `shared/README.md`
- New deployment/test index entries linking `deploy/README.md`, `deployments/k8s/README.md`, `tests/README.md`

### 11 missing prose cross-references converted to links
- `cookbook/README.md` -> `authoring-patterns.md`, `authoring-components.md` (the `docs/` structure-table cell)
- `docs/adr/0015-standard-service-directory-structure.md` -> `circuit-breaker-usage`, `incident-response`, `service-coupling-analysis`, `COVERAGE_ANALYSIS` (Example column)
- `docs/prd/049-codebase-consistency.md` -> `new-bian-service-checklist`, `error-conventions`, `repository-conventions`, `value-types` (Files Affected bullets)
- `docs/prd/README.md` -> `archive/panic-audit-inventory` (corrected the path to its real location under `docs/archive/`)

## Testing
- A link-resolution script over all changed/new files: 253 links checked, 0 broken.
- `markdownlint-cli2` passes on all changed and new files (pre-commit hook green).

## Risk Assessment
Documentation-only. No build, schema, or runtime impact.

## Notes for the lead
- `services/internal-account/README.md` is also edited by unit `assess-2026-06-04.4` (lying-map reconciliation). This PR touches only its `## References` section (two appended link lines), so a merge conflict there should be trivial to resolve.
- `docs/prd/README.md` previously filed `panic-audit-inventory.md` under a `.taskmaster/docs/` heading, but the file actually lives at `docs/archive/panic-audit-inventory.md`; the link points there.
