### PR TITLE
fix: Truncate now to whole seconds for forecasting granularity validation (DAT-4)

### DIFF
--- a/services/forecasting/starlark/runner.go
+++ b/services/forecasting/starlark/runner.go
@@ -173,10 +173,16 @@ func (r *ForecastRunner) ExecuteStrategy(ctx context.Context, input StrategyInpu
 		return nil, err
 	}
 
+	// Truncate to whole seconds - single source of truth for both the script
+	// context (ctx["now"] is formatted as RFC3339, which already drops any
+	// sub-second component) and granularity validation below. Without this,
+	// production's time.Now() sub-second precision desyncs the two, causing
+	// spurious ErrGranularityMismatch failures.
 	now := input.Now
 	if now.IsZero() {
 		now = time.Now()
 	}
+	now = now.Truncate(time.Second)
 
 	horizon := time.Duration(input.HorizonHours) * time.Hour
 	granularity := time.Duration(input.GranularityHours) * time.Hour

--- a/services/forecasting/starlark/runner_test.go
+++ b/services/forecasting/starlark/runner_test.go
@@ -694,6 +694,68 @@ func TestValidateForecastPoints_Valid(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// --- Sub-second now / granularity consistency tests ---
+
+// DAT-4: production Now() carries sub-second precision. The script sees ctx["now"]
+// as an RFC3339 string (which drops the fractional component), but validation used
+// to compare against the untruncated Go time.Time - causing spurious
+// ErrGranularityMismatch failures on real (non-test) executions.
+func TestExecuteStrategy_SubSecondNow_GranularityAligned(t *testing.T) {
+	now := baseTime().Add(750 * time.Millisecond) // simulates production time.Now() precision
+
+	mis := &mockMISClient{observations: map[string][]Observation{}}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	script := `
+def compute_forecast(ctx):
+    ts = add_seconds(ctx["now"], 3600)
+    return [{"timestamp": ts, "value": "1"}]
+`
+
+	points, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{},
+		OutputDatasetCode: "TEST",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err, "sub-second now must not cause spurious granularity mismatch")
+	require.Len(t, points, 1)
+	assert.Equal(t, now.Truncate(time.Second).Add(time.Hour), points[0].Timestamp)
+}
+
+// TestExecuteStrategy_SubSecondNow_BoundaryTruncatesDown confirms truncation rounds
+// down to the current second (not up to the next one) at the boundary edge.
+func TestExecuteStrategy_SubSecondNow_BoundaryTruncatesDown(t *testing.T) {
+	now := baseTime().Add(999 * time.Millisecond) // 1ms shy of the next whole second
+
+	mis := &mockMISClient{observations: map[string][]Observation{}}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	script := `
+def compute_forecast(ctx):
+    ts = add_seconds(ctx["now"], 3600)
+    return [{"timestamp": ts, "value": "1"}]
+`
+
+	points, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{},
+		OutputDatasetCode: "TEST",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, points, 1)
+	assert.Equal(t, baseTime().Add(time.Hour), points[0].Timestamp, "truncation must floor to the second, not round up")
+}
+
 // --- Empty data cold start handling ---
 
 func TestExecuteStrategy_EmptyObservations(t *testing.T) {


### PR DESCRIPTION
## Summary
- `ForecastRunner.ExecuteStrategy` computed `now` once, but the Starlark script only ever saw a whole-second value: `ctx["now"]` is RFC3339-formatted, which silently drops any sub-second component. Granularity validation (`validateForecastPoints` in `runner_convert.go`), however, compared forecast point offsets against the untruncated `now` from `time.Now()`.
- On real (non-test) executions, the sub-second remainder made `offset % granularity != 0` for otherwise correctly aligned points, producing spurious `ErrGranularityMismatch` failures.
- Fix: truncate `now` to whole seconds once, immediately after resolving it in `runner.go`, so the script context and validation both derive from the identical value. Single source of truth, per the task's crux.

## Changes Made
- `services/forecasting/starlark/runner.go`: `now = now.Truncate(time.Second)` right after resolving `now` (from `input.Now` or `time.Now()`), before it flows into both `buildForecastContext` and `validateForecastPoints`.
- `services/forecasting/starlark/runner_test.go`: two new tests reproducing the bug and locking in the fix:
  - `TestExecuteStrategy_SubSecondNow_GranularityAligned` - sub-second `now` (750ms) no longer causes a spurious granularity mismatch.
  - `TestExecuteStrategy_SubSecondNow_BoundaryTruncatesDown` - boundary case (999ms) confirms truncation floors to the current second rather than rounding up.

## Technical Details
Root cause: two independent representations of the same instant drifted apart.
1. `ctx["now"]` is serialized via `time.Format(time.RFC3339)`, which has no fractional-seconds specifier, so any script computing timestamps off `ctx["now"]` implicitly worked with a whole-second value.
2. `validateForecastPoints` computed `offset := p.Timestamp.Sub(now)` using the original, unmodified `now` (sub-second precision in production).

These two only agree when `now` happens to fall exactly on a second boundary - never true for real `time.Now()` calls, so this was a live-fire bug (not a fluke on sub-second-precision only).

## Testing
- `go test ./services/forecasting/starlark/... -v` - all 39 tests pass, including reproduction tests confirmed red-then-green against the fix.
- `go vet ./services/forecasting/...` and `gofmt -l` clean.
- Verified with a direct reproduction: reverting the one-line fix reintroduces `ErrGranularityMismatch: offset 59m59.25s is not aligned to 1h0m0s granularity` on the new tests.

## Risk Assessment
Low risk, single-line functional change plus test coverage. `now` was already truncated implicitly for the script path (via RFC3339 formatting); this makes the Go-side validation consistent with that existing behavior rather than introducing new semantics.