### PR TITLE
fix: Resolve reconciliation FK surrogates and select baseline by valid time (DAT-1, LOW-7)

### DIFF
--- a/services/reconciliation/adapters/persistence/fk_resolution.go
+++ b/services/reconciliation/adapters/persistence/fk_resolution.go
@@ -1,0 +1,35 @@
+package persistence
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// resolveRunSurrogate looks up the settlement_run surrogate PK (settlement_run.id)
+// for a business run_id (settlement_run.run_id). The surrogate is what child tables
+// (settlement_snapshot, variance) store in their run_id FK columns, since those FKs
+// reference settlement_run.id, not the business identifier.
+//
+// The returned error wraps gorm.ErrRecordNotFound when no run matches, so callers can
+// branch on errors.Is(err, gorm.ErrRecordNotFound) to treat a missing run as a no-op.
+func resolveRunSurrogate(tx *gorm.DB, businessRunID uuid.UUID) (uuid.UUID, error) {
+	var run SettlementRunEntity
+	if err := tx.Select("id").Where("run_id = ?", businessRunID).First(&run).Error; err != nil {
+		return uuid.Nil, fmt.Errorf("resolving surrogate ID for run %s: %w", businessRunID, err)
+	}
+	return run.ID, nil
+}
+
+// resolveSnapshotSurrogate looks up the settlement_snapshot surrogate PK
+// (settlement_snapshot.id) for a business snapshot_id (settlement_snapshot.snapshot_id).
+// The surrogate is what variance.snapshot_id stores, since that FK references
+// settlement_snapshot.id, not the business identifier.
+func resolveSnapshotSurrogate(tx *gorm.DB, businessSnapshotID uuid.UUID) (uuid.UUID, error) {
+	var snap SettlementSnapshotEntity
+	if err := tx.Select("id").Where("snapshot_id = ?", businessSnapshotID).First(&snap).Error; err != nil {
+		return uuid.Nil, fmt.Errorf("resolving surrogate ID for snapshot %s: %w", businessSnapshotID, err)
+	}
+	return snap.ID, nil
+}

--- a/services/reconciliation/adapters/persistence/settlement_snapshot_repository.go
+++ b/services/reconciliation/adapters/persistence/settlement_snapshot_repository.go
@@ -3,7 +3,6 @@ package persistence
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -30,6 +29,12 @@ type SettlementSnapshotEntity struct {
 	SourceSystem    string          `gorm:"column:source_system;size:100;not null"`
 	Attributes      JSONMap         `gorm:"column:attributes;type:jsonb"`
 	CapturedAt      time.Time       `gorm:"column:captured_at;not null"`
+
+	// BusinessRunID is populated read-only on retrieval via a join to
+	// settlement_run.run_id. It is not a stored column: settlement_snapshot.run_id
+	// holds the settlement_run surrogate PK (FK target), while the domain layer works
+	// in business run identifiers.
+	BusinessRunID uuid.UUID `gorm:"->;column:business_run_id"`
 }
 
 // TableName returns the table name for the settlement snapshot entity.
@@ -68,15 +73,23 @@ func (r *SettlementSnapshotRepository) isInTransaction() bool {
 	return ok && committer != nil
 }
 
-// Create persists a new SettlementSnapshot.
+// Create persists a new SettlementSnapshot. The snapshot's domain RunID is the
+// business run identifier; it is resolved to the settlement_run surrogate PK before
+// being written to the run_id FK column.
 func (r *SettlementSnapshotRepository) Create(ctx context.Context, snapshot *domain.SettlementSnapshot) error {
 	entity := toSnapshotEntity(snapshot)
 	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		surrogate, err := resolveRunSurrogate(tx, snapshot.RunID)
+		if err != nil {
+			return err
+		}
+		entity.RunID = surrogate
 		return tx.Create(entity).Error
 	})
 }
 
-// CreateBatch persists multiple snapshots atomically.
+// CreateBatch persists multiple snapshots atomically. Each snapshot's business RunID
+// is resolved to the settlement_run surrogate PK for the run_id FK column.
 func (r *SettlementSnapshotRepository) CreateBatch(ctx context.Context, snapshots []*domain.SettlementSnapshot) error {
 	if len(snapshots) == 0 {
 		return nil
@@ -88,8 +101,39 @@ func (r *SettlementSnapshotRepository) CreateBatch(ctx context.Context, snapshot
 	}
 
 	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		if err := assignSnapshotRunSurrogates(tx, entities, snapshots); err != nil {
+			return err
+		}
 		return tx.CreateInBatches(entities, 100).Error
 	})
