### PR TITLE
feat: Reclaim stuck DISPATCHING instructions via expiry worker (PAY-2)

### DIFF
--- a/services/operational-gateway/adapters/persistence/instruction_repository.go
+++ b/services/operational-gateway/adapters/persistence/instruction_repository.go
@@ -332,6 +332,29 @@ func (r *InstructionRepository) FindExpired(ctx context.Context, batchSize int) 
 	return results, nil
 }
 
+// FindStuckDispatching returns up to batchSize instructions stuck in DISPATCHING whose
+// lease has expired: their updated_at is older than leaseTimeout before now. Such rows
+// indicate that the worker which claimed them crashed or stalled before completing the
+// dispatch. Results are ordered by updated_at ASC so the most-stuck instructions are
+// reclaimed first.
+func (r *InstructionRepository) FindStuckDispatching(ctx context.Context, leaseTimeout time.Duration, batchSize int) ([]*domain.Instruction, error) {
+	if batchSize <= 0 {
+		batchSize = 100
+	}
+	cutoff := time.Now().Add(-leaseTimeout)
+
+	var entities []InstructionEntity
+	err := r.db.WithContext(ctx).
+		Where("status = ? AND updated_at < ?", string(domain.InstructionStatusDispatching), cutoff).
+		Order("updated_at ASC").
+		Limit(batchSize).
+		Find(&entities).Error
+	if err != nil {
+		return nil, err
+	}
+	return r.entitiesToInstructions(ctx, entities)
+}
+
 // fetchAttempts loads instruction_attempts for a given instruction ID.
 func (r *InstructionRepository) fetchAttempts(ctx context.Context, instructionID uuid.UUID) ([]InstructionAttemptEntity, error) {
 	var attempts []InstructionAttemptEntity

--- a/services/operational-gateway/adapters/persistence/instruction_repository_test.go
+++ b/services/operational-gateway/adapters/persistence/instruction_repository_test.go
@@ -428,6 +428,81 @@ func TestInstructionRepository_FindExpired_ReturnsNilWhenEmpty(t *testing.T) {
 	assert.Nil(t, results)
 }
 
+// insertDispatching inserts a DISPATCHING instruction with an explicit updated_at, used to
+// simulate rows whose dispatch lease has (or has not) expired.
+func insertDispatching(t *testing.T, db *gorm.DB, tenantID, connID uuid.UUID, updatedAt time.Time, amount string) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	require.NoError(t, db.Exec(`
+		INSERT INTO instructions
+			(id, tenant_id, instruction_type, provider_connection_id, payload, priority, status, attempt_count, max_attempts, idempotency_key, version, dispatched_at, updated_at)
+		VALUES (?, ?, 'kyc.verify', ?, ?, 2, 'DISPATCHING', 1, 3, ?, 1, ?, ?)
+	`, id, tenantID, connID, fmt.Sprintf(`{"amount":"%s"}`, amount), fmt.Sprintf("idem-disp-%s", id), updatedAt, updatedAt).Error)
+	return id
+}
+
+// TestInstructionRepository_FindStuckDispatching verifies that only DISPATCHING rows whose
+// lease has expired (updated_at older than the lease timeout) are returned; fresh DISPATCHING
+// rows and non-DISPATCHING rows are excluded.
+func TestInstructionRepository_FindStuckDispatching(t *testing.T) {
+	db, ctx := setupTestDB(t)
+
+	tenantID := uuid.New()
+	connID := uuid.New()
+	insertTestConnection(t, db, tenantID, connID)
+
+	repo := NewInstructionRepository(db)
+
+	staleUpdate := time.Now().Add(-30 * time.Minute)
+	freshUpdate := time.Now().Add(-1 * time.Minute)
+
+	// Stuck DISPATCHING - lease expired. Should be returned.
+	stuckID := insertDispatching(t, db, tenantID, connID, staleUpdate, "10")
+
+	// Fresh DISPATCHING - still within lease. Should NOT be returned.
+	insertDispatching(t, db, tenantID, connID, freshUpdate, "20")
+
+	// PENDING - not DISPATCHING at all. Should NOT be returned.
+	pending := makeInstruction(t, tenantID, connID.String(), domain.PriorityNormal)
+	require.NoError(t, repo.Save(ctx, pending, fmt.Sprintf("idem-pending-%s", pending.ID)))
+
+	results, err := repo.FindStuckDispatching(ctx, 5*time.Minute, 100)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, stuckID, results[0].ID)
+	assert.Equal(t, domain.InstructionStatusDispatching, results[0].Status)
+}
+
+// TestInstructionRepository_FindStuckDispatching_LimitEnforced verifies the batchSize parameter.
+func TestInstructionRepository_FindStuckDispatching_LimitEnforced(t *testing.T) {
+	db, ctx := setupTestDB(t)
+
+	tenantID := uuid.New()
+	connID := uuid.New()
+	insertTestConnection(t, db, tenantID, connID)
+
+	repo := NewInstructionRepository(db)
+
+	stale := time.Now().Add(-30 * time.Minute)
+	for i := 0; i < 5; i++ {
+		insertDispatching(t, db, tenantID, connID, stale, fmt.Sprintf("%d", i))
+	}
+
+	results, err := repo.FindStuckDispatching(ctx, 5*time.Minute, 3)
+	require.NoError(t, err)
+	assert.Len(t, results, 3)
+}
+
+// TestInstructionRepository_FindStuckDispatching_ReturnsNilWhenEmpty verifies empty handling.
+func TestInstructionRepository_FindStuckDispatching_ReturnsNilWhenEmpty(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	repo := NewInstructionRepository(db)
+
+	results, err := repo.FindStuckDispatching(ctx, 5*time.Minute, 100)
+	require.NoError(t, err)
+	assert.Nil(t, results)
+}
+
 // TestInstructionRepository_FetchDispatchable_RespectsNextRetryAt verifies that
 // RETRYING instructions with a future next_retry_at are not fetched until the backoff expires.
 func TestInstructionRepository_FetchDispatchable_RespectsNextRetryAt(t *testing.T) {

--- a/services/operational-gateway/cmd/main.go
+++ b/services/operational-gateway/cmd/main.go
@@ -224,6 +224,7 @@ func buildWorkers(
 		worker.ExpiryWorkerConfig{
 			ScanInterval: cfg.ExpiryWorker.ScanInterval,
 			BatchSize:    cfg.ExpiryWorker.BatchSize,
+			LeaseTimeout: cfg.ExpiryWorker.LeaseTimeout,
 		},
 		logger,
 	)

--- a/services/operational-gateway/config/config.go
+++ b/services/operational-gateway/config/config.go
@@ -41,6 +41,9 @@ type ExpiryWorkerConfig struct {
 	ScanInterval time.Duration
 	// BatchSize is the maximum number of expired instructions to process per scan.
 	BatchSize int
+	// LeaseTimeout is how long an instruction may remain in DISPATCHING before the expiry
+	// worker treats it as stuck (crashed worker) and reclaims it for another attempt.
+	LeaseTimeout time.Duration
 }
 
 // LoadConfig loads configuration from environment variables with sensible defaults.
@@ -56,6 +59,7 @@ func LoadConfig() Config {
 		ExpiryWorker: ExpiryWorkerConfig{
 			ScanInterval: env.GetEnvAsDuration("EXPIRY_WORKER_SCAN_INTERVAL", 30*time.Second),
 			BatchSize:    env.GetEnvAsInt("EXPIRY_WORKER_BATCH_SIZE", 100),
+			LeaseTimeout: env.GetEnvAsDuration("EXPIRY_WORKER_LEASE_TIMEOUT", 5*time.Minute),
 		},
 	}
 }

