### PR TITLE
docs: Resolve cross-document service-port contradictions (assess-2026-06-04.10)

### DIFF
--- a/docs/guides/multi-asset-integration.md
+++ b/docs/guides/multi-asset-integration.md
@@ -72,10 +72,10 @@ Multi-asset operations coordinate across these BIAN-aligned services:
 
 | Service | Port | Role in Multi-Asset Flow |
 |---------|------|--------------------------|
-| Reference Data | 50051 | Instrument definitions, CEL validation rules, fungibility logic |
+| Reference Data | 50059 | Instrument definitions, CEL validation rules, fungibility logic |
 | Position Keeping | 50053 | Track quantities in native units with audit trail |
 | Financial Accounting | 50052 | Record valued amounts in settlement currency |
-| Current Account | 50057 | Customer-facing operations with overdraft and liens |
+| Current Account | 50051 | Customer-facing operations with overdraft and liens |
 
 ```mermaid
 sequenceDiagram
@@ -352,7 +352,7 @@ import (
 
 func recordEnergyConsumption(ctx context.Context, accountID string, kwhAmount decimal.Decimal, touPeriod int) error {
     // Step 1: Connect to services
-    refDataConn, err := grpc.Dial("reference-data:50051", grpc.WithInsecure())
+    refDataConn, err := grpc.Dial("reference-data:50059", grpc.WithInsecure())
     if err != nil {
         return err
     }
@@ -432,7 +432,7 @@ func recordCarbonCredit(
     projectID string,
 ) error {
     // Connect to Reference Data service
-    refDataConn, err := grpc.Dial("reference-data:50051", grpc.WithInsecure())
+    refDataConn, err := grpc.Dial("reference-data:50059", grpc.WithInsecure())
     if err != nil {
         return err
     }

--- a/docs/runbooks/internal-account-operations.md
+++ b/docs/runbooks/internal-account-operations.md
@@ -40,7 +40,7 @@ handling account lifecycle operations, or recovering from service failures.
 | Service | Port | Purpose |
 |---------|------|---------|
 | Position Keeping | 50053 | Balance queries (source of truth) |
-| Reference Data | 50052 | Instrument validation |
+| Reference Data | 50059 | Instrument validation |
 | CockroachDB | 26257 | Persistent storage |
 
 ### Account Types

--- a/docs/runbooks/market-information-operations.md
+++ b/docs/runbooks/market-information-operations.md
@@ -11,7 +11,7 @@ triggers:
   - Quality ladder supersession issues
 instructions: |
   Use this runbook for Market Information Management service operations.
-  Port: 50061 (gRPC). Database: market_information.
+  Port: 50058 (gRPC). Database: market_information.
   Bi-temporal model: observed_at (event time) + created_at (knowledge time).
   Quality ladder: ESTIMATE < PROVISIONAL < ACTUAL < REVISED.
   Trust levels: 0-100 (higher = more authoritative source).
@@ -30,8 +30,8 @@ debugging bi-temporal queries, configuring data sources, or investigating CEL va
 | Property | Value |
 |----------|-------|
 | **Service Name** | market-information |
-| **gRPC Port** | 50061 |
-| **HTTP/REST Port** | 8061 (via gRPC gateway) |
+| **gRPC Port** | 50058 |
+| **HTTP Port** | 8082 (`/metrics`, `/health`, `/ready`) |
 | **Database** | market_information (schema-per-tenant) |
 | **Namespace** | production / staging |
 | **Deployment** | market-information |
@@ -40,7 +40,7 @@ debugging bi-temporal queries, configuring data sources, or investigating CEL va
 
 | Service | Port | Purpose |
 |---------|------|---------|
-| Tenant | 50050 | Tenant provisioning and multi-tenancy |
+| Tenant | 50056 | Tenant provisioning and multi-tenancy |
 | CockroachDB | 26257 | Persistent storage |
 | Kafka | 9092 | Event publishing (optional) |
 
@@ -129,7 +129,7 @@ grpcurl -plaintext \
     "resolution_key_expression": "observation_context.base_currency + \"/\" + observation_context.quote_currency",
     "error_message_expression": "\"Invalid exchange rate: must be positive\""
   }' \
-  market-information.production.svc.cluster.local:50061 \
+  market-information.production.svc.cluster.local:50058 \
   meridian.market_information.v1.MarketInformationService/RegisterDataSet
 ```
 
