### PR TITLE
fix: Aggregate account balance across all position logs (MON-1)

### DIFF
--- a/services/position-keeping/adapters/persistence/position_log_read.go
+++ b/services/position-keeping/adapters/persistence/position_log_read.go
@@ -149,6 +149,90 @@ func (r *PostgresRepository) FindByAccountID(ctx context.Context, accountID stri
 	return result, nil
 }
 
+// SumAccountBalances aggregates the net transaction movement across ALL
+// FinancialPositionLogs for an account using a single SQL aggregate query,
+// grouped by instrument. This avoids loading every log (with its entries,
+// lineage, and audit trail) into memory on the balance read hot path.
+//
+// Net movement per instrument is Σ(DEBIT amount_cents) − Σ(CREDIT amount_cents)
+// summed at the database. The bool return reports whether the account has any
+// (non-deleted) position log, so callers can distinguish a missing account from
+// an account with logs but no entries (a zero balance).
+//
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
+func (r *PostgresRepository) SumAccountBalances(ctx context.Context, accountID string) ([]domain.AccountInstrumentBalance, bool, error) {
+	var balances []domain.AccountInstrumentBalance
+	var hasLogs bool
+
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		// Determine whether the account has any position logs at all. This is
+		// what distinguishes "account not found" from "account with a zero
+		// balance" (a log may exist with no entries, e.g. a zero opening balance).
+		existsQuery := `
+			SELECT EXISTS (
+				SELECT 1 FROM financial_position_log
+				WHERE account_id = $1 AND deleted_at IS NULL
+			)`
+		if err := tx.QueryRow(ctx, existsQuery, accountID).Scan(&hasLogs); err != nil {
+			return fmt.Errorf("failed to check account log existence: %w", err)
+		}
+		if !hasLogs {
+			return nil
+		}
+
+		// Aggregate the signed net movement per instrument across every entry of
+		// every log belonging to the account. DEBIT increases the balance,
+		// CREDIT decreases it (matching domain.BalanceComputer.sumEntries).
+		sumQuery := `
+			SELECT e.currency,
+				COALESCE(SUM(
+					CASE
+						WHEN e.direction = 'DEBIT' THEN e.amount_cents
+						WHEN e.direction = 'CREDIT' THEN -e.amount_cents
+						ELSE 0
+					END
+				), 0) AS net_cents
+			FROM transaction_log_entry e
+			JOIN financial_position_log l ON l.id = e.financial_position_log_id
+			WHERE l.account_id = $1
+				AND l.deleted_at IS NULL
+				AND e.deleted_at IS NULL
+			GROUP BY e.currency
+			ORDER BY e.currency`
+
+		rows, err := tx.Query(ctx, sumQuery, accountID)
+		if err != nil {
+			return fmt.Errorf("failed to aggregate account balances: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var currency string
+			var netCents int64
+			if err := rows.Scan(&currency, &netCents); err != nil {
+				return fmt.Errorf("failed to scan account balance aggregate: %w", err)
+			}
+
+			netMovement, err := domain.NewMoneyFromInstrumentCode(centsToDecimal(netCents), currency)
+			if err != nil {
+				return fmt.Errorf("failed to build aggregated money for instrument %q: %w", currency, err)
+			}
+
+			balances = append(balances, domain.AccountInstrumentBalance{
+				Instrument:  netMovement.Instrument,
+				NetMovement: netMovement,
+			})
+		}
+
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, false, err
+	}
+
+	return balances, hasLogs, nil
+}
+
 // List retrieves FinancialPositionLogs matching the given filter with pagination.
 // In multi-tenant mode, the context must contain the tenant ID for schema routing.
 func (r *PostgresRepository) List(ctx context.Context, filter domain.PositionLogFilter) ([]*domain.FinancialPositionLog, error) {

--- a/services/position-keeping/adapters/persistence/position_log_read.go
+++ b/services/position-keeping/adapters/persistence/position_log_read.go
@@ -165,72 +165,89 @@ func (r *PostgresRepository) SumAccountBalances(ctx context.Context, accountID s
 	var hasLogs bool
 
 	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
-		// Determine whether the account has any position logs at all. This is
-		// what distinguishes "account not found" from "account with a zero
-		// balance" (a log may exist with no entries, e.g. a zero opening balance).
-		existsQuery := `
-			SELECT EXISTS (
-				SELECT 1 FROM financial_position_log
-				WHERE account_id = $1 AND deleted_at IS NULL
-			)`
-		if err := tx.QueryRow(ctx, existsQuery, accountID).Scan(&hasLogs); err != nil {
-			return fmt.Errorf("failed to check account log existence: %w", err)
+		var txErr error
+		hasLogs, txErr = accountHasLogs(ctx, tx, accountID)
+		if txErr != nil {
+			return txErr
 		}
 		if !hasLogs {
 			return nil
 		}
 
-		// Aggregate the signed net movement per instrument across every entry of
-		// every log belonging to the account. DEBIT increases the balance,
-		// CREDIT decreases it (matching domain.BalanceComputer.sumEntries).
-		sumQuery := `
-			SELECT e.currency,
-				COALESCE(SUM(
-					CASE
-						WHEN e.direction = 'DEBIT' THEN e.amount_cents
-						WHEN e.direction = 'CREDIT' THEN -e.amount_cents
-						ELSE 0
-					END
-				), 0) AS net_cents
-			FROM transaction_log_entry e
-			JOIN financial_position_log l ON l.id = e.financial_position_log_id
-			WHERE l.account_id = $1
-				AND l.deleted_at IS NULL
-				AND e.deleted_at IS NULL
-			GROUP BY e.currency
-			ORDER BY e.currency`
-
-		rows, err := tx.Query(ctx, sumQuery, accountID)
-		if err != nil {
-			return fmt.Errorf("failed to aggregate account balances: %w", err)
-		}
-		defer rows.Close()
-
-		for rows.Next() {
-			var currency string
-			var netCents int64
-			if err := rows.Scan(&currency, &netCents); err != nil {
-				return fmt.Errorf("failed to scan account balance aggregate: %w", err)
-			}
-
-			netMovement, err := domain.NewMoneyFromInstrumentCode(centsToDecimal(netCents), currency)
-			if err != nil {
-				return fmt.Errorf("failed to build aggregated money for instrument %q: %w", currency, err)
-			}
-
-			balances = append(balances, domain.AccountInstrumentBalance{
-				Instrument:  netMovement.Instrument,
-				NetMovement: netMovement,
-			})
-		}
-
-		return rows.Err()
+		balances, txErr = aggregateAccountBalances(ctx, tx, accountID)
+		return txErr
 	})
 	if err != nil {
 		return nil, false, err
 	}
 
 	return balances, hasLogs, nil
+}
+
+// accountHasLogs reports whether the account has at least one non-deleted
+// position log. This distinguishes "account not found" from "account with a
+// zero balance" (a log may exist with no entries, e.g. a zero opening balance).
+func accountHasLogs(ctx context.Context, tx pgx.Tx, accountID string) (bool, error) {
+	query := `
+		SELECT EXISTS (
+			SELECT 1 FROM financial_position_log
+			WHERE account_id = $1 AND deleted_at IS NULL
+		)`
+
+	var hasLogs bool
+	if err := tx.QueryRow(ctx, query, accountID).Scan(&hasLogs); err != nil {
+		return false, fmt.Errorf("failed to check account log existence: %w", err)
+	}
+	return hasLogs, nil
+}
+
+// aggregateAccountBalances sums the signed net movement per instrument across
+// every entry of every log belonging to the account. DEBIT increases the
+// balance, CREDIT decreases it (matching domain.BalanceComputer.sumEntries).
+func aggregateAccountBalances(ctx context.Context, tx pgx.Tx, accountID string) ([]domain.AccountInstrumentBalance, error) {
+	query := `
+		SELECT e.currency,
+			COALESCE(SUM(
+				CASE
+					WHEN e.direction = 'DEBIT' THEN e.amount_cents
+					WHEN e.direction = 'CREDIT' THEN -e.amount_cents
+					ELSE 0
+				END
+			), 0) AS net_cents
+		FROM transaction_log_entry e
+		JOIN financial_position_log l ON l.id = e.financial_position_log_id
+		WHERE l.account_id = $1
+			AND l.deleted_at IS NULL
+			AND e.deleted_at IS NULL
+		GROUP BY e.currency
+		ORDER BY e.currency`
+
+	rows, err := tx.Query(ctx, query, accountID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate account balances: %w", err)
+	}
+	defer rows.Close()
+
+	var balances []domain.AccountInstrumentBalance
+	for rows.Next() {
+		var currency string
+		var netCents int64
+		if err := rows.Scan(&currency, &netCents); err != nil {
+			return nil, fmt.Errorf("failed to scan account balance aggregate: %w", err)
+		}
+
+		netMovement, err := domain.NewMoneyFromInstrumentCode(centsToDecimal(netCents), currency)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build aggregated money for instrument %q: %w", currency, err)
+		}
+
+		balances = append(balances, domain.AccountInstrumentBalance{
+			Instrument:  netMovement.Instrument,
+			NetMovement: netMovement,
+		})
+	}
+
+	return balances, rows.Err()
 }
 
 // List retrieves FinancialPositionLogs matching the given filter with pagination.