--- a/services/operational-gateway/ports/repositories.go
+++ b/services/operational-gateway/ports/repositories.go
@@ -77,6 +77,12 @@ type InstructionRepository interface {
 	// FindExpired returns up to batchSize instructions whose expires_at has passed and
 	// whose status is PENDING or RETRYING (non-terminal, expirable states).
 	FindExpired(ctx context.Context, batchSize int) ([]*domain.Instruction, error)
+
+	// FindStuckDispatching returns up to batchSize instructions stuck in DISPATCHING whose
+	// lease has expired (updated_at older than leaseTimeout), indicating the worker that
+	// claimed them crashed or stalled before completing dispatch. Results are ordered by
+	// updated_at ASC so the most-stuck instructions are reclaimed first.
+	FindStuckDispatching(ctx context.Context, leaseTimeout time.Duration, batchSize int) ([]*domain.Instruction, error)
 }
 
 // RouteRepository defines persistence operations for instruction routes.

--- a/services/operational-gateway/service/grpc_service_test.go
+++ b/services/operational-gateway/service/grpc_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
@@ -115,6 +116,10 @@ func (m *mockInstructionRepo) FetchDispatchable(_ context.Context, _ ports.Fetch
 }
 
 func (m *mockInstructionRepo) FindExpired(_ context.Context, _ int) ([]*domain.Instruction, error) {
+	return nil, nil
+}
+
+func (m *mockInstructionRepo) FindStuckDispatching(_ context.Context, _ time.Duration, _ int) ([]*domain.Instruction, error) {
 	return nil, nil
 }
 

