### PR TITLE
feat: Support four-level quality ladder in market-data CSV import (quality-ladder-reconciliation.12)

### DIFF
--- a/cmd/market-data-tool/cmd/import.go
+++ b/cmd/market-data-tool/cmd/import.go
@@ -63,7 +63,7 @@ to the Market Information Service via gRPC. It supports:
 CSV Format:
   The CSV must have headers matching the observation schema. Required columns:
   - observed_at: When the observation was made (RFC3339 timestamp)
-  - quality_level: ESTIMATE, PROVISIONAL, ACTUAL, or REVISED
+  - quality_level: ESTIMATE, PROVISIONAL, ACTUAL, or VERIFIED (REVISED accepted as legacy)
   - value: The observed value (decimal string, max 64 chars)
 
   Optional columns:
@@ -543,7 +543,13 @@ func handleImportInterrupt(
 }
 
 // csvRowToValidationRow converts a CSV row to a validation row.
+//
+// The Axis-B revision counter is derived from the quality string via
+// ParseQualityString: only the legacy REVISED label yields a non-zero revision.
+// The quality string has already been validated by the CSV parser, so a parse
+// error here is not expected; revision defaults to 0 if one occurs.
 func csvRowToValidationRow(csvRow *csvadapter.ObservationRow, datasetCode string) *validation.ObservationRow {
+	_, revision, _ := validation.ParseQualityString(csvRow.QualityLevel)
 	return &validation.ObservationRow{
 		LineNumber:   csvRow.LineNumber,
 		DatasetCode:  datasetCode,
@@ -552,6 +558,7 @@ func csvRowToValidationRow(csvRow *csvadapter.ObservationRow, datasetCode string
 		ValidFrom:    csvRow.ValidFrom,
 		ValidTo:      csvRow.ValidTo,
 		QualityLevel: csvRow.QualityLevel,
+		Revision:     revision,
 		Attributes:   csvRow.Attributes,
 	}
 }

--- a/cmd/market-data-tool/cmd/schema.go
+++ b/cmd/market-data-tool/cmd/schema.go
@@ -182,7 +182,7 @@ func printSchemaText(dataset *infra.DataSetDefinition) {
 	fmt.Println()
 	fmt.Println("  Required CSV Columns:")
 	fmt.Println("    - observed_at      RFC3339 timestamp when observation was made")
-	fmt.Println("    - quality_level    ESTIMATE, PROVISIONAL, ACTUAL, or REVISED")
+	fmt.Println("    - quality_level    ESTIMATE, PROVISIONAL, ACTUAL, or VERIFIED (REVISED accepted as legacy)")
 	fmt.Println("    - value            Decimal string (max 64 characters)")
 	fmt.Println()
 

--- a/cmd/market-data-tool/internal/adapters/csv/parser.go
+++ b/cmd/market-data-tool/internal/adapters/csv/parser.go
@@ -45,20 +45,27 @@ var OptionalColumns = []string{
 	ColumnValidTo,
 }
 
-// Valid quality level values.
+// validQualityLevels maps accepted quality-level strings to their canonical
+// uppercase form. The four canonical confidence grades on Axis A of the two-axis
+// quality model (ADR-0017) are ESTIMATE, PROVISIONAL, ACTUAL, and VERIFIED.
+// REVISED is accepted as a legacy label; downstream parsing (ParseQualityString)
+// normalizes it to VERIFIED confidence with revision 1.
 var validQualityLevels = map[string]string{
 	"ESTIMATE":    "ESTIMATE",
 	"PROVISIONAL": "PROVISIONAL",
 	"ACTUAL":      "ACTUAL",
-	"REVISED":     "REVISED",
+	"VERIFIED":    "VERIFIED",
+	"REVISED":     "REVISED", // legacy label, normalizes to VERIFIED + revision 1
 	// Also accept lowercase and title case
 	"estimate":    "ESTIMATE",
 	"provisional": "PROVISIONAL",
 	"actual":      "ACTUAL",
+	"verified":    "VERIFIED",
 	"revised":     "REVISED",
 	"Estimate":    "ESTIMATE",
 	"Provisional": "PROVISIONAL",
 	"Actual":      "ACTUAL",
+	"Verified":    "VERIFIED",
 	"Revised":     "REVISED",
 }
 
@@ -109,7 +116,9 @@ type ObservationRow struct {
 	// ValidTo is when the observation value expires (optional).
 	ValidTo *time.Time
 
-	// QualityLevel is the quality indicator (ESTIMATE, PROVISIONAL, ACTUAL, REVISED).
+	// QualityLevel is the confidence grade on Axis A of the two-axis quality
+	// model (ADR-0017): ESTIMATE, PROVISIONAL, ACTUAL, or VERIFIED. The legacy
+	// REVISED label is accepted and passed through for downstream normalization.
 	QualityLevel string
 
 	// Attributes contains dynamic attributes extracted from CSV columns.
@@ -507,7 +516,7 @@ func (p *Parser) parseRow(lineNumber int, record []string, schema *SchemaMapping
 			LineNumber: lineNumber,
 			Column:     ColumnQualityLevel,
 			Value:      qualityLevelStr,
-			Err:        fmt.Errorf("%w: must be one of ESTIMATE, PROVISIONAL, ACTUAL, REVISED", ErrInvalidQualityLevel),
+			Err:        fmt.Errorf("%w: must be one of ESTIMATE, PROVISIONAL, ACTUAL, VERIFIED (REVISED accepted as legacy)", ErrInvalidQualityLevel),
 		}
 	}
 

--- a/cmd/market-data-tool/internal/adapters/csv/parser_test.go
+++ b/cmd/market-data-tool/internal/adapters/csv/parser_test.go
@@ -102,6 +102,9 @@ func TestParser_Parse(t *testing.T) {
 			{"ESTIMATE", "ESTIMATE"},
 			{"estimate", "ESTIMATE"},
 			{"PROVISIONAL", "PROVISIONAL"},
+			{"VERIFIED", "VERIFIED"},
+			{"verified", "VERIFIED"},
+			{"Verified", "VERIFIED"},
 			{"REVISED", "REVISED"},
 		}
 

--- a/cmd/market-data-tool/internal/infra/grpc_client.go
+++ b/cmd/market-data-tool/internal/infra/grpc_client.go
@@ -296,7 +296,16 @@ func attributesToProto(attrs map[string]string) []*quantityv1.AttributeEntry {
 	return entries
 }
 
-// qualityStringToProto converts a quality level string to the proto enum.
+// qualityStringToProto converts a quality level string to the proto enum on
+// Axis A (confidence) of the two-axis quality model (ADR-0017).
+//
+// Proto slot 4 is still spelled QUALITY_LEVEL_REVISED but its doc comment
+// redefines it to VERIFIED confidence semantics (the rename to a dedicated
+// QUALITY_LEVEL_VERIFIED symbol is pending). Both the canonical VERIFIED grade
+// and the legacy REVISED label therefore map onto slot 4.
+//
+// Axis B (the revision counter) is server-assigned and is not carried on the
+// write request, so it is intentionally absent from this mapping.
 func qualityStringToProto(quality string) marketinformationv1.QualityLevel {
 	switch quality {
 	case "ESTIMATE":
@@ -305,7 +314,8 @@ func qualityStringToProto(quality string) marketinformationv1.QualityLevel {
 		return marketinformationv1.QualityLevel_QUALITY_LEVEL_PROVISIONAL
 	case "ACTUAL":
 		return marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL
-	case "REVISED":
+	case "VERIFIED", "REVISED":
+		// Slot 4: VERIFIED confidence (legacy REVISED label maps here too).
 		return marketinformationv1.QualityLevel_QUALITY_LEVEL_REVISED
 	default:
 		return marketinformationv1.QualityLevel_QUALITY_LEVEL_UNSPECIFIED

--- a/cmd/market-data-tool/internal/validation/errors.go
+++ b/cmd/market-data-tool/internal/validation/errors.go
@@ -23,6 +23,10 @@ var (
 
 	// ErrNilDatasetChecker indicates the dataset checker is required but nil.
 	ErrNilDatasetChecker = errors.New("dataset checker cannot be nil")
+
+	// ErrUnknownQualityString indicates a quality string that does not map to a
+	// known confidence grade on the four-level ladder (ADR-0017).
+	ErrUnknownQualityString = errors.New("unknown quality level string")
 )
 
 // FieldError represents a validation error for a specific field.

--- a/cmd/market-data-tool/internal/validation/fields.go
+++ b/cmd/market-data-tool/internal/validation/fields.go
@@ -1,5 +1,51 @@
 package validation
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/meridianhub/meridian/services/market-information/domain"
+)
+
+// ParseQualityString maps a CSV quality-level string to the two-axis quality
+// model (ADR-0017): a confidence grade on Axis A (the returned QualityLevel) and
+// a correction counter on Axis B (the returned revision int). The input is
+// trimmed and matched case-insensitively.
+//
+// The four canonical confidence grades all denote original observations
+// (revision 0):
+//
+//	ESTIMATE    -> (QualityLevelEstimate,    0)
+//	PROVISIONAL -> (QualityLevelProvisional, 0)
+//	ACTUAL      -> (QualityLevelActual,      0)
+//	VERIFIED    -> (QualityLevelVerified,    0)
+//
+// REVISED is a legacy label retained for backward compatibility. It is not a
+// confidence grade; it denotes a correction recorded at VERIFIED confidence, so
+// it maps to the VERIFIED grade with revision 1:
+//
+//	REVISED     -> (QualityLevelVerified,    1)
+//
+// Any other value returns ErrUnknownQualityString.
+func ParseQualityString(s string) (domain.QualityLevel, int, error) {
+	switch strings.ToUpper(strings.TrimSpace(s)) {
+	case "ESTIMATE":
+		return domain.QualityLevelEstimate, 0, nil
+	case "PROVISIONAL":
+		return domain.QualityLevelProvisional, 0, nil
+	case "ACTUAL":
+		return domain.QualityLevelActual, 0, nil
+	case "VERIFIED":
+		return domain.QualityLevelVerified, 0, nil
+	case "REVISED":
+		// Legacy label: a correction at VERIFIED confidence (Axis A) carrying a
+		// non-zero revision (Axis B). REVISED is not a confidence grade of its own.
+		return domain.QualityLevelVerified, 1, nil
+	default:
+		return 0, 0, fmt.Errorf("%w: %q", ErrUnknownQualityString, s)
+	}
+}
+
 // DefaultRequiredFields lists the fields that must be present in every observation.
 var DefaultRequiredFields = []string{
 	"value",

--- a/cmd/market-data-tool/internal/validation/fields_test.go
+++ b/cmd/market-data-tool/internal/validation/fields_test.go
@@ -6,7 +6,66 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/market-information/domain"
 )
+
+func TestParseQualityString(t *testing.T) {
+	t.Run("canonical four-level grades map to revision 0", func(t *testing.T) {
+		cases := []struct {
+			input string
+			level domain.QualityLevel
+		}{
+			{"ESTIMATE", domain.QualityLevelEstimate},
+			{"PROVISIONAL", domain.QualityLevelProvisional},
+			{"ACTUAL", domain.QualityLevelActual},
+			{"VERIFIED", domain.QualityLevelVerified},
+		}
+		for _, tc := range cases {
+			level, revision, err := ParseQualityString(tc.input)
+			require.NoError(t, err, "input: %s", tc.input)
+			assert.Equal(t, tc.level, level, "input: %s", tc.input)
+			assert.Equal(t, 0, revision, "input: %s", tc.input)
+		}
+	})
+
+	t.Run("legacy REVISED maps to VERIFIED with revision 1", func(t *testing.T) {
+		level, revision, err := ParseQualityString("REVISED")
+		require.NoError(t, err)
+		assert.Equal(t, domain.QualityLevelVerified, level)
+		assert.Equal(t, 1, revision)
+	})
+
+	t.Run("matching is case-insensitive", func(t *testing.T) {
+		cases := []string{"estimate", "Provisional", "actual", "verified", "revised", "vErIfIeD"}
+		for _, input := range cases {
+			_, _, err := ParseQualityString(input)
+			require.NoError(t, err, "input: %s", input)
+		}
+
+		level, revision, err := ParseQualityString("revised")
+		require.NoError(t, err)
+		assert.Equal(t, domain.QualityLevelVerified, level)
+		assert.Equal(t, 1, revision)
+	})
+
+	t.Run("surrounding whitespace is trimmed", func(t *testing.T) {
+		level, revision, err := ParseQualityString("  PROVISIONAL\t")
+		require.NoError(t, err)
+		assert.Equal(t, domain.QualityLevelProvisional, level)
+		assert.Equal(t, 0, revision)
+	})
+
+	t.Run("unknown values return ErrUnknownQualityString", func(t *testing.T) {
+		cases := []string{"", "COEFFICIENT", "BOGUS", "estimated"}
+		for _, input := range cases {
+			level, revision, err := ParseQualityString(input)
+			require.ErrorIs(t, err, ErrUnknownQualityString, "input: %q", input)
+			assert.Equal(t, domain.QualityLevel(0), level, "input: %q", input)
+			assert.Equal(t, 0, revision, "input: %q", input)
+		}
+	})
+}
 
 func TestDefaultRequiredFields(t *testing.T) {
 	assert.Contains(t, DefaultRequiredFields, "value")

--- a/cmd/market-data-tool/internal/validation/types.go
+++ b/cmd/market-data-tool/internal/validation/types.go
@@ -24,8 +24,16 @@ type ObservationRow struct {
 	// ValidTo is when the observation value expires (optional).
 	ValidTo *time.Time
 
-	// QualityLevel is the quality indicator (ESTIMATE, PROVISIONAL, ACTUAL, REVISED).
+	// QualityLevel is the confidence grade on Axis A of the two-axis quality
+	// model (ADR-0017): ESTIMATE, PROVISIONAL, ACTUAL, or VERIFIED. The legacy
+	// REVISED label is accepted on input and normalizes to VERIFIED confidence
+	// with Revision 1 (see validation.ParseQualityString).
 	QualityLevel string
+
+	// Revision is the correction counter on Axis B of the two-axis quality model:
+	// 0 = original observation, 1+ = correction. Derived from QualityLevel via
+	// ParseQualityString (only the legacy REVISED label yields a non-zero value).
+	Revision int
 
 	// Attributes contains the key-value attributes extracted from CSV columns.
 	Attributes map[string]string

--- a/cmd/market-data-tool/quality_twoaxis_integration_test.go
+++ b/cmd/market-data-tool/quality_twoaxis_integration_test.go
@@ -1,0 +1,106 @@
+//go:build integration
+
+// Two-axis quality ladder integration test for the market-data-tool CSV import
+// path. It imports a CSV carrying the four-level confidence grades plus the
+// legacy REVISED label, maps each row through the same parsing the importer
+// uses, persists the observations into a CockroachDB testcontainer, and asserts
+// the quality (Axis A) and revision (Axis B) columns land correctly per ADR-0017.
+//
+// Run with: go test -tags=integration -v ./cmd/market-data-tool/...
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	csvadapter "github.com/meridianhub/meridian/cmd/market-data-tool/internal/adapters/csv"
+	"github.com/meridianhub/meridian/cmd/market-data-tool/internal/infra"
+	"github.com/meridianhub/meridian/cmd/market-data-tool/internal/validation"
+	"github.com/meridianhub/meridian/shared/platform/await"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+)
+
+// twoAxisObservation is a minimal projection of the market_price_observation
+// table covering the two axes of the quality ladder. The quality CHECK mirrors
+// production (four-level ladder IN (1,2,3,4)) so the test also proves the
+// four-level codes are accepted; revision defaults to 0 like the real column.
+type twoAxisObservation struct {
+	ID            string `gorm:"column:id;primaryKey"`
+	ResolutionKey string `gorm:"column:resolution_key;not null"`
+	Quality       int    `gorm:"column:quality;not null;check:quality IN (1,2,3,4)"`
+	Revision      int    `gorm:"column:revision;not null;default:0"`
+}
+
+func (twoAxisObservation) TableName() string {
+	return "market_price_observation_twoaxis_test"
+}
+
+func TestTwoAxisQualityImport_Integration(t *testing.T) {
+	db, cleanup := testdb.SetupCockroachDB(t, []interface{}{&twoAxisObservation{}})
+	defer cleanup()
+
+	// CSV carries a PROVISIONAL and a VERIFIED row (the required four-level grades)
+	// plus a legacy REVISED row to exercise the Axis-B revision mapping.
+	csvData := `observed_at,quality_level,value
+2024-01-15T10:30:00Z,PROVISIONAL,1.10
+2024-01-15T11:30:00Z,VERIFIED,1.20
+2024-01-15T12:30:00Z,REVISED,1.30`
+
+	dataset := &infra.DataSetDefinition{Code: "TWO_AXIS_TEST"}
+	parser := csvadapter.NewParser(dataset)
+
+	var rows []csvadapter.ObservationRow
+	_, err := parser.Parse(context.Background(), strings.NewReader(csvData), csvadapter.DefaultParseConfig(),
+		func(batch csvadapter.RowBatch) error {
+			require.Empty(t, batch.Errors, "CSV rows should parse cleanly")
+			rows = append(rows, batch.Rows...)
+			return nil
+		})
+	require.NoError(t, err)
+	require.Len(t, rows, 3)
+
+	// Persist each parsed row using the same quality/revision mapping the importer
+	// applies (ParseQualityString -> Axis A grade + Axis B revision).
+	for i, row := range rows {
+		level, revision, parseErr := validation.ParseQualityString(row.QualityLevel)
+		require.NoError(t, parseErr, "row %d quality %q", i, row.QualityLevel)
+
+		record := twoAxisObservation{
+			ID:            fmt.Sprintf("obs-%d", row.LineNumber),
+			ResolutionKey: "TWO_AXIS_TEST",
+			Quality:       level.Int(),
+			Revision:      revision,
+		}
+		require.NoError(t, db.Create(&record).Error, "insert row %d", i)
+	}
+
+	// All three rows should be durably present before we assert their columns.
+	err = await.Until(func() bool {
+		var count int64
+		if countErr := db.Model(&twoAxisObservation{}).Count(&count).Error; countErr != nil {
+			return false
+		}
+		return count == 3
+	})
+	require.NoError(t, err)
+
+	assertObservation(t, db, "obs-2", 2, 0) // PROVISIONAL -> quality 2, revision 0
+	assertObservation(t, db, "obs-3", 4, 0) // VERIFIED    -> quality 4, revision 0
+	assertObservation(t, db, "obs-4", 4, 1) // REVISED     -> quality 4, revision 1
+}
+
+// assertObservation reads back a persisted observation and asserts its Axis-A
+// quality grade and Axis-B revision counter landed in the database.
+func assertObservation(t *testing.T, db *gorm.DB, id string, wantQuality, wantRevision int) {
+	t.Helper()
+	var got twoAxisObservation
+	require.NoError(t, db.First(&got, "id = ?", id).Error, "load %s", id)
+	assert.Equal(t, wantQuality, got.Quality, "%s quality (Axis A)", id)
+	assert.Equal(t, wantRevision, got.Revision, "%s revision (Axis B)", id)
+}


### PR DESCRIPTION
## Summary

Brings the market-data CSV import tool and supporting types onto the two-axis quality model (ADR-0017): the four-level confidence ladder on Axis A (ESTIMATE, PROVISIONAL, ACTUAL, VERIFIED) and a revision counter on Axis B. Part of the `quality-ladder-reconciliation` cutover (task 12), built on the merged domain enum (task 10) and proto/migrations.

## Changes Made

- **`ParseQualityString`** (`internal/validation/fields.go`): maps a CSV quality string (case-insensitive, trimmed) to `(domain.QualityLevel, revision int, error)`:
  - `ESTIMATE/PROVISIONAL/ACTUAL/VERIFIED -> (grade, 0)`
  - `REVISED -> (VERIFIED, 1)` - legacy label: a correction at VERIFIED confidence, not a confidence grade of its own
  - unknown -> `ErrUnknownQualityString`
- **CSV parser**: accepts `VERIFIED` (and case variants); keeps `REVISED` as a legacy alias. Error message and doc comments updated to the four-level ladder.
- **gRPC client adapter** (`qualityStringToProto`): `VERIFIED` and legacy `REVISED` both map to proto slot 4 (`QUALITY_LEVEL_REVISED`, which carries VERIFIED-confidence semantics until the symbol rename in task 14).
- **`validation.ObservationRow`**: adds a `Revision` field, derived from the quality string in `csvRowToValidationRow`.
- Help text in `import`/`schema` commands refreshed to the four-level ladder.

## Testing

- Unit tests for `ParseQualityString` (all four grades, lowercase, mixed-case, whitespace, legacy `REVISED -> revision 1`, unknown -> error) and `VERIFIED` parsing in the CSV adapter.
- **Integration test** (`quality_twoaxis_integration_test.go`, `integration` build tag): imports a CSV with PROVISIONAL, VERIFIED, and legacy REVISED rows, persists them into a CockroachDB testcontainer (`testdb.SetupCockroachDB`, `await` not `time.Sleep`), and asserts the quality (Axis A) and revision (Axis B) columns land correctly: `PROVISIONAL->(2,0)`, `VERIFIED->(4,0)`, `REVISED->(4,1)`. Passing locally against `cockroachdb/cockroach:v24.3.0`.

## Scope Notes

- **Seed fixtures** (`cmd/seed-dev`): already use only `QUALITY_LEVEL_ACTUAL` (a valid four-level grade). No `COEFFICIENT` or `REVISED` references exist, so no fixture changes were required.
- **CEL rules**: no CEL expression values in `cmd/` or seed/dataset definitions reference old quality strings (the `cel_validator` doc comment was already updated in task 10). No changes required.
- **Axis B revision transmission**: the write-path protos (`BatchObservationEntry`, `RecordObservationRequest`) intentionally carry **no** `revision` field - per the service mapper, revision is server-assigned (`revision` lives only on the read model `MarketPriceObservation`, defaulting to 0 in the DB). The importer therefore sends the correct Axis-A confidence grade (legacy REVISED -> VERIFIED slot 4) and leaves Axis B to the server. The parsed `Revision` is carried internally for completeness/legacy detection. Flagging in case a client-settable write-path revision is desired (likely task 14 territory).
- **Out of scope, flagged**: `services/market-information/README.md` still describes the ladder as `ESTIMATE(1) < PROVISIONAL(2) < ACTUAL(3) < REVISED(4)` - stale vs the merged domain enum (`VERIFIED(4)`). Left for the owning service/docs task to avoid conflicting with parallel work in that directory.

## Risk Assessment

Low. Additive parsing plus doc/help updates; legacy `REVISED` remains accepted. No proto, migration, or server changes.