+}
+
+// assignSnapshotRunSurrogates resolves each snapshot's business RunID to the
+// settlement_run surrogate PK and writes it into the entity's run_id FK column,
+// caching resolutions so a batch sharing one run issues a single lookup.
+func assignSnapshotRunSurrogates(tx *gorm.DB, entities []SettlementSnapshotEntity, snapshots []*domain.SettlementSnapshot) error {
+	cache := make(map[uuid.UUID]uuid.UUID)
+	for i := range entities {
+		businessRunID := snapshots[i].RunID
+		surrogate, ok := cache[businessRunID]
+		if !ok {
+			var err error
+			if surrogate, err = resolveRunSurrogate(tx, businessRunID); err != nil {
+				return err
+			}
+			cache[businessRunID] = surrogate
+		}
+		entities[i].RunID = surrogate
+	}
+	return nil
+}
+
+// snapshotReadQuery builds a query that joins settlement_run so the business run_id
+// is projected into BusinessRunID, keeping the domain model in business identifiers.
+func snapshotReadQuery(tx *gorm.DB) *gorm.DB {
+	return tx.Model(&SettlementSnapshotEntity{}).
+		Select(`"settlement_snapshot".*, "settlement_run"."run_id" AS business_run_id`).
+		Joins(`JOIN "settlement_run" ON "settlement_run"."id" = "settlement_snapshot"."run_id"`)
 }
 
 // FindByID retrieves a SettlementSnapshot by its SnapshotID.
@@ -98,7 +142,7 @@ func (r *SettlementSnapshotRepository) FindByID(ctx context.Context, snapshotID 
 	var queryErr error
 
 	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
-		result := tx.Where("snapshot_id = ?", snapshotID).First(&entity)
+		result := snapshotReadQuery(tx).Where(`"settlement_snapshot"."snapshot_id" = ?`, snapshotID).First(&entity)
 		if result.Error != nil {
 			queryErr = result.Error
 			return result.Error
@@ -115,13 +159,16 @@ func (r *SettlementSnapshotRepository) FindByID(ctx context.Context, snapshotID 
 	return toSnapshotDomain(&entity), nil
 }
 
-// FindByRunID retrieves all snapshots for a settlement run.
+// FindByRunID retrieves all snapshots for a settlement run, keyed by the business
+// run identifier. The join filters on settlement_run.run_id, so an unknown run yields
+// an empty slice.
 func (r *SettlementSnapshotRepository) FindByRunID(ctx context.Context, runID uuid.UUID) ([]*domain.SettlementSnapshot, error) {
 	var entities []SettlementSnapshotEntity
 
 	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
-		return tx.Where("run_id = ?", runID).
-			Order("created_at ASC").
+		return snapshotReadQuery(tx).
+			Where(`"settlement_run"."run_id" = ?`, runID).
+			Order(`"settlement_snapshot"."created_at" ASC`).
 			Find(&entities).Error
 	})
 	if err != nil {
@@ -131,10 +178,18 @@ func (r *SettlementSnapshotRepository) FindByRunID(ctx context.Context, runID uu
 	return toSnapshotDomainSlice(entities), nil
 }
 
-// DeleteByRunID removes all snapshots for a given settlement run.
+// DeleteByRunID removes all snapshots for a given settlement run, keyed by the
+// business run identifier. An unknown run is a no-op.
 func (r *SettlementSnapshotRepository) DeleteByRunID(ctx context.Context, runID uuid.UUID) error {
 	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
-		return tx.Where("run_id = ?", runID).Delete(&SettlementSnapshotEntity{}).Error
+		surrogate, err := resolveRunSurrogate(tx, runID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil
+			}
+			return err
+		}
+		return tx.Where("run_id = ?", surrogate).Delete(&SettlementSnapshotEntity{}).Error
 	})
 }
 
@@ -143,16 +198,16 @@ func (r *SettlementSnapshotRepository) DeleteByRunID(ctx context.Context, runID 
 // (settlement_run.id) before updating, since settlement_snapshot.run_id is a FK to settlement_run.id.
 func (r *SettlementSnapshotRepository) MarkRunSnapshotsFinal(ctx context.Context, runID uuid.UUID) error {
 	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
-		var runEntity SettlementRunEntity
-		if err := tx.Select("id").Where("run_id = ?", runID).First(&runEntity).Error; err != nil {
-			return fmt.Errorf("resolving surrogate ID for run %s: %w", runID, err)
+		surrogate, err := resolveRunSurrogate(tx, runID)
+		if err != nil {
+			return err
 		}
 		// Use CASE to handle NULL/JSON-null attributes vs existing JSONB objects.
 		// CockroachDB's || operator requires both operands to be JSONB objects,
 		// so we must replace NULL/json-null with an empty object before merging.
 		return tx.Exec(
 			`UPDATE "settlement_snapshot" SET "attributes" = CASE WHEN "attributes" IS NULL OR "attributes"::text = 'null' THEN '{"settlement_type":"FINAL"}'::jsonb ELSE "attributes" || '{"settlement_type":"FINAL"}'::jsonb END WHERE "run_id" = ?`,
-			runEntity.ID,
+			surrogate,
 		).Error
 	})
 }
@@ -180,10 +235,12 @@ func toSnapshotEntity(s *domain.SettlementSnapshot) *SettlementSnapshotEntity {
 }
 
 // toSnapshotDomain converts a persistence entity to a domain SettlementSnapshot.