--- a/services/operational-gateway/worker/dispatch_worker_test.go
+++ b/services/operational-gateway/worker/dispatch_worker_test.go
@@ -60,6 +60,10 @@ func (m *mockInstructionRepo) FindExpired(_ context.Context, _ int) ([]*domain.I
 	return nil, nil
 }
 
+func (m *mockInstructionRepo) FindStuckDispatching(_ context.Context, _ time.Duration, _ int) ([]*domain.Instruction, error) {
+	return nil, nil
+}
+
 func (m *mockInstructionRepo) getSavedInstructions() []*domain.Instruction {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/services/operational-gateway/worker/expiry_worker.go
+++ b/services/operational-gateway/worker/expiry_worker.go
@@ -15,6 +15,13 @@ import (
 const (
 	defaultExpiryScanInterval = 30 * time.Second
 	defaultExpiryBatchSize    = 100
+	defaultLeaseTimeout       = 5 * time.Minute
+)
+
+// Reason and error code recorded when a stuck DISPATCHING instruction is reclaimed.
+const (
+	leaseExpiredReason    = "dispatch lease expired: reclaimed by reaper"
+	leaseExpiredErrorCode = "DISPATCH_LEASE_EXPIRED"
 )
 
 // ExpiryWorkerConfig configures the expiry worker's scan behavior.
@@ -23,6 +30,9 @@ type ExpiryWorkerConfig struct {
 	ScanInterval time.Duration
 	// BatchSize is the maximum number of expired instructions to process per scan cycle.
 	BatchSize int
+	// LeaseTimeout is how long an instruction may remain in DISPATCHING before it is
+	// considered stuck (the claiming worker crashed) and reclaimed to RETRYING.
+	LeaseTimeout time.Duration
 }
 
 // applyDefaults fills in zero-valued fields with sensible defaults.
@@ -32,6 +42,9 @@ func (c *ExpiryWorkerConfig) applyDefaults() {
 	}
 	if c.BatchSize <= 0 {
 		c.BatchSize = defaultExpiryBatchSize
+	}
+	if c.LeaseTimeout <= 0 {
+		c.LeaseTimeout = defaultLeaseTimeout
 	}
 }
 
@@ -82,6 +95,7 @@ func (w *ExpiryWorker) Start(ctx context.Context) {
 		w.logger.InfoContext(ctx, "expiry worker started",
 			"batch_size", w.config.BatchSize,
 			"scan_interval", w.config.ScanInterval,
+			"lease_timeout", w.config.LeaseTimeout,
 		)
 	})
 }
@@ -114,6 +128,7 @@ func (w *ExpiryWorker) run(ctx context.Context) {
 			return
 		case <-ticker.C:
 			w.scanAndExpire(ctx)
+			w.reapStuckDispatching(ctx)
 		}
 	}
 }
@@ -201,4 +216,93 @@ func (w *ExpiryWorker) expireInstruction(ctx context.Context, instr *domain.Inst
 		"expires_at", instr.ExpiresAt,
 	)
 	return expiryExpired
