### PR TITLE
docs: Refresh stale architecture docs against current code (assess-2026-06-04.7)

### DIFF
--- a/docs/architecture/bian-service-boundaries.md
+++ b/docs/architecture/bian-service-boundaries.md
@@ -1,10 +1,16 @@
 # BIAN Service Boundaries
 
-**Document Version:** 1.1
-**Last Updated:** 2026-01-19
+**Document Version:** 1.2
+**Last Updated:** 2026-06-08
 **Status:** Active
 **Related ADR:** [ADR-0002: Microservices Per BIAN Domain](../adr/0002-microservices-per-bian-domain.md)
 **Related Analysis:** [Service Coupling Analysis](service-coupling-analysis.md)
+
+> **Scope note (2026-06-08):** This document details four representative service domains (CurrentAccount,
+> PositionKeeping, FinancialAccounting, MarketInformation). The codebase now contains 19 services under
+> `services/`. For the complete service-to-BIAN-domain mapping and current coupling metrics, see the
+> [Service Coupling Analysis](service-coupling-analysis.md). Platform code has been migrated out of
+> `internal/platform/` into `shared/platform/`; references below have been updated accordingly.
 
 ## Overview
 
@@ -17,8 +23,8 @@ Meridian follows a microservices-per-BIAN-domain architecture where:
 1. **One Service per BIAN Domain**: Each BIAN service domain is implemented as an independently deployable microservice
 2. **Independent Databases**: Each service owns its database schema with no cross-service database access
 3. **Proto-Based Communication**: Services communicate exclusively via protobuf-defined gRPC (synchronous) and Kafka events (asynchronous)
-4. **No Internal Package Coupling**: Services must not import `internal/<other-service>/` packages
-5. **Shared Platform Code**: Common infrastructure resides in `pkg/platform/` (currently being migrated from `internal/platform/`)
+4. **No Internal Package Coupling**: Services must not import another service's `internal/` packages (`services/<other-service>/internal/...`)
+5. **Shared Platform Code**: Common infrastructure resides in `shared/platform/`, with reusable libraries in `shared/pkg/` and shared domain types in `shared/domain/`
 
 ### BIAN Compliance
 
@@ -31,20 +37,23 @@ The service boundaries defined in this document adhere to BIAN Service Landscape
 
 ### Current Coupling Analysis Summary
 
-As of the [2025-11-19 coupling analysis](service-coupling-analysis.md):
+As of the [2026-06-08 coupling analysis](service-coupling-analysis.md):
 
 - **Zero cross-service domain violations**: No service imports another service's internal packages
-- **17 platform usage violations**: Services import `internal/platform/*` packages (remediation in progress to move to `pkg/platform/`)
-- **Clean proto dependencies**: 14 safe cross-service proto imports for gRPC client communication
-- **Stable architecture**: Position-keeping (I=0.00) and financial-accounting (I=0.00) are stable provider services; current-account (I=1.00) is an orchestration layer with expected high instability
+- **Platform separation complete**: Platform code now lives in `shared/platform/` (the former
+  `internal/platform` violation class no longer exists)
+- **Clean proto dependencies**: Cross-service calls use generated gRPC clients only
+- **Stable architecture**: Foundational providers (reference-data Ca=5, position-keeping Ca=4,
+  market-information, party, current-account, financial-accounting) are stable; orchestration/aggregation
+  layers (control-plane, event-router, payment-order, mcp-server) carry instability by design
 
 ---
 
 ## CurrentAccount Service
 
 **BIAN Domain:** Current Account
-**Service Location:** `cmd/current-account/`
-**Internal Package:** `internal/current-account/`
+**Service Location:** `services/current-account/`
+**Package Layout:** `services/current-account/{domain,service,adapters,app,client}`
 **Proto Definition:** `api/proto/meridian/current_account/v1/current_account.proto`
 **Database Schema:** `current_account_audit` (audit_log, audit_outbox)
 
@@ -182,8 +191,8 @@ The CurrentAccount service owns:
    - MUST NOT maintain its own transaction log
 
 4. **Cross-service internal imports** - Architectural boundary violation
-   - MUST NOT import `internal/position-keeping/*` packages
-   - MUST NOT import `internal/financial-accounting/*` packages
+   - MUST NOT import `services/position-keeping/*` packages
+   - MUST NOT import `services/financial-accounting/*` packages
    - MUST use proto-defined gRPC clients only
 
 5. **Database schema access to other services**
@@ -217,8 +226,8 @@ This service acts as an orchestration layer coordinating operations across posit
 ## PositionKeeping Service
 
 **BIAN Domain:** Position Keeping
-**Service Location:** `cmd/position-keeping/`
-**Internal Package:** `internal/position-keeping/`
+**Service Location:** `services/position-keeping/`
+**Package Layout:** `services/position-keeping/{domain,service,adapters,app,client}`
 **Proto Definition:** `api/proto/meridian/position_keeping/v1/position_keeping.proto`
 **Event Publications:** `api/proto/meridian/events/v1/position_keeping_events.proto`
 
@@ -367,8 +376,8 @@ The PositionKeeping service owns:
 - Position update events (42 publisher usages identified in coupling analysis)
 - Transaction status change events
 - Audit trail events
-- **Implementation:** `internal/position-keeping/adapters/messaging/kafka_event_publisher.go`
-- **Domain Interface:** `internal/position-keeping/domain/event_publisher.go`
+- **Implementation:** `services/position-keeping/adapters/messaging/kafka_event_publisher.go`
+- **Domain Interface:** `services/position-keeping/domain/event_publisher.go`
 
 #### What This Service DEPENDS ON
 
@@ -403,8 +412,8 @@ The PositionKeeping service owns:
    - MUST provide data services only (create, retrieve, update logs)
 
 4. **Cross-service internal imports**
-   - MUST NOT import `internal/current-account/*` packages
-   - MUST NOT import `internal/financial-accounting/*` packages
+   - MUST NOT import `services/current-account/*` packages
+   - MUST NOT import `services/financial-accounting/*` packages
 
 5. **Business rule enforcement beyond transaction logging**
    - MUST NOT validate business rules (e.g., transaction limits)
@@ -439,8 +448,8 @@ This service is a stable foundation for transaction tracking with:
 ## FinancialAccounting Service
 
 **BIAN Domain:** Financial Accounting
-**Service Location:** `cmd/financial-accounting/`
-**Internal Package:** `internal/financial-accounting/`
+**Service Location:** `services/financial-accounting/`
+**Package Layout:** `services/financial-accounting/{domain,service,adapters,app,client}`
 **Proto Definition:** `api/proto/meridian/financial_accounting/v1/financial_accounting.proto`
 **Event Subscriptions:** `api/proto/meridian/events/v1/deposit_event.proto`, `api/proto/meridian/events/v1/financial_accounting_events.proto`
 
@@ -526,7 +535,7 @@ The FinancialAccounting service owns:
   - Listens to deposit events from Kafka
   - Automatically creates booking logs and postings for deposits
   - Asynchronous transaction processing
-  - **Implementation:** `internal/financial-accounting/adapters/messaging/deposit_consumer.go`
+  - **Implementation:** `services/financial-accounting/adapters/messaging/deposit_consumer.go`
 
 - **Financial accounting event publication** (9 publisher usages identified)
   - Publishes posting completion events
@@ -610,8 +619,8 @@ The FinancialAccounting service owns:
    - MUST process events and API requests independently
 
 4. **Cross-service internal imports**
-   - MUST NOT import `internal/current-account/*` packages
-   - MUST NOT import `internal/position-keeping/*` packages
+   - MUST NOT import `services/current-account/*` packages
+   - MUST NOT import `services/position-keeping/*` packages
 
 5. **Transaction log persistence beyond accounting entries**
    - MUST NOT duplicate position-keeping's transaction log
@@ -798,82 +807,37 @@ This service is a stable foundation for market data with:
 
 ## Shared vs Service-Specific Code
 
-### Platform Code (`pkg/platform/` - Shared Infrastructure)
+### Platform Code (`shared/platform/` - Shared Infrastructure)
 
