### PR TITLE
docs: Reconcile core ledger service READMEs against current code (assess-2026-06-04.4)

### DIFF
--- a/services/control-plane/README.md
+++ b/services/control-plane/README.md
@@ -29,8 +29,10 @@ instructions: |
   AuthService.ValidateAPIKey is called by api-gateway on every request. Key format:
   pk_{tenant_slug}_{entropy}. Hash is SHA-256; prefix enables O(1) tenant routing.
 
-  gRPC port 50062. Stripe webhook handling runs in the unified binary's HTTP server.
-  Kafka required for Stripe payment event publishing (KAFKA_BOOTSTRAP_SERVERS).
+  gRPC port 50062. The control-plane binary (cmd/main.go) serves gRPC only. The
+  Stripe webhook handler and HMAC-SHA256 signature verification live in
+  internal/stripe/webhook.go but are not currently wired to an HTTP route; live
+  Stripe webhook ingestion runs in financial-gateway.
 ---
 
 # control-plane
@@ -78,12 +80,11 @@ Proto files: `api/proto/meridian/control_plane/v1/` (relative to repo root).
 
 ### HTTP endpoints
 
-Stripe webhook handling runs in the unified binary's shared HTTP server, not in the
-standalone control-plane binary.
-
-| Method | Path | Purpose |
-|--------|------|---------|
-| `POST` | `/stripe/webhook` | Stripe webhook: HMAC-SHA256 verified, publishes payment events to Kafka |
+control-plane serves gRPC only. The Stripe webhook handler in
+`internal/stripe/webhook.go` (HMAC-SHA256 signature verification, 5-minute replay
+guard, Kafka payment-event publishing) is implemented but is not currently
+registered to an HTTP route in this service. Live Stripe webhook ingestion runs in
+`financial-gateway` (`POST /webhooks/stripe/{tenantID}`).
 
 ## Domain Model
 
@@ -197,7 +198,7 @@ Paths are relative to `services/control-plane/`.
 | `internal/differ/manifest_differ.go` | Kubernetes-style diff engine (`CREATE/UPDATE/DELETE/NO_CHANGE`); safety-checks deletions |
 | `internal/planner/manifest_planner.go` | Maps diff actions to dependency-ordered phased gRPC calls with idempotency keys |
 | `internal/admin/handler.go` | `CausationVisualizerService` and `BalanceSheetService` gRPC implementations |
-| `internal/stripe/webhook.go` | HMAC-SHA256 signature verification and Kafka payment event publishing; 5-minute replay guard |
+| `internal/stripe/webhook.go` | HMAC-SHA256 signature verification and Kafka payment event publishing; 5-minute replay guard (handler implemented but not currently wired to an HTTP route in this service) |
 | `rbac/method_permissions.go` | RBAC method-to-permission mapping; all RPC authorization rules live here |
 
 ## Configuration