+}
+
+// reapStuckDispatching finds instructions stuck in DISPATCHING past the lease timeout -
+// evidence that the worker which claimed them crashed or stalled - and reclaims each for
+// another dispatch attempt, or marks it FAILED when its retry budget is exhausted.
+func (w *ExpiryWorker) reapStuckDispatching(ctx context.Context) {
+	instructions, err := w.instructionRepo.FindStuckDispatching(ctx, w.config.LeaseTimeout, w.config.BatchSize)
+	if err != nil {
+		w.logger.ErrorContext(ctx, "failed to find stuck dispatching instructions", "error", err)
+		return
+	}
+	if len(instructions) == 0 {
+		return
+	}
+
+	w.logger.InfoContext(ctx, "processing stuck dispatch batch", "count", len(instructions))
+
+	var retrying, failed, errored int
+	for _, instr := range instructions {
+		if ctx.Err() != nil {
+			w.logger.InfoContext(ctx, "stuck dispatch batch interrupted by context cancellation")
+			return
+		}
+		switch w.reclaimInstruction(ctx, instr) {
+		case reclaimRetrying:
+			retrying++
+		case reclaimExhausted:
+			failed++
+		case reclaimError:
+			errored++
+		case reclaimSkipped:
+			// No longer DISPATCHING (e.g. concurrently progressed); nothing to count.
+		}
+	}
+
+	w.logger.InfoContext(ctx, "stuck dispatch batch completed",
+		"retrying", retrying,
+		"failed", failed,
+		"errored", errored,
+		"total", len(instructions),
+	)
+}
+
+// reclaimOutcome represents the result of reclaiming a single stuck instruction.
+type reclaimOutcome int
+
+const (
+	reclaimRetrying  reclaimOutcome = iota // reclaimed to RETRYING for another attempt
+	reclaimExhausted                       // retry budget exhausted; marked FAILED
+	reclaimError                           // transition or save failed
+	reclaimSkipped                         // no longer DISPATCHING; nothing to do
+)
+
+// reclaimInstruction transitions a single stuck DISPATCHING instruction back to RETRYING
+// (eligible for immediate re-dispatch) or to FAILED when no retry attempts remain.
+func (w *ExpiryWorker) reclaimInstruction(ctx context.Context, instr *domain.Instruction) reclaimOutcome {
+	if instr.Status != domain.InstructionStatusDispatching {
+		return reclaimSkipped
+	}
+
+	outcome := reclaimRetrying
+	if instr.CanRetry() {
+		if err := instr.MarkRetrying(leaseExpiredReason, leaseExpiredErrorCode); err != nil {
+			w.logger.ErrorContext(ctx, "failed to reclaim stuck instruction",
+				"instruction_id", instr.ID, "error", err)
+			return reclaimError
+		}
+		instr.NextRetryAt = nil // reclaimed instructions are eligible for immediate re-dispatch
+	} else {
+		if err := instr.MarkFailed(leaseExpiredReason, leaseExpiredErrorCode); err != nil {
+			w.logger.ErrorContext(ctx, "failed to fail stuck instruction",
+				"instruction_id", instr.ID, "error", err)
+			return reclaimError
+		}
+		outcome = reclaimExhausted
+	}
+
+	if err := w.instructionRepo.Save(ctx, instr, ""); err != nil {
+		w.logger.ErrorContext(ctx, "failed to save reclaimed instruction",
+			"instruction_id", instr.ID, "error", err)
+		return reclaimError
+	}
+
+	w.logger.InfoContext(ctx, "reclaimed stuck dispatching instruction",
+		"instruction_id", instr.ID,
+		"status", instr.Status,
+		"attempt_count", instr.AttemptCount,
+	)
+	return outcome
 }