-**IMPORTANT: Migration in Progress**
-Platform code is currently in `internal/platform/` but is being migrated to `pkg/platform/` to follow Go module semantics. See [Coupling Analysis - P1-1 Remediation](service-coupling-analysis.md#p1-1-migrate-platform-code-from-internalplatform-to-pkgplatform) for details.
+Platform code lives in `shared/platform/` (the `internal/platform` → shared migration is complete; see
+[Coupling Analysis - P1-1](service-coupling-analysis.md#p1-1-migrate-platform-code-out-of-internalplatform-completed)).
+Reusable, domain-agnostic libraries live in `shared/pkg/`, and shared domain types in `shared/domain/`.
 
-#### Current Platform Packages (To Be Moved to `pkg/platform/`)
+#### Platform Packages (`shared/platform/`)
 
-**`observability/` - OpenTelemetry Integration**
+| Package | Purpose |
+|---------|---------|
+| `observability/` | OpenTelemetry tracing, structured logging, metrics, trace propagation |
+| `kafka/` | Kafka producer/consumer with protobuf serialization, offset management, DLQ |
+| `events/` | Outbox pattern (`outbox.go`) and the topic registry (`events/topics/topics.yaml`) |
+| `db/` | Database access helpers (GORM tenant scoping, transactions) |
+| `auth/` | JWT validation and gRPC authorization middleware |
+| `testdb/` | CockroachDB Testcontainers integration for tests |
+| `scheduler/` | Scheduled job execution |
+| `ratelimit/` | Rate limiting |
+| `gateway/` | HTTP/gRPC gateway helpers |
+| `tenant/` | Multi-tenant context propagation |
+| `bootstrap/`, `defaults/`, `env/`, `ports/`, `quantity/`, `redislock/`, `sandbox/`, `await/` | Supporting infrastructure |
 
-- Distributed tracing with OpenTelemetry
-- Structured logging with contextual fields
-- Metrics collection (counters, histograms, gauges)
-- Trace context propagation across gRPC calls
-- **Used by:** All services (7 imports detected)
-- **Files:**
-  - `cmd/current-account/main.go` - Service startup tracing
-  - `internal/current-account/service/grpc_service.go` - Request tracing
-  - `services/current-account/client/` - Client-side tracing
-  - `cmd/financial-accounting/main.go` - Service startup tracing
-  - `internal/position-keeping/app/container.go` - Dependency injection with tracing
+#### Reusable Libraries (`shared/pkg/`)
 
-**`kafka/` - Kafka Producer/Consumer Infrastructure**
+Domain-agnostic helpers including `clients` (resilient gRPC clients: retry, circuit breaker), `saga`
+(saga orchestration patterns), `money`/`amount`, `cel`, `validation`, `idempotency`, `grpc`, `health`,
+`interceptors`, and `valuation`.
 
-- Kafka producer with protobuf serialization
-- Kafka consumer with offset management
-- Consumer group coordination
-- Error handling and retry logic
-- **Used by:** Position-keeping, financial-accounting (3 imports detected)
-- **Files:**
-  - `internal/position-keeping/adapters/messaging/kafka_event_publisher.go`
-  - `internal/financial-accounting/adapters/messaging/deposit_consumer.go`
+#### Shared Domain (`shared/domain/`)
 
-**`testdb/` - Testcontainers Integration**
-
-- PostgreSQL Testcontainers setup
-- Database schema initialization for tests
-- Transaction isolation for test cases
-- Connection pool management for tests
-- **Used by:** Current-account, financial-accounting (5 imports detected)
-- **Files:**
-  - `internal/current-account/adapters/persistence/repository_test.go`
-  - `internal/current-account/service/grpc_service_test.go`
-  - `internal/financial-accounting/adapters/persistence/repository_test.go`
-  - `internal/financial-accounting/service/posting_service_test.go`
-  - `internal/financial-accounting/adapters/messaging/deposit_consumer_test.go`
-
-**`auth/` - JWT Validation and Authorization**
-
-- JWT token parsing and validation
-- Authorization middleware for gRPC
-- Role-based access control (RBAC)
-- **Used by:** Position-keeping (1 import detected)
-- **Files:**
-  - `internal/position-keeping/app/container.go`
-
-#### Future Platform Packages (Not Yet Implemented)
-
-**`database/` - Database Connection Management**
-
-- Connection pooling
-- Transaction management
-- Database health checks
-- Migration coordination with Atlas
-
-**`grpc/` - gRPC Server and Client Utilities**
-
-- Server interceptors (logging, tracing, auth)
-- Client interceptors (retry, circuit breaker)
-- Health check implementations
-- gRPC connection management
-
-**`idempotency/` - Idempotency Key Management**
-
-- Redis-based idempotency key storage
-- Duplicate request detection
-- Response caching for idempotent operations
+Domain types shared across service boundaries (e.g. `models`, common entity types).
 
 ### Service Structure
 
@@ -973,9 +937,9 @@ These rules enforce architectural boundaries and prevent coupling violations. Th
 **Examples:**
 
 ```go
-// FORBIDDEN - Cross-service internal import
-import "github.com/meridianhub/meridian/internal/position-keeping/domain"
-import "github.com/meridianhub/meridian/internal/financial-accounting/service"
+// FORBIDDEN - Cross-service package import
+import "github.com/meridianhub/meridian/services/position-keeping/domain"
+import "github.com/meridianhub/meridian/services/financial-accounting/service"
 
 // CORRECT - Use proto-defined gRPC client
 import pb "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
@@ -1001,20 +965,22 @@ import fa_pb "github.com/meridianhub/meridian/api/proto/meridian/financial_accou
 - Clear contract boundaries prevent implementation leakage
 - Supports polyglot service implementations
 
-**Current Status:** COMPLIANT (14 safe proto imports detected)
+**Current Status:** COMPLIANT (cross-service calls use generated gRPC clients only)
 
-**Communication Patterns:**
+**Communication Patterns (representative current edges):**
 
 **Synchronous (gRPC):**
 
-- Current-account → Position-keeping (balance queries, transaction retrieval)
-- Current-account → Financial-accounting (posting creation)
+- Position-keeping → Reference-data, Internal-account, Current-account
+- Reconciliation → Current-account, Position-keeping, Reference-data
+- Control-plane → Reference-data, Internal-account, Market-information, Party, Operational-gateway
 
 **Asynchronous (Kafka):**
 
-- Current-account → Financial-accounting (deposit events)
-- Position-keeping → All consumers (position update events)
-- Financial-accounting → All consumers (posting completion events)
+- Position-keeping → consumers of transaction lifecycle events
+- Financial-gateway → consumers of validated payment-provider events
+- See [Event-Driven Architecture](event-driven-architecture.md) and
+  `shared/platform/events/topics/topics.yaml` for the full topic map
 
 **Examples:**
 
@@ -1031,7 +997,7 @@ event := &events.DepositEvent{
 publisher.Publish(ctx, event)
 
 // FORBIDDEN - Direct function call to another service
-import "github.com/meridianhub/meridian/internal/position-keeping/service"
+import "github.com/meridianhub/meridian/services/position-keeping/service"
 result := service.CreateTransactionLog(log)  // ❌ NOT ALLOWED
 ```
 
@@ -1042,46 +1008,34 @@ result := service.CreateTransactionLog(log)  // ❌ NOT ALLOWED
 buf breaking --against '.git#branch=develop'
 ```
 
-#### Rule 3: Platform Code in `pkg/platform/` Only
+#### Rule 3: Shared Platform Code in `shared/` Only
 
-**Rule:** Shared platform code MUST reside in `pkg/platform/` and MUST NOT be in `internal/platform/`.
+**Rule:** Shared infrastructure MUST reside under `shared/platform/` (or `shared/pkg/`, `shared/domain/`)
+and MUST NOT be placed in the top-level `internal/` tree.
 
 **Rationale:**
 
-- `internal/` is semantically private and should not be imported across services
-- `pkg/` is the correct location for shared, reusable libraries
-- Clarifies which code is truly internal vs shared infrastructure
-- Follows Go module semantics for public packages
-- Enables external tools to import platform utilities
+- `shared/` is importable across all services by design
+- Clarifies which code is truly service-private (`services/<svc>/...`) vs shared infrastructure
+- Enables platform utilities to be reused by every service and supporting tool
 
-**Current Status:** NON-COMPLIANT (17 violations - migration in progress)
-
-**Remediation:** See [Coupling Analysis - P1-1](service-coupling-analysis.md#p1-1-migrate-platform-code-from-internalplatform-to-pkgplatform) for detailed migration plan.
-
-**Affected Packages:**
-
-- `internal/platform/observability` → `pkg/platform/observability` (7 files)
-- `internal/platform/kafka` → `pkg/platform/kafka` (3 files)
-- `internal/platform/testdb` → `pkg/platform/testdb` (5 files)
-- `internal/platform/auth` → `pkg/platform/auth` (1 file)
+**Current Status:** COMPLIANT (migration from `internal/platform/` to `shared/platform/` complete; see
+[Coupling Analysis - P1-1](service-coupling-analysis.md#p1-1-migrate-platform-code-out-of-internalplatform-completed)).
 
 **Examples:**
 
 ```go
-// CURRENT (NON-COMPLIANT) - Will be removed
-import "github.com/meridianhub/meridian/internal/platform/observability"
+// CORRECT - Import shared platform code
+import "github.com/meridianhub/meridian/shared/platform/observability"
+import "github.com/meridianhub/meridian/shared/platform/kafka"
 
-// TARGET (COMPLIANT) - Migration target
-import "github.com/meridianhub/meridian/pkg/platform/observability"
+// CORRECT - Reusable libraries and shared domain types
+import "github.com/meridianhub/meridian/shared/pkg/clients"
+import "github.com/meridianhub/meridian/shared/domain/models"
 ```
 
-**Migration Checklist:**
-
-- [ ] Move package from `internal/platform/` to `pkg/platform/`
-- [ ] Update all import statements across services
-- [ ] Update go.mod if package exports change
-- [ ] Run full test suite to verify compatibility
-- [ ] Update documentation references
+**Guardrail:** New shared code goes under `shared/`; service-private code stays under
+`services/<service>/`. A service must never import another service's non-public packages.
 
 #### Rule 4: Independent Database Schemas
 
@@ -1126,10 +1080,10 @@ client.UpdateFinancialBookingLog(ctx, &pb.UpdateRequest{LogId: logID, Status: st
 
 ```go
 // Each service maintains its own database connection pool
-// internal/current-account/app/container.go
+// services/current-account/app/container.go
 db, err := sql.Open("postgres", os.Getenv("CURRENT_ACCOUNT_DB_URL"))
 
-// internal/position-keeping/app/container.go
+// services/position-keeping/app/container.go
 db, err := sql.Open("postgres", os.Getenv("POSITION_KEEPING_DB_URL"))
 ```
 
@@ -1171,7 +1125,7 @@ db, err := sql.Open("postgres", os.Getenv("POSITION_KEEPING_DB_URL"))
 
 ```go
 // CORRECT - Domain logic in service's domain package
-// internal/current-account/domain/account.go
+// services/current-account/domain/account.go
 func (a *Account) ValidateOverdraftLimit(amount Money) error {
     if !a.OverdraftEnabled {
         return errors.New("overdraft not enabled")
@@ -1241,10 +1195,10 @@ These dependency patterns are architecturally permitted and support the BIAN-ali
 **Direction:** Services → Platform utilities
 **Allowed Packages:**
 
-- `pkg/platform/observability` - OpenTelemetry tracing, logging, metrics
-- `pkg/platform/kafka` - Kafka producer/consumer infrastructure
-- `pkg/platform/auth` - JWT validation and authorization
-- `pkg/platform/testdb` - Testcontainers integration for tests
+- `shared/platform/observability` - OpenTelemetry tracing, logging, metrics
+- `shared/platform/kafka` - Kafka producer/consumer infrastructure
+- `shared/platform/auth` - JWT validation and authorization
+- `shared/platform/testdb` - CockroachDB Testcontainers integration for tests
 
 **Justification:**
 
@@ -1271,11 +1225,11 @@ These patterns violate architectural boundaries and MUST be prevented:
 // FORBIDDEN - Circular dependency
 // CurrentAccount → FinancialAccounting → CurrentAccount
 
-// internal/current-account/service/account_service.go
+// services/current-account/service/account_service.go
 import fa_pb "meridian/financial_accounting/v1"
 faClient.InitiateBookingLog(...)
 
-// internal/financial-accounting/service/posting_service.go
+// services/financial-accounting/service/posting_service.go
 import ca_pb "meridian/current_account/v1"  // ❌ NOT ALLOWED
 caClient.RetrieveAccount(...)
 ```
@@ -1295,7 +1249,7 @@ caClient.RetrieveAccount(...)
 
 ```go
 // FORBIDDEN - Position-keeping calling other services
-// internal/position-keeping/service/position_service.go
+// services/position-keeping/service/position_service.go
 import fa_pb "meridian/financial_accounting/v1"  // ❌ NOT ALLOWED
 faClient.InitiateBookingLog(...)
 ```
@@ -1315,7 +1269,7 @@ faClient.InitiateBookingLog(...)
 
 ```go
 // FORBIDDEN - Bypassing financial-accounting
-// internal/current-account/service/deposit_service.go
+// services/current-account/service/deposit_service.go
 pkClient.UpdateFinancialPositionLog(ctx, &pb.UpdateRequest{
     TransactionLog: &pb.TransactionLogEntry{
         Amount: depositAmount,  // ❌ Missing double-entry validation
@@ -1457,7 +1411,7 @@ When reviewing pull requests, verify:
 
 - [ ] **No cross-service internal imports** - Check import statements in changed files
 - [ ] **Proto-only communication** - All inter-service calls use gRPC or events
-- [ ] **Platform code location** - New shared code in `pkg/platform/`, not `internal/platform/`
+- [ ] **Platform code location** - New shared code in `shared/platform/` (or `shared/pkg/`), not in a service's package or the top-level `internal/`
 - [ ] **Database isolation** - No direct queries to other service schemas
 - [ ] **Domain logic placement** - Business rules in owning service's domain package
 - [ ] **Dependency direction** - New dependencies follow allowed patterns
@@ -1724,7 +1678,7 @@ resp, err := faClient.CaptureLedgerPosting(ctx, &pb.CaptureRequest{
 **Consumer:**
 
 - **Service:** FinancialAccounting
-- **Implementation:** `internal/financial-accounting/adapters/messaging/deposit_consumer.go`
+- **Implementation:** `services/financial-accounting/adapters/messaging/deposit_consumer.go`
 
 **Event Flow:**
 
@@ -1744,7 +1698,7 @@ resp, err := faClient.CaptureLedgerPosting(ctx, &pb.CaptureRequest{
 **Publisher:**
 
 - **Service:** PositionKeeping
-- **Implementation:** `internal/position-keeping/adapters/messaging/kafka_event_publisher.go`
+- **Implementation:** `services/position-keeping/adapters/messaging/kafka_event_publisher.go`
 - **Usage:** 42 event publisher usages detected
 
 **Consumers:**
@@ -1835,11 +1789,11 @@ Each service has integration tests that validate boundaries are respected:
 
 **Manual Review Checklist:**
 
-- [ ] No `internal/<other-service>/` imports
+- [ ] No imports of another service's `services/<other-service>/` packages
 - [ ] All cross-service calls use proto-defined gRPC or events
 - [ ] No direct database access to other service schemas
 - [ ] Business logic resides in owning service's domain package
-- [ ] Platform code uses `pkg/platform/` (post-migration)
+- [ ] Platform code uses `shared/platform/` (or `shared/pkg/`)
 
 ---
 
@@ -1855,13 +1809,13 @@ graph TD
         CLIENT[Client Applications<br/>Web/Mobile/API]
     end
 
-    subgraph Services["Microservices Layer"]
-        CA[CurrentAccount<br/>BIAN: Current Account<br/><b>I=1.00 Orchestrator</b>]
+    subgraph Services["Microservices Layer (representative subset of 19)"]
+        CA[CurrentAccount<br/>BIAN: Current Account<br/><b>I=0.00 Stable provider</b>]
         FA[FinancialAccounting<br/>BIAN: Financial Accounting<br/><b>I=0.00 Stable</b>]
-        PK[PositionKeeping<br/>BIAN: Position Keeping<br/><b>I=0.00 Stable</b>]
+        PK[PositionKeeping<br/>BIAN: Position Keeping<br/><b>I=0.43 Balanced</b>]
     end
 
-    subgraph Platform["Platform Layer pkg/platform/"]
+    subgraph Platform["Platform Layer shared/platform/"]
         OBS[Observability<br/>OpenTelemetry]
         KAFKA_PLAT[Kafka Infrastructure<br/>Producer/Consumer]
         AUTH[Authentication<br/>JWT Validation]
@@ -1988,29 +1942,25 @@ graph TD
 
 - **Used by:** All services
 - **Provides:** Distributed tracing, structured logging, metrics collection
-- **Current Location:** `internal/platform/observability` (migration to `pkg/platform/observability` in progress)
-- **Imports:** 7 files across all services
+- **Location:** `shared/platform/observability`
 
 **Kafka Infrastructure:**
 
-- **Used by:** FinancialAccounting, PositionKeeping
-- **Provides:** Proto-based producer/consumer, offset management, error handling
-- **Current Location:** `internal/platform/kafka` (migration to `pkg/platform/kafka` in progress)
-- **Imports:** 3 files
+- **Used by:** All publishing/consuming services
+- **Provides:** Proto-based producer/consumer, offset management, DLQ, error handling
+- **Location:** `shared/platform/kafka` (topic registry in `shared/platform/events/topics/`)
 
 **Authentication (JWT):**
 
-- **Used by:** PositionKeeping
+- **Used by:** Services exposing authenticated gRPC/HTTP
 - **Provides:** JWT token validation, authorization middleware, RBAC
-- **Current Location:** `internal/platform/auth` (migration to `pkg/platform/auth` in progress)
-- **Imports:** 1 file
+- **Location:** `shared/platform/auth`
 
 **Test Infrastructure (Testcontainers):**
 
-- **Used by:** CurrentAccount, FinancialAccounting
-- **Provides:** PostgreSQL Testcontainers setup, database schema initialization
-- **Current Location:** `internal/platform/testdb` (migration to `pkg/platform/testdb` in progress)
-- **Imports:** 5 test files
+- **Used by:** Services with integration tests
+- **Provides:** CockroachDB Testcontainers setup, database schema initialization
+- **Location:** `shared/platform/testdb`
 
 #### Database Layer (Gray Components)
 

--- a/docs/architecture/bian-service-boundaries.md
+++ b/docs/architecture/bian-service-boundaries.md
@@ -201,25 +201,23 @@ The CurrentAccount service owns:
 
 ### Service Instability Analysis
 
-**Coupling Metrics (from 2025-11-19 analysis):**
+**Coupling Metrics (from 2026-06-08 analysis):**
 
-- **Afferent Coupling (Ca):** 0 (no services depend on current-account)
-- **Efferent Coupling (Ce):** 2 (depends on position-keeping and financial-accounting)
-- **Instability (I):** 1.00 (fully dependent, no dependents)
-- **Assessment:** Orchestration layer pattern - expected high instability
+- **Afferent Coupling (Ca):** 2 (position-keeping and reconciliation depend on current-account)
+- **Efferent Coupling (Ce):** 0 (no outbound cross-service gRPC dependencies)
+- **Instability (I):** 0.00 (stable provider)
+- **Assessment:** Stable provider - account state is consumed by other services
 
 **Interpretation:**
-This service acts as an orchestration layer coordinating operations across position-keeping and financial-accounting. High instability (I=1.00) is architecturally appropriate for this role, as it:
-
-- Shields clients from multi-service complexity
-- Provides a unified API for account operations
-- Adapts to changes in downstream service contracts
+Current-account is now a stable provider service. In the current topology it exposes account state that
+position-keeping and reconciliation consume; it does not itself call other domain services over gRPC. (In
+earlier analyses current-account was modelled as an orchestration layer with I=1.00; that orchestration is
+no longer expressed as direct outbound gRPC dependencies.)
 
 **Mitigation Strategies:**
 
-- Anti-corruption layer pattern insulates from proto changes
-- Circuit breakers prevent cascade failures
-- Comprehensive integration testing validates orchestration logic
+- Treat its proto surface as a stable contract (other services depend on it)
+- Publish account lifecycle changes via the outbox pattern for downstream consumers
 
 ---
 
@@ -422,24 +420,23 @@ The PositionKeeping service owns:
 
 ### Service Stability Analysis
 
-**Coupling Metrics (from 2025-11-19 analysis):**
+**Coupling Metrics (from 2026-06-08 analysis):**
 
-- **Afferent Coupling (Ca):** 1 (current-account depends on this service)
-- **Efferent Coupling (Ce):** 0 (no dependencies on other domain services)
-- **Instability (I):** 0.00 (fully stable)
-- **Assessment:** Stable provider service - foundational layer
+- **Afferent Coupling (Ca):** 4 (event-router, internal-account, reconciliation, mcp-server depend on it)
+- **Efferent Coupling (Ce):** 3 (reference-data, internal-account, current-account)
+- **Instability (I):** 0.43 (balanced - both provider and consumer)
+- **Assessment:** Central balance/position service - widely depended upon, with a few provider lookups
 
 **Interpretation:**
-This service is a stable foundation for transaction tracking with:
-
-- No outbound dependencies on other BIAN domains
-- Single consumer (current-account) with well-defined proto contract
-- Low risk of cascading changes
-- Appropriate role as a data persistence and audit service
+Position-keeping sits near the middle of the stability spectrum. It is a heavily-used provider (four
+services consume its position/balance data) and also performs provider lookups of its own (reference-data
+for instruments, internal-account, and current-account for account state). This is a deliberate part of
+the current topology; its provider role makes its proto surface a contract that downstream services rely
+on.
 
 **Stability Benefits:**
 
-- Changes isolated to this service only
+- Position/balance data is consumed widely, so its proto contract is treated as stable
 - Proto contract evolution is controlled
 - Event schema managed via buf breaking change detection (ADR-0004)
 
@@ -629,9 +626,9 @@ The FinancialAccounting service owns:
 
 ### Service Stability Analysis
 
-**Coupling Metrics (from 2025-11-19 analysis):**
+**Coupling Metrics (from 2026-06-08 analysis):**
 
-- **Afferent Coupling (Ca):** 1 (current-account depends on this service)
+- **Afferent Coupling (Ca):** 1 (mcp-server depends on this service)
 - **Efferent Coupling (Ce):** 0 (no dependencies on other domain services)
 - **Instability (I):** 0.00 (fully stable)
 - **Assessment:** Stable provider service - foundational layer
@@ -781,9 +778,9 @@ The MarketInformation service owns:
 
 ### Service Stability Analysis
 
-**Coupling Metrics:**
+**Coupling Metrics (from 2026-06-08 analysis):**
 
-- **Afferent Coupling (Ca):** 0 (no services depend on market-information yet)
+- **Afferent Coupling (Ca):** 3 (control-plane, event-router, mcp-server depend on it)
 - **Efferent Coupling (Ce):** 0 (no dependencies on other domain services)
 - **Instability (I):** 0.00 (fully stable)
 - **Assessment:** Stable provider service - foundational layer
@@ -1236,22 +1233,25 @@ caClient.RetrieveAccount(...)
 
 **Solution:** Introduce events or shared data entities to break the cycle
 
-#### ❌ PositionKeeping → Any Service (Outbound Dependencies)
+#### ❌ PositionKeeping Orchestrating Writes into Other Domains
 
-**Pattern:** PositionKeeping calling other services
+**Pattern:** PositionKeeping driving write/transaction operations in other services
 **Why Forbidden:**
 
-- Position-keeping is a stable provider service (I=0.00)
-- Should have zero efferent coupling to maintain stability
-- Acts as authoritative data source, not orchestrator
+- Position-keeping is a widely-consumed provider (Ca=4); it must not become a write orchestrator
+- Orchestrating writes into other domains would couple their write paths to position-keeping
+
+**Acceptable today:** In the current topology position-keeping performs read-only provider lookups
+(reference-data for instruments, internal-account, and current-account for account state). These reads are
+acceptable; what remains forbidden is position-keeping initiating writes/transactions in other domains.
 
 **Example:**
 
 ```go
-// FORBIDDEN - Position-keeping calling other services
+// FORBIDDEN - Position-keeping initiating a write in another domain
 // services/position-keeping/service/position_service.go
-import fa_pb "meridian/financial_accounting/v1"  // ❌ NOT ALLOWED
-faClient.InitiateBookingLog(...)
+import fa_pb "meridian/financial_accounting/v1"
+faClient.InitiateBookingLog(...)  // ❌ NOT ALLOWED - PK must not drive other domains' writes
 ```
 
 **Solution:** Position-keeping publishes events; other services consume and react
@@ -1288,45 +1288,42 @@ pkClient.UpdateFinancialPositionLog(ctx, &pb.UpdateRequest{
 
 ### Dependency Rationale and Trade-offs
 
-#### Why CurrentAccount Has High Instability (I=1.00)
+#### Why CurrentAccount Is a Stable Provider (I=0.00)
 
 **Coupling Metrics:**
 
-- **Afferent Coupling (Ca):** 0 (no services depend on current-account)
-- **Efferent Coupling (Ce):** 2 (depends on position-keeping and financial-accounting)
-- **Instability (I):** 1.00 (fully dependent, no dependents)
+- **Afferent Coupling (Ca):** 2 (position-keeping and reconciliation depend on it)
+- **Efferent Coupling (Ce):** 0 (no outbound cross-service gRPC dependencies)
+- **Instability (I):** 0.00 (stable provider)
 
 **Architectural Justification:**
 
-- Current-account is an **orchestration layer** coordinating account operations
-- Acts as API gateway for client applications
-- Shields clients from multi-service complexity
-- High instability is expected and appropriate for this role
+- Current-account exposes account state that other services consume
+- It does not call other domain services directly over gRPC
+- (In earlier 3-service analyses it was modelled as an I=1.00 orchestrator; that orchestration is no
+  longer expressed as direct outbound gRPC dependencies)
 
 **Trade-offs:**
 
-- **Benefit:** Unified API for account operations reduces client complexity
-- **Cost:** Changes in downstream services may require current-account updates
-- **Mitigation:** Anti-corruption layer pattern insulates from proto changes
+- **Benefit:** Stable contract for downstream consumers (position-keeping, reconciliation)
+- **Cost:** Must maintain backward compatibility in its proto contract
+- **Mitigation:** `buf breaking` detects contract violations in CI
 
-#### Why PositionKeeping and FinancialAccounting Are Stable (I=0.00)
+#### Why FinancialAccounting Is Stable and PositionKeeping Is Balanced
 
-**Coupling Metrics:**
+**FinancialAccounting (I=0.00):**
 
-- **Afferent Coupling (Ca):** 1 (current-account depends on each)
-- **Efferent Coupling (Ce):** 0 (no dependencies on other domain services)
-- **Instability (I):** 0.00 (fully stable)
+- **Afferent Coupling (Ca):** 1; **Efferent (Ce):** 0 - stable provider
 
-**Architectural Justification:**
+**PositionKeeping (I=0.43):**
 
-- Both are **provider services** offering data and computation
-- Act as stable foundations for orchestration layers
-- Changes isolated to service boundaries
-- Event-driven architecture for asynchronous coupling
+- **Afferent Coupling (Ca):** 4 (event-router, internal-account, reconciliation, mcp-server)
+- **Efferent Coupling (Ce):** 3 (reference-data, internal-account, current-account)
+- Both a widely-used provider and a consumer of provider lookups; sits mid-spectrum
 
 **Trade-offs:**
 
-- **Benefit:** Low risk of cascading changes, independent evolution
+- **Benefit:** Low risk of cascading changes for the stable providers; independent evolution
 - **Cost:** Must maintain backward compatibility in proto contracts
 - **Mitigation:** `buf breaking` detects contract violations in CI
 
@@ -1835,17 +1832,13 @@ graph TD
     %% Client to Services
     CLIENT -->|gRPC| CA
 
-    %% Synchronous Inter-Service Communication (gRPC)
-    CA -->|gRPC: RetrieveFinancialPositionLog<br/>ListFinancialPositionLogs| PK
-    CA -->|gRPC: InitiateFinancialBookingLog<br/>CaptureLedgerPosting| FA
+    %% Synchronous Inter-Service Communication (gRPC) - current topology
+    PK -->|gRPC: RetrieveAccount<br/>account state| CA
 
     %% Asynchronous Inter-Service Communication (Kafka)
-    CA -.->|Event: DepositInitiated| KAFKA
-    FA -.->|Event: PostingsCaptured<br/>BookingLogStatusChanged| KAFKA
-    PK -.->|Event: PositionUpdated<br/>TransactionStatusChanged| KAFKA
-
-    KAFKA -.->|Consume: DepositEvent| FA
-    KAFKA -.->|Future: Position Events| PK
+    CA -.->|Event: AccountFrozen / WithdrawalStatus| KAFKA
+    FA -.->|Event: BookingLogControlled| KAFKA
+    PK -.->|Event: TransactionCaptured / Posted| KAFKA
 
     %% Service to Database
     CA --> CADB
@@ -1866,15 +1859,15 @@ graph TD
     KAFKA_PLAT --> KAFKA
 
     %% Styling
-    classDef unstable fill:#ffd43b,stroke:#fab005,stroke-width:3px,color:#000
+    classDef balanced fill:#ffd43b,stroke:#fab005,stroke-width:3px,color:#000
     classDef stable fill:#51cf66,stroke:#37b24d,stroke-width:3px,color:#000
     classDef platform fill:#748ffc,stroke:#4c6ef5,stroke-width:2px,color:#fff
     classDef database fill:#495057,stroke:#343a40,stroke-width:2px,color:#fff
     classDef external fill:#e9ecef,stroke:#adb5bd,stroke-width:2px,color:#495057
     classDef messaging fill:#ff6b6b,stroke:#c92a2a,stroke-width:2px,color:#fff
 
-    class CA unstable
-    class FA,PK stable
+    class CA,FA stable
+    class PK balanced
     class OBS,KAFKA_PLAT,AUTH,TESTDB platform
     class CADB,FADB,PKDB database
     class CLIENT external
@@ -1884,8 +1877,8 @@ graph TD
     subgraph Legend["Legend"]
         direction TB
         L1["<b>Service Stability (Instability Metric I)</b>"]
-        L2["🟨 Yellow I=1.00: Unstable Orchestrator - Depends on other services"]
-        L3["🟩 Green I=0.00: Stable Provider - No dependencies on other services"]
+        L2["🟨 Yellow: Balanced (e.g. position-keeping I=0.43) - both provider and consumer"]
+        L3["🟩 Green I=0.00: Stable Provider - no outbound cross-service gRPC dependencies"]
         L4["<b>Communication Patterns</b>"]
         L5["━━━ Solid Line: Synchronous gRPC (request-response)"]
         L6["┄┄┄ Dashed Line: Asynchronous Kafka Events (fire-and-forget)"]
@@ -1900,41 +1893,39 @@ graph TD
 
 #### Service Layer Characteristics
 
-**CurrentAccount (Yellow - I=1.00):**
+**CurrentAccount (Green - I=0.00):**
 
-- **Role:** Orchestration layer and client-facing API gateway
-- **Instability Metric:** I = Ce / (Ca + Ce) = 2 / (0 + 2) = 1.00
-- **Dependencies:** Synchronously calls PositionKeeping and FinancialAccounting via gRPC
-- **Dependents:** None (no other services depend on current-account)
-- **Assessment:** High instability is architecturally appropriate for an orchestration layer
+- **Role:** Account state provider
+- **Instability Metric:** I = Ce / (Ca + Ce) = 0 / (2 + 0) = 0.00
+- **Dependencies:** No outbound cross-service gRPC dependencies
+- **Dependents:** position-keeping and reconciliation (Ca=2)
+- **Assessment:** Stable provider (earlier 3-service analyses modelled it as an I=1.00 orchestrator)
 - **Communication:**
-  - Outbound gRPC: 2 synchronous dependencies
-  - Outbound Events: Publishes deposit events to Kafka
-  - Inbound: Receives requests from external clients only
+  - Inbound gRPC: Account state queries from consumers
+  - Outbound Events: Publishes account lifecycle and withdrawal-status events to Kafka
 
 **FinancialAccounting (Green - I=0.00):**
 
 - **Role:** Double-entry bookkeeping and ledger posting provider
 - **Instability Metric:** I = Ce / (Ca + Ce) = 0 / (1 + 0) = 0.00
 - **Dependencies:** None on other BIAN domain services (only platform)
-- **Dependents:** CurrentAccount service (1 afferent coupling)
+- **Dependents:** mcp-server (Ca=1)
 - **Assessment:** Stable foundation service with no outbound domain dependencies
 - **Communication:**
-  - Inbound gRPC: Receives booking log and posting requests from CurrentAccount
-  - Inbound Events: Consumes deposit events from Kafka
-  - Outbound Events: Publishes posting completion and booking log status events
+  - Inbound gRPC: Booking log and posting requests
+  - Outbound Events: Publishes booking-log control events
 
-**PositionKeeping (Green - I=0.00):**
+**PositionKeeping (I=0.43 - Balanced):**
 
-- **Role:** Transaction log and audit trail provider
-- **Instability Metric:** I = Ce / (Ca + Ce) = 0 / (1 + 0) = 0.00
-- **Dependencies:** None on other BIAN domain services (only platform)
-- **Dependents:** CurrentAccount service (1 afferent coupling)
-- **Assessment:** Stable foundation service acting as authoritative transaction log
+- **Role:** Position/balance provider; performs provider lookups of its own
+- **Instability Metric:** I = Ce / (Ca + Ce) = 3 / (4 + 3) = 0.43
+- **Dependencies:** reference-data, internal-account, current-account (read-only provider lookups)
+- **Dependents:** event-router, internal-account, reconciliation, mcp-server (Ca=4)
+- **Assessment:** Widely-consumed provider sitting mid-spectrum on the stability scale
 - **Communication:**
-  - Inbound gRPC: Receives position log queries from CurrentAccount
-  - Outbound Events: Publishes position update and transaction status events
-  - No synchronous outbound dependencies (maintains stability)
+  - Inbound gRPC: Position/balance queries from consumers
+  - Outbound gRPC: Read-only lookups to reference-data and account services
+  - Outbound Events: Publishes transaction-lifecycle events
 
 #### Platform Layer (Blue Components)
 
@@ -2020,19 +2011,19 @@ graph TD
 
 #### Dependency Rule Enforcement
 
-**Allowed Patterns (Shown in Diagram):**
+**Allowed Patterns (current topology):**
 
-- ✅ CurrentAccount → PositionKeeping (gRPC sync)
-- ✅ CurrentAccount → FinancialAccounting (gRPC sync)
-- ✅ FinancialAccounting → PositionKeeping (Kafka async via events)
-- ✅ All Services → Platform (shared infrastructure)
+- ✅ PositionKeeping → CurrentAccount (gRPC sync, account-state read)
+- ✅ PositionKeeping → Reference-data / Internal-account (read-only provider lookups)
+- ✅ Services → Kafka (async events via the outbox pattern)
+- ✅ All Services → Platform (shared infrastructure in `shared/`)
 
-**Forbidden Patterns (Not in Diagram):**
+**Forbidden Patterns:**
 
-- ❌ PositionKeeping → Any Service (would violate I=0.00 stability)
-- ❌ FinancialAccounting → CurrentAccount (would create circular dependency)
+- ❌ PositionKeeping orchestrating writes into another domain's write path
+- ❌ Circular synchronous gRPC dependencies between domains
 - ❌ Direct database access across service boundaries
-- ❌ Internal package imports between services
+- ❌ Importing another service's internal packages
 
 #### Scalability and Failure Isolation
 

--- a/docs/architecture/event-driven-architecture.md
+++ b/docs/architecture/event-driven-architecture.md
@@ -8,7 +8,7 @@
 
 > **Topic source of truth:** All Kafka topics are registered in
 > `shared/platform/events/topics/topics.yaml` (with Go constants in `topics.go`). As of 2026-06-08 the
-> registry defines 49 topics across 11 publishing service groups: audit, current-account,
+> registry defines 48 topics across 11 publishing service groups: audit, current-account,
 > internal-account, financial-accounting, market-information, payment-order, position-keeping, party,
 > reconciliation, operational-gateway, and financial-gateway. The Event Catalog below is kept consistent
 > with that registry; when they diverge, `topics.yaml` is authoritative. A `TestTopicsYAML_ConsistentWithGoConstants`

--- a/docs/architecture/event-driven-architecture.md
+++ b/docs/architecture/event-driven-architecture.md
@@ -1,10 +1,18 @@
 # Event-Driven Architecture
 
-**Document Version:** 1.0
-**Last Updated:** 2025-11-19
+**Document Version:** 1.1
+**Last Updated:** 2026-06-08
 **Status:** Active
 **Related ADR:** [ADR-0004: Event Schema Evolution](../adr/0004-event-schema-evolution.md)
 **Related Documentation:** [BIAN Service Boundaries](bian-service-boundaries.md)
+
+> **Topic source of truth:** All Kafka topics are registered in
+> `shared/platform/events/topics/topics.yaml` (with Go constants in `topics.go`). As of 2026-06-08 the
+> registry defines 49 topics across 11 publishing service groups: audit, current-account,
+> internal-account, financial-accounting, market-information, payment-order, position-keeping, party,
+> reconciliation, operational-gateway, and financial-gateway. The Event Catalog below is kept consistent
+> with that registry; when they diverge, `topics.yaml` is authoritative. A `TestTopicsYAML_ConsistentWithGoConstants`
+> test enforces that the YAML and Go constants agree.
 
 ## Overview
 
@@ -125,55 +133,137 @@ google.type.Money amount = 4 [
 
 ## Event Catalog
 
+> **Registered topics vs proto messages:** The event proto files
+> (`api/proto/meridian/events/v1/*_events.proto`) define more message types than there are registered
+> Kafka topics. Only the topics present in `topics.yaml` are published today; the tables below list the
+> registered topics. Additional proto messages (e.g. `AccountCreatedEvent`, the
+> `FinancialBookingLog*`/`LedgerPosting*` set) are defined for future use or in-process use but do not have
+> dedicated registered topics yet.
+
 ### CurrentAccount Service Events
 
 **Event Proto:** `api/proto/meridian/events/v1/current_account_events.proto`
 
-| Event Type | Topic | Description | Consumers | Partition Key |
-|------------|-------|-------------|-----------|---------------|
-| `AccountCreatedEvent` | `current-account.account-created.v1` | New account facility initiated | Position-keeping, Financial-accounting, Risk-management | `account_id` |
-| `AccountStatusChangedEvent` | `current-account.account-status-changed.v1` | Account status transition (ACTIVE↔FROZEN↔CLOSED) | Position-keeping, Compliance, Reporting | `account_id` |
-| `AccountClosedEvent` | `current-account.account-closed.v1` | Account permanently closed (terminal state) | Position-keeping, Financial-accounting, Regulatory | `account_id` |
-| `TransactionInitiatedEvent` | `current-account.transaction-initiated.v1` | Transaction validated and ready for processing | Financial-accounting, Position-keeping | `account_id` |
-| `TransactionCompletedEvent` | `current-account.transaction-completed.v1` | Transaction successfully processed by all services | Notification, Reporting | `account_id` |
-| `TransactionFailedEvent` | `current-account.transaction-failed.v1` | Transaction failed during processing | Monitoring, DLQ, Notification | `account_id` |
-| `OverdraftConfiguredEvent` | `current-account.overdraft-configured.v1` | Overdraft facility configured or updated | Risk-management, Reporting | `account_id` |
-| `OverdraftLimitExceededEvent` | `current-account.overdraft-limit-exceeded.v1` | Transaction rejected due to insufficient funds | Fraud-detection, Notification | `account_id` |
+| Event Type | Topic | Description | Partition Key |
+|------------|-------|-------------|---------------|
+| `AccountFrozenEvent` | `current-account.account-frozen.v1` | Account frozen (no debits or credits permitted) | `account_id` |
+| `AccountUnfrozenEvent` | `current-account.account-unfrozen.v1` | Previously frozen account unfrozen | `account_id` |
+| `AccountClosedEvent` | `current-account.account-closed.v1` | Account permanently closed (terminal state) | `account_id` |
+| `WithdrawalStatusUpdated` | `current-account.withdrawal-status.v1` | Withdrawal status change (initiated, completed, failed, reversed) | `account_id` |
 
 **Legacy Event (Deprecated):**
 
-- `DepositEvent` (in `deposit_event.proto`) - Being replaced by `TransactionInitiatedEvent` with `transaction_type = DEPOSIT`
+- `DepositEvent` (in `deposit_event.proto`) - retained for backward compatibility
+
+### InternalAccount Service Events
+
+**Event Proto:** `api/proto/meridian/events/v1/internal_account_events.proto`
+
+| Event Type | Topic | Description | Partition Key |
+|------------|-------|-------------|---------------|
+| `FacilityCreatedEvent` | `internal-account.facility-created.v1` | New internal account facility initiated | `facility_id` |
+| `BookingCreatedEvent` | `internal-account.booking-created.v1` | New booking posted to an internal account | `account_id` |
 
 ### FinancialAccounting Service Events
 
 **Event Proto:** `api/proto/meridian/events/v1/financial_accounting_events.proto`
 
-| Event Type | Topic | Description | Consumers | Partition Key |
-|------------|-------|-------------|-----------|---------------|
-| `FinancialBookingLogInitiatedEvent` | `financial-accounting.booking-log-initiated.v1` | New booking log created (PENDING state) | Audit, Reporting | `booking_log_id` |
-| `FinancialBookingLogUpdatedEvent` | `financial-accounting.booking-log-updated.v1` | Booking log status or rules updated | Audit, Compliance | `booking_log_id` |
-| `FinancialBookingLogPostedEvent` | `financial-accounting.booking-log-posted.v1` | Booking log posted to GL (balanced, final state) | General-ledger, Reporting, Reconciliation | `booking_log_id` |
-| `FinancialBookingLogClosedEvent` | `financial-accounting.booking-log-closed.v1` | Booking log closed (terminal state) | Audit, Archival | `booking_log_id` |
-| `LedgerPostingCapturedEvent` | `financial-accounting.ledger-posting-captured.v1` | Debit/credit posting created | Trial-balance, Account-summary | `booking_log_id` |
-| `LedgerPostingAmendedEvent` | `financial-accounting.ledger-posting-amended.v1` | Posting amount amended before posting | Audit, Compliance | `booking_log_id` |
-| `LedgerPostingPostedEvent` | `financial-accounting.ledger-posting-posted.v1` | Posting finalized to general ledger | General-ledger, Reporting | `booking_log_id` |
-| `LedgerPostingRejectedEvent` | `financial-accounting.ledger-posting-rejected.v1` | Posting rejected during validation (terminal) | Monitoring, DLQ | `booking_log_id` |
-| `BalanceValidationFailedEvent` | `financial-accounting.balance-validation-failed.v1` | Debits ≠ Credits (double-entry violation) | Monitoring, Audit, Alerting | `booking_log_id` |
+| Event Type | Topic | Description | Partition Key |
+|------------|-------|-------------|---------------|
+| `BookingLogControlledEvent` | `financial-accounting.booking-log-controlled.v1` | Booking log receives a control action (SUSPEND, RESUME, TERMINATE) | `booking_log_id` |
+| `BookingLogControlledEvent` | `financial-accounting.booking-log.controlled` | Legacy topic (deprecated, retained for dual-publish) | `booking_log_id` |
+
+### MarketInformation Service Events
+
+| Event Type | Topic | Description | Partition Key |
+|------------|-------|-------------|---------------|
+| `ObservationRecorded` | `market-information.observation-recorded.v1` | New market price observation recorded | `instrument_id` |
+
+### PaymentOrder Service Events
+
+**Event Proto:** `api/proto/meridian/events/v1/payment_order_events.proto`
+
+| Event Type | Topic | Description | Partition Key |
+|------------|-------|-------------|---------------|
+| `PaymentOrderInitiated` | `payment-order.initiated.v1` | New payment order initiated | `payment_order_id` |
+| `PaymentOrderReserved` | `payment-order.reserved.v1` | Funds reserved for a payment order | `payment_order_id` |
+| `PaymentOrderExecuting` | `payment-order.executing.v1` | Payment order begins execution with the gateway | `payment_order_id` |
+| `PaymentOrderCompleted` | `payment-order.completed.v1` | Payment order successfully completed | `payment_order_id` |
+| `PaymentOrderFailed` | `payment-order.failed.v1` | Payment order failed (non-retryable) | `payment_order_id` |
+| `PaymentOrderCancelled` | `payment-order.cancelled.v1` | Payment order cancelled before execution | `payment_order_id` |
+| `PaymentOrderReversed` | `payment-order.reversed.v1` | Completed payment order reversed | `payment_order_id` |
 
 ### PositionKeeping Service Events
 
 **Event Proto:** `api/proto/meridian/events/v1/position_keeping_events.proto`
 
-| Event Type | Topic | Description | Consumers | Partition Key |
-|------------|-------|-------------|-----------|---------------|
-| `TransactionCapturedEvent` | `position-keeping.transaction-captured.v1` | Transaction log entry created (draft state) | Reconciliation, Reporting | `log_id` |
-| `TransactionAmendedEvent` | `position-keeping.transaction-amended.v1` | Transaction amended before posting | Audit, Compliance | `log_id` |
-| `TransactionReconciledEvent` | `position-keeping.transaction-reconciled.v1` | Transaction reconciled against external records | Reconciliation-dashboard, Reporting | `log_id` |
-| `TransactionPostedEvent` | `position-keeping.transaction-posted.v1` | Transaction posted to GL (final state) | Reporting, Analytics | `log_id` |
-| `TransactionRejectedEvent` | `position-keeping.transaction-rejected.v1` | Transaction rejected during validation (terminal) | Monitoring, DLQ | `log_id` |
-| `TransactionFailedEvent` | `position-keeping.transaction-failed.v1` | Technical failure during processing | Monitoring, SRE, Alerting | `log_id` |
-| `TransactionCancelledEvent` | `position-keeping.transaction-cancelled.v1` | Transaction cancelled before posting | Audit, Reporting | `log_id` |
-| `BulkTransactionCapturedEvent` | `position-keeping.bulk-transaction-captured.v1` | Bulk import completed (1-10,000 transactions) | Reconciliation, Monitoring | `batch_id` |
+| Event Type | Topic | Description | Partition Key |
+|------------|-------|-------------|---------------|
+| `TransactionCaptured` | `position-keeping.transaction-captured.v1` | New financial transaction captured | `log_id` |
+| `TransactionAmended` | `position-keeping.transaction-amended.v1` | Captured transaction amended | `log_id` |
+| `TransactionReconciled` | `position-keeping.transaction-reconciled.v1` | Transaction reconciled against settlement data | `log_id` |
+| `TransactionPosted` | `position-keeping.transaction-posted.v1` | Transaction posted to the ledger | `log_id` |
+| `TransactionRejected` | `position-keeping.transaction-rejected.v1` | Transaction rejected (validation failure) | `log_id` |
+| `TransactionFailed` | `position-keeping.transaction-failed.v1` | Transaction failed (system error) | `log_id` |
+| `TransactionCancelled` | `position-keeping.transaction-cancelled.v1` | Transaction cancelled | `log_id` |
+| `BulkTransactionCaptured` | `position-keeping.bulk-transaction-captured.v1` | Batch of transactions captured atomically | `batch_id` |
+| `OpeningBalanceRecorded` | `position-keeping.opening-balance-recorded.v1` | Opening balance recorded for a new account | `account_id` |
+
+### Party Service Events
+
+**Event Proto:** `api/proto/meridian/events/v1/party_events.proto`
+
+| Event Type | Topic | Description | Partition Key |
+|------------|-------|-------------|---------------|
+| `PartyCreatedEvent` | `party.created.v1` | New party registered | `party_id` |
+| `PartyUpdatedEvent` | `party.updated.v1` | Party details updated | `party_id` |
+| `PartyControlledEvent` | `party.controlled.v1` | Control action applied (suspend, terminate, reactivate) | `party_id` |
+| `PartyVerificationCompletedEvent` | `party.verification-completed.v1` | KYC/AML verification reaches terminal state | `party_id` |
+
+### Reconciliation Service Events
+
+**Event Proto:** `api/proto/meridian/events/v1/reconciliation_events.proto`
+
+| Event Type | Topic | Description | Partition Key |
+|------------|-------|-------------|---------------|
+| `ReconciliationRunStarted` | `reconciliation.run-started.v1` | Reconciliation run begins | `run_id` |
+| `ReconciliationRunCompleted` | `reconciliation.run-completed.v1` | Reconciliation run completes | `run_id` |
+| `VarianceDetected` | `reconciliation.variance-detected.v1` | Position variance detected | `run_id` |
+| `PositionLockRequested` | `reconciliation.position-lock-requested.v1` | Position lock requested to freeze a position | `position_id` |
+| `DisputeCreated` | `reconciliation.dispute-created.v1` | Reconciliation dispute raised | `dispute_id` |
+| `DisputeResolved` | `reconciliation.dispute-resolved.v1` | Reconciliation dispute resolved | `dispute_id` |
+
+### OperationalGateway Service Events
+
+**Event Proto:** `api/proto/meridian/events/v1/operational_gateway_events.proto`
+
+| Event Type | Topic | Description | Partition Key |
+|------------|-------|-------------|---------------|
+| `InstructionCreatedEvent` | `operational-gateway.instruction-created.v1` | Instruction accepted (PENDING state) | `instruction_id` |
+| `InstructionDispatchedEvent` | `operational-gateway.instruction-dispatched.v1` | Instruction transitions to DISPATCHING | `instruction_id` |
+| `InstructionDeliveredEvent` | `operational-gateway.instruction-delivered.v1` | Instruction delivered to the provider | `instruction_id` |
+| `InstructionAcknowledgedEvent` | `operational-gateway.instruction-acknowledged.v1` | Provider confirms processing | `instruction_id` |
+| `InstructionFailedEvent` | `operational-gateway.instruction-failed.v1` | Instruction permanently failed after retries | `instruction_id` |
+| `InstructionExpiredEvent` | `operational-gateway.instruction-expired.v1` | Instruction expired before delivery | `instruction_id` |
+| `InstructionCancelledEvent` | `operational-gateway.instruction-cancelled.v1` | Pending instruction explicitly cancelled | `instruction_id` |
+
+### FinancialGateway Service Events
+
+Inbound payment-provider webhooks, validated and republished onto Kafka.
+
+| Event Type | Topic | Description | Partition Key |
+|------------|-------|-------------|---------------|
+| `PaymentCapturedEvent` | `financial-gateway.payment-captured.v1` | `payment_intent.succeeded` webhook validated | `payment_intent_id` |
+| `PaymentFailedEvent` | `financial-gateway.payment-failed.v1` | `payment_intent.payment_failed` webhook validated | `payment_intent_id` |
+| `PaymentRefundedEvent` | `financial-gateway.payment-refunded.v1` | `charge.refunded` webhook validated | `charge_id` |
+| `PaymentDisputedEvent` | `financial-gateway.payment-disputed.v1` | `charge.dispute.created` webhook validated | `charge_id` |
+
+### Audit Topic
+
+| Topic | Description |
+|-------|-------------|
+| `audit.events.v1` | Audit events for all service operations (consumed by audit-worker / event-router) |
+| `audit.events.v1.dlq` | Dead letter queue for audit events that could not be processed |
 
 ---
 
@@ -289,8 +379,10 @@ sequenceDiagram
 
 **Implementation:**
 
-- Outbox table: `audit_outbox` in each service's database
-- Polling worker: Background goroutine in each service
+- Shared implementation: `shared/platform/events/outbox.go` (`EventOutbox` model and poller)
+- Outbox tables: `event_outbox` for domain events; `audit_outbox` for audit-trail events (each in the
+  owning service's database)
+- Polling worker: Background goroutine in each publishing service
 - Batch size: 100 events per poll
 - Polling interval: 100ms (configurable)
 
@@ -374,9 +466,16 @@ CREATE INDEX idx_idempotency_expiry ON event_idempotency (processed_at);
 
 | Service | Publishes Events | Publishing Method | Trigger |
 |---------|------------------|-------------------|---------|
-| **CurrentAccount** | Account lifecycle, transaction orchestration events | Outbox pattern | After successful gRPC calls to downstream services |
-| **FinancialAccounting** | Booking log and posting events | Outbox pattern | After database writes (booking log creation, posting capture) |
-| **PositionKeeping** | Transaction log and position events | Outbox pattern | After database writes (transaction log creation, status updates) |
+| **CurrentAccount** | Account freeze/unfreeze/close, withdrawal status | Outbox pattern | After database write commits |
+| **InternalAccount** | Facility created, booking created | Outbox pattern | After database write commits |
+| **FinancialAccounting** | Booking log control events | Outbox pattern | After database write commits |
+| **MarketInformation** | Market price observations | Outbox pattern | After observation persisted |
+| **PaymentOrder** | Payment order lifecycle transitions | Outbox pattern | After state transition commits |
+| **PositionKeeping** | Transaction lifecycle, opening balances | Outbox pattern | After database write commits |
+| **Party** | Party created/updated/controlled, verification completed | Outbox pattern | After database write commits |
+| **Reconciliation** | Run lifecycle, variance/dispute, position locks | Outbox pattern | After database write commits |
+| **OperationalGateway** | Instruction lifecycle | Outbox pattern | After database write commits |
+| **FinancialGateway** | Validated payment-provider webhooks | Outbox pattern | After webhook validation commits |
 
 ### Publishing Rules
 
@@ -413,7 +512,7 @@ CREATE INDEX idx_idempotency_expiry ON event_idempotency (processed_at);
 ### Example: Publishing an Account Created Event
 
 ```go
-// internal/current-account/service/account_service.go
+// services/current-account/service/account_service.go
 
 func (s *AccountService) CreateAccount(ctx context.Context, req *pb.CreateAccountRequest) (*pb.AccountResponse, error) {
     // 1. Domain logic: Create account entity
@@ -508,7 +607,7 @@ consumerConfig := kafka.ConsumerConfig{
 ### Idempotent Consumer Pattern
 
 ```go
-// internal/financial-accounting/adapters/messaging/transaction_initiated_consumer.go
+// services/financial-accounting/adapters/messaging/transaction_initiated_consumer.go
 
 func (c *TransactionInitiatedConsumer) handleMessage(ctx context.Context, key []byte, msg proto.Message) error {
     event, ok := msg.(*eventsv1.TransactionInitiatedEvent)
@@ -570,7 +669,7 @@ func (c *TransactionInitiatedConsumer) handleMessage(ctx context.Context, key []
 Events that fail processing after retries are sent to a DLQ topic for investigation.
 
 ```go
-// internal/platform/kafka/consumer.go
+// shared/platform/kafka/consumer.go
 
 func (c *ProtoConsumer) processMessage(ctx context.Context, msg *kafka.Message) error {
     handlerCtx, cancel := context.WithTimeout(ctx, c.handlerTimeout)
@@ -868,16 +967,19 @@ jobs:
 ```text
 <service>.<event-name>.<version>
 
-Service:    current-account | financial-accounting | position-keeping
-Event Name: account-created | ledger-posting-captured | transaction-captured
+Service:    current-account | position-keeping | party | payment-order | operational-gateway | ...
+Event Name: account-frozen | transaction-captured | instruction-created | ...
 Version:    v1 | v2 | v3
 ```
 
+The service segment uses the hyphenated service name; the event-name segment is hyphenated; the version is
+`v<N>`. See `shared/platform/events/topics/topics.yaml` for the full registry.
+
 **Examples:**
 
-- `current-account.account-created.v1`
-- `financial-accounting.booking-log-posted.v1`
+- `current-account.account-frozen.v1`
 - `position-keeping.transaction-captured.v1`
+- `operational-gateway.instruction-created.v1`
 
 ### Topic Configuration Standards
 
@@ -1119,7 +1221,7 @@ func TestAccountCreatedEvent_Serialization(t *testing.T) {
 ### Integration Tests: End-to-End Event Flow
 
 ```go
-// internal/current-account/service/account_service_integration_test.go
+// services/current-account/service/account_service_integration_test.go
 
 func TestCreateAccount_PublishesEvent(t *testing.T) {
     // Start Kafka testcontainer
@@ -1154,7 +1256,7 @@ func TestCreateAccount_PublishesEvent(t *testing.T) {
 ### Contract Tests: Consumer Expectations
 
 ```go
-// internal/financial-accounting/adapters/messaging/account_created_consumer_test.go
+// services/financial-accounting/adapters/messaging/account_created_consumer_test.go
 
 func TestAccountCreatedConsumer_HandleEvent(t *testing.T) {
     // Arrange: Create test event
@@ -1438,6 +1540,6 @@ Command: ExecuteDeposit (causation_id = cmd-123)
 
 ---
 
-**Document Version:** 1.0
-**Last Updated:** 2025-11-19
-**Next Review:** 2026-02-19 (quarterly)
+**Document Version:** 1.1
+**Last Updated:** 2026-06-08
+**Next Review:** 2026-09-08 (quarterly)

--- a/docs/architecture/service-coupling-analysis.md
+++ b/docs/architecture/service-coupling-analysis.md
@@ -1,8 +1,20 @@
 # Service Coupling Analysis
 
-**Analysis Date:** 2025-11-19
+**Analysis Date:** 2026-06-08
 **Repository:** github.com/meridianhub/meridian
-**Services Analyzed:** position-keeping, current-account, financial-accounting
+**Services Analyzed:** All 19 services under `services/` (api-gateway, audit-worker, control-plane,
+current-account, event-router, financial-accounting, financial-gateway, forecasting, identity,
+internal-account, market-information, mcp-server, operational-gateway, party, payment-order,
+position-keeping, reconciliation, reference-data, tenant)
+
+> **Methodology note (2026-06-08 refresh):** The codebase has since migrated services out of the
+> top-level `internal/` tree into `services/<service>/`, and platform code out of `internal/platform/`
+> into `shared/platform/`. The `scripts/analyze-coupling.sh` helper still discovers services by scanning
+> the top-level `internal/` directory, which now contains only `bootstrap` and `migrations`. As a result
+> the script reports zero domain services and cannot produce current coupling metrics until it is updated
+> to scan `services/` (see [P1-3](#p1-3-update-coupling-tooling-to-scan-services)). The figures below were
+> derived directly from the `services/` tree using `rg` over cross-service gRPC client instantiation,
+> Kafka topic usage, and import paths.
 
 ## Executive Summary
 
@@ -12,234 +24,272 @@ adherence to BIAN domain boundaries as defined in
 
 ### Key Findings
 
-- **Total Cross-Service Imports:** 17 violations detected
-- **Services Violating Boundaries:** All three services (position-keeping, current-account, financial-accounting)
-- **Primary Violation Pattern:** Improper use of `internal/platform` packages
-- **Severity:** MEDIUM - All violations are platform-related, not cross-service domain violations
+- **Cross-service internal imports:** 0 - no service imports another service's internal packages
+- **Platform code location:** `shared/platform/` (the `internal/platform` → shared migration is complete;
+  see [P1-1](#p1-1-migrate-platform-code-out-of-internalplatform-completed)). Shared reusable libraries
+  also live under `shared/pkg/` and `shared/domain/`.
+- **Inter-service communication:** synchronous gRPC clients and asynchronous Kafka events only, consistent
+  with ADR-0002 and ADR-0004
+- **Severity:** LOW - BIAN domain boundaries are respected across all 19 services
 
-### Top 5 Coupling Hotspots
+### Top Coupling Hotspots (Provider Services)
 
-1. **internal/platform/observability** - 10 imports across all services
-2. **internal/platform/testdb** - 4 imports for testing infrastructure
-3. **internal/platform/kafka** - 2 imports for event publishing
-4. **internal/platform/auth** - 1 import for authentication
-5. **Proto definitions** - 14 safe cross-service proto imports (expected for gRPC clients)
+Afferent coupling (how many other services call a service over gRPC) concentrates on foundational
+provider/registry services:
+
+1. **reference-data** - depended on by 5 services (instrument/account-type/saga registry lookups)
+2. **position-keeping** - depended on by 4 services (balance and position queries)
+3. **control-plane** - depended on by 3 services (manifest history, saga orchestration)
+4. **market-information** - depended on by 3 services (price observations)
+5. **mcp-server** - pure consumer/aggregator (depends on 7 services, no inbound dependencies)
 
 ### Risk Assessment
 
-#### Overall Risk: LOW-MEDIUM
+#### Overall Risk: LOW
 
-- No direct cross-service domain imports detected (services properly respect BIAN boundaries)
-- All violations are `internal/platform` usage patterns that should be refactored to `pkg/platform`
+- No cross-service domain imports detected (services properly respect BIAN boundaries)
+- Platform code now lives in `shared/platform/`, so the former `internal/platform` violation class no
+  longer exists
 - gRPC and Kafka communication patterns follow architectural guidelines
-- Current-account shows highest instability (I=1.00) due to dependencies on two other services
+- Pure-consumer services (mcp-server, event-router, payment-order, financial-gateway) show high
+  instability (I=1.00) by design - they orchestrate or aggregate without exposing inbound dependencies
 
 ## Dependency Graph
 
+Edges show cross-service gRPC client dependencies (consumer → provider) derived from
+`New<Service>ServiceClient` instantiation in non-test code under `services/`. All edges are dashed because
+every inter-service call goes through proto/gRPC - there are no cross-service internal imports. The
+`mcp-server` aggregator (consumes 7 services for the MCP tool surface) is omitted from the graph to reduce
+clutter; it is reflected in the metrics table below.
+
 ```mermaid
-graph TD
-    %% Service Nodes
-    PK[Position Keeping]
-    CA[Current Account]
-    FA[Financial Accounting]
-    PLAT[Platform]
+graph LR
+    %% Provider / foundational services
+    RD[reference-data]
+    PK[position-keeping]
+    CA[current-account]
+    IA[internal-account]
+    MI[market-information]
+    PARTY[party]
+    OG[operational-gateway]
 
-    %% Proto Dependencies (Safe - Green)
-    CA -.->|proto/gRPC| PK
-    CA -.->|proto/gRPC| FA
+    %% control-plane is both a provider and a consumer (orchestrator)
+    CP[control-plane]
 
-    %% Internal/Platform Usage (Warning - Yellow)
-    PK -->|observability| PLAT
-    PK -->|kafka| PLAT
-    PK -->|auth| PLAT
+    %% Consumer / orchestration services
+    ER[event-router]
+    FG[financial-gateway]
+    PO[payment-order]
+    REC[reconciliation]
 
-    CA -->|observability| PLAT
-    CA -->|testdb| PLAT
+    %% gRPC dependencies (consumer -.-> provider)
+    CP -.-> RD
+    CP -.-> IA
+    CP -.-> MI
+    CP -.-> PARTY
+    CP -.-> OG
 
-    FA -->|observability| PLAT
-    FA -->|kafka| PLAT
-    FA -->|testdb| PLAT
+    ER -.-> CP
+    ER -.-> MI
+    ER -.-> PK
 
-    %% Styling
-    classDef violation fill:#ff6b6b,stroke:#c92a2a,stroke-width:2px,color:#fff
-    classDef warning fill:#ffd43b,stroke:#fab005,stroke-width:2px,color:#000
-    classDef safe fill:#51cf66,stroke:#37b24d,stroke-width:2px,color:#000
-    classDef platform fill:#748ffc,stroke:#4c6ef5,stroke-width:2px,color:#fff
+    FG -.-> CP
 
-    class PK,CA,FA warning
-    class PLAT platform
+    IA -.-> PK
 
-    %% Legend
-    subgraph Legend
-        direction LR
-        L1[Safe: Proto only]:::safe
-        L2[Warning: Platform usage]:::warning
-        L3[Platform]:::platform
-    end
+    PO -.-> PARTY
+    PO -.-> RD
+
+    PK -.-> CA
+    PK -.-> IA
+    PK -.-> RD
+
+    REC -.-> CA
+    REC -.-> PK
+    REC -.-> RD
+
+    %% Styling - hue by afferent coupling role
+    classDef provider fill:#51cf66,stroke:#37b24d,stroke-width:2px,color:#000
+    classDef consumer fill:#ffd43b,stroke:#fab005,stroke-width:2px,color:#000
+
+    class RD,PK,CA,IA,MI,PARTY,OG provider
+    class ER,FG,PO,REC consumer
 ```
 
 ### Graph Interpretation
 
-- **Solid arrows:** `internal/platform` imports (requires refactoring to `pkg/platform`)
-- **Dashed arrows:** Proto/gRPC dependencies (safe and expected)
-- **Yellow nodes:** Services with platform coupling violations
-- **Blue node:** Shared platform code
+- **Dashed arrows:** Proto/gRPC dependencies (the only permitted inter-service coupling)
+- **Green nodes:** Provider services with inbound dependencies (afferent coupling)
+- **Yellow nodes:** Pure-consumer/orchestration services (no inbound dependencies)
+- **No solid arrows:** There are zero cross-service internal package imports - platform code is shared
+  via `shared/platform/` and `shared/pkg/`, not via cross-service imports
 
 ## Detailed Findings
 
 ### Table 1: Cross-Service Internal Imports (VIOLATIONS)
 
-All detected violations involve `internal/platform` imports rather than cross-service domain violations,
-which indicates proper BIAN boundary respect.
+No cross-service internal imports were detected. No service under `services/` imports another service's
+`internal/` or domain packages; all inter-service interaction is via proto/gRPC and Kafka.
 
-| Service | Imports From | Files Affected | Risk | Recommendation |
-|---------|--------------|----------------|------|----------------|
-| position-keeping | internal/platform/observability | 1 | MEDIUM | Move to pkg/platform |
-| position-keeping | internal/platform/kafka | 1 | MEDIUM | Move to pkg/platform |
-| position-keeping | internal/platform/auth | 1 | MEDIUM | Move to pkg/platform |
-| current-account | internal/platform/observability | 5 | MEDIUM | Move to pkg/platform |
-| current-account | internal/platform/testdb | 2 | MEDIUM | Move to pkg/platform |
-| financial-accounting | internal/platform/observability | 1 | MEDIUM | Move to pkg/platform |
-| financial-accounting | internal/platform/kafka | 2 | MEDIUM | Move to pkg/platform |
-| financial-accounting | internal/platform/testdb | 2 | MEDIUM | Move to pkg/platform |
+**Total violations:** 0
 
-**Total Files Affected:** 15 files across 3 services
+The former violation class - services importing `internal/platform/*` - no longer applies because platform
+code has been relocated to `shared/platform/` (see Table 2). Shared infrastructure is now imported through
+its public `shared/...` path by design, which does not violate Go internal-package semantics.
 
-### Table 2: Shared Code Classification
+### Table 2: Shared Code Location (current)
 
-| Package | Current Location | Should Be | Reason |
-|---------|------------------|-----------|--------|
-| observability | internal/platform/observability | pkg/platform/observability | Shared OpenTelemetry, logging, metrics |
-| kafka | internal/platform/kafka | pkg/platform/kafka | Kafka producer/consumer with protobuf |
-| testdb | internal/platform/testdb | pkg/platform/testdb | Shared Testcontainers infrastructure |
-| auth | internal/platform/auth | pkg/platform/auth | JWT validation and authorization |
+| Package family | Location | Examples | Purpose |
+|----------------|----------|----------|---------|
+| Platform infrastructure | `shared/platform/` | observability, kafka, events, db, auth, testdb, scheduler, ratelimit, gateway, tenant | Cross-cutting runtime infrastructure |
+| Reusable libraries | `shared/pkg/` | clients, saga, money, amount, cel, validation, idempotency, grpc, health, valuation | Domain-agnostic helpers and patterns |
+| Shared domain models | `shared/domain/` | models, common entity types | Types shared across service domains |
 
-### Table 3: Proto Dependencies (SAFE)
+### Table 3: Cross-Service gRPC Dependencies (SAFE)
 
-These imports represent proper gRPC client patterns and do not violate service boundaries.
+These edges represent proper gRPC client patterns (consumer service constructs the provider's generated
+client). They do not violate service boundaries.
 
-| Consumer Service | Proto Package | Provider Service | Usage Count | Pattern |
-|------------------|---------------|------------------|-------------|---------|
-| current-account | position_keeping | position-keeping | 7 | gRPC client calls |
-| current-account | financial_accounting | financial-accounting | 7 | gRPC client calls |
+| Consumer Service | Provider Service(s) | Pattern |
+|------------------|---------------------|---------|
+| control-plane | reference-data, internal-account, market-information, party, operational-gateway | gRPC client calls |
+| event-router | control-plane, market-information, position-keeping | gRPC client calls |
+| financial-gateway | control-plane | gRPC client calls |
+| internal-account | position-keeping | gRPC client calls |
+| payment-order | party, reference-data | gRPC client calls |
+| position-keeping | current-account, internal-account, reference-data | gRPC client calls |
+| reconciliation | current-account, position-keeping, reference-data | gRPC client calls |
+| mcp-server | reconciliation, control-plane, financial-accounting, market-information, operational-gateway, position-keeping, reference-data | MCP tool aggregator (read-only client surface) |
 
-**Total Proto Imports:** 14 (all safe and expected)
+Provider/registry RPCs (saga registry, account-type registry) are served by `reference-data`; manifest
+history and economy-generation RPCs are served by `control-plane`; provider-connection and
+instruction-route RPCs are served by `operational-gateway`.
 
 ## Data Flow Patterns
 
 ### Synchronous Communication (gRPC)
 
-The architecture follows proper gRPC patterns with protobuf-based communication:
+The architecture follows proper gRPC patterns with protobuf-based communication. Each consuming service
+constructs the provider's generated client (see Table 3). Representative dependencies:
 
-**Current Account Dependencies:**
-
-- `current-account` → `position-keeping` (gRPC client for balance queries)
-- `current-account` → `financial-accounting` (gRPC client for journal entries)
+- `position-keeping` → `reference-data`, `internal-account`, `current-account`
+- `reconciliation` → `current-account`, `position-keeping`, `reference-data`
+- `control-plane` → `reference-data`, `internal-account`, `market-information`, `party`, `operational-gateway`
 
 **Pattern Compliance:**
 
-- Services only depend on proto definitions (expected pattern)
+- Services only depend on generated proto clients (expected pattern)
 - No direct internal package imports between services (compliant with BIAN boundaries)
-- gRPC health checks implemented (detected in `service/health.go` files)
-
-**Files Using gRPC Clients:**
-
-- `services/current-account/client/client.go`
-- `shared/pkg/clients/resilient.go` (circuit breaker pattern)
+- Resilience (retry, circuit breaker) provided by `shared/pkg/clients`
 
 ### Asynchronous Communication (Kafka)
 
-Event-driven patterns detected across services:
+Event-driven publishing and consumption is implemented through the outbox pattern. The canonical machine-
+readable list of all Kafka topics lives at `shared/platform/events/topics/topics.yaml` (49 topics across
+11 publishing service groups), with Go constants in `shared/platform/events/topics/topics.go`.
 
-**Event Publishers:**
+**Event Publishers (outbox-based):** current-account, internal-account, financial-accounting,
+market-information, payment-order, position-keeping, party, reconciliation, operational-gateway,
+financial-gateway
 
-- position-keeping: 42 event publisher usages
-- financial-accounting: 9 event publisher usages
-
-**Event Consumers:**
-
-- financial-accounting: DepositConsumer implementation
+**Event Consumers:** financial-accounting (deposit consumer), payment-order (payment event consumer),
+event-router (audit consumer), audit-worker (audit consumer)
 
 **Pattern Compliance:**
 
-- Services use domain-defined EventPublisher interfaces
-- Kafka adapter implementations in `adapters/messaging/` layer
+- Services use domain-defined `EventPublisher` interfaces with outbox adapters in `adapters/messaging/`
+  (or `service/` for some services)
 - Protobuf serialization for events (as per ADR-0004)
+- Shared outbox implementation: `shared/platform/events/outbox.go`
 
 **Key Files:**
 
-- `internal/position-keeping/domain/event_publisher.go` (domain interface)
-- `internal/position-keeping/adapters/messaging/kafka_event_publisher.go` (implementation)
-- `internal/financial-accounting/adapters/messaging/deposit_consumer.go` (consumer)
+- `services/position-keeping/domain/event_publisher.go` (domain interface)
+- `services/position-keeping/adapters/messaging/outbox_event_publisher.go` (outbox publisher)
+- `services/financial-accounting/adapters/messaging/deposit_consumer.go` (consumer)
 
 ### Database Patterns
 
 **Schema Ownership (Compliant):**
 
-- Each service owns its own database schema
+- Each service owns its own database schema and migrations under `services/<service>/migrations/`
 - No cross-service database access detected
+- Migrations are managed by Atlas (per-service `atlas/atlas.hcl`), not Flyway
 
-**Detected Schemas:**
+**Outbox Pattern:**
 
-| Service | Schema | Tables | Migration Path |
-|---------|--------|--------|----------------|
-| current-account | current_account_audit | audit_log, audit_outbox | 20251103181700_audit_system.sql |
-
-**Outbox Pattern Detection:**
-
-- current-account implements audit outbox table
-- Supports reliable event publishing with transactional guarantees
+- Publishing services maintain an outbox table written in the same transaction as the state change
+- A background poller publishes to Kafka, providing at-least-once delivery (see
+  [Event-Driven Architecture](event-driven-architecture.md))
 
 ## Coupling Metrics
 
 ### Service-Level Metrics
 
-| Service | Afferent (Ca) | Efferent (Ce) | Instability (I) | Assessment | Abstractness (A) | Distance (D) |
-|---------|---------------|---------------|-----------------|------------|------------------|--------------|
-| position-keeping | 1 | 0 | 0.00 | **Stable** | 0.50 | 0.50 |
-| current-account | 0 | 2 | 1.00 | **Too Dependent** | 0.50 | 0.50 |
-| financial-accounting | 1 | 0 | 0.00 | **Stable** | 0.50 | 0.50 |
+Afferent (Ca) and efferent (Ce) coupling below are computed from cross-service gRPC client edges under
+`services/` (Table 3), excluding self-references. Abstractness is not recomputed in this refresh (the
+former tooling that produced it is stale); the column is omitted pending a tooling update.
+
+| Service | Afferent (Ca) | Efferent (Ce) | Instability (I) | Assessment |
+|---------|---------------|---------------|-----------------|------------|
+| reference-data | 5 | 0 | 0.00 | **Stable** (foundational registry/provider) |
+| position-keeping | 4 | 3 | 0.43 | Balanced (provider and consumer) |
+| control-plane | 3 | 5 | 0.63 | Orchestrator (depends on more than depend on it) |
+| market-information | 3 | 0 | 0.00 | **Stable** provider |
+| current-account | 2 | 0 | 0.00 | **Stable** provider |
+| internal-account | 2 | 1 | 0.33 | Mostly stable provider |
+| party | 2 | 0 | 0.00 | **Stable** provider |
+| operational-gateway | 2 | 0 | 0.00 | **Stable** provider |
+| financial-accounting | 1 | 0 | 0.00 | **Stable** provider |
+| reconciliation | 1 | 3 | 0.75 | Consumer-heavy |
+| payment-order | 0 | 2 | 1.00 | Pure consumer (orchestration) |
+| event-router | 0 | 3 | 1.00 | Pure consumer (event fan-out) |
+| financial-gateway | 0 | 1 | 1.00 | Pure consumer |
+| mcp-server | 0 | 7 | 1.00 | Pure consumer (MCP aggregator) |
+| tenant | 0 | 0 | n/a | Isolated (no cross-service gRPC edges) |
+
+Services with no cross-service gRPC edges in either direction (api-gateway, audit-worker, forecasting,
+identity) are omitted; they interact via Kafka and the gateway layer rather than direct gRPC clients.
 
 ### Metric Definitions
 
 - **Afferent Coupling (Ca):** Number of services that depend on this service
 - **Efferent Coupling (Ce):** Number of services this service depends on
 - **Instability (I):** Ce / (Ca + Ce), where 0 = stable, 1 = unstable
-- **Abstractness (A):** Ratio of abstract to concrete types (0.5 indicates balanced design)
-- **Distance from Main Sequence (D):** |A + I - 1|, ideal value near 0
 
 ### Interpretation
 
-**Position Keeping (I=0.00 - Stable):**
+**reference-data (I=0.00 - Stable):**
 
-- Acts as a provider service (Ca=1, Ce=0)
-- No outbound dependencies on other domain services
-- Low risk of cascading changes
-- Aligns with its role as a foundational balance tracking service
+- Highest afferent coupling (Ca=5): instrument, account-type, and saga-registry lookups make it a
+  foundational provider
+- No outbound gRPC dependencies on other domain services
+- Changes here have the widest blast radius - treat its proto surface as a stable contract
 
-**Current Account (I=1.00 - Too Dependent):**
+**position-keeping (I=0.43 - Balanced):**
 
-- Depends on both position-keeping and financial-accounting
-- Zero services depend on it (orchestration layer pattern)
-- High instability means changes in dependencies may ripple here
-- Expected pattern for a business transaction orchestration service
+- Both a provider (Ca=4: event-router, internal-account, reconciliation, mcp-server) and a consumer
+  (Ce=3: current-account, internal-account, reference-data)
+- Central to the position/balance flow; sits near the middle of the stability spectrum
 
-**Financial Accounting (I=0.00 - Stable):**
+**control-plane (I=0.63 - Orchestrator):**
 
-- Provider service for journal entries and postings
-- Single consumer (current-account)
-- Low risk profile
-- Stable foundation for financial operations
+- Depends on five services to orchestrate manifests and sagas while three services depend on its manifest
+  history and economy-generation RPCs
+- Higher instability is expected for an orchestration layer
 
-### Distance from Main Sequence
+**Pure consumers (I=1.00 - payment-order, event-router, financial-gateway, mcp-server):**
 
-All services show D=0.50, indicating they are moderately far from the ideal main sequence. This is primarily driven by:
+- Zero services depend on them; they aggregate or orchestrate
+- High instability is by design - changes in their dependencies may ripple here, but nothing downstream
+  depends on them
 
-- Moderate abstractness (A=0.50) in all services
-- Mixed stability characteristics (I values ranging 0.00-1.00)
+### Stability Observations
 
-**Recommendation:** Consider increasing abstraction in current-account to improve its position
-on the main sequence given its high instability.
+The topology is healthy: foundational providers (reference-data, market-information, party,
+current-account, financial-accounting) are stable (I=0.00), while orchestration and aggregation layers
+(control-plane, event-router, payment-order, mcp-server) carry the instability by design. There are no
+cyclic cross-service gRPC dependencies in the edges sampled.
 
 ## BIAN Context
 
@@ -252,14 +302,20 @@ Per [ADR-0002](../adr/0002-microservices-per-bian-domain.md), Meridian implement
 | position-keeping | Position Keeping | Tracks and updates financial positions | **COMPLIANT** - No cross-domain imports |
 | current-account | Current Account | Manages customer deposit accounts | **COMPLIANT** - Only uses proto interfaces |
 | financial-accounting | Financial Accounting | Records and reports financial transactions | **COMPLIANT** - Domain isolation maintained |
+| market-information | Market Information Management | Captures market price observations | **COMPLIANT** - Provider only |
+| party | Party Reference Data Management | Party registration and lifecycle (KYC/AML) | **COMPLIANT** - Provider only |
+| internal-account | Internal Account / Bank Internal Position | Internal facility and booking management | **COMPLIANT** |
+| reference-data | (Platform) Product/Instrument Directory | Instrument, account-type, and saga registry | **COMPLIANT** - Provider only |
+| reconciliation | Reconciliation | Settlement reconciliation and variance detection | **COMPLIANT** |
+| payment-order | Payment Order | Payment order lifecycle orchestration | **COMPLIANT** - Consumer/orchestrator |
+| operational-gateway | (Platform) Operational Instruction Routing | Instruction dispatch to external providers | **COMPLIANT** |
+| financial-gateway | (Platform) Payment Provider Gateway | Inbound payment-provider webhooks | **COMPLIANT** |
+| control-plane | (Platform) Manifest and Saga Orchestration | Economy manifest apply and saga execution | **COMPLIANT** - Orchestrator |
+
+A complete BIAN domain mapping for all services is maintained in
+[BIAN Service Boundaries](bian-service-boundaries.md).
 
 ### Service Boundary Validation
-
-**Expected Boundaries (per BIAN):**
-
-- Position Keeping: Maintains real-time position state
-- Current Account: Customer account operations and orchestration
-- Financial Accounting: Double-entry ledger and journal management
 
 **Actual Implementation:**
 
@@ -267,19 +323,19 @@ Per [ADR-0002](../adr/0002-microservices-per-bian-domain.md), Meridian implement
 - Communication follows specified patterns:
   - Synchronous: gRPC for queries and commands
   - Asynchronous: Kafka events for domain events
-- Each service has its own database schema
+- Each service has its own database schema and Atlas migrations
 - No shared database access detected
 
 ### ADR-0002 Compliance Summary
 
 | Principle | Status | Evidence |
 |-----------|--------|----------|
-| One service per BIAN domain | PASS | 3 services map to 3 BIAN domains |
-| Independent databases | PASS | No cross-service database access |
-| gRPC for sync communication | PASS | 14 proto imports for gRPC clients |
-| Kafka for async events | PASS | EventPublisher interfaces, 51 event patterns |
+| One service per BIAN domain | PASS | 19 services under `services/` map to distinct domains |
+| Independent databases | PASS | No cross-service database access; per-service Atlas migrations |
+| gRPC for sync communication | PASS | Cross-service calls use generated proto clients (Table 3) |
+| Kafka for async events | PASS | Outbox publishers + 49 registered topics (`topics.yaml`) |
 | No cross-service internal imports | PASS | Zero domain-to-domain internal imports |
-| Platform code separation | FAIL | 17 internal/platform imports (should be pkg/platform) |
+| Platform code separation | PASS | Platform code relocated to `shared/platform/` (P1-1 complete) |
 
 ## Prioritized Remediation Plan
 
@@ -299,176 +355,93 @@ boundaries with zero cross-service internal imports detected.
 
 **Prevention:** The absence of P0 violations demonstrates proper architectural discipline. To maintain this:
 
-- Enable CI gates (see P1-1 below) to prevent future violations
+- Update and enable the coupling CI gate (see P1-3) to prevent future violations
 - Require architectural review for any new service dependencies
-- Maintain strict separation between `internal/` packages across services
+- Maintain strict separation between each service's `internal/` packages
 
 ### P1 - High (Architectural Debt)
 
-#### P1-1: Migrate Platform Code from internal/platform to pkg/platform
+#### P1-1: Migrate Platform Code out of internal/platform (COMPLETED)
 
-**Problem:** Services import `internal/platform/*` packages, violating Go's internal package semantics.
-The `internal/` directory is meant for code that should not be imported by other modules, but our services
-need shared platform utilities.
+**Status:** COMPLETED. Platform code no longer lives in `internal/platform/`. The migration relocated
+shared infrastructure to `shared/platform/` (e.g. `observability`, `kafka`, `events`, `db`, `auth`,
+`testdb`, `scheduler`, `gateway`, `tenant`), with additional reusable libraries under `shared/pkg/` and
+shared domain types under `shared/domain/`. Services themselves moved from the top-level `internal/<service>/`
+tree to `services/<service>/`.
 
-**Impact:**
+> The original remediation plan proposed `pkg/platform/` as the target; the actual implementation used
+> `shared/platform/`. Either location resolves the original problem (platform code is no longer behind a
+> non-importable `internal/` boundary). The only `internal/platform` reference remaining in the codebase is
+> a documentation comment in `shared/domain/models/base.go`.
 
-- Violates Go module semantics (15 files affected across 3 services)
-- Prevents platform code reuse by external tools or future services
-- Creates confusion about which code is truly internal vs shared
-
-**Affected Files (15 total):**
-
-**Observability (7 files):**
-
-- `cmd/current-account/main.go:18`
-- `cmd/financial-accounting/main.go:17`
-- `internal/current-account/service/grpc_service.go:22`
-- `services/current-account/client/client.go:10`
-- `services/current-account/client/client_test.go:8`
-- `internal/position-keeping/app/container.go:10`
-
-**Kafka (2 files):**
-
-- `internal/position-keeping/adapters/messaging/kafka_event_publisher_test.go:9`
-- `internal/financial-accounting/adapters/messaging/deposit_consumer.go:12`
-- `internal/financial-accounting/adapters/messaging/deposit_consumer_test.go:12`
-
-**TestDB (4 files):**
-
-- `internal/current-account/adapters/persistence/repository_test.go:10`
-- `internal/current-account/service/grpc_service_test.go:12`
-- `internal/financial-accounting/adapters/persistence/repository_test.go:12`
-- `internal/financial-accounting/service/posting_service_test.go:11`
-- `internal/financial-accounting/adapters/messaging/deposit_consumer_test.go:13`
-
-**Auth (1 file):**
-
-- `internal/position-keeping/app/container.go:9`
-
-**Solution:**
-
-**Step 1: Create pkg/platform structure** (1 story point)
+**Verification:**
 
 ```bash
-mkdir -p pkg/platform/{observability,kafka,testdb,auth}
+# No production code imports internal/platform any more
+rg -l "meridian/internal/platform" --type go | grep -v _test.go
+# (returns nothing)
+
+# Platform code is present under shared/platform
+ls shared/platform/
 ```
 
-**Step 2: Move platform packages** (2 story points)
-
-- Move `internal/platform/observability` → `pkg/platform/observability`
-- Move `internal/platform/kafka` → `pkg/platform/kafka`
-- Move `internal/platform/testdb` → `pkg/platform/testdb`
-- Move `internal/platform/auth` → `pkg/platform/auth`
-- Preserve git history using `git mv`
-
-**Step 3: Update import paths** (2 story points)
-
-```bash
-# Automated with find/replace
-find ./cmd ./internal -name "*.go" -exec sed -i '' \
-  's|github.com/meridianhub/meridian/internal/platform|github.com/meridianhub/meridian/pkg/platform|g' {} \;
-```
-
-**Step 4: Verify with tests** (1 story point)
-
-```bash
-# Run all tests to ensure no regressions
-make test
-
-# Run coupling analysis to verify fix
-./scripts/analyze-coupling.sh | jq '.violations[] | select(.type == "internal-platform-import")'
-# Should return empty
-```
-
-**Effort Estimate:** 5 story points (1-2 days)
-
-**Dependencies:** None - can be done independently
-
-**Risk:** Low - Mechanical refactoring with automated tooling support. No business logic changes.
-
-**Alignment:**
-
-- **ADR-0002:** Supports proper platform code separation for microservices
-- **ADR-0005:** Platform adapters remain reusable across services
-
-**Related Tasks:** Foundation for all future platform work
+**Residual follow-up:** Update `scripts/analyze-coupling.sh` (see P1-3) so the CI gate can be re-enabled
+against the new `services/` and `shared/platform/` layout.
 
 ---
 
-#### P1-2: Reduce Current Account Service Instability
+#### P1-2: Monitor Instability of Orchestration and Aggregation Services
 
-**Problem:** Current Account service has an instability score of 1.00 (I=Ce/(Ca+Ce) = 2/(0+2) = 1.00),
-indicating it depends on two services (position-keeping, financial-accounting) but has zero services
-depending on it.
+**Problem:** Several services carry high instability (I=1.00) by design - they orchestrate or aggregate
+without exposing inbound dependencies: `payment-order`, `event-router`, `financial-gateway`, and the
+`mcp-server` MCP aggregator. `control-plane` (I=0.63) and `reconciliation` (I=0.75) are also
+consumer-heavy.
+
+**Why This Matters:**
+High instability is expected for orchestration and aggregation layers, but it means changes in their
+dependencies may ripple into them. This is acceptable as long as those services use the shared resilience
+layer and are not themselves depended upon.
+
+**Mitigation (already in place):**
+
+- Resilience (retry, circuit breaker) via `shared/pkg/clients`
+- Saga orchestration patterns via `shared/pkg/saga`
+- No service depends on these high-instability consumers, so their churn does not propagate downstream
+
+**Action:** No structural change required. Re-run the (updated) coupling tooling each release and alert if a
+service's instability shifts by more than 0.2 or if a previously stable provider gains outbound dependencies.
+
+**Effort Estimate:** 0 story points (monitoring only, gated on P1-3)
+
+---
+
+#### P1-3: Update Coupling Tooling to Scan services/
+
+**Problem:** `scripts/analyze-coupling.sh` (and the `calculate-coupling-metrics.sh` /
+`generate-coupling-mermaid.sh` helpers that consume its JSON) discover services by scanning the top-level
+`internal/` directory. After the service and platform migration, `internal/` contains only `bootstrap` and
+`migrations`, so the script reports zero domain services and produces empty violation/proto/schema sections.
+The metrics in this document were therefore derived manually from `services/`.
 
 **Impact:**
 
-- High change propagation risk - changes in dependencies ripple here
-- Service acts as orchestration layer without its own dependents
-- Distance from main sequence (D=0.50) indicates room for architectural improvement
+- The coupling CI gate cannot be enabled until the script is fixed (it would always pass with zero services)
+- `docs/architecture/coupling-metrics.json` cannot be regenerated automatically
 
-**Why This Matters:**
-This is expected for an orchestration service but indicates architectural fragility. The service is vulnerable
-to changes in both position-keeping and financial-accounting.
+**Solution:**
 
-**Affected Components:**
+- Change service discovery to enumerate `services/*/` (and treat `shared/platform/`, `shared/pkg/`,
+  `shared/domain/` as shared, non-service code)
+- Update the cross-service import detection to look for `services/<other>/internal` imports
+- Re-point the platform-usage check at `shared/platform` (informational only - this is now an allowed
+  shared import, not a violation)
+- Regenerate `coupling-metrics.json` from the corrected output
 
-- `services/current-account/client/client.go` (depends on position-keeping and financial-accounting)
-- `shared/pkg/clients/resilient.go` (circuit breaker - partial mitigation)
-- `shared/pkg/clients/circuitbreaker.go` (circuit breaker implementation)
+**Effort Estimate:** 3 story points
 
-**Solution Options:**
+**Dependencies:** None - unblocks the CI gate (P2-2)
 
-**Option A: Enhance Anti-Corruption Layer** (Recommended - 3 story points)
-
-```go
-// Add abstraction layer between current-account and dependencies
-
-// Define domain-level interfaces (not proto-coupled)
-type PositionReader interface {
-    GetBalance(ctx context.Context, accountID string) (Balance, error)
-}
-
-type JournalWriter interface {
-    RecordEntry(ctx context.Context, entry JournalEntry) error
-}
-
-// Implement adapters that translate to gRPC
-type PositionKeepingAdapter struct {
-    client pb.PositionKeepingServiceClient
-}
-
-func (a *PositionKeepingAdapter) GetBalance(ctx context.Context, accountID string) (Balance, error) {
-    // Translate domain request → proto → domain response
-    // Insulates current-account from proto changes in position-keeping
-}
-```
-
-**Option B: Extract Orchestration Patterns** (5 story points)
-
-- Create shared `pkg/orchestration` package with Saga patterns
-- Move orchestration logic out of current-account
-- Benefits future services that need similar patterns
-
-**Option C: Accept Current State** (0 story points)
-
-- Instability is expected for orchestration services
-- Existing `resilient_client.go` already mitigates cascade failures
-- No action needed unless change frequency becomes problematic
-
-**Effort Estimate:** 3 story points (Option A recommended)
-
-**Dependencies:** None - orthogonal to other remediation items
-
-**Risk:** Medium - Requires careful testing of service interactions
-
-**Alignment:**
-
-- **ADR-0002:** Maintains service independence through abstraction
-- **ADR-0005:** Anti-corruption layer follows adapter pattern
-
-**Related Tasks:** Consider in future architecture reviews
+**Risk:** Low - tooling-only change
 
 ---
 
@@ -517,9 +490,9 @@ None - current-account operates synchronously via gRPC.
 
 **Files to Create:**
 
-- `cmd/current-account/DEPENDENCIES.md`
-- `cmd/position-keeping/DEPENDENCIES.md`
-- `cmd/financial-accounting/DEPENDENCIES.md`
+- `services/current-account/DEPENDENCIES.md`
+- `services/position-keeping/DEPENDENCIES.md`
+- `services/financial-accounting/DEPENDENCIES.md`
 
 **Effort Estimate:** 2 story points (1 file per service × 3 services)
 
@@ -604,10 +577,10 @@ fi
 
 **Dependencies:**
 
-- Should be implemented after P1-1 (platform migration) to avoid false positives
-- Requires P1-1 completion first
+- Requires P1-3 (coupling tooling update) first - the script must discover services from `services/`
+  before a CI gate is meaningful
 
-**Risk:** Low - Scripts already exist, just need CI integration
+**Risk:** Low - Scripts exist but need updating (P1-3), then CI integration
 
 **Alignment:**
 
@@ -620,21 +593,22 @@ fi
 
 ### Summary Table
 
-| ID | Priority | Description | Effort (SP) | Risk | Dependencies |
-|----|----------|-------------|-------------|------|--------------|
-| P1-1 | High | Migrate internal/platform to pkg/platform | 5 | Low | None |
-| P1-2 | High | Reduce current-account instability | 3 | Medium | None |
-| P2-1 | Medium | Document service dependencies | 2 | None | None |
-| P2-2 | Medium | Implement CI coupling gates | 3 | Low | P1-1 |
+| ID | Priority | Description | Effort (SP) | Risk | Dependencies | Status |
+|----|----------|-------------|-------------|------|--------------|--------|
+| P1-1 | High | Migrate platform code out of internal/platform | 5 | Low | None | Completed |
+| P1-3 | High | Update coupling tooling to scan `services/` | 3 | Low | None | Open |
+| P1-2 | High | Monitor instability of orchestration services | 0 | Low | P1-3 | Open (monitoring) |
+| P2-1 | Medium | Document service dependencies | 2 | None | None | Open |
+| P2-2 | Medium | Implement CI coupling gates | 3 | Low | P1-3 | Open |
 
-**Total Effort:** 13 story points (approximately 2-3 weeks for one developer)
+**Remaining Effort:** 8 story points (P1-1 complete)
 
 **Recommended Execution Order:**
 
-1. **P1-1** (Week 1) - Platform migration unblocks everything else
-2. **P2-2** (Week 1-2) - CI gates prevent regression after P1-1
-3. **P2-1** (Week 2) - Documentation can happen in parallel
-4. **P1-2** (Week 3) - Architectural improvement, consider in next sprint
+1. **P1-3** - Update coupling tooling to scan `services/` (unblocks the CI gate and metric regeneration)
+2. **P2-2** - Enable the CI coupling gate once the tooling is corrected
+3. **P2-1** - Document service dependencies (can happen in parallel)
+4. **P1-2** - Ongoing monitoring of instability trends
 
 ---
 
@@ -644,7 +618,7 @@ After implementing remediation items:
 
 **Continuous Monitoring:**
 
-- Run `./scripts/analyze-coupling.sh` weekly to track metrics
+- Run `./scripts/analyze-coupling.sh` weekly to track metrics (after P1-3 updates it to scan `services/`)
 - Review coupling metrics in sprint retrospectives
 - Alert on instability score changes > 0.2
 
@@ -656,10 +630,10 @@ After implementing remediation items:
 
 **Success Criteria:**
 
-- Zero `internal-platform-import` violations (tracked in CI)
-- All services maintain I < 0.8 (instability score)
-- Service dependency graph matches BIAN architecture
-- < 5 minutes for new developers to understand service dependencies (via DEPENDENCIES.md)
+- Zero cross-service internal imports (tracked in CI once P1-3/P2-2 land)
+- Provider/registry services (reference-data, market-information, party) remain stable (I near 0.00)
+- Service dependency graph matches BIAN architecture (no cyclic cross-service gRPC edges)
+- Service dependencies are discoverable from the proto clients and `topics.yaml`
 
 ## Testing Strategy
 
@@ -673,7 +647,7 @@ After implementing remediation items:
 
 **Test Infrastructure:**
 
-- Testcontainers for PostgreSQL (internal/platform/testdb)
+- CockroachDB Testcontainers via `shared/platform/testdb`
 - Mock gRPC clients for resilience testing
 - Kafka test harness for consumer testing
 
@@ -688,53 +662,55 @@ After implementing remediation items:
    - Validate circuit breaker patterns in resilient_client.go
 
 3. **Coupling Regression Tests:**
-   - Automated checks for new `internal/` cross-service imports
-   - Pre-commit hooks running `scripts/analyze-coupling.sh`
+   - Automated checks for new cross-service `services/<other>/internal` imports
+   - Pre-commit hooks running `scripts/analyze-coupling.sh` (after P1-3)
 
 ## Appendix
 
 ### Analysis Methodology
 
-This analysis was performed using custom Go AST parsing scripts:
+The original analysis used custom scripts:
 
 1. `scripts/analyze-coupling.sh` - Detects import violations and patterns
 2. `scripts/calculate-coupling-metrics.sh` - Computes coupling metrics
 3. `scripts/generate-coupling-mermaid.sh` - Visualizes dependencies
 
+These scripts discover services from the top-level `internal/` directory and are stale relative to the
+current `services/` layout (see [P1-3](#p1-3-update-coupling-tooling-to-scan-services)). The 2026-06-08
+refresh therefore derived metrics directly from `services/` using `rg` over `New<Service>ServiceClient`
+instantiation (cross-service gRPC edges), Kafka topic usage, and import paths.
+
 **Analysis Coverage:**
 
-- Import declarations (cross-service and platform)
-- Proto message usage
-- gRPC client instantiation
-- Database schema ownership
-- Kafka event patterns
+- Cross-service gRPC client instantiation (consumer → provider edges)
+- Kafka topic ownership via `shared/platform/events/topics/topics.yaml`
+- Cross-service internal import scan (zero found)
+- Per-service database schema/migration ownership
 
 ### Raw Metrics Output
 
-Full metrics available in: `docs/architecture/coupling-metrics.json`
+Full metrics available in: `docs/architecture/coupling-metrics.json` (regenerate automatically once P1-3
+updates the tooling). Current code-derived values:
 
 ```json
 {
-  "timestamp": "2025-11-19T15:14:06Z",
+  "timestamp": "2026-06-08T00:00:00Z",
+  "method": "manual-rg-over-services-tree",
   "services": {
-    "position-keeping": {
-      "afferent_coupling": 1,
-      "efferent_coupling": 0,
-      "instability": 0,
-      "assessment": "stable"
-    },
-    "current-account": {
-      "afferent_coupling": 0,
-      "efferent_coupling": 2,
-      "instability": 1.00,
-      "assessment": "too-dependent"
-    },
-    "financial-accounting": {
-      "afferent_coupling": 1,
-      "efferent_coupling": 0,
-      "instability": 0,
-      "assessment": "stable"
-    }
+    "reference-data":      { "afferent_coupling": 5, "efferent_coupling": 0, "instability": 0.00, "assessment": "stable" },
+    "position-keeping":    { "afferent_coupling": 4, "efferent_coupling": 3, "instability": 0.43, "assessment": "balanced" },
+    "control-plane":       { "afferent_coupling": 3, "efferent_coupling": 5, "instability": 0.63, "assessment": "orchestrator" },
+    "market-information":  { "afferent_coupling": 3, "efferent_coupling": 0, "instability": 0.00, "assessment": "stable" },
+    "current-account":     { "afferent_coupling": 2, "efferent_coupling": 0, "instability": 0.00, "assessment": "stable" },
+    "internal-account":    { "afferent_coupling": 2, "efferent_coupling": 1, "instability": 0.33, "assessment": "stable" },
+    "party":               { "afferent_coupling": 2, "efferent_coupling": 0, "instability": 0.00, "assessment": "stable" },
+    "operational-gateway": { "afferent_coupling": 2, "efferent_coupling": 0, "instability": 0.00, "assessment": "stable" },
+    "financial-accounting":{ "afferent_coupling": 1, "efferent_coupling": 0, "instability": 0.00, "assessment": "stable" },
+    "reconciliation":      { "afferent_coupling": 1, "efferent_coupling": 3, "instability": 0.75, "assessment": "consumer-heavy" },
+    "payment-order":       { "afferent_coupling": 0, "efferent_coupling": 2, "instability": 1.00, "assessment": "pure-consumer" },
+    "event-router":        { "afferent_coupling": 0, "efferent_coupling": 3, "instability": 1.00, "assessment": "pure-consumer" },
+    "financial-gateway":   { "afferent_coupling": 0, "efferent_coupling": 1, "instability": 1.00, "assessment": "pure-consumer" },
+    "mcp-server":          { "afferent_coupling": 0, "efferent_coupling": 7, "instability": 1.00, "assessment": "aggregator" }
   }
 }
 ```

--- a/docs/architecture/service-coupling-analysis.md
+++ b/docs/architecture/service-coupling-analysis.md
@@ -128,10 +128,13 @@ graph LR
 
 ### Table 1: Cross-Service Internal Imports (VIOLATIONS)
 
-No cross-service internal imports were detected. No service under `services/` imports another service's
-`internal/` or domain packages; all inter-service interaction is via proto/gRPC and Kafka.
+No cross-service internal imports were detected. Services under `services/` do not import another
+service's `internal/` packages; inter-service interaction is primarily via proto/gRPC and Kafka. A small
+number of shared domain types are imported across services as a known, allowlisted pattern (for example
+`api-gateway` importing `identity`/`tenant` domain types and `event-router` importing `audit-worker`
+domain types); these are tracked separately in architecture tests and are not boundary violations.
 
-**Total violations:** 0
+**Total internal-package violations:** 0
 
 The former violation class - services importing `internal/platform/*` - no longer applies because platform
 code has been relocated to `shared/platform/` (see Table 2). Shared infrastructure is now imported through

--- a/docs/architecture/service-coupling-analysis.md
+++ b/docs/architecture/service-coupling-analysis.md
@@ -188,7 +188,7 @@ constructs the provider's generated client (see Table 3). Representative depende
 ### Asynchronous Communication (Kafka)
 
 Event-driven publishing and consumption is implemented through the outbox pattern. The canonical machine-
-readable list of all Kafka topics lives at `shared/platform/events/topics/topics.yaml` (49 topics across
+readable list of all Kafka topics lives at `shared/platform/events/topics/topics.yaml` (48 topics across
 11 publishing service groups), with Go constants in `shared/platform/events/topics/topics.go`.
 
 **Event Publishers (outbox-based):** current-account, internal-account, financial-accounting,
@@ -336,7 +336,7 @@ A complete BIAN domain mapping for all services is maintained in
 | One service per BIAN domain | PASS | 19 services under `services/` map to distinct domains |
 | Independent databases | PASS | No cross-service database access; per-service Atlas migrations |
 | gRPC for sync communication | PASS | Cross-service calls use generated proto clients (Table 3) |
-| Kafka for async events | PASS | Outbox publishers + 49 registered topics (`topics.yaml`) |
+| Kafka for async events | PASS | Outbox publishers + 48 registered topics (`topics.yaml`) |
 | No cross-service internal imports | PASS | Zero domain-to-domain internal imports |
 | Platform code separation | PASS | Platform code relocated to `shared/platform/` (P1-1 complete) |
 


### PR DESCRIPTION
## Summary

Refreshes three stale architecture docs against the current codebase (unit `assess-2026-06-04.7`). Markdown-only; no app code or tests. Ground truth was the actual `services/` tree plus `rg` over cross-service gRPC client instantiation, Kafka topic usage, and the topic registry.

## Key finding: the coupling tooling itself is stale

`scripts/analyze-coupling.sh` discovers services by scanning the top-level `internal/` directory. After the service/platform migration, `internal/` holds only `bootstrap` and `migrations`, so the script reports **zero domain services** and produces empty violation/proto/schema output. Metrics in this refresh were therefore derived manually. The docs now flag this as remediation item **P1-3 (update the tooling to scan `services/`)**, which also blocks the CI coupling gate (P2-2) and automatic regeneration of `coupling-metrics.json`.

## Changes Made

### `service-coupling-analysis.md` (153 days stale)
- Analysis date → 2026-06-08; scope broadened from 3 services to all 19 under `services/`
- **P1-1 (platform migration) marked COMPLETE** - platform code moved to `shared/platform/` (plan had targeted `pkg/platform/`; actual target was `shared/`). Only residual `internal/platform` reference is a doc comment in `shared/domain/models/base.go`
- Replaced the 3-service Ca/Ce/I table with a code-derived table for all services with cross-service gRPC edges (reference-data Ca=5 is the top provider; pure consumers mcp-server/event-router/payment-order/financial-gateway are I=1.00 by design)
- Rebuilt the dependency-graph mermaid to the real topology; updated ADR-0002 compliance summary, remediation plan, and inline raw-metrics JSON
- Added **P1-3** (tooling update) and reframed P1-2 as instability monitoring

### `event-driven-architecture.md` (95 days stale)
- Added `shared/platform/events/topics/topics.yaml` as the authoritative topic source (49 topics, 11 publishing service groups)
- Rebuilt the Event Catalog to match the **registered** topics: corrected current-account (frozen/unfrozen/closed/withdrawal-status), financial-accounting (booking-log-controlled), position-keeping (added opening-balance-recorded), and added tables for internal-account, payment-order, party, reconciliation, operational-gateway, financial-gateway, and the audit topics
- Noted proto messages exist for more events than there are registered topics
- Corrected the outbox documentation (`event_outbox` for domain events, `audit_outbox` for audit; shared impl `shared/platform/events/outbox.go`) and fixed stale `internal/...` and `internal/platform/kafka` code-path comments

### `bian-service-boundaries.md` (95 days stale)
- Corrected platform location from `pkg/platform/` to `shared/platform/` throughout (principles, Rule 3, dependency rationale, checklists, component diagram)
- Updated service locations from the old `cmd/<svc>` + `internal/<svc>` layout to `services/<svc>/`
- Added a scope note (doc details 4 representative domains; 19 exist - full mapping in the coupling doc), expanded the BIAN domain mapping, and refreshed communication patterns

## Out-of-scope notes (not changed)
- `docs/architecture/coupling-metrics.json` remains stale. The task scope permitted editing a committed artifact only if `analyze-coupling.sh` regenerates it; it does not (and would emit empty output), so it was left untouched. The coupling doc flags it for regeneration once P1-3 lands.
- `docs/architecture/boundary-migration-plan.md` already documents the `internal/platform` → `shared/platform` decision and corroborates the P1-1-complete finding; left to its owner.
- The `buf breaking` base-branch reference in the event doc was left as-is (not verified against CI config).

## Risk Assessment
Documentation-only. `docs/architecture/**` is excluded from the markdownlint gate; pre-commit (gitleaks + markdownlint) passed locally.