@@ -153,7 +153,7 @@ grpcurl -plaintext \
 ```bash
 grpcurl -plaintext \
   -d '{"code": "USD_EUR_FX", "version": 1}' \
-  market-information.production.svc.cluster.local:50061 \
+  market-information.production.svc.cluster.local:50058 \
   meridian.market_information.v1.MarketInformationService/ActivateDataSet
 ```
 
@@ -169,7 +169,7 @@ grpcurl -plaintext \
     "description": "European Central Bank daily FX reference rates",
     "trust_level": 90
   }' \
-  market-information.production.svc.cluster.local:50061 \
+  market-information.production.svc.cluster.local:50058 \
   meridian.market_information.v1.MarketInformationService/RegisterDataSource
 ```
 
@@ -199,7 +199,7 @@ grpcurl -plaintext \
     },
     "numeric_value": {"value": "0.9215", "scale": 4}
   }' \
-  market-information.production.svc.cluster.local:50061 \
+  market-information.production.svc.cluster.local:50058 \
   meridian.market_information.v1.MarketInformationService/RecordObservation
 ```
 
@@ -215,7 +215,7 @@ grpcurl -plaintext \
     "resolution_key": "USD/EUR",
     "as_of_time": "2026-01-19T16:00:00Z"
   }' \
-  market-information.production.svc.cluster.local:50061 \
+  market-information.production.svc.cluster.local:50058 \
   meridian.market_information.v1.MarketInformationService/QueryBestKnownValue
 ```
 
@@ -238,7 +238,7 @@ rpc error: code = InvalidArgument desc = validation failed: rate must be positiv
    ```bash
    grpcurl -plaintext \
      -d '{"code": "USD_EUR_FX", "version": 0}' \
-     market-information.production.svc.cluster.local:50061 \
+     market-information.production.svc.cluster.local:50058 \
      meridian.market_information.v1.MarketInformationService/RetrieveDataSet
    ```
 
@@ -268,7 +268,7 @@ rpc error: code = FailedPrecondition desc = data source EXTERNAL_API is not acti
 ```bash
 # Check data source status
 grpcurl -plaintext \
-  market-information.production.svc.cluster.local:50061 \
+  market-information.production.svc.cluster.local:50058 \
   meridian.market_information.v1.MarketInformationService/ListDataSources
 ```
 
@@ -291,7 +291,7 @@ rpc error: code = NotFound desc = dataset not found: UNKNOWN_CODE
 ```bash
 # List all datasets
 grpcurl -plaintext \
-  market-information.production.svc.cluster.local:50061 \
+  market-information.production.svc.cluster.local:50058 \
   meridian.market_information.v1.MarketInformationService/ListDataSets
 ```
 
@@ -395,7 +395,7 @@ ORDER BY trust_level DESC;
 ```bash
 # gRPC health check
 grpcurl -plaintext \
-  market-information.production.svc.cluster.local:50061 \
+  market-information.production.svc.cluster.local:50058 \
   grpc.health.v1.Health/Check
 ```
 
@@ -434,7 +434,7 @@ grpcurl -plaintext \
     "observation_context": {"base_currency": "USD", "quote_currency": "EUR", "rate": "0.9220"},
     "numeric_value": {"value": "0.9220", "scale": 4}
   }' \
-  market-information.production.svc.cluster.local:50061 \
+  market-information.production.svc.cluster.local:50058 \
   meridian.market_information.v1.MarketInformationService/RecordObservation
 ```
 