+// RunID is taken from BusinessRunID (projected via the read-path join to
+// settlement_run.run_id), not the surrogate FK stored in the run_id column.
 func toSnapshotDomain(e *SettlementSnapshotEntity) *domain.SettlementSnapshot {
 	s := &domain.SettlementSnapshot{
 		SnapshotID:      e.SnapshotID,
-		RunID:           e.RunID,
+		RunID:           e.BusinessRunID,
 		AccountID:       e.AccountID,
 		InstrumentCode:  e.InstrumentCode,
 		ExpectedBalance: e.ExpectedBalance,

--- a/services/reconciliation/adapters/persistence/settlement_snapshot_repository_test.go
+++ b/services/reconciliation/adapters/persistence/settlement_snapshot_repository_test.go
@@ -24,11 +24,12 @@ type seedRunIDs struct {
 	BusinessID uuid.UUID
 }
 
-// seedSettlementRun creates a settlement_run record and returns the surrogate ID (settlement_run.id).
-// For tests that also need the business run_id, use seedSettlementRunFull.
+// seedSettlementRun creates a settlement_run record and returns the business run_id
+// (settlement_run.run_id), which is the identifier the repositories accept and return.
+// For tests that also need the surrogate PK, use seedSettlementRunFull.
 func seedSettlementRun(t *testing.T, ctx context.Context, db *gorm.DB) uuid.UUID {
 	t.Helper()
-	return seedSettlementRunFull(t, ctx, db).SurrogateID
+	return seedSettlementRunFull(t, ctx, db).BusinessID
 }
 
 // seedSettlementRunFull creates a settlement_run record and returns both the surrogate ID and the business run_id.
@@ -87,6 +88,35 @@ func TestSettlementSnapshotRepository_Create(t *testing.T) {
 	assert.Equal(t, "position-keeping", found.SourceSystem)
 	assert.Equal(t, "default", found.Attributes["bucket"])
 	assert.WithinDuration(t, snapshot.CapturedAt, found.CapturedAt, time.Second)
+}
+
+func TestSettlementSnapshotRepository_Create_StoresSurrogateFK(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewSettlementSnapshotRepository(db)
+	ctx := tenantCtx()
+
+	run := seedSettlementRunFull(t, ctx, db)
+	snapshot := newTestSnapshot(t, run.BusinessID) // domain carries the business run_id
+	require.NoError(t, repo.Create(ctx, snapshot))
+
+	// The domain round-trips the business run_id.
+	found, err := repo.FindByID(ctx, snapshot.SnapshotID)
+	require.NoError(t, err)
+	assert.Equal(t, run.BusinessID, found.RunID, "domain RunID must be the business identifier")
+
+	// The stored FK column holds the surrogate PK, not the business id, so the FK to
+	// settlement_run.id resolves and joins succeed.
+	tid := tenant.TenantID("test-tenant-01")
+	quoted := fmt.Sprintf("%q", tid.SchemaName())
+	var storedRunID string
+	require.NoError(t, db.WithContext(ctx).Raw(
+		fmt.Sprintf(`SELECT run_id::text FROM %s."settlement_snapshot" WHERE snapshot_id = ?`, quoted),
+		snapshot.SnapshotID,
+	).Scan(&storedRunID).Error)
+	assert.Equal(t, run.SurrogateID.String(), storedRunID, "run_id FK column must store the surrogate PK")
+	assert.NotEqual(t, run.BusinessID.String(), storedRunID, "run_id FK column must not store the business id")
 }
 
 func TestSettlementSnapshotRepository_CreateBatch(t *testing.T) {
@@ -251,20 +281,21 @@ func TestSettlementSnapshotRepository_MarkRunSnapshotsFinal(t *testing.T) {
 
 	// Use seedSettlementRunFull so we have both IDs:
 	//   SurrogateID → stored in settlement_snapshot.run_id (FK target)
-	//   BusinessID  → passed to MarkRunSnapshotsFinal (business identifier)
+	//   BusinessID  → the identifier the repository accepts and returns
 	run := seedSettlementRunFull(t, ctx, db)
 
-	// Create snapshots with the surrogate ID so the FK constraint is satisfied.
-	s1 := newTestSnapshot(t, run.SurrogateID)
+	// Create snapshots with the business run_id; the repository resolves it to the
+	// surrogate PK before writing the FK column.
+	s1 := newTestSnapshot(t, run.BusinessID)
 	s1.Attributes = map[string]string{"bucket": "default"}
 	require.NoError(t, repo.Create(ctx, s1))
 
-	s2 := newTestSnapshot(t, run.SurrogateID)
+	s2 := newTestSnapshot(t, run.BusinessID)
 	s2.AccountID = "ACC-002"
 	s2.Attributes = nil // Test nil attributes case
 	require.NoError(t, repo.Create(ctx, s2))
 
-	s3 := newTestSnapshot(t, run.SurrogateID)
+	s3 := newTestSnapshot(t, run.BusinessID)
 	s3.AccountID = "ACC-003"
 	s3.Attributes = map[string]string{"region": "eu-west-1"}
 	require.NoError(t, repo.Create(ctx, s3))
@@ -275,7 +306,7 @@ func TestSettlementSnapshotRepository_MarkRunSnapshotsFinal(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify all snapshots have settlement_type=FINAL
-	found, err := repo.FindByRunID(ctx, run.SurrogateID)
+	found, err := repo.FindByRunID(ctx, run.BusinessID)
 	require.NoError(t, err)
 	assert.Len(t, found, 3)
 	for _, snap := range found {

--- a/services/reconciliation/adapters/persistence/variance_repository.go
+++ b/services/reconciliation/adapters/persistence/variance_repository.go
@@ -36,6 +36,13 @@ type VarianceEntity struct {
 	ResolvedBy     *string         `gorm:"column:resolved_by;size:100"`
 	ResolvedAt     *time.Time      `gorm:"column:resolved_at"`
 	Attributes     JSONMap         `gorm:"column:attributes;type:jsonb"`
+
+	// BusinessRunID and BusinessSnapshotID are populated read-only on retrieval via
+	// joins to settlement_run.run_id and settlement_snapshot.snapshot_id. They are not
+	// stored columns: variance.run_id and variance.snapshot_id hold surrogate PKs (FK
+	// targets), while the domain layer and API work in business identifiers.
+	BusinessRunID      uuid.UUID `gorm:"->;column:business_run_id"`
+	BusinessSnapshotID uuid.UUID `gorm:"->;column:business_snapshot_id"`
 }
 
 // TableName returns the table name for the variance entity.
@@ -74,15 +81,21 @@ func (r *VarianceRepository) isInTransaction() bool {
 	return ok && committer != nil
 }
 
-// Create persists a new Variance.
+// Create persists a new Variance. The variance's domain RunID and SnapshotID are
+// business identifiers; they are resolved to the settlement_run and settlement_snapshot
+// surrogate PKs before being written to the run_id and snapshot_id FK columns.
 func (r *VarianceRepository) Create(ctx context.Context, variance *domain.Variance) error {
-	entity := toVarianceEntity(variance)
+	entities := []VarianceEntity{*toVarianceEntity(variance)}
 	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
-		return tx.Create(entity).Error
+		if err := assignVarianceSurrogates(tx, entities, []*domain.Variance{variance}); err != nil {
+			return err
+		}
+		return tx.Create(&entities[0]).Error
 	})
 }
 
-// CreateBatch persists multiple variances atomically.
+// CreateBatch persists multiple variances atomically. Each variance's business RunID
+// and SnapshotID are resolved to surrogate PKs for the FK columns.
 func (r *VarianceRepository) CreateBatch(ctx context.Context, variances []*domain.Variance) error {
 	if len(variances) == 0 {
 		return nil
@@ -94,8 +107,61 @@ func (r *VarianceRepository) CreateBatch(ctx context.Context, variances []*domai
 	}
 
 	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		if err := assignVarianceSurrogates(tx, entities, variances); err != nil {
+			return err
+		}
 		return tx.CreateInBatches(entities, 100).Error
 	})
+}
+
+// assignVarianceSurrogates resolves each variance's business RunID and SnapshotID to
+// the settlement_run and settlement_snapshot surrogate PKs and writes them into the
+// entity's FK columns, caching resolutions to minimize lookups within a batch.
+func assignVarianceSurrogates(tx *gorm.DB, entities []VarianceEntity, variances []*domain.Variance) error {
+	runCache := make(map[uuid.UUID]uuid.UUID)
+	snapCache := make(map[uuid.UUID]uuid.UUID)
+	for i := range entities {
+		runSurrogate, err := cachedResolve(runCache, variances[i].RunID, tx, resolveRunSurrogate)
+		if err != nil {
+			return err
+		}
+		snapSurrogate, err := cachedResolve(snapCache, variances[i].SnapshotID, tx, resolveSnapshotSurrogate)
+		if err != nil {
+			return err
+		}
+		entities[i].RunID = runSurrogate
+		entities[i].SnapshotID = snapSurrogate
+	}
+	return nil
+}
+
+// cachedResolve returns the surrogate for a business ID, resolving via fn and caching
+// the result so repeated business IDs in a batch issue a single lookup.
+func cachedResolve(
+	cache map[uuid.UUID]uuid.UUID,
+	businessID uuid.UUID,
+	tx *gorm.DB,
+	fn func(*gorm.DB, uuid.UUID) (uuid.UUID, error),
+) (uuid.UUID, error) {
+	if surrogate, ok := cache[businessID]; ok {
+		return surrogate, nil
+	}
+	surrogate, err := fn(tx, businessID)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	cache[businessID] = surrogate
+	return surrogate, nil
+}
+
+// varianceReadQuery builds a query that joins settlement_run and settlement_snapshot so
+// the business run_id and snapshot_id are projected into the entity, keeping the domain
+// model and API in business identifiers rather than surrogate PKs.
+func varianceReadQuery(tx *gorm.DB) *gorm.DB {
+	return tx.Model(&VarianceEntity{}).
+		Select(`"variance".*, "settlement_run"."run_id" AS business_run_id, "settlement_snapshot"."snapshot_id" AS business_snapshot_id`).
+		Joins(`JOIN "settlement_run" ON "settlement_run"."id" = "variance"."run_id"`).
+		Joins(`JOIN "settlement_snapshot" ON "settlement_snapshot"."id" = "variance"."snapshot_id"`)
 }
 
 // FindByID retrieves a Variance by its VarianceID.
@@ -104,7 +170,7 @@ func (r *VarianceRepository) FindByID(ctx context.Context, varianceID uuid.UUID)
 	var queryErr error
 
 	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
-		result := tx.Where("variance_id = ?", varianceID).First(&entity)
+		result := varianceReadQuery(tx).Where(`"variance"."variance_id" = ?`, varianceID).First(&entity)
 		if result.Error != nil {
 			queryErr = result.Error
 			return result.Error
@@ -121,13 +187,16 @@ func (r *VarianceRepository) FindByID(ctx context.Context, varianceID uuid.UUID)
 	return toVarianceDomain(&entity), nil
 }
 
-// FindByRunID retrieves all variances for a settlement run.
+// FindByRunID retrieves all variances for a settlement run, keyed by the business run
+// identifier. The join filters on settlement_run.run_id, so an unknown run yields an
+// empty slice.
 func (r *VarianceRepository) FindByRunID(ctx context.Context, runID uuid.UUID) ([]*domain.Variance, error) {
 	var entities []VarianceEntity
 
 	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
-		return tx.Where("run_id = ?", runID).
-			Order("created_at ASC").
+		return varianceReadQuery(tx).
+			Where(`"settlement_run"."run_id" = ?`, runID).
+			Order(`"variance"."created_at" ASC`).
 			Find(&entities).Error
 	})
 	if err != nil {
@@ -170,10 +239,18 @@ func (r *VarianceRepository) Update(ctx context.Context, variance *domain.Varian
 	return nil
 }
 
-// DeleteByRunID removes all variances for a given settlement run.
+// DeleteByRunID removes all variances for a given settlement run, keyed by the business
+// run identifier. An unknown run is a no-op.
 func (r *VarianceRepository) DeleteByRunID(ctx context.Context, runID uuid.UUID) error {
 	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
-		return tx.Where("run_id = ?", runID).Delete(&VarianceEntity{}).Error
+		surrogate, err := resolveRunSurrogate(tx, runID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil
+			}
+			return err
+		}
+		return tx.Where("run_id = ?", surrogate).Delete(&VarianceEntity{}).Error
 	})
 }
 
