### PR TITLE
fix: Scope reference-data CEL program cache to tenant (DAT-6)

### DIFF
--- a/services/reference-data/registry/postgres_registry_test.go
+++ b/services/reference-data/registry/postgres_registry_test.go
@@ -595,6 +595,66 @@ func TestPostgresRegistry_ValidateAttributes(t *testing.T) {
 	})
 }
 
+// TestPostgresRegistry_ValidateAttributes_TenantCacheIsolation guards against
+// DAT-6: the compiled-CEL-program cache key must be scoped by tenant.
+// Two tenants defining the same instrument code+version with different
+// validation logic must never observe each other's compiled program.
+func TestPostgresRegistry_ValidateAttributes_TenantCacheIsolation(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctxA := setupTenantContext(t, pool, "cel-cache-tenant-a")
+	ctxB := setupTenantContext(t, pool, "cel-cache-tenant-b")
+
+	// Same code+version in both tenant schemas, but opposite validation rules.
+	defA := &registry.InstrumentDefinition{
+		Code:                   "SHARED",
+		Version:                1,
+		Dimension:              registry.DimensionMonetary,
+		Precision:              2,
+		ValidationExpression:   `parse_int(amount) > 0`,
+		ErrorMessageExpression: `"tenant-a rejected: " + amount`,
+	}
+	require.NoError(t, reg.CreateDraft(ctxA, defA))
+	require.NoError(t, reg.ActivateInstrument(ctxA, "SHARED", 1))
+
+	defB := &registry.InstrumentDefinition{
+		Code:                   "SHARED",
+		Version:                1,
+		Dimension:              registry.DimensionMonetary,
+		Precision:              2,
+		ValidationExpression:   `parse_int(amount) < 0`,
+		ErrorMessageExpression: `"tenant-b rejected: " + amount`,
+	}
+	require.NoError(t, reg.CreateDraft(ctxB, defB))
+	require.NoError(t, reg.ActivateInstrument(ctxB, "SHARED", 1))
+
+	// Populate tenant A's cache entry first.
+	resultA, err := reg.ValidateAttributes(ctxA, "SHARED", 1, registry.AttributeBag{Amount: "100"})
+	require.NoError(t, err)
+	assert.True(t, resultA.Valid, "tenant A: positive amount should pass tenant A's rule")
+
+	// Tenant B validating the same code+version+amount must apply its OWN
+	// rule, not the cached program compiled for tenant A. Pre-fix, this
+	// would incorrectly return Valid=true (tenant A's compiled program).
+	resultB, err := reg.ValidateAttributes(ctxB, "SHARED", 1, registry.AttributeBag{Amount: "100"})
+	require.NoError(t, err)
+	assert.False(t, resultB.Valid, "tenant B: positive amount must fail tenant B's rule, not reuse tenant A's cached program")
+	assert.Contains(t, resultB.ErrorMessage, "tenant-b rejected")
+
+	// Tenant B's own valid case confirms its rule (and error-message
+	// expression) compiled and cached correctly under its own key.
+	resultB2, err := reg.ValidateAttributes(ctxB, "SHARED", 1, registry.AttributeBag{Amount: "-50"})
+	require.NoError(t, err)
+	assert.True(t, resultB2.Valid, "tenant B: negative amount should pass tenant B's rule")
+
+	// Same-tenant caching still works: repeated calls for tenant A keep
+	// applying tenant A's rule and error message after tenant B populated
+	// cache entries for the same code+version.
+	resultA2, err := reg.ValidateAttributes(ctxA, "SHARED", 1, registry.AttributeBag{Amount: "-50"})
+	require.NoError(t, err)
+	assert.False(t, resultA2.Valid, "tenant A: negative amount must still fail tenant A's rule")
+	assert.Contains(t, resultA2.ErrorMessage, "tenant-a rejected")
+}
+
 func TestPostgresRegistry_CELCompilationAtCreation(t *testing.T) {
 	reg, pool := setupTestRegistry(t)
 	ctx := setupTenantContext(t, pool, "test-tenant-9")

--- a/services/reference-data/registry/registry_instrument.go
+++ b/services/reference-data/registry/registry_instrument.go
@@ -293,7 +293,7 @@ func (r *PostgresRegistry) UpdateDefinition(ctx context.Context, code string, ve
 		}
 
 		// Invalidate cache for this instrument
-		r.invalidateCache(code, version)
+		r.invalidateCache(ctx, code, version)
 
 		return nil
 	})