@@ -468,8 +468,8 @@ ORDER BY o.created_at DESC;
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `GRPC_PORT` | gRPC server port | 50061 |
-| `HTTP_PORT` | HTTP gateway port | 8061 |
+| `GRPC_PORT` | gRPC server port | 50058 |
+| `METRICS_PORT` | HTTP port for `/metrics`, `/health`, `/ready` | 8082 |
 | `DATABASE_URL` | CockroachDB connection string | Required |
 | `KAFKA_BROKERS` | Kafka broker addresses | Optional |
 | `LOG_LEVEL` | Logging level | info |

--- a/services/README.md
+++ b/services/README.md
@@ -30,7 +30,7 @@ flowchart LR
             FA["FinancialAccounting<br/>:50052"]
             Party["Party<br/>:50055"]
             PO["PaymentOrder<br/>:50054, :8080"]
-            RD["ReferenceData<br/>:50051"]
+            RD["ReferenceData<br/>:50059"]
             MI["MarketInformation<br/>:50058"]
             IBA["InternalAccount<br/>:50057"]
             Recon["Reconciliation<br/>:50060"]
@@ -274,6 +274,7 @@ Redis provides optional distributed idempotency for exactly-once semantics:
 | Tenant | 50056 | - | 9090 |
 | InternalAccount | 50057 | - | 9090 |
 | MarketInformation | 50058 | - | 8082 |
+| ReferenceData | 50059 | - | 9090 |
 | Reconciliation | 50060 | - | 9090 |
 | Forecasting | 50061 | - | 9090 |
 | ControlPlane | - | - | - |
@@ -632,7 +633,7 @@ When `Resilience` is configured, clients automatically include:
 | InternalAccount | `services/internal-account/client` | 50057 |
 | MarketInformation | `services/market-information/client` | 50058 |
 | Reconciliation | `services/reconciliation/client` | 50060 |
-| ReferenceData | `services/reference-data/client` | 50051 |
+| ReferenceData | `services/reference-data/client` | 50059 |
 
 ## Service Directory Structure
 

--- a/services/README.md
+++ b/services/README.md
@@ -274,7 +274,7 @@ Redis provides optional distributed idempotency for exactly-once semantics:
 | Tenant | 50056 | - | 9090 |
 | InternalAccount | 50057 | - | 9090 |
 | MarketInformation | 50058 | - | 8082 |
-| ReferenceData | 50059 | - | 9090 |
+| ReferenceData | 50059 | - | 8082 |
 | Reconciliation | 50060 | - | 9090 |
 | Forecasting | 50061 | - | 9090 |
 | ControlPlane | - | - | - |


### PR DESCRIPTION
## Summary

LLM contradiction sweep over `docs/` and the root/service docs they reference (unit `assess-2026-06-04.10`). Compared documentation against code in focused passes: `docs/architecture-layers.md` vs service READMEs, `docs/patterns.md` and `docs/saga-handler-loading.md` canonical paths vs actual files, and service-port claims across all operational docs vs the canonical registry.

The single clear theme was **service port numbers**. The authoritative source is `shared/platform/ports/ports.go` (self-described "single source of truth for service port assignments"), corroborated by the `Tiltfile`, each service's `cmd/main.go` default, the per-service READMEs, and the already-correct `docs/runbooks/production-deployment.md`. Several operational docs had swapped or stale ports that resolve to the wrong service.

## Files checked (no changes needed - verified clean)

- `docs/patterns.md` - all 6 canonical locations, every cited file path, and the sandbox preset table (5s/1M, 5s/5M, 10s/1M, 64KB) match code exactly.
- `docs/saga-handler-loading.md` - all cited files and symbols (`BuildServiceModules`, `DeriveSchema`, `loadSagaAsset`, seeder/registry) exist.
- `docs/architecture-layers.md` - 8-layer / 19-service mapping is internally consistent and matches `services/`. "19 services" count is consistent across all docs.
- `docs/data-flows.md` - no port/path conflicts.
- `docs/runbooks/production-deployment.md` - port table and topology already correct (used as the cross-check reference).

