### PR TITLE
fix: Gate handleSettledStatus on EXECUTING before posting ledger entries

### DIFF
--- a/services/payment-order/service/grpc_service_test.go
+++ b/services/payment-order/service/grpc_service_test.go
@@ -1348,6 +1348,151 @@ func TestUpdatePaymentOrder_PendingRejectsStaleCallbacks(t *testing.T) {
 	assert.Contains(t, st.Message(), "COMPLETED")
 }
 
+// TestUpdatePaymentOrder_SettledAfterRejected_DoesNotPostLedger verifies that a late
+// SETTLED webhook arriving after the order was already REJECTED (FAILED) is dropped
+// without posting any ledger entries. Regression test for the bug where
+// handleSettledStatus posted ledger entries before checking the order's state.
+func TestUpdatePaymentOrder_SettledAfterRejected_DoesNotPostLedger(t *testing.T) {
+	repo := NewMockRepository()
+	caClient := &MockCurrentAccountClient{
+		terminateLienResp: &currentaccountv1.TerminateLienResponse{
+			Lien: &currentaccountv1.Lien{
+				LienId: "lien-123",
+				Status: currentaccountv1.LienStatus_LIEN_STATUS_TERMINATED,
+			},
+		},
+	}
+	faClient := &MockFinancialAccountingClient{}
+	gwConfig := testGatewayAccountConfig()
+
+	svc := &Service{
+		repo:                      repo,
+		currentAccountClient:      caClient,
+		financialAccountingClient: faClient,
+		gatewayAccountConfig:      gwConfig,
+		idempotencyService:        NewMockIdempotencyService(),
+		logger:                    testLogger(),
+		orchestrator:              testOrchestrator(repo, caClient, faClient, gwConfig),
+	}
+
+	// Create a payment order in EXECUTING state
+	amount, _ := domain.NewMoney("GBP", 10000)
+	po, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "test-key", uuid.New().String())
+	_ = po.Reserve("lien-123")
+	_ = po.Execute("gateway-ref-123")
+	_ = repo.Create(context.Background(), po)
+
+	// Gateway rejects the payment first
+	rejectReq := &pb.UpdatePaymentOrderRequest{
+		PaymentOrderId: po.ID.String(),
+		GatewayStatus:  pb.GatewayStatus_GATEWAY_STATUS_REJECTED,
+		GatewayMessage: "Insufficient funds at destination",
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "reject-key"},
+	}
+	rejectResp, err := svc.UpdatePaymentOrder(context.Background(), rejectReq)
+	require.NoError(t, err)
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_FAILED, rejectResp.PaymentOrder.Status)
+
+	// A late SETTLED webhook arrives after the REJECTED callback was already processed
+	settledReq := &pb.UpdatePaymentOrderRequest{
+		PaymentOrderId: po.ID.String(),
+		GatewayStatus:  pb.GatewayStatus_GATEWAY_STATUS_SETTLED,
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "late-settled-key"},
+	}
+	settledResp, err := svc.UpdatePaymentOrder(context.Background(), settledReq)
+
+	require.NoError(t, err)
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_FAILED, settledResp.PaymentOrder.Status,
+		"order must remain FAILED, not be pushed to COMPLETED by the late webhook")
+	assert.False(t, faClient.initiateCalled, "InitiateFinancialBookingLog must NOT be called for a late SETTLED callback on a FAILED order")
+	assert.False(t, faClient.captureCalled, "CaptureLedgerPosting (debit/credit) must NOT be called for a late SETTLED callback on a FAILED order")
+
+	// Verify persisted state was not mutated back to COMPLETED
+	persisted, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.PaymentOrderStatusFailed, persisted.Status)
+}
+
+// TestUpdatePaymentOrder_SettledOnFailed_DoesNotPostLedger verifies that a SETTLED
+// webhook for an order already in FAILED state (independent of how it got there) is
+// dropped silently with no ledger postings and no debit.
+func TestUpdatePaymentOrder_SettledOnFailed_DoesNotPostLedger(t *testing.T) {
+	repo := NewMockRepository()
+	faClient := &MockFinancialAccountingClient{}
+	gwConfig := testGatewayAccountConfig()
+	caClient := &MockCurrentAccountClient{}
+
+	svc := &Service{
+		repo:                      repo,
+		currentAccountClient:      caClient,
+		financialAccountingClient: faClient,
+		gatewayAccountConfig:      gwConfig,
+		idempotencyService:        NewMockIdempotencyService(),
+		logger:                    testLogger(),
+		orchestrator:              testOrchestrator(repo, caClient, faClient, gwConfig),
+	}
+
+	amount, _ := domain.NewMoney("GBP", 10000)
+	po, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "test-key", uuid.New().String())
+	_ = po.Reserve("lien-123")
+	_ = po.Execute("gateway-ref-123")
+	require.NoError(t, po.Fail("gateway timeout", "GATEWAY_TIMEOUT"))
+	_ = repo.Create(context.Background(), po)
+
+	req := &pb.UpdatePaymentOrderRequest{
+		PaymentOrderId: po.ID.String(),
+		GatewayStatus:  pb.GatewayStatus_GATEWAY_STATUS_SETTLED,
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "settled-on-failed-key"},
+	}
+
+	resp, err := svc.UpdatePaymentOrder(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_FAILED, resp.PaymentOrder.Status)
+	assert.False(t, faClient.initiateCalled, "InitiateFinancialBookingLog must NOT be called for SETTLED on a FAILED order")
+	assert.False(t, faClient.captureCalled, "CaptureLedgerPosting must NOT be called for SETTLED on a FAILED order - no debit without payment success")
+}
+
+// TestUpdatePaymentOrder_SettledOnCompleted_DoesNotPostLedgerAgain verifies the existing
+// idempotency guard (already-COMPLETED short circuit) also results in no additional
+// ledger postings, guarding against regressions that might reorder the checks.
+func TestUpdatePaymentOrder_SettledOnCompleted_DoesNotPostLedgerAgain(t *testing.T) {
+	repo := NewMockRepository()
+	faClient := &MockFinancialAccountingClient{}
+	gwConfig := testGatewayAccountConfig()
+	caClient := &MockCurrentAccountClient{}
+
+	svc := &Service{
+		repo:                      repo,
+		currentAccountClient:      caClient,
+		financialAccountingClient: faClient,
+		gatewayAccountConfig:      gwConfig,
+		idempotencyService:        NewMockIdempotencyService(),
+		logger:                    testLogger(),
+		orchestrator:              testOrchestrator(repo, caClient, faClient, gwConfig),
+	}
+
+	amount, _ := domain.NewMoney("GBP", 10000)
+	po, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "test-key", uuid.New().String())
+	_ = po.Reserve("lien-123")
+	_ = po.Execute("gateway-ref-123")
+	require.NoError(t, po.Complete("existing-ledger-booking-id"))
+	_ = repo.Create(context.Background(), po)
+
+	req := &pb.UpdatePaymentOrderRequest{
+		PaymentOrderId: po.ID.String(),
+		GatewayStatus:  pb.GatewayStatus_GATEWAY_STATUS_SETTLED,
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "duplicate-settled-key"},
+	}
+
+	resp, err := svc.UpdatePaymentOrder(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED, resp.PaymentOrder.Status)
+	assert.False(t, faClient.initiateCalled, "InitiateFinancialBookingLog must NOT be called for a duplicate SETTLED webhook on an already-COMPLETED order")
+	assert.False(t, faClient.captureCalled, "CaptureLedgerPosting must NOT be called for a duplicate SETTLED webhook on an already-COMPLETED order")
+}
+
 // Test ListPaymentOrders
 func TestListPaymentOrders_Success(t *testing.T) {
 	repo := NewMockRepository()

--- a/services/payment-order/service/grpc_update.go
+++ b/services/payment-order/service/grpc_update.go
@@ -231,6 +231,20 @@ func (s *Service) handleSettledStatus(ctx context.Context, po *domain.PaymentOrd
 		return &updateResult{po: po, isIdempotent: true}, nil
 	}
 
+	// Guard: only an order in EXECUTING state can be settled. A SETTLED webhook
+	// arriving for any other non-terminal-completed state (e.g. FAILED after a
+	// REJECTED callback, or CANCELLED) is stale or duplicate - dropping it here
+	// prevents ledger entries from being posted for an order that was already
+	// rejected/failed/cancelled. Do NOT post ledger entries before this check.
+	if po.Status != domain.PaymentOrderStatusExecuting {
+		s.logger.Warn("dropping stale or late SETTLED callback - payment order not in EXECUTING state",
+			"payment_order_id", po.ID.String(),
+			"current_status", po.Status,
+			"correlation_id", po.CorrelationID)
+		poobservability.RecordIdempotentRequest("update_payment_order_settled_stale")
+		return &updateResult{po: po, isIdempotent: true}, nil
+	}
+
 	// Post ledger entries BEFORE completing the payment order
 	ledgerBookingID, err := s.postLedgerAndComplete(ctx, po)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Late or duplicate SETTLED webhooks were posted to the ledger before the payment order's state was validated, allowing debits on orders that had already been REJECTED, FAILED, or CANCELLED.
- Adds a status guard at the start of `handleSettledStatus` that runs before any ledger posting.

## Problem Statement

`handleSettledStatus` in `services/payment-order/service/grpc_update.go` only short-circuited when the order was already `COMPLETED`. For any other non-`EXECUTING` state (most notably `FAILED`, reached via a prior `REJECTED` gateway callback), the handler proceeded straight to `postLedgerAndComplete`, which calls `orchestrator.PostLedgerEntries` (the double-entry debit/credit) *before* attempting `po.Complete()`. `po.Complete()` correctly rejects the transition when the order isn't `EXECUTING`, but by then the ledger entries had already been posted - the state guard existed only on the domain transition, not on the ledger side effect.

## Technical Context

Sequence that triggered the bug:
1. Order reaches `EXECUTING`.
2. Gateway sends `REJECTED` -> order transitions to `FAILED`, lien released.
3. A late/duplicate `SETTLED` webhook arrives for the same order (out-of-order delivery, gateway retry, etc.).
4. `handleSettledStatus` sees `po.Status != COMPLETED`, so it calls `postLedgerAndComplete`, which posts ledger entries immediately, then fails when `po.Complete()` rejects the `FAILED -> COMPLETED` transition.
5. The RPC returns an error, but the debit has already been posted against the account - the order is left `FAILED` with a stray ledger entry.

## Impact

- Real debits could post against customer accounts for payment orders that were rejected, failed, or cancelled, with no corresponding successful payment.
- Classified HIGH in the bug sweep backlog (PAY-3).

## Root Cause

`handleSettledStatus` performed the ledger-posting side effect before validating the order was in a state where settlement is valid (`EXECUTING`). Only the COMPLETED idempotency case was guarded; other terminal/non-EXECUTING states fell through to the posting call.

## Solution

Added a guard at the top of `handleSettledStatus`, mirroring the `EXECUTING` check already used in `handlePendingStatus`, that runs before `postLedgerAndComplete`/`PostLedgerEntries` is ever called:

```go
if po.Status != domain.PaymentOrderStatusExecuting {
    s.logger.Warn("dropping stale or late SETTLED callback - payment order not in EXECUTING state", ...)
    poobservability.RecordIdempotentRequest("update_payment_order_settled_stale")
    return &updateResult{po: po, isIdempotent: true}, nil
}
```

Unlike `handlePendingStatus` (which returns a `FailedPrecondition` error for stale PENDING callbacks), a non-EXECUTING SETTLED callback is dropped silently with no error - consistent with the requirement that it may be a legitimate duplicate/late webhook, not necessarily a client error. The order's existing status is returned unchanged.

## Testing

Added to `services/payment-order/service/grpc_service_test.go`:
- `TestUpdatePaymentOrder_SettledAfterRejected_DoesNotPostLedger` - full REJECTED-then-late-SETTLED sequence; asserts no ledger calls and status remains FAILED.
- `TestUpdatePaymentOrder_SettledOnFailed_DoesNotPostLedger` - SETTLED directly against a FAILED order; asserts no ledger calls.
- `TestUpdatePaymentOrder_SettledOnCompleted_DoesNotPostLedgerAgain` - duplicate SETTLED on a COMPLETED order; asserts no additional ledger calls (regression guard on the existing idempotency branch).
- Existing `TestUpdatePaymentOrder_Settled` / `TestUpdatePaymentOrder_Settled_LienExecutionStatusTracking` continue to cover the SETTLED-on-EXECUTING happy path.

Verified the new tests fail against the pre-fix code (ledger posting is attempted and `po.Complete()` errors with `FailedPrecondition: cannot complete payment order in FAILED state`), confirming they exercise the bug.

```
go build ./...
go vet ./services/payment-order/...
go test ./services/payment-order/...
gofmt -l services/payment-order/service/grpc_update.go services/payment-order/service/grpc_service_test.go
golangci-lint run services/payment-order/service/...
```
All pass; golangci-lint has 23 pre-existing `goconst` findings in unrelated files, none introduced by this change.

## Risk Assessment

- Low risk, behavior-narrowing change: SETTLED callbacks for `EXECUTING` orders are unaffected (existing happy-path tests pass unchanged). The only behavior change is that SETTLED callbacks for non-EXECUTING orders no longer post ledger entries or attempt an invalid state transition - they are now logged and dropped.
- No schema or API changes.

## Deployment Notes

No migrations required. No config changes required.