### PR TITLE
feat: Cut market-information quality ladder over to four levels (Axis A)

### DIFF
--- a/services/market-information/adapters/persistence/testhelpers/testcontainer.go
+++ b/services/market-information/adapters/persistence/testhelpers/testcontainer.go
@@ -321,6 +321,7 @@ func createSchemaObservationTable(ctx context.Context, conn *pgxpool.Conn) error
 			created_at timestamptz NOT NULL DEFAULT now(),
 			created_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
 			quality integer NOT NULL,
+			revision integer NOT NULL DEFAULT 0,
 			observation_context jsonb NOT NULL DEFAULT '{}'::jsonb,
 			numeric_value numeric NULL,
 			text_value text NULL,
@@ -333,7 +334,10 @@ func createSchemaObservationTable(ctx context.Context, conn *pgxpool.Conn) error
 				FOREIGN KEY (data_source_id) REFERENCES data_source(id) ON DELETE RESTRICT,
 			CONSTRAINT fk_observation_superseded_by
 				FOREIGN KEY (superseded_by) REFERENCES market_price_observation(id) ON DELETE SET NULL,
-			CONSTRAINT chk_observation_quality CHECK (quality IN (1, 2, 3)),
+			-- Quality is Axis A (confidence): four-level ladder IN (1,2,3,4) per ADR-0017,
+			-- mirroring migration 20260608000002_quality_level_verified.sql. revision is
+			-- Axis B (lifecycle), mirroring migration 20260608000003_add_revision_column.sql.
+			CONSTRAINT chk_observation_quality CHECK (quality IN (1, 2, 3, 4)),
 			CONSTRAINT chk_observation_value_present CHECK (numeric_value IS NOT NULL OR text_value IS NOT NULL)
 		)
 	`)

--- a/services/market-information/domain/quality_level.go
+++ b/services/market-information/domain/quality_level.go
@@ -1,45 +1,60 @@
 // Package domain contains the core business logic for market information.
 package domain
 
-// QualityLevel represents the quality tier of market data in the Time-Bound Quality Ladder.
-// Higher values indicate more reliable data that should take precedence in reconciliation.
+// QualityLevel represents the confidence grade of market data on Axis A of the
+// two-axis quality model (ADR-0017). Higher values indicate greater confidence
+// and take precedence during reconciliation.
 //
-// The quality ladder follows this hierarchy:
-//   - ESTIMATE (1): Forecasted or projected values based on models/patterns
-//   - ACTUAL (2): Real measured values from data sources
-//   - VERIFIED (3): Actual values that have been cross-checked and validated
+// The four-level confidence ladder:
+//   - ESTIMATE (1): Forecasted or projected values based on models/patterns.
+//   - PROVISIONAL (2): Metered/received data that has not yet been validated.
+//   - ACTUAL (3): Metered, validated data.
+//   - VERIFIED (4): Actual values that have been cross-checked against multiple
+//     sources or manually verified.
 //
-// This ordering is fundamental to the Estimates vs. Actuals reconciliation pattern:
-// when multiple values exist for the same time period, higher quality levels supersede lower ones.
+// This ordering drives the Estimates vs. Actuals reconciliation pattern: when
+// multiple values exist for the same time period, higher confidence grades
+// supersede lower ones via Supersedes.
+//
+// Axis A (confidence, this enum) is orthogonal to Axis B (lifecycle/correction
+// lineage), which is tracked by the revision counter and supersession links, not
+// by a confidence grade.
 type QualityLevel int
 
-// Quality level constants for the Time-Bound Quality Ladder.
+// Quality level constants for the Axis-A confidence ladder.
 const (
 	// QualityLevelEstimate represents forecasted or projected values.
 	// These are typically generated from models, historical patterns, or forward curves.
 	QualityLevelEstimate QualityLevel = 1
 
-	// QualityLevelActual represents real measured values from data sources.
+	// QualityLevelProvisional represents metered or received data that has not yet
+	// been validated. It sits above ESTIMATE (real measurement, not a forecast) but
+	// below ACTUAL (not yet validated).
+	QualityLevelProvisional QualityLevel = 2
+
+	// QualityLevelActual represents metered, validated data from data sources.
 	// These are received from APIs, feeds, or manual entry of observed data.
-	QualityLevelActual QualityLevel = 2
+	QualityLevelActual QualityLevel = 3
 
 	// QualityLevelVerified represents actual values that have been cross-checked.
 	// These have undergone validation against multiple sources or manual verification.
-	QualityLevelVerified QualityLevel = 3
+	QualityLevelVerified QualityLevel = 4
 )
 
 // qualityLevelNames maps quality levels to their display names.
 var qualityLevelNames = map[QualityLevel]string{
-	QualityLevelEstimate: "Estimate",
-	QualityLevelActual:   "Actual",
-	QualityLevelVerified: "Verified",
+	QualityLevelEstimate:    "Estimate",
+	QualityLevelProvisional: "Provisional",
+	QualityLevelActual:      "Actual",
+	QualityLevelVerified:    "Verified",
 }
 
 // validQualityLevels contains all valid quality levels for efficient lookup.
 var validQualityLevels = map[QualityLevel]bool{
-	QualityLevelEstimate: true,
-	QualityLevelActual:   true,
-	QualityLevelVerified: true,
+	QualityLevelEstimate:    true,
+	QualityLevelProvisional: true,
+	QualityLevelActual:      true,
+	QualityLevelVerified:    true,
 }
 
 // String returns the human-readable name of the quality level.
@@ -56,8 +71,10 @@ func (q QualityLevel) IsValid() bool {
 	return validQualityLevels[q]
 }
 
-// Supersedes returns true if this quality level should take precedence over the other.
-// Higher quality levels supersede lower ones in the reconciliation process.
+// Supersedes returns true if this quality level should take precedence over the
+// other. This is Axis A only: a higher confidence grade supersedes a lower one.
+// Lifecycle/correction state (Axis B) is handled separately by the revision
+// counter and supersession links and must not influence this comparison.
 func (q QualityLevel) Supersedes(other QualityLevel) bool {
 	return q > other
 }

--- a/services/market-information/domain/quality_level_test.go
+++ b/services/market-information/domain/quality_level_test.go
@@ -18,6 +18,11 @@ func TestQualityLevel_IsValid(t *testing.T) {
 			want:  true,
 		},
 		{
+			name:  "PROVISIONAL is valid",
+			level: QualityLevelProvisional,
+			want:  true,
+		},
+		{
 			name:  "ACTUAL is valid",
 			level: QualityLevelActual,
 			want:  true,
@@ -50,8 +55,8 @@ func TestQualityLevel_IsValid_Invalid(t *testing.T) {
 			level: QualityLevel(-1),
 		},
 		{
-			name:  "four is invalid (above range)",
-			level: QualityLevel(4),
+			name:  "five is invalid (above range)",
+			level: QualityLevel(5),
 		},
 		{
 			name:  "large number is invalid",
@@ -76,6 +81,11 @@ func TestQualityLevel_String(t *testing.T) {
 			name:  "ESTIMATE string",
 			level: QualityLevelEstimate,
 			want:  "Estimate",
+		},
+		{
+			name:  "PROVISIONAL string",
+			level: QualityLevelProvisional,
+			want:  "Provisional",
 		},
 		{
 			name:  "ACTUAL string",
@@ -103,7 +113,7 @@ func TestQualityLevel_String_Invalid(t *testing.T) {
 	}{
 		{"zero", QualityLevel(0)},
 		{"negative", QualityLevel(-1)},
-		{"above range", QualityLevel(4)},
+		{"above range", QualityLevel(5)},
 		{"large number", QualityLevel(999)},
 	}
 
@@ -115,16 +125,19 @@ func TestQualityLevel_String_Invalid(t *testing.T) {
 }
 
 func TestQualityLevel_Constants(t *testing.T) {
-	// Verify the constant values are as expected
+	// Verify the constant values are as expected for the four-level ladder.
 	assert.Equal(t, QualityLevel(1), QualityLevelEstimate)
-	assert.Equal(t, QualityLevel(2), QualityLevelActual)
-	assert.Equal(t, QualityLevel(3), QualityLevelVerified)
+	assert.Equal(t, QualityLevel(2), QualityLevelProvisional)
+	assert.Equal(t, QualityLevel(3), QualityLevelActual)
+	assert.Equal(t, QualityLevel(4), QualityLevelVerified)
 }
 
 func TestQualityLevel_Ordering(t *testing.T) {
-	// Verify the natural ordering: ESTIMATE < ACTUAL < VERIFIED
-	assert.True(t, QualityLevelEstimate < QualityLevelActual,
-		"ESTIMATE should be less than ACTUAL")
+	// Verify the natural ordering: ESTIMATE < PROVISIONAL < ACTUAL < VERIFIED
+	assert.True(t, QualityLevelEstimate < QualityLevelProvisional,
+		"ESTIMATE should be less than PROVISIONAL")
+	assert.True(t, QualityLevelProvisional < QualityLevelActual,
+		"PROVISIONAL should be less than ACTUAL")
 	assert.True(t, QualityLevelActual < QualityLevelVerified,
 		"ACTUAL should be less than VERIFIED")
 	assert.True(t, QualityLevelEstimate < QualityLevelVerified,
@@ -138,64 +151,27 @@ func TestQualityLevel_Supersedes(t *testing.T) {
 		other    QualityLevel
 		expected bool
 	}{
-		// VERIFIED supersedes ACTUAL and ESTIMATE
-		{
-			name:     "VERIFIED supersedes ACTUAL",
-			level:    QualityLevelVerified,
-			other:    QualityLevelActual,
-			expected: true,
-		},
-		{
-			name:     "VERIFIED supersedes ESTIMATE",
-			level:    QualityLevelVerified,
-			other:    QualityLevelEstimate,
-			expected: true,
-		},
-		// ACTUAL supersedes ESTIMATE but not VERIFIED
-		{
-			name:     "ACTUAL supersedes ESTIMATE",
-			level:    QualityLevelActual,
-			other:    QualityLevelEstimate,
-			expected: true,
-		},
-		{
-			name:     "ACTUAL does not supersede VERIFIED",
-			level:    QualityLevelActual,
-			other:    QualityLevelVerified,
-			expected: false,
-		},
-		// ESTIMATE doesn't supersede anything
-		{
-			name:     "ESTIMATE does not supersede ACTUAL",
-			level:    QualityLevelEstimate,
-			other:    QualityLevelActual,
-			expected: false,
-		},
-		{
-			name:     "ESTIMATE does not supersede VERIFIED",
-			level:    QualityLevelEstimate,
-			other:    QualityLevelVerified,
-			expected: false,
-		},
-		// Same level does not supersede itself
-		{
-			name:     "ESTIMATE does not supersede itself",
-			level:    QualityLevelEstimate,
-			other:    QualityLevelEstimate,
-			expected: false,
-		},
-		{
-			name:     "ACTUAL does not supersede itself",
-			level:    QualityLevelActual,
-			other:    QualityLevelActual,
-			expected: false,
-		},
-		{
-			name:     "VERIFIED does not supersede itself",
-			level:    QualityLevelVerified,
-			other:    QualityLevelVerified,
-			expected: false,
-		},
+		// VERIFIED supersedes everything below it.
+		{"VERIFIED supersedes ACTUAL", QualityLevelVerified, QualityLevelActual, true},
+		{"VERIFIED supersedes PROVISIONAL", QualityLevelVerified, QualityLevelProvisional, true},
+		{"VERIFIED supersedes ESTIMATE", QualityLevelVerified, QualityLevelEstimate, true},
+		// ACTUAL supersedes lower grades but not VERIFIED.
+		{"ACTUAL supersedes PROVISIONAL", QualityLevelActual, QualityLevelProvisional, true},
+		{"ACTUAL supersedes ESTIMATE", QualityLevelActual, QualityLevelEstimate, true},
+		{"ACTUAL does not supersede VERIFIED", QualityLevelActual, QualityLevelVerified, false},
+		// PROVISIONAL supersedes ESTIMATE only.
+		{"PROVISIONAL supersedes ESTIMATE", QualityLevelProvisional, QualityLevelEstimate, true},
+		{"PROVISIONAL does not supersede ACTUAL", QualityLevelProvisional, QualityLevelActual, false},
+		{"PROVISIONAL does not supersede VERIFIED", QualityLevelProvisional, QualityLevelVerified, false},
+		// ESTIMATE supersedes nothing.
+		{"ESTIMATE does not supersede PROVISIONAL", QualityLevelEstimate, QualityLevelProvisional, false},
+		{"ESTIMATE does not supersede ACTUAL", QualityLevelEstimate, QualityLevelActual, false},
+		{"ESTIMATE does not supersede VERIFIED", QualityLevelEstimate, QualityLevelVerified, false},
+		// Same level never supersedes itself.
+		{"ESTIMATE does not supersede itself", QualityLevelEstimate, QualityLevelEstimate, false},
+		{"PROVISIONAL does not supersede itself", QualityLevelProvisional, QualityLevelProvisional, false},
+		{"ACTUAL does not supersede itself", QualityLevelActual, QualityLevelActual, false},
+		{"VERIFIED does not supersede itself", QualityLevelVerified, QualityLevelVerified, false},
 	}
 
 	for _, tt := range tests {
@@ -205,27 +181,38 @@ func TestQualityLevel_Supersedes(t *testing.T) {
 	}
 }
 
+// TestQualityLevel_Supersedes_AxisAOnly proves Supersedes ranks purely on the
+// confidence grade (Axis A). A correction/revision is an Axis-B concern tracked
+// by the revision counter and supersession links, never by the enum. So a
+// low-confidence row that happens to be a later correction must NOT outrank a
+// higher-confidence row via Supersedes.
+func TestQualityLevel_Supersedes_AxisAOnly(t *testing.T) {
+	// Imagine a PROVISIONAL observation that is itself a correction (revision >= 1)
+	// of an earlier reading. Its lifecycle state is irrelevant to Supersedes: it
+	// still must not outrank an ACTUAL or VERIFIED value on confidence alone.
+	revisedLowConfidence := QualityLevelProvisional
+
+	assert.False(t, revisedLowConfidence.Supersedes(QualityLevelActual),
+		"a revised low-confidence row must not outrank a higher-confidence ACTUAL via Supersedes")
+	assert.False(t, revisedLowConfidence.Supersedes(QualityLevelVerified),
+		"a revised low-confidence row must not outrank a higher-confidence VERIFIED via Supersedes")
+
+	// And the reverse holds: higher confidence still supersedes regardless of any
+	// lifecycle/correction state the lower row might carry.
+	assert.True(t, QualityLevelVerified.Supersedes(revisedLowConfidence),
+		"a higher-confidence VERIFIED supersedes a lower-confidence row irrespective of revision state")
+}
+
 func TestQualityLevel_Int(t *testing.T) {
 	tests := []struct {
 		name  string
 		level QualityLevel
 		want  int
 	}{
-		{
-			name:  "ESTIMATE int value",
-			level: QualityLevelEstimate,
-			want:  1,
-		},
-		{
-			name:  "ACTUAL int value",
-			level: QualityLevelActual,
-			want:  2,
-		},
-		{
-			name:  "VERIFIED int value",
-			level: QualityLevelVerified,
-			want:  3,
-		},
+		{"ESTIMATE int value", QualityLevelEstimate, 1},
+		{"PROVISIONAL int value", QualityLevelProvisional, 2},
+		{"ACTUAL int value", QualityLevelActual, 3},
+		{"VERIFIED int value", QualityLevelVerified, 4},
 	}
 
 	for _, tt := range tests {
@@ -236,9 +223,10 @@ func TestQualityLevel_Int(t *testing.T) {
 }
 
 func TestQualityLevel_AllValidLevelsCount(t *testing.T) {
-	// Test that we have exactly 3 valid quality levels
+	// Test that we have exactly 4 valid quality levels.
 	validLevels := []QualityLevel{
 		QualityLevelEstimate,
+		QualityLevelProvisional,
 		QualityLevelActual,
 		QualityLevelVerified,
 	}
@@ -247,7 +235,7 @@ func TestQualityLevel_AllValidLevelsCount(t *testing.T) {
 		assert.True(t, level.IsValid(), "expected %d to be valid", level)
 	}
 
-	assert.Len(t, validLevels, 3, "expected exactly 3 valid quality levels")
+	assert.Len(t, validLevels, 4, "expected exactly 4 valid quality levels")
 }
 
 func TestQualityLevel_ComparisonOperators(t *testing.T) {
@@ -261,8 +249,17 @@ func TestQualityLevel_ComparisonOperators(t *testing.T) {
 		equal    bool
 	}{
 		{
-			name:     "ESTIMATE vs ACTUAL",
+			name:     "ESTIMATE vs PROVISIONAL",
 			a:        QualityLevelEstimate,
+			b:        QualityLevelProvisional,
+			lessEq:   true,
+			greater:  false,
+			lessOnly: true,
+			equal:    false,
+		},
+		{
+			name:     "PROVISIONAL vs ACTUAL",
+			a:        QualityLevelProvisional,
 			b:        QualityLevelActual,
 			lessEq:   true,
 			greater:  false,
@@ -314,6 +311,8 @@ func TestQualityLevel_UsedInSwitch(t *testing.T) {
 		switch level {
 		case QualityLevelEstimate:
 			return "estimated"
+		case QualityLevelProvisional:
+			return "provisional"
 		case QualityLevelActual:
 			return "actual"
 		case QualityLevelVerified:
@@ -324,6 +323,7 @@ func TestQualityLevel_UsedInSwitch(t *testing.T) {
 	}
 
 	assert.Equal(t, "estimated", getLevelDescription(QualityLevelEstimate))
+	assert.Equal(t, "provisional", getLevelDescription(QualityLevelProvisional))
 	assert.Equal(t, "actual", getLevelDescription(QualityLevelActual))
 	assert.Equal(t, "verified", getLevelDescription(QualityLevelVerified))
 	assert.Equal(t, "unknown", getLevelDescription(QualityLevel(0)))
@@ -333,12 +333,14 @@ func TestQualityLevel_UsedInSwitch(t *testing.T) {
 func TestQualityLevel_UsedAsMapKey(t *testing.T) {
 	// Test that quality levels can be used as map keys
 	descriptions := map[QualityLevel]string{
-		QualityLevelEstimate: "Forecasted value",
-		QualityLevelActual:   "Measured value",
-		QualityLevelVerified: "Validated value",
+		QualityLevelEstimate:    "Forecasted value",
+		QualityLevelProvisional: "Unvalidated measured value",
+		QualityLevelActual:      "Measured value",
+		QualityLevelVerified:    "Validated value",
 	}
 
 	assert.Equal(t, "Forecasted value", descriptions[QualityLevelEstimate])
+	assert.Equal(t, "Unvalidated measured value", descriptions[QualityLevelProvisional])
 	assert.Equal(t, "Measured value", descriptions[QualityLevelActual])
 	assert.Equal(t, "Validated value", descriptions[QualityLevelVerified])
 

--- a/services/market-information/migrations/20260608000005_remap_quality_to_4level.sql
+++ b/services/market-information/migrations/20260608000005_remap_quality_to_4level.sql
@@ -21,6 +21,20 @@
 --
 -- CockroachDB: plain UPDATEs, no plpgsql, no CONCURRENTLY. The CHECK already
 -- admits 1-4, so both intermediate and final states validate.
+--
+-- DEPLOY SEQUENCING (read before deploying to an env with existing rows): the
+-- code flip and this re-encode are atomic in the PR but NOT automatically atomic
+-- at runtime. They must not overlap with the old binary serving traffic:
+--   - If this migration runs while OLD pods still serve: a re-encoded 3 reads as
+--     old VERIFIED (wrong) and a re-encoded 4 fails the old domain IsValid (old
+--     range was 1-3).
+--   - If NEW pods start before this migration runs: a legacy 2 reads as
+--     PROVISIONAL - the silent downgrade this migration exists to prevent.
+-- Therefore deploy as a single cutover with no mixed-version window: drain/stop
+-- the old binary, run the migration to completion, then start the new binary
+-- (equivalently, a brief maintenance pause around the migration). On the demo/
+-- develop unified-binary deploy this is satisfied by running `--migrate` to
+-- completion before the new container serves traffic.
 
 UPDATE market_price_observation SET quality = 4 WHERE quality = 3;
 UPDATE market_price_observation SET quality = 3 WHERE quality = 2;

--- a/services/market-information/migrations/20260608000005_remap_quality_to_4level.sql
+++ b/services/market-information/migrations/20260608000005_remap_quality_to_4level.sql
@@ -1,0 +1,26 @@
+-- Re-encode existing quality values from the legacy three-level domain encoding
+-- to the four-level confidence ladder (Axis A) per ADR-0017.
+--
+-- This migration is the data half of the Wave 2 cutover. The widened CHECK
+-- (IN (1,2,3,4)) landed in 20260608000002_quality_level_verified.sql, but the
+-- stored integers still carry the LEGACY meaning:
+--   legacy: 1=ESTIMATE, 2=ACTUAL,      3=VERIFIED
+-- The new domain/proto encoding the application now reads is:
+--   new:    1=ESTIMATE, 2=PROVISIONAL, 3=ACTUAL,     4=VERIFIED
+-- Without this remap every stored 2 would silently read as PROVISIONAL and every
+-- stored 3 as ACTUAL: a silent confidence downgrade. The code flip (domain enum +
+-- lossless adapter) ships in the same PR, so the re-encode and the read change are
+-- atomic.
+--
+-- Mapping: 1 stays 1 (ESTIMATE unchanged), 2 (legacy ACTUAL) -> 3 (ACTUAL),
+-- 3 (legacy VERIFIED) -> 4 (VERIFIED). No legacy row uses the new PROVISIONAL(2).
+--
+-- Order matters: re-encode 3->4 BEFORE 2->3, otherwise the 2->3 step would create
+-- new value-3 rows that the 3->4 step would then wrongly promote to 4. Doing 3->4
+-- first clears value 3 so the subsequent 2->3 cannot collide.
+--
+-- CockroachDB: plain UPDATEs, no plpgsql, no CONCURRENTLY. The CHECK already
+-- admits 1-4, so both intermediate and final states validate.
+
+UPDATE market_price_observation SET quality = 4 WHERE quality = 3;
+UPDATE market_price_observation SET quality = 3 WHERE quality = 2;

--- a/services/market-information/migrations/atlas.sum
+++ b/services/market-information/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:WeGHAGBs4qhJysCOZSO6h2vQdMBcyfjjAJAwxl6RaNw=
+h1:ca96Qg6Ef0VstXE9UicS6188tf/1aOIWxqaNyyeXDk8=
 20260116000001_initial.sql h1:CzgBK2HKBimqrB1SWGLD2tLaJdypAJ9IQfLqJ44EBu0=
 20260119000002_add_shared_dataset_support.sql h1:iztVWFVc76jnUhqNaNJyE6n51PxTnJsG2D6yjP21L7w=
 20260119000003_add_shared_dataset_index.sql h1:HL5xRFvhhqF5dmptHdppPUadAcpwfDZYDIvazD35KCk=
@@ -10,3 +10,4 @@ h1:WeGHAGBs4qhJysCOZSO6h2vQdMBcyfjjAJAwxl6RaNw=
 20260608000002_quality_level_verified.sql h1:3ilHbcQXS+wLMcuHQPVK/4SZxGZB/bo+0DE1pNFciRU=
 20260608000003_add_revision_column.sql h1:qgsZmqgQ4ph6QQpxh+dMoEXuuVMJUTfcoJq6CYZ9l9s=
 20260608000004_backfill_revision.sql h1:cNK3uPSpDxoaHi0ZhPOufRkPTytNn4ZvclGaCDt2j0w=
+20260608000005_remap_quality_to_4level.sql h1:c2cFqExq7Y3dSuHIEeENbtscXMbGxqYpb8FDgzns3yo=

--- a/services/market-information/migrations/atlas.sum
+++ b/services/market-information/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:ca96Qg6Ef0VstXE9UicS6188tf/1aOIWxqaNyyeXDk8=
+h1:xl1M7soIVqtHIwHj8VrduIcIglrNaWAWK5XjnGwLrdQ=
 20260116000001_initial.sql h1:CzgBK2HKBimqrB1SWGLD2tLaJdypAJ9IQfLqJ44EBu0=
 20260119000002_add_shared_dataset_support.sql h1:iztVWFVc76jnUhqNaNJyE6n51PxTnJsG2D6yjP21L7w=
 20260119000003_add_shared_dataset_index.sql h1:HL5xRFvhhqF5dmptHdppPUadAcpwfDZYDIvazD35KCk=
@@ -10,4 +10,4 @@ h1:ca96Qg6Ef0VstXE9UicS6188tf/1aOIWxqaNyyeXDk8=
 20260608000002_quality_level_verified.sql h1:3ilHbcQXS+wLMcuHQPVK/4SZxGZB/bo+0DE1pNFciRU=
 20260608000003_add_revision_column.sql h1:qgsZmqgQ4ph6QQpxh+dMoEXuuVMJUTfcoJq6CYZ9l9s=
 20260608000004_backfill_revision.sql h1:cNK3uPSpDxoaHi0ZhPOufRkPTytNn4ZvclGaCDt2j0w=
-20260608000005_remap_quality_to_4level.sql h1:c2cFqExq7Y3dSuHIEeENbtscXMbGxqYpb8FDgzns3yo=
+20260608000005_remap_quality_to_4level.sql h1:kQosstLRJbrmbzkQ8f1GO4+WZu1EciyUL/xBN7e2/lM=

--- a/services/market-information/migrations/quality_revision_migration_test.go
+++ b/services/market-information/migrations/quality_revision_migration_test.go
@@ -85,6 +85,13 @@ func TestMigrations_QualityLadder_AcceptsFourLevels(t *testing.T) {
 	datasetID, sourceID := seedIDs(ctx, t, pool)
 
 	t.Run("accepts each level 1-4 including VERIFIED", func(t *testing.T) {
+		// quality=4 is the VERIFIED level under the four-level confidence encoding
+		// (proto slot 4, still spelled QUALITY_LEVEL_REVISED; the symbol rename is
+		// pending task 14). PR #2249 only widened the CHECK to accept value 4; it
+		// did NOT re-encode existing rows. The data re-encode from the legacy
+		// three-level encoding to the four-level ladder lands in
+		// 20260608000005_remap_quality_to_4level.sql (this PR), exercised by
+		// TestMigrations_RemapQuality_ReEncodesLegacyLevels below.
 		for quality := 1; quality <= 4; quality++ {
 			_, err := insertObservation(ctx, pool, datasetID, sourceID, "EUR/USD", quality)
 			require.NoError(t, err, "quality %d should be accepted", quality)
@@ -171,4 +178,50 @@ func TestMigrations_BackfillRevision_MarksCorrectionRows(t *testing.T) {
 		"the superseded original should remain revision 0")
 	assert.Equal(t, 0, revisionOf(ctx, t, pool, standaloneID),
 		"a standalone observation should remain revision 0")
+}
+
+// qualityOf returns the quality value for a given observation id.
+func qualityOf(ctx context.Context, t *testing.T, pool *pgxpool.Pool, id uuid.UUID) int {
+	t.Helper()
+	var quality int
+	err := pool.QueryRow(ctx,
+		`SELECT quality FROM market_price_observation WHERE id = $1`, id).Scan(&quality)
+	require.NoError(t, err)
+	return quality
+}
+
+// TestMigrations_RemapQuality_ReEncodesLegacyLevels verifies the data-remap
+// migration re-encodes the legacy three-level quality encoding
+// (1=ESTIMATE, 2=ACTUAL, 3=VERIFIED) to the four-level confidence ladder
+// (1=ESTIMATE, 2=PROVISIONAL, 3=ACTUAL, 4=VERIFIED). Without this remap, the
+// post-cutover code would silently misread every legacy 2 as PROVISIONAL and
+// every legacy 3 as ACTUAL: a silent confidence downgrade.
+func TestMigrations_RemapQuality_ReEncodesLegacyLevels(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping migration test in short mode")
+	}
+
+	ctx := context.Background()
+	pool := testdb.NewCockroachTestPool(t, testdb.WithMigrations("market-information"))
+	datasetID, sourceID := seedIDs(ctx, t, pool)
+
+	// Seed rows carrying the legacy encoding. legacy 1=ESTIMATE, 2=ACTUAL,
+	// 3=VERIFIED. The widened CHECK (PR #2249) admits all of these.
+	legacyEstimateID, err := insertObservation(ctx, pool, datasetID, sourceID, "EUR/USD", 1)
+	require.NoError(t, err)
+	legacyActualID, err := insertObservation(ctx, pool, datasetID, sourceID, "GBP/USD", 2)
+	require.NoError(t, err)
+	legacyVerifiedID, err := insertObservation(ctx, pool, datasetID, sourceID, "USD/JPY", 3)
+	require.NoError(t, err)
+
+	// Re-run the actual remap migration SQL against this legacy-encoded data.
+	_, err = pool.Exec(ctx, readMigration(t, "20260608000005_remap_quality_to_4level.sql"))
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, qualityOf(ctx, t, pool, legacyEstimateID),
+		"legacy ESTIMATE (1) should remain 1 (ESTIMATE)")
+	assert.Equal(t, 3, qualityOf(ctx, t, pool, legacyActualID),
+		"legacy ACTUAL (2) should re-encode to 3 (ACTUAL)")
+	assert.Equal(t, 4, qualityOf(ctx, t, pool, legacyVerifiedID),
+		"legacy VERIFIED (3) should re-encode to 4 (VERIFIED)")
 }

--- a/services/market-information/service/cel_validator.go
+++ b/services/market-information/service/cel_validator.go
@@ -106,7 +106,11 @@ func NewCelValidator() (*CelValidator, error) {
 //   - valid_from: timestamp - start of effective time range
 //   - valid_to: timestamp - end of effective time range
 //   - source_id: string - the data source identifier
-//   - quality: int - quality level (1=Estimate, 2=Actual, 3=Verified)
+//   - quality: int - confidence grade on the proto QualityLevel scale
+//     (1=Estimate, 2=Provisional, 3=Actual, 4=Verified). This is the proto enum
+//     value (int(req.Quality)), which cut over to the four-level ladder in #2248.
+//     CEL rules comparing quality to an integer literal must account for the new
+//     intermediate PROVISIONAL=2 (e.g. `quality >= 2` now includes Provisional).
 func createValidationEnv() (*cel.Env, error) {
 	return cel.NewEnv(
 		cel.Variable("value", cel.StringType),

--- a/services/market-information/service/event_publisher.go
+++ b/services/market-information/service/event_publisher.go
@@ -191,17 +191,8 @@ func mapObservationToProtoEvent(obs domain.MarketPriceObservation) *marketinform
 }
 
 // mapQualityLevelToProto converts a domain QualityLevel to a proto QualityLevel.
+// It delegates to the canonical lossless adapter (domainQualityLevelToProto) so
+// event publishing and the RPC path share one mapping table and cannot drift.
 func mapQualityLevelToProto(level domain.QualityLevel) marketinformationv1.QualityLevel {
-	switch level {
-	case domain.QualityLevelEstimate:
-		return marketinformationv1.QualityLevel_QUALITY_LEVEL_ESTIMATE
-	case domain.QualityLevelActual:
-		return marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL
-	case domain.QualityLevelVerified:
-		// Map Verified to ACTUAL since proto has ESTIMATE, PROVISIONAL, ACTUAL, REVISED
-		// The domain QualityLevelVerified is semantically closest to ACTUAL
-		return marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL
-	default:
-		return marketinformationv1.QualityLevel_QUALITY_LEVEL_UNSPECIFIED
-	}
+	return domainQualityLevelToProto(level)
 }

--- a/services/market-information/service/event_publisher_test.go
+++ b/services/market-information/service/event_publisher_test.go
@@ -192,8 +192,10 @@ func TestMapQualityLevelToProto(t *testing.T) {
 		expected marketinformationv1.QualityLevel
 	}{
 		{"estimate", domain.QualityLevelEstimate, marketinformationv1.QualityLevel_QUALITY_LEVEL_ESTIMATE},
+		{"provisional", domain.QualityLevelProvisional, marketinformationv1.QualityLevel_QUALITY_LEVEL_PROVISIONAL},
 		{"actual", domain.QualityLevelActual, marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL},
-		{"verified maps to actual", domain.QualityLevelVerified, marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL},
+		// VERIFIED maps onto proto slot 4 (still spelled REVISED, semantically VERIFIED; rename pending task 14).
+		{"verified maps to revised slot", domain.QualityLevelVerified, marketinformationv1.QualityLevel_QUALITY_LEVEL_REVISED},
 		{"unknown maps to unspecified", domain.QualityLevel(99), marketinformationv1.QualityLevel_QUALITY_LEVEL_UNSPECIFIED},
 	}
 

--- a/services/market-information/service/event_publisher_test.go
+++ b/services/market-information/service/event_publisher_test.go
@@ -215,6 +215,9 @@ func TestShouldPublishObservationEvent(t *testing.T) {
 	}{
 		{"actual publishes", domain.QualityLevelActual, true},
 		{"verified publishes", domain.QualityLevelVerified, true},
+		// PROVISIONAL is metered but unvalidated, so it must not trigger publishing
+		// (only ACTUAL and VERIFIED do).
+		{"provisional does not publish", domain.QualityLevelProvisional, false},
 		{"estimate does not publish", domain.QualityLevelEstimate, false},
 		{"unknown does not publish", domain.QualityLevel(99), false},
 	}

--- a/services/market-information/service/observation_service.go
+++ b/services/market-information/service/observation_service.go
@@ -92,39 +92,57 @@ func shouldPublishObservationEvent(quality domain.QualityLevel) bool {
 	return quality == domain.QualityLevelActual || quality == domain.QualityLevelVerified
 }
 
-// protoQualityLevelToDomain converts proto QualityLevel to domain QualityLevel.
-func protoQualityLevelToDomain(protoQuality pb.QualityLevel) domain.QualityLevel {
-	switch protoQuality {
-	case pb.QualityLevel_QUALITY_LEVEL_UNSPECIFIED:
-		return domain.QualityLevelEstimate // Default to lowest quality
-	case pb.QualityLevel_QUALITY_LEVEL_ESTIMATE:
-		return domain.QualityLevelEstimate
-	case pb.QualityLevel_QUALITY_LEVEL_PROVISIONAL:
-		// Map PROVISIONAL to ESTIMATE (domain doesn't have PROVISIONAL)
-		return domain.QualityLevelEstimate
-	case pb.QualityLevel_QUALITY_LEVEL_ACTUAL:
-		return domain.QualityLevelActual
-	case pb.QualityLevel_QUALITY_LEVEL_REVISED:
-		// Map REVISED to VERIFIED (corrected values are verified)
-		return domain.QualityLevelVerified
-	default:
-		return domain.QualityLevelEstimate // Default to lowest quality
+// Proto<->domain quality mapping (Axis A, confidence) per ADR-0017.
+//
+// The mapping is LOSSLESS: every domain level round-trips through proto back to
+// itself. The four confidence grades line up one-to-one with the proto enum:
+//
+//	ESTIMATE     <-> QUALITY_LEVEL_ESTIMATE    (1)
+//	PROVISIONAL  <-> QUALITY_LEVEL_PROVISIONAL (2)
+//	ACTUAL       <-> QUALITY_LEVEL_ACTUAL      (3)
+//	VERIFIED     <-> QUALITY_LEVEL_REVISED     (4)
+//
+// Proto slot 4 is still spelled QUALITY_LEVEL_REVISED, but its doc comment
+// redefines it to VERIFIED confidence semantics; no QUALITY_LEVEL_VERIFIED symbol
+// exists yet. Slot 4 is therefore the only level-4 symbol available, so VERIFIED
+// maps onto it (and back) until the symbol rename/reserve lands (task 14).
+//
+// Mapping is by confidence grade only. Lifecycle/correction state (Axis B) is the
+// server-assigned revision field, independent of this enum, so the mappers never
+// read or set revision.
+var (
+	protoToDomainQuality = map[pb.QualityLevel]domain.QualityLevel{
+		pb.QualityLevel_QUALITY_LEVEL_UNSPECIFIED: domain.QualityLevelEstimate,
+		pb.QualityLevel_QUALITY_LEVEL_ESTIMATE:    domain.QualityLevelEstimate,
+		pb.QualityLevel_QUALITY_LEVEL_PROVISIONAL: domain.QualityLevelProvisional,
+		pb.QualityLevel_QUALITY_LEVEL_ACTUAL:      domain.QualityLevelActual,
+		pb.QualityLevel_QUALITY_LEVEL_REVISED:     domain.QualityLevelVerified, // slot 4 = VERIFIED-semantically (rename pending task 14)
 	}
+
+	domainToProtoQuality = map[domain.QualityLevel]pb.QualityLevel{
+		domain.QualityLevelEstimate:    pb.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+		domain.QualityLevelProvisional: pb.QualityLevel_QUALITY_LEVEL_PROVISIONAL,
+		domain.QualityLevelActual:      pb.QualityLevel_QUALITY_LEVEL_ACTUAL,
+		domain.QualityLevelVerified:    pb.QualityLevel_QUALITY_LEVEL_REVISED, // slot 4 is the only level-4 symbol until task 14 renames it
+	}
+)
+
+// protoQualityLevelToDomain converts proto QualityLevel to domain QualityLevel.
+// Unrecognized or UNSPECIFIED values default to the lowest confidence (ESTIMATE).
+func protoQualityLevelToDomain(protoQuality pb.QualityLevel) domain.QualityLevel {
+	if level, ok := protoToDomainQuality[protoQuality]; ok {
+		return level
+	}
+	return domain.QualityLevelEstimate // Default to lowest confidence
 }
 
 // domainQualityLevelToProto converts domain QualityLevel to proto QualityLevel.
+// Unrecognized values map to UNSPECIFIED.
 func domainQualityLevelToProto(domainQuality domain.QualityLevel) pb.QualityLevel {
-	switch domainQuality {
-	case domain.QualityLevelEstimate:
-		return pb.QualityLevel_QUALITY_LEVEL_ESTIMATE
-	case domain.QualityLevelActual:
-		return pb.QualityLevel_QUALITY_LEVEL_ACTUAL
-	case domain.QualityLevelVerified:
-		// Domain VERIFIED maps to proto ACTUAL (highest reliable quality)
-		return pb.QualityLevel_QUALITY_LEVEL_ACTUAL
-	default:
-		return pb.QualityLevel_QUALITY_LEVEL_UNSPECIFIED
+	if level, ok := domainToProtoQuality[domainQuality]; ok {
+		return level
 	}
+	return pb.QualityLevel_QUALITY_LEVEL_UNSPECIFIED
 }
 
 // domainObservationToProto converts a domain MarketPriceObservation to proto.

--- a/services/market-information/service/observation_service_unhappy_test.go
+++ b/services/market-information/service/observation_service_unhappy_test.go
@@ -278,9 +278,10 @@ func TestProtoQualityLevelToDomain(t *testing.T) {
 	}{
 		{"unspecified defaults to estimate", pb.QualityLevel_QUALITY_LEVEL_UNSPECIFIED, domain.QualityLevelEstimate},
 		{"estimate", pb.QualityLevel_QUALITY_LEVEL_ESTIMATE, domain.QualityLevelEstimate},
-		{"provisional maps to estimate", pb.QualityLevel_QUALITY_LEVEL_PROVISIONAL, domain.QualityLevelEstimate},
+		{"provisional", pb.QualityLevel_QUALITY_LEVEL_PROVISIONAL, domain.QualityLevelProvisional},
 		{"actual", pb.QualityLevel_QUALITY_LEVEL_ACTUAL, domain.QualityLevelActual},
-		{"revised maps to verified", pb.QualityLevel_QUALITY_LEVEL_REVISED, domain.QualityLevelVerified},
+		// Proto slot 4 is still spelled REVISED but is semantically VERIFIED (rename pending task 14).
+		{"revised slot maps to verified", pb.QualityLevel_QUALITY_LEVEL_REVISED, domain.QualityLevelVerified},
 		{"unknown defaults to estimate", pb.QualityLevel(999), domain.QualityLevelEstimate},
 	}
 
@@ -299,8 +300,10 @@ func TestDomainQualityLevelToProto(t *testing.T) {
 		expected pb.QualityLevel
 	}{
 		{"estimate", domain.QualityLevelEstimate, pb.QualityLevel_QUALITY_LEVEL_ESTIMATE},
+		{"provisional", domain.QualityLevelProvisional, pb.QualityLevel_QUALITY_LEVEL_PROVISIONAL},
 		{"actual", domain.QualityLevelActual, pb.QualityLevel_QUALITY_LEVEL_ACTUAL},
-		{"verified maps to actual", domain.QualityLevelVerified, pb.QualityLevel_QUALITY_LEVEL_ACTUAL},
+		// VERIFIED maps onto proto slot 4 (still spelled REVISED, semantically VERIFIED; rename pending task 14).
+		{"verified maps to revised slot", domain.QualityLevelVerified, pb.QualityLevel_QUALITY_LEVEL_REVISED},
 		{"unknown maps to unspecified", domain.QualityLevel(99), pb.QualityLevel_QUALITY_LEVEL_UNSPECIFIED},
 	}
 
@@ -308,6 +311,27 @@ func TestDomainQualityLevelToProto(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := domainQualityLevelToProto(tt.input)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestQualityLevel_ProtoDomainRoundTrip is the golden lossless round-trip: every
+// domain confidence grade must survive domain -> proto -> domain as the identity.
+// This guards against a regression to the old lossy mapping (where VERIFIED and
+// PROVISIONAL collapsed onto other levels and lost information).
+func TestQualityLevel_ProtoDomainRoundTrip(t *testing.T) {
+	levels := []domain.QualityLevel{
+		domain.QualityLevelEstimate,
+		domain.QualityLevelProvisional,
+		domain.QualityLevelActual,
+		domain.QualityLevelVerified,
+	}
+
+	for _, level := range levels {
+		t.Run(level.String(), func(t *testing.T) {
+			roundTripped := protoQualityLevelToDomain(domainQualityLevelToProto(level))
+			assert.Equal(t, level, roundTripped,
+				"domain -> proto -> domain must be identity for %s", level)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Wave 2 cutover of the market-information quality ladder to the four-level confidence model (Axis A) per ADR-0017. Both dependencies are merged on develop: proto (#2248) and DB migrations (#2249). This PR flips the domain encoding, makes the proto<->domain mapping lossless, and re-encodes existing rows so the code flip and data re-encode land atomically.

## Changes Made

- **Domain enum** (`domain/quality_level.go`): expand to `ESTIMATE(1) -> PROVISIONAL(2) -> ACTUAL(3) -> VERIFIED(4)`. `PROVISIONAL` is new; `ACTUAL` moves 2->3 and `VERIFIED` 3->4. `Supersedes()` stays Axis-A only (`q > other`).
- **Lossless adapter** (`service/observation_service.go`): replace the two switch-based mappers with table-driven maps that round-trip every level to identity. `UNSPECIFIED`/unknown still default to `ESTIMATE`.
- **Deduplicate** (`service/event_publisher.go`): collapse the duplicate (and previously lossy) `mapQualityLevelToProto` to delegate to the canonical `domainQualityLevelToProto`, so the RPC and event paths share one mapping table and cannot drift.
- **Data-remap migration** (`migrations/20260608000005_remap_quality_to_4level.sql`): re-encode existing rows from the legacy three-level encoding (`1=EST, 2=ACTUAL, 3=VERIFIED`) to the four-level ladder. Ordered `3->4` before `2->3` to avoid a transient collision on value 3. Without this, every stored 2 would silently read as PROVISIONAL and every 3 as ACTUAL - a silent confidence downgrade.
- **Test schema parity** (`adapters/persistence/testhelpers/testcontainer.go`): widen the hand-rolled `chk_observation_quality` to `IN (1,2,3,4)` and add the `revision` column to match the merged migrations.

## Technical Details

Proto slot 4 is still spelled `QUALITY_LEVEL_REVISED` but its doc comment redefines it to VERIFIED semantics; no `QUALITY_LEVEL_VERIFIED` symbol exists yet. The adapter maps domain `VERIFIED <-> REVISED(slot 4)` with a code comment noting the symbol rename/reserve is deferred to task 14. Mapping is by confidence grade only - the `revision` field (Axis B, lifecycle) is server-assigned and independent of this enum.

## Testing

- Domain enum suite updated for four levels (validity, naming, ordering, supersession, int).
- Golden lossless round-trip: `domain -> proto -> domain == identity` for all four levels (both the RPC and event mappers).
- Axis-A-only supersession boundary: a revised low-confidence row does not outrank a higher-confidence row.
- Integration test (CockroachDB testcontainer): seed legacy quality 1/2/3, run the remap migration, assert 1->1, 2->3, 3->4.
- Clarifying comment folded into `quality_revision_migration_test.go` near the quality=4 assertion (PR #2249 review follow-up).
- `go build ./...`, full `go test ./services/market-information/...`, `atlas migrate validate`, golangci-lint, and `buf generate` (no diff) all pass.

## Risk Assessment

The remap migration mutates existing data. Mitigations: ordered updates avoid intermediate collisions; the widened CHECK (PR #2249) admits both intermediate and final states; the migration is covered by an integration test; and the code flip ships in the same PR so reads and stored values stay consistent.

## Deployment Notes

Standard Atlas migration. Run after deploy on environments with existing market_price_observation rows.
