### PR TITLE
fix: Enforce tenant_id matches authenticated tenant in mcp-server

### DIFF
--- a/services/mcp-server/README.md
+++ b/services/mcp-server/README.md
@@ -345,10 +345,19 @@ validator.
 
 ### Tenant isolation
 
-The MCP server is a single-tenant process. `MERIDIAN_API_KEY` is forwarded as a
-Bearer token on every outgoing gRPC call. The `api-gateway` uses this key to
-resolve the tenant and enforce boundaries — no tool call can reach a different
-tenant's data.
+In stdio / API-key mode the MCP server is a single-tenant process.
+`MERIDIAN_API_KEY` is forwarded as a Bearer token on every outgoing gRPC call.
+The `api-gateway` uses this key to resolve the tenant and enforce boundaries — no
+tool call can reach a different tenant's data.
+
+In HTTP mode with `MCP_OAUTH_ENABLED=true`, the bearer token's tenant claim is
+authoritative: `auth.BearerMiddleware` injects it into the request context, and
+tools that accept a `tenant_id` parameter (`meridian_manifest_validate`,
+`meridian_economy_generate`, `meridian_economy_generate_context`) reconcile the
+supplied value against it. A `tenant_id` that differs from the authenticated
+tenant is rejected with `PermissionDenied`; an omitted `tenant_id` falls back to
+the authenticated tenant. This prevents a caller authenticated for one tenant
+from reaching another tenant's data by supplying an arbitrary `tenant_id`.
 
 ### Plan-hash binding
 

