### PR TITLE
fix: Align client DefaultPort constants with canonical ports registry

### DIFF
--- a/services/market-information/client/client.go
+++ b/services/market-information/client/client.go
@@ -13,7 +13,7 @@
 //	client, cleanup, err := client.New(ctx, client.Config{
 //	    ServiceName: "market-information",
 //	    Namespace:   "default",
-//	    Port:        50051,
+//	    Port:        50058,
 //	})
 //	if err != nil {
 //	    return err
@@ -26,7 +26,7 @@
 // Usage with direct address (development):
 //
 //	client, cleanup, err := client.New(ctx, client.Config{
-//	    Target: "localhost:50051",
+//	    Target: "localhost:50058",
 //	})
 package client
 
@@ -61,7 +61,7 @@ const (
 
 // Config holds configuration for the Market Information client.
 type Config struct {
-	// Target is the gRPC server address (e.g., "localhost:50051").
+	// Target is the gRPC server address (e.g., "localhost:50058").
 	// If set, overrides Kubernetes DNS-based discovery.
 	//
 	// Deprecated: Use ServiceName, Namespace, and Port for DNS-based load balancing.
@@ -76,7 +76,7 @@ type Config struct {
 	Namespace string
 
 	// Port is the service port number.
-	// Defaults to 50051 if not specified.
+	// Defaults to 50058 if not specified.
 	Port int
 
 	// Timeout is the default timeout for RPC calls.

--- a/services/market-information/client/client.go
+++ b/services/market-information/client/client.go
@@ -42,11 +42,12 @@ import (
 	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/meridianhub/meridian/shared/platform/observability"
+	"github.com/meridianhub/meridian/shared/platform/ports"
 )
 
 const (
 	// DefaultPort is the default gRPC port for the Market Information service.
-	DefaultPort = 50051
+	DefaultPort = ports.MarketInformation
 
 	// DefaultTimeout is the default timeout for gRPC calls.
 	DefaultTimeout = 30 * time.Second

--- a/services/operational-gateway/client/client.go
+++ b/services/operational-gateway/client/client.go
@@ -32,12 +32,13 @@ import (
 	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/meridianhub/meridian/shared/platform/observability"
+	"github.com/meridianhub/meridian/shared/platform/ports"
 	"google.golang.org/grpc"
 )
 
 const (
 	// DefaultPort is the default gRPC port for the OperationalGateway service.
-	DefaultPort = 50051
+	DefaultPort = ports.OperationalGateway
 
 	// DefaultTimeout is the default timeout for gRPC calls.
 	DefaultTimeout = 30 * time.Second

--- a/services/operational-gateway/client/client.go
+++ b/services/operational-gateway/client/client.go
@@ -9,7 +9,7 @@
 //	client, cleanup, err := client.New(client.Config{
 //	    ServiceName: "operational-gateway",
 //	    Namespace:   "default",
-//	    Port:        50051,
+//	    Port:        50063,
 //	})
 //	if err != nil {
 //	    return err
@@ -19,7 +19,7 @@
 // Usage with direct connection (for local development):
 //
 //	client, cleanup, err := client.New(client.Config{
-//	    Target:  "localhost:50051",
+//	    Target:  "localhost:50063",
 //	    Timeout: 30 * time.Second,
 //	})
 package client
@@ -55,7 +55,7 @@ var ErrTargetRequired = clients.ErrConnTargetRequired
 
 // Config holds configuration for the OperationalGateway client.
 type Config struct {
-	// Target is the gRPC server address (e.g., "localhost:50051").
+	// Target is the gRPC server address (e.g., "localhost:50063").
 	// If set, overrides Kubernetes DNS-based discovery.
 	//
 	// Deprecated: Use ServiceName, Namespace, and Port for DNS-based load balancing.
@@ -70,7 +70,7 @@ type Config struct {
 	Namespace string
 
 	// Port is the service port number.
-	// Defaults to 50051 if not specified.
+	// Defaults to 50063 if not specified.
 	Port int
 
 	// Timeout is the default timeout for RPC calls.

--- a/services/reconciliation/client/client.go
+++ b/services/reconciliation/client/client.go
@@ -9,7 +9,7 @@
 //	client, cleanup, err := client.New(client.Config{
 //	    ServiceName: "reconciliation",
 //	    Namespace:   "default",
-//	    Port:        50058,
+//	    Port:        50060,
 //	    Tracer:      tracer,
 //	})
 //	if err != nil {
@@ -20,7 +20,7 @@
 // Usage with direct connection (for local development):
 //
 //	client, cleanup, err := client.New(client.Config{
-//	    Target:  "localhost:50058",
+//	    Target:  "localhost:50060",
 //	    Timeout: 30 * time.Second,
 //	})
 package client
@@ -56,7 +56,7 @@ var ErrTargetRequired = clients.ErrConnTargetRequired
 
 // Config holds configuration for the AccountReconciliation client.
 type Config struct {
-	// Target is the gRPC server address (e.g., "localhost:50058" or "reconciliation:50058").
+	// Target is the gRPC server address (e.g., "localhost:50060" or "reconciliation:50060").
 	// If set, overrides Kubernetes DNS-based discovery.
 	Target string
 
@@ -69,7 +69,7 @@ type Config struct {
 	Namespace string
 
 	// Port is the service port number.
-	// Defaults to 50058 if not specified.
+	// Defaults to 50060 if not specified.
 	Port int
 
 	// Timeout is the default timeout for RPC calls.

--- a/services/reconciliation/client/client.go
+++ b/services/reconciliation/client/client.go
@@ -33,12 +33,13 @@ import (
 	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/meridianhub/meridian/shared/platform/observability"
+	"github.com/meridianhub/meridian/shared/platform/ports"
 	"google.golang.org/grpc"
 )
 
 const (
 	// DefaultPort is the default gRPC port for the AccountReconciliation service.
-	DefaultPort = 50058
+	DefaultPort = ports.Reconciliation
 
 	// DefaultTimeout is the default timeout for gRPC calls.
 	DefaultTimeout = 30 * time.Second

--- a/services/reconciliation/client/client_test.go
+++ b/services/reconciliation/client/client_test.go
@@ -205,7 +205,7 @@ func TestNew_ServiceNameConnection(t *testing.T) {
 	_, _, err := client.New(client.Config{
 		ServiceName: "reconciliation",
 		Namespace:   "test-ns",
-		Port:        50058,
+		Port:        client.DefaultPort,
 	})
 	// This may succeed (creating a lazy connection) or fail depending on resolver
 	// The key is it doesn't panic and handles the path

--- a/services/reference-data/client/client.go
+++ b/services/reference-data/client/client.go
@@ -42,11 +42,12 @@ import (
 	refcel "github.com/meridianhub/meridian/services/reference-data/cel"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/meridianhub/meridian/shared/platform/observability"
+	"github.com/meridianhub/meridian/shared/platform/ports"
 )
 
 const (
 	// DefaultPort is the default gRPC port for the Reference Data service.
-	DefaultPort = 50051
+	DefaultPort = ports.ReferenceData
 
 	// DefaultTimeout is the default timeout for gRPC calls.
 	DefaultTimeout = 30 * time.Second

--- a/services/reference-data/client/client.go
+++ b/services/reference-data/client/client.go
@@ -11,7 +11,7 @@
 //	client, cleanup, err := client.New(ctx, client.Config{
 //	    ServiceName: "reference-data",
 //	    Namespace:   "default",
-//	    Port:        50051,
+//	    Port:        50059,
 //	    RedisAddr:   "redis:6379",
 //	})
 //	if err != nil {
@@ -24,7 +24,7 @@
 //	client, cleanup, err := client.New(ctx, client.Config{
 //	    ServiceName: "reference-data",
 //	    Namespace:   "default",
-//	    Port:        50051,
+//	    Port:        50059,
 //	})
 package client
 
@@ -70,7 +70,7 @@ const (
 
 // Config holds configuration for the Reference Data client.
 type Config struct {
-	// Target is the gRPC server address (e.g., "localhost:50051").
+	// Target is the gRPC server address (e.g., "localhost:50059").
 	// If set, overrides Kubernetes DNS-based discovery.
 	//
 	// Deprecated: Use ServiceName, Namespace, and Port for DNS-based load balancing.
@@ -85,7 +85,7 @@ type Config struct {
 	Namespace string
 
 	// Port is the service port number.
-	// Defaults to 50051 if not specified.
+	// Defaults to 50059 if not specified.
 	Port int
 
 	// Timeout is the default timeout for RPC calls.

--- a/services/reference-data/client/client_test.go
+++ b/services/reference-data/client/client_test.go
@@ -18,12 +18,13 @@ import (
 	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
 	"github.com/meridianhub/meridian/services/reference-data/cache"
 	"github.com/meridianhub/meridian/services/reference-data/registry"
+	"github.com/meridianhub/meridian/shared/platform/ports"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
 
 func TestConfig_Defaults(t *testing.T) {
 	// Verify constants are defined correctly
-	assert.Equal(t, 50051, DefaultPort)
+	assert.Equal(t, ports.ReferenceData, DefaultPort)
 	assert.Equal(t, 30*time.Second, DefaultTimeout)
 	assert.Equal(t, "default", DefaultNamespace)
 	assert.Equal(t, "reference-data", ServiceName)

--- a/shared/platform/ports/ports_test.go
+++ b/shared/platform/ports/ports_test.go
@@ -3,6 +3,17 @@ package ports_test
 import (
 	"testing"
 
+	currentaccountclient "github.com/meridianhub/meridian/services/current-account/client"
+	financialaccountingclient "github.com/meridianhub/meridian/services/financial-accounting/client"
+	financialgatewayclient "github.com/meridianhub/meridian/services/financial-gateway/client"
+	internalaccountclient "github.com/meridianhub/meridian/services/internal-account/client"
+	marketinformationclient "github.com/meridianhub/meridian/services/market-information/client"
+	operationalgatewayclient "github.com/meridianhub/meridian/services/operational-gateway/client"
+	partyclient "github.com/meridianhub/meridian/services/party/client"
+	positionkeepingclient "github.com/meridianhub/meridian/services/position-keeping/client"
+	reconciliationclient "github.com/meridianhub/meridian/services/reconciliation/client"
+	referencedataclient "github.com/meridianhub/meridian/services/reference-data/client"
+	tenantclient "github.com/meridianhub/meridian/services/tenant/client"
 	"github.com/meridianhub/meridian/shared/platform/ports"
 	"github.com/stretchr/testify/assert"
 )
@@ -35,6 +46,38 @@ func TestGrpcPortsAreInExpectedRange(t *testing.T) {
 	for _, port := range grpcPorts {
 		assert.GreaterOrEqual(t, port, 50051, "gRPC port should be >= 50051")
 		assert.LessOrEqual(t, port, 50099, "gRPC port should be <= 50099")
+	}
+}
+
+// TestClientDefaultPortsMatchRegistry is a drift-prevention guard: every service
+// client's DefaultPort must equal its canonical constant in this registry. If anyone
+// re-hardcodes a port that diverges from the registry, this test fails loudly.
+//
+// To add a new service client, append one row to the table below.
+func TestClientDefaultPortsMatchRegistry(t *testing.T) {
+	cases := []struct {
+		service      string
+		clientPort   int
+		registryPort int
+	}{
+		{"current-account", currentaccountclient.DefaultPort, ports.CurrentAccount},
+		{"financial-accounting", financialaccountingclient.DefaultPort, ports.FinancialAccounting},
+		{"position-keeping", positionkeepingclient.DefaultPort, ports.PositionKeeping},
+		{"party", partyclient.DefaultPort, ports.Party},
+		{"tenant", tenantclient.DefaultPort, ports.Tenant},
+		{"internal-account", internalaccountclient.DefaultPort, ports.InternalAccount},
+		{"market-information", marketinformationclient.DefaultPort, ports.MarketInformation},
+		{"reference-data", referencedataclient.DefaultPort, ports.ReferenceData},
+		{"reconciliation", reconciliationclient.DefaultPort, ports.Reconciliation},
+		{"operational-gateway", operationalgatewayclient.DefaultPort, ports.OperationalGateway},
+		{"financial-gateway", financialgatewayclient.DefaultPort, ports.FinancialGateway},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.service, func(t *testing.T) {
+			assert.Equal(t, tc.registryPort, tc.clientPort,
+				"%s client DefaultPort must match ports registry constant", tc.service)
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Several service client packages hardcoded `DefaultPort` constants that diverged from the canonical ports registry (`shared/platform/ports/ports.go`), pointing client traffic at the wrong service ports. This fixes the mismatches and adds a drift-prevention test so it cannot silently recur.

Addresses an `/assess` follow-up finding (assess-followups.1).

## Changes Made

Replaced hardcoded `DefaultPort` literals with the canonical registry constants:

| Client | Before | After (registry constant) |
|--------|--------|---------------------------|
| `market-information` | `50051` | `ports.MarketInformation` (50058) |
| `reference-data` | `50051` | `ports.ReferenceData` (50059) |
| `operational-gateway` | `50051` | `ports.OperationalGateway` (50063) |
| `reconciliation` | `50058` | `ports.Reconciliation` (50060) |

The `reconciliation` client was listed as already-correct in the task brief, but it hardcoded `50058` - which is actually `market-information`'s port. The reconciliation service listens on `50060` everywhere else (k8s manifests, config, Tiltfile, README, Dockerfile), so the client default was a genuine wrong-port bug. Fixed it in the same pass.

Added `TestClientDefaultPortsMatchRegistry` in `shared/platform/ports/ports_test.go` - a data-driven table asserting every service client's `DefaultPort` equals its registry constant. Covers all 11 client packages (the 4 fixed plus current-account, financial-accounting, position-keeping, party, tenant, internal-account, financial-gateway). Adding a new client is one table row.

Updated client test assertions that hardcoded port literals to reference the registry constants instead (`reference-data` and `reconciliation` tests).

## Technical Details

- `ports` is a leaf package; the drift test lives in the external `ports_test` package so it can import every client without creating an import cycle (`go build ./...` confirms no cycle).
- No public API or client struct changes - only the value of the `DefaultPort` constant and a new test.

## Testing

- `go build ./...` - clean
- `go vet` on all affected packages - clean
- `go test ./shared/platform/ports/... ./services/market-information/client/... ./services/reference-data/client/... ./services/operational-gateway/client/... ./services/reconciliation/client/...` - all pass
- Confirmed the new drift test fails on the un-fixed clients before the fix (TDD red), passes after (green)
- Pre-commit: gofumpt, golangci-lint, gitleaks all pass

## Risk Assessment

Low. Mechanical correctness fix. The clients now connect to the correct, registry-defined ports. The drift test is the durable value - it fails loudly if any client re-hardcodes a port that diverges from the registry.