### PR TITLE
feat: event-router DLQ, per-event idempotency, and state-based readiness (DAT-5/DAT-7/LOW-4)

### DIFF
--- a/services/event-router/adapters/grpc/position_keeping_client.go
+++ b/services/event-router/adapters/grpc/position_keeping_client.go
@@ -7,11 +7,13 @@ import (
 	"log/slog"
 	"time"
 
+	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	auditdomain "github.com/meridianhub/meridian/services/audit-worker/domain"
 	"github.com/meridianhub/meridian/services/event-router/domain"
 	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
+	"github.com/meridianhub/meridian/shared/platform/quantity"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -212,34 +214,45 @@ func (c *PositionKeepingGRPCClient) buildRecordMeasurementRequest(measurement *a
 	// Timestamp from the period start (audit events are point-in-time)
 	timestamp := timestamppb.New(measurement.Period.Start)
 
-	// Build metadata from measurement attributes
-	metadata := make(map[string]string)
-	for k, v := range measurement.Attributes {
-		metadata[k] = v
-	}
-	// Add source info to metadata
-	metadata["source"] = measurement.Source
-	metadata["quality_score"] = fmt.Sprintf("%d", measurement.QualityScore)
-
-	// Add instrument metadata for typed quantity reconstruction.
-	// Position Keeping can use these fields to create properly typed quantities
-	// using the Universal Asset System's InstrumentAmount proto or domain types.
-	metadata["instrument_code"] = instrument.Code
-	metadata["instrument_version"] = fmt.Sprintf("%d", instrument.Version)
-	metadata["instrument_dimension"] = instrument.Dimension
-	metadata["instrument_precision"] = fmt.Sprintf("%d", instrument.Precision)
-
 	// Position state ID is the AccountID (the billing account for this tenant)
 	positionStateID := measurement.AccountID.String()
 
-	return &positionkeepingv1.RecordMeasurementRequest{
+	req := &positionkeepingv1.RecordMeasurementRequest{
 		MeasurementType: measurementType,
 		Value:           value,
 		Unit:            unit,
 		Timestamp:       timestamp,
-		Metadata:        metadata,
+		Metadata:        buildMeasurementMetadata(measurement, instrument),
 		PositionStateId: positionStateID,
 	}
+
+	// Derive a per-event idempotency key from the stable source audit event ID
+	// so Kafka redelivery of the same event is deduplicated by Position Keeping
+	// instead of double-counting utilization. Absent when the event ID is not
+	// carried on the measurement (e.g. non-audit callers); we omit the key
+	// rather than sending the measurement's random ID, which would not dedupe.
+	if eventID := measurement.Attributes[domain.MeasurementAttrEventID]; eventID != "" {
+		req.IdempotencyKey = &commonv1.IdempotencyKey{Key: eventID}
+	}
+
+	return req
+}
+
+// buildMeasurementMetadata assembles the proto metadata map from the measurement
+// attributes, source/quality info, and instrument fields for typed quantity
+// reconstruction on the Position Keeping side (Universal Asset System).
+func buildMeasurementMetadata(measurement *auditdomain.Measurement, instrument quantity.Instrument) map[string]string {
+	metadata := make(map[string]string, len(measurement.Attributes)+6)
+	for k, v := range measurement.Attributes {
+		metadata[k] = v
+	}
+	metadata["source"] = measurement.Source
+	metadata["quality_score"] = fmt.Sprintf("%d", measurement.QualityScore)
+	metadata["instrument_code"] = instrument.Code
+	metadata["instrument_version"] = fmt.Sprintf("%d", instrument.Version)
+	metadata["instrument_dimension"] = instrument.Dimension
+	metadata["instrument_precision"] = fmt.Sprintf("%d", instrument.Precision)
+	return metadata
 }
 
 // handleRecordMeasurementError logs and records metrics for RecordMeasurement errors.

--- a/services/event-router/adapters/grpc/position_keeping_client_test.go
+++ b/services/event-router/adapters/grpc/position_keeping_client_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	auditdomain "github.com/meridianhub/meridian/services/audit-worker/domain"
+	eventrouterdomain "github.com/meridianhub/meridian/services/event-router/domain"
 	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
@@ -312,6 +313,47 @@ func TestPositionKeepingGRPCClient_buildRecordMeasurementRequest(t *testing.T) {
 	assert.Equal(t, "1", req.Metadata["instrument_version"])
 	assert.Equal(t, "COUNT", req.Metadata["instrument_dimension"])
 	assert.Equal(t, "0", req.Metadata["instrument_precision"])
+}
+
+func TestPositionKeepingGRPCClient_buildRecordMeasurementRequest_SetsIdempotencyKeyFromEventID(t *testing.T) {
+	client := &PositionKeepingGRPCClient{}
+	measurement := createTestMeasurement()
+	measurement.Attributes[eventrouterdomain.MeasurementAttrEventID] = "evt-abc-123"
+
+	req := client.buildRecordMeasurementRequest(measurement)
+
+	require.NotNil(t, req.IdempotencyKey)
+	assert.Equal(t, "evt-abc-123", req.IdempotencyKey.Key)
+}
+
+func TestPositionKeepingGRPCClient_buildRecordMeasurementRequest_StableIdempotencyKeyAcrossRedelivery(t *testing.T) {
+	client := &PositionKeepingGRPCClient{}
+
+	// Two transforms of the same audit event mint different random measurement
+	// IDs but carry the same event_id, so the idempotency key must be identical.
+	first := createTestMeasurement()
+	first.ID = uuid.New()
+	first.Attributes[eventrouterdomain.MeasurementAttrEventID] = "evt-stable-1"
+	second := createTestMeasurement()
+	second.ID = uuid.New()
+	second.Attributes[eventrouterdomain.MeasurementAttrEventID] = "evt-stable-1"
+
+	reqA := client.buildRecordMeasurementRequest(first)
+	reqB := client.buildRecordMeasurementRequest(second)
+
+	require.NotNil(t, reqA.IdempotencyKey)
+	require.NotNil(t, reqB.IdempotencyKey)
+	assert.Equal(t, reqA.IdempotencyKey.Key, reqB.IdempotencyKey.Key)
+	assert.NotEqual(t, first.ID, second.ID)
+}
+
+func TestPositionKeepingGRPCClient_buildRecordMeasurementRequest_NoIdempotencyKeyWhenEventIDAbsent(t *testing.T) {
+	client := &PositionKeepingGRPCClient{}
+	measurement := createTestMeasurement() // no event_id attribute
+
+	req := client.buildRecordMeasurementRequest(measurement)
+
+	assert.Nil(t, req.IdempotencyKey)
 }
 
 func TestPositionKeepingGRPCClient_buildRecordMeasurementRequest_TransactionUnit(t *testing.T) {

--- a/services/event-router/adapters/messaging/platform_metering_handler.go
+++ b/services/event-router/adapters/messaging/platform_metering_handler.go
@@ -118,6 +118,12 @@ func (h *PlatformMeteringHandler) handleAuditEvent(ctx context.Context, channel 
 		return nil
 	}
 
+	// Carry the stable source event ID on the measurement so the Position
+	// Keeping client can derive a per-event idempotency key. The transformer
+	// mints a fresh random measurement ID on every call, so redelivery must key
+	// off the audit event's own ID to avoid double-counting utilization.
+	stampEventID(measurement, event.EventId)
+
 	if err := h.recordMeasurement(ctx, event, measurement); err != nil {
 		return err
 	}
@@ -171,6 +177,19 @@ func (h *PlatformMeteringHandler) publishToMDS(measurement *auditdomain.Measurem
 	utilMeasurement := domain.MeasurementToUtilization(measurement)
 	h.mdPublisher.Publish(utilMeasurement)
 	domain.RecordMDSPublish("success")
+}
+
+// stampEventID records the source audit event ID on the measurement attributes
+// under domain.MeasurementAttrEventID. Empty IDs are skipped so an absent key
+// simply omits the idempotency key downstream rather than sending a blank one.
+func stampEventID(measurement *auditdomain.Measurement, eventID string) {
+	if eventID == "" {
+		return
+	}
+	if measurement.Attributes == nil {
+		measurement.Attributes = make(map[string]string, 1)
+	}
+	measurement.Attributes[domain.MeasurementAttrEventID] = eventID
 }
 
 // HasMDSPublisher returns whether the handler has an MDS publisher configured.

--- a/services/event-router/adapters/messaging/platform_metering_handler_test.go
+++ b/services/event-router/adapters/messaging/platform_metering_handler_test.go
@@ -91,6 +91,24 @@ func TestPlatformMeteringHandler_Handle_Success(t *testing.T) {
 	assert.Equal(t, "INSERT", measurements[0].Attributes["operation"])
 }
 
+// TestPlatformMeteringHandler_Handle_StampsEventIDForIdempotency verifies the
+// stable source event ID is carried on the measurement attributes so downstream
+// idempotency can dedupe Kafka redeliveries.
+func TestPlatformMeteringHandler_Handle_StampsEventIDForIdempotency(t *testing.T) {
+	transformer := newTestTransformer()
+	mockPK := newMockPositionKeepingClient()
+
+	h, err := NewPlatformMeteringHandler(transformer, mockPK)
+	require.NoError(t, err)
+
+	event := newValidAuditEvent()
+	require.NoError(t, h.Handle(context.Background(), "audit.events", event, nil))
+
+	measurements := mockPK.getMeasurements()
+	require.Len(t, measurements, 1)
+	assert.Equal(t, event.EventId, measurements[0].Attributes[domain.MeasurementAttrEventID])
+}
+
 // TestPlatformMeteringHandler_Handle_PKError verifies error propagation when the PK client fails.
 func TestPlatformMeteringHandler_Handle_PKError(t *testing.T) {
 	transformer := newTestTransformer()

--- a/services/event-router/cmd/main.go
+++ b/services/event-router/cmd/main.go
@@ -144,81 +144,85 @@ func run(logger *slog.Logger) error {
 	serverErrors, httpCleanup := launchHTTPServer(httpServer, logger)
 	defer httpCleanup()
 
-	// Initialize upstream clients and Kafka consumer
-	pkClient, consumer, mdPublisher, mdsConn, err := initConsumerPipeline(config, logger)
+	// Initialize upstream clients and Kafka consumer. Readiness is driven by the
+	// consumer's OnReady hook so /ready reflects genuine consumer state rather
+	// than being flipped optimistically before the consumer is actually up.
+	onReady := newReadinessCallback(readiness, readinessMu, logger)
+	pipeline, err := initConsumerPipeline(config, onReady, logger)
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if err := pkClient.Close(); err != nil {
-			logger.Error("failed to close position keeping client", "error", err)
-		}
-	}()
-	defer func() {
-		if err := consumer.Close(); err != nil {
-			logger.Error("failed to close audit consumer", "error", err)
-		}
-	}()
+	defer pipeline.closeClients(logger)
 
-	// Start consuming in background
+	// Start consuming in background. Start blocks until shutdown; readiness is
+	// signaled from inside the consume loop via onReady, not here.
 	consumerErrors := make(chan error, 1)
 	go func() {
 		logger.Info("starting audit event consumption")
-		if err := consumer.Start(config.AuditTopics); err != nil {
+		if err := pipeline.consumer.Start(config.AuditTopics); err != nil {
 			logger.Error("consumer error", "error", err)
 			consumerErrors <- fmt.Errorf("consumer error: %w", err)
-			return
 		}
-		readinessMu.Lock()
-		readiness.consumerInitialized = true
-		readinessMu.Unlock()
-		logger.Info("audit consumer ready")
 	}()
 
-	return awaitAndShutdown(httpServer, consumer, mdPublisher, mdsConn, serverErrors, consumerErrors, logger)
+	return awaitAndShutdown(httpServer, pipeline, serverErrors, consumerErrors, logger)
+}
+
+// consumerPipeline bundles the upstream clients and Kafka consumer that make up
+// the event-router processing pipeline, along with the resources released on shutdown.
+type consumerPipeline struct {
+	pkClient    *grpc.PositionKeepingGRPCClient
+	consumer    *messaging.AuditConsumer
+	mdPublisher *mds.MarketDataPublisher
+	mdsConn     *grpclib.ClientConn
+	dlqProducer *kafka.DLQProducer
+}
+
+// closeClients releases the Kafka consumer and position-keeping client.
+func (p *consumerPipeline) closeClients(logger *slog.Logger) {
+	if err := p.consumer.Close(); err != nil {
+		logger.Error("failed to close audit consumer", "error", err)
+	}
+	if err := p.pkClient.Close(); err != nil {
+		logger.Error("failed to close position keeping client", "error", err)
+	}
+}
+
+// newReadinessCallback returns the callback wired into the Kafka consumer's
+// OnReady hook. It marks the consumer ready by writing a bool under the mutex,
+// so it never blocks and can never stall the consume loop.
+func newReadinessCallback(readiness *readinessState, mu *sync.RWMutex, logger *slog.Logger) func() {
+	return func() {
+		mu.Lock()
+		readiness.consumerInitialized = true
+		mu.Unlock()
+		logger.Info("audit consumer ready")
+	}
 }
 
 // initConsumerPipeline creates the Position Keeping client, optional MDS publisher,
-// and Kafka audit consumer.
-func initConsumerPipeline(config *app.Config, logger *slog.Logger) (*grpc.PositionKeepingGRPCClient, *messaging.AuditConsumer, *mds.MarketDataPublisher, *grpclib.ClientConn, error) {
-	// Initialize Position Keeping client
+// dead-letter-queue producer, and Kafka audit consumer. onReady is wired into the
+// consumer so readiness reflects genuine consumer state.
+func initConsumerPipeline(config *app.Config, onReady func(), logger *slog.Logger) (*consumerPipeline, error) {
 	pkClient, err := initPKClient(config, logger)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, err
 	}
 
-	// Initialize MDS publisher (optional, controlled by feature flag)
-	var consumerOpts []messaging.AuditConsumerOption
-	var mdPublisher *mds.MarketDataPublisher
-	var mdsConn *grpclib.ClientConn
+	consumerOpts, mdPublisher, mdsConn := buildMDSOutput(config, logger)
 
-	if config.EnableMDSOutput && config.MDSServiceAddr != "" {
-		logger.Info("initializing MDS publisher",
-			"mds_service_addr", config.MDSServiceAddr,
-			"aggregation_window", config.MDSAggregationWindow,
-			"flush_interval", config.MDSFlushInterval)
-
-		mdPublisher, mdsConn, err = initMDSPublisher(config, logger)
-		if err != nil {
-			logger.Error("failed to initialize MDS publisher, continuing without MDS output",
-				"error", err)
-		} else {
-			consumerOpts = append(consumerOpts, messaging.WithMDSPublisher(mdPublisher))
-		}
-	} else {
-		logger.Info("MDS output disabled",
-			"enable_mds_output", config.EnableMDSOutput,
-			"mds_service_addr", config.MDSServiceAddr)
-	}
-
-	// Parse tenant mapping and create transformer
 	transformer, err := createTransformer(config, logger)
 	if err != nil {
 		_ = pkClient.Close()
-		return nil, nil, nil, nil, err
+		return nil, err
 	}
 
-	// Initialize Kafka consumer
+	dlqProducer, dlqConfig, err := initDLQProducer(config, logger)
+	if err != nil {
+		_ = pkClient.Close()
+		return nil, err
+	}
+
 	logger.Info("initializing kafka consumer",
 		"topics", config.AuditTopics,
 		"group_id", config.ConsumerGroupID)
@@ -229,15 +233,76 @@ func initConsumerPipeline(config *app.Config, logger *slog.Logger) (*grpc.Positi
 		ClientID:         "event-router",
 		AutoOffsetReset:  "earliest",
 		EnableAutoCommit: false,
+		DLQProducer:      dlqProducer,
+		DLQConfig:        &dlqConfig,
+		OnReady:          onReady,
 	}
 
 	consumer, err := messaging.NewAuditConsumer(kafkaConfig, transformer, pkClient, consumerOpts...)
 	if err != nil {
 		_ = pkClient.Close()
-		return nil, nil, nil, nil, fmt.Errorf("failed to create audit consumer: %w", err)
+		dlqProducer.Close()
+		return nil, fmt.Errorf("failed to create audit consumer: %w", err)
 	}
 
-	return pkClient, consumer, mdPublisher, mdsConn, nil
+	return &consumerPipeline{
+		pkClient:    pkClient,
+		consumer:    consumer,
+		mdPublisher: mdPublisher,
+		mdsConn:     mdsConn,
+		dlqProducer: dlqProducer,
+	}, nil
+}
+
+// buildMDSOutput initializes the optional MDS publisher and returns the consumer
+// options plus the resources released on shutdown. A failed MDS init is logged
+// and the pipeline continues without MDS output (best-effort dual output).
+func buildMDSOutput(config *app.Config, logger *slog.Logger) ([]messaging.AuditConsumerOption, *mds.MarketDataPublisher, *grpclib.ClientConn) {
+	if !config.EnableMDSOutput || config.MDSServiceAddr == "" {
+		logger.Info("MDS output disabled",
+			"enable_mds_output", config.EnableMDSOutput,
+			"mds_service_addr", config.MDSServiceAddr)
+		return nil, nil, nil
+	}
+
+	logger.Info("initializing MDS publisher",
+		"mds_service_addr", config.MDSServiceAddr,
+		"aggregation_window", config.MDSAggregationWindow,
+		"flush_interval", config.MDSFlushInterval)
+
+	mdPublisher, mdsConn, err := initMDSPublisher(config, logger)
+	if err != nil {
+		logger.Error("failed to initialize MDS publisher, continuing without MDS output",
+			"error", err)
+		return nil, nil, nil
+	}
+	return []messaging.AuditConsumerOption{messaging.WithMDSPublisher(mdPublisher)}, mdPublisher, mdsConn
+}
+
+// initDLQProducer creates the Kafka dead-letter-queue producer for poison audit
+// messages. After the configured retries are exhausted, a failing message is
+// routed to a per-topic DLQ ("<topic>-dlq") instead of blocking the consumer or
+// looping indefinitely, and the offset is committed so consumption proceeds.
+func initDLQProducer(config *app.Config, logger *slog.Logger) (*kafka.DLQProducer, kafka.DLQConfig, error) {
+	producer, err := kafka.NewProtoProducer(kafka.ProducerConfig{
+		BootstrapServers: config.KafkaBootstrapServers,
+		ClientID:         "event-router-dlq",
+	})
+	if err != nil {
+		return nil, kafka.DLQConfig{}, fmt.Errorf("failed to create DLQ producer: %w", err)
+	}
+
+	dlqConfig := kafka.DefaultDLQConfig(config.ConsumerGroupID)
+	dlqProducer, err := kafka.NewDLQProducer(producer, dlqConfig)
+	if err != nil {
+		producer.Close()
+		return nil, kafka.DLQConfig{}, fmt.Errorf("failed to create DLQ producer wrapper: %w", err)
+	}
+
+	logger.Info("dead letter queue configured",
+		"topic_suffix", dlqConfig.DLQTopicSuffix,
+		"max_retries", dlqConfig.MaxRetries)
+	return dlqProducer, dlqConfig, nil
 }
 
 // launchHTTPServer starts the HTTP server in a background goroutine and returns
@@ -320,9 +385,7 @@ func initPKClient(config *app.Config, logger *slog.Logger) (*grpc.PositionKeepin
 // awaitAndShutdown waits for a shutdown signal or error, then gracefully stops all components.
 func awaitAndShutdown(
 	httpServer *http.Server,
-	consumer *messaging.AuditConsumer,
-	mdPublisher *mds.MarketDataPublisher,
-	mdsConn *grpclib.ClientConn,
+	pipeline *consumerPipeline,
 	serverErrors, consumerErrors chan error,
 	logger *slog.Logger,
 ) error {
@@ -347,16 +410,26 @@ func awaitAndShutdown(
 	defer cancel()
 
 	logger.Info("stopping kafka consumer...")
-	consumer.Stop()
+	pipeline.consumer.Stop()
 	logger.Info("kafka consumer stopped")
 
-	if mdPublisher != nil {
+	// Flush the consumer (no longer producing) before closing the DLQ producer
+	// so any poison messages captured just before shutdown are delivered.
+	if pipeline.dlqProducer != nil {
+		if err := pipeline.dlqProducer.Flush(shutdownCtx); err != nil {
+			logger.Error("failed to flush DLQ producer", "error", err)
+		}
+		pipeline.dlqProducer.Close()
+		logger.Info("DLQ producer stopped")
+	}
+
+	if pipeline.mdPublisher != nil {
 		logger.Info("flushing MDS publisher...")
-		mdPublisher.Stop()
+		pipeline.mdPublisher.Stop()
 		logger.Info("MDS publisher stopped")
 	}
-	if mdsConn != nil {
-		if err := mdsConn.Close(); err != nil {
+	if pipeline.mdsConn != nil {
+		if err := pipeline.mdsConn.Close(); err != nil {
 			logger.Error("failed to close MDS gRPC connection", "error", err)
 		}
 	}

--- a/services/event-router/cmd/main_test.go
+++ b/services/event-router/cmd/main_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/meridianhub/meridian/services/event-router/app"
 	"github.com/meridianhub/meridian/shared/platform/await"
 )
 
@@ -44,6 +45,59 @@ func TestHealthEndpoint_Liveness(_ *testing.T) {
 	// This is a placeholder test that will be expanded with full integration tests.
 	// The actual service startup is tested in TestHealthEndpoint_Integration.
 	// This test just verifies environment variable handling and basic setup.
+}
+
+func TestInitDLQProducer_ConfiguresDeadLetterQueue(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cfg := &app.Config{
+		KafkaBootstrapServers: "localhost:9092",
+		ConsumerGroupID:       "event-router-test",
+	}
+
+	dlqProducer, dlqConfig, err := initDLQProducer(cfg, logger)
+	if err != nil {
+		t.Fatalf("initDLQProducer() error = %v", err)
+	}
+	defer dlqProducer.Close()
+
+	if dlqProducer == nil {
+		t.Fatal("expected non-nil DLQ producer")
+	}
+	if dlqConfig.ConsumerGroupID != "event-router-test" {
+		t.Errorf("consumer group: got %q, want %q", dlqConfig.ConsumerGroupID, "event-router-test")
+	}
+	// Poison messages route to a per-topic DLQ using the configured suffix.
+	if got := dlqConfig.DLQTopicName("audit.events.current-account.v1"); got != "audit.events.current-account.v1-dlq" {
+		t.Errorf("DLQ topic: got %q, want %q", got, "audit.events.current-account.v1-dlq")
+	}
+	if dlqConfig.MaxRetries < 1 {
+		t.Errorf("expected at least one retry before DLQ, got %d", dlqConfig.MaxRetries)
+	}
+}
+
+func TestNewReadinessCallback_MarksConsumerReady(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	readiness := &readinessState{}
+	readinessMu := &sync.RWMutex{}
+
+	callback := newReadinessCallback(readiness, readinessMu, logger)
+
+	// Before the callback fires, the consumer must not be reported ready.
+	readinessMu.RLock()
+	before := readiness.consumerInitialized
+	readinessMu.RUnlock()
+	if before {
+		t.Fatal("expected consumer to start not-ready")
+	}
+
+	callback()
+
+	readinessMu.RLock()
+	after := readiness.consumerInitialized
+	readinessMu.RUnlock()
+	if !after {
+		t.Error("expected callback to mark the consumer ready")
+	}
 }
 
 func TestCreateHTTPServer(t *testing.T) {

--- a/services/event-router/domain/measurement.go
+++ b/services/event-router/domain/measurement.go
@@ -8,6 +8,12 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/quantity"
 )
 
+// MeasurementAttrEventID is the measurement attribute key that carries the
+// source audit event's stable ID. It is populated by the metering handler and
+// read by the Position Keeping client to derive a per-event idempotency key so
+// Kafka redelivery of the same audit event does not double-count utilization.
+const MeasurementAttrEventID = "event_id"
+
 // UtilizationMeasurement represents a single utilization measurement derived from an audit event.
 // This will be sent to Position Keeping service as a position change for tenant-zero billing.
 type UtilizationMeasurement struct {

--- a/shared/platform/kafka/consumer.go
+++ b/shared/platform/kafka/consumer.go
@@ -45,6 +45,11 @@ type ProtoConsumer struct {
 	dlqProducer *DLQProducer
 	// dlqConfig contains DLQ behavior configuration
 	dlqConfig *DLQConfig
+	// onReady is an optional callback fired once the consumer is genuinely
+	// subscribed and polling without broker errors (see signalReady).
+	onReady func()
+	// readyOnce guarantees onReady is invoked at most once.
+	readyOnce sync.Once
 	// wg tracks the Subscribe goroutine for graceful shutdown
 	wg sync.WaitGroup
 	// ctx provides cancellation signal for graceful shutdown
@@ -80,6 +85,13 @@ type ConsumerConfig struct {
 	// DLQConfig contains DLQ behavior configuration (retry count, backoff, etc.).
 	// Only used if DLQProducer is not nil.
 	DLQConfig *DLQConfig
+	// OnReady is an optional callback invoked exactly once when the consumer has
+	// genuinely joined the group and completed its first poll cycle without a
+	// broker-level fetch error. Use it to drive readiness probes from actual
+	// consumer state instead of a best-effort guess. The callback MUST NOT block:
+	// it runs inline on the consume loop and is guarded by a sync.Once, so it can
+	// never stall consumption or fire more than once.
+	OnReady func()
 }
 
 var (
@@ -134,9 +146,21 @@ func NewProtoConsumer(config ConsumerConfig, msgFactory func() proto.Message, ha
 		handlerTimeout: config.HandlerTimeout,
 		dlqProducer:    config.DLQProducer,
 		dlqConfig:      config.DLQConfig,
+		onReady:        config.OnReady,
 		ctx:            ctx,
 		cancel:         cancel,
 	}, nil
+}
+
+// signalReady invokes the OnReady callback exactly once. It is safe to call on
+// every poll cycle and from any goroutine; only the first invocation runs the
+// callback. The callback is expected to be non-blocking, so readiness signaling
+// can never stall the consume loop or block forever.
+func (c *ProtoConsumer) signalReady() {
+	if c.onReady == nil {
+		return
+	}
+	c.readyOnce.Do(c.onReady)
 }
 
 // validateConsumerConfig checks required consumer configuration parameters.
@@ -270,16 +294,28 @@ func (c *ProtoConsumer) Subscribe(topics []string) error {
 			fetches := c.client.PollFetches(pollCtx)
 			pollCancel()
 
-			// Check for errors in fetches
+			// Check for errors in fetches. A poll cycle is "clean" when it
+			// completes without a broker-level fetch error (poll-timeout and
+			// shutdown cancellations do not count). The first clean cycle means
+			// the consumer has joined the group and is genuinely polling.
+			cleanPoll := true
 			if errs := fetches.Errors(); len(errs) > 0 {
 				for _, err := range errs {
-					// Context cancellation is expected during shutdown
+					// Context cancellation is expected during shutdown and on
+					// idle poll timeouts - neither indicates a broker failure.
 					if errors.Is(err.Err, context.Canceled) || errors.Is(err.Err, context.DeadlineExceeded) {
 						continue
 					}
+					cleanPoll = false
 					log.Printf("WARN: Fetch error for topic=%s partition=%d: %v",
 						err.Topic, err.Partition, err.Err)
 				}
+			}
+
+			// Signal readiness once the consumer is subscribed and polling
+			// without broker errors, so /ready reflects actual consumer state.
+			if cleanPoll && c.ctx.Err() == nil {
+				c.signalReady()
 			}
 
 			// Track whether any record processing failed (especially DLQ failures)

--- a/shared/platform/kafka/consumer_unit_test.go
+++ b/shared/platform/kafka/consumer_unit_test.go
@@ -157,6 +157,54 @@ func TestProcessMessage_HandlerError(t *testing.T) {
 	}
 }
 
+func TestSignalReady_FiresCallbackExactlyOnce(t *testing.T) {
+	var calls int
+	consumer := createTestConsumer(func(_ context.Context, _ []byte, _ proto.Message) error {
+		return nil
+	}, nil, nil)
+	defer consumer.cancel()
+	consumer.onReady = func() { calls++ }
+
+	// Multiple invocations must run the callback at most once.
+	consumer.signalReady()
+	consumer.signalReady()
+	consumer.signalReady()
+
+	if calls != 1 {
+		t.Errorf("expected onReady to fire exactly once, got %d", calls)
+	}
+}
+
+func TestSignalReady_NilCallbackIsSafe(_ *testing.T) {
+	consumer := createTestConsumer(func(_ context.Context, _ []byte, _ proto.Message) error {
+		return nil
+	}, nil, nil)
+	defer consumer.cancel()
+	consumer.onReady = nil
+
+	// Must not panic when no callback is configured.
+	consumer.signalReady()
+}
+
+func TestNewProtoConsumer_WiresOnReadyCallback(t *testing.T) {
+	var fired bool
+	consumer, err := NewProtoConsumer(ConsumerConfig{
+		BootstrapServers: "localhost:9092",
+		GroupID:          "test-group",
+		OnReady:          func() { fired = true },
+	}, func() proto.Message { return &timestamppb.Timestamp{} },
+		func(_ context.Context, _ []byte, _ proto.Message) error { return nil })
+	if err != nil {
+		t.Skip("Kafka client init unavailable, skipping")
+	}
+	defer func() { _ = consumer.Close() }()
+
+	consumer.signalReady()
+	if !fired {
+		t.Error("expected OnReady from config to be wired into the consumer")
+	}
+}
+
 func TestProcessMessageWithRetry_NoDLQ(t *testing.T) {
 	handlerErr := errors.New("processing failed")
 	handler := func(_ context.Context, _ []byte, _ proto.Message) error {


### PR DESCRIPTION
## Summary

Hardens the `event-router` metering pipeline across three bug-sweep findings, all scoped to this service plus one additive hook on the shared Kafka consumer.

- **DAT-5 (#15) - Dead-letter queue for poison metering messages.** The metering `ConsumerConfig` now carries a DLQ producer. After the configured retries are exhausted, a failing audit message is routed to a per-topic DLQ (`<topic>-dlq`) and its offset is committed, instead of blocking the consumer or looping the same poison message indefinitely. The producer is flushed and closed on graceful shutdown so messages captured just before exit are not lost.
- **DAT-7 (#25) - Per-event idempotency key on utilization measurements.** `buildRecordMeasurementRequest` now sets `RecordMeasurementRequest.idempotency_key` from the stable source audit event ID, so Kafka redelivery of the same event is deduplicated by Position Keeping rather than double-counting utilization. The transformer mints a fresh random measurement ID on every call, so the key is derived from the audit event's own ID (carried on the measurement attributes by the metering handler), not the measurement ID.
- **LOW-4 (#30) - State-based readiness probe.** `/ready` is now driven by the consumer's actual state via an `OnReady` callback that fires once the consumer is subscribed and polling without broker errors, replacing the flag that was set after `Start()` returned (i.e. only at shutdown). The callback is guarded by `sync.Once` and only writes a bool under a mutex, so it never blocks and can never fire more than once - the probe cannot hang.

## Changes Made

- `shared/platform/kafka/consumer.go`: additive optional `OnReady` hook on `ConsumerConfig`/`ProtoConsumer`, fired once from the consume loop after the first clean poll cycle (`signalReady`, `sync.Once`).
- `services/event-router/cmd/main.go`: wire a DLQ producer and the readiness callback into the consumer; bundle pipeline components into a `consumerPipeline` struct; flush/close the DLQ producer on shutdown. Extracted `buildMDSOutput`, `initDLQProducer`, `newReadinessCallback` to keep functions under the 60-line limit.
- `services/event-router/adapters/messaging/platform_metering_handler.go`: stamp the source event ID onto the measurement attributes (`stampEventID`).
- `services/event-router/adapters/grpc/position_keeping_client.go`: set the idempotency key from the event-ID attribute; extracted `buildMeasurementMetadata` to stay under the size limit.
- `services/event-router/domain/measurement.go`: `MeasurementAttrEventID` constant shared by the handler and client.

## Testing

- New unit tests: idempotency key set from event ID + stable across redelivery + omitted when absent; handler stamps event ID; readiness callback marks ready; DLQ producer wiring (topic naming, retries, consumer group); `signalReady` once-semantics and nil-safety.
- `go test ./services/event-router/... ./shared/platform/kafka/... -short` - all green.
- `go build ./shared/... ./services/...`, `gofumpt`, `golangci-lint`, and `tests/architecture` `TestFunctionSize` - all pass.
- DLQ end-to-end routing against a live broker follows the repo's existing skip-if-unavailable pattern; the routing mechanism itself is already covered by `shared/platform/kafka` DLQ tests.

## Risk Assessment

Low. The shared Kafka change is additive (nil `OnReady` = no-op, backward compatible). DLQ and idempotency reuse existing, tested platform primitives. No schema or migration changes.
