### PR TITLE
fix: Atomic idempotency for MarkPending and deposit processing (MON-2, MON-3)

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -165,7 +165,7 @@ jobs:
           # Define expected tables per service (all use unqualified/singular names)
           declare -A SERVICE_TABLES
           SERVICE_TABLES[current_account]="account lien audit_log audit_outbox"
-          SERVICE_TABLES[financial_accounting]="financial_booking_log ledger_posting audit_log audit_outbox"
+          SERVICE_TABLES[financial_accounting]="financial_booking_log ledger_posting deposit_idempotency audit_log audit_outbox"
           SERVICE_TABLES[party]="party party_association party_demographic party_reference party_bank_relation audit_log audit_outbox"
           SERVICE_TABLES[payment_order]="payment_order audit_log audit_outbox"
           SERVICE_TABLES[position_keeping]="financial_position_log audit_trail_entry transaction_lineage transaction_log_entry audit_log audit_outbox"

--- a/services/financial-accounting/adapters/messaging/deposit_consumer.go
+++ b/services/financial-accounting/adapters/messaging/deposit_consumer.go
@@ -3,12 +3,15 @@ package messaging
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"buf.build/go/protovalidate"
-	"github.com/google/uuid"
 
 	eventsv1 "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
 	"github.com/meridianhub/meridian/services/financial-accounting/service"
@@ -29,27 +32,23 @@ var (
 	ErrUnexpectedMessageType = errors.New("unexpected message type")
 	// ErrNilIdempotencyService is returned when the idempotency service is nil
 	ErrNilIdempotencyService = errors.New("idempotency service cannot be nil")
-	// ErrConcurrentProcessing is returned when another consumer is processing the same event
-	ErrConcurrentProcessing = errors.New("deposit event is being processed by another consumer")
 )
 
-// Idempotency TTL constants. These control how long results are cached in Redis.
-const (
-	// lockTTL is how long a processing lock is held before automatic expiration.
-	// This prevents deadlocks if a consumer crashes while processing.
-	lockTTL = 5 * time.Minute
-
-	// successResultTTL is how long successful results are cached.
-	// Longer TTL reduces Redis lookups for frequently retried events.
-	successResultTTL = 24 * time.Hour
-
-	// failureResultTTL is how long failed results are cached.
-	// Shorter TTL allows retries after transient failures are resolved.
-	failureResultTTL = 1 * time.Hour
-)
+// successResultTTL is how long the Redis fast-path "already processed" marker is
+// cached. This marker is an optimisation only: it lets redeliveries short-circuit
+// before touching the database. Correctness does not depend on it - the database
+// idempotency marker (written in the same transaction as the postings) is the
+// source of truth.
+const successResultTTL = 24 * time.Hour
 
 // DepositConsumer consumes DepositEvent messages from Kafka and processes them
 // through the PostingService to create double-entry ledger postings.
