### PR TITLE
docs: Self-referential test review for App.tsx and doctor.sh (assess-followups.3)

### DIFF
--- a/docs/architecture/self-referential-test-review.md
+++ b/docs/architecture/self-referential-test-review.md
@@ -1,0 +1,164 @@
+# Self-Referential Test Review: `App.tsx` and `doctor.sh`
+
+> Paths in this document are relative to the repository root.
+
+## Context
+
+The `/assess` cross-layer scan flagged two files as `self_referential_tests`:
+
+- `frontend/src/App.tsx` - the most-churned production file (66 commits).
+- `scripts/doctor.sh` - the development-environment doctor.
+
+The concern behind the flag: when tests are co-entered with the code they cover,
+they risk **pinning the author's mental model** (internal structure, naming,
+implementation detail) rather than **specified or observable behaviour**. A
+structure-pinning test breaks on a safe refactor and can pass while the behaviour
+is broken - it gives false confidence.
+
+This review classifies each relevant test against two criteria:
+
+| Class | Definition | Examples |
+|-------|------------|----------|
+| **Behaviour-pinning** (good) | Asserts observable outcomes a user or caller can see | Rendered text, navigation/URL outcomes, `aria-current`, error messages, exit codes, stdout |
+| **Structure-pinning** (bad) | Asserts internal construction the user never sees | CSS class names, DOM nesting, presence of a function name / comment in source, private state |
+
+## Method
+
+A structured, multi-lens (Six-Hats-style) classification was applied solo:
+
+- **White (facts):** read `App.tsx`, `doctor.sh`, and every test that exercises them.
+- **Black (risk):** which assertions break on a behaviour-preserving refactor, or pass on broken behaviour?
+- **Yellow (value):** which assertions survive refactors and would catch a real regression?
+- **Green (alternatives):** which structure assertions can be re-expressed as behaviour?
+- **Red (smell):** does the flag feel like a true positive or a false positive?
+- **Blue (synthesis):** the verdict and the conservative change set below.
+
+---
+
+## Part 1 - `frontend/src/App.tsx`
+
+`App.tsx` is a routing/composition root: it wires providers (`QueryClientProvider`,
+`AuthProvider`, `TenantProvider`, `ApiClientProvider`), declares the route table,
+and gates routes with `ProtectedRoute` / `PlatformOnlyRoute` / `AdminOnlyRoute` /
+`FeatureGuard`. Its observable behaviour is **what renders at each URL for each
+auth/role state** - which is exactly what its tests assert.
+
+### Tests reviewed
+
+| Test file | Type | Classification | Notes |
+|-----------|------|----------------|-------|
+| `frontend/e2e/smoke.spec.ts` | Playwright e2e | **Behaviour** | Asserts page title matches `/Meridian/`, `/healthz` responds OK. |
+| `frontend/e2e/login-redirect.spec.ts` | Playwright e2e | **Behaviour** | Asserts redirect URLs (`/login`), visible headings, tenant subtitle text, skeleton disappearance. |
+| `frontend/e2e/navigation.spec.ts` | Playwright e2e | **Behaviour** | Asserts each sidebar route renders its `h1`, `aria-current="page"` on the active link, 404 copy, mobile sidebar `data-open` toggle. |
+| `frontend/e2e/auth-flows.spec.ts` | Playwright e2e | **Behaviour** | Asserts role normalization outcomes, callback token handling, visible error messages, return-to-login navigation. |
+| `frontend/src/test/App.test.tsx` | Vitest unit | **Behaviour** | Asserts the rendered `h1` text and that the tree renders without crashing. |
+| `frontend/src/test/app-routing.test.tsx` | Vitest unit | **Behaviour** | Asserts redirect/render outcomes of the route guards via visible text (`Login Page`, `Protected Content`, `Tenant Management`). |
+| `frontend/src/test/page-structure.test.tsx` | Vitest unit | **Structure (intentional)** | Asserts CSS classes (`.space-y-6`, `text-3xl font-bold tracking-tight`) and DOM nesting. Does **not** test `App.tsx`; it is a cross-page UI-convention fitness function. |
+| `frontend/src/test/router.test.tsx` | Vitest unit | **Mixed** | Tests `@/lib/router`, **not** `App.tsx`. Error-boundary cases are behaviour; `getRoutes`/`getRouteHandlers` shape assertions are structure. |
+| `frontend/src/test/architecture/*.test.ts` | Vitest unit | **Structure (intentional)** | Architecture fitness functions (barrel exports, cross-feature import bans, file-size ratchets). Not `App.tsx` tests. |
+
+### Verdict: false positive for `App.tsx`
+
+Every test that **actually exercises `App.tsx`** (the four e2e specs plus
+`App.test.tsx` and `app-routing.test.tsx`) is behaviour-pinning. They assert
+user-visible outcomes - rendered headings, navigation URLs, redirect targets,
+active-link state, error copy - none of which depend on `App.tsx`'s internal
+component decomposition. They would survive a refactor of `App.tsx`'s internals
+and would fail on a real routing/auth regression. That is the correct shape.
+
+The genuinely structure-pinning suites in the frontend
+(`page-structure.test.tsx`, `architecture/*.test.ts`) are **deliberate fitness
+functions** that enforce documented, cross-cutting conventions. They do not pin
+*one author's mental model of `App.tsx`*; they pin a team-wide standard by design.
+They are out of scope for this flag and were left unchanged.
+
+**No conversions made for `App.tsx`. The flag is a well-evidenced false positive.**
+
+### Observation left for human decision (not a test issue)
+
+`frontend/src/lib/router.tsx` (`getRoutes` / `getRouteHandlers` / `createRouteHandler`)
+is **not imported by `App.tsx` or `main.tsx`** - `App.tsx` declares its routes
+inline as JSX. `router.test.tsx` is the only consumer of that module. This is a
+parallel route abstraction whose structure-pinning tests guard code that is not
+wired into the running app. Deciding whether to wire it in or remove it is a
+product/architecture call, not a test conversion - flagged here for a human.
+
+---
+
+## Part 2 - `scripts/doctor.sh`
+
+`doctor.sh` validates (and with `--fix`, repairs) the local dev environment. Its
+observable behaviour is its **exit code, stdout/stderr messages, and fix actions**.
+It is exercised by `scripts/doctor_test.sh` (not wired into CI).
+
+### Tests reviewed (`scripts/doctor_test.sh`, as committed)
+
+| Test | Mechanism | Classification | Notes |
+|------|-----------|----------------|-------|
+| Script exists and is executable | `[ -f ] && [ -x ]` | **Behaviour** (artifact property) | Fine. |
+| `--help` prints `Usage:` / `--check` / `--fix` / `--verbose` | runs script, greps stdout | **Behaviour** | Exemplary - asserts actual output. |
+| PKG_MANAGER validation exists | `grep 'case "$PKG_MANAGER" in'` source | **Structure** | Passes on rename-free source; says nothing about runtime safety. |
+| No `eval` with install cmd | `grep 'eval.*install_cmd'` absent | **Structure** | Source-pattern assertion. |
+| Security model documented | `grep "Security model:"` source | **Structure** | Asserts a *comment* exists - no runtime behaviour at all. |
+| Git hooks function exists | `grep check_git_hooks` source | **Structure** | Function-name presence. |
+| `cmp` detects out-of-sync hooks | re-implements `cmp` in the test | **Vacuous** | Tests the `cmp` binary, not `doctor.sh`. |
+| `get_install_cmd` exists | `grep get_install_cmd()` source | **Structure** | Function-name presence. |
+| macOS/Linux Go install strings | `grep "macos-go.*brew install go"` etc. | **Structure** | Pins exact source strings. |
+| PKG_MANAGER is utilized | `grep '\$PKG_MANAGER'` source | **Structure** | Source-pattern assertion. |
+| Network uses `curl --fail` | `grep "curl.*--fail"` source | **Structure** | Source-pattern assertion. |
+| Handles `gtimeout` | `grep "gtimeout"` source | **Structure** | Source-pattern assertion. |
+| Validates Docker daemon | `grep "docker info"` / `check_docker_daemon` | **Structure** | Source-pattern assertion. |
+
+### Verdict: partially valid - and the harness was broken
+
+Two findings:
+
+1. **Structure-pinning dominates.** Apart from the `--help` suite and the
+   exists/executable check, the harness greps `doctor.sh`'s source for function
+   names, command substrings, and comments. These break on a behaviour-preserving
+   refactor (rename a function, reword a comment) and pass even if the
+   corresponding behaviour is broken. This part of the `/assess` flag is correct.
+
+2. **Pre-existing defect: the harness never ran to completion.** `doctor_test.sh`
+   sets `set -euo pipefail` and increments counters with `((TESTS_PASSED++))`.
+   Post-increment evaluates to the *old* value, so `((TESTS_PASSED++))` when the
+   counter is `0` returns exit status `1`, which `set -e` treats as fatal. The
+   script therefore **aborted after the first passing assertion** (exit 1) and
+   silently never executed the remaining suites. It is not in CI, so this went
+   unnoticed - a textbook self-referential-test failure mode: co-authored with
+   the code, never actually exercised end-to-end.
+
+### Changes made
+
+| Change | File | Rationale |
+|--------|------|-----------|
+| Replace `((TESTS_PASSED++))` / `((TESTS_FAILED++))` with `VAR=$((VAR + 1))` | `scripts/doctor_test.sh` | Root-cause fix for the `set -e` abort; the harness now runs all suites (20 assertions, exit 0). |
+| Add behaviour test: `--help` exits `0` | `scripts/doctor_test.sh` | Uses the previously-defined-but-unused `assert_exit_code` helper to pin the observable exit contract. |
+| Add behaviour test: unknown option exits `1` and prints `Unknown option` | `scripts/doctor_test.sh` | Exercises the real argument parser at runtime instead of grepping for the `case` statement - a true structure→behaviour conversion. |
+
+The existing grep-based structure assertions were **left in place** (conservative:
+they still function as cheap source-lint smoke checks and removing them would drop
+signal). They are documented above as structure-pinning.
+
+### Items left for human decision
+
+- **Hermetic behaviour coverage of the environment checks.** Asserting
+  doctor.sh's real behaviour (e.g. "on macOS with Go absent, suggest
+  `brew install go`"; "exits non-zero when Docker daemon is down") requires a
+  controlled/containerized environment with tools selectively present or absent.
+  That is a meaningful test-infrastructure investment, not an in-place conversion,
+  and is left for a human to scope. Until then the install-command and
+  daemon-detection assertions remain source-pattern greps.
+- **Wire `doctor_test.sh` into CI.** It currently runs nowhere. A broken harness
+  that no one runs provides no protection. Adding it to a lightweight CI job would
+  have caught the `set -e` abort immediately. Flagged for a human decision on CI
+  placement.
+
+---
+
+## Summary
+
+| File | `/assess` flag verdict | Action |
+|------|------------------------|--------|
+| `frontend/src/App.tsx` | **False positive** | None. Tests that exercise `App.tsx` are behaviour-pinning. |
+| `scripts/doctor.sh` | **Partially valid** | Fixed a pre-existing `set -e` abort in `doctor_test.sh`; added 3 behaviour assertions; documented remaining structure-pinning greps and flagged hermetic env coverage + CI wiring for human decision. |