--- a/services/reference-data/registry/registry_validation.go
+++ b/services/reference-data/registry/registry_validation.go
@@ -2,11 +2,14 @@ package registry
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/cel-go/cel"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
 
 // ValidateAttributes executes the CEL validation expression against the provided attributes.
@@ -20,13 +23,13 @@ func (r *PostgresRegistry) ValidateAttributes(ctx context.Context, code string, 
 		return ValidationResult{Valid: true}, nil
 	}
 
-	prg, err := r.getOrCompileValidation(code, version, def.ValidationExpression)
+	prg, err := r.getOrCompileValidation(ctx, code, version, def.ValidationExpression)
 	if err != nil {
 		return ValidationResult{}, fmt.Errorf("failed to get validation program: %w", err)
 	}
 
 	input := r.buildCELInput(attrs)
-	return r.executeValidation(prg, input, def, code, version)
+	return r.executeValidation(ctx, prg, input, def, code, version)
 }
 
 // buildCELInput constructs the input map for CEL evaluation.
@@ -56,7 +59,7 @@ func (r *PostgresRegistry) buildCELInput(attrs AttributeBag) map[string]any {
 }
 
 // executeValidation runs the CEL program and handles the result.
-func (r *PostgresRegistry) executeValidation(prg cel.Program, input map[string]any, def *InstrumentDefinition, code string, version int) (ValidationResult, error) {
+func (r *PostgresRegistry) executeValidation(ctx context.Context, prg cel.Program, input map[string]any, def *InstrumentDefinition, code string, version int) (ValidationResult, error) {
 	result, _, err := prg.Eval(input)
 	if err != nil {
 		return ValidationResult{
@@ -77,19 +80,19 @@ func (r *PostgresRegistry) executeValidation(prg cel.Program, input map[string]a
 		return ValidationResult{Valid: true}, nil
 	}
 
-	errorMsg := r.getCustomErrorMessage(def, code, version, input)
+	errorMsg := r.getCustomErrorMessage(ctx, def, code, version, input)
 	return ValidationResult{Valid: false, ErrorMessage: errorMsg}, nil
 }
 
 const defaultValidationErrorMsg = "validation failed"
 
 // getCustomErrorMessage evaluates the error message expression if defined.
-func (r *PostgresRegistry) getCustomErrorMessage(def *InstrumentDefinition, code string, version int, input map[string]any) string {
+func (r *PostgresRegistry) getCustomErrorMessage(ctx context.Context, def *InstrumentDefinition, code string, version int, input map[string]any) string {
 	if def.ErrorMessageExpression == "" {
 		return defaultValidationErrorMsg
 	}
 
-	errorPrg, err := r.getOrCompileErrorMessage(code, version, def.ErrorMessageExpression)
+	errorPrg, err := r.getOrCompileErrorMessage(ctx, code, version, def.ErrorMessageExpression)
 	if err != nil {
 		return defaultValidationErrorMsg
 	}
@@ -133,9 +136,27 @@ func (r *PostgresRegistry) compileCELExpressions(def *InstrumentDefinition) erro
 	return nil
 }
 
+// celCacheKeyPrefix builds the tenant-and-instrument-scoped prefix shared by
+// every cache entry for a given (tenant, code, version, exprType) tuple.
+// Tenant id is included so that two tenants defining the same instrument
+// code/version with different CEL expressions never share a compiled
+// program - see DAT-6.
+func (r *PostgresRegistry) celCacheKeyPrefix(ctx context.Context, code string, version int, exprType string) string {
+	tenantID, _ := tenant.FromContext(ctx)
+	return fmt.Sprintf("%s:%s:%d:%s:", tenantID, code, version, exprType)
+}
+
+// celCacheKey builds the full cache key, including a hash of the expression
+// text so that updated expressions never collide with a stale cached
+// program for the same tenant/code/version/type.
+func (r *PostgresRegistry) celCacheKey(ctx context.Context, code string, version int, exprType, expr string) string {
+	exprHash := sha256.Sum256([]byte(expr))
+	return fmt.Sprintf("%s%x", r.celCacheKeyPrefix(ctx, code, version, exprType), exprHash)
+}
+
 // getOrCompileValidation gets a cached validation program or compiles one.
-func (r *PostgresRegistry) getOrCompileValidation(code string, version int, expr string) (cel.Program, error) {
-	cacheKey := fmt.Sprintf("%s:%d:validation", code, version)
+func (r *PostgresRegistry) getOrCompileValidation(ctx context.Context, code string, version int, expr string) (cel.Program, error) {
+	cacheKey := r.celCacheKey(ctx, code, version, "validation", expr)
 
 	r.programCacheMu.RLock()
 	prg, ok := r.programCache[cacheKey]
@@ -159,8 +180,8 @@ func (r *PostgresRegistry) getOrCompileValidation(code string, version int, expr
 }
 
 // getOrCompileErrorMessage gets a cached error message program or compiles one.
-func (r *PostgresRegistry) getOrCompileErrorMessage(code string, version int, expr string) (cel.Program, error) {
-	cacheKey := fmt.Sprintf("%s:%d:error", code, version)
+func (r *PostgresRegistry) getOrCompileErrorMessage(ctx context.Context, code string, version int, expr string) (cel.Program, error) {
+	cacheKey := r.celCacheKey(ctx, code, version, "error", expr)
 
 	r.programCacheMu.RLock()
 	prg, ok := r.programCache[cacheKey]
@@ -183,12 +204,26 @@ func (r *PostgresRegistry) getOrCompileErrorMessage(code string, version int, ex
 	return prg, nil
 }
 
-// invalidateCache removes cached programs for an instrument.
-func (r *PostgresRegistry) invalidateCache(code string, version int) {
+// invalidateCache removes cached programs for an instrument, scoped to the
+// tenant on ctx. Because cache keys include a hash of the expression text,
+// entries are removed by tenant:code:version:type prefix rather than by an
+// exact key match.
+func (r *PostgresRegistry) invalidateCache(ctx context.Context, code string, version int) {
+	prefixes := []string{
+		r.celCacheKeyPrefix(ctx, code, version, "validation"),
+		r.celCacheKeyPrefix(ctx, code, version, "error"),
+		r.celCacheKeyPrefix(ctx, code, version, "bucket"),
+	}
+
 	r.programCacheMu.Lock()
 	defer r.programCacheMu.Unlock()
 
-	delete(r.programCache, fmt.Sprintf("%s:%d:validation", code, version))
-	delete(r.programCache, fmt.Sprintf("%s:%d:error", code, version))
-	delete(r.programCache, fmt.Sprintf("%s:%d:bucket", code, version))
+	for key := range r.programCache {
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(key, prefix) {
+				delete(r.programCache, key)
+				break
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- The compiled CEL program cache in `services/reference-data/registry/registry_validation.go` keyed entries by `code:version:type` only, with no tenant discriminator.
- Two tenants defining the same instrument code and version with different validation/error-message expressions could collide - a compiled program for one tenant's expression could be returned to another tenant's validation call.
- Cache keys now include the tenant id (from `tenant.FromContext(ctx)`) plus a sha256 hash of the expression text, following the pattern already used in `services/reference-data/accounttype/postgres_registry_cel.go`.
- `invalidateCache` now deletes by `tenant:code:version:type` prefix (since the key no longer has a fixed suffix once the expression hash is included), scoped to the tenant on the calling context.

## Technical Details
- `getOrCompileValidation` / `getOrCompileErrorMessage` now take `ctx` and derive the cache key via a shared `celCacheKey` helper.
- `executeValidation` / `getCustomErrorMessage` thread `ctx` through so the error-message program lookup is also tenant-scoped.
- `UpdateDefinition`'s cache invalidation call site now passes `ctx` so invalidation only clears the calling tenant's cache entries.

## Testing
- Added `TestPostgresRegistry_ValidateAttributes_TenantCacheIsolation`: two tenants create the same instrument code+version with opposite CEL validation rules; verifies tenant B's validation call applies tenant B's rule (not tenant A's cached program), and that same-tenant caching continues to work correctly afterward.
- Verified the new test fails against the pre-fix code (reproducing the collision) and passes after the fix.
- `go test ./services/reference-data/...` - all packages pass.
- `golangci-lint run services/reference-data/registry/...` - 0 issues.

## Risk Assessment
Low risk, isolated to the reference-data CEL program cache. No schema or proto changes. Fix tightens tenant isolation, a hard architectural requirement for this repo.