--- a/services/operational-gateway/worker/expiry_worker.go
+++ b/services/operational-gateway/worker/expiry_worker.go
@@ -233,7 +233,7 @@ func (w *ExpiryWorker) reapStuckDispatching(ctx context.Context) {
 
 	w.logger.InfoContext(ctx, "processing stuck dispatch batch", "count", len(instructions))
 
-	var retrying, failed, errored int
+	var retrying, expired, failed, errored int
 	for _, instr := range instructions {
 		if ctx.Err() != nil {
 			w.logger.InfoContext(ctx, "stuck dispatch batch interrupted by context cancellation")
@@ -242,6 +242,8 @@ func (w *ExpiryWorker) reapStuckDispatching(ctx context.Context) {
 		switch w.reclaimInstruction(ctx, instr) {
 		case reclaimRetrying:
 			retrying++
+		case reclaimExpired:
+			expired++
 		case reclaimExhausted:
 			failed++
 		case reclaimError:
@@ -253,6 +255,7 @@ func (w *ExpiryWorker) reapStuckDispatching(ctx context.Context) {
 
 	w.logger.InfoContext(ctx, "stuck dispatch batch completed",
 		"retrying", retrying,
+		"expired", expired,
 		"failed", failed,
 		"errored", errored,
 		"total", len(instructions),
@@ -264,16 +267,24 @@ type reclaimOutcome int
 
 const (
 	reclaimRetrying  reclaimOutcome = iota // reclaimed to RETRYING for another attempt
+	reclaimExpired                         // TTL already passed; marked EXPIRED
 	reclaimExhausted                       // retry budget exhausted; marked FAILED
 	reclaimError                           // transition or save failed
 	reclaimSkipped                         // no longer DISPATCHING; nothing to do
 )
 
 // reclaimInstruction transitions a single stuck DISPATCHING instruction back to RETRYING
-// (eligible for immediate re-dispatch) or to FAILED when no retry attempts remain.
+// (eligible for immediate re-dispatch) or to FAILED when no retry attempts remain. An
+// instruction whose TTL has already passed is expired instead of resurrected: the 1s
+// dispatch worker would otherwise re-dispatch a reclaimed row before the next expiry scan,
+// delivering to the provider after its deadline.
 func (w *ExpiryWorker) reclaimInstruction(ctx context.Context, instr *domain.Instruction) reclaimOutcome {
 	if instr.Status != domain.InstructionStatusDispatching {
 		return reclaimSkipped
+	}
+
+	if instr.ExpiresAt != nil && instr.ExpiresAt.Before(time.Now()) {
+		return w.expireStuck(ctx, instr)
 	}
 
 	outcome := reclaimRetrying
@@ -305,4 +316,25 @@ func (w *ExpiryWorker) reclaimInstruction(ctx context.Context, instr *domain.Ins
 		"attempt_count", instr.AttemptCount,
 	)
 	return outcome
+}
+
+// expireStuck transitions a stuck DISPATCHING instruction whose TTL has passed straight to
+// EXPIRED, so it is never re-dispatched after its deadline.
+func (w *ExpiryWorker) expireStuck(ctx context.Context, instr *domain.Instruction) reclaimOutcome {
+	if err := instr.MarkExpired(); err != nil {
+		w.logger.ErrorContext(ctx, "failed to expire stuck instruction",
+			"instruction_id", instr.ID, "error", err)
+		return reclaimError
+	}
+	if err := w.instructionRepo.Save(ctx, instr, ""); err != nil {
+		w.logger.ErrorContext(ctx, "failed to save expired stuck instruction",
+			"instruction_id", instr.ID, "error", err)
+		return reclaimError
+	}
+
+	w.logger.InfoContext(ctx, "expired stuck dispatching instruction past TTL",
+		"instruction_id", instr.ID,
+		"expires_at", instr.ExpiresAt,
+	)
+	return reclaimExpired
 }

--- a/services/operational-gateway/worker/expiry_worker_test.go
+++ b/services/operational-gateway/worker/expiry_worker_test.go
@@ -44,11 +44,35 @@ func retryingExpiredInstruction() *domain.Instruction {
 	return instr
 }
 
+// stuckDispatchingInstruction creates a DISPATCHING instruction that has exceeded its lease.
+func stuckDispatchingInstruction() *domain.Instruction {
+	stale := time.Now().Add(-30 * time.Minute)
+	return &domain.Instruction{
+		ID:                   uuid.New(),
+		TenantID:             testTenantID(),
+		InstructionType:      "kyc.verify",
+		ProviderConnectionID: "conn-123",
+		Payload:              map[string]any{"amount": "100.00"},
+		Priority:             domain.PriorityNormal,
+		Status:               domain.InstructionStatusDispatching,
+		DispatchedAt:         &stale,
+		MaxAttempts:          3,
+		AttemptCount:         1,
+		Attempts:             []domain.InstructionAttempt{},
+		Version:              1,
+		CreatedAt:            time.Now().Add(-1 * time.Hour),
+		UpdatedAt:            stale,
+	}
+}
+
 // mockExpiryRepo is a minimal mock satisfying ports.InstructionRepository for expiry worker tests.
 type mockExpiryRepo struct {
 	mockInstructionRepo
 	findExpired      func(ctx context.Context, batchSize int) ([]*domain.Instruction, error)
 	findExpiredCalls int
+	findStuck        func(ctx context.Context, leaseTimeout time.Duration, batchSize int) ([]*domain.Instruction, error)
+	findStuckCalls   int
+	lastLeaseTimeout time.Duration
 }
 
 func (m *mockExpiryRepo) FindExpired(ctx context.Context, batchSize int) ([]*domain.Instruction, error) {
@@ -61,10 +85,27 @@ func (m *mockExpiryRepo) FindExpired(ctx context.Context, batchSize int) ([]*dom
 	return nil, nil
 }
 
+func (m *mockExpiryRepo) FindStuckDispatching(ctx context.Context, leaseTimeout time.Duration, batchSize int) ([]*domain.Instruction, error) {
+	m.mu.Lock()
+	m.findStuckCalls++
+	m.lastLeaseTimeout = leaseTimeout
+	m.mu.Unlock()
+	if m.findStuck != nil {
+		return m.findStuck(ctx, leaseTimeout, batchSize)
+	}
+	return nil, nil
+}
+
 func (m *mockExpiryRepo) getFindExpiredCalls() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.findExpiredCalls
+}
+
+func (m *mockExpiryRepo) getLastLeaseTimeout() time.Duration {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastLeaseTimeout
 }
 
 // --- Tests ---
@@ -75,7 +116,84 @@ func TestNewExpiryWorker_AppliesDefaults(t *testing.T) {
 
 	assert.Equal(t, defaultExpiryScanInterval, w.config.ScanInterval)
 	assert.Equal(t, defaultExpiryBatchSize, w.config.BatchSize)
+	assert.Equal(t, defaultLeaseTimeout, w.config.LeaseTimeout)
 	assert.NotNil(t, w.logger)
+}
+
+// TestExpiryWorker_ReapStuckDispatching_ReclaimsToRetrying verifies a DISPATCHING instruction
+// whose lease has expired and which still has attempts remaining is reclaimed to RETRYING and
+// made eligible for immediate re-dispatch.
+func TestExpiryWorker_ReapStuckDispatching_ReclaimsToRetrying(t *testing.T) {
+	stuck := stuckDispatchingInstruction()
+	stuck.AttemptCount = 1
+	stuck.MaxAttempts = 3
+
+	repo := &mockExpiryRepo{
+		findStuck: func(_ context.Context, _ time.Duration, _ int) ([]*domain.Instruction, error) {
+			return []*domain.Instruction{stuck}, nil
+		},
+	}
+	w := NewExpiryWorker(repo, ExpiryWorkerConfig{}, nil)
+
+	w.reapStuckDispatching(context.Background())
+
+	saved := repo.getSavedInstructions()
+	require.Len(t, saved, 1)
+	assert.Equal(t, domain.InstructionStatusRetrying, saved[0].Status)
+	assert.Nil(t, saved[0].NextRetryAt, "reclaimed instruction should retry immediately")
+	assert.Equal(t, defaultLeaseTimeout, repo.getLastLeaseTimeout())
+}
+
+// TestExpiryWorker_ReapStuckDispatching_ExhaustedMarksFailed verifies a stuck DISPATCHING
+// instruction with no remaining attempts is marked FAILED rather than retried forever.
+func TestExpiryWorker_ReapStuckDispatching_ExhaustedMarksFailed(t *testing.T) {
+	stuck := stuckDispatchingInstruction()
+	stuck.AttemptCount = 3
+	stuck.MaxAttempts = 3
+
+	repo := &mockExpiryRepo{
+		findStuck: func(_ context.Context, _ time.Duration, _ int) ([]*domain.Instruction, error) {
+			return []*domain.Instruction{stuck}, nil
+		},
+	}
+	w := NewExpiryWorker(repo, ExpiryWorkerConfig{}, nil)
+
+	w.reapStuckDispatching(context.Background())
+
+	saved := repo.getSavedInstructions()
+	require.Len(t, saved, 1)
+	assert.Equal(t, domain.InstructionStatusFailed, saved[0].Status)
+	assert.Equal(t, leaseExpiredReason, saved[0].FailureReason)
+}
+
+// TestExpiryWorker_ReapStuckDispatching_NoStuckRowsNoSave verifies the reaper does not persist
+// anything when there are no stuck DISPATCHING instructions.
+func TestExpiryWorker_ReapStuckDispatching_NoStuckRowsNoSave(t *testing.T) {
+	repo := &mockExpiryRepo{
+		findStuck: func(_ context.Context, _ time.Duration, _ int) ([]*domain.Instruction, error) {
+			return nil, nil
+		},
+	}
+	w := NewExpiryWorker(repo, ExpiryWorkerConfig{}, nil)
+
+	w.reapStuckDispatching(context.Background())
+
+	assert.Empty(t, repo.getSavedInstructions())
+}
+
+// TestExpiryWorker_ReclaimInstruction_SkipsNonDispatching verifies an instruction that is no
+// longer DISPATCHING (e.g. concurrently progressed) is left untouched.
+func TestExpiryWorker_ReclaimInstruction_SkipsNonDispatching(t *testing.T) {
+	repo := &mockExpiryRepo{}
+	w := NewExpiryWorker(repo, ExpiryWorkerConfig{}, nil)
+
+	instr := stuckDispatchingInstruction()
+	instr.Status = domain.InstructionStatusDelivered
+
+	outcome := w.reclaimInstruction(context.Background(), instr)
+
+	assert.Equal(t, reclaimSkipped, outcome)
+	assert.Empty(t, repo.getSavedInstructions())
 }
 
 func TestNewExpiryWorker_RespectsCustomConfig(t *testing.T) {

--- a/services/operational-gateway/worker/expiry_worker_test.go
+++ b/services/operational-gateway/worker/expiry_worker_test.go
@@ -166,6 +166,31 @@ func TestExpiryWorker_ReapStuckDispatching_ExhaustedMarksFailed(t *testing.T) {
 	assert.Equal(t, leaseExpiredReason, saved[0].FailureReason)
 }
 
+// TestExpiryWorker_ReapStuckDispatching_PastTTLMarksExpired verifies a stuck DISPATCHING
+// instruction whose TTL has already passed is expired rather than resurrected, so the fast
+// dispatch worker cannot re-deliver it after its deadline.
+func TestExpiryWorker_ReapStuckDispatching_PastTTLMarksExpired(t *testing.T) {
+	stuck := stuckDispatchingInstruction()
+	stuck.AttemptCount = 1
+	stuck.MaxAttempts = 3
+	past := time.Now().Add(-1 * time.Minute)
+	stuck.ExpiresAt = &past
+
+	repo := &mockExpiryRepo{
+		findStuck: func(_ context.Context, _ time.Duration, _ int) ([]*domain.Instruction, error) {
+			return []*domain.Instruction{stuck}, nil
+		},
+	}
+	w := NewExpiryWorker(repo, ExpiryWorkerConfig{}, nil)
+
+	w.reapStuckDispatching(context.Background())
+
+	saved := repo.getSavedInstructions()
+	require.Len(t, saved, 1)
+	assert.Equal(t, domain.InstructionStatusExpired, saved[0].Status,
+		"instruction past its TTL must be expired, not reclaimed to RETRYING")
+}
+
 // TestExpiryWorker_ReapStuckDispatching_NoStuckRowsNoSave verifies the reaper does not persist
 // anything when there are no stuck DISPATCHING instructions.
 func TestExpiryWorker_ReapStuckDispatching_NoStuckRowsNoSave(t *testing.T) {


### PR DESCRIPTION
## Summary

Instructions in the operational gateway can remain in `DISPATCHING` indefinitely when the worker that claimed them crashes or stalls mid-dispatch. Nothing ever moves them out of that state, so delivery is blocked forever and the row is never retried or expired.

This adds a dispatch-lease reaper that reclaims such stuck rows. It is folded into the existing expiry worker scan loop (no new goroutine), as the task preferred.

## Changes Made

- **`ports/repositories.go`**: Add `InstructionRepository.FindStuckDispatching(ctx, leaseTimeout, batchSize)`.
- **`adapters/persistence/instruction_repository.go`**: Implement `FindStuckDispatching` - returns `DISPATCHING` rows whose `updated_at` is older than the lease timeout, ordered `updated_at ASC` (most-stuck first).
- **`worker/expiry_worker.go`**: After each expiry scan, reap stuck `DISPATCHING` rows:
  - Rows whose TTL (`expires_at`) has already passed are transitioned straight to `EXPIRED` (never re-dispatched after deadline).
  - Otherwise, rows with attempts remaining (`CanRetry()`) transition to `RETRYING` with `NextRetryAt = nil` (immediate re-dispatch); rows whose retry budget is exhausted are marked `FAILED`.
  - Adds a `LeaseTimeout` config field (default 5m).
- **`config/config.go`** + **`cmd/main.go`**: Add `EXPIRY_WORKER_LEASE_TIMEOUT` (default 5m) and wire it through.

## Technical Details

- Reclaim reuses existing domain transitions (`MarkExpired` / `MarkRetrying` / `MarkFailed`), mirroring the dispatch worker's retry-or-fail logic, so lifecycle invariants and optimistic locking are preserved.
- The lease is keyed on `updated_at`: any progress Save moves it forward and resets the lease.
- Past-TTL guard: because the dispatch worker polls every 1s and `FetchDispatchable` does not filter `expires_at`, a reclaimed-to-RETRYING row would be re-dispatched within ~1s - before the 30s expiry scan could expire it. The reaper therefore expires past-TTL rows directly rather than resurrecting them (per the domain `DISPATCHING -> EXPIRED` transition).

## Testing

- Unit (`worker`): stuck row reclaimed to `RETRYING` with immediate re-dispatch and correct lease timeout passed; past-TTL row marked `EXPIRED` (not retried); exhausted row marked `FAILED`; no-stuck-rows persists nothing; non-`DISPATCHING` row skipped.
- Integration (`persistence`, CockroachDB testcontainers): stuck `DISPATCHING` returned while a fresh `DISPATCHING` row and a `PENDING` row are excluded; batch-size limit enforced; empty result returns nil.
- Existing `FindExpired` / PENDING-RETRYING expiry tests unchanged and green. `TestFunctionSize` ratchet green; gofumpt + golangci-lint clean.

## Risk Assessment

Low. Additive interface method plus a new reap pass in the existing worker loop; existing expiry behavior is untouched. Default lease (5m) is conservative and configurable.

## Related Discoveries (out of scope for this task)

CodeRabbit flagged that a reclaimed dispatch is not provider-idempotent: `HTTPDispatcher.Dispatch` sets a fresh `X-Request-ID` per attempt (`http_dispatcher.go:205`) rather than a stable key, so any duplicate delivery (inherent to at-least-once) is not deduplicated at the provider.

This is a **pre-existing** property of the dispatch adapter that affects every retry path, not something introduced by the reaper:
- `domain.Instruction` does not carry the idempotency key (it is passed separately to `Save`), so propagating a stable key requires domain + adapter plumbing.
- The HTTP client timeout is 30s vs the 5m lease, so the reaper only reclaims genuinely crashed/stalled workers, not live-but-slow calls; the residual duplicate is the classic "provider processed, worker crashed before recording DELIVERED" at-least-once case.

Fixing it properly (lease heartbeat/extension, or stable provider idempotency-key propagation through `HTTPDispatcher`) is a Major/Heavy-lift change to the dispatch adapter and is better tracked as a dedicated follow-up rather than expanding a reaper task.