### PR TITLE
refactor: Scope API-key cache index to per-validator secret (follow-up to #2274)

### DIFF
--- a/services/api-gateway/auth/combined_middleware.go
+++ b/services/api-gateway/auth/combined_middleware.go
@@ -164,7 +164,7 @@ func (m *CombinedAuthMiddleware) handleRPCAPIKeyAuth(w http.ResponseWriter, r *h
 	// Check per-key rate limit using the rate_limit_rps from the validation
 	// result. The limiter is keyed on the HMAC index of the full key so that
 	// distinct keys sharing a truncated prefix do not share a rate-limit bucket.
-	if !m.rpcValidator.AllowRequest(apiKeyCacheIndex(apiKey), result.RateLimitRPS) {
+	if !m.rpcValidator.AllowRequest(m.rpcValidator.cacheIndex(apiKey), result.RateLimitRPS) {
 		m.logger.Warn("rate limit exceeded",
 			slog.String("identity", result.Identity),
 			slog.String("path", r.URL.Path),

--- a/services/api-gateway/auth/rpc_apikey_validator.go
+++ b/services/api-gateway/auth/rpc_apikey_validator.go
@@ -20,35 +20,12 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// apiKeyIndexSecret is a per-process random secret used to derive opaque cache
-// and rate-limiter indices from API keys via HMAC. It never leaves the process
-// and is regenerated on each start; the cache and limiters are in-memory only,
-// so a fresh secret per process is fine.
-var apiKeyIndexSecret = mustRandomBytes(32)
-
 func mustRandomBytes(n int) []byte {
 	b := make([]byte, n)
 	if _, err := rand.Read(b); err != nil {
 		panic(fmt.Sprintf("auth: failed to initialize API-key index secret: %v", err))
 	}
 	return b
-}
-
-// apiKeyCacheIndex derives an opaque, non-reversible index for the full API key
-// using HMAC-SHA-256 under a per-process secret.
-//
-// The validation cache and per-key rate limiters are keyed on this index so
-// that entries are scoped to the exact full key without retaining the plaintext
-// key in memory. Keying on the truncated prefix (pk_{slug}_{first 8 entropy
-// chars}) would let a forged key that shares a legitimate key's prefix read the
-// legitimate key's cached validation result - authenticating on the prefix
-// alone - or poison it with a negative result. This is a keyed MAC used purely
-// as an in-memory lookup index, not a password hash, and is never persisted or
-// logged.
-func apiKeyCacheIndex(apiKey string) string {
-	mac := hmac.New(sha256.New, apiKeyIndexSecret)
-	mac.Write([]byte(apiKey))
-	return hex.EncodeToString(mac.Sum(nil))
 }
 
 // ErrNotPrefixedKey is returned when the API key is not in the pk_{slug}_{entropy} format.
@@ -77,11 +54,16 @@ type RPCAPIKeyValidator struct {
 	slugResolver SlugResolver
 	logger       *slog.Logger
 
+	// cacheKeySecret is a random secret generated once at construction, used to
+	// derive opaque HMAC cache/rate-limiter indices from API keys. It never
+	// leaves the process and is unique per validator instance.
+	cacheKeySecret []byte
+
 	// Cache for validation results
 	cache    sync.Map // map[string]*cachedValidation
 	cacheTTL time.Duration
 
-	// Per-key rate limiters (keyed by an HMAC index of the full key, see apiKeyCacheIndex)
+	// Per-key rate limiters (keyed by an HMAC index of the full key, see cacheIndex)
 	limiters  sync.Map // map[string]*rpcRateLimiterEntry
 	stopCh    chan struct{}
 	wg        sync.WaitGroup
@@ -143,6 +125,7 @@ func NewRPCAPIKeyValidator(config RPCValidatorConfig) *RPCAPIKeyValidator {
 		client:             config.Client,
 		slugResolver:       config.SlugResolver,
 		logger:             config.Logger,
+		cacheKeySecret:     mustRandomBytes(32),
 		cacheTTL:           config.CacheTTL,
 		cleanupInterval:    config.CleanupInterval,
 		limiterIdleTimeout: config.LimiterIdleTimeout,
@@ -153,6 +136,24 @@ func NewRPCAPIKeyValidator(config RPCValidatorConfig) *RPCAPIKeyValidator {
 	go v.cleanupLoop()
 
 	return v
+}
+
+// cacheIndex derives an opaque, non-reversible index for the full API key using
+// HMAC-SHA-256 under this validator's per-instance secret.
+//
+// The validation cache and per-key rate limiters are keyed on this index so
+// that entries are scoped to the exact full key without retaining the plaintext
+// key in memory. Keying on the truncated prefix (pk_{slug}_{first 8 entropy
+// chars}) would let a forged key that shares a legitimate key's prefix read the
+// legitimate key's cached validation result - authenticating on the prefix
+// alone - or poison it with a negative result. This is a keyed MAC used purely
+// as an in-memory lookup index, not a password hash, and is never persisted or
+// logged; the per-instance secret also prevents an observer of cache indices
+// from precomputing them for candidate keys.
+func (v *RPCAPIKeyValidator) cacheIndex(apiKey string) string {
+	mac := hmac.New(sha256.New, v.cacheKeySecret)
+	mac.Write([]byte(apiKey))
+	return hex.EncodeToString(mac.Sum(nil))
 }
 
 // Close stops the background cleanup goroutine.
@@ -211,7 +212,7 @@ func (v *RPCAPIKeyValidator) Validate(ctx context.Context, apiKey string) (*APIK
 	// poison) the legitimate key's cached result. The index binds to the exact
 	// full key without retaining the plaintext key in memory; entries are held
 	// in process memory only and expire after cacheTTL.
-	cacheKey := apiKeyCacheIndex(apiKey)
+	cacheKey := v.cacheIndex(apiKey)
 
 	// Check cache first
 	if cached := v.getCached(cacheKey); cached != nil {
@@ -245,9 +246,13 @@ func (v *RPCAPIKeyValidator) Validate(ctx context.Context, apiKey string) (*APIK
 		RateLimitRPS: resp.GetRateLimitRps(),
 	}
 
-	// Cache the result (even if invalid, to prevent brute force). The negative
-	// cache entry is scoped to the exact full key's index, so it cannot affect
-	// any other key that happens to share this key's prefix.
+	// Cache the result, including invalid results. Because the negative cache
+	// entry is scoped to the exact full key's index, it only absorbs repeated
+	// attempts with that same key - it prevents one bad key from re-hitting the
+	// control plane on every request, but it is NOT brute-force or flood
+	// control: each distinct key (valid or not) is a fresh cache miss and drives
+	// its own validation RPC. It also cannot affect any other key that happens
+	// to share this key's prefix.
 	v.setCache(cacheKey, result)
 
 	return result, nil
@@ -255,7 +260,7 @@ func (v *RPCAPIKeyValidator) Validate(ctx context.Context, apiKey string) (*APIK
 
 // AllowRequest checks if the given rate-limit key is within its rate limit.
 // The rate-limit key should be the HMAC index of the full key (see
-// apiKeyCacheIndex) so that two distinct keys sharing a truncated prefix do not
+// cacheIndex) so that two distinct keys sharing a truncated prefix do not
 // share a rate-limit bucket.
 func (v *RPCAPIKeyValidator) AllowRequest(rateKey string, rateLimitRPS int32) bool {
 	if rateLimitRPS <= 0 {

--- a/services/api-gateway/auth/rpc_apikey_validator_test.go
+++ b/services/api-gateway/auth/rpc_apikey_validator_test.go
@@ -339,6 +339,35 @@ func TestRPCAPIKeyValidator_CacheKeyedOnFullKey(t *testing.T) {
 	})
 }
 
+// TestRPCAPIKeyValidator_CacheIndexPerInstance verifies that the cache index is
+// derived under a per-validator-instance secret: it is stable within one
+// validator but differs across instances for the same input, confirming the
+// keyed HMAC (not a bare hash) is actually applied.
+func TestRPCAPIKeyValidator_CacheIndexPerInstance(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	newValidator := func() *RPCAPIKeyValidator {
+		return NewRPCAPIKeyValidator(RPCValidatorConfig{
+			Client:       &mockAuthServiceClient{},
+			SlugResolver: &mockSlugResolver{},
+			Logger:       logger,
+		})
+	}
+
+	v1 := newValidator()
+	defer v1.Close()
+	v2 := newValidator()
+	defer v2.Close()
+
+	const key = "pk_acme_abc12345xyz67890abcdef"
+
+	// Stable within one instance.
+	assert.Equal(t, v1.cacheIndex(key), v1.cacheIndex(key))
+	// Different across instances (per-instance secret applied).
+	assert.NotEqual(t, v1.cacheIndex(key), v2.cacheIndex(key))
+	// The index is not the plaintext key.
+	assert.NotEqual(t, key, v1.cacheIndex(key))
+}
+
 func TestRPCAPIKeyValidator_AllowRequest(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 


### PR DESCRIPTION
## Summary

Follow-up to #2274 (SEC-3 API-key cache hardening). Two review refinements were requested after #2274 had already merged, so they land here as a small, behaviour-neutral follow-up.

## Changes Made

- **Per-instance cache-index secret.** The HMAC secret used to derive the cache/rate-limiter index moved from a package-level variable to a `cacheKeySecret` field on `RPCAPIKeyValidator`, generated once at construction. The derivation is now the method `(v *RPCAPIKeyValidator) cacheIndex(apiKey)`, so each validator instance uses a distinct secret.
- **Corrected negative-cache comment.** The prior comment justified caching invalid results "to prevent brute force," which is inaccurate now that entries are keyed on the exact full key's index. Updated to state that the negative entry only absorbs repeated attempts with that same key (preventing one bad key from re-hitting the control plane on every request) and is explicitly not brute-force or flood control, since each distinct key is a fresh cache miss driving its own validation RPC.

## Technical Details

- `combined_middleware.go` now calls `m.rpcValidator.cacheIndex(apiKey)` for the rate-limiter key, matching the validation cache derivation on the same instance.
- No change to validation behaviour, cache TTL, or rate limiting. The index remains an HMAC-SHA-256 keyed MAC over the full key; the per-instance secret additionally prevents an observer of cache indices from precomputing them for candidate keys.

## Testing

- Added `TestRPCAPIKeyValidator_CacheIndexPerInstance`: the index is stable within one validator instance, differs across instances for the same input (confirming the per-instance secret is applied), and is not the plaintext key.
- Existing cache-collision/poison and constant-time-lookup tests remain green. `go test ./services/api-gateway/...`, `go vet`, `gofumpt`, and `golangci-lint` all clean.

## Risk Assessment

- Low. Internal refactor of an in-memory index derivation plus a comment correction and one added test. No external contract, storage, or behaviour change.

## Deployment Notes

- No configuration or schema changes. No migrations. The per-instance index secret is generated at validator construction; cache entries repopulate transparently.

## Related Follow-up (out of scope)

- There is no upstream per-IP rate limit in front of the general API-key validation path; per-IP limiters exist only on the registration and tenant-info endpoints, and the API-key path has only the per-key token bucket applied after validation. As a result, many distinct invalid `pk_` keys from one source each drive a separate `ValidateAPIKey` RPC to the control plane. Adding a per-IP throttle in front of API-key validation is noted for separate triage and intentionally not included here.