--- a/scripts/doctor_test.sh
+++ b/scripts/doctor_test.sh
@@ -29,13 +29,13 @@ assert_equals() {
 
     if [ "$expected" = "$actual" ]; then
         echo -e "${GREEN}✓${NC} $test_name"
-        ((TESTS_PASSED++))
+        TESTS_PASSED=$((TESTS_PASSED + 1))
         return 0
     else
         echo -e "${RED}✗${NC} $test_name"
         echo "  Expected: $expected"
         echo "  Actual:   $actual"
-        ((TESTS_FAILED++))
+        TESTS_FAILED=$((TESTS_FAILED + 1))
         return 1
     fi
 }
@@ -48,13 +48,13 @@ assert_contains() {
     # Use grep -F for literal string matching, with -- to prevent option interpretation
     if echo "$haystack" | grep -qF -- "$needle"; then
         echo -e "${GREEN}✓${NC} $test_name"
-        ((TESTS_PASSED++))
+        TESTS_PASSED=$((TESTS_PASSED + 1))
         return 0
     else
         echo -e "${RED}✗${NC} $test_name"
         echo "  Expected to contain: $needle"
         echo "  Actual output: $haystack"
-        ((TESTS_FAILED++))
+        TESTS_FAILED=$((TESTS_FAILED + 1))
         return 1
     fi
 }