--- a/services/current-account/README.md
+++ b/services/current-account/README.md
@@ -94,7 +94,7 @@ classDiagram
     class Lien {
         +string LienID
         +string AccountID
-        +MoneyAmount Amount
+        +Money Amount
         +LienStatus Status
         +string PaymentOrderReference
         +InstrumentAmount ReservedQuantity
@@ -106,7 +106,7 @@ classDiagram
     class Withdrawal {
         +string WithdrawalID
         +string AccountID
-        +MoneyAmount Amount
+        +Money Amount
         +WithdrawalStatus Status
         +string Reference
         +int Version
@@ -235,4 +235,3 @@ terminal. Withdrawal lifecycle is PENDING -> COMPLETED / FAILED / CANCELLED.
 - [Architecture Layers - Core Ledger](../../docs/architecture-layers.md#4-core-ledger)
 - [Service Coupling Analysis](../../docs/architecture/service-coupling-analysis.md)
 - [BIAN Current Account specification](https://github.com/bian-official/public/blob/main/release14.0.0/semantic-apis/oas3%20/yamls/CurrentAccount.yaml)
-

--- a/services/financial-accounting/README.md
+++ b/services/financial-accounting/README.md
@@ -73,7 +73,7 @@ classDiagram
         +string ProductServiceReference
         +string BusinessUnitReference
         +string ChartOfAccountsRules
-        +string BaseInstrumentCode
+        +Currency BaseCurrency
         +TransactionStatus Status
         +time CreatedAt
         +time UpdatedAt
@@ -83,9 +83,9 @@ classDiagram
         +string ID
         +string FinancialBookingLogID
         +PostingDirection Direction
-        +InstrumentAmount PostingAmount
+        +Money Amount
         +string AccountID
-        +AccountServiceDomain AccountServiceDomain
+        +string AccountServiceDomain
         +time ValueDate
         +string PostingResult
         +TransactionStatus Status
@@ -115,8 +115,10 @@ classDiagram
 Every financial transaction creates at least one debit and one credit posting.
 The booking log transitions to `POSTED` only when the sum of all `DEBIT` postings
 equals the sum of all `CREDIT` postings (double-entry invariant enforced at service layer).
-`PostingAmount` uses `InstrumentAmount` for multi-asset support: currencies, energy (kWh),
-carbon credits, and compute hours are all valid posting units.
+A posting's `Amount` is a `Money` value (the `Qty[Monetary]` type from the Universal
+Asset System), pairing a decimal amount with a validated currency instrument so any
+currency is a valid posting unit. Commodity quantities (energy kWh, carbon credits,
+compute hours) are tracked in `position-keeping`, not posted to the general ledger here.
 
 `POSTED`, `CANCELLED`, and `REVERSED` are behaviorally terminal: control actions block
 further transitions on them. `FAILED` is the suspended state produced by the `SUSPEND` control
@@ -150,8 +152,10 @@ produceable via `ControlFinancialBookingLog`.
 | `cmd/main.go` | Process wiring; initialises container, gRPC server, and metrics server |
 | `app/container.go` | Dependency injection; wires database, Redis, Kafka, and optional service clients |
 | `service/server.go` | gRPC service registration; changes here affect the public contract |
-| `service/posting_service.go` | Core double-entry validation; enforces debits-equal-credits invariant |
-| `service/grpc_booking_endpoints.go` | Booking log RPC handlers; booking log lifecycle state machine |
+| `service/posting_service.go` | Posting construction and double-entry helpers for deposit and settlement flows |
+| `domain/validation.go` | Reusable double-entry primitives (`ValidateTransactionBalance`, `ValidateDoubleEntryPair`); per-instrument balancing and cross-instrument rejection |
+| `service/grpc_mappers.go` | `validateDoubleEntryBalance` - enforces the debits-equal-credits invariant on the PENDING -> POSTED transition |
+| `service/grpc_booking_endpoints.go` | Booking log RPC handlers; booking log lifecycle state machine; gates the POSTED transition on the balance check |
 | `service/grpc_ledger_endpoints.go` | Ledger posting RPC handlers; idempotency enforcement per posting |
 | `domain/financial_booking_log.go` | FinancialBookingLog entity; status transition rules and aggregate invariants |
 | `domain/ledger_posting.go` | LedgerPosting entity; direction semantics and immutability rules after capture |
@@ -183,7 +187,7 @@ produceable via `ControlFinancialBookingLog`.
 | Variable | Required | Default | Purpose |
 |----------|----------|---------|---------|
 | `KAFKA_BOOTSTRAP_SERVERS` | No | - | Kafka broker list; enables audit event publishing when set |
-| `KAFKA_AUDIT_TOPIC` | No | `audit.events.*` | Audit event topic name override |
+| `KAFKA_AUDIT_TOPIC` | No | `audit.events.v1` | Audit event topic name override |
 
 ### Idempotency Store (Redis)
 

--- a/services/internal-account/README.md
+++ b/services/internal-account/README.md
@@ -16,7 +16,7 @@ instructions: |
 
   Key patterns:
   - Account lifecycle: ACTIVE -> SUSPENDED -> CLOSED (no PENDING state; CLOSED is terminal)
-  - Account types: CLEARING, NOSTRO, VOSTRO, HOLDING, SUSPENSE, REVENUE, EXPENSE, INVENTORY
+  - Account types: CLEARING, NOSTRO, VOSTRO, HOLDING, SUSPENSE, REVENUE, EXPENSE
   - NOSTRO and VOSTRO accounts require CounterpartyDetails; other types must not include them
   - CLEARING accounts carry a ClearingPurpose (DEPOSIT / WITHDRAWAL / SETTLEMENT / GENERAL)
   - Balance is NOT stored locally - delegated to position-keeping per ADR-0023
@@ -88,25 +88,28 @@ classDiagram
     class CounterpartyDetails {
         +string CounterpartyID
         +string CounterpartyName
-        +string CounterpartyExternalRef
-        +CounterpartyType CounterpartyType
+        +string ExternalRef
+        +map Attributes
     }
 
     class Lien {
-        +string LienID
+        +string ID
         +string AccountID
-        +InstrumentAmount Amount
+        +int64 AmountCents
+        +string InstrumentCode
         +LienStatus Status
         +string PaymentOrderReference
+        +string BucketID
         +time ExpiresAt
     }
 
     class ValuationFeature {
-        +string FeatureID
+        +string ID
         +string AccountID
-        +string SourceInstrumentCode
-        +string TargetInstrumentCode
-        +string ValuationMethod
+        +string InstrumentCode
+        +string ValuationMethodID
+        +int ValuationMethodVersion
+        +LifecycleStatus LifecycleStatus
     }
 
     class InternalAccountType {
@@ -118,7 +121,6 @@ classDiagram
         SUSPENSE
         REVENUE
         EXPENSE
-        INVENTORY
     }
 
     class ClearingPurpose {
@@ -144,19 +146,12 @@ classDiagram
         TERMINATED
     }
 
-    class CounterpartyType {
-        <<enumeration>>
-        NOSTRO
-        VOSTRO
-    }
-
     InternalAccountFacility --> InternalAccountType
     InternalAccountFacility --> ClearingPurpose
     InternalAccountFacility --> InternalAccountStatus
     InternalAccountFacility "1" --> "0..1" CounterpartyDetails : required for NOSTRO/VOSTRO
     InternalAccountFacility "1" --> "*" Lien : has
     InternalAccountFacility "1" --> "*" ValuationFeature : has
-    CounterpartyDetails --> CounterpartyType
     Lien --> LienStatus
 ```
 

--- a/services/position-keeping/README.md
+++ b/services/position-keeping/README.md
@@ -14,12 +14,14 @@ instructions: |
   Do not compute balances in any other service.
 
   FinancialPositionLog is the aggregate root. Each log is append-only and
-  enforces a hard limit of 10,000 entries. Transaction status machine:
-  PENDING -> RECONCILED -> POSTED -> REVERSED. POSTED is effectively immutable
+  enforces a hard limit of 10,000 entries. Status is tracked on the log via
+  StatusTracking through eight states: PENDING, RECONCILED, POSTED, FAILED,
+  REJECTED, AMENDED, CANCELLED, REVERSED. POSTED is effectively immutable
   (terminal for most mutations).
 
-  Parent-child lineage: reversals and amendments reference their parent log entry
-  via parent_log_id. This is how the audit chain for compensation is maintained.
+  Parent-child lineage: reversals and amendments reference their parent
+  transaction via TransactionLineage.parentTransactionID. This is how the audit
+  chain for compensation is maintained.
 
   7 BIAN balance types: OPENING, CLOSING, CURRENT, AVAILABLE, LEDGER, RESERVE, FREE.
   GetAccountBalance and GetAccountBalances are the two balance query RPCs; all other
@@ -81,21 +83,21 @@ classDiagram
     class FinancialPositionLog {
         +UUID logId
         +string accountId
-        +string instrumentCode
-        +TransactionStatus status
+        +string accountServiceDomain
+        +StatusTracking statusTracking
         +int64 version
-        +int entryCount
+        +Money openingBalance
         +time createdAt
+        +time updatedAt
     }
-    class TransactionEntry {
+    class TransactionLogEntry {
         +UUID entryId
-        +UUID logId
-        +UUID parentLogId
-        +decimal amount
+        +UUID transactionId
+        +string accountId
+        +Money amount
         +PostingDirection direction
-        +TransactionStatus status
         +TransactionSource source
-        +time effectiveAt
+        +time timestamp
     }
     class Balance {
         +BalanceType type
@@ -103,26 +105,31 @@ classDiagram
         +string instrumentCode
     }
     class Measurement {
-        +UUID measurementId
-        +string accountId
-        +string metricCode
+        +UUID id
+        +UUID financialPositionLogId
+        +MeasurementType measurementType
         +decimal value
-        +time recordedAt
+        +string unit
+        +time timestamp
     }
     class Reservation {
-        +UUID reservationId
+        +UUID lienId
         +string accountId
-        +decimal amount
+        +string instrumentCode
+        +decimal reservedAmount
         +ReservationStatus status
-        +time expiresAt
+        +time executedAt
+        +time terminatedAt
     }
-    FinancialPositionLog "1" --> "*" TransactionEntry : contains (append-only)
-    TransactionEntry --> TransactionEntry : parent-child lineage (reversals)
+    FinancialPositionLog "1" --> "*" TransactionLogEntry : contains (append-only)
+    TransactionLogEntry --> TransactionLogEntry : lineage via parentTransactionID (reversals)
     FinancialPositionLog ..> Balance : computed from entries
 ```
 
-`TransactionEntry.status`: `PENDING` -> `RECONCILED` -> `POSTED` -> `REVERSED`.
-`POSTED` entries are immutable; reversals create a new child entry referencing the parent.
+Status is tracked on the position log (`StatusTracking.CurrentStatus`) and flows
+through eight states: `PENDING`, `RECONCILED`, `POSTED`, `FAILED`, `REJECTED`,
+`AMENDED`, `CANCELLED`, `REVERSED`. `POSTED` entries are immutable; reversals append a
+new entry that references the parent transaction via `TransactionLineage`.
 Hard limit: 10,000 entries per `FinancialPositionLog`.
 
 **7 BIAN Balance Types:**


### PR DESCRIPTION
## Summary

Reconciles the five core ledger service READMEs against current code (unit `assess-2026-06-04.4`). These READMEs are AI-navigability maps; verification found drift between documented API/domain/config claims and the live services. Each claim below was checked against the cited proto/domain/Go file before editing. Pure-markdown changes; template structure preserved.

## Changes Made

### control-plane
- The `POST /stripe/webhook` HTTP endpoint does not exist in code. The handler in `internal/stripe/webhook.go` is implemented (HMAC-SHA256 verification, replay guard, Kafka publishing) but is **not registered to any HTTP route** in this service; the binary serves gRPC only. Live Stripe webhook ingestion runs in `financial-gateway` (`POST /webhooks/stripe/{tenantID}`). Corrected the HTTP endpoints section, frontmatter, and the load-bearing-file note.
- gRPC API surface (18 RPCs), load-bearing paths, dependents, port 50062, and the three documented env vars all verified accurate.

### current-account
- Materially accurate. Single fix: Lien/Withdrawal amount type label `MoneyAmount` -> `Money` (the actual domain type). API surface (20 RPCs), lien/account/withdrawal lifecycle states, file paths, config, port 50051 all verified correct.

### financial-accounting
- `LedgerPosting` field is `Amount` (`Money`), not `PostingAmount` (`InstrumentAmount`); `AccountServiceDomain` is a plain string.
- `FinancialBookingLog` field is `BaseCurrency` (`Currency`), not `BaseInstrumentCode` (string).
- Corrected the multi-asset prose: the general ledger posts `Money` (`Qty[Monetary]`); commodity quantities (kWh, carbon, compute) are tracked in `position-keeping`.
- `KAFKA_AUDIT_TOPIC` default is `audit.events.v1`, not `audit.events.*`.
- Re-attributed the debits-equal-credits enforcement: it runs in `service/grpc_mappers.go` (`validateDoubleEntryBalance`) gated on the PENDING->POSTED transition, with reusable primitives in `domain/validation.go`. `posting_service.go` does not gate the POSTED transition.

### internal-account
- Removed the `INVENTORY` account type (domain defines 7 types: CLEARING, NOSTRO, VOSTRO, HOLDING, SUSPENSE, REVENUE, EXPENSE).
- `Lien`: `ID` + `AmountCents` (int64) + `InstrumentCode` + `BucketID`, not `LienID` + `Amount` (`InstrumentAmount`).
- `ValuationFeature`: `ID`, single `InstrumentCode`, `ValuationMethodID` + `ValuationMethodVersion`, `LifecycleStatus` - not `FeatureID`/`SourceInstrumentCode`/`TargetInstrumentCode`/`ValuationMethod`.
- `CounterpartyDetails`: `ExternalRef` + `Attributes`; `CounterpartyType` is a proto-only enum, not a domain field (removed the enum class and edge).

### position-keeping
- Status machine has eight states (PENDING, RECONCILED, POSTED, FAILED, REJECTED, AMENDED, CANCELLED, REVERSED), tracked on the log via `StatusTracking` - not a four-state chain on entries.
- Entry type is `TransactionLogEntry` (`entryId`, `transactionId`, `accountId`, `amount`, `direction`, `source`, `timestamp`); no `logId`/`parentLogId`/`status`/`effectiveAt`.
- Lineage references the parent via `TransactionLineage.parentTransactionID`, not `parent_log_id`.
- `FinancialPositionLog`: `accountServiceDomain`, `statusTracking`, `openingBalance`, `updatedAt`; no `instrumentCode` field.
- `Reservation`: `lienId`/`reservedAmount`/`executedAt`/`terminatedAt` (no `expiresAt`). `Measurement`: `id`/`financialPositionLogId`/`measurementType`/`unit`/`timestamp`.
- API surface (15 RPCs incl. UNIMPLEMENTED stubs), 7 BIAN balance types, compaction defaults, 10k entry cap, full config table, ports 50053/9090 verified accurate.

## Testing

Pure-markdown documentation change. markdownlint passes (pre-commit gitleaks + markdownlint green on every commit). No code changes.

## Risk Assessment

Low. Documentation only; no behavioural change. All edits verified against the cited source files.

## Notes / Unrelated Findings

- The `control-plane` frontmatter previously claimed Kafka was required for Stripe publishing, but `control-plane/cmd/main.go` wires neither Kafka nor the Stripe handler. Per `docs/prd/033-gateway-architecture.md`, `control-plane/internal/stripe/` is slated to move to `financial-gateway/adapters/stripe/` - the unwired handler may be removed there.
- `internal-account` keeps the BIAN-style `InternalAccountFacility` entity name in the diagram (Go type is `InternalAccount`), consistent with `current-account`'s `CurrentAccountFacility` documentation convention.
