### PR TITLE
ci: Run gitleaks via official Docker image instead of licensed action

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -280,8 +280,17 @@ jobs:
       with:
         fetch-depth: 0  # Full history for secret scanning
 
+    # Use the open-source gitleaks binary directly, not gitleaks/gitleaks-action.
+    # The action requires a paid GITLEAKS_LICENSE for GitHub organizations, and
+    # Actions secrets are withheld from Dependabot-triggered runs - so the action
+    # fails on every Dependabot PR with "missing gitleaks license". The CLI is
+    # MIT-licensed, needs no key, scans identically, and matches our pre-commit
+    # hook (which also runs the gitleaks binary). It auto-loads .gitleaks.toml and
+    # .gitleaksignore from the repo root.
     - name: Run Gitleaks
-      uses: gitleaks/gitleaks-action@v3
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}  # Optional: for Gitleaks Pro features
+        GITLEAKS_VERSION: "8.30.1"
+      run: |
+        curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+          | tar -xzf - gitleaks
+        ./gitleaks git . --redact --verbose --exit-code 1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -280,17 +280,15 @@ jobs:
       with:
         fetch-depth: 0  # Full history for secret scanning
 
-    # Use the open-source gitleaks binary directly, not gitleaks/gitleaks-action.
+    # Run gitleaks via its official Docker image, not gitleaks/gitleaks-action.
     # The action requires a paid GITLEAKS_LICENSE for GitHub organizations, and
     # Actions secrets are withheld from Dependabot-triggered runs - so the action
-    # fails on every Dependabot PR with "missing gitleaks license". The CLI is
-    # MIT-licensed, needs no key, scans identically, and matches our pre-commit
-    # hook (which also runs the gitleaks binary). It auto-loads .gitleaks.toml and
-    # .gitleaksignore from the repo root.
+    # failed on every Dependabot PR with "missing gitleaks license". The image is
+    # the same MIT-licensed scanner, needs no key, and - unlike a version pinned in
+    # a run step - its tag IS tracked and auto-bumped by Dependabot's github-actions
+    # ecosystem (so it can't silently rot). It scans full git history and auto-loads
+    # .gitleaks.toml / .gitleaksignore from the repo root (mounted at /github/workspace).
     - name: Run Gitleaks
-      env:
-        GITLEAKS_VERSION: "8.30.1"
-      run: |
-        curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-          | tar -xzf - gitleaks
-        ./gitleaks git . --redact --verbose --exit-code 1
+      uses: docker://ghcr.io/gitleaks/gitleaks:v8.30.1
+      with:
+        args: git /github/workspace --redact --verbose --exit-code 1


### PR DESCRIPTION
## Summary

CI's `Secret Scanning with Gitleaks` job fails on **every Dependabot PR** with `🛑 missing gitleaks license`. This blocks the dependency-update workflow with a red check unrelated to the change.

## Root Cause

Two rules collide:
1. `gitleaks/gitleaks-action@v3` requires a paid `GITLEAKS_LICENSE` for GitHub **organizations** (`meridianhub` is an org).
2. GitHub withholds Actions secrets from workflows triggered by Dependabot PRs (security hardening). So `secrets.GITLEAKS_LICENSE` resolves empty on those runs and the action aborts.

Human PRs pass (they have secret access); only Dependabot PRs fail.

## Changes Made

Replace the licensed action with the official **`ghcr.io/gitleaks/gitleaks` Docker image** (pinned `v8.30.1`) via `uses: docker://`, in `.github/workflows/security.yml`:
- Same MIT-licensed scanner, no license key required.
- Full git-history scan; auto-loads `.gitleaks.toml` + `.gitleaksignore` from the repo root (mounted at `/github/workspace`).

## Why a Docker image (not a curl-installed binary)

A version string pinned inside a `run:` step is invisible to Dependabot, so it would silently go stale - the same maintenance gap that removing the (Dependabot-tracked) action created. Dependabot's **github-actions** ecosystem tracks and auto-bumps `uses: docker://` image tags, so the pin stays current via the normal weekly Dependabot PRs - while remaining pinned/reproducible.

## Why this over "skip the job on Dependabot PRs"

Secret scanning now runs on **all** PRs including Dependabot's, rather than dropping coverage there. It also removes the license cost/coupling for every run.

## Testing

Verified locally against the official image (gitleaks 8.30.1):
- Scans a root-mounted, host-owned repo with **no git "dubious ownership" error**.
- Detects a planted PEM private key (`RuleID: private-key`, **exit 1**, value redacted) - confirms the gate still fails on real findings.
- Full-history scan of this repo via the gitleaks binary: 3,117 commits, `no leaks found`, exit 0 - parity with the action's prior behaviour.

## Risk Assessment

Low. Loses the "Gitleaks Pro" org-dashboard features of the action (unused for a single repo that also has pre-commit gitleaks + GitHub-native secret scanning). Detection rules are unchanged (`useDefault = true` in `.gitleaks.toml`).