@@ -66,13 +66,13 @@ assert_exit_code() {
 
     if [ "$expected" -eq "$actual" ]; then
         echo -e "${GREEN}✓${NC} $test_name"
-        ((TESTS_PASSED++))
+        TESTS_PASSED=$((TESTS_PASSED + 1))
         return 0
     else
         echo -e "${RED}✗${NC} $test_name"
         echo "  Expected exit code: $expected"
         echo "  Actual exit code:   $actual"
-        ((TESTS_FAILED++))
+        TESTS_FAILED=$((TESTS_FAILED + 1))
         return 1
     fi
 }
@@ -86,10 +86,10 @@ echo "Test Suite: Basic Script Properties"
 echo "------------------------------------"
 if [ -f "$SCRIPT_DIR/doctor.sh" ] && [ -x "$SCRIPT_DIR/doctor.sh" ]; then
     echo -e "${GREEN}✓${NC} doctor.sh exists and is executable"
-    ((TESTS_PASSED++))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
 else
     echo -e "${RED}✗${NC} doctor.sh exists and is executable"
-    ((TESTS_FAILED++))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 echo ""
 
@@ -101,6 +101,18 @@ assert_contains "$help_output" "Usage:" "Shows help message with --help"
 assert_contains "$help_output" "--check" "Help includes --check option"
 assert_contains "$help_output" "--fix" "Help includes --fix option"
 assert_contains "$help_output" "--verbose" "Help includes --verbose option"