@@ -182,19 +259,19 @@ func (r *VarianceRepository) List(ctx context.Context, filter domain.VarianceFil
 	var entities []VarianceEntity
 
 	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
-		query := tx.Model(&VarianceEntity{})
+		query := varianceReadQuery(tx)
 
 		if filter.RunID != nil {
-			query = query.Where("run_id = ?", *filter.RunID)
+			query = query.Where(`"settlement_run"."run_id" = ?`, *filter.RunID)
 		}
 		if filter.AccountID != nil {
-			query = query.Where("account_id = ?", *filter.AccountID)
+			query = query.Where(`"variance"."account_id" = ?`, *filter.AccountID)
 		}
 		if filter.Status != nil {
-			query = query.Where("status = ?", string(*filter.Status))
+			query = query.Where(`"variance"."status" = ?`, string(*filter.Status))
 		}
 		if filter.Reason != nil {
-			query = query.Where("reason = ?", string(*filter.Reason))
+			query = query.Where(`"variance"."reason" = ?`, string(*filter.Reason))
 		}
 
 		limit := filter.Limit
@@ -210,7 +287,7 @@ func (r *VarianceRepository) List(ctx context.Context, filter domain.VarianceFil
 			query = query.Offset(filter.Offset)
 		}
 
-		return query.Order("created_at DESC").Find(&entities).Error
+		return query.Order(`"variance"."created_at" DESC`).Find(&entities).Error
 	})
 	if err != nil {
 		return nil, err
@@ -278,12 +355,15 @@ func toVarianceEntity(v *domain.Variance) *VarianceEntity {
 	return entity
 }
 
-// toVarianceDomain converts a persistence entity to a domain Variance.
+// toVarianceDomain converts a persistence entity to a domain Variance. RunID and
+// SnapshotID are taken from the business identifiers projected via the read-path joins
+// (settlement_run.run_id and settlement_snapshot.snapshot_id), not the surrogate FKs
+// stored in the run_id and snapshot_id columns.
 func toVarianceDomain(e *VarianceEntity) *domain.Variance {
 	v := &domain.Variance{
 		VarianceID:     e.VarianceID,
-		RunID:          e.RunID,
-		SnapshotID:     e.SnapshotID,
+		RunID:          e.BusinessRunID,
+		SnapshotID:     e.BusinessSnapshotID,
 		AccountID:      e.AccountID,
 		InstrumentCode: e.InstrumentCode,
 		ExpectedAmount: e.ExpectedAmount,

--- a/services/reconciliation/adapters/persistence/variance_repository_test.go
+++ b/services/reconciliation/adapters/persistence/variance_repository_test.go
@@ -16,53 +16,47 @@ import (
 	"gorm.io/gorm"
 )
 
-// seedRunAndSnapshot creates prerequisite settlement_run and snapshot records,
-// returning the surrogate IDs needed for variance FK references.
-func seedRunAndSnapshot(ctx context.Context, t *testing.T, db *gorm.DB, runBusinessID, snapshotBusinessID uuid.UUID) (runSurrogateID, snapshotSurrogateID uuid.UUID) {
+// seedRunAndSnapshot creates prerequisite settlement_run and snapshot records and
+// returns the business identifiers (settlement_run.run_id, settlement_snapshot.snapshot_id)
+// that the repositories accept and return. The snapshot's run_id FK is wired to the run's
+// surrogate PK internally, as production requires.
+func seedRunAndSnapshot(ctx context.Context, t *testing.T, db *gorm.DB, runBusinessID, snapshotBusinessID uuid.UUID) (runID, snapshotID uuid.UUID) {
 	t.Helper()
 	tid := tenant.TenantID("test-tenant-01")
 	quoted := fmt.Sprintf("%q", tid.SchemaName())
 
-	// Insert settlement_run and capture surrogate ID
+	// Insert settlement_run.
 	err := db.WithContext(ctx).Exec(
 		fmt.Sprintf(`INSERT INTO %s."settlement_run" (run_id, account_id, scope, settlement_type, period_start, period_end, initiated_by) VALUES (?, 'ACC-001', 'ACCOUNT', 'DAILY', NOW() - INTERVAL '1 day', NOW(), 'system')`, quoted),
 		runBusinessID,
 	).Error
 	require.NoError(t, err)
 
-	var runIDStr string
+	// Resolve the run surrogate PK to wire the snapshot FK correctly.
+	var runSurrogateStr string
 	err = db.WithContext(ctx).Raw(
 		fmt.Sprintf(`SELECT id::text FROM %s."settlement_run" WHERE run_id = ?`, quoted),
 		runBusinessID,
-	).Scan(&runIDStr).Error
+	).Scan(&runSurrogateStr).Error
 	require.NoError(t, err)
-	runSurrogateID, err = uuid.Parse(runIDStr)
+	runSurrogateID, err := uuid.Parse(runSurrogateStr)
 	require.NoError(t, err)
 
-	// Insert settlement_snapshot and capture surrogate ID
+	// Insert settlement_snapshot with the run surrogate PK as its FK.
 	err = db.WithContext(ctx).Exec(
 		fmt.Sprintf(`INSERT INTO %s."settlement_snapshot" (snapshot_id, run_id, account_id, instrument_code, expected_balance, actual_balance, variance_amount, source_system, captured_at) VALUES (?, ?, 'ACC-001', 'GBP', 100.00, 90.00, -10.00, 'test', NOW())`, quoted),
 		snapshotBusinessID, runSurrogateID,
 	).Error
 	require.NoError(t, err)
 
-	var snapIDStr string
-	err = db.WithContext(ctx).Raw(
-		fmt.Sprintf(`SELECT id::text FROM %s."settlement_snapshot" WHERE snapshot_id = ?`, quoted),
-		snapshotBusinessID,
-	).Scan(&snapIDStr).Error
-	require.NoError(t, err)
-	snapshotSurrogateID, err = uuid.Parse(snapIDStr)
-	require.NoError(t, err)
-
-	return runSurrogateID, snapshotSurrogateID
+	return runBusinessID, snapshotBusinessID
 }
 
-func newTestVariance(t *testing.T, runSurrogateID, snapshotSurrogateID uuid.UUID) *domain.Variance {
+func newTestVariance(t *testing.T, runID, snapshotID uuid.UUID) *domain.Variance {
 	t.Helper()
 	v, err := domain.NewVariance(
-		runSurrogateID,
-		snapshotSurrogateID,
+		runID,
+		snapshotID,
 		"ACC-001",
 		"GBP",
 		decimal.NewFromFloat(100.00),
@@ -102,6 +96,45 @@ func TestVarianceRepository_Create(t *testing.T) {
 	assert.Empty(t, found.ResolutionNote)
 	assert.Empty(t, found.ResolvedBy)
 	assert.Nil(t, found.ResolvedAt)
+}
+
+func TestVarianceRepository_Create_StoresSurrogateFKs(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewVarianceRepository(db)
+	ctx := tenantCtx()
+
+	runBusinessID, snapBusinessID := uuid.New(), uuid.New()
+	runID, snapshotID := seedRunAndSnapshot(ctx, t, db, runBusinessID, snapBusinessID)
+
+	v := newTestVariance(t, runID, snapshotID)
+	require.NoError(t, repo.Create(ctx, v))
+
+	// Domain round-trips the business identifiers (the client-facing API values).
+	found, err := repo.FindByID(ctx, v.VarianceID)
+	require.NoError(t, err)
+	assert.Equal(t, runBusinessID, found.RunID, "domain RunID must be the business run identifier")
+	assert.Equal(t, snapBusinessID, found.SnapshotID, "domain SnapshotID must be the business snapshot identifier")
+
+	// Stored FK columns hold surrogate PKs so fk_variance_run/fk_variance_snapshot resolve.
+	tid := tenant.TenantID("test-tenant-01")
+	quoted := fmt.Sprintf("%q", tid.SchemaName())
+
+	scan := func(query string, arg interface{}) string {
+		var out string
+		require.NoError(t, db.WithContext(ctx).Raw(fmt.Sprintf(query, quoted), arg).Scan(&out).Error)
+		return out
+	}
+	storedRunID := scan(`SELECT run_id::text FROM %s."variance" WHERE variance_id = ?`, v.VarianceID)
+	storedSnapshotID := scan(`SELECT snapshot_id::text FROM %s."variance" WHERE variance_id = ?`, v.VarianceID)
+	runSurrogate := scan(`SELECT id::text FROM %s."settlement_run" WHERE run_id = ?`, runBusinessID)
+	snapSurrogate := scan(`SELECT id::text FROM %s."settlement_snapshot" WHERE snapshot_id = ?`, snapBusinessID)
+
+	assert.Equal(t, runSurrogate, storedRunID, "variance.run_id must store the settlement_run surrogate PK")
+	assert.Equal(t, snapSurrogate, storedSnapshotID, "variance.snapshot_id must store the settlement_snapshot surrogate PK")
+	assert.NotEqual(t, runBusinessID.String(), storedRunID, "variance.run_id must not store the business id")
+	assert.NotEqual(t, snapBusinessID.String(), storedSnapshotID, "variance.snapshot_id must not store the business id")
 }
 
 func TestVarianceRepository_CreateBatch(t *testing.T) {

--- a/services/reconciliation/service/variance_detector.go
+++ b/services/reconciliation/service/variance_detector.go
@@ -90,14 +90,22 @@ func (vd *VarianceDetector) DetectVariances(ctx context.Context, runID uuid.UUID
 }
 
 // findPreviousSnapshots finds the snapshots from the most recent completed run
-// for the same account. Returns nil (no error) if no previous run exists,
+// for the same settlement period. Returns nil (no error) if no previous run exists,
 // meaning this is a D+1 run comparing against initial booking.
+//
+// The baseline is selected by valid time (the settlement period), not by the physical
+// CreatedAt (transaction time). The reconciliation ladder (D+1, D+5, M+3, M+14) produces
+// several runs for the SAME period, so the comparator must share the current run's
+// period. Filtering on period bounds excludes backfill runs for other periods that may
+// carry a newer CreatedAt. The completed-status filter excludes the current (running)
+// run, and ordering by CreatedAt DESC then selects the latest prior run for the period.
 func (vd *VarianceDetector) findPreviousSnapshots(ctx context.Context, run *domain.SettlementRun) ([]*domain.SettlementSnapshot, error) {
 	completedStatus := domain.RunStatusCompleted
 	runs, err := vd.runRepo.List(ctx, domain.RunFilter{
 		AccountID: &run.AccountID,
 		Status:    &completedStatus,
-		ToDate:    &run.CreatedAt,
+		FromDate:  &run.PeriodStart,
+		ToDate:    &run.PeriodEnd,
 		Limit:     1,
 	})
 	if err != nil {

--- a/services/reconciliation/service/variance_detector_test.go
+++ b/services/reconciliation/service/variance_detector_test.go
@@ -17,10 +17,11 @@ import (
 // --- Variance-specific mock repos (distinct from snapshot_capturer mocks) ---
 
 type vdRunRepo struct {
-	runs     map[uuid.UUID]*domain.SettlementRun
-	listRuns []*domain.SettlementRun
-	findErr  error
-	listErr  error
+	runs       map[uuid.UUID]*domain.SettlementRun
+	listRuns   []*domain.SettlementRun
+	lastFilter domain.RunFilter
+	findErr    error
+	listErr    error
 }
 
 func newVdRunRepo() *vdRunRepo { return &vdRunRepo{runs: make(map[uuid.UUID]*domain.SettlementRun)} }
@@ -46,7 +47,8 @@ func (m *vdRunRepo) Update(_ context.Context, run *domain.SettlementRun) error {
 	return nil
 }
 
-func (m *vdRunRepo) List(_ context.Context, _ domain.RunFilter) ([]*domain.SettlementRun, error) {
+func (m *vdRunRepo) List(_ context.Context, filter domain.RunFilter) ([]*domain.SettlementRun, error) {
+	m.lastFilter = filter
 	if m.listErr != nil {
 		return nil, m.listErr
 	}
@@ -378,6 +380,35 @@ func TestDetectVariances_FindPreviousSnapshotsFails(t *testing.T) {
 	_, err := vd.DetectVariances(context.Background(), run.RunID)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to find previous snapshots")
+}
+
+func TestFindPreviousSnapshots_SelectsBaselineByValidTime(t *testing.T) {
+	// A run whose physical CreatedAt is much later than its settlement period,
+	// simulating a run recorded well after the period it reconciles.
+	run := testhelpers.NewSettlementRun(t)
+	require.NoError(t, run.Start())
+	run.CreatedAt = run.PeriodEnd.Add(120 * time.Hour)
+
+	runRepo := newVdRunRepo()
+	runRepo.runs[run.RunID] = run
+	vd := NewVarianceDetector(runRepo, newVdSnapRepo(), &vdVarianceRepo{})
+
+	_, err := vd.findPreviousSnapshots(context.Background(), run)
+	require.NoError(t, err)
+
+	f := runRepo.lastFilter
+	// Baseline selection must be driven by valid time (the settlement period),
+	// never the physical CreatedAt (transaction time).
+	require.NotNil(t, f.FromDate)
+	require.NotNil(t, f.ToDate)
+	assert.Equal(t, run.PeriodStart, *f.FromDate, "lower bound must be the settlement period start")
+	assert.Equal(t, run.PeriodEnd, *f.ToDate, "upper bound must be the settlement period end")
+	assert.NotEqual(t, run.CreatedAt, *f.ToDate, "must not select the baseline by physical CreatedAt")
+
+	require.NotNil(t, f.AccountID)
+	assert.Equal(t, run.AccountID, *f.AccountID)
+	require.NotNil(t, f.Status)
+	assert.Equal(t, domain.RunStatusCompleted, *f.Status)
 }
 
 func TestClassifyVarianceReason_NoPrevious(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes two reconciliation-service data-integrity bugs from the bug sweep:

- **DAT-1 (#11, high):** Snapshot and variance persistence wrote business identifiers into foreign-key columns that reference surrogate primary keys, violating FK integrity on insert.
- **LOW-7 (#33, low):** Baseline (previous-run) selection mixed physical creation time into a valid-time (settlement-period) filter, so it could pick the wrong comparator.

## Changes Made

### DAT-1: FK surrogate resolution (`adapters/persistence`)
`settlement_snapshot.run_id`, `variance.run_id`, and `variance.snapshot_id` are FKs to the **surrogate** PKs of `settlement_run` / `settlement_snapshot`, but the repositories copied the **business** identifiers (`run_id` / `snapshot_id`) straight into those columns.

- **Write** (`Create`, `CreateBatch`): resolve business identifiers to surrogate PKs before insert (new `fk_resolution.go` helpers, with per-batch caching).
- **Read** (`FindByID`, `FindByRunID`, `List`): join `settlement_run` / `settlement_snapshot` to project the business `run_id` / `snapshot_id` back into the domain model, so the domain layer and the gRPC API keep exposing business identifiers (`VarianceDetail.run_id` / `snapshot_id`).
- **`DeleteByRunID`**: resolve the business run to its surrogate; unknown run is a no-op.
- `MarkRunSnapshotsFinal` refactored onto the shared resolver (behaviour unchanged).

The repository contract is now explicit: **accept and return business identifiers; surrogate resolution is an internal persistence concern.**

### LOW-7: baseline selection by valid time (`service/variance_detector.go`)
`findPreviousSnapshots` passed `ToDate: &run.CreatedAt` (transaction time) into a filter mapped to `period_end <= ?` (valid time). It now filters on the settlement **period bounds** (`FromDate: PeriodStart`, `ToDate: PeriodEnd`), so the comparator shares the current run's valid-time period and backfill runs for other periods with a newer `CreatedAt` are excluded. The reconciliation ladder (D+1, D+5, M+3, M+14) produces several runs for the same period; the completed-status filter excludes the current running run and `created_at DESC` selects the latest prior run for the period.

## Testing

- New `TestSettlementSnapshotRepository_Create_StoresSurrogateFK` and `TestVarianceRepository_Create_StoresSurrogateFKs`: assert the stored FK columns hold the surrogate PK (resolvable joins) while the domain round-trips the business identifier.
- Existing snapshot/variance repository tests updated to the corrected business-identifier contract (they previously worked around the bug by passing surrogate IDs).
- New `TestFindPreviousSnapshots_SelectsBaselineByValidTime`: asserts baseline selection uses `PeriodStart`/`PeriodEnd`, never `CreatedAt`.
- Full `adapters/persistence` and `service` packages pass against CockroachDB testcontainers; `TestFunctionSize` and `golangci-lint` clean.

## Risk Assessment

Persistence-layer change to reconciliation only. No schema/migration changes (the FK schema was already correct; the code was writing the wrong values). Backward-compatible at the domain/API boundary - business identifiers in and out are unchanged; only the on-disk FK values are corrected.