### PR TITLE
test: Quality-ladder architecture pin test + four-level doc corrections (quality-ladder-reconciliation.13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,10 +274,12 @@ Big Tech won't do this (not their problem space).
 Most systems treat data as binary (present/absent). Meridian treats data as having **provenance**:
 
 ```
-Quality Ladder: ESTIMATE → COEFFICIENT → ACTUAL → REVISED
-                   ↓           ↓           ↓         ↓
-             (forecast)  (modeled)    (metered)  (corrected)
+Quality Ladder: ESTIMATE → PROVISIONAL → ACTUAL → VERIFIED
+                   ↓            ↓           ↓         ↓
+             (forecast)   (unvalidated) (metered) (cross-checked)
 ```
+
+COEFFICIENT is a data source (maps to ESTIMATE), not a level. REVISED is a lifecycle event (revision>0), not a confidence tier. See ADR-0017.
 
 Every measurement carries:
 

--- a/docs/architecture-layers.md
+++ b/docs/architecture-layers.md
@@ -367,7 +367,7 @@ declarative validation.
   `tenant` during provisioning; tenant instruments are user-managed.
 - **market-information:** BIAN Market Information Management. Bi-temporal price
   observations with the time-bound quality ladder
-  (`ESTIMATE -> PROVISIONAL -> ACTUAL -> REVISED`). Data sources carry trust levels
+  (`ESTIMATE -> PROVISIONAL -> ACTUAL -> VERIFIED`). Data sources carry trust levels
   for conflict resolution.
 
 ### Boundary Rules

--- a/docs/prd/011-valuation-service.md
+++ b/docs/prd/011-valuation-service.md
@@ -713,7 +713,7 @@ message ValuationAnalysis {
 
 message MarketDataQuality {
   string observation_id = 1;
-  string source_trust_level = 2;  // "ESTIMATE", "COEFFICIENT", "ACTUAL", "REVISED"
+  string source_trust_level = 2;  // "ESTIMATE", "PROVISIONAL", "ACTUAL", "VERIFIED"
   string instrument_code = 3;     // e.g., "EPEX_SPOT"
   string value = 4;               // The rate/price used
 }
@@ -1107,9 +1107,12 @@ of the evidence used for that valuation.
 Per ADR-018, the `ValuationAnalysis` MUST include the `SourceTrustLevel` of each market data observation used:
 
 - `ESTIMATE` (Quality 1): Forecast or projection
-- `COEFFICIENT` (Quality 2): Model-derived value
-- `ACTUAL` (Quality 3): Metered or observed value
-- `REVISED` (Quality 4): Corrected after audit
+- `PROVISIONAL` (Quality 2): Metered but not yet validated
+- `ACTUAL` (Quality 3): Metered, validated value
+- `VERIFIED` (Quality 4): Cross-checked against multiple sources or manually verified
+
+COEFFICIENT is a data source (maps to ESTIMATE), not a level. REVISED is a lifecycle event
+(revision>0), not a confidence tier. See ADR-0017.
 
 **Why This Matters:**
 

--- a/docs/prd/016-market-data-dynamic-pricing.md
+++ b/docs/prd/016-market-data-dynamic-pricing.md
@@ -133,7 +133,7 @@ Before detailing work streams, here is what already exists and what this PRD bui
 | Component | Status | Key Capabilities |
 |-----------|--------|------------------|
 | `utilization-metering-consumer` | Implemented | Consumes `AuditEvent` from 6+ Kafka topics (`{schema}.audit.events`), transforms to `UtilizationMeasurement`, sends to Position Keeping for tenant-zero billing. **WS-1 adds MDS output alongside PK** for time-of-use pricing analytics |
-| Market Information Management | Implemented (17/18 tasks) | Bi-temporal observations, quality ladder (ESTIMATE/PROVISIONAL/ACTUAL/REVISED), CEL validation, resolution keys, data sources with trust levels, batch ingestion, Kafka event publishing (`ObservationRecorded`) |
+| Market Information Management | Implemented (17/18 tasks) | Bi-temporal observations, quality ladder (ESTIMATE/PROVISIONAL/ACTUAL/VERIFIED), CEL validation, resolution keys, data sources with trust levels, batch ingestion, Kafka event publishing (`ObservationRecorded`) |
 | Reference Data (Instrument Registry) | Implemented | Instrument definitions, CEL validation expressions, fungibility keys, lifecycle management (DRAFT/ACTIVE/DEPRECATED), tiered caching |
 | Starlark Runtime | Implemented | `shared/pkg/saga/starlark_runner.go`, service module injection from `handlers.yaml`, compensation support, bounded execution |
 | CEL Runtime | Implemented | `cel-go v0.27.0`, used in market information (validation, resolution keys), reference data (instrument validation), saga evaluation |
@@ -147,14 +147,15 @@ The Market Information Service defines a 4-level quality ladder at the proto lev
 | Level | Proto Enum | Domain Mapping | Value |
 |-------|-----------|----------------|-------|
 | ESTIMATE | `QUALITY_LEVEL_ESTIMATE` | `QualityLevelEstimate` | 1 |
-| PROVISIONAL | `QUALITY_LEVEL_PROVISIONAL` | maps to `QualityLevelEstimate` | 1 |
-| ACTUAL | `QUALITY_LEVEL_ACTUAL` | `QualityLevelActual` | 2 |
-| REVISED | `QUALITY_LEVEL_REVISED` | maps to `QualityLevelVerified` | 3 |
+| PROVISIONAL | `QUALITY_LEVEL_PROVISIONAL` | `QualityLevelProvisional` | 2 |
+| ACTUAL | `QUALITY_LEVEL_ACTUAL` | `QualityLevelActual` | 3 |
+| VERIFIED | `QUALITY_LEVEL_REVISED` (slot 4) | `QualityLevelVerified` | 4 |
 
-**Note:** The domain layer currently collapses PROVISIONAL into ESTIMATE and
-REVISED into VERIFIED (3-level model). This PRD's forecasting output should
-publish at `QUALITY_LEVEL_ESTIMATE` quality, allowing actuals to naturally
-supersede forecasts via the existing quality ladder.
+**Note:** The domain layer is a 1:1 four-level confidence ladder (Axis A of
+ADR-0017): ESTIMATE=1, PROVISIONAL=2, ACTUAL=3, VERIFIED=4. Proto slot 4 is still
+spelled `QUALITY_LEVEL_REVISED` but is semantically VERIFIED; the symbol rename is
+deferred. This PRD's forecasting output should publish at `QUALITY_LEVEL_ESTIMATE`
+quality, allowing actuals to naturally supersede forecasts via the quality ladder.
 
 ### Reference Data Service: Instrument Registry vs Hierarchical Nodes
 

--- a/docs/prd/026-operations-console-ui.md
+++ b/docs/prd/026-operations-console-ui.md
@@ -491,7 +491,7 @@ Phase 1 and file issues to add count RPCs or
 **Layout:**
 
 - **List view:** DataTable with columns: Log ID, Account ID, Amount, Currency/Instrument, Direction (DEBIT/CREDIT), Status, Quality Level, Transaction Date. Filterable by account, direction, quality level.
-- **Detail view:** Position log details with quality ladder indicator (ESTIMATE → COEFFICIENT → ACTUAL → REVISED). Balance view showing provisional vs available balance.
+- **Detail view:** Position log details with quality ladder indicator (ESTIMATE → PROVISIONAL → ACTUAL → VERIFIED). Balance view showing provisional vs available balance.
 - **Measurement view:** Quality ladder visualization for a position — shows the progression from estimate to actual.
 - **Actions:** Record position log, record measurement,
   update position, merge positions, record reservation,
@@ -718,7 +718,7 @@ their expressions to affect assertion behavior.
 Variance detection uses **strict equality** (zero vs non-zero).
 There are no user-configurable tolerance thresholds — this is
 intentional for financial integrity. The quality ladder
-(ESTIMATE, COEFFICIENT, ACTUAL, REVISED) drives variance detection
+(ESTIMATE, PROVISIONAL, ACTUAL, VERIFIED) drives variance detection
 when data quality improves between reconciliation runs.
 
 Persistent imbalances trigger P1 alerts after 3 consecutive days
@@ -1436,7 +1436,7 @@ const STATUS_MAP: Record<string, StatusVariant> = {
   PROVISIONING: 'info', PROVISIONING_PENDING: 'info',
   PROVISIONING_FAILED: 'error', DEPROVISIONED: 'neutral',
   // Position quality ladder
-  ESTIMATE: 'warning', COEFFICIENT: 'info', ACTUAL: 'success', REVISED: 'info',
+  ESTIMATE: 'warning', PROVISIONAL: 'info', ACTUAL: 'success', VERIFIED: 'info',
 };
 ```
 
@@ -1624,8 +1624,8 @@ provides a browsable reference alongside the editor.
 Visual indicator for position keeping quality levels.
 
 ```text
-ESTIMATE → COEFFICIENT → ACTUAL → REVISED
-  [○]         [◐]         [●]       [↻]
+ESTIMATE → PROVISIONAL → ACTUAL → VERIFIED
+  [○]         [◐]         [●]       [✓]
 ```
 
 Each level has a distinct icon and color, showing the data provenance chain.

--- a/docs/prd/039-meridian-vm.md
+++ b/docs/prd/039-meridian-vm.md
@@ -918,7 +918,7 @@ financial performance across historical data?"
 
 The bitemporal data model makes this architecturally possible. Every position, posting,
 and valuation is timestamped with both valid-time and transaction-time. The quality ladder
-(ESTIMATE → COEFFICIENT → ACTUAL → REVISED) means the system already handles multiple
+(ESTIMATE → PROVISIONAL → ACTUAL → VERIFIED) means the system already handles multiple
 versions of truth.
 
 ```text

--- a/docs/runbooks/market-information-operations.md
+++ b/docs/runbooks/market-information-operations.md
@@ -13,7 +13,7 @@ instructions: |
   Use this runbook for Market Information Management service operations.
   Port: 50058 (gRPC). Database: market_information.
   Bi-temporal model: observed_at (event time) + created_at (knowledge time).
-  Quality ladder: ESTIMATE < PROVISIONAL < ACTUAL < REVISED.
+  Quality ladder: ESTIMATE < PROVISIONAL < ACTUAL < VERIFIED.
   Trust levels: 0-100 (higher = more authoritative source).
 ---
 
@@ -61,16 +61,20 @@ debugging bi-temporal queries, configuring data sources, or investigating CEL va
 Observations are ranked by quality level (higher takes precedence):
 
 ```text
-VERIFIED (3)   ← Cross-checked, audited values (highest)
+VERIFIED (4)     ← Cross-checked, audited values (highest)
     │
-ACTUAL (2)     ← Real measured values from data sources
+ACTUAL (3)       ← Metered, validated values from data sources
     │
-ESTIMATE (1)   ← Forecasted or projected values (lowest)
+PROVISIONAL (2)  ← Metered but not yet validated
+    │
+ESTIMATE (1)     ← Forecasted or projected values (lowest)
 ```
 
-> **Note**: The proto defines 4 quality levels (ESTIMATE, PROVISIONAL, ACTUAL, REVISED) but the domain
-> implementation currently supports 3 levels (ESTIMATE, ACTUAL, VERIFIED) for the core reconciliation
-> use case. PROVISIONAL and REVISED are mapped appropriately at the service layer.
+> **Note**: This is Axis A (confidence grade) of the two-axis quality model (ADR-0017). The domain enum
+> has four levels (ESTIMATE=1, PROVISIONAL=2, ACTUAL=3, VERIFIED=4). The proto enum slot 4 is still
+> spelled `QUALITY_LEVEL_REVISED` but is semantically VERIFIED; the symbol rename is deferred. COEFFICIENT
+> is a data source (maps to ESTIMATE), not a level. REVISED (revision>0) is a lifecycle event on Axis B,
+> not a confidence tier.
 
 #### Bi-Temporal Model
 
@@ -420,7 +424,8 @@ kubectl logs -l app=market-information -n production | grep "data source"
 
 If an incorrect observation was recorded:
 
-1. Record a REVISED quality observation with correct value
+1. Record a corrected observation (at the appropriate confidence level, e.g. VERIFIED) with the
+   correct value; the correction carries revision>0 (Axis B)
 2. The system automatically supersedes the incorrect observation
 3. Bi-temporal queries will return the corrected value
 

--- a/docs/runbooks/market-information-operations.md
+++ b/docs/runbooks/market-information-operations.md
@@ -429,6 +429,9 @@ If an incorrect observation was recorded:
 2. The system automatically supersedes the incorrect observation
 3. Bi-temporal queries will return the corrected value
 
+<!-- QUALITY_LEVEL_REVISED is the proto symbol for slot 4 (semantically VERIFIED, the
+     highest confidence grade); the symbol rename is deferred. See the note above. -->
+
 ```bash
 grpcurl -plaintext \
   -d '{

--- a/services/market-information/service/quality_level_arch_test.go
+++ b/services/market-information/service/quality_level_arch_test.go
@@ -1,0 +1,130 @@
+package service
+
+// Architecture pin test for the two-axis quality ladder (ADR-0017, Axis A:
+// confidence grade). This is the single cross-layer contract guard: it fails if
+// the proto enum, the domain enum, or the DB CHECK range ever drift apart.
+//
+// It lives in package service (not the domain package) on purpose: the canonical
+// proto<->domain adapter (protoQualityLevelToDomain / domainQualityLevelToProto,
+// added in task 10) is unexported, and the task requires calling the REAL adapter
+// rather than re-implementing the mapping. Package service is the only package
+// that can both call that adapter and reference the domain enum, so it is the only
+// place a proto+domain+DB guard can live in one file.
+//
+// The three layers it pins:
+//   - Proto enum: ESTIMATE=1, PROVISIONAL=2, ACTUAL=3, and slot 4 (still spelled
+//     QUALITY_LEVEL_REVISED but semantically VERIFIED until the symbol rename in
+//     task 14).
+//   - Domain enum: QualityLevelEstimate=1, QualityLevelProvisional=2,
+//     QualityLevelActual=3, QualityLevelVerified=4.
+//   - DB CHECK: market_price_observation.quality IN (1,2,3,4). The live DB guard
+//     (a CockroachDB testcontainer that accepts 1-4 and rejects 0/5/99) already
+//     exists as TestMigrations_QualityLadder_AcceptsFourLevels in
+//     services/market-information/migrations. This file pins the same range
+//     statically and asserts the domain enum maps onto it, so it does not spin a
+//     second container that would duplicate that coverage.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	"github.com/meridianhub/meridian/services/market-information/domain"
+)
+
+// dbQualityCheckRange is the set of quality values admitted by the
+// market_price_observation quality CHECK constraint
+// (20260608000002_quality_level_verified.sql: CHECK (quality IN (1, 2, 3, 4))).
+// Pinned here so a change to the CHECK without a matching domain change (or vice
+// versa) is caught at compile/test time, complementing the live testcontainer
+// guard in the migrations package.
+var dbQualityCheckRange = map[int]bool{1: true, 2: true, 3: true, 4: true}
+
+// TestArch_QualityLevel_DomainIntegerValues pins the domain enum integer values.
+// These integers ARE the on-disk encoding: domain QualityLevel values are written
+// verbatim into the quality column, so changing them silently corrupts existing
+// rows. They must never drift.
+func TestArch_QualityLevel_DomainIntegerValues(t *testing.T) {
+	assert.Equal(t, 1, domain.QualityLevelEstimate.Int(), "ESTIMATE must be 1")
+	assert.Equal(t, 2, domain.QualityLevelProvisional.Int(), "PROVISIONAL must be 2")
+	assert.Equal(t, 3, domain.QualityLevelActual.Int(), "ACTUAL must be 3")
+	assert.Equal(t, 4, domain.QualityLevelVerified.Int(), "VERIFIED must be 4")
+}
+
+// TestArch_QualityLevel_DomainMatchesDBCheckRange asserts every domain confidence
+// level is admitted by the DB CHECK range and that the four levels exactly fill
+// that range (no gap, no extra). If a fifth level is added to the domain enum
+// without widening the CHECK, or the CHECK is narrowed, this fails.
+func TestArch_QualityLevel_DomainMatchesDBCheckRange(t *testing.T) {
+	domainLevels := []domain.QualityLevel{
+		domain.QualityLevelEstimate,
+		domain.QualityLevelProvisional,
+		domain.QualityLevelActual,
+		domain.QualityLevelVerified,
+	}
+
+	covered := make(map[int]bool, len(domainLevels))
+	for _, level := range domainLevels {
+		assert.Truef(t, dbQualityCheckRange[level.Int()],
+			"domain level %s (%d) must be admitted by the DB CHECK range (1,2,3,4)",
+			level, level.Int())
+		covered[level.Int()] = true
+	}
+
+	assert.Equal(t, dbQualityCheckRange, covered,
+		"the four domain levels must exactly fill the DB CHECK range (1,2,3,4) - no gap, no extra")
+}
+
+// TestArch_QualityLevel_ProtoDomainRoundTrip pins the proto<->domain adapter as a
+// lossless bijection over the four confidence grades. It calls the REAL adapter
+// (task 10) in both directions and asserts identity, so any change to one side of
+// the mapping without the other breaks the build.
+//
+// Slot 4 is exercised under its current symbol QUALITY_LEVEL_REVISED, which is
+// semantically VERIFIED until task 14 renames it. When that rename lands, the
+// pb.QualityLevel_QUALITY_LEVEL_REVISED reference below stops compiling, which is
+// the intended signal to update this pin.
+func TestArch_QualityLevel_ProtoDomainRoundTrip(t *testing.T) {
+	t.Run("domain->proto->domain identity", func(t *testing.T) {
+		domainLevels := []domain.QualityLevel{
+			domain.QualityLevelEstimate,
+			domain.QualityLevelProvisional,
+			domain.QualityLevelActual,
+			domain.QualityLevelVerified,
+		}
+		for _, level := range domainLevels {
+			roundTripped := protoQualityLevelToDomain(domainQualityLevelToProto(level))
+			assert.Equalf(t, level, roundTripped,
+				"domain %s must round-trip through proto back to itself", level)
+		}
+	})
+
+	t.Run("proto->domain->proto identity", func(t *testing.T) {
+		// The four defined proto confidence slots. UNSPECIFIED is intentionally
+		// excluded: it is a lossy alias for ESTIMATE (defensive default), not a
+		// distinct grade, so it is not part of the bijection.
+		protoLevels := []pb.QualityLevel{
+			pb.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+			pb.QualityLevel_QUALITY_LEVEL_PROVISIONAL,
+			pb.QualityLevel_QUALITY_LEVEL_ACTUAL,
+			// Slot 4: spelled REVISED, semantically VERIFIED (rename pending task 14).
+			pb.QualityLevel_QUALITY_LEVEL_REVISED,
+		}
+		for _, level := range protoLevels {
+			roundTripped := domainQualityLevelToProto(protoQualityLevelToDomain(level))
+			assert.Equalf(t, level, roundTripped,
+				"proto %s must round-trip through domain back to itself", level)
+		}
+	})
+
+	t.Run("proto slot integers match domain integers", func(t *testing.T) {
+		// The proto enum numbers and domain enum numbers share the on-disk
+		// encoding, so the defined confidence slots must agree numerically.
+		assert.Equal(t, domain.QualityLevelEstimate.Int(), int(pb.QualityLevel_QUALITY_LEVEL_ESTIMATE))
+		assert.Equal(t, domain.QualityLevelProvisional.Int(), int(pb.QualityLevel_QUALITY_LEVEL_PROVISIONAL))
+		assert.Equal(t, domain.QualityLevelActual.Int(), int(pb.QualityLevel_QUALITY_LEVEL_ACTUAL))
+		// Slot 4 (REVISED symbol) carries the VERIFIED confidence integer.
+		assert.Equal(t, domain.QualityLevelVerified.Int(), int(pb.QualityLevel_QUALITY_LEVEL_REVISED))
+	})
+}


### PR DESCRIPTION
## Summary

Adds the architecture pin test that guards the two-axis quality ladder (ADR-0017, Axis A: confidence grade) against cross-layer drift, and corrects all remaining old-ladder references in the mission doc and PRDs/architecture/runbook docs.

The four-level confidence ladder is now canonical everywhere: `ESTIMATE → PROVISIONAL → ACTUAL → VERIFIED`. The old ladder (`ESTIMATE → COEFFICIENT → ACTUAL → REVISED`) conflated two orthogonal axes: COEFFICIENT is a data source (maps to ESTIMATE), and REVISED is a lifecycle event (revision>0), neither is a confidence tier.

## Changes Made

### Architecture pin test
`services/market-information/service/quality_level_arch_test.go` - a single cross-layer contract guard that fails on proto/domain/DB drift:
- Proto<->domain round-trip identity (both directions) for ESTIMATE, PROVISIONAL, ACTUAL, and slot 4 (VERIFIED<->REVISED), calling the **real** task-10 adapter (`protoQualityLevelToDomain`/`domainQualityLevelToProto`) rather than re-implementing the mapping.
- Domain integer pins: ESTIMATE=1, PROVISIONAL=2, ACTUAL=3, VERIFIED=4 (these integers are the on-disk encoding).
- Domain enum exactly fills the DB CHECK range (1,2,3,4), no gap/extra.

**Package placement note:** the requested path was `domain/quality_level_arch_test.go`, but the task-10 adapter is unexported in `package service`. A `domain`-package test cannot call it without re-implementing the mapping (which the task forbids), and only `package service` can reference both the adapter and the domain enum in one file. Placed there so the proto+domain+DB guard lives in a single file calling the real adapter. The file header documents this.

**DB CHECK coverage:** the live testcontainer guard (accepts 1-4, rejects 0/5/99) already exists as `TestMigrations_QualityLadder_AcceptsFourLevels`. The arch test pins the same range statically and asserts the domain enum maps onto it, complementing rather than duplicating that coverage.

### Doc corrections
- Root `CLAUDE.md` - "Temporal Data Quality" ladder diagram + COEFFICIENT/REVISED clarifying note.
- `docs/prd/011-valuation-service.md` - source_trust_level comment + quality-level list.
- `docs/prd/016-market-data-dynamic-pricing.md` - stale 3-level mapping table (now 1:1 four-level) + summary line.
- `docs/prd/026-operations-console-ui.md` - 4 badge/ladder references.
- `docs/prd/039-meridian-vm.md` - replay-engine ladder line.
- `docs/architecture-layers.md` - market-information ladder description.
- `docs/runbooks/market-information-operations.md` - ladder header, ASCII ladder (now 4 levels), stale "domain supports 3 levels" note, DR correction step.

ADR-0017 (amended in task 8) and migration files left untouched per task scope.

## Testing
- `go test ./services/market-information/...` passes (arch test + existing suites).
- Negative check confirmed the arch test fails on any layer drift.
- `go build ./...` clean.
- markdownlint clean on all changed docs.

## Risk Assessment
Low. Test-only addition plus documentation corrections; no production code paths changed.