+
+# Behaviour: --help exits 0 (observable contract, not source structure)
+"$SCRIPT_DIR/doctor.sh" --help >/dev/null 2>&1
+assert_exit_code 0 $? "Exits 0 after printing help"
+
+# Behaviour: an unknown option is rejected at runtime with a non-zero exit
+# and a diagnostic message. This exercises the actual argument parser rather
+# than grepping the source for the case statement.
+unknown_exit=0
+unknown_output=$("$SCRIPT_DIR/doctor.sh" --not-a-real-flag 2>&1) || unknown_exit=$?
+assert_exit_code 1 "$unknown_exit" "Exits 1 on unknown option"
+assert_contains "$unknown_output" "Unknown option" "Reports the unknown option to the user"
 echo ""
 
 # Test 3: PKG_MANAGER validation (security test)
@@ -110,28 +122,28 @@ echo "--------------------------"
 # We'll test this by checking the script's actual commands
 if grep -q 'case "$PKG_MANAGER" in' "$SCRIPT_DIR/doctor.sh"; then
     echo -e "${GREEN}✓${NC} PKG_MANAGER validation exists"
-    ((TESTS_PASSED++))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
 else
     echo -e "${RED}✗${NC} PKG_MANAGER validation exists"
-    ((TESTS_FAILED++))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 
 # Check that dangerous patterns are not present
 if grep -q 'eval.*install_cmd' "$SCRIPT_DIR/doctor.sh"; then
     echo -e "${RED}✗${NC} Script does not use eval with install commands"
-    ((TESTS_FAILED++))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 else
     echo -e "${GREEN}✓${NC} Script does not use eval with install commands"
-    ((TESTS_PASSED++))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
 fi
 
 # Check security documentation exists
 if grep -q "Security model:" "$SCRIPT_DIR/doctor.sh"; then
     echo -e "${GREEN}✓${NC} Security model documentation present"
-    ((TESTS_PASSED++))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
 else
     echo -e "${RED}✗${NC} Security model documentation present"
-    ((TESTS_FAILED++))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 echo ""
 
@@ -142,10 +154,10 @@ echo "---------------------------------"
 # Check that doctor.sh has git hooks validation function
 if grep -qF -- "check_git_hooks" "$SCRIPT_DIR/doctor.sh"; then
     echo -e "${GREEN}✓${NC} Git hooks validation function exists"
-    ((TESTS_PASSED++))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
 else
     echo -e "${RED}✗${NC} Git hooks validation function exists"
-    ((TESTS_FAILED++))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 
 # Create a mock git repository to test cmp logic
@@ -165,10 +177,10 @@ echo "# modified" >> "$TEST_DIR/test-repo/.githooks/pre-commit"
 # The cmp command (as used in doctor.sh) should detect the difference
 if ! cmp -s "$TEST_DIR/test-repo/.githooks/pre-commit" "$TEST_DIR/test-repo/.git/hooks/pre-commit"; then
     echo -e "${GREEN}✓${NC} cmp correctly detects out-of-sync hooks"
-    ((TESTS_PASSED++))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
 else
     echo -e "${RED}✗${NC} cmp correctly detects out-of-sync hooks"
-    ((TESTS_FAILED++))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 echo ""
 
@@ -179,36 +191,36 @@ echo "---------------------------------------"
 # Check that get_install_cmd function exists and has proper structure
 if grep -q "get_install_cmd()" "$SCRIPT_DIR/doctor.sh"; then
     echo -e "${GREEN}✓${NC} get_install_cmd function exists"
-    ((TESTS_PASSED++))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
 else
     echo -e "${RED}✗${NC} get_install_cmd function exists"
-    ((TESTS_FAILED++))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 
 # Check for platform-specific commands
 if grep -q "macos-go.*brew install go" "$SCRIPT_DIR/doctor.sh"; then
     echo -e "${GREEN}✓${NC} macOS Go install command present"
-    ((TESTS_PASSED++))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
 else
     echo -e "${RED}✗${NC} macOS Go install command present"
-    ((TESTS_FAILED++))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 
 if grep -q "linux-go.*golang-go" "$SCRIPT_DIR/doctor.sh"; then
     echo -e "${GREEN}✓${NC} Linux Go install command present"
-    ((TESTS_PASSED++))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
 else
     echo -e "${RED}✗${NC} Linux Go install command present"
-    ((TESTS_FAILED++))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 
 # Check that PKG_MANAGER is actually used in commands
 if grep -q '\$PKG_MANAGER' "$SCRIPT_DIR/doctor.sh" && grep -q "get_install_cmd" "$SCRIPT_DIR/doctor.sh"; then
     echo -e "${GREEN}✓${NC} PKG_MANAGER variable is utilized"
-    ((TESTS_PASSED++))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
 else
     echo -e "${RED}✗${NC} PKG_MANAGER variable is utilized"
-    ((TESTS_FAILED++))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 echo ""
 
@@ -219,19 +231,19 @@ echo "------------------------------"
 # Check that network detection uses curl with --fail
 if grep -q "curl.*--fail" "$SCRIPT_DIR/doctor.sh"; then
     echo -e "${GREEN}✓${NC} Network detection uses curl with --fail flag"
-    ((TESTS_PASSED++))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
 else
     echo -e "${RED}✗${NC} Network detection uses curl with --fail flag"
-    ((TESTS_FAILED++))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 
 # Check for timeout portability handling
 if grep -q "gtimeout" "$SCRIPT_DIR/doctor.sh"; then
     echo -e "${GREEN}✓${NC} Handles GNU timeout (gtimeout) for macOS"
-    ((TESTS_PASSED++))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
 else
     echo -e "${RED}✗${NC} Handles GNU timeout (gtimeout) for macOS"
-    ((TESTS_FAILED++))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 echo ""
 
@@ -242,10 +254,10 @@ echo "------------------------------"
 # Check that script validates docker daemon, not just docker binary
 if grep -q "docker info" "$SCRIPT_DIR/doctor.sh" || grep -q "check_docker_daemon" "$SCRIPT_DIR/doctor.sh"; then
     echo -e "${GREEN}✓${NC} Validates Docker daemon is running"
