### PR TITLE
fix: Harden API-key authentication cache and legacy key lookup

### DIFF
--- a/services/api-gateway/auth/apikey_middleware.go
+++ b/services/api-gateway/auth/apikey_middleware.go
@@ -3,6 +3,7 @@ package auth
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -255,8 +256,11 @@ func (m *APIKeyMiddleware) Handler(next http.Handler) http.Handler {
 			return
 		}
 
-		// Validate API key
-		identity, valid := m.config.APIKeys[apiKey]
+		// Validate API key using a constant-time comparison against every
+		// configured key. A plain map lookup is timing-attackable: the byte
+		// comparison short-circuits on the first mismatch, leaking how much of
+		// a guessed key matches a configured one.
+		identity, valid := m.lookupAPIKey(apiKey)
 		if !valid {
 			m.logger.Warn("invalid API key", "path", r.URL.Path)
 			writeJSONError(w, "invalid API key", http.StatusUnauthorized)
@@ -276,6 +280,32 @@ func (m *APIKeyMiddleware) Handler(next http.Handler) http.Handler {
 		ctx := context.WithValue(r.Context(), APIKeyIdentityKey, identity)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+// lookupAPIKey resolves an API key to its identity using a constant-time
+// comparison against every configured key.
+//
+// It deliberately avoids a map lookup (m.config.APIKeys[apiKey]) because the
+// underlying string comparison short-circuits on the first differing byte,
+// which leaks - via response timing - how many leading bytes of a guessed key
+// match a configured key, enabling byte-by-byte key recovery. Instead it
+// compares the presented key against all configured keys with
+// subtle.ConstantTimeCompare and does not break early, so the work performed is
+// independent of whether or where a match occurs.
+func (m *APIKeyMiddleware) lookupAPIKey(apiKey string) (string, bool) {
+	presented := []byte(apiKey)
+
+	var (
+		identity string
+		found    bool
+	)
+	for key, id := range m.config.APIKeys {
+		if subtle.ConstantTimeCompare(presented, []byte(key)) == 1 {
+			identity = id
+			found = true
+		}
+	}
+	return identity, found
 }
 
 // allowRequest checks if the request from the given API key should be allowed.

--- a/services/api-gateway/auth/apikey_middleware_test.go
+++ b/services/api-gateway/auth/apikey_middleware_test.go
@@ -533,8 +533,6 @@ func TestAPIKeyMiddleware_MultipleAPIKeys(t *testing.T) {
 	}
 }
 
-// TestAPIKeyMiddleware_ZeroConfigValues verifies that zero config values
-// are replaced with defaults.
 // TestAPIKeyMiddleware_ConstantTimeLookup verifies that the constant-time key
 // lookup returns the correct identity for exact matches and rejects near-misses
 // such as prefixes and superstrings of configured keys.
@@ -572,6 +570,8 @@ func TestAPIKeyMiddleware_ConstantTimeLookup(t *testing.T) {
 	}
 }
 