+//
+// Exactly-once processing is guaranteed at the database layer: each deposit's
+// postings are written together with a per-deposit idempotency marker in a
+// single transaction, and the marker's unique key rejects redeliveries. Redis is
+// used only as a best-effort fast path to skip the database round-trip for
+// deposits already known to be complete.
 type DepositConsumer struct {
 	consumer       *kafka.ProtoConsumer
 	postingService *service.PostingService
@@ -64,7 +63,7 @@ type DepositConsumer struct {
 // Parameters:
 // - config: Kafka consumer configuration (bootstrap servers, group ID, etc.)
 // - postingService: Service that creates ledger postings
-// - idempotencySvc: Service that provides distributed idempotency protection
+// - idempotencySvc: Best-effort fast-path idempotency cache (must not be nil)
 //
 // Returns an error if the consumer cannot be initialized or if idempotency service is nil.
 func NewDepositConsumer(config kafka.ConsumerConfig, postingService *service.PostingService, idempotencySvc idempotency.Service) (*DepositConsumer, error) {
@@ -106,39 +105,60 @@ func NewDepositConsumer(config kafka.ConsumerConfig, postingService *service.Pos
 	return dc, nil
 }
 
-// handleDepositEvent processes a single DepositEvent by converting it to
-// the PostingService format and creating double-entry ledger postings.
-// Uses Redis-based idempotency to prevent duplicate ledger entries from
-// Kafka's at-least-once delivery semantics.
+// handleDepositEvent processes a single DepositEvent by converting it to the
+// PostingService format and creating double-entry ledger postings.
+//
+// Idempotency is enforced at the database layer: the deposit's postings and a
+// per-deposit idempotency marker are written in one transaction, so Kafka's
+// at-least-once redelivery cannot produce duplicate postings even if the process
+// crashes or Redis is unavailable. Redis is consulted only as a fast path.
 func (dc *DepositConsumer) handleDepositEvent(ctx context.Context, event *eventsv1.DepositEvent) error {
 	if err := dc.validateDepositEvent(event); err != nil {
 		return err
 	}
 
-	idempotencyKey := buildDepositIdempotencyKey(ctx, event)
+	dedupeKey := buildDepositDedupeKey(ctx, event)
+	redisKey := buildDepositIdempotencyKey(ctx, event, dedupeKey)
 
-	// Check if already processed (fast path for duplicates)
-	if alreadyProcessed, err := dc.checkIdempotency(ctx, idempotencyKey); alreadyProcessed {
+	// Fast path: if Redis already knows this deposit completed, skip the database
+	// work. Best-effort only - any Redis error is treated as "unknown" so the
+	// authoritative database path still runs.
+	if dc.redisMarksProcessed(ctx, redisKey) {
 		return nil
-	} else if err != nil {
-		return err
 	}
 
-	// Acquire distributed lock and re-check
-	lockToken, err := dc.acquireDepositLock(ctx, idempotencyKey)
+	currencyCode := event.InstrumentCode
+	if currencyCode == "" {
+		return fmt.Errorf("%w: %v", ErrInvalidCurrency, event.InstrumentCode)
+	}
+
+	// Pass the raw minor-unit value as a string. The PostingService will
+	// resolve instrument precision and convert from minor to major units.
+	// This avoids hardcoding a /100 divisor that would be wrong for
+	// non-2dp instruments (e.g., JPY=0dp, KWH=3dp).
+	depositEvent := service.DepositEvent{
+		AccountID:       event.AccountId,
+		AmountMinorUnit: event.AmountCents,
+		InstrumentCode:  currencyCode,
+		CorrelationID:   event.CorrelationId,
+		ValueDate:       event.ValueDate.AsTime(),
+	}
+
+	err := dc.postingService.ProcessDepositWithDedupeKey(ctx, depositEvent, dedupeKey)
 	if err != nil {
-		return err
+		if errors.Is(err, service.ErrDepositAlreadyProcessed) {
+			// Duplicate delivery: the deposit is already on the ledger. Refresh the
+			// Redis fast-path marker so future redeliveries short-circuit, then
+			// treat this as a successful no-op.
+			dc.markRedisProcessed(ctx, redisKey)
+			return nil
+		}
+		return fmt.Errorf("failed to process deposit: %w", err)
 	}
-	defer func() { _ = dc.idempotency.Release(ctx, idempotencyKey, lockToken) }()
 
-	// Re-check after acquiring lock (double-check pattern)
-	if alreadyProcessed, err := dc.recheckIdempotency(ctx, idempotencyKey); alreadyProcessed {
-		return nil
-	} else if err != nil {
-		return err
-	}
-
-	return dc.processAndStoreResult(ctx, event, idempotencyKey)
+	// Best-effort: record completion in Redis for the fast path on future deliveries.
+	dc.markRedisProcessed(ctx, redisKey)
+	return nil
 }
 
 // validateDepositEvent validates the proto message and required fields.
@@ -155,87 +175,65 @@ func (dc *DepositConsumer) validateDepositEvent(event *eventsv1.DepositEvent) er
 	return nil
 }
 
-// buildDepositIdempotencyKey constructs the idempotency key for a deposit event.
-func buildDepositIdempotencyKey(ctx context.Context, event *eventsv1.DepositEvent) idempotency.Key {
+// buildDepositDedupeKey derives a deterministic, per-deposit idempotency
+// fingerprint from the event's identifying fields.
+//
+// The key is stable across Kafka redeliveries of the same event (identical bytes
+// produce an identical key) but distinct for genuinely different deposits -
+// including deposits that reuse a correlation ID, which is why correlation_id
+// alone must NOT be used as the idempotency key. The event timestamp is included
+// so that two economically-identical deposits emitted at different times remain
+// distinct.
+func buildDepositDedupeKey(ctx context.Context, event *eventsv1.DepositEvent) string {
+	var b strings.Builder
+	b.WriteString(extractTenantID(ctx))
+	b.WriteByte('|')
+	b.WriteString(event.AccountId)
+	b.WriteByte('|')
+	b.WriteString(strconv.FormatInt(event.AmountCents, 10))
+	b.WriteByte('|')
+	b.WriteString(event.InstrumentCode)
+	b.WriteByte('|')
+	b.WriteString(event.CorrelationId)
+	b.WriteByte('|')
+	b.WriteString(formatTimestamp(event.ValueDate.GetSeconds(), event.ValueDate.GetNanos()))
+	b.WriteByte('|')
+	b.WriteString(formatTimestamp(event.Timestamp.GetSeconds(), event.Timestamp.GetNanos()))
+
+	sum := sha256.Sum256([]byte(b.String()))
+	return hex.EncodeToString(sum[:])
+}
+
+// formatTimestamp renders a protobuf timestamp's seconds/nanos as a stable string.
+func formatTimestamp(seconds int64, nanos int32) string {
+	return strconv.FormatInt(seconds, 10) + ":" + strconv.FormatInt(int64(nanos), 10)
+}
+
+// buildDepositIdempotencyKey constructs the Redis fast-path idempotency key for a
+// deposit event. It keys on the per-deposit dedupe fingerprint (NOT the
+// correlation ID) so the fast path agrees with the authoritative database marker.
+func buildDepositIdempotencyKey(ctx context.Context, event *eventsv1.DepositEvent, dedupeKey string) idempotency.Key {
 	return idempotency.Key{
 		TenantID:  extractTenantID(ctx),
 		Namespace: "financial-accounting",
 		Operation: "process-deposit",
 		EntityID:  event.AccountId,
-		RequestID: event.CorrelationId,
+		RequestID: dedupeKey,
 	}
 }
 
-// checkIdempotency checks if the operation was already processed.
-// Returns (true, nil) if already processed, (false, nil) if not found, or (false, err) on failure.
-func (dc *DepositConsumer) checkIdempotency(ctx context.Context, key idempotency.Key) (bool, error) {
+// redisMarksProcessed reports whether Redis already has a completed marker for
+// this deposit. Best-effort: any Redis error (including Redis being down) is
+// treated as "not processed" so the authoritative database path still runs.
+func (dc *DepositConsumer) redisMarksProcessed(ctx context.Context, key idempotency.Key) bool {
 	_, err := dc.idempotency.Check(ctx, key)
-	if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) {
-		return true, nil
-	}
-	if err != nil && !errors.Is(err, idempotency.ErrResultNotFound) {
-		return false, fmt.Errorf("idempotency check failed: %w", err)
-	}
-	return false, nil
+	return errors.Is(err, idempotency.ErrOperationAlreadyProcessed)
 }
 
-// recheckIdempotency performs the post-lock idempotency re-check (double-check pattern).
-// Returns (true, nil) if already processed, (false, nil) if not found, or (false, err) on failure.
-func (dc *DepositConsumer) recheckIdempotency(ctx context.Context, key idempotency.Key) (bool, error) {
-	_, err := dc.idempotency.Check(ctx, key)
-	if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) {
-		return true, nil
-	}
-	if err != nil && !errors.Is(err, idempotency.ErrResultNotFound) {
-		return false, fmt.Errorf("idempotency re-check failed: %w", err)
-	}
-	return false, nil
-}
-
-// acquireDepositLock acquires a distributed lock for the deposit event.
-func (dc *DepositConsumer) acquireDepositLock(ctx context.Context, key idempotency.Key) (string, error) {
-	lockToken := uuid.New().String()
-	lockOpts := idempotency.LockOptions{
-		TTL:        lockTTL,
-		Token:      lockToken,
-		MaxRetries: 0,
-		RetryDelay: 0,
-	}
-	if err := dc.idempotency.Acquire(ctx, key, lockOpts); err != nil {
-		if errors.Is(err, idempotency.ErrLockAcquisitionFailed) {
-			return "", ErrConcurrentProcessing
-		}
-		return "", fmt.Errorf("failed to acquire lock: %w", err)
-	}
-	return lockToken, nil
-}
-
-// processAndStoreResult validates the currency, processes the deposit, and stores the idempotency result.
-func (dc *DepositConsumer) processAndStoreResult(ctx context.Context, event *eventsv1.DepositEvent, key idempotency.Key) error {
-	currencyCode := event.InstrumentCode
-	if currencyCode == "" {
-		dc.storeFailureResult(ctx, key, fmt.Sprintf("%v: %v", ErrInvalidCurrency, event.InstrumentCode))
-		return fmt.Errorf("%w: %v", ErrInvalidCurrency, event.InstrumentCode)
-	}
-
-	// Pass the raw minor-unit value as a string. The PostingService will
-	// resolve instrument precision and convert from minor to major units.
-	// This avoids hardcoding a /100 divisor that would be wrong for
-	// non-2dp instruments (e.g., JPY=0dp, KWH=3dp).
-	depositEvent := service.DepositEvent{
-		AccountID:       event.AccountId,
-		AmountMinorUnit: event.AmountCents,
-		InstrumentCode:  currencyCode,
-		CorrelationID:   event.CorrelationId,
-		ValueDate:       event.ValueDate.AsTime(),
-	}
-
-	if err := dc.postingService.ProcessDeposit(ctx, depositEvent); err != nil {
-		dc.storeFailureResult(ctx, key, err.Error())
-		return fmt.Errorf("failed to process deposit: %w", err)
-	}
-
-	successResult := idempotency.Result{
+// markRedisProcessed records a completed marker in Redis for the fast path.
+// Best-effort: failures are ignored because the database is the source of truth.
+func (dc *DepositConsumer) markRedisProcessed(ctx context.Context, key idempotency.Key) {
+	result := idempotency.Result{
 		Key:         key,
 		Status:      idempotency.StatusCompleted,
 		Data:        nil,
@@ -243,25 +241,7 @@ func (dc *DepositConsumer) processAndStoreResult(ctx context.Context, event *eve
 		CompletedAt: time.Now(),
 		TTL:         successResultTTL,
 	}
-	if err := dc.idempotency.StoreResult(ctx, successResult); err != nil {
-		return fmt.Errorf("failed to store idempotency result: %w", err)
-	}
-
-	return nil
-}
-
-// storeFailureResult stores a failure result in the idempotency cache (best-effort).
-// Failed operations are cached for failureResultTTL to prevent retry storms.
-func (dc *DepositConsumer) storeFailureResult(ctx context.Context, key idempotency.Key, errMsg string) {
-	failureResult := idempotency.Result{
-		Key:         key,
-		Status:      idempotency.StatusFailed,
-		Data:        nil,
-		Error:       errMsg,
-		CompletedAt: time.Now(),
-		TTL:         failureResultTTL,
-	}
-	_ = dc.idempotency.StoreResult(ctx, failureResult) // Best effort
+	_ = dc.idempotency.StoreResult(ctx, result) // Best effort
 }
 
 // extractTenantID extracts the tenant ID from context for multi-tenant isolation.

--- a/services/financial-accounting/adapters/messaging/deposit_consumer_test.go
+++ b/services/financial-accounting/adapters/messaging/deposit_consumer_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/lib/pq"
+	"gorm.io/gorm"
 
 	eventsv1 "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
 	"github.com/meridianhub/meridian/services/financial-accounting/adapters/persistence"
@@ -25,6 +26,9 @@ import (
 const testTenantID = "test_tenant"
 
 // mockIdempotencyService provides a mock implementation of idempotency.Service for testing.
+// The deposit consumer uses it only as a best-effort fast-path cache; correctness
+// is enforced by the database, so these mocks let us simulate Redis being present,
+// stale, or entirely unavailable.
 type mockIdempotencyService struct {
 	checkFunc       func(ctx context.Context, key idempotency.Key) (*idempotency.Result, error)
 	markPendingFunc func(ctx context.Context, key idempotency.Key, ttl time.Duration) error
@@ -97,12 +101,13 @@ func (m *mockIdempotencyService) IsHeld(ctx context.Context, key idempotency.Key
 	return m.isHeldFunc(ctx, key)
 }
 
-func setupTestServices(t *testing.T) (*service.PostingService, context.Context, func()) {
+func setupTestServices(t *testing.T) (*service.PostingService, *gorm.DB, context.Context, func()) {
 	t.Helper()
 
 	db, cleanup := testdb.SetupPostgres(t, []interface{}{
 		&persistence.LedgerPostingEntity{},
 		&persistence.FinancialBookingLogEntity{},
+		&persistence.DepositIdempotencyEntity{},
 		&audit.AuditOutbox{},
 	})
 
@@ -155,10 +160,17 @@ func setupTestServices(t *testing.T) (*service.PostingService, context.Context, 
 	)`, pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
+	// Per-deposit idempotency marker table (MON-3). The unique primary key on
+	// dedupe_key enforces exactly-once deposit processing at the database layer.
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.deposit_idempotency (
+		dedupe_key VARCHAR(64) PRIMARY KEY,
+		account_id VARCHAR(255) NOT NULL,
+		correlation_id VARCHAR(255),
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL
+	)`, pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
 	// Create audit_outbox table for GORM hooks
-	// Note: Uses TEXT instead of JSONB for old_values/new_values for compatibility with
-	// the shared audit infrastructure which writes empty strings when values are nil.
-	// record_id is VARCHAR(50) to match the shared AuditOutbox which uses string IDs.
 	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.audit_outbox (
 		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 		table_name VARCHAR(100) NOT NULL,
@@ -185,14 +197,52 @@ func setupTestServices(t *testing.T) (*service.PostingService, context.Context, 
 	ctx := tenant.WithTenant(context.Background(), tid)
 
 	repo := persistence.NewLedgerRepository(db)
-	return service.NewPostingServiceWithConfig(service.PostingServiceConfig{
+	svc := service.NewPostingServiceWithConfig(service.PostingServiceConfig{
 		Repo:              repo,
 		BankCashAccountID: "BANK-CASH-001",
-	}), ctx, cleanup
+	})
+	return svc, db, ctx, cleanup
+}
+
+// countPostings returns the total number of ledger postings in the test tenant
+// schema. Each deposit writes two postings (debit + credit), so this is used to
+// assert the exactly-once guarantee. Each test gets its own isolated database.
+func countPostings(t *testing.T, db *gorm.DB) int64 {
+	t.Helper()
+	schema := tenant.TenantID(testTenantID).SchemaName()
+	var count int64
+	err := db.Table(schema + ".ledger_posting").Count(&count).Error
+	require.NoError(t, err)
+	return count
+}
+
+func validDepositEvent(accountID, correlationID string, amountCents int64) *eventsv1.DepositEvent {
+	now := timestamppb.Now()
+	return &eventsv1.DepositEvent{
+		AccountId:      accountID,
+		AmountCents:    amountCents,
+		InstrumentCode: "GBP",
+		CorrelationId:  correlationID,
+		ValueDate:      now,
+		Timestamp:      now,
+	}
+}
+
+func newTestConsumer(t *testing.T, postingService *service.PostingService, idemp idempotency.Service) *DepositConsumer {
+	t.Helper()
+	consumer, err := NewDepositConsumer(kafka.ConsumerConfig{
+		BootstrapServers: "localhost:9092",
+		GroupID:          "test-group",
+	}, postingService, idemp)
+	if err != nil {
+		t.Skip("Kafka not available, skipping integration test")
+	}
+	t.Cleanup(func() { _ = consumer.Close() })
+	return consumer
 }
 
 func TestNewDepositConsumer(t *testing.T) {
-	postingService, _, cleanup := setupTestServices(t)
+	postingService, _, _, cleanup := setupTestServices(t)
 	defer cleanup()
 
 	mockIdemp := newMockIdempotencyService()
@@ -263,7 +313,7 @@ func TestNewDepositConsumer(t *testing.T) {
 }
 
 func TestDepositConsumer_NilIdempotencyService(t *testing.T) {
-	postingService, _, cleanup := setupTestServices(t)
+	postingService, _, _, cleanup := setupTestServices(t)
 	defer cleanup()
 
 	_, err := NewDepositConsumer(kafka.ConsumerConfig{
@@ -276,21 +326,10 @@ func TestDepositConsumer_NilIdempotencyService(t *testing.T) {
 }
 
 func TestDepositConsumer_HandleDepositEvent(t *testing.T) {
-	postingService, ctx, cleanup := setupTestServices(t)
+	postingService, _, ctx, cleanup := setupTestServices(t)
 	defer cleanup()
 
-	mockIdemp := newMockIdempotencyService()
-
-	consumer, err := NewDepositConsumer(kafka.ConsumerConfig{
-		BootstrapServers: "localhost:9092",
-		GroupID:          "test-group",
-	}, postingService, mockIdemp)
-	if err != nil {
-		t.Skip("Kafka not available, skipping integration test")
-	}
-	defer func() {
-		_ = consumer.Close()
-	}()
+	consumer := newTestConsumer(t, postingService, newMockIdempotencyService())
 
 	tests := []struct {
 		name    string
@@ -298,15 +337,8 @@ func TestDepositConsumer_HandleDepositEvent(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "valid deposit event",
-			event: &eventsv1.DepositEvent{
-				AccountId:      "ACC-123",
-				AmountCents:    10000,
-				InstrumentCode: "GBP",
-				CorrelationId:  "deposit-001",
-				ValueDate:      timestamppb.Now(),
-				Timestamp:      timestamppb.Now(),
-			},
+			name:    "valid deposit event",
+			event:   validDepositEvent("ACC-123", "deposit-001", 10000),
 			wantErr: false,
 		},
 		{
@@ -349,7 +381,7 @@ func TestDepositConsumer_HandleDepositEvent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			testCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+			testCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
 
 			err := consumer.handleDepositEvent(testCtx, tt.event)
@@ -360,460 +392,11 @@ func TestDepositConsumer_HandleDepositEvent(t *testing.T) {
 	}
 }
 
-func TestDepositConsumer_IdempotencyCache(t *testing.T) {
-	postingService, ctx, cleanup := setupTestServices(t)
-	defer cleanup()
-
-	// Mock idempotency service that returns already processed
-	mockIdemp := newMockIdempotencyService()
-	mockIdemp.checkFunc = func(_ context.Context, _ idempotency.Key) (*idempotency.Result, error) {
-		return &idempotency.Result{
-			Status: idempotency.StatusCompleted,
-		}, idempotency.ErrOperationAlreadyProcessed
-	}
-
-	consumer, err := NewDepositConsumer(kafka.ConsumerConfig{
-		BootstrapServers: "localhost:9092",
-		GroupID:          "test-group",
-	}, postingService, mockIdemp)
-	if err != nil {
-		t.Skip("Kafka not available, skipping integration test")
-	}
-	defer func() {
-		_ = consumer.Close()
-	}()
-
-	event := &eventsv1.DepositEvent{
-		AccountId:      "ACC-DUPLICATE",
-		AmountCents:    10000,
-		InstrumentCode: "GBP",
-		CorrelationId:  "deposit-duplicate",
-		ValueDate:      timestamppb.Now(),
-		Timestamp:      timestamppb.Now(),
-	}
-
-	testCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-	defer cancel()
-
-	// Should succeed without error (idempotent success)
-	err = consumer.handleDepositEvent(testCtx, event)
-	require.NoError(t, err, "handleDepositEvent should return nil for already processed events")
-}
-
-func TestDepositConsumer_IdempotencyLockAcquisition(t *testing.T) {
-	postingService, ctx, cleanup := setupTestServices(t)
-	defer cleanup()
-
-	var acquireCalled bool
-	var capturedKey idempotency.Key
-	var capturedOpts idempotency.LockOptions
-
-	mockIdemp := newMockIdempotencyService()
-	mockIdemp.acquireFunc = func(_ context.Context, key idempotency.Key, opts idempotency.LockOptions) error {
-		acquireCalled = true
-		capturedKey = key
-		capturedOpts = opts
-		return nil
-	}
-
-	consumer, err := NewDepositConsumer(kafka.ConsumerConfig{
-		BootstrapServers: "localhost:9092",
-		GroupID:          "test-group",
-	}, postingService, mockIdemp)
-	if err != nil {
-		t.Skip("Kafka not available, skipping integration test")
-	}
-	defer func() {
-		_ = consumer.Close()
-	}()
-
-	event := &eventsv1.DepositEvent{
-		AccountId:      "ACC-LOCK",
-		AmountCents:    10000,
-		InstrumentCode: "GBP",
-		CorrelationId:  "deposit-lock-test",
-		ValueDate:      timestamppb.Now(),
-		Timestamp:      timestamppb.Now(),
-	}
-
-	testCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-	defer cancel()
-
-	_ = consumer.handleDepositEvent(testCtx, event)
-
-	assert.True(t, acquireCalled, "Acquire should be called for lock")
-	assert.Equal(t, "financial-accounting", capturedKey.Namespace)
-	assert.Equal(t, "process-deposit", capturedKey.Operation)
-	assert.Equal(t, "ACC-LOCK", capturedKey.EntityID)
-	assert.Equal(t, "deposit-lock-test", capturedKey.RequestID)
-	assert.Equal(t, lockTTL, capturedOpts.TTL)
-	assert.NotEmpty(t, capturedOpts.Token, "Lock token should be generated")
-	assert.Equal(t, 0, capturedOpts.MaxRetries, "Should not retry lock acquisition")
-}
-
-func TestDepositConsumer_IdempotencyStoreSuccess(t *testing.T) {
-	postingService, ctx, cleanup := setupTestServices(t)
-	defer cleanup()
-
-	var storeResultCalled bool
-	var capturedResult idempotency.Result
-
-	mockIdemp := newMockIdempotencyService()
-	mockIdemp.storeResultFunc = func(_ context.Context, result idempotency.Result) error {
-		storeResultCalled = true
-		capturedResult = result
-		return nil
-	}
-
-	consumer, err := NewDepositConsumer(kafka.ConsumerConfig{
-		BootstrapServers: "localhost:9092",
-		GroupID:          "test-group",
-	}, postingService, mockIdemp)
-	if err != nil {
-		t.Skip("Kafka not available, skipping integration test")
-	}
-	defer func() {
-		_ = consumer.Close()
-	}()
-
-	event := &eventsv1.DepositEvent{
-		AccountId:      "ACC-SUCCESS",
-		AmountCents:    10000,
-		InstrumentCode: "GBP",
-		CorrelationId:  "deposit-success-test",
-		ValueDate:      timestamppb.Now(),
-		Timestamp:      timestamppb.Now(),
-	}
-
-	testCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-	defer cancel()
-
-	err = consumer.handleDepositEvent(testCtx, event)
-	require.NoError(t, err)
-
-	assert.True(t, storeResultCalled, "StoreResult should be called on success")
-	assert.Equal(t, idempotency.StatusCompleted, capturedResult.Status)
-	assert.Equal(t, 24*time.Hour, capturedResult.TTL)
-	assert.Nil(t, capturedResult.Data, "Data should be nil for events")
-}
-
-func TestDepositConsumer_IdempotencyStoreFailure(t *testing.T) {
-	// This test verifies that failure results are stored in the idempotency cache.
-	// Proto validation rejects CURRENCY_UNSPECIFIED (not_in: [0]), so we can't use
-	// that to trigger a currency conversion failure. Instead, we test by observing
-	// the call pattern: if proto validation fails first, no idempotency calls happen.
-	//
-	// To properly test failure storage, we would need to mock the PostingService to
-	// fail ProcessDeposit. For now, we verify the error path through proto validation.
-	postingService, ctx, cleanup := setupTestServices(t)
-	defer cleanup()
-
-	var checkCalled bool
-	var acquireCalled bool
-
-	mockIdemp := newMockIdempotencyService()
-	mockIdemp.checkFunc = func(_ context.Context, _ idempotency.Key) (*idempotency.Result, error) {
-		checkCalled = true
-		return nil, idempotency.ErrResultNotFound
-	}
-	mockIdemp.acquireFunc = func(_ context.Context, _ idempotency.Key, _ idempotency.LockOptions) error {
-		acquireCalled = true
-		return nil
-	}
-
-	consumer, err := NewDepositConsumer(kafka.ConsumerConfig{
-		BootstrapServers: "localhost:9092",
-		GroupID:          "test-group",
-	}, postingService, mockIdemp)
-	if err != nil {
-		t.Skip("Kafka not available, skipping integration test")
-	}
-	defer func() {
-		_ = consumer.Close()
-	}()
-
-	// Use unspecified currency - proto validation will fail first (not_in: [0])
-	event := &eventsv1.DepositEvent{
-		AccountId:      "ACC-FAILURE",
-		AmountCents:    10000,
-		InstrumentCode: "",
-		CorrelationId:  "deposit-failure-test",
-		ValueDate:      timestamppb.Now(),
-		Timestamp:      timestamppb.Now(),
-	}
-
-	testCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-	defer cancel()
-
-	err = consumer.handleDepositEvent(testCtx, event)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid deposit event", "Error should indicate proto validation failure")
-
-	// Proto validation fails before idempotency check, so no idempotency calls should be made
-	assert.False(t, checkCalled, "Idempotency check should not be called when proto validation fails")
-	assert.False(t, acquireCalled, "Acquire should not be called when proto validation fails")
-}
-
-func TestDepositConsumer_IdempotencyKeyFormat(t *testing.T) {
-	postingService, ctx, cleanup := setupTestServices(t)
-	defer cleanup()
-
-	var capturedKey idempotency.Key
-
-	mockIdemp := newMockIdempotencyService()
-	mockIdemp.checkFunc = func(_ context.Context, key idempotency.Key) (*idempotency.Result, error) {
-		capturedKey = key
-		return nil, idempotency.ErrResultNotFound
-	}
-
-	consumer, err := NewDepositConsumer(kafka.ConsumerConfig{
-		BootstrapServers: "localhost:9092",
-		GroupID:          "test-group",
-	}, postingService, mockIdemp)
-	if err != nil {
-		t.Skip("Kafka not available, skipping integration test")
-	}
-	defer func() {
-		_ = consumer.Close()
-	}()
-
-	event := &eventsv1.DepositEvent{
-		AccountId:      "ACC-KEY-FORMAT",
-		AmountCents:    10000,
-		InstrumentCode: "GBP",
-		CorrelationId:  "correlation-123",
-		ValueDate:      timestamppb.Now(),
-		Timestamp:      timestamppb.Now(),
-	}
-
-	testCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-	defer cancel()
-
-	_ = consumer.handleDepositEvent(testCtx, event)
-
-	assert.Equal(t, "financial-accounting", capturedKey.Namespace)
-	assert.Equal(t, "process-deposit", capturedKey.Operation)
-	assert.Equal(t, "ACC-KEY-FORMAT", capturedKey.EntityID)
-	assert.Equal(t, "correlation-123", capturedKey.RequestID)
-	assert.Equal(t, testTenantID, capturedKey.TenantID)
-}
-
-// errRedisConnection is a test error for simulating Redis failures
-var errRedisConnection = errors.New("redis connection error")
-
-func TestDepositConsumer_IdempotencyCheckFailed(t *testing.T) {
-	postingService, ctx, cleanup := setupTestServices(t)
-	defer cleanup()
-
-	mockIdemp := newMockIdempotencyService()
-	mockIdemp.checkFunc = func(_ context.Context, _ idempotency.Key) (*idempotency.Result, error) {
-		return nil, errRedisConnection
-	}
-
-	consumer, err := NewDepositConsumer(kafka.ConsumerConfig{
-		BootstrapServers: "localhost:9092",
-		GroupID:          "test-group",
-	}, postingService, mockIdemp)
-	if err != nil {
-		t.Skip("Kafka not available, skipping integration test")
-	}
-	defer func() {
-		_ = consumer.Close()
-	}()
-
-	event := &eventsv1.DepositEvent{
-		AccountId:      "ACC-CHECK-FAIL",
-		AmountCents:    10000,
-		InstrumentCode: "GBP",
-		CorrelationId:  "deposit-check-fail",
-		ValueDate:      timestamppb.Now(),
-		Timestamp:      timestamppb.Now(),
-	}
-
-	testCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-	defer cancel()
-
-	err = consumer.handleDepositEvent(testCtx, event)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "idempotency check failed")
-}
-
-func TestDepositConsumer_ConcurrentProcessingRejected(t *testing.T) {
-	postingService, ctx, cleanup := setupTestServices(t)
-	defer cleanup()
-
-	// Mock idempotency service that fails to acquire lock (another consumer holds it)
-	mockIdemp := newMockIdempotencyService()
-	mockIdemp.acquireFunc = func(_ context.Context, _ idempotency.Key, _ idempotency.LockOptions) error {
-		return idempotency.ErrLockAcquisitionFailed
-	}
-
-	consumer, err := NewDepositConsumer(kafka.ConsumerConfig{
-		BootstrapServers: "localhost:9092",
-		GroupID:          "test-group",
-	}, postingService, mockIdemp)
-	if err != nil {
-		t.Skip("Kafka not available, skipping integration test")
-	}
-	defer func() {
-		_ = consumer.Close()
-	}()
-
-	event := &eventsv1.DepositEvent{
-		AccountId:      "ACC-CONCURRENT-REJECT",
-		AmountCents:    10000,
-		InstrumentCode: "GBP",
-		CorrelationId:  "deposit-concurrent-reject",
-		ValueDate:      timestamppb.Now(),
-		Timestamp:      timestamppb.Now(),
-	}
-
-	testCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-	defer cancel()
-
-	err = consumer.handleDepositEvent(testCtx, event)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrConcurrentProcessing)
-}
-
-func TestDepositConsumer_StoreFailureResult(t *testing.T) {
-	postingService, ctx, cleanup := setupTestServices(t)
-	defer cleanup()
-
-	var storeResultCalled bool
-	var capturedResult idempotency.Result
-
-	mockIdemp := newMockIdempotencyService()
-	mockIdemp.storeResultFunc = func(_ context.Context, result idempotency.Result) error {
-		storeResultCalled = true
-		capturedResult = result
-		return nil
-	}
-
-	consumer, err := NewDepositConsumer(kafka.ConsumerConfig{
-		BootstrapServers: "localhost:9092",
-		GroupID:          "test-group",
-	}, postingService, mockIdemp)
-	if err != nil {
-		t.Skip("Kafka not available, skipping integration test")
-	}
-	defer func() {
-		_ = consumer.Close()
-	}()
-
-	// Call storeFailureResult directly
-	key := idempotency.Key{
-		Namespace: "financial-accounting",
-		Operation: "process-deposit",
-		EntityID:  "ACC-FAIL-STORE",
-		RequestID: "req-fail-store",
-	}
-	consumer.storeFailureResult(ctx, key, "test error message")
-
-	assert.True(t, storeResultCalled, "StoreResult should be called")
-	assert.Equal(t, idempotency.StatusFailed, capturedResult.Status)
-	assert.Equal(t, "test error message", capturedResult.Error)
-	assert.Equal(t, failureResultTTL, capturedResult.TTL)
-	assert.Nil(t, capturedResult.Data)
-	assert.False(t, capturedResult.CompletedAt.IsZero())
-}
-
-func TestDepositConsumer_StoreFailureResult_BestEffort(t *testing.T) {
-	postingService, ctx, cleanup := setupTestServices(t)
-	defer cleanup()
-
-	mockIdemp := newMockIdempotencyService()
-	mockIdemp.storeResultFunc = func(_ context.Context, _ idempotency.Result) error {
-		return errors.New("redis unavailable")
-	}
-
-	consumer, err := NewDepositConsumer(kafka.ConsumerConfig{
-		BootstrapServers: "localhost:9092",
-		GroupID:          "test-group",
-	}, postingService, mockIdemp)
-	if err != nil {
-		t.Skip("Kafka not available, skipping integration test")
-	}
-	defer func() {
-		_ = consumer.Close()
-	}()
-
-	// storeFailureResult is best-effort, should not panic
-	key := idempotency.Key{
-		Namespace: "financial-accounting",
-		Operation: "process-deposit",
-		EntityID:  "ACC-FAIL-BEST-EFFORT",
-		RequestID: "req-fail-best-effort",
-	}
-	// Should not panic even when StoreResult fails
-	consumer.storeFailureResult(ctx, key, "some error")
-}
-
-func TestDepositConsumer_HandleDepositEvent_EmptyCurrencyStoresFailure(t *testing.T) {
-	postingService, ctx, cleanup := setupTestServices(t)
-	defer cleanup()
-
-	var storeResultCalled bool
-	var capturedResult idempotency.Result
-
-	mockIdemp := newMockIdempotencyService()
-	mockIdemp.storeResultFunc = func(_ context.Context, result idempotency.Result) error {
-		storeResultCalled = true
-		capturedResult = result
-		return nil
-	}
-
-	consumer, err := NewDepositConsumer(kafka.ConsumerConfig{
-		BootstrapServers: "localhost:9092",
-		GroupID:          "test-group",
-	}, postingService, mockIdemp)
-	if err != nil {
-		t.Skip("Kafka not available, skipping integration test")
-	}
-	defer func() {
-		_ = consumer.Close()
-	}()
-
-	// Valid event but with empty currency - passes proto validation, fails currency check
-	// which triggers storeFailureResult
-	event := &eventsv1.DepositEvent{
-		AccountId:      "ACC-EMPTY-CURRENCY",
-		AmountCents:    10000,
-		InstrumentCode: "", // empty triggers currency validation failure after proto
-		CorrelationId:  "deposit-empty-currency",
-		ValueDate:      timestamppb.Now(),
-		Timestamp:      timestamppb.Now(),
-	}
-
-	testCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-	defer cancel()
-
-	err = consumer.handleDepositEvent(testCtx, event)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid deposit event")
-
-	// Proto validation catches empty instrument_code before the currency check,
-	// so storeFailureResult is NOT called for this case
-	_ = storeResultCalled
-	_ = capturedResult
-}
-
 func TestDepositConsumer_HandleDepositEvent_NilTimestamp(t *testing.T) {
-	postingService, ctx, cleanup := setupTestServices(t)
+	postingService, _, ctx, cleanup := setupTestServices(t)
 	defer cleanup()
 
-	mockIdemp := newMockIdempotencyService()
-
-	consumer, err := NewDepositConsumer(kafka.ConsumerConfig{
-		BootstrapServers: "localhost:9092",
-		GroupID:          "test-group",
-	}, postingService, mockIdemp)
-	if err != nil {
-		t.Skip("Kafka not available, skipping integration test")
-	}
-	defer func() {
-		_ = consumer.Close()
-	}()
+	consumer := newTestConsumer(t, postingService, newMockIdempotencyService())
 
 	event := &eventsv1.DepositEvent{
 		AccountId:      "ACC-NO-TS",
@@ -824,201 +407,228 @@ func TestDepositConsumer_HandleDepositEvent_NilTimestamp(t *testing.T) {
 		Timestamp:      nil,
 	}
 
-	testCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	testCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	err = consumer.handleDepositEvent(testCtx, event)
+	err := consumer.handleDepositEvent(testCtx, event)
 	require.Error(t, err)
 }
 
-func TestDepositConsumer_IdempotencyRecheckAfterLock(t *testing.T) {
-	postingService, ctx, cleanup := setupTestServices(t)
+// TestDepositConsumer_RedisFastPath_Skips verifies that when Redis reports a
+// deposit as already processed, the consumer short-circuits and writes no
+// postings to the database.
+func TestDepositConsumer_RedisFastPath_Skips(t *testing.T) {
+	postingService, db, ctx, cleanup := setupTestServices(t)
 	defer cleanup()
 
-	// First Check returns not-found, second Check (re-check) returns already-processed
-	checkCallCount := 0
 	mockIdemp := newMockIdempotencyService()
 	mockIdemp.checkFunc = func(_ context.Context, _ idempotency.Key) (*idempotency.Result, error) {
-		checkCallCount++
-		if checkCallCount == 1 {
-			return nil, idempotency.ErrResultNotFound
-		}
-		return &idempotency.Result{
-			Status: idempotency.StatusCompleted,
-		}, idempotency.ErrOperationAlreadyProcessed
+		return &idempotency.Result{Status: idempotency.StatusCompleted}, idempotency.ErrOperationAlreadyProcessed
 	}
 
-	consumer, err := NewDepositConsumer(kafka.ConsumerConfig{
-		BootstrapServers: "localhost:9092",
-		GroupID:          "test-group",
-	}, postingService, mockIdemp)
-	if err != nil {
-		t.Skip("Kafka not available, skipping integration test")
-	}
-	defer func() {
-		_ = consumer.Close()
-	}()
+	consumer := newTestConsumer(t, postingService, mockIdemp)
 
-	event := &eventsv1.DepositEvent{
-		AccountId:      "ACC-RECHECK",
-		AmountCents:    10000,
-		InstrumentCode: "GBP",
-		CorrelationId:  "deposit-recheck",
-		ValueDate:      timestamppb.Now(),
-		Timestamp:      timestamppb.Now(),
-	}
+	event := validDepositEvent("ACC-FASTPATH", "deposit-fastpath", 10000)
 
-	testCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	testCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	err = consumer.handleDepositEvent(testCtx, event)
-	require.NoError(t, err, "should return nil when re-check finds already processed")
-	assert.Equal(t, 2, checkCallCount, "Check should be called twice (initial + re-check)")
+	require.NoError(t, consumer.handleDepositEvent(testCtx, event))
+	assert.Equal(t, int64(0), countPostings(t, db),
+		"Redis fast path should skip the database write entirely")
 }
 
-func TestDepositConsumer_IdempotencyRecheckFailed(t *testing.T) {
-	postingService, ctx, cleanup := setupTestServices(t)
+// TestDepositConsumer_RedisDown_StillProcesses proves that idempotency survives
+// Redis being unavailable: even when both Check and StoreResult error, the
+// deposit is processed via the authoritative database path.
+func TestDepositConsumer_RedisDown_StillProcesses(t *testing.T) {
+	postingService, db, ctx, cleanup := setupTestServices(t)
 	defer cleanup()
 
-	checkCallCount := 0
+	redisErr := errors.New("redis connection refused")
 	mockIdemp := newMockIdempotencyService()
 	mockIdemp.checkFunc = func(_ context.Context, _ idempotency.Key) (*idempotency.Result, error) {
-		checkCallCount++
-		if checkCallCount == 1 {
-			return nil, idempotency.ErrResultNotFound
-		}
-		// Re-check returns a non-standard error
-		return nil, errors.New("redis timeout on re-check")
+		return nil, redisErr
 	}
-
-	consumer, err := NewDepositConsumer(kafka.ConsumerConfig{
-		BootstrapServers: "localhost:9092",
-		GroupID:          "test-group",
-	}, postingService, mockIdemp)
-	if err != nil {
-		t.Skip("Kafka not available, skipping integration test")
-	}
-	defer func() {
-		_ = consumer.Close()
-	}()
-
-	event := &eventsv1.DepositEvent{
-		AccountId:      "ACC-RECHECK-FAIL",
-		AmountCents:    10000,
-		InstrumentCode: "GBP",
-		CorrelationId:  "deposit-recheck-fail",
-		ValueDate:      timestamppb.Now(),
-		Timestamp:      timestamppb.Now(),
-	}
-
-	testCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-	defer cancel()
-
-	err = consumer.handleDepositEvent(testCtx, event)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "idempotency re-check failed")
-}
-
-func TestDepositConsumer_AcquireLockFailed_NonLockError(t *testing.T) {
-	postingService, ctx, cleanup := setupTestServices(t)
-	defer cleanup()
-
-	mockIdemp := newMockIdempotencyService()
-	mockIdemp.acquireFunc = func(_ context.Context, _ idempotency.Key, _ idempotency.LockOptions) error {
-		return errors.New("redis connection refused")
-	}
-
-	consumer, err := NewDepositConsumer(kafka.ConsumerConfig{
-		BootstrapServers: "localhost:9092",
-		GroupID:          "test-group",
-	}, postingService, mockIdemp)
-	if err != nil {
-		t.Skip("Kafka not available, skipping integration test")
-	}
-	defer func() {
-		_ = consumer.Close()
-	}()
-
-	event := &eventsv1.DepositEvent{
-		AccountId:      "ACC-ACQUIRE-ERR",
-		AmountCents:    10000,
-		InstrumentCode: "GBP",
-		CorrelationId:  "deposit-acquire-err",
-		ValueDate:      timestamppb.Now(),
-		Timestamp:      timestamppb.Now(),
-	}
-
-	testCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-	defer cancel()
-
-	err = consumer.handleDepositEvent(testCtx, event)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to acquire lock")
-	assert.NotErrorIs(t, err, ErrConcurrentProcessing)
-}
-
-func TestDepositConsumer_StoreSuccessResultFailed(t *testing.T) {
-	postingService, ctx, cleanup := setupTestServices(t)
-	defer cleanup()
-
-	mockIdemp := newMockIdempotencyService()
 	mockIdemp.storeResultFunc = func(_ context.Context, _ idempotency.Result) error {
-		return errors.New("redis write failed")
+		return redisErr
 	}
 
-	consumer, err := NewDepositConsumer(kafka.ConsumerConfig{
-		BootstrapServers: "localhost:9092",
-		GroupID:          "test-group",
-	}, postingService, mockIdemp)
-	if err != nil {
-		t.Skip("Kafka not available, skipping integration test")
-	}
-	defer func() {
-		_ = consumer.Close()
-	}()
+	consumer := newTestConsumer(t, postingService, mockIdemp)
 
-	event := &eventsv1.DepositEvent{
-		AccountId:      "ACC-STORE-FAIL",
-		AmountCents:    10000,
-		InstrumentCode: "GBP",
-		CorrelationId:  "deposit-store-fail",
-		ValueDate:      timestamppb.Now(),
-		Timestamp:      timestamppb.Now(),
-	}
+	event := validDepositEvent("ACC-REDIS-DOWN", "deposit-redis-down", 10000)
 
-	testCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	testCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	err = consumer.handleDepositEvent(testCtx, event)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to store idempotency result")
+	require.NoError(t, consumer.handleDepositEvent(testCtx, event),
+		"deposit must succeed even when Redis is unavailable")
+	assert.Equal(t, int64(2), countPostings(t, db),
+		"deposit should be posted (debit + credit) despite Redis errors")
+}
+
+// TestDepositConsumer_DuplicateRedelivery_NoDoublePosting is the core MON-3
+// guarantee: redelivering the same committed deposit produces no second posting.
+func TestDepositConsumer_DuplicateRedelivery_NoDoublePosting(t *testing.T) {
+	postingService, db, ctx, cleanup := setupTestServices(t)
+	defer cleanup()
+
+	// Redis is deliberately blind (always "not processed") so the database marker
+	// is the only thing preventing a duplicate.
+	mockIdemp := newMockIdempotencyService()
+	mockIdemp.checkFunc = func(_ context.Context, _ idempotency.Key) (*idempotency.Result, error) {
+		return nil, idempotency.ErrResultNotFound
+	}
+
+	consumer := newTestConsumer(t, postingService, mockIdemp)
+
+	event := validDepositEvent("ACC-REDELIVER", "deposit-redeliver", 10000)
+
+	testCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	// First delivery.
+	require.NoError(t, consumer.handleDepositEvent(testCtx, event))
+	// Redelivery of the identical event (same bytes -> same dedupe key).
+	require.NoError(t, consumer.handleDepositEvent(testCtx, event))
+
+	assert.Equal(t, int64(2), countPostings(t, db),
+		"redelivery must not create a second double-entry posting")
+}
+
+// TestDepositConsumer_DistinctDepositsSameCorrelation_BothPost verifies that two
+// genuinely distinct deposits that happen to share a correlation ID are BOTH
+// processed - i.e. the dedupe key is not the correlation ID.
+func TestDepositConsumer_DistinctDepositsSameCorrelation_BothPost(t *testing.T) {
+	postingService, db, ctx, cleanup := setupTestServices(t)
+	defer cleanup()
+
+	consumer := newTestConsumer(t, postingService, newMockIdempotencyService())
+
+	testCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	// Same account and correlation ID, but different amounts -> distinct deposits.
+	first := validDepositEvent("ACC-SAME-CORR", "shared-correlation", 10000)
+	second := validDepositEvent("ACC-SAME-CORR", "shared-correlation", 25000)
+
+	require.NoError(t, consumer.handleDepositEvent(testCtx, first))
+	require.NoError(t, consumer.handleDepositEvent(testCtx, second))
+
+	assert.Equal(t, int64(4), countPostings(t, db),
+		"distinct deposits sharing a correlation ID must both post")
+}
+
+// TestDepositConsumer_IdempotencyKeyFormat verifies the Redis fast-path key is
+// keyed on the per-deposit dedupe fingerprint, not the correlation ID.
+func TestDepositConsumer_IdempotencyKeyFormat(t *testing.T) {
+	postingService, _, ctx, cleanup := setupTestServices(t)
+	defer cleanup()
+
+	var capturedKey idempotency.Key
+	mockIdemp := newMockIdempotencyService()
+	mockIdemp.checkFunc = func(_ context.Context, key idempotency.Key) (*idempotency.Result, error) {
+		capturedKey = key
+		return nil, idempotency.ErrResultNotFound
+	}
+
+	consumer := newTestConsumer(t, postingService, mockIdemp)
+
+	event := validDepositEvent("ACC-KEY-FORMAT", "correlation-123", 10000)
+
+	testCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	_ = consumer.handleDepositEvent(testCtx, event)
+
+	expectedDedupe := buildDepositDedupeKey(testCtx, event)
+	assert.Equal(t, "financial-accounting", capturedKey.Namespace)
+	assert.Equal(t, "process-deposit", capturedKey.Operation)
+	assert.Equal(t, "ACC-KEY-FORMAT", capturedKey.EntityID)
+	assert.Equal(t, testTenantID, capturedKey.TenantID)
+	assert.Equal(t, expectedDedupe, capturedKey.RequestID,
+		"Redis key must use the per-deposit dedupe fingerprint, not the correlation ID")
+	assert.NotEqual(t, "correlation-123", capturedKey.RequestID)
+}
+
+// TestDepositConsumer_MarksRedisOnSuccess verifies that a successful deposit
+// records a completed marker in Redis for the fast path on future deliveries.
+func TestDepositConsumer_MarksRedisOnSuccess(t *testing.T) {
+	postingService, _, ctx, cleanup := setupTestServices(t)
+	defer cleanup()
+
+	var storeResultCalled bool
+	var capturedResult idempotency.Result
+	mockIdemp := newMockIdempotencyService()
+	mockIdemp.storeResultFunc = func(_ context.Context, result idempotency.Result) error {
+		storeResultCalled = true
+		capturedResult = result
+		return nil
+	}
+
+	consumer := newTestConsumer(t, postingService, mockIdemp)
+
+	event := validDepositEvent("ACC-SUCCESS", "deposit-success", 10000)
+
+	testCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, consumer.handleDepositEvent(testCtx, event))
+
+	assert.True(t, storeResultCalled, "StoreResult should be called on success")
+	assert.Equal(t, idempotency.StatusCompleted, capturedResult.Status)
+	assert.Equal(t, 24*time.Hour, capturedResult.TTL)
+	assert.Nil(t, capturedResult.Data, "Data should be nil for events")
+}
+
+func TestBuildDepositDedupeKey(t *testing.T) {
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID(testTenantID))
+	now := timestamppb.Now()
+	later := timestamppb.New(now.AsTime().Add(time.Second))
+
+	// newEvent constructs a fresh DepositEvent so we never copy a proto value
+	// (proto messages contain a mutex and must not be copied).
+	newEvent := func(amount int64, ts *timestamppb.Timestamp) *eventsv1.DepositEvent {
+		return &eventsv1.DepositEvent{
+			AccountId:      "ACC-DEDUPE",
+			AmountCents:    amount,
+			InstrumentCode: "GBP",
+			CorrelationId:  "corr-1",
+			ValueDate:      now,
+			Timestamp:      ts,
+		}
+	}
+
+	key1 := buildDepositDedupeKey(ctx, newEvent(10000, now))
+	key2 := buildDepositDedupeKey(ctx, newEvent(10000, now))
+	assert.Equal(t, key1, key2, "identical events must produce identical dedupe keys")
+	assert.Len(t, key1, 64, "dedupe key should be a hex-encoded SHA-256 (64 chars)")
+
+	// Differing amount -> different key.
+	assert.NotEqual(t, key1, buildDepositDedupeKey(ctx, newEvent(20000, now)))
+
+	// Same correlation ID but different timestamp -> different key.
+	assert.NotEqual(t, key1, buildDepositDedupeKey(ctx, newEvent(10000, later)))
+
+	// Different tenant -> different key.
+	otherCtx := tenant.WithTenant(context.Background(), tenant.TenantID("other_tenant"))
+	assert.NotEqual(t, key1, buildDepositDedupeKey(otherCtx, newEvent(10000, now)))
 }
 
 func TestDepositConsumer_LifecycleMethods_Exist(t *testing.T) {
 	// Verify Start, Stop, and Close methods exist and have correct signatures.
 	// Actual lifecycle testing requires a Kafka broker, so we test the
 	// consumer's struct fields are properly initialized instead.
-	postingService, _, cleanup := setupTestServices(t)
+	postingService, _, _, cleanup := setupTestServices(t)
 	defer cleanup()
 
-	mockIdemp := newMockIdempotencyService()
-
-	consumer, err := NewDepositConsumer(kafka.ConsumerConfig{
-		BootstrapServers: "localhost:9092",
-		GroupID:          "test-group",
-	}, postingService, mockIdemp)
-	if err != nil {
-		t.Skip("Kafka not available, skipping integration test")
-	}
+	consumer := newTestConsumer(t, postingService, newMockIdempotencyService())
 
 	// Verify all fields are initialized
 	assert.NotNil(t, consumer.consumer, "ProtoConsumer should be initialized")
 	assert.NotNil(t, consumer.postingService, "PostingService should be set")
 	assert.NotNil(t, consumer.idempotency, "Idempotency service should be set")
 	assert.NotNil(t, consumer.validator, "Validator should be initialized")
-
-	// Close the consumer (does not require Kafka to be running for cleanup)
-	_ = consumer.Close()
 }
 
 func TestExtractTenantID(t *testing.T) {

--- a/services/financial-accounting/adapters/persistence/deposit_idempotency_entity.go
+++ b/services/financial-accounting/adapters/persistence/deposit_idempotency_entity.go
@@ -1,0 +1,46 @@
+package persistence
+
+import "time"
+
+// DepositIdempotencyEntity is a per-deposit idempotency marker written in the
+// SAME database transaction as the ledger postings for a deposit.
+//
+// # Why this exists
+//
+// Deposit events arrive over Kafka with at-least-once delivery. The consumer
+// previously relied on a Redis marker written AFTER the ledger postings were
+// committed. A crash (or Redis outage) between the ledger commit and the Redis
+// write left the deposit committed with no idempotency marker, so a redelivery
+// re-processed it and produced a duplicate double-entry posting.
+//
+// Writing this marker inside the same transaction as the postings makes
+// exactly-once processing a database invariant: the unique primary key on
+// DedupeKey guarantees that a second attempt to record the same deposit fails
+// the whole transaction (marker + postings roll back together). Redis is then
+// only an optimisation (a fast-path "already done" cache), never a correctness
+// dependency.
+//
+// DedupeKey is a deterministic per-deposit fingerprint (see the deposit
+// consumer's dedupe-key derivation), NOT the correlation ID: correlation IDs
+// can be reused across distinct deposits, so keying on them would incorrectly
+// collapse distinct deposits into one.
+type DepositIdempotencyEntity struct {
+	// DedupeKey is the per-deposit idempotency fingerprint (hex-encoded SHA-256).
+	DedupeKey string `gorm:"column:dedupe_key;primaryKey;size:64"`
+
+	// AccountID is the account that received the deposit (for observability/forensics).
+	AccountID string `gorm:"column:account_id;not null;size:255"`
+
+	// CorrelationID links the marker back to the originating event stream.
+	CorrelationID string `gorm:"column:correlation_id;size:255"`
+
+	// CreatedAt is when the deposit was recorded.
+	CreatedAt time.Time `gorm:"column:created_at;not null"`
+}
+
+// TableName overrides the default table name.
+// Uses singular, unqualified name per database-per-service architecture
+// (search_path routing to the tenant schema).
+func (DepositIdempotencyEntity) TableName() string {
+	return "deposit_idempotency"
+}

--- a/services/financial-accounting/adapters/persistence/repository.go
+++ b/services/financial-accounting/adapters/persistence/repository.go
@@ -31,6 +31,9 @@ var (
 	ErrFractionalCents = errors.New("amount has fractional cents that cannot be represented")
 	// ErrDuplicateIdempotencyKey is returned when a booking log with the same idempotency key already exists
 	ErrDuplicateIdempotencyKey = errors.New("booking log with this idempotency key already exists")
+	// ErrDepositAlreadyProcessed is returned when a deposit with the same dedupe key
+	// has already been recorded (its idempotency marker already exists).
+	ErrDepositAlreadyProcessed = errors.New("deposit already processed")
 	// ErrInvalidPageToken is returned when the pagination token has an invalid format
 	ErrInvalidPageToken = errors.New("invalid page token format")
 )
@@ -163,6 +166,58 @@ func (r *LedgerRepository) SavePostingsInTransaction(ctx context.Context, postin
 		return nil
 	})
 	if err != nil {
+		return fmt.Errorf("transaction failed: %w", err)
+	}
+	return nil
+}
+
+// SaveDepositWithIdempotency persists deposit postings together with a
+// per-deposit idempotency marker in a single atomic transaction.
+//
+// The marker is inserted first; its unique primary key (DedupeKey) enforces
+// exactly-once processing at the database layer. If a marker with the same
+// DedupeKey already exists, the whole transaction is rolled back (no postings
+// are written) and ErrDepositAlreadyProcessed is returned. This makes duplicate
+// suppression a database invariant that does not depend on Redis timing.
+//
+// The context must contain the tenant ID for schema routing.
+func (r *LedgerRepository) SaveDepositWithIdempotency(
+	ctx context.Context,
+	marker DepositIdempotencyEntity,
+	postings []*domain.LedgerPosting,
+) error {
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		scopedTx, scopeErr := r.withTenantScope(ctx, tx)
+		if scopeErr != nil {
+			return scopeErr
+		}
+
+		// Insert the idempotency marker first. A unique-violation here means the
+		// deposit was already recorded, so we abort the transaction (rolling back
+		// any postings) and surface ErrDepositAlreadyProcessed.
+		if err := scopedTx.Create(&marker).Error; err != nil {
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+				return ErrDepositAlreadyProcessed
+			}
+			return err
+		}
+
+		for _, posting := range postings {
+			entity, err := toPostingEntity(posting)
+			if err != nil {
+				return err
+			}
+			if err := scopedTx.Create(&entity).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, ErrDepositAlreadyProcessed) {
+			return ErrDepositAlreadyProcessed
+		}
 		return fmt.Errorf("transaction failed: %w", err)
 	}
 	return nil

--- a/services/financial-accounting/adapters/persistence/repository_test.go
+++ b/services/financial-accounting/adapters/persistence/repository_test.go
@@ -292,6 +292,96 @@ func TestSaveDepositWithIdempotency_DistinctKeysBothPersist(t *testing.T) {
 	assert.Equal(t, int64(2), count, "distinct dedupe keys should both persist")
 }
 
+// TestSaveDepositWithIdempotency_RollsBackMarkerOnPostingFailure proves the
+// exactly-once property at the heart of MON-3: because the idempotency marker
+// and the ledger postings are written in one transaction, a posting insert
+// failure rolls back the marker too. A failed deposit is therefore NOT silently
+// suppressed - a later redelivery reprocesses it instead of seeing a stale
+// marker and skipping.
+func TestSaveDepositWithIdempotency_RollsBackMarkerOnPostingFailure(t *testing.T) {
+	db, ctx, cleanup := setupDepositIdempotencyTestDB(t)
+	defer cleanup()
+
+	repo := NewLedgerRepository(db)
+
+	gbpInstrument := domain.MustCurrencyToInstrument(domain.CurrencyGBP)
+	money := domain.NewMoney(decimal.NewFromInt(100), gbpInstrument)
+	bookingLogID := uuid.New()
+
+	// Pre-insert a committed posting so that a later insert reusing the same
+	// primary key fails with a unique violation - a genuine DB posting-insert
+	// failure inside the deposit transaction.
+	conflictID := uuid.New()
+	require.NoError(t, repo.SavePosting(ctx, &domain.LedgerPosting{
+		ID:                    conflictID,
+		FinancialBookingLogID: bookingLogID,
+		Direction:             domain.PostingDirectionDebit,
+		Amount:                money,
+		AccountID:             "ACC-PRE",
+		ValueDate:             time.Now(),
+		Status:                domain.TransactionStatusPosted,
+		CorrelationID:         "CORR-PRE",
+		CreatedAt:             time.Now(),
+	}))
+
+	dedupeKey := "dedupe-rollback"
+	marker := DepositIdempotencyEntity{
+		DedupeKey:     dedupeKey,
+		AccountID:     "ACC-ROLLBACK",
+		CorrelationID: "CORR-ROLLBACK",
+		CreatedAt:     time.Now(),
+	}
+
+	// This deposit's posting reuses conflictID, so its insert fails inside the tx.
+	failingPostings := []*domain.LedgerPosting{
+		{
+			ID:                    conflictID, // duplicate primary key -> insert fails
+			FinancialBookingLogID: bookingLogID,
+			Direction:             domain.PostingDirectionDebit,
+			Amount:                money,
+			AccountID:             "ACC-ROLLBACK",
+			ValueDate:             time.Now(),
+			Status:                domain.TransactionStatusPosted,
+			CorrelationID:         "CORR-ROLLBACK",
+			CreatedAt:             time.Now(),
+		},
+	}
+
+	err := repo.SaveDepositWithIdempotency(ctx, marker, failingPostings)
+	require.Error(t, err, "posting insert failure must propagate")
+	assert.NotErrorIs(t, err, ErrDepositAlreadyProcessed,
+		"a posting failure is not an already-processed condition")
+
+	// (a) The idempotency marker must have been rolled back with the postings.
+	var markerCount int64
+	require.NoError(t, db.Model(&DepositIdempotencyEntity{}).
+		Where("dedupe_key = ?", dedupeKey).Count(&markerCount).Error)
+	assert.Equal(t, int64(0), markerCount,
+		"marker must roll back when the postings fail (same transaction)")
+
+	// (b) Redelivery of the same deposit (with a fresh posting id) reprocesses
+	// successfully - it is NOT silently suppressed by a stale marker.
+	redelivered := []*domain.LedgerPosting{
+		{
+			ID:                    uuid.New(),
+			FinancialBookingLogID: bookingLogID,
+			Direction:             domain.PostingDirectionDebit,
+			Amount:                money,
+			AccountID:             "ACC-ROLLBACK",
+			ValueDate:             time.Now(),
+			Status:                domain.TransactionStatusPosted,
+			CorrelationID:         "CORR-ROLLBACK",
+			CreatedAt:             time.Now(),
+		},
+	}
+	require.NoError(t, repo.SaveDepositWithIdempotency(ctx, marker, redelivered),
+		"redelivery must reprocess a previously-failed deposit")
+
+	require.NoError(t, db.Model(&DepositIdempotencyEntity{}).
+		Where("dedupe_key = ?", dedupeKey).Count(&markerCount).Error)
+	assert.Equal(t, int64(1), markerCount, "marker present after successful redelivery")
+}
+
 func TestGetPosting_NotFound(t *testing.T) {
 	db, ctx, cleanup := setupTestDB(t)
 	defer cleanup()

--- a/services/financial-accounting/adapters/persistence/repository_test.go
+++ b/services/financial-accounting/adapters/persistence/repository_test.go
@@ -181,6 +181,117 @@ func TestSavePostingsInTransaction_RollbackOnError(t *testing.T) {
 	assert.Equal(t, int64(0), count)
 }
 
+func setupDepositIdempotencyTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
+	t.Helper()
+	return testdb.SetupTestDB(t,
+		testdb.WithModels(
+			&FinancialBookingLogEntity{},
+			&LedgerPostingEntity{},
+			&DepositIdempotencyEntity{},
+			&audit.AuditOutbox{},
+		),
+		testdb.WithTenant(testTenantID),
+	)
+}
+
+func TestSaveDepositWithIdempotency_FirstSucceedsDuplicateRejected(t *testing.T) {
+	db, ctx, cleanup := setupDepositIdempotencyTestDB(t)
+	defer cleanup()
+
+	repo := NewLedgerRepository(db)
+
+	bookingLogID := uuid.New()
+	gbpInstrument := domain.MustCurrencyToInstrument(domain.CurrencyGBP)
+	money := domain.NewMoney(decimal.NewFromInt(100), gbpInstrument)
+
+	newPostings := func() []*domain.LedgerPosting {
+		return []*domain.LedgerPosting{
+			{
+				ID:                    uuid.New(),
+				FinancialBookingLogID: bookingLogID,
+				Direction:             domain.PostingDirectionDebit,
+				Amount:                money,
+				AccountID:             "ACC-001",
+				ValueDate:             time.Now(),
+				Status:                domain.TransactionStatusPosted,
+				CorrelationID:         "CORR-DUP",
+				CreatedAt:             time.Now(),
+			},
+			{
+				ID:                    uuid.New(),
+				FinancialBookingLogID: bookingLogID,
+				Direction:             domain.PostingDirectionCredit,
+				Amount:                money,
+				AccountID:             "ACC-002",
+				ValueDate:             time.Now(),
+				Status:                domain.TransactionStatusPosted,
+				CorrelationID:         "CORR-DUP",
+				CreatedAt:             time.Now(),
+			},
+		}
+	}
+
+	marker := DepositIdempotencyEntity{
+		DedupeKey:     "dedupe-abc",
+		AccountID:     "ACC-001",
+		CorrelationID: "CORR-DUP",
+		CreatedAt:     time.Now(),
+	}
+
+	// First deposit persists marker + postings atomically.
+	require.NoError(t, repo.SaveDepositWithIdempotency(ctx, marker, newPostings()))
+
+	var count int64
+	require.NoError(t, db.Model(&LedgerPostingEntity{}).Count(&count).Error)
+	assert.Equal(t, int64(2), count)
+
+	// Duplicate deposit (same dedupe key) is rejected and writes no postings.
+	err := repo.SaveDepositWithIdempotency(ctx, marker, newPostings())
+	assert.ErrorIs(t, err, ErrDepositAlreadyProcessed)
+
+	require.NoError(t, db.Model(&LedgerPostingEntity{}).Count(&count).Error)
+	assert.Equal(t, int64(2), count, "duplicate deposit must not add postings")
+}
+
+func TestSaveDepositWithIdempotency_DistinctKeysBothPersist(t *testing.T) {
+	db, ctx, cleanup := setupDepositIdempotencyTestDB(t)
+	defer cleanup()
+
+	repo := NewLedgerRepository(db)
+
+	bookingLogID := uuid.New()
+	gbpInstrument := domain.MustCurrencyToInstrument(domain.CurrencyGBP)
+	money := domain.NewMoney(decimal.NewFromInt(100), gbpInstrument)
+
+	postingsFor := func() []*domain.LedgerPosting {
+		return []*domain.LedgerPosting{
+			{
+				ID:                    uuid.New(),
+				FinancialBookingLogID: bookingLogID,
+				Direction:             domain.PostingDirectionDebit,
+				Amount:                money,
+				AccountID:             "ACC-001",
+				ValueDate:             time.Now(),
+				Status:                domain.TransactionStatusPosted,
+				CorrelationID:         "CORR-SHARED",
+				CreatedAt:             time.Now(),
+			},
+		}
+	}
+
+	// Two distinct dedupe keys (even sharing a correlation ID) both persist.
+	require.NoError(t, repo.SaveDepositWithIdempotency(ctx,
+		DepositIdempotencyEntity{DedupeKey: "dedupe-1", AccountID: "ACC-001", CorrelationID: "CORR-SHARED", CreatedAt: time.Now()},
+		postingsFor()))
+	require.NoError(t, repo.SaveDepositWithIdempotency(ctx,
+		DepositIdempotencyEntity{DedupeKey: "dedupe-2", AccountID: "ACC-001", CorrelationID: "CORR-SHARED", CreatedAt: time.Now()},
+		postingsFor()))
+
+	var count int64
+	require.NoError(t, db.Model(&LedgerPostingEntity{}).Count(&count).Error)
+	assert.Equal(t, int64(2), count, "distinct dedupe keys should both persist")
+}
+
 func TestGetPosting_NotFound(t *testing.T) {
 	db, ctx, cleanup := setupTestDB(t)
 	defer cleanup()

--- a/services/financial-accounting/migrations/20260707000001_add_deposit_idempotency.sql
+++ b/services/financial-accounting/migrations/20260707000001_add_deposit_idempotency.sql
@@ -1,0 +1,13 @@
+-- Create "deposit_idempotency" table
+-- Per-deposit idempotency marker written in the same transaction as a deposit's
+-- ledger postings, making exactly-once deposit processing a database invariant.
+-- The primary key on dedupe_key rejects a redelivered deposit before any
+-- duplicate postings are written. See DepositIdempotencyEntity and the deposit
+-- consumer's dedupe-key derivation.
+CREATE TABLE "deposit_idempotency" (
+  "dedupe_key" character varying(64) NOT NULL,
+  "account_id" character varying(255) NOT NULL,
+  "correlation_id" character varying(255) NULL,
+  "created_at" timestamptz NOT NULL,
+  PRIMARY KEY ("dedupe_key")
+);

--- a/services/financial-accounting/migrations/atlas.sum
+++ b/services/financial-accounting/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:vDNQBYhTosPAEk6+nl2NkwG2XFpSFe07+kOQcvia3PI=
+h1:BLBWJu7AtbVVT57Rrz5R9FyPIIaZNmusAEf0R+sQSwk=
 20251216000001_initial.sql h1:QyCFEl6iIRccIm/rlDMmm0p0IrN93AlxtaHZHiWWYq0=
 20251217000001_audit_system.sql h1:yyJlrBFDysy+cDtEsb+QePFjXJSFi8OKO+di10S7tYs=
 20251219000001_fix_audit_schema_compatibility.sql h1:kvPAApDaUen53jDQKyCXYWb2031nv1xwYwrPbP2iJVk=
@@ -10,3 +10,4 @@ h1:vDNQBYhTosPAEk6+nl2NkwG2XFpSFe07+kOQcvia3PI=
 20260316000002_add_event_outbox_tenant_id_index.sql h1:EphmMrVOQ2k0wYlsqCQxVFyIl0bBBQE4CCaPhwwP4Ew=
 20260323000001_align_audit_schema.sql h1:TMEpylGBxM2W7kyuNtRigAv5YUoE0GdxelwS9JhLfFk=
 20260323000002_align_audit_schema_data.sql h1:odRmDBvPm03A9WWBXwuVZhhntKsW0cdrYyVM1dMQR3o=
+20260707000001_add_deposit_idempotency.sql h1:WAau1Ffswv/eF5xD+nGu8FN5+Bi+3opzW3dpvd7Ygis=

--- a/services/financial-accounting/service/grpc_booking_endpoints.go
+++ b/services/financial-accounting/service/grpc_booking_endpoints.go
@@ -111,6 +111,10 @@ func (s *FinancialAccountingService) checkAndMarkPendingSimple(ctx context.Conte
 	}
 
 	if err := s.idempotency.MarkPending(ctx, key, defaultIdempotencyTTL); err != nil {
+		if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) {
+			// Concurrent duplicate: another request already claimed this key.
+			return status.Error(codes.Aborted, "operation already in progress, please retry")
+		}
 		return status.Errorf(codes.Internal, "failed to mark operation as pending: %v", err)
 	}
 	return nil

--- a/services/financial-accounting/service/grpc_control_endpoints.go
+++ b/services/financial-accounting/service/grpc_control_endpoints.go
@@ -138,6 +138,10 @@ func (s *FinancialAccountingService) checkControlIdempotency(
 	}
 
 	if err := s.idempotency.MarkPending(ctx, key, defaultIdempotencyTTL); err != nil {
+		if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) {
+			// Concurrent duplicate: another request already claimed this key.
+			return nil, status.Error(codes.Aborted, "operation already in progress, please retry")
+		}
 		return nil, status.Errorf(codes.Internal, "failed to mark operation as pending: %v", err)
 	}
 	return nil, nil //nolint:nilnil // intentional: nil,nil signals "no cached result, proceed with operation"

--- a/services/financial-accounting/service/grpc_posting_endpoints.go
+++ b/services/financial-accounting/service/grpc_posting_endpoints.go
@@ -181,6 +181,10 @@ func (s *FinancialAccountingService) checkCapturePostingIdempotency(
 	}
 
 	if err := s.idempotency.MarkPending(ctx, key, defaultIdempotencyTTL); err != nil {
+		if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) {
+			// Concurrent duplicate: another request already claimed this key.
+			return nil, status.Error(codes.Aborted, "operation already in progress, please retry")
+		}
 		return nil, status.Errorf(codes.Internal, "failed to mark operation as pending: %v", err)
 	}
 	return nil, nil //nolint:nilnil // intentional: nil,nil signals "no cached result, proceed with operation"

--- a/services/financial-accounting/service/posting_service.go
+++ b/services/financial-accounting/service/posting_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -13,6 +14,12 @@ import (
 	"github.com/meridianhub/meridian/shared/pkg/refdata"
 	"github.com/shopspring/decimal"
 )
+
+// ErrDepositAlreadyProcessed indicates a deposit with the same dedupe key has
+// already been recorded on the ledger. It is a successful no-op condition for
+// idempotent deposit processing, re-exported from the persistence layer so
+// callers depend only on the service package.
+var ErrDepositAlreadyProcessed = persistence.ErrDepositAlreadyProcessed
 
 // PostingService handles ledger posting operations
 type PostingService struct {
@@ -131,6 +138,68 @@ func (s *PostingService) ProcessDeposit(ctx context.Context, event DepositEvent)
 
 	// Save both postings atomically in a transaction
 	if err := s.repo.SavePostingsInTransaction(ctx, []*domain.LedgerPosting{debitPosting, creditPosting}); err != nil {
+		timer.ObserveError(observability.ErrorCategoryDatabase)
+		observability.RecordDepositProcessed(event.InstrumentCode, observability.StatusError)
+		return fmt.Errorf("failed to save postings: %w", err)
+	}
+
+	// Record successful metrics using the resolved amount from the debit posting
+	timer.ObserveSuccess()
+	recordDepositSuccessMetrics(event.InstrumentCode, debitPosting.Amount.Amount)
+
+	return nil
+}
+
+// ProcessDepositWithDedupeKey creates the double-entry postings for a deposit
+// and records a per-deposit idempotency marker in the SAME database transaction,
+// guaranteeing exactly-once processing at the database layer.
+//
+// dedupeKey must be a stable per-deposit fingerprint (NOT the correlation ID,
+// which can be reused across distinct deposits). If the deposit has already been
+// recorded, it returns persistence.ErrDepositAlreadyProcessed and writes no
+// postings; callers should treat that as a successful no-op because the deposit
+// is already on the ledger.
+func (s *PostingService) ProcessDepositWithDedupeKey(ctx context.Context, event DepositEvent, dedupeKey string) error {
+	timer := observability.NewOperationTimer(observability.OperationProcessDeposit)
+
+	bookingLogID := uuid.New()
+
+	debitPosting, creditPosting, err := s.buildDepositPostings(ctx, bookingLogID, event)
+	if err != nil {
+		timer.ObserveError(observability.ErrorCategoryValidation)
+		observability.RecordDepositProcessed(event.InstrumentCode, observability.StatusError)
+		return err
+	}
+
+	if err := debitPosting.Post("Deposit processed"); err != nil {
+		timer.ObserveError(observability.ErrorCategoryInternal)
+		observability.RecordDepositProcessed(event.InstrumentCode, observability.StatusError)
+		return fmt.Errorf("failed to post debit: %w", err)
+	}
+
+	if err := creditPosting.Post("Deposit processed"); err != nil {
+		timer.ObserveError(observability.ErrorCategoryInternal)
+		observability.RecordDepositProcessed(event.InstrumentCode, observability.StatusError)
+		return fmt.Errorf("failed to post credit: %w", err)
+	}
+
+	marker := persistence.DepositIdempotencyEntity{
+		DedupeKey:     dedupeKey,
+		AccountID:     event.AccountID,
+		CorrelationID: event.CorrelationID,
+		CreatedAt:     time.Now(),
+	}
+
+	err = s.repo.SaveDepositWithIdempotency(ctx, marker, []*domain.LedgerPosting{debitPosting, creditPosting})
+	if err != nil {
+		if errors.Is(err, persistence.ErrDepositAlreadyProcessed) {
+			// Duplicate delivery: the deposit is already on the ledger. This is a
+			// successful no-op, not an error - report success and propagate the
+			// sentinel so the caller can skip any post-processing.
+			timer.ObserveSuccess()
+			observability.RecordDepositProcessed(event.InstrumentCode, observability.StatusSuccess)
+			return persistence.ErrDepositAlreadyProcessed
+		}
 		timer.ObserveError(observability.ErrorCategoryDatabase)
 		observability.RecordDepositProcessed(event.InstrumentCode, observability.StatusError)
 		return fmt.Errorf("failed to save postings: %w", err)

--- a/services/payment-order/service/grpc_initiate.go
+++ b/services/payment-order/service/grpc_initiate.go
@@ -145,6 +145,10 @@ func (s *Service) checkInitiateRedisIdempotency(ctx context.Context, idempKey id
 	// the pending lock remains until TTL expires (5 minutes). This is intentional - it prevents
 	// concurrent retry attempts from creating duplicates. The client should retry after TTL expiry.
 	if err := s.idempotencyService.MarkPending(ctx, idempKey, idempotencyPendingTTL); err != nil {
+		if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) {
+			// Concurrent duplicate: another request already claimed this key.
+			return nil, status.Error(codes.Aborted, "operation already in progress, please retry")
+		}
 		s.logger.Error("failed to mark operation pending", "error", err)
 		return nil, status.Error(codes.Internal, "failed to acquire idempotency lock")
 	}

--- a/services/payment-order/service/grpc_lifecycle.go
+++ b/services/payment-order/service/grpc_lifecycle.go
@@ -214,6 +214,10 @@ func (s *Service) ReversePaymentOrder(ctx context.Context, req *pb.ReversePaymen
 
 	// Mark operation as pending (distributed lock)
 	if err := s.idempotencyService.MarkPending(ctx, idempKey, idempotencyPendingTTL); err != nil {
+		if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) {
+			// Concurrent duplicate: another request already claimed this key.
+			return nil, status.Error(codes.Aborted, "operation already in progress, please retry")
+		}
 		s.logger.Error("failed to mark reversal operation pending", "error", err)
 		return nil, status.Error(codes.Internal, "failed to acquire reversal idempotency lock")
 	}

--- a/services/payment-order/service/grpc_update.go
+++ b/services/payment-order/service/grpc_update.go
@@ -67,6 +67,11 @@ func (s *Service) UpdatePaymentOrder(ctx context.Context, req *pb.UpdatePaymentO
 	}
 
 	if err := s.idempotencyService.MarkPending(ctx, idempKey, idempotencyPendingTTL); err != nil {
+		if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) {
+			// Concurrent duplicate: another request already claimed this key.
+			operationStatus = opStatusIdempotent
+			return nil, status.Error(codes.Aborted, "operation already in progress, please retry")
+		}
 		s.logger.Error("failed to mark webhook operation pending", "error", err)
 		operationStatus = opStatusError
 		return nil, status.Error(codes.Internal, "failed to acquire webhook idempotency lock")

--- a/services/position-keeping/service/initiate.go
+++ b/services/position-keeping/service/initiate.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
@@ -340,6 +341,10 @@ func (s *PositionKeepingService) checkIdempotencyAndAcquireLock(
 	// Mark operation as pending to prevent concurrent execution
 	// Use 5-minute TTL for operation lock
 	if err := s.idempotency.MarkPending(ctx, key, 5*time.Minute); err != nil {
+		if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) {
+			// Concurrent duplicate: another request already claimed this key.
+			return nil, nil, status.Error(codes.Aborted, "operation already in progress, please retry")
+		}
 		return nil, nil, status.Errorf(codes.Internal, "failed to mark operation as pending: %v", err)
 	}
 

--- a/services/position-keeping/service/initiate_batch.go
+++ b/services/position-keeping/service/initiate_batch.go
@@ -348,6 +348,10 @@ func (s *PositionKeepingService) checkBatchIdempotencyAndAcquireLock(
 
 	// Mark operation as pending
 	if err := s.idempotency.MarkPending(ctx, key, 10*time.Minute); err != nil {
+		if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) {
+			// Concurrent duplicate: another request already claimed this key.
+			return nil, nil, status.Error(codes.Aborted, "operation already in progress, please retry")
+		}
 		return nil, nil, status.Errorf(codes.Internal, "failed to mark batch operation as pending: %v", err)
 	}
 

--- a/services/position-keeping/service/initiate_migration.go
+++ b/services/position-keeping/service/initiate_migration.go
@@ -184,6 +184,10 @@ func (s *PositionKeepingService) checkMigrationIdempotencyAndAcquireLock(
 	}
 
 	if err := s.idempotency.MarkPending(ctx, key, 5*time.Minute); err != nil {
+		if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) {
+			// Concurrent duplicate: another request already claimed this key.
+			return nil, nil, status.Error(codes.Aborted, "operation already in progress, please retry")
+		}
 		return nil, nil, status.Errorf(codes.Internal, "failed to mark operation as pending: %v", err)
 	}
 

--- a/services/position-keeping/service/record_measurement.go
+++ b/services/position-keeping/service/record_measurement.go
@@ -260,6 +260,10 @@ func (s *PositionKeepingService) checkMeasurementIdempotencyAndAcquireLock(
 
 	// Mark operation as pending to prevent concurrent execution
 	if err := s.idempotency.MarkPending(ctx, key, 5*time.Minute); err != nil {
+		if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) {
+			// Concurrent duplicate: another request already claimed this key.
+			return nil, nil, status.Error(codes.Aborted, "operation already in progress, please retry")
+		}
 		return nil, nil, status.Errorf(codes.Internal, "failed to mark operation as pending: %v", err)
 	}
 

--- a/services/position-keeping/service/update.go
+++ b/services/position-keeping/service/update.go
@@ -204,6 +204,10 @@ func (s *PositionKeepingService) checkUpdateIdempotencyAndAcquireLock(
 
 	// Mark operation as pending
 	if err := s.idempotency.MarkPending(ctx, key, 5*time.Minute); err != nil {
+		if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) {
+			// Concurrent duplicate: another request already claimed this key.
+			return nil, nil, status.Error(codes.Aborted, "operation already in progress, please retry")
+		}
 		return nil, nil, status.Errorf(codes.Internal, "failed to mark operation as pending: %v", err)
 	}
 

--- a/shared/pkg/idempotency/postgres_service.go
+++ b/shared/pkg/idempotency/postgres_service.go
@@ -147,16 +147,22 @@ func (s *PostgresService) MarkPending(ctx context.Context, key Key, ttl time.Dur
 	}
 
 	if tag.RowsAffected() == 0 {
-		// Key already existed - atomically replace it only if it's expired.
-		// The WHERE clause guards against race conditions where another writer
-		// refreshes the row between our INSERT and this UPDATE.
-		_, err = s.pool.Exec(ctx,
+		// Key already existed. Atomically reclaim it only if it has expired.
+		// The WHERE clause guards against a race where another writer refreshes
+		// the row between our INSERT and this UPDATE.
+		updateTag, err := s.pool.Exec(ctx,
 			`UPDATE _idempotency_keys SET status = $1, expires_at = $2, result = NULL, token = NULL, created_at = CURRENT_TIMESTAMP
 			 WHERE key = $3 AND expires_at IS NOT NULL AND expires_at < NOW()`,
 			string(StatusPending), expiresAt, dbKey,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to replace expired key: %w", err)
+		}
+		if updateTag.RowsAffected() == 0 {
+			// A live (non-expired) row already owns this key - another request is
+			// processing it or has already completed it. Report as already
+			// processed so concurrent callers do not both proceed and duplicate.
+			return ErrOperationAlreadyProcessed
 		}
 	}
 

--- a/shared/pkg/idempotency/postgres_service_test.go
+++ b/shared/pkg/idempotency/postgres_service_test.go
@@ -144,6 +144,88 @@ func TestPostgresService_MarkPending_ThenCheck(t *testing.T) {
 	}
 }
 
+// TestPostgresService_MarkPending_DuplicateLiveKey verifies that a second
+// MarkPending for a live (non-expired) key returns ErrOperationAlreadyProcessed
+// instead of silently succeeding.
+func TestPostgresService_MarkPending_DuplicateLiveKey(t *testing.T) {
+	svc := freshService(t)
+	ctx := context.Background()
+	key := pgTestKey()
+
+	if err := svc.MarkPending(ctx, key, time.Hour); err != nil {
+		t.Fatalf("first MarkPending failed: %v", err)
+	}
+
+	err := svc.MarkPending(ctx, key, time.Hour)
+	if !errors.Is(err, ErrOperationAlreadyProcessed) {
+		t.Errorf("expected ErrOperationAlreadyProcessed for duplicate live key, got %v", err)
+	}
+}
+
+// TestPostgresService_MarkPending_ReclaimsExpired verifies that MarkPending can
+// still atomically reclaim a key whose previous PENDING marker has expired.
+func TestPostgresService_MarkPending_ReclaimsExpired(t *testing.T) {
+	svc := freshService(t)
+	pool := getSharedPool(t)
+	ctx := context.Background()
+	key := pgTestKey()
+
+	if err := svc.MarkPending(ctx, key, time.Hour); err != nil {
+		t.Fatalf("first MarkPending failed: %v", err)
+	}
+
+	// Force the existing marker to be expired.
+	if _, err := pool.Exec(ctx,
+		`UPDATE _idempotency_keys SET expires_at = NOW() - INTERVAL '1 hour' WHERE key = $1`,
+		key.String(),
+	); err != nil {
+		t.Fatalf("failed to expire key: %v", err)
+	}
+
+	// A new MarkPending should reclaim the expired row and succeed.
+	if err := svc.MarkPending(ctx, key, time.Hour); err != nil {
+		t.Errorf("expected reclaim of expired key to succeed, got %v", err)
+	}
+}
+
+// TestPostgresService_MarkPending_Concurrent fires many concurrent MarkPending
+// calls for the same key and asserts exactly one wins; the rest receive
+// ErrOperationAlreadyProcessed.
+func TestPostgresService_MarkPending_Concurrent(t *testing.T) {
+	svc := freshService(t)
+	ctx := context.Background()
+	key := pgTestKey()
+
+	const goroutines = 50
+	var successCount atomic.Int32
+	var alreadyCount atomic.Int32
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := svc.MarkPending(ctx, key, time.Hour)
+			switch {
+			case err == nil:
+				successCount.Add(1)
+			case errors.Is(err, ErrOperationAlreadyProcessed):
+				alreadyCount.Add(1)
+			default:
+				t.Errorf("unexpected MarkPending error: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if successCount.Load() != 1 {
+		t.Errorf("expected exactly 1 successful MarkPending, got %d", successCount.Load())
+	}
+	if alreadyCount.Load() != goroutines-1 {
+		t.Errorf("expected %d ErrOperationAlreadyProcessed, got %d", goroutines-1, alreadyCount.Load())
+	}
+}
+
 func TestPostgresService_StoreResult_ThenCheck(t *testing.T) {
 	svc := freshService(t)
 	ctx := context.Background()

--- a/shared/pkg/idempotency/redis_service.go
+++ b/shared/pkg/idempotency/redis_service.go
@@ -62,10 +62,19 @@ func (r *RedisService) Check(ctx context.Context, key Key) (*Result, error) {
 	return result, nil
 }
 
-// MarkPending marks an operation as in-progress
+// MarkPending marks an operation as in-progress.
+//
+// It uses Redis SET NX (set-if-not-exists) so that concurrent MarkPending calls
+// for the same key are mutually exclusive: exactly one caller sets the key and
+// the rest receive ErrOperationAlreadyProcessed. This closes the race where a
+// plain SET let two callers both "win" MarkPending and duplicate-process a
+// message (e.g. Kafka at-least-once redelivery, or concurrent requests).
 func (r *RedisService) MarkPending(ctx context.Context, key Key, ttl time.Duration) error {
 	if err := key.Validate(); err != nil {
 		return err
+	}
+	if ttl <= 0 {
+		return ErrInvalidTTL
 	}
 
 	result := Result{
@@ -78,7 +87,26 @@ func (r *RedisService) MarkPending(ctx context.Context, key Key, ttl time.Durati
 		TTL:         ttl,
 	}
 
-	return r.StoreResult(ctx, result)
+	// Serialize the pending marker using the same protobuf format as StoreResult
+	// so cleanup workers and Check can deserialize it uniformly.
+	pbResult := toProto(result)
+	data, err := proto.Marshal(pbResult)
+	if err != nil {
+		return fmt.Errorf("failed to serialize pending marker: %w", err)
+	}
+
+	redisKey := r.resultKey(key)
+	created, err := r.client.SetNX(ctx, redisKey, data, ttl).Result()
+	if err != nil {
+		return fmt.Errorf("failed to mark pending: %w", err)
+	}
+	if !created {
+		// Key already exists - another request is processing it or has already
+		// completed it. Report as already-processed so callers do not duplicate.
+		return ErrOperationAlreadyProcessed
+	}
+
+	return nil
 }
 
 // StoreResult saves the operation result for future idempotency checks

--- a/shared/pkg/idempotency/redis_service_test.go
+++ b/shared/pkg/idempotency/redis_service_test.go
@@ -150,6 +150,68 @@ func TestRedisService_MarkPending(t *testing.T) {
 	}
 }
 
+// TestRedisService_MarkPending_DuplicateLiveKey verifies that a second
+// MarkPending for a key already marked pending returns ErrOperationAlreadyProcessed
+// (SET NX semantics), rather than silently overwriting.
+func TestRedisService_MarkPending_DuplicateLiveKey(t *testing.T) {
+	service, _, cleanup := setupRedisService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	key := testKey()
+
+	if err := service.MarkPending(ctx, key, time.Hour); err != nil {
+		t.Fatalf("first MarkPending failed: %v", err)
+	}
+
+	err := service.MarkPending(ctx, key, time.Hour)
+	if !errors.Is(err, ErrOperationAlreadyProcessed) {
+		t.Errorf("expected ErrOperationAlreadyProcessed for duplicate live key, got %v", err)
+	}
+}
+
+// TestRedisService_MarkPending_Concurrent fires many concurrent MarkPending
+// calls for the same key and asserts that exactly one wins and the rest receive
+// ErrOperationAlreadyProcessed. This is the core atomicity guarantee that
+// prevents duplicate processing under Kafka at-least-once redelivery or racing
+// requests.
+func TestRedisService_MarkPending_Concurrent(t *testing.T) {
+	service, _, cleanup := setupRedisService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	key := testKey()
+
+	const goroutines = 20
+	var successCount atomic.Int32
+	var alreadyCount atomic.Int32
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := service.MarkPending(ctx, key, time.Hour)
+			switch {
+			case err == nil:
+				successCount.Add(1)
+			case errors.Is(err, ErrOperationAlreadyProcessed):
+				alreadyCount.Add(1)
+			default:
+				t.Errorf("unexpected MarkPending error: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if successCount.Load() != 1 {
+		t.Errorf("expected exactly 1 successful MarkPending, got %d", successCount.Load())
+	}
+	if alreadyCount.Load() != goroutines-1 {
+		t.Errorf("expected %d ErrOperationAlreadyProcessed, got %d", goroutines-1, alreadyCount.Load())
+	}
+}
+
 func TestRedisService_StoreResult(t *testing.T) {
 	service, mr, cleanup := setupRedisService(t)
 	defer cleanup()

--- a/shared/platform/testdb/schema_validation_test.go
+++ b/shared/platform/testdb/schema_validation_test.go
@@ -137,6 +137,10 @@ func TestMigrationsMatchEntities(t *testing.T) {
 		testLedgerPostingEntity(t, gormDB)
 	})
 
+	t.Run("FinancialAccounting/DepositIdempotencyEntity", func(t *testing.T) {
+		testDepositIdempotencyEntity(t, gormDB)
+	})
+
 	t.Run("ControlPlane/ManifestVersionEntity", func(t *testing.T) {
 		testManifestVersionEntity(t, gormDB)
 	})
@@ -712,6 +716,45 @@ func testLedgerPostingEntity(t *testing.T, db *gorm.DB) {
 	assert.Equal(t, entity.DimensionType, retrieved.DimensionType)
 	assert.Equal(t, entity.InstrumentVersion, retrieved.InstrumentVersion)
 	assert.Equal(t, entity.InstrumentPrecision, retrieved.InstrumentPrecision)
+}
+
+// testDepositIdempotencyEntity tests that DepositIdempotencyEntity works with the
+// migrated schema, including its unique dedupe_key primary key.
+func testDepositIdempotencyEntity(t *testing.T, db *gorm.DB) {
+	t.Helper()
+
+	entity := &fapersistence.DepositIdempotencyEntity{
+		DedupeKey:     uuid.New().String(),
+		AccountID:     "ACC-DEDUPE-001",
+		CorrelationID: "CORR-DEDUPE-001",
+		CreatedAt:     time.Now(),
+	}
+
+	// Create - will fail if columns don't match
+	err := db.Create(entity).Error
+	if err != nil {
+		t.Fatalf("Failed to create DepositIdempotencyEntity - schema mismatch detected: %v", err)
+	}
+
+	// Read back - will fail if columns don't match
+	var retrieved fapersistence.DepositIdempotencyEntity
+	err = db.First(&retrieved, "dedupe_key = ?", entity.DedupeKey).Error
+	if err != nil {
+		t.Fatalf("Failed to read DepositIdempotencyEntity - schema mismatch detected: %v", err)
+	}
+
+	assert.Equal(t, entity.AccountID, retrieved.AccountID)
+	assert.Equal(t, entity.CorrelationID, retrieved.CorrelationID)
+
+	// Constraint validation: duplicate dedupe_key (primary key) rejected.
+	dup := &fapersistence.DepositIdempotencyEntity{
+		DedupeKey:     entity.DedupeKey,
+		AccountID:     "ACC-OTHER",
+		CorrelationID: "CORR-OTHER",
+		CreatedAt:     time.Now(),
+	}
+	err = db.Create(dup).Error
+	assert.Error(t, err, "Expected error for duplicate dedupe_key")
 }
 
 // testManifestVersionEntity tests that the control-plane manifest_version table

--- a/utilities/atlas-loader/main.go
+++ b/utilities/atlas-loader/main.go
@@ -64,6 +64,7 @@ func main() {
 		modelList = []interface{}{
 			&fapersistence.FinancialBookingLogEntity{},
 			&fapersistence.LedgerPostingEntity{},
+			&fapersistence.DepositIdempotencyEntity{},
 		}
 	case schemaIdentity:
 		// Identity service for platform user accounts, roles, and invitations


### PR DESCRIPTION
## Summary

Fixes two HIGH-severity idempotency defects from the 2026-07-07 bug sweep:

- **MON-2** - `MarkPending` in the shared idempotency package was non-atomic, so two concurrent callers could both "win" and duplicate-process a message.
- **MON-3** - the deposit consumer committed ledger postings before writing its Redis idempotency marker, so a crash (or Redis outage) between the two produced a duplicate double-entry posting on Kafka redelivery.

Task 7 (MON-3) builds on task 6 (MON-2); both ship together.

## Changes Made

### MON-2 - atomic `MarkPending` (`shared/pkg/idempotency`)
- `RedisService.MarkPending` now uses Redis **SET NX** instead of a plain SET. If the key already exists it returns `ErrOperationAlreadyProcessed`.
- `PostgresService.MarkPending` now checks `RowsAffected` on the `INSERT ... ON CONFLICT DO NOTHING`; a live (non-expired) key returns `ErrOperationAlreadyProcessed`. Expired keys are still atomically reclaimed via the guarded UPDATE.
- The `markPendingWithRetry` contract (mapping `ErrOperationAlreadyProcessed` → `ErrOperationInProgress`) is unchanged.
- Added concurrent race tests for both backends (exactly one of N callers wins), plus duplicate-live-key and expired-reclaim tests.

### MON-3 - DB-atomic deposit idempotency (`services/financial-accounting`)
- New `deposit_idempotency` table (Atlas migration `20260707000001`, GORM entity `DepositIdempotencyEntity`, registered in `atlas-loader`).
- New repo method `SaveDepositWithIdempotency` writes the idempotency marker **and** the ledger postings in a single transaction; a unique-key violation rolls the whole transaction back and returns `ErrDepositAlreadyProcessed`.
- New `PostingService.ProcessDepositWithDedupeKey`; the deposit consumer now calls it and treats `ErrDepositAlreadyProcessed` as a successful no-op.
- The consumer's Redis usage is now a **best-effort fast path only** (check-before, mark-after); the distributed lock was removed. Correctness no longer depends on Redis - deposits process correctly with Redis down.
- Dedupe key is a deterministic per-deposit SHA-256 fingerprint over tenant + account + amount + instrument + correlation id + value date + event timestamp. It is **not** the correlation id, which can be reused across distinct deposits.

### Related caller hardening
Direct `MarkPending` callers that mapped *any* error to `codes.Internal` would surface a misleading 500 on the newly-reachable `ErrOperationAlreadyProcessed` race path. Mapped it to retryable `codes.Aborted` in payment-order (3), position-keeping (5), and financial-accounting (3) endpoints, matching the existing double-check pattern in current-account/internal-account. This is an additive branch; the normal path is unchanged.

## Technical Details

- Multi-tenancy is schema-per-tenant (search_path); the marker table lives in each tenant schema, so its unique constraint is naturally tenant-scoped. The provisioner applies the new migration into tenant schemas like every other table.
- CockroachDB migration rules honoured: plain `CREATE TABLE`, no triggers, no partial index on a new column, no `COMMENT ON INDEX`, no `CONCURRENTLY`.
- `atlas migrate hash` regenerated; `atlas migrate validate` passes.

## Testing

All run against testcontainers (CockroachDB / Postgres):
- `shared/pkg/idempotency` - Redis + Postgres, incl. new concurrent race tests. PASS
- `services/financial-accounting/adapters/messaging` - incl. duplicate-redelivery (no double posting), Redis-down-still-processes, distinct-deposits-same-correlation-both-post, dedupe-key stability. PASS
- `services/financial-accounting/adapters/persistence` - incl. new `SaveDepositWithIdempotency` duplicate/distinct tests. PASS
- `services/financial-accounting/service` - posting + idempotency chaos. PASS
- `shared/platform/testdb` `TestMigrationsMatchEntities` - incl. new `DepositIdempotencyEntity` subtest. PASS
- `go build ./...`, `gofumpt`, `golangci-lint` clean.

## Risk Assessment

- **Shared package**: `MarkPending` now returns `ErrOperationAlreadyProcessed` on the concurrent-duplicate race where it previously returned nil. Audit of all 15 production direct callers: 4 already handled this error (their latent double-process bug is now fixed); the other 11 are hardened here to return `Aborted`. This only changes behaviour in the race window; the normal path is unchanged.
- **Deposit consumer**: the Redis distributed lock was removed; concurrency is now handled by the DB unique constraint. Two concurrent consumers both hit the DB and exactly one wins; the other gets a clean no-op.
- New table only; no changes to existing columns or data.

## Deployment Notes

Requires the new migration to be applied (per-tenant schema). No config changes.