## Contradictions found and resolved

Canonical ports: current-account `50051`, financial-accounting `50052`, position-keeping `50053`, payment-order `50054`, party `50055`, tenant `50056`, internal-account `50057`, market-information `50058`, **reference-data `50059`**, reconciliation `50060`, forecasting `50061`.

| File | Was | Now | Why |
|------|-----|-----|-----|
| `docs/runbooks/market-information-operations.md` | gRPC `50061` (frontmatter, table, env, 10x grpcurl examples) | `50058` | `50061` is Forecasting's port; MI binds `50058` (`ports.MarketInformation`, `cmd/main.go`, service README) |
| `docs/runbooks/market-information-operations.md` | HTTP `8061` / `HTTP_PORT` env | `8082` / `METRICS_PORT` | Service exposes HTTP on `METRICS_PORT` default `8082`; there is no `HTTP_PORT` env var |
| `docs/runbooks/market-information-operations.md` | Tenant dep `50050` | `50056` | `50050` is unassigned; Tenant is `50056` |
| `docs/runbooks/internal-account-operations.md` | Reference Data dep `50052` | `50059` | `50052` is Financial Accounting; Reference Data is `50059` |
| `docs/guides/multi-asset-integration.md` | Reference Data `50051` (table + 2 `grpc.Dial` examples) | `50059` | `50051` is Current Account; Reference Data is `50059` |
| `docs/guides/multi-asset-integration.md` | Current Account `50057` | `50051` | `50057` is Internal Account; Current Account is `50051` |
| `services/README.md` | Reference Data `:50051` (topology diagram + client default-port table) | `50059` | Collided with Current Account; the Service Ports table also omitted Reference Data - added the missing `50059` row |

## Ambiguous items left for human judgement (not changed)

1. **Quality ladder has three representations.** Proto (`market_information.proto`) defines a 4-level ladder `ESTIMATE -> PROVISIONAL -> ACTUAL -> REVISED`; the domain code (`domain/quality_level.go`) implements 3 levels `ESTIMATE -> ACTUAL -> VERIFIED`; some PRDs/UI docs use `ESTIMATE -> COEFFICIENT -> ACTUAL -> REVISED` ("COEFFICIENT" appears nowhere in code or proto). `docs/runbooks/market-information-operations.md` already documents the proto-vs-domain divergence honestly (its "Note" block). This is a real code-vs-code split, not a doc typo - left for a deliberate decision on which ladder is canonical.

2. **Stale ports in PRDs and reports (historical design docs).** `docs/prd/013-reconciliation-service.md` (Reconciliation `:50059`, Reference Data `:50051`, Current Account `:50057`, `GRPC_PORT` default `50059`), `docs/prd/016-market-data-dynamic-pricing.md`, and `docs/reports/market-information-*.md` cite pre-finalisation port assignments. PRDs/reports are point-in-time artifacts in this repo's convention, so they were left as-is rather than rewritten.

3. **Latent code inconsistency (out of docs scope).** Several client `DefaultPort` constants disagree with `ports.go`: `reference-data/client` = `50051` (should be `50059`), `market-information/client` = `50051` (should be `50058`), `operational-gateway/client` = `50051`, `reconciliation/client` = `50058` (should be `50060`). Callers pass explicit `ports.*` values so this is currently harmless, but the stale client constants are worth a follow-up code fix.

4. **`HTTP/REST Port` rows in other runbooks.** `docs/runbooks/internal-account-operations.md` lists "HTTP/REST Port 8057 (via gRPC gateway)"; most services expose HTTP metrics on `9090`, not an `80NN` port. Left unchanged pending confirmation of the intended convention.

## Risk

Documentation only (Markdown). No code or behaviour changes. Markdown-only PR.