-    ((TESTS_PASSED++))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
 else
     echo -e "${RED}✗${NC} Validates Docker daemon is running"
-    ((TESTS_FAILED++))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 echo ""
 


### PR DESCRIPTION
## Summary

Structured review of the two files the `/assess` cross-layer scan flagged as
`self_referential_tests` - `frontend/src/App.tsx` (most-churned production file,
66 commits) and `scripts/doctor.sh`. The concern: tests co-entered with the code
may pin the author's mental model (internal structure) rather than specified or
observable behaviour. Each test was classified as **behaviour-pinning** (good) or
**structure-pinning** (bad), and structure-pinning assertions were converted to
behaviour where unambiguous.

The durable deliverable is the findings doc:
`docs/architecture/self-referential-test-review.md` (path relative to repo root).

> **Note:** This is a docs-dominant PR. The only code change is a fix + 3 added
> assertions in a shell test harness (`scripts/doctor_test.sh`); no production
> code was modified.

## Findings (behaviour vs structure)

### `App.tsx` - false positive

Every test that actually exercises `App.tsx` is behaviour-pinning:

| Test | Classification |
|------|----------------|
| `frontend/e2e/{smoke,login-redirect,navigation,auth-flows}.spec.ts` | Behaviour (URLs, headings, `aria-current`, error copy) |
| `frontend/src/test/App.test.tsx` | Behaviour (rendered `h1`, no-crash) |
| `frontend/src/test/app-routing.test.tsx` | Behaviour (guard redirect/render outcomes) |
| `frontend/src/test/page-structure.test.tsx` | Structure - but an **intentional** cross-page UI fitness function, not an `App.tsx` test |
| `frontend/src/test/router.test.tsx` | Mixed - tests `@/lib/router`, not `App.tsx` |
| `frontend/src/test/architecture/*.test.ts` | Structure - **intentional** architecture fitness functions |

No conversions made. The flag is a well-evidenced false positive.

### `doctor.sh` - partially valid, plus a latent harness bug

`scripts/doctor_test.sh` is predominantly structure-pinning (greps the source for
function names, command substrings, and comments). More importantly, it had a
**pre-existing defect**: under `set -euo pipefail`, `((TESTS_PASSED++))` returns
exit status 1 when incrementing from 0, so the harness **aborted after its first
assertion** and never ran the remaining suites. It is not in CI, so this went
unnoticed - a textbook self-referential-test failure.

## Changes Made

- **Fix** `((VAR++))` → `VAR=$((VAR + 1))` in `doctor_test.sh` so the harness runs
  to completion (now 20 assertions, exit 0).
- **Convert** the unknown-option check from a source grep to a runtime behaviour
  assertion (exit code 1 + `Unknown option` message).
- **Add** an exit-code assertion for `--help` (exit 0), using the
  previously-defined-but-unused `assert_exit_code` helper.
- Existing grep-based structure checks left in place (conservative; they still act
  as source-lint smoke checks) and documented as structure-pinning.
- **Add** `docs/architecture/self-referential-test-review.md` with the full
  classification, conversions, and items left for human decision (hermetic
  environment-check coverage; wiring `doctor_test.sh` into CI; the unused
  `@/lib/router` module).

## Testing

- `bash scripts/doctor_test.sh` → 20 passed, 0 failed, exit 0 (was: aborted after
  1 assertion, exit 1).
- `bash -n scripts/doctor_test.sh` → syntax OK.
- No frontend test files were modified; `App.tsx` tests verified by static
  classification only. Frontend e2e requires a running dev server/backend not
  available in the worktree - relied on static analysis + existing CI e2e shards.
- Pre-commit hooks (gitleaks, markdownlint) passed.

## Risk

Minimal. One shell test harness fixed (was non-functional) plus a new docs file.
No production code changed.

Addresses `/assess` finding `self_referential_tests` for `App.tsx` and `doctor.sh`.