+// TestAPIKeyMiddleware_ZeroConfigValues verifies that zero config values
+// are replaced with defaults.
 func TestAPIKeyMiddleware_ZeroConfigValues(t *testing.T) {
 	config := APIKeyConfig{
 		APIKeys: map[string]string{"key": "identity"},

--- a/services/api-gateway/auth/apikey_middleware_test.go
+++ b/services/api-gateway/auth/apikey_middleware_test.go
@@ -535,6 +535,43 @@ func TestAPIKeyMiddleware_MultipleAPIKeys(t *testing.T) {
 
 // TestAPIKeyMiddleware_ZeroConfigValues verifies that zero config values
 // are replaced with defaults.
+// TestAPIKeyMiddleware_ConstantTimeLookup verifies that the constant-time key
+// lookup returns the correct identity for exact matches and rejects near-misses
+// such as prefixes and superstrings of configured keys.
+func TestAPIKeyMiddleware_ConstantTimeLookup(t *testing.T) {
+	config := DefaultAPIKeyConfig()
+	config.APIKeys = map[string]string{
+		"svc-payments-prod-abcdef":  "payments-service",
+		"svc-reporting-prod-123456": "reporting-service",
+	}
+
+	m := NewAPIKeyMiddleware(config)
+	defer m.Close()
+
+	tests := []struct {
+		name   string
+		key    string
+		wantID string
+		wantOK bool
+	}{
+		{"exact match first key", "svc-payments-prod-abcdef", "payments-service", true},
+		{"exact match second key", "svc-reporting-prod-123456", "reporting-service", true},
+		{"empty key", "", "", false},
+		{"unknown key", "totally-different", "", false},
+		{"prefix of a valid key", "svc-payments-prod", "", false},
+		{"superstring of a valid key", "svc-payments-prod-abcdefEXTRA", "", false},
+		{"valid key with trailing space", "svc-payments-prod-abcdef ", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, ok := m.lookupAPIKey(tt.key)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantID, id)
+		})
+	}
+}
+
 func TestAPIKeyMiddleware_ZeroConfigValues(t *testing.T) {
 	config := APIKeyConfig{
 		APIKeys: map[string]string{"key": "identity"},

--- a/services/api-gateway/auth/combined_middleware.go
+++ b/services/api-gateway/auth/combined_middleware.go
@@ -162,9 +162,9 @@ func (m *CombinedAuthMiddleware) handleRPCAPIKeyAuth(w http.ResponseWriter, r *h
 	}
 
 	// Check per-key rate limit using the rate_limit_rps from the validation
-	// result. The limiter is keyed on the exact full key so that distinct keys
-	// sharing a truncated prefix do not share a rate-limit bucket.
-	if !m.rpcValidator.AllowRequest(apiKey, result.RateLimitRPS) {
+	// result. The limiter is keyed on the HMAC index of the full key so that
+	// distinct keys sharing a truncated prefix do not share a rate-limit bucket.
+	if !m.rpcValidator.AllowRequest(apiKeyCacheIndex(apiKey), result.RateLimitRPS) {
 		m.logger.Warn("rate limit exceeded",
 			slog.String("identity", result.Identity),
 			slog.String("path", r.URL.Path),

--- a/services/api-gateway/auth/combined_middleware.go
+++ b/services/api-gateway/auth/combined_middleware.go
@@ -162,9 +162,9 @@ func (m *CombinedAuthMiddleware) handleRPCAPIKeyAuth(w http.ResponseWriter, r *h
 	}
 
 	// Check per-key rate limit using the rate_limit_rps from the validation
-	// result. The limiter is keyed on the full-key hash so that distinct keys
+	// result. The limiter is keyed on the exact full key so that distinct keys
 	// sharing a truncated prefix do not share a rate-limit bucket.
-	if !m.rpcValidator.AllowRequest(HashAPIKey(apiKey), result.RateLimitRPS) {
+	if !m.rpcValidator.AllowRequest(apiKey, result.RateLimitRPS) {
 		m.logger.Warn("rate limit exceeded",
 			slog.String("identity", result.Identity),
 			slog.String("path", r.URL.Path),

--- a/services/api-gateway/auth/combined_middleware.go
+++ b/services/api-gateway/auth/combined_middleware.go
@@ -161,9 +161,10 @@ func (m *CombinedAuthMiddleware) handleRPCAPIKeyAuth(w http.ResponseWriter, r *h
 		return
 	}
 
-	// Check per-key rate limit using the rate_limit_rps from the validation result
-	_, keyPrefix, _ := ParsePrefixedKey(apiKey)
-	if !m.rpcValidator.AllowRequest(keyPrefix, result.RateLimitRPS) {
+	// Check per-key rate limit using the rate_limit_rps from the validation
+	// result. The limiter is keyed on the full-key hash so that distinct keys
+	// sharing a truncated prefix do not share a rate-limit bucket.
+	if !m.rpcValidator.AllowRequest(HashAPIKey(apiKey), result.RateLimitRPS) {
 		m.logger.Warn("rate limit exceeded",
 			slog.String("identity", result.Identity),
 			slog.String("path", r.URL.Path),

--- a/services/api-gateway/auth/rpc_apikey_validator.go
+++ b/services/api-gateway/auth/rpc_apikey_validator.go
@@ -2,8 +2,6 @@ package auth
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -48,7 +46,7 @@ type RPCAPIKeyValidator struct {
 	cache    sync.Map // map[string]*cachedValidation
 	cacheTTL time.Duration
 
-	// Per-key rate limiters (keyed by the full-key hash for RPC-validated keys)
+	// Per-key rate limiters (keyed by the exact full key for RPC-validated keys)
 	limiters  sync.Map // map[string]*rpcRateLimiterEntry
 	stopCh    chan struct{}
 	wg        sync.WaitGroup
@@ -164,18 +162,6 @@ func ParsePrefixedKey(apiKey string) (tenantSlug, keyPrefix string, ok bool) {
 	return slug, prefix, true
 }
 
-// HashAPIKey returns a hex-encoded SHA-256 digest of the full API key.
-//
-// The validation cache and per-key rate limiters are keyed on this digest so
-// that entries are scoped to the exact key. Keying on the truncated key prefix
-// (pk_{slug}_{first 8 entropy chars}) would let a forged key that shares a
-// legitimate key's prefix read the legitimate key's cached validation result -
-// authenticating on the prefix alone - or poison it with a negative result.
-func HashAPIKey(apiKey string) string {
-	sum := sha256.Sum256([]byte(apiKey))
-	return hex.EncodeToString(sum[:])
-}
-
 // Validate validates an API key via the Control Plane RPC.
 // Returns the validation result if the key is in pk_{slug}_{...} format and valid.
 // Returns ErrNotPrefixedKey if the key format is not recognized (caller should fall back to legacy).
@@ -185,10 +171,12 @@ func (v *RPCAPIKeyValidator) Validate(ctx context.Context, apiKey string) (*APIK
 		return nil, ErrNotPrefixedKey
 	}
 
-	// Cache is keyed on a hash of the full key, not the truncated prefix, so a
+	// Cache is keyed on the exact full key, not the truncated prefix, so a
 	// forged key that shares a legitimate key's prefix cannot read (or poison)
-	// the legitimate key's cached result.
-	cacheKey := HashAPIKey(apiKey)
+	// the legitimate key's cached result. Exact-match keying gives perfect
+	// collision resistance without hashing the secret; entries are held in
+	// process memory only and expire after cacheTTL.
+	cacheKey := apiKey
 
 	// Check cache first
 	if cached := v.getCached(cacheKey); cached != nil {
@@ -223,7 +211,7 @@ func (v *RPCAPIKeyValidator) Validate(ctx context.Context, apiKey string) (*APIK
 	}
 
 	// Cache the result (even if invalid, to prevent brute force). The negative
-	// cache entry is scoped to the exact full-key hash, so it cannot affect any
+	// cache entry is scoped to the exact full key, so it cannot affect any
 	// other key that happens to share this key's prefix.
 	v.setCache(cacheKey, result)
 
@@ -231,8 +219,8 @@ func (v *RPCAPIKeyValidator) Validate(ctx context.Context, apiKey string) (*APIK
 }
 
 // AllowRequest checks if the given rate-limit key is within its rate limit.
-// The rate-limit key should be the full-key hash (see HashAPIKey) so that two
-// distinct keys sharing a truncated prefix do not share a rate-limit bucket.
+// The rate-limit key should be the exact full key so that two distinct keys
+// sharing a truncated prefix do not share a rate-limit bucket.
 func (v *RPCAPIKeyValidator) AllowRequest(rateKey string, rateLimitRPS int32) bool {
 	if rateLimitRPS <= 0 {
 		rateLimitRPS = 100 // default

--- a/services/api-gateway/auth/rpc_apikey_validator.go
+++ b/services/api-gateway/auth/rpc_apikey_validator.go
@@ -2,6 +2,10 @@ package auth
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -15,6 +19,37 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
+
+// apiKeyIndexSecret is a per-process random secret used to derive opaque cache
+// and rate-limiter indices from API keys via HMAC. It never leaves the process
+// and is regenerated on each start; the cache and limiters are in-memory only,
+// so a fresh secret per process is fine.
+var apiKeyIndexSecret = mustRandomBytes(32)
+
+func mustRandomBytes(n int) []byte {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("auth: failed to initialize API-key index secret: %v", err))
+	}
+	return b
+}
+
+// apiKeyCacheIndex derives an opaque, non-reversible index for the full API key
+// using HMAC-SHA-256 under a per-process secret.
+//
+// The validation cache and per-key rate limiters are keyed on this index so
+// that entries are scoped to the exact full key without retaining the plaintext
+// key in memory. Keying on the truncated prefix (pk_{slug}_{first 8 entropy
+// chars}) would let a forged key that shares a legitimate key's prefix read the
+// legitimate key's cached validation result - authenticating on the prefix
+// alone - or poison it with a negative result. This is a keyed MAC used purely
+// as an in-memory lookup index, not a password hash, and is never persisted or
+// logged.
+func apiKeyCacheIndex(apiKey string) string {
+	mac := hmac.New(sha256.New, apiKeyIndexSecret)
+	mac.Write([]byte(apiKey))
+	return hex.EncodeToString(mac.Sum(nil))
+}
 
 // ErrNotPrefixedKey is returned when the API key is not in the pk_{slug}_{entropy} format.
 // Callers should fall back to legacy API key validation.
@@ -46,7 +81,7 @@ type RPCAPIKeyValidator struct {
 	cache    sync.Map // map[string]*cachedValidation
 	cacheTTL time.Duration
 
-	// Per-key rate limiters (keyed by the exact full key for RPC-validated keys)
+	// Per-key rate limiters (keyed by an HMAC index of the full key, see apiKeyCacheIndex)
 	limiters  sync.Map // map[string]*rpcRateLimiterEntry
 	stopCh    chan struct{}
 	wg        sync.WaitGroup
@@ -171,12 +206,12 @@ func (v *RPCAPIKeyValidator) Validate(ctx context.Context, apiKey string) (*APIK
 		return nil, ErrNotPrefixedKey
 	}
 
-	// Cache is keyed on the exact full key, not the truncated prefix, so a
-	// forged key that shares a legitimate key's prefix cannot read (or poison)
-	// the legitimate key's cached result. Exact-match keying gives perfect
-	// collision resistance without hashing the secret; entries are held in
-	// process memory only and expire after cacheTTL.
-	cacheKey := apiKey
+	// Cache is keyed on an HMAC index of the full key, not the truncated prefix,
+	// so a forged key that shares a legitimate key's prefix cannot read (or
+	// poison) the legitimate key's cached result. The index binds to the exact
+	// full key without retaining the plaintext key in memory; entries are held
+	// in process memory only and expire after cacheTTL.
+	cacheKey := apiKeyCacheIndex(apiKey)
 
 	// Check cache first
 	if cached := v.getCached(cacheKey); cached != nil {
@@ -211,16 +246,17 @@ func (v *RPCAPIKeyValidator) Validate(ctx context.Context, apiKey string) (*APIK
 	}
 
 	// Cache the result (even if invalid, to prevent brute force). The negative
-	// cache entry is scoped to the exact full key, so it cannot affect any
-	// other key that happens to share this key's prefix.
+	// cache entry is scoped to the exact full key's index, so it cannot affect
+	// any other key that happens to share this key's prefix.
 	v.setCache(cacheKey, result)
 
 	return result, nil
 }
 
 // AllowRequest checks if the given rate-limit key is within its rate limit.
-// The rate-limit key should be the exact full key so that two distinct keys
-// sharing a truncated prefix do not share a rate-limit bucket.
+// The rate-limit key should be the HMAC index of the full key (see
+// apiKeyCacheIndex) so that two distinct keys sharing a truncated prefix do not
+// share a rate-limit bucket.
 func (v *RPCAPIKeyValidator) AllowRequest(rateKey string, rateLimitRPS int32) bool {
 	if rateLimitRPS <= 0 {
 		rateLimitRPS = 100 // default

--- a/services/api-gateway/auth/rpc_apikey_validator.go
+++ b/services/api-gateway/auth/rpc_apikey_validator.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -46,7 +48,7 @@ type RPCAPIKeyValidator struct {
 	cache    sync.Map // map[string]*cachedValidation
 	cacheTTL time.Duration
 
-	// Per-key rate limiters (keyed by API key prefix for RPC-validated keys)
+	// Per-key rate limiters (keyed by the full-key hash for RPC-validated keys)
 	limiters  sync.Map // map[string]*rpcRateLimiterEntry
 	stopCh    chan struct{}
 	wg        sync.WaitGroup
@@ -162,6 +164,18 @@ func ParsePrefixedKey(apiKey string) (tenantSlug, keyPrefix string, ok bool) {
 	return slug, prefix, true
 }
 
+// HashAPIKey returns a hex-encoded SHA-256 digest of the full API key.
+//
+// The validation cache and per-key rate limiters are keyed on this digest so
+// that entries are scoped to the exact key. Keying on the truncated key prefix
+// (pk_{slug}_{first 8 entropy chars}) would let a forged key that shares a
+// legitimate key's prefix read the legitimate key's cached validation result -
+// authenticating on the prefix alone - or poison it with a negative result.
+func HashAPIKey(apiKey string) string {
+	sum := sha256.Sum256([]byte(apiKey))
+	return hex.EncodeToString(sum[:])
+}
+
 // Validate validates an API key via the Control Plane RPC.
 // Returns the validation result if the key is in pk_{slug}_{...} format and valid.
 // Returns ErrNotPrefixedKey if the key format is not recognized (caller should fall back to legacy).
@@ -171,8 +185,13 @@ func (v *RPCAPIKeyValidator) Validate(ctx context.Context, apiKey string) (*APIK
 		return nil, ErrNotPrefixedKey
 	}
 
+	// Cache is keyed on a hash of the full key, not the truncated prefix, so a
+	// forged key that shares a legitimate key's prefix cannot read (or poison)
+	// the legitimate key's cached result.
+	cacheKey := HashAPIKey(apiKey)
+
 	// Check cache first
-	if cached := v.getCached(keyPrefix); cached != nil {
+	if cached := v.getCached(cacheKey); cached != nil {
 		return cached, nil
 	}
 
@@ -203,21 +222,25 @@ func (v *RPCAPIKeyValidator) Validate(ctx context.Context, apiKey string) (*APIK
 		RateLimitRPS: resp.GetRateLimitRps(),
 	}
 
-	// Cache the result (even if invalid, to prevent brute force)
-	v.setCache(keyPrefix, result)
+	// Cache the result (even if invalid, to prevent brute force). The negative
+	// cache entry is scoped to the exact full-key hash, so it cannot affect any
+	// other key that happens to share this key's prefix.
+	v.setCache(cacheKey, result)
 
 	return result, nil
 }
 
-// AllowRequest checks if the given key prefix is within its rate limit.
-func (v *RPCAPIKeyValidator) AllowRequest(keyPrefix string, rateLimitRPS int32) bool {
+// AllowRequest checks if the given rate-limit key is within its rate limit.
+// The rate-limit key should be the full-key hash (see HashAPIKey) so that two
+// distinct keys sharing a truncated prefix do not share a rate-limit bucket.
+func (v *RPCAPIKeyValidator) AllowRequest(rateKey string, rateLimitRPS int32) bool {
 	if rateLimitRPS <= 0 {
 		rateLimitRPS = 100 // default
 	}
 
 	now := time.Now()
 
-	value, loaded := v.limiters.Load(keyPrefix)
+	value, loaded := v.limiters.Load(rateKey)
 	if loaded {
 		entry, ok := value.(*rpcRateLimiterEntry)
 		if !ok {
@@ -235,7 +258,7 @@ func (v *RPCAPIKeyValidator) AllowRequest(keyPrefix string, rateLimitRPS int32) 
 		lastAccess: now,
 	}
 
-	actual, loaded := v.limiters.LoadOrStore(keyPrefix, entry)
+	actual, loaded := v.limiters.LoadOrStore(rateKey, entry)
 	if loaded {
 		existingEntry, ok := actual.(*rpcRateLimiterEntry)
 		if !ok {

--- a/services/api-gateway/auth/rpc_apikey_validator_test.go
+++ b/services/api-gateway/auth/rpc_apikey_validator_test.go
@@ -107,6 +107,18 @@ func (m *mockAuthServiceClient) ValidateAPIKey(_ context.Context, _ *controlplan
 	return m.response, m.err
 }
 
+// funcAuthServiceClient is a mock that computes its response from the request,
+// allowing tests to distinguish between different plaintext keys.
+type funcAuthServiceClient struct {
+	fn        func(req *controlplanev1.ValidateAPIKeyRequest) (*controlplanev1.ValidateAPIKeyResponse, error)
+	callCount atomic.Int32
+}
+
+func (m *funcAuthServiceClient) ValidateAPIKey(_ context.Context, req *controlplanev1.ValidateAPIKeyRequest, _ ...grpc.CallOption) (*controlplanev1.ValidateAPIKeyResponse, error) {
+	m.callCount.Add(1)
+	return m.fn(req)
+}
+
 // mockSlugResolver is a mock for the SlugResolver interface.
 type mockSlugResolver struct {
 	tenantID tenant.TenantID
@@ -240,6 +252,90 @@ func TestRPCAPIKeyValidator_Validate(t *testing.T) {
 		_, err := v.Validate(context.Background(), "pk_acme_abc12345xyz67890abcdef")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "resolve tenant slug")
+	})
+}
+
+// TestRPCAPIKeyValidator_CacheKeyedOnFullKey verifies that the validation cache
+// is keyed on a hash of the full key rather than the truncated prefix. Two keys
+// that share the same pk_{slug}_{first 8 entropy chars} prefix must not collide.
+func TestRPCAPIKeyValidator_CacheKeyedOnFullKey(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Both keys share the prefix "pk_acme_abc12345".
+	const legitKey = "pk_acme_abc12345LEGITIMATEKEY"
+	const forgedKey = "pk_acme_abc12345FORGEDKEYVALUE"
+
+	// Sanity check: the two keys really do share the truncated prefix.
+	_, legitPrefix, ok := ParsePrefixedKey(legitKey)
+	require.True(t, ok)
+	_, forgedPrefix, ok := ParsePrefixedKey(forgedKey)
+	require.True(t, ok)
+	require.Equal(t, legitPrefix, forgedPrefix, "test keys must share the truncated prefix")
+
+	t.Run("distinct keys sharing a prefix do not collide in cache", func(t *testing.T) {
+		client := &funcAuthServiceClient{
+			fn: func(req *controlplanev1.ValidateAPIKeyRequest) (*controlplanev1.ValidateAPIKeyResponse, error) {
+				return &controlplanev1.ValidateAPIKeyResponse{
+					Valid:    req.GetPlaintextKey() == legitKey,
+					TenantId: "test_tenant",
+					Identity: "Alice",
+				}, nil
+			},
+		}
+		resolver := &mockSlugResolver{tenantID: tenant.MustNewTenantID("test_tenant")}
+
+		v := NewRPCAPIKeyValidator(RPCValidatorConfig{
+			Client:       client,
+			SlugResolver: resolver,
+			CacheTTL:     5 * time.Minute,
+			Logger:       logger,
+		})
+		defer v.Close()
+
+		// Validate the legitimate key: valid, and cached.
+		res, err := v.Validate(context.Background(), legitKey)
+		require.NoError(t, err)
+		assert.True(t, res.Valid)
+
+		// The forged key shares the prefix but is a different full key. With
+		// prefix-based caching it would collide and read the legitimate result.
+		res, err = v.Validate(context.Background(), forgedKey)
+		require.NoError(t, err)
+		assert.False(t, res.Valid, "forged key sharing a prefix must not authenticate from cache")
+
+		// Both keys must have triggered their own RPC validation.
+		assert.Equal(t, int32(2), client.callCount.Load())
+	})
+
+	t.Run("negative cache entry does not poison a legitimate key", func(t *testing.T) {
+		client := &funcAuthServiceClient{
+			fn: func(req *controlplanev1.ValidateAPIKeyRequest) (*controlplanev1.ValidateAPIKeyResponse, error) {
+				return &controlplanev1.ValidateAPIKeyResponse{
+					Valid:    req.GetPlaintextKey() == legitKey,
+					TenantId: "test_tenant",
+					Identity: "Alice",
+				}, nil
+			},
+		}
+		resolver := &mockSlugResolver{tenantID: tenant.MustNewTenantID("test_tenant")}
+
+		v := NewRPCAPIKeyValidator(RPCValidatorConfig{
+			Client:       client,
+			SlugResolver: resolver,
+			CacheTTL:     5 * time.Minute,
+			Logger:       logger,
+		})
+		defer v.Close()
+
+		// A forged key sharing the prefix is validated first and cached as invalid.
+		res, err := v.Validate(context.Background(), forgedKey)
+		require.NoError(t, err)
+		assert.False(t, res.Valid)
+
+		// The legitimate key must not inherit the negative cache entry.
+		res, err = v.Validate(context.Background(), legitKey)
+		require.NoError(t, err)
+		assert.True(t, res.Valid, "legitimate key must not be poisoned by a forged key's negative cache entry")
 	})
 }
 


### PR DESCRIPTION
## Summary

Hardens API-key authentication in the api-gateway across two related issues in `services/api-gateway/auth/`:

- **SEC-3 (HIGH):** The RPC API-key validation cache was keyed on the truncated key prefix (`pk_{slug}_{first 8 entropy chars}`) rather than the full key. Two distinct full keys that shared a prefix collided in the cache, so a cached validation result could be returned for a key whose full plaintext was never verified.
- **LOW-8:** The legacy env-var API-key middleware resolved keys with a plain map lookup, whose underlying byte comparison short-circuits on the first mismatch and is therefore timing-attackable.

## Changes Made

- `rpc_apikey_validator.go`
  - Added `apiKeyCacheIndex`, which derives an opaque, non-reversible index for the full key using HMAC-SHA-256 under a per-process random secret.
  - The validation cache (both positive and negative entries) is now keyed on `apiKeyCacheIndex(fullKey)`, scoping each entry to the exact key without retaining the plaintext key in memory.
  - `AllowRequest` is documented to take the full-key index as its rate-limit key; the `keyPrefix` parameter was renamed to `rateKey`.
- `combined_middleware.go`
  - The per-key rate limiter is now keyed on `apiKeyCacheIndex(apiKey)` instead of the truncated prefix, so distinct keys sharing a prefix no longer share a rate-limit bucket.
- `apikey_middleware.go`
  - Added `lookupAPIKey`, which resolves an API key to its identity using `subtle.ConstantTimeCompare` against every configured key, iterating without an early exit.
  - The handler now uses `lookupAPIKey` in place of the direct map lookup.

## Technical Details

- The cache index is an HMAC-SHA-256 keyed MAC, so a prefix collision no longer produces a cache collision; a cache hit requires the exact full key. Negative cache entries are likewise scoped to the exact full-key index and cannot affect any other key sharing the prefix. Using a keyed MAC (rather than a bare hash or the plaintext key) binds the index to the exact key without storing the plaintext secret; the secret is per-process, in-memory only, and never persisted or logged.
- `subtle.ConstantTimeCompare` returns 0 for length mismatches and performs a constant-time comparison for equal-length inputs. The lookup compares against all configured keys and never breaks early, so the work performed is independent of whether or where a match occurs.
- The legacy env-var API-key path remains live (wired from the `API_KEYS` env var via `auth_builder.go` and documented in the service README), so it was hardened rather than removed.

## Testing

- Added `TestRPCAPIKeyValidator_CacheKeyedOnFullKey`: two full keys sharing a prefix each trigger their own validation and do not collide; a negative cache entry for one key does not poison another key sharing the prefix. These tests fail against the previous prefix-keyed cache and pass with the fix.
- Added `TestAPIKeyMiddleware_ConstantTimeLookup`: exact matches resolve to the correct identity; prefixes, superstrings, trailing-whitespace variants, empty, and unknown keys are rejected.
- `go test ./services/api-gateway/...` passes; `go vet`, `gofumpt`, and `golangci-lint` clean.

## Risk Assessment

- Low. The cache and rate-limiter index derivations are internal; external key formats and the validation contract are unchanged. Existing behaviour (caching, TTL, rate limiting, fallback to legacy keys) is preserved. The constant-time lookup is functionally equivalent to the previous map lookup for correct keys.

## Deployment Notes

- No configuration or schema changes. No migrations. The per-process index secret is generated at startup; cache entries are transparently repopulated under the new index derivation on next validation.