--- a/services/mcp-server/internal/tools/economy_generator.go
+++ b/services/mcp-server/internal/tools/economy_generator.go
@@ -77,7 +77,7 @@ func buildEconomyGenerateContextTool(client EconomyGeneratorClient) Tool {
 				},
 				"include_current_economy": map[string]interface{}{
 					"type":        "boolean",
-					"description": "When true, includes the tenant's current manifest YAML in the response. Requires tenant_id.",
+					"description": "When true, includes the tenant's current manifest YAML in the response. Requires tenant_id unless an authenticated tenant is available.",
 				},
 				"tenant_id": map[string]interface{}{
 					"type":        "string",
@@ -179,7 +179,7 @@ func buildEconomyGenerateTool(client EconomyGeneratorClient) Tool {
 		Description: "Generate a tenant manifest from a natural language description using AI assistance. " +
 			"Produces a manifest YAML, validates it, and iterates to fix any validation errors. " +
 			"Does not apply the manifest — use meridian_manifest_plan and meridian_manifest_apply to deploy it. " +
-			"Use mode=amend with a tenant_id to incorporate changes into an existing economy.",
+			"Use mode=amend to incorporate changes into an existing economy (tenant_id defaults to the authenticated tenant).",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
@@ -189,7 +189,7 @@ func buildEconomyGenerateTool(client EconomyGeneratorClient) Tool {
 				},
 				"mode": map[string]interface{}{
 					"type":        "string",
-					"description": "Generation mode: 'create' (default) generates a fresh manifest; 'amend' incorporates changes into the existing manifest (requires tenant_id).",
+					"description": "Generation mode: 'create' (default) generates a fresh manifest; 'amend' incorporates changes into the existing manifest (requires tenant_id unless an authenticated tenant is available).",
 					"enum":        []interface{}{"create", "amend"},
 				},
 				"tenant_id": map[string]interface{}{

--- a/services/mcp-server/internal/tools/economy_generator.go
+++ b/services/mcp-server/internal/tools/economy_generator.go
@@ -81,7 +81,7 @@ func buildEconomyGenerateContextTool(client EconomyGeneratorClient) Tool {
 				},
 				"tenant_id": map[string]interface{}{
 					"type":        "string",
-					"description": "Tenant identifier. Required when include_current_economy is true.",
+					"description": "Tenant identifier, used when include_current_economy is true. Under an authenticated session it must match the authenticated tenant; if omitted, the authenticated tenant is used.",
 				},
 			},
 			"required": []interface{}{"description"},
@@ -107,7 +107,14 @@ func handleEconomyGenerateContext(ctx context.Context, client EconomyGeneratorCl
 		return mcperrors.FormatGRPCError(err), nil
 	}
 
-	if p.IncludeCurrentEconomy && p.TenantID == "" {
+	// Reconcile the client-supplied tenant_id with the authenticated tenant.
+	// A mismatch under an authenticated (OAuth/JWT) context is rejected.
+	effectiveTenant, err := resolveTenantID(ctx, p.TenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	if p.IncludeCurrentEconomy && effectiveTenant == "" {
 		return map[string]interface{}{
 			"error":   "tenant_id is required when include_current_economy is true",
 			"message": "Provide a tenant_id to include the current economy in the context.",
@@ -121,7 +128,7 @@ func handleEconomyGenerateContext(ctx context.Context, client EconomyGeneratorCl
 		Description:           p.Description,
 		ExcludePatterns:       excludePatterns,
 		IncludeCurrentEconomy: p.IncludeCurrentEconomy,
-		TenantId:              p.TenantID,
+		TenantId:              effectiveTenant,
 	}
 
 	resp, err := client.GetGenerationContext(ctx, req)
@@ -187,7 +194,7 @@ func buildEconomyGenerateTool(client EconomyGeneratorClient) Tool {
 				},
 				"tenant_id": map[string]interface{}{
 					"type":        "string",
-					"description": "Tenant identifier. Required when mode is 'amend'.",
+					"description": "Tenant identifier, used when mode is 'amend'. Under an authenticated session it must match the authenticated tenant; if omitted, the authenticated tenant is used.",
 				},
 				"preferences": map[string]interface{}{
 					"type":        "object",
@@ -290,7 +297,14 @@ func handleEconomyGenerate(ctx context.Context, client EconomyGeneratorClient, p
 		return mcperrors.FormatGRPCError(err), nil
 	}
 
-	mode, errResp := resolveGenerationMode(p.Mode, p.TenantID)
+	// Reconcile the client-supplied tenant_id with the authenticated tenant.
+	// A mismatch under an authenticated (OAuth/JWT) context is rejected.
+	effectiveTenant, err := resolveTenantID(ctx, p.TenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	mode, errResp := resolveGenerationMode(p.Mode, effectiveTenant)
 	if errResp != nil {
 		return errResp, nil
 	}
@@ -298,7 +312,7 @@ func handleEconomyGenerate(ctx context.Context, client EconomyGeneratorClient, p
 	req := &controlplanev1.GenerateManifestRequest{
 		Description:      p.Description,
 		Mode:             mode,
-		TenantId:         p.TenantID,
+		TenantId:         effectiveTenant,
 		MaxFixIterations: p.MaxFixIterations,
 	}
 

--- a/services/mcp-server/internal/tools/economy_manifest.go
+++ b/services/mcp-server/internal/tools/economy_manifest.go
@@ -36,7 +36,7 @@ func buildManifestValidateTool(client ManifestApplier) Tool {
 		Category: CategorySimulate,
 		Description: "Validate a manifest YAML/JSON without applying it. " +
 			"Runs structural validation and returns any errors with paths and suggestions. " +
-			"Use mode='create' (default) for new economy validation or mode='amend' with tenant_id to validate against an existing tenant's manifest.",
+			"Use mode='create' (default) for new economy validation or mode='amend' to validate against an existing tenant's manifest (tenant_id defaults to the authenticated tenant).",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
@@ -49,7 +49,7 @@ func buildManifestValidateTool(client ManifestApplier) Tool {
 				},
 				"mode": map[string]interface{}{
 					"type":        "string",
-					"description": "Validation mode: 'create' (default) performs schema-only validation for new economies; 'amend' validates against the existing tenant's manifest.",
+					"description": "Validation mode: 'create' (default) performs schema-only validation for new economies; 'amend' validates against the existing tenant's manifest (tenant_id defaults to the authenticated tenant).",
 					"enum":        []interface{}{"create", "amend"},
 				},
 				"tenant_id": map[string]interface{}{

--- a/services/mcp-server/internal/tools/economy_manifest.go
+++ b/services/mcp-server/internal/tools/economy_manifest.go
@@ -54,7 +54,7 @@ func buildManifestValidateTool(client ManifestApplier) Tool {
 				},
 				"tenant_id": map[string]interface{}{
 					"type":        "string",
-					"description": "Required for amend mode. The tenant whose manifest to compare against.",
+					"description": "The tenant whose manifest to compare against, for amend mode. Under an authenticated session it must match the authenticated tenant; if omitted, the authenticated tenant is used.",
 				},
 			},
 			"required": []interface{}{"manifest"},
@@ -88,14 +88,20 @@ func handleManifestValidate(ctx context.Context, client ManifestApplier, params 
 		// can be validated without comparing against any existing tenant state.
 		skipImmutabilityChecks = true
 	case "amend":
-		if p.TenantID == "" {
+		// Reconcile the client-supplied tenant_id with the authenticated tenant.
+		// A mismatch under an authenticated (OAuth/JWT) context is rejected.
+		effectiveTenant, err := resolveTenantID(ctx, p.TenantID)
+		if err != nil {
+			return nil, err
+		}
+		if effectiveTenant == "" {
 			return map[string]interface{}{
 				"error":   "tenant_id is required when mode is 'amend'",
 				"message": "Provide a tenant_id to validate against the tenant's existing manifest.",
 			}, nil
 		}
 		// Inject tenant context so the control plane validates against the correct tenant's state.
-		ctx = tenant.WithTenant(ctx, tenant.TenantID(p.TenantID))
+		ctx = tenant.WithTenant(ctx, tenant.TenantID(effectiveTenant))
 	default:
 		return map[string]interface{}{
 			"error":   "invalid mode: " + p.Mode,

--- a/services/mcp-server/internal/tools/tenant.go
+++ b/services/mcp-server/internal/tools/tenant.go
@@ -1,0 +1,42 @@
+package tools
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// resolveTenantID reconciles a client-supplied tenant_id against the tenant
+// established by the authenticated request context, returning the tenant that
+// tool handlers must scope their backend calls to.
+//
+// When the request context carries an authenticated tenant — the OAuth/JWT HTTP
+// transport injects it via auth.BearerMiddleware from the token's tenant claim —
+// that tenant is authoritative:
+//   - a supplied tenant_id that differs is rejected with codes.PermissionDenied,
+//     preventing a caller authenticated for tenant A from reaching tenant B's data;
+//   - a supplied tenant_id that matches, or an omitted tenant_id, resolves to the
+//     authenticated tenant.
+//
+// When the context carries no authenticated tenant — the stdio / API-key
+// transport, where the api-gateway resolves the tenant from the bearer key —
+// the supplied tenant_id is returned unchanged and the gateway remains the
+// enforcement point.
+//
+// The error deliberately omits the supplied tenant_id so a caller cannot probe
+// for the existence of other tenants.
+func resolveTenantID(ctx context.Context, requested string) (string, error) {
+	authTenant, ok := tenant.FromContext(ctx)
+	if !ok || authTenant.IsEmpty() {
+		return requested, nil
+	}
+	authID := string(authTenant)
+	if requested != "" && requested != authID {
+		return "", status.Error(codes.PermissionDenied,
+			"tenant_id does not match the authenticated tenant")
+	}
+	return authID, nil
+}

--- a/services/mcp-server/internal/tools/tenant_enforcement_test.go
+++ b/services/mcp-server/internal/tools/tenant_enforcement_test.go
@@ -1,0 +1,251 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// These white-box tests verify that a client-supplied tenant_id cannot override
+// the tenant established by the authenticated request context. The in-memory MCP
+// transport used by the black-box tests does not propagate context values across
+// the client/server boundary, so tenant-context enforcement is exercised by
+// calling the handlers directly.
+
+// --- resolveTenantID ---
+
+func TestResolveTenantID_NoAuthContext_ReturnsRequested(t *testing.T) {
+	got, err := resolveTenantID(context.Background(), "tenant-a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "tenant-a" {
+		t.Errorf("expected requested tenant to pass through, got %q", got)
+	}
+}
+
+func TestResolveTenantID_NoAuthContext_EmptyRequested(t *testing.T) {
+	got, err := resolveTenantID(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty tenant, got %q", got)
+	}
+}
+
+func TestResolveTenantID_AuthContext_MatchingRequested(t *testing.T) {
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("tenant-a"))
+	got, err := resolveTenantID(ctx, "tenant-a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "tenant-a" {
+		t.Errorf("expected tenant-a, got %q", got)
+	}
+}
+
+func TestResolveTenantID_AuthContext_OmittedRequested_UsesAuthTenant(t *testing.T) {
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("tenant-a"))
+	got, err := resolveTenantID(ctx, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "tenant-a" {
+		t.Errorf("expected authenticated tenant to be used, got %q", got)
+	}
+}
+
+func TestResolveTenantID_AuthContext_MismatchedRequested_PermissionDenied(t *testing.T) {
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("tenant-a"))
+	_, err := resolveTenantID(ctx, "tenant-b")
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %v", err)
+	}
+	// The error must not echo the requested tenant_id (no tenant enumeration).
+	if msg := status.Convert(err).Message(); strings.Contains(msg, "tenant-b") {
+		t.Errorf("error message leaks requested tenant_id: %q", msg)
+	}
+}
+
+// --- handleManifestValidate (amend) ---
+
+func TestHandleManifestValidate_CrossTenant_DeniedAndNoBackendCall(t *testing.T) {
+	called := false
+	mock := &enforcementManifestApplier{
+		fn: func(context.Context, *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			called = true
+			return &controlplanev1.ApplyManifestResponse{}, nil
+		},
+	}
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("tenant-a"))
+	params := json.RawMessage(`{"manifest": {"version": "1.0"}, "mode": "amend", "tenant_id": "tenant-b"}`)
+
+	_, err := handleManifestValidate(ctx, mock, params)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %v", err)
+	}
+	if called {
+		t.Error("backend must not be called on a cross-tenant request (leak)")
+	}
+}
+
+func TestHandleManifestValidate_MatchingTenant_UsesAuthTenant(t *testing.T) {
+	var capturedCtx context.Context
+	mock := &enforcementManifestApplier{
+		fn: func(ctx context.Context, _ *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			capturedCtx = ctx
+			return &controlplanev1.ApplyManifestResponse{
+				Status: controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_DRY_RUN,
+			}, nil
+		},
+	}
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("tenant-a"))
+	params := json.RawMessage(`{"manifest": {"version": "1.0"}, "mode": "amend", "tenant_id": "tenant-a"}`)
+
+	if _, err := handleManifestValidate(ctx, mock, params); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	tid, ok := tenant.FromContext(capturedCtx)
+	if !ok || string(tid) != "tenant-a" {
+		t.Errorf("expected backend call scoped to tenant-a, got %q (ok=%v)", tid, ok)
+	}
+}
+
+func TestHandleManifestValidate_OmittedTenant_UsesAuthTenant(t *testing.T) {
+	var capturedCtx context.Context
+	mock := &enforcementManifestApplier{
+		fn: func(ctx context.Context, _ *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			capturedCtx = ctx
+			return &controlplanev1.ApplyManifestResponse{
+				Status: controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_DRY_RUN,
+			}, nil
+		},
+	}
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("tenant-a"))
+	params := json.RawMessage(`{"manifest": {"version": "1.0"}, "mode": "amend"}`)
+
+	if _, err := handleManifestValidate(ctx, mock, params); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	tid, ok := tenant.FromContext(capturedCtx)
+	if !ok || string(tid) != "tenant-a" {
+		t.Errorf("expected omitted tenant_id to fall back to auth tenant, got %q (ok=%v)", tid, ok)
+	}
+}
+
+// --- handleEconomyGenerateContext ---
+
+func TestHandleEconomyGenerateContext_CrossTenant_DeniedAndNoBackendCall(t *testing.T) {
+	called := false
+	mock := &enforcementGeneratorClient{
+		contextFn: func(context.Context, *controlplanev1.GetGenerationContextRequest) (*controlplanev1.GetGenerationContextResponse, error) {
+			called = true
+			return &controlplanev1.GetGenerationContextResponse{}, nil
+		},
+	}
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("tenant-a"))
+	params := json.RawMessage(`{"description": "x", "include_current_economy": true, "tenant_id": "tenant-b"}`)
+
+	_, err := handleEconomyGenerateContext(ctx, mock, params)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %v", err)
+	}
+	if called {
+		t.Error("backend must not be called on a cross-tenant request (leak)")
+	}
+}
+
+func TestHandleEconomyGenerateContext_MatchingTenant_ScopesRequest(t *testing.T) {
+	var captured *controlplanev1.GetGenerationContextRequest
+	mock := &enforcementGeneratorClient{
+		contextFn: func(_ context.Context, req *controlplanev1.GetGenerationContextRequest) (*controlplanev1.GetGenerationContextResponse, error) {
+			captured = req
+			return &controlplanev1.GetGenerationContextResponse{}, nil
+		},
+	}
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("tenant-a"))
+	params := json.RawMessage(`{"description": "x", "include_current_economy": true, "tenant_id": "tenant-a"}`)
+
+	if _, err := handleEconomyGenerateContext(ctx, mock, params); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.TenantId != "tenant-a" {
+		t.Errorf("expected request scoped to tenant-a, got %q", captured.TenantId)
+	}
+}
+
+// --- handleEconomyGenerate ---
+
+func TestHandleEconomyGenerate_CrossTenant_DeniedAndNoBackendCall(t *testing.T) {
+	called := false
+	mock := &enforcementGeneratorClient{
+		generateFn: func(context.Context, *controlplanev1.GenerateManifestRequest) (*controlplanev1.GenerateManifestResponse, error) {
+			called = true
+			return &controlplanev1.GenerateManifestResponse{}, nil
+		},
+	}
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("tenant-a"))
+	params := json.RawMessage(`{"description": "x", "mode": "amend", "tenant_id": "tenant-b"}`)
+
+	_, err := handleEconomyGenerate(ctx, mock, params)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %v", err)
+	}
+	if called {
+		t.Error("backend must not be called on a cross-tenant request (leak)")
+	}
+}
+
+func TestHandleEconomyGenerate_OmittedTenant_UsesAuthTenant(t *testing.T) {
+	var captured *controlplanev1.GenerateManifestRequest
+	mock := &enforcementGeneratorClient{
+		generateFn: func(_ context.Context, req *controlplanev1.GenerateManifestRequest) (*controlplanev1.GenerateManifestResponse, error) {
+			captured = req
+			return &controlplanev1.GenerateManifestResponse{Valid: true}, nil
+		},
+	}
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("tenant-a"))
+	// amend mode with no tenant_id must fall back to the authenticated tenant.
+	params := json.RawMessage(`{"description": "x", "mode": "amend"}`)
+
+	if _, err := handleEconomyGenerate(ctx, mock, params); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.TenantId != "tenant-a" {
+		t.Errorf("expected request scoped to auth tenant-a, got %q", captured.TenantId)
+	}
+	if captured.Mode != controlplanev1.GenerationMode_GENERATION_MODE_AMEND {
+		t.Errorf("expected AMEND mode, got %v", captured.Mode)
+	}
+}
+
+// --- test doubles ---
+
+type enforcementManifestApplier struct {
+	fn func(context.Context, *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error)
+}
+
+func (m *enforcementManifestApplier) ApplyManifest(ctx context.Context, req *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+	return m.fn(ctx, req)
+}
+
+type enforcementGeneratorClient struct {
+	generateFn func(context.Context, *controlplanev1.GenerateManifestRequest) (*controlplanev1.GenerateManifestResponse, error)
+	contextFn  func(context.Context, *controlplanev1.GetGenerationContextRequest) (*controlplanev1.GetGenerationContextResponse, error)
+}
+
+func (m *enforcementGeneratorClient) GenerateManifest(ctx context.Context, req *controlplanev1.GenerateManifestRequest) (*controlplanev1.GenerateManifestResponse, error) {
+	return m.generateFn(ctx, req)
+}
+
+func (m *enforcementGeneratorClient) GetGenerationContext(ctx context.Context, req *controlplanev1.GetGenerationContextRequest) (*controlplanev1.GetGenerationContextResponse, error) {
+	return m.contextFn(ctx, req)
+}


### PR DESCRIPTION
## Summary

The mcp-server exposed tools that accepted a client-supplied `tenant_id` and used it to scope backend calls, overriding the tenant established by the authenticated request context. Under the OAuth/JWT HTTP transport - where the bearer token's tenant claim is injected into the request context by `auth.BearerMiddleware` - a caller authenticated for one tenant could supply a different `tenant_id` and reach another tenant's data.

This change makes the authenticated tenant authoritative and reconciles any supplied `tenant_id` against it.

## Changes Made

- Added `resolveTenantID` (`services/mcp-server/internal/tools/tenant.go`), a shared helper that reconciles a client-supplied `tenant_id` against the authenticated tenant from the request context.
- Applied the check in the three tools that accept a `tenant_id` parameter:
  - `meridian_manifest_validate` (amend mode)
  - `meridian_economy_generate`
  - `meridian_economy_generate_context`
- Updated the tool schema descriptions and the service README `Tenant isolation` section to document the enforcement and the token-fallback behavior.

## Technical Details

`resolveTenantID(ctx, requested)` resolves the effective tenant:

- **Authenticated context present** (OAuth/JWT HTTP transport injects the tenant claim via `tenant.WithTenant`):
  - a `requested` value that differs is rejected with `codes.PermissionDenied`;
  - a matching `requested` value, or an omitted one, resolves to the authenticated tenant.
- **No authenticated context** (stdio / API-key transport, where the api-gateway resolves the tenant from the bearer key): the `requested` value passes through unchanged and the api-gateway remains the enforcement point.

The denial error deliberately omits the supplied `tenant_id` so a caller cannot enumerate tenants by probing.

A sweep of `services/mcp-server/internal/tools/` confirmed these three tools are the only handlers that accept a `tenant_id` parameter. The write tools (`meridian_manifest_plan`, `meridian_manifest_apply`) already derive the tenant solely from the request context and were unaffected.

Option B (removing the parameter entirely and always deriving from the token) is not feasible: the stdio / API-key transport carries no authenticated tenant inside the mcp-server process, so amend-mode operations still require the parameter there. Option A (reconcile-and-reject) preserves that path while closing the cross-tenant override under authenticated sessions.

## Testing

Added `tenant_enforcement_test.go` (white-box, since the in-memory MCP transport used by the existing black-box tests does not propagate context values across the client/server boundary):

- `resolveTenantID` unit cases: no-auth passthrough, matching tenant, omitted tenant falls back to the authenticated tenant, and mismatched tenant returns `PermissionDenied` without leaking the requested id.
- Per-handler cases for all three tools: a cross-tenant request returns `PermissionDenied` and does not call the backend (no leak); a matching or omitted `tenant_id` scopes the backend call to the authenticated tenant.

`go build`, `go vet`, `gofumpt`, `golangci-lint`, and the full `services/mcp-server/...` test suite pass.

## Risk Assessment

Low. Behavior is unchanged for the stdio / API-key transport (the common local-development path) and for authenticated callers that omit `tenant_id` or supply their own tenant. The only behavioral change is rejecting a `tenant_id` that contradicts the authenticated tenant, which was the vulnerable case. Existing tests continue to pass unmodified.

## Deployment Notes

None. No schema or migration changes.