--- a/services/position-keeping/adapters/persistence/postgres_repository_test.go
+++ b/services/position-keeping/adapters/persistence/postgres_repository_test.go
@@ -371,6 +371,40 @@ func TestPostgresRepository_FindByAccountID(t *testing.T) {
 	assert.Equal(t, 0, len(logs))
 }
 
+func TestPostgresRepository_SumAccountBalances(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+
+	// Two logs for the same account, each a single DEBIT of 100.50 GBP.
+	// The aggregate must sum both logs: 100.50 + 100.50 = 201.00.
+	log1 := createTestLog(t, testAccountID)
+	log2 := createTestLog(t, testAccountID)
+	otherLog := createTestLog(t, "GB33BUKB20201555555556")
+
+	require.NoError(t, tc.repo.Create(ctx, log1))
+	require.NoError(t, tc.repo.Create(ctx, log2))
+	require.NoError(t, tc.repo.Create(ctx, otherLog))
+
+	t.Run("aggregates net movement across all logs for the account", func(t *testing.T) {
+		balances, hasLogs, err := tc.repo.SumAccountBalances(ctx, testAccountID)
+		require.NoError(t, err)
+		assert.True(t, hasLogs)
+		require.Len(t, balances, 1)
+		assert.Equal(t, string(domain.CurrencyGBP), balances[0].Instrument.Code)
+		assert.True(t, balances[0].NetMovement.Amount.Equal(decimal.NewFromInt(201)),
+			"net movement = %s, want 201", balances[0].NetMovement.Amount)
+	})
+
+	t.Run("account with no logs reports hasLogs=false", func(t *testing.T) {
+		balances, hasLogs, err := tc.repo.SumAccountBalances(ctx, "GB33BUKB20201555555999")
+		require.NoError(t, err)
+		assert.False(t, hasLogs)
+		assert.Empty(t, balances)
+	})
+}
+
 func TestPostgresRepository_Update(t *testing.T) {
 	tc := setupTestContainer(t)
 	defer tc.cleanup(t)

--- a/services/position-keeping/domain/repository.go
+++ b/services/position-keeping/domain/repository.go
@@ -43,6 +43,23 @@ type FinancialPositionLogRepository interface {
 	// Returns an empty slice if no logs exist for the account.
 	FindByAccountID(ctx context.Context, accountID string) ([]*FinancialPositionLog, error)
 
+	// SumAccountBalances aggregates the net transaction movement across ALL
+	// FinancialPositionLogs for an account, computed in a single database
+	// aggregate query rather than by loading every log into memory.
+	//
+	// For each instrument held by the account it returns the net movement,
+	// defined as the sum of DEBIT entry amounts minus the sum of CREDIT entry
+	// amounts across every (non-deleted) entry in every (non-deleted) log. This
+	// is the authoritative account balance because opening balances are stored
+	// as transaction entries and are therefore already included in the sum.
+	//
+	// The returned slice contains one entry per instrument that has transaction
+	// entries. The bool return value reports whether the account has at least
+	// one position log at all, allowing callers to distinguish "account not
+	// found" (no logs) from "account exists with a zero balance" (logs but no
+	// entries).
+	SumAccountBalances(ctx context.Context, accountID string) ([]AccountInstrumentBalance, bool, error)
+
 	// Update updates an existing FinancialPositionLog.
 	// Uses optimistic locking via the Version field.
 	// Returns ErrNotFound if the log doesn't exist.
@@ -69,6 +86,17 @@ type FinancialPositionLogRepository interface {
 	// This is a specialized query for batch reconciliation processes.
 	// The limit parameter controls the maximum number of logs returned (0 = no limit).
 	FindPendingForReconciliation(ctx context.Context, limit int) ([]*FinancialPositionLog, error)
+}
+
+// AccountInstrumentBalance is the net transaction movement for a single
+// instrument, aggregated across all of an account's FinancialPositionLogs.
+//
+// NetMovement is Σ(DEBIT) − Σ(CREDIT) over every transaction entry recorded
+// for the account in the given instrument. It is a signed value: positive when
+// debits exceed credits, negative otherwise.
+type AccountInstrumentBalance struct {
+	Instrument  Instrument
+	NetMovement Money
 }
 
 // PositionLogFilter defines filtering and pagination options for listing financial position logs.

--- a/services/position-keeping/service/balance.go
+++ b/services/position-keeping/service/balance.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -43,20 +44,9 @@ func (s *PositionKeepingService) GetAccountBalance(
 		return nil, status.Errorf(codes.InvalidArgument, "invalid balance_type: %v", err)
 	}
 
-	log, openingBalance, currency, err := s.loadLogForBalance(ctx, req.GetAccountId())
+	lbc, err := s.loadBalanceComputer(ctx, req.GetAccountId(), req.GetInstrumentCode())
 	if err != nil {
 		return nil, err
-	}
-
-	if req.GetInstrumentCode() != "" {
-		if currency.Code != req.GetInstrumentCode() {
-			return nil, status.Errorf(codes.NotFound, "no balance found for instrument: %s", req.GetInstrumentCode())
-		}
-	}
-
-	lbc, err := domain.NewLogBalanceComputer(log, openingBalance, s.currentAccountClient)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to create balance computer: %v", err)
 	}
 
 	balance, err := s.computeBalance(ctx, lbc, balanceType)
@@ -84,20 +74,9 @@ func (s *PositionKeepingService) GetAccountBalances(
 		return nil, status.Errorf(codes.InvalidArgument, "account_id is required")
 	}
 
-	log, openingBalance, currency, err := s.loadLogForBalance(ctx, req.GetAccountId())
+	lbc, err := s.loadBalanceComputer(ctx, req.GetAccountId(), req.GetInstrumentCode())
 	if err != nil {
 		return nil, err
-	}
-
-	if req.GetInstrumentCode() != "" {
-		if currency.Code != req.GetInstrumentCode() {
-			return nil, status.Errorf(codes.NotFound, "no balances found for instrument: %s", req.GetInstrumentCode())
-		}
-	}
-
-	lbc, err := domain.NewLogBalanceComputer(log, openingBalance, s.currentAccountClient)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to create balance computer: %v", err)
 	}
 
 	asOf := time.Now().UTC()
@@ -123,43 +102,117 @@ func (s *PositionKeepingService) GetAccountBalances(
 	}, nil
 }
 
-// loadLogForBalance loads the first position log for an account and resolves
-// the opening balance for balance computation. Returns a gRPC status error on failure.
-func (s *PositionKeepingService) loadLogForBalance(
+// loadBalanceComputer aggregates the account's net transaction movement across
+// ALL of its position logs and returns a LogBalanceComputer that computes every
+// BIAN balance type over the aggregated position.
+//
+// Each account transaction (deposit, withdrawal, settlement, ...) is recorded as
+// a separate FinancialPositionLog, so a correct balance must sum every entry of
+// every log - not just the most recent log. The summation is performed by the
+// repository as a single SQL aggregate query (the balance read hot path) and
+// materialized here as a synthetic single-entry log so the existing
+// LogBalanceComputer logic is reused unchanged.
+func (s *PositionKeepingService) loadBalanceComputer(
 	ctx context.Context,
 	accountID string,
-) (*domain.FinancialPositionLog, domain.Money, domain.Instrument, error) {
-	logs, err := s.repository.FindByAccountID(ctx, accountID)
+	instrumentCode string,
+) (*domain.LogBalanceComputer, error) {
+	balances, hasLogs, err := s.repository.SumAccountBalances(ctx, accountID)
 	if err != nil {
-		if errors.Is(err, domain.ErrNotFound) {
-			return nil, domain.Money{}, domain.Instrument{}, status.Errorf(codes.NotFound, "account not found: %s", accountID)
-		}
-		return nil, domain.Money{}, domain.Instrument{}, status.Errorf(codes.Internal, "failed to retrieve position logs: %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to aggregate account balances: %v", err)
 	}
 
-	if len(logs) == 0 {
-		return nil, domain.Money{}, domain.Instrument{}, status.Errorf(codes.NotFound, "no position logs found for account: %s", accountID)
+	if !hasLogs {
+		return nil, status.Errorf(codes.NotFound, "no position logs found for account: %s", accountID)
 	}
 
-	log := logs[0]
-	openingBalance, currency := resolveOpeningBalance(log)
-	return log, openingBalance, currency, nil
+	netMovement, err := resolveAggregateInstrument(balances, instrumentCode)
+	if err != nil {
+		return nil, err
+	}
+
+	aggregateLog, err := buildAggregateLog(accountID, netMovement)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to build aggregate position log: %v", err)
+	}
+
+	// The opening balance passed to the computer is ZERO: opening balances are
+	// recorded as transaction entries and are therefore already included in the
+	// aggregated net movement. The instrument carries through so that a zero
+	// balance still reports the correct instrument.
+	openingBalance := domain.NewQty[domain.Monetary](decimal.Zero, netMovement.Instrument)
+
+	lbc, err := domain.NewLogBalanceComputer(aggregateLog, openingBalance, s.currentAccountClient)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to create balance computer: %v", err)
+	}
+
+	return lbc, nil
 }
 
-// resolveOpeningBalance determines the opening balance and currency for balance computation.
-// If the log was created with NewFinancialPositionLogWithOpeningBalance, the opening balance
-// is already represented by a transaction entry, so we return ZERO to avoid double-counting.
-func resolveOpeningBalance(log *domain.FinancialPositionLog) (domain.Money, domain.Instrument) {
-	if log.HasOpeningBalance() {
-		currency := log.OpeningBalance.Instrument
-		return domain.NewQty[domain.Monetary](decimal.Zero, currency), currency
+// resolveAggregateInstrument selects the aggregated net movement for the balance
+// query. When instrumentCode is provided, the matching instrument's movement is
+// returned (or NotFound if the account holds no balance in that instrument).
+// When instrumentCode is empty, the account must hold exactly one instrument; a
+// multi-instrument account requires the caller to disambiguate.
+func resolveAggregateInstrument(
+	balances []domain.AccountInstrumentBalance,
+	instrumentCode string,
+) (domain.Money, error) {
+	if instrumentCode != "" {
+		for _, b := range balances {
+			if b.Instrument.Code == instrumentCode {
+				return b.NetMovement, nil
+			}
+		}
+		return domain.Money{}, status.Errorf(codes.NotFound, "no balance found for instrument: %s", instrumentCode)
 	}
-	if len(log.TransactionLogEntries) > 0 {
-		currency := log.TransactionLogEntries[0].Amount.Instrument
-		return domain.NewQty[domain.Monetary](decimal.Zero, currency), currency
+
+	switch len(balances) {
+	case 0:
+		// The account has logs but no transaction entries (e.g. a zero opening
+		// balance). Report a zero balance in the platform default instrument.
+		return domain.MustNewMoney(decimal.Zero, domain.CurrencyGBP), nil
+	case 1:
+		return balances[0].NetMovement, nil
+	default:
+		return domain.Money{}, status.Errorf(codes.InvalidArgument, "account holds multiple instruments; instrument_code is required")
 	}
-	openingBalance := domain.MustNewMoney(decimal.Zero, domain.CurrencyGBP)
-	return openingBalance, openingBalance.Instrument
+}
+
+// buildAggregateLog constructs a synthetic FinancialPositionLog whose net
+// movement equals the aggregated movement across all of the account's logs. A
+// positive movement is represented as a single DEBIT entry, a negative movement
+// as a single CREDIT entry, and a zero movement as a log with no entries. This
+// lets the existing LogBalanceComputer derive every BIAN balance type from one
+// representative position.
+func buildAggregateLog(accountID string, netMovement domain.Money) (*domain.FinancialPositionLog, error) {
+	if netMovement.IsZero() {
+		return domain.NewFinancialPositionLog(accountID, nil, nil)
+	}
+
+	direction := domain.PostingDirectionDebit
+	amount := netMovement
+	if netMovement.IsNegative() {
+		direction = domain.PostingDirectionCredit
+		amount = netMovement.Negate()
+	}
+
+	entry, err := domain.NewTransactionLogEntry(
+		uuid.New(),
+		accountID,
+		amount,
+		direction,
+		time.Now().UTC(),
+		"aggregated net movement",
+		"",
+		domain.TransactionSourceManual,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return domain.NewFinancialPositionLog(accountID, entry, nil)
 }
 
 // computeBalance computes the specified balance type using the LogBalanceComputer.

--- a/services/position-keeping/service/balance_integration_test.go
+++ b/services/position-keeping/service/balance_integration_test.go
@@ -417,6 +417,136 @@ func TestIntegration_GetAccountBalance_AllBalanceTypes(t *testing.T) {
 	}
 }
 
+// createSingleEntryLog persists a new position log containing exactly one
+// transaction entry, mirroring how current-account records every deposit or
+// withdrawal as its own FinancialPositionLog.
+func createSingleEntryLog(
+	t *testing.T,
+	ctx context.Context,
+	repo *persistence.PostgresRepository,
+	accountID string,
+	amount int64,
+	direction domain.PostingDirection,
+	currency domain.Currency,
+	reference string,
+) {
+	t.Helper()
+
+	entry, err := domain.NewTransactionLogEntry(
+		uuid.New(),
+		accountID,
+		domain.MustNewMoney(decimal.NewFromInt(amount), currency),
+		direction,
+		time.Now().UTC(),
+		"transaction",
+		reference,
+		domain.TransactionSourceManual,
+	)
+	require.NoError(t, err)
+
+	log, err := domain.NewFinancialPositionLog(accountID, entry, nil)
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, log))
+}
+
+// TestIntegration_GetAccountBalance_AggregatesAcrossMultipleLogs is the
+// regression test for MON-1: the balance must sum every entry across ALL of the
+// account's position logs, not just the most recent one.
+func TestIntegration_GetAccountBalance_AggregatesAcrossMultipleLogs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tc := SetupBalanceIntegrationTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	accountID := "ACC-MULTI-LOG-001"
+
+	// Three sequential deposits, each recorded as a SEPARATE position log.
+	// Before the fix, only the newest log (25) was read, so the balance was 25.
+	createSingleEntryLog(t, ctx, tc.Repo, accountID, 100, domain.PostingDirectionDebit, domain.CurrencyGBP, "DEP-1")
+	createSingleEntryLog(t, ctx, tc.Repo, accountID, 50, domain.PostingDirectionDebit, domain.CurrencyGBP, "DEP-2")
+	createSingleEntryLog(t, ctx, tc.Repo, accountID, 25, domain.PostingDirectionDebit, domain.CurrencyGBP, "DEP-3")
+
+	for _, bt := range []positionkeepingv1.BalanceType{
+		positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
+		positionkeepingv1.BalanceType_BALANCE_TYPE_LEDGER,
+		positionkeepingv1.BalanceType_BALANCE_TYPE_CLOSING,
+	} {
+		t.Run(bt.String(), func(t *testing.T) {
+			req := &positionkeepingv1.GetAccountBalanceRequest{
+				AccountId:   accountID,
+				BalanceType: bt,
+			}
+
+			resp, err := tc.Service.GetAccountBalance(ctx, req)
+			require.NoError(t, err)
+			assert.Equal(t, "175.00", resp.Amount.Amount,
+				"balance must aggregate all three deposit logs (100 + 50 + 25)")
+			assert.Equal(t, "GBP", resp.Amount.InstrumentCode)
+		})
+	}
+}
+
+// TestIntegration_GetAccountBalance_MixedCreditsDebitsAcrossLogs verifies that
+// credits and debits spread across multiple logs net correctly.
+func TestIntegration_GetAccountBalance_MixedCreditsDebitsAcrossLogs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tc := SetupBalanceIntegrationTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	accountID := "ACC-MULTI-LOG-MIXED-001"
+
+	// Deposits (DEBIT increases balance) and withdrawals (CREDIT decreases it),
+	// each as a separate log. Net: 1000 + 500 - 200 - 300 = 1000.
+	createSingleEntryLog(t, ctx, tc.Repo, accountID, 1000, domain.PostingDirectionDebit, domain.CurrencyGBP, "DEP-1")
+	createSingleEntryLog(t, ctx, tc.Repo, accountID, 500, domain.PostingDirectionDebit, domain.CurrencyGBP, "DEP-2")
+	createSingleEntryLog(t, ctx, tc.Repo, accountID, 200, domain.PostingDirectionCredit, domain.CurrencyGBP, "WD-1")
+	createSingleEntryLog(t, ctx, tc.Repo, accountID, 300, domain.PostingDirectionCredit, domain.CurrencyGBP, "WD-2")
+
+	req := &positionkeepingv1.GetAccountBalanceRequest{
+		AccountId:   accountID,
+		BalanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
+	}
+
+	resp, err := tc.Service.GetAccountBalance(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, "1000.00", resp.Amount.Amount)
+}
+
+// TestIntegration_GetAccountBalance_NetsToZeroAcrossLogs verifies an account
+// whose credits exactly offset its debits reports a zero balance in the correct
+// instrument (not a NotFound).
+func TestIntegration_GetAccountBalance_NetsToZeroAcrossLogs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tc := SetupBalanceIntegrationTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	accountID := "ACC-MULTI-LOG-ZERO-001"
+
+	createSingleEntryLog(t, ctx, tc.Repo, accountID, 400, domain.PostingDirectionDebit, domain.CurrencyGBP, "DEP-1")
+	createSingleEntryLog(t, ctx, tc.Repo, accountID, 400, domain.PostingDirectionCredit, domain.CurrencyGBP, "WD-1")
+
+	req := &positionkeepingv1.GetAccountBalanceRequest{
+		AccountId:   accountID,
+		BalanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
+	}
+
+	resp, err := tc.Service.GetAccountBalance(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, "0.00", resp.Amount.Amount)
+	assert.Equal(t, "GBP", resp.Amount.InstrumentCode)
+}
+
 func TestIntegration_GetAccountBalance_WithLiens(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")

--- a/services/position-keeping/service/balance_resolve_test.go
+++ b/services/position-keeping/service/balance_resolve_test.go
@@ -2,118 +2,111 @@ package service_test
 
 import (
 	"testing"
-	"time"
 
-	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
 	"github.com/meridianhub/meridian/services/position-keeping/service"
 )
 
-// TestResolveOpeningBalance_CurrencyResolution targets two mutation-testing
-// survivors on the `len(log.TransactionLogEntries) > 0` guard in
-// resolveOpeningBalance (balance.go:157):
-//
-//   - CONDITIONALS_BOUNDARY (`> 0` -> `>= 0`): an empty entry slice would then
-//     index TransactionLogEntries[0] and panic. The empty-log case below pins
-//     the fallback path so the boundary cannot drift.
-//   - CONDITIONALS_NEGATION (`> 0` -> `<= 0`): a log with entries would skip the
-//     entry-currency branch and fall through to the hard-coded GBP default,
-//     resolving the wrong currency for the opening balance. The non-GBP-entry
-//     case asserts the resolved currency comes from the entry, not the default.
-//
-// Currency resolution feeds every downstream balance computation, so a wrong
-// currency here silently misattributes a balance to the wrong instrument.
-func TestResolveOpeningBalance_CurrencyResolution(t *testing.T) {
-	t.Run("empty log with no opening balance falls back to GBP", func(t *testing.T) {
-		// No initial entry, no opening balance: TransactionLogEntries is empty
-		// and HasOpeningBalance() is false, so resolveOpeningBalance must take
-		// the GBP fallback rather than indexing into the empty slice.
-		log, err := domain.NewFinancialPositionLog("ACC-EMPTY", nil, nil)
-		if err != nil {
-			t.Fatalf("failed to create log: %v", err)
-		}
-		if log.HasOpeningBalance() {
-			t.Fatal("precondition failed: expected HasOpeningBalance() to be false")
-		}
-		if len(log.TransactionLogEntries) != 0 {
-			t.Fatalf("precondition failed: expected 0 entries, got %d", len(log.TransactionLogEntries))
+func gbp(amount int64) domain.Money {
+	return domain.MustNewMoney(decimal.NewFromInt(amount), domain.CurrencyGBP)
+}
+
+func usd(amount int64) domain.Money {
+	return domain.MustNewMoney(decimal.NewFromInt(amount), domain.CurrencyUSD)
+}
+
+// TestResolveAggregateInstrument covers instrument selection from the per-instrument
+// aggregate returned by the repository. Currency resolution feeds every downstream
+// balance computation, so a wrong instrument silently misattributes a balance.
+func TestResolveAggregateInstrument(t *testing.T) {
+	t.Run("empty instrument code with single instrument returns that instrument", func(t *testing.T) {
+		balances := []domain.AccountInstrumentBalance{
+			{Instrument: gbp(0).Instrument, NetMovement: gbp(175)},
 		}
 
-		opening, currency := service.ResolveOpeningBalanceForTesting(log)
-
-		if currency.Code != string(domain.CurrencyGBP) {
-			t.Errorf("currency = %q, want GBP fallback", currency.Code)
-		}
-		if !opening.Amount.IsZero() {
-			t.Errorf("opening balance = %s, want zero", opening.Amount)
-		}
+		got, err := service.ResolveAggregateInstrumentForTesting(balances, "")
+		require.NoError(t, err)
+		assert.Equal(t, "GBP", got.Instrument.Code)
+		assert.Equal(t, "175", got.Amount.String())
 	})
 
-	t.Run("log with non-GBP entry resolves the entry currency", func(t *testing.T) {
-		// A USD entry and no opening balance: resolveOpeningBalance must read the
-		// instrument from the first transaction entry (USD), not default to GBP.
-		entry, err := domain.NewTransactionLogEntry(
-			uuid.New(),
-			"ACC-USD",
-			domain.MustNewMoney(decimal.NewFromInt(250), domain.CurrencyUSD),
-			domain.PostingDirectionDebit,
-			time.Now(),
-			"USD entry",
-			"REF-USD",
-			domain.TransactionSourceManual,
-		)
-		if err != nil {
-			t.Fatalf("failed to create entry: %v", err)
-		}
-
-		log, err := domain.NewFinancialPositionLog("ACC-USD", entry, nil)
-		if err != nil {
-			t.Fatalf("failed to create log: %v", err)
-		}
-		if log.HasOpeningBalance() {
-			t.Fatal("precondition failed: expected HasOpeningBalance() to be false")
-		}
-
-		opening, currency := service.ResolveOpeningBalanceForTesting(log)
-
-		if currency.Code != string(domain.CurrencyUSD) {
-			t.Errorf("currency = %q, want USD (resolved from entry, not GBP default)", currency.Code)
-		}
-		// The opening balance amount is always zero here; only the currency is
-		// derived from the entry to avoid double-counting the entry itself.
-		if !opening.Amount.IsZero() {
-			t.Errorf("opening balance = %s, want zero", opening.Amount)
-		}
-		if opening.Instrument.Code != string(domain.CurrencyUSD) {
-			t.Errorf("opening instrument = %q, want USD", opening.Instrument.Code)
-		}
+	t.Run("empty instrument code with no entries falls back to zero GBP", func(t *testing.T) {
+		got, err := service.ResolveAggregateInstrumentForTesting(nil, "")
+		require.NoError(t, err)
+		assert.Equal(t, "GBP", got.Instrument.Code)
+		assert.True(t, got.IsZero())
 	})
 
-	t.Run("log constructed with opening balance uses its instrument", func(t *testing.T) {
-		log, err := domain.NewFinancialPositionLogWithOpeningBalance(
-			"ACC-OB",
-			domain.MustNewMoney(decimal.NewFromInt(1000), domain.CurrencyEUR),
-			time.Now().Add(-time.Hour),
-			"migration-ref",
-		)
-		if err != nil {
-			t.Fatalf("failed to create log with opening balance: %v", err)
-		}
-		if !log.HasOpeningBalance() {
-			t.Fatal("precondition failed: expected HasOpeningBalance() to be true")
+	t.Run("empty instrument code with multiple instruments is ambiguous", func(t *testing.T) {
+		balances := []domain.AccountInstrumentBalance{
+			{Instrument: gbp(0).Instrument, NetMovement: gbp(100)},
+			{Instrument: usd(0).Instrument, NetMovement: usd(200)},
 		}
 
-		opening, currency := service.ResolveOpeningBalanceForTesting(log)
+		_, err := service.ResolveAggregateInstrumentForTesting(balances, "")
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
 
-		if currency.Code != string(domain.CurrencyEUR) {
-			t.Errorf("currency = %q, want EUR (from opening balance instrument)", currency.Code)
+	t.Run("matching instrument code selects that instrument", func(t *testing.T) {
+		balances := []domain.AccountInstrumentBalance{
+			{Instrument: gbp(0).Instrument, NetMovement: gbp(100)},
+			{Instrument: usd(0).Instrument, NetMovement: usd(200)},
 		}
-		// Opening balance entry is already represented as a transaction, so the
-		// resolved opening amount is zero to avoid double-counting.
-		if !opening.Amount.IsZero() {
-			t.Errorf("opening balance = %s, want zero", opening.Amount)
+
+		got, err := service.ResolveAggregateInstrumentForTesting(balances, "USD")
+		require.NoError(t, err)
+		assert.Equal(t, "USD", got.Instrument.Code)
+		assert.Equal(t, "200", got.Amount.String())
+	})
+
+	t.Run("non-matching instrument code returns NotFound", func(t *testing.T) {
+		balances := []domain.AccountInstrumentBalance{
+			{Instrument: gbp(0).Instrument, NetMovement: gbp(100)},
 		}
+
+		_, err := service.ResolveAggregateInstrumentForTesting(balances, "USD")
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.NotFound, st.Code())
+		assert.Contains(t, st.Message(), "USD")
+	})
+}
+
+// TestBuildAggregateLog verifies the synthetic aggregate log encodes the net
+// movement so the LogBalanceComputer derives the correct balance.
+func TestBuildAggregateLog(t *testing.T) {
+	t.Run("positive net movement becomes a single DEBIT entry", func(t *testing.T) {
+		log, err := service.BuildAggregateLogForTesting("ACC-POS", gbp(175))
+		require.NoError(t, err)
+		require.Len(t, log.TransactionLogEntries, 1)
+		entry := log.TransactionLogEntries[0]
+		assert.Equal(t, domain.PostingDirectionDebit, entry.Direction)
+		assert.Equal(t, "175", entry.Amount.Amount.String())
+		assert.Equal(t, "GBP", entry.Amount.Instrument.Code)
+	})
+
+	t.Run("negative net movement becomes a single CREDIT entry", func(t *testing.T) {
+		log, err := service.BuildAggregateLogForTesting("ACC-NEG", gbp(-50))
+		require.NoError(t, err)
+		require.Len(t, log.TransactionLogEntries, 1)
+		entry := log.TransactionLogEntries[0]
+		assert.Equal(t, domain.PostingDirectionCredit, entry.Direction)
+		assert.Equal(t, "50", entry.Amount.Amount.String())
+	})
+
+	t.Run("zero net movement yields a log with no entries", func(t *testing.T) {
+		log, err := service.BuildAggregateLogForTesting("ACC-ZERO", gbp(0))
+		require.NoError(t, err)
+		assert.Empty(t, log.TransactionLogEntries)
 	})
 }

--- a/services/position-keeping/service/balance_test.go
+++ b/services/position-keeping/service/balance_test.go
@@ -3,9 +3,7 @@ package service_test
 import (
 	"context"
 	"testing"
-	"time"
 
-	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -31,38 +29,15 @@ func (m *MockCurrentAccountClient) GetActiveAmountBlocks(ctx context.Context, ac
 	return args.Get(0).([]domain.AmountBlock), args.Error(1)
 }
 
-// createTestLogWithEntries creates a test FinancialPositionLog with transaction entries.
-// Uses DEBIT entries to add to the balance (since DEBIT = add, CREDIT = subtract in this model).
-func createTestLogWithEntries(t *testing.T, accountID string, amount decimal.Decimal, currency domain.Currency) *domain.FinancialPositionLog {
-	t.Helper()
-
-	// For positive amounts, use DEBIT entries (which add to balance)
-	// For negative amounts, use CREDIT entries (which subtract from balance)
-	var direction domain.PostingDirection
-	var entryAmount decimal.Decimal
-	if amount.IsNegative() {
-		direction = domain.PostingDirectionCredit
-		entryAmount = amount.Neg()
-	} else {
-		direction = domain.PostingDirectionDebit
-		entryAmount = amount
-	}
-
-	entry, err := domain.NewTransactionLogEntry(
-		uuid.New(),
-		accountID,
-		domain.MustNewMoney(entryAmount, currency),
-		direction,
-		time.Now(),
-		"test transaction",
-		"REF-001",
-		domain.TransactionSourceManual,
+// expectAccountBalance configures the repository mock to return an aggregated
+// net movement for an account, exactly as SumAccountBalances would after summing
+// every transaction entry across all of the account's position logs.
+func expectAccountBalance(repo *MockRepository, accountID string, amount decimal.Decimal, currency domain.Currency) {
+	money := domain.MustNewMoney(amount, currency)
+	repo.On("SumAccountBalances", mock.Anything, accountID).Return(
+		[]domain.AccountInstrumentBalance{{Instrument: money.Instrument, NetMovement: money}},
+		true, nil,
 	)
-	require.NoError(t, err)
-
-	log, err := domain.NewFinancialPositionLog(accountID, entry, nil)
-	require.NoError(t, err)
-	return log
 }
 
 // TestGetAccountBalance_Success tests successful balance retrieval for all 7 balance types
@@ -78,8 +53,7 @@ func TestGetAccountBalance_Success(t *testing.T) {
 			balanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_OPENING,
 			setupMocks: func(repo *MockRepository, _ *MockCurrentAccountClient) {
 				// Log with DEBIT 1000 entry (adds to balance)
-				log := createTestLogWithEntries(t, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
-				repo.On("FindByAccountID", mock.Anything, "test-account").Return([]*domain.FinancialPositionLog{log}, nil)
+				expectAccountBalance(repo, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
 			},
 			expectAmount: 0, // Opening balance is 0 (passed to LogBalanceComputer)
 		},
@@ -88,8 +62,7 @@ func TestGetAccountBalance_Success(t *testing.T) {
 			balanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
 			setupMocks: func(repo *MockRepository, _ *MockCurrentAccountClient) {
 				// Log with DEBIT 500 entry (adds to balance)
-				log := createTestLogWithEntries(t, "test-account", decimal.NewFromInt(500), domain.CurrencyGBP)
-				repo.On("FindByAccountID", mock.Anything, "test-account").Return([]*domain.FinancialPositionLog{log}, nil)
+				expectAccountBalance(repo, "test-account", decimal.NewFromInt(500), domain.CurrencyGBP)
 			},
 			expectAmount: 500, // 0 (opening) + 500 (DEBIT entry) = 500
 		},
@@ -98,8 +71,7 @@ func TestGetAccountBalance_Success(t *testing.T) {
 			balanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_CLOSING,
 			setupMocks: func(repo *MockRepository, _ *MockCurrentAccountClient) {
 				// Log with DEBIT 750 entry
-				log := createTestLogWithEntries(t, "test-account", decimal.NewFromInt(750), domain.CurrencyGBP)
-				repo.On("FindByAccountID", mock.Anything, "test-account").Return([]*domain.FinancialPositionLog{log}, nil)
+				expectAccountBalance(repo, "test-account", decimal.NewFromInt(750), domain.CurrencyGBP)
 			},
 			expectAmount: 750, // Closing balance at current time
 		},
@@ -108,8 +80,7 @@ func TestGetAccountBalance_Success(t *testing.T) {
 			balanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_LEDGER,
 			setupMocks: func(repo *MockRepository, _ *MockCurrentAccountClient) {
 				// Log with DEBIT 800 entry
-				log := createTestLogWithEntries(t, "test-account", decimal.NewFromInt(800), domain.CurrencyGBP)
-				repo.On("FindByAccountID", mock.Anything, "test-account").Return([]*domain.FinancialPositionLog{log}, nil)
+				expectAccountBalance(repo, "test-account", decimal.NewFromInt(800), domain.CurrencyGBP)
 			},
 			expectAmount: 800, // Sum of entries (ledger balance ignores opening)
 		},
@@ -117,8 +88,7 @@ func TestGetAccountBalance_Success(t *testing.T) {
 			name:        "returns reserve balance with zero liens",
 			balanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_RESERVE,
 			setupMocks: func(repo *MockRepository, client *MockCurrentAccountClient) {
-				log := createTestLogWithEntries(t, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
-				repo.On("FindByAccountID", mock.Anything, "test-account").Return([]*domain.FinancialPositionLog{log}, nil)
+				expectAccountBalance(repo, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
 				client.On("GetActiveAmountBlocks", mock.Anything, "test-account").Return([]domain.AmountBlock{}, nil)
 			},
 			expectAmount: 0, // No liens
@@ -127,8 +97,7 @@ func TestGetAccountBalance_Success(t *testing.T) {
 			name:        "returns available balance",
 			balanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_AVAILABLE,
 			setupMocks: func(repo *MockRepository, client *MockCurrentAccountClient) {
-				log := createTestLogWithEntries(t, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
-				repo.On("FindByAccountID", mock.Anything, "test-account").Return([]*domain.FinancialPositionLog{log}, nil)
+				expectAccountBalance(repo, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
 				client.On("GetActiveAmountBlocks", mock.Anything, "test-account").Return([]domain.AmountBlock{}, nil)
 			},
 			expectAmount: 1000, // Current (1000) - Reserve (0) + Overdraft (0)
@@ -137,8 +106,7 @@ func TestGetAccountBalance_Success(t *testing.T) {
 			name:        "returns free balance",
 			balanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_FREE,
 			setupMocks: func(repo *MockRepository, client *MockCurrentAccountClient) {
-				log := createTestLogWithEntries(t, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
-				repo.On("FindByAccountID", mock.Anything, "test-account").Return([]*domain.FinancialPositionLog{log}, nil)
+				expectAccountBalance(repo, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
 				client.On("GetActiveAmountBlocks", mock.Anything, "test-account").Return([]domain.AmountBlock{}, nil)
 			},
 			expectAmount: 1000, // Current (1000) - Reserve (0)
@@ -258,13 +226,13 @@ func TestGetAccountBalance_NotFound(t *testing.T) {
 		{
 			name: "returns NotFound when repository returns ErrNotFound",
 			setupMocks: func(repo *MockRepository) {
-				repo.On("FindByAccountID", mock.Anything, "nonexistent-account").Return(nil, domain.ErrNotFound)
+				repo.On("SumAccountBalances", mock.Anything, "nonexistent-account").Return(nil, false, nil)
 			},
 		},
 		{
 			name: "returns NotFound when no logs exist for account",
 			setupMocks: func(repo *MockRepository) {
-				repo.On("FindByAccountID", mock.Anything, "nonexistent-account").Return([]*domain.FinancialPositionLog{}, nil)
+				repo.On("SumAccountBalances", mock.Anything, "nonexistent-account").Return(nil, false, nil)
 			},
 		},
 	}
@@ -316,8 +284,7 @@ func TestGetAccountBalance_CurrencyFilter(t *testing.T) {
 		mockEventPublisher := domain.NewInMemoryEventPublisher()
 		mockIdempotency := new(MockIdempotencyService)
 
-		log := createTestLogWithEntries(t, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
-		mockRepo.On("FindByAccountID", mock.Anything, "test-account").Return([]*domain.FinancialPositionLog{log}, nil)
+		expectAccountBalance(mockRepo, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
 
 		svc, err := service.NewPositionKeepingService(
 			mockRepo,
@@ -350,8 +317,7 @@ func TestGetAccountBalance_CurrencyFilter(t *testing.T) {
 		mockEventPublisher := domain.NewInMemoryEventPublisher()
 		mockIdempotency := new(MockIdempotencyService)
 
-		log := createTestLogWithEntries(t, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
-		mockRepo.On("FindByAccountID", mock.Anything, "test-account").Return([]*domain.FinancialPositionLog{log}, nil)
+		expectAccountBalance(mockRepo, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
 
 		svc, err := service.NewPositionKeepingService(
 			mockRepo,
@@ -388,7 +354,7 @@ func TestGetAccountBalance_RepositoryFailure(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	mockRepo.On("FindByAccountID", mock.Anything, "test-account").Return(nil, assert.AnError)
+	mockRepo.On("SumAccountBalances", mock.Anything, "test-account").Return(nil, false, assert.AnError)
 
 	svc, err := service.NewPositionKeepingService(
 		mockRepo,
@@ -430,8 +396,7 @@ func TestGetAccountBalance_NoCurrentAccountClient(t *testing.T) {
 			mockEventPublisher := domain.NewInMemoryEventPublisher()
 			mockIdempotency := new(MockIdempotencyService)
 
-			log := createTestLogWithEntries(t, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
-			mockRepo.On("FindByAccountID", mock.Anything, "test-account").Return([]*domain.FinancialPositionLog{log}, nil)
+			expectAccountBalance(mockRepo, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
 
 			// Create service WITHOUT CurrentAccountClient
 			svc, err := service.NewPositionKeepingService(
@@ -470,8 +435,7 @@ func TestGetAccountBalances_Success(t *testing.T) {
 	mockIdempotency := new(MockIdempotencyService)
 	mockCurrentAccount := new(MockCurrentAccountClient)
 
-	log := createTestLogWithEntries(t, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
-	mockRepo.On("FindByAccountID", mock.Anything, "test-account").Return([]*domain.FinancialPositionLog{log}, nil)
+	expectAccountBalance(mockRepo, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
 	mockCurrentAccount.On("GetActiveAmountBlocks", mock.Anything, "test-account").Return([]domain.AmountBlock{}, nil)
 
 	svc, err := service.NewPositionKeepingService(
@@ -521,8 +485,7 @@ func TestGetAccountBalances_WithoutCurrentAccountClient(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	log := createTestLogWithEntries(t, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
-	mockRepo.On("FindByAccountID", mock.Anything, "test-account").Return([]*domain.FinancialPositionLog{log}, nil)
+	expectAccountBalance(mockRepo, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
 
 	// Create service WITHOUT CurrentAccountClient
 	svc, err := service.NewPositionKeepingService(
@@ -604,8 +567,7 @@ func TestGetAccountBalances_CurrencyFilter(t *testing.T) {
 		mockEventPublisher := domain.NewInMemoryEventPublisher()
 		mockIdempotency := new(MockIdempotencyService)
 
-		log := createTestLogWithEntries(t, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
-		mockRepo.On("FindByAccountID", mock.Anything, "test-account").Return([]*domain.FinancialPositionLog{log}, nil)
+		expectAccountBalance(mockRepo, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
 
 		svc, err := service.NewPositionKeepingService(
 			mockRepo,
@@ -637,8 +599,7 @@ func TestGetAccountBalances_CurrencyFilter(t *testing.T) {
 		mockEventPublisher := domain.NewInMemoryEventPublisher()
 		mockIdempotency := new(MockIdempotencyService)
 
-		log := createTestLogWithEntries(t, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
-		mockRepo.On("FindByAccountID", mock.Anything, "test-account").Return([]*domain.FinancialPositionLog{log}, nil)
+		expectAccountBalance(mockRepo, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
 
 		svc, err := service.NewPositionKeepingService(
 			mockRepo,
@@ -673,7 +634,7 @@ func TestGetAccountBalances_NotFound(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	mockRepo.On("FindByAccountID", mock.Anything, "nonexistent-account").Return([]*domain.FinancialPositionLog{}, nil)
+	mockRepo.On("SumAccountBalances", mock.Anything, "nonexistent-account").Return(nil, false, nil)
 
 	svc, err := service.NewPositionKeepingService(
 		mockRepo,
@@ -707,8 +668,7 @@ func TestGetAccountBalance_WithLiens(t *testing.T) {
 	mockIdempotency := new(MockIdempotencyService)
 	mockCurrentAccount := new(MockCurrentAccountClient)
 
-	log := createTestLogWithEntries(t, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
-	mockRepo.On("FindByAccountID", mock.Anything, "test-account").Return([]*domain.FinancialPositionLog{log}, nil)
+	expectAccountBalance(mockRepo, "test-account", decimal.NewFromInt(1000), domain.CurrencyGBP)
 
 	// Configure mock to return liens totaling 200 GBP
 	liens := []domain.AmountBlock{

--- a/services/position-keeping/service/export_test.go
+++ b/services/position-keeping/service/export_test.go
@@ -15,5 +15,8 @@ var ValidateUpdateRequestForTesting = validateUpdateRequest
 // ProtoAuditEntryToDomainForTesting exposes protoAuditEntryToDomain for testing.
 var ProtoAuditEntryToDomainForTesting = protoAuditEntryToDomain
 
-// ResolveOpeningBalanceForTesting exposes resolveOpeningBalance for testing.
-var ResolveOpeningBalanceForTesting = resolveOpeningBalance
+// ResolveAggregateInstrumentForTesting exposes resolveAggregateInstrument for testing.
+var ResolveAggregateInstrumentForTesting = resolveAggregateInstrument
+
+// BuildAggregateLogForTesting exposes buildAggregateLog for testing.
+var BuildAggregateLogForTesting = buildAggregateLog

--- a/services/position-keeping/service/initiate_test.go
+++ b/services/position-keeping/service/initiate_test.go
@@ -75,6 +75,15 @@ func (m *MockRepository) FindByAccountID(ctx context.Context, accountID string) 
 	return args.Get(0).([]*domain.FinancialPositionLog), args.Error(1)
 }
 
+func (m *MockRepository) SumAccountBalances(ctx context.Context, accountID string) ([]domain.AccountInstrumentBalance, bool, error) {
+	args := m.Called(ctx, accountID)
+	var balances []domain.AccountInstrumentBalance
+	if args.Get(0) != nil {
+		balances = args.Get(0).([]domain.AccountInstrumentBalance)
+	}
+	return balances, args.Bool(1), args.Error(2)
+}
+
 func (m *MockRepository) Update(ctx context.Context, log *domain.FinancialPositionLog) error {
 	args := m.Called(ctx, log)
 	return args.Error(0)


### PR DESCRIPTION
## Summary

Account balance queries returned only the most recent transaction's amount instead of the account total. `GetAccountBalance` / `GetAccountBalances` read `logs[0]` from `FindByAccountID` (ordered `created_at DESC`), and because each account transaction is recorded as a **separate** `FinancialPositionLog`, the balance reflected only the latest log.

Concretely: three sequential deposits of 100, 50, 25 returned a balance of **25** instead of **175**.

## Root Cause

`loadLogForBalance` (balance.go) selected `logs[0]` and computed the balance from that single log's entries:

```go
log := logs[0]
```

Investigation (Chesterton's Fence): each deposit/withdrawal calls `InitiateFinancialPositionLog`, which creates a new aggregate-root log with one entry (`services/current-account/service/saga_handler_position_keeping.go`). A log is **not** a cumulative snapshot, so reading one log loses every prior transaction. Opening balances are recorded as transaction entries (`addOpeningBalanceEntry`), so the opening balance passed to the computer was already zero and the total balance is purely `Σ(DEBIT) − Σ(CREDIT)` across all entries of all logs.

## Changes Made

- **`domain/repository.go`**: added `SumAccountBalances(ctx, accountID) ([]AccountInstrumentBalance, bool, error)` to `FinancialPositionLogRepository`, plus the `AccountInstrumentBalance` value type. The bool reports whether the account has any logs, distinguishing "not found" from "zero balance".
- **`adapters/persistence/position_log_read.go`**: implemented the method as a single SQL aggregate — `SUM(CASE WHEN direction='DEBIT' THEN amount_cents ELSE -amount_cents END)` joined across all of the account's logs, grouped by instrument. This is the balance read hot path (position-keeping is the most-depended-on service), so the sum is computed in the database rather than by loading every log (with entries, lineage, and audit trail) into memory.
- **`service/balance.go`**: `loadBalanceComputer` now sources the aggregated net movement and materializes it as a synthetic single-entry log, then feeds the existing `LogBalanceComputer`. All 7 BIAN balance types (including reserve/available/free via `CurrentAccountClient`) are computed unchanged.

## Technical Details

- All money math uses `decimal.Decimal`; amounts are summed as integer `amount_cents` in SQL and converted with the existing `centsToDecimal`, identical to the write/read paths.
- Instrument selection: `instrument_code` filters to that instrument (NotFound if absent); with no filter, a single-instrument account resolves automatically and a multi-instrument account returns `InvalidArgument` requesting `instrument_code` (previously it silently returned the newest log's instrument).
- A net-zero balance (credits offset debits) correctly reports `0.00` in the account's instrument, not NotFound.
- **Status filtering unchanged and out of scope**: the existing domain `BalanceComputer` sums all entries regardless of transaction status (the existing suite creates PENDING logs and expects their entries counted). This change preserves that semantic across all logs; it does not add per-status filtering. Whether compensated/CANCELLED logs should be excluded from balances is a pre-existing, separate question and is noted here rather than changed.

## Testing

- **Unit** (`service/balance_test.go`, `balance_resolve_test.go`): migrated repository mocks to `SumAccountBalances`; added coverage for instrument resolution (single, multi-instrument ambiguity, NotFound) and synthetic-log construction (positive→DEBIT, negative→CREDIT, zero→no entries).
- **Persistence** (`adapters/persistence/postgres_repository_test.go`): `TestPostgresRepository_SumAccountBalances` against a CockroachDB-compatible testcontainer — two logs of 100.50 aggregate to 201.00; unknown account reports `hasLogs=false`.
- **Integration** (`service/balance_integration_test.go`, real Postgres testcontainer):
  - deposits 100 + 50 + 25 → **175.00** (CURRENT, LEDGER, CLOSING)
  - mixed credits/debits across four logs (1000 + 500 − 200 − 300) → **1000.00**
  - credits offsetting debits across logs → **0.00** in GBP
- Existing lien/reserve/available/free, currency-filtering, NotFound, and concurrency integration tests pass unchanged. Full `go test ./services/position-keeping/... ./services/current-account/...` green.

## Risk Assessment

- Low-to-moderate. The change is confined to the balance read path; writes, saga handlers, and the domain `BalanceComputer` are untouched. All 7 balance types flow through the same computer as before.
- Behavior change for multi-instrument-per-account with no `instrument_code`: now `InvalidArgument` instead of a (previously incorrect) single-log result. Callers disambiguate by passing `instrument_code`.

## Deployment Notes

No migration required — the aggregate query reads existing columns (`amount_cents`, `currency`, `direction`, `deleted_at`) already indexed by `account_id`.
