### PR TITLE
fix: Instrument-derived decimal precision in amount inputs + event-stream tenant comparison (FE-1, LOW-12)

### DIFF
--- a/frontend/src/features/accounts/pages/create-lien-dialog.test.tsx
+++ b/frontend/src/features/accounts/pages/create-lien-dialog.test.tsx
@@ -362,6 +362,40 @@ describe('CreateLienDialog - decimal places', () => {
       })
     })
   })
+
+  it('derives decimal places from the instrument when no override is provided', async () => {
+    let capturedBody: unknown
+    server.use(
+      http.post('*/meridian.current_account.v1.CurrentAccountService/InitiateLien', async ({ request }) => {
+        capturedBody = await request.json()
+        return HttpResponse.json({ lien: { lienId: 'lien-001' } })
+      }),
+    )
+
+    // No decimalPlaces prop: dialog must derive 3 dp from the kWh instrument.
+    renderWithProviders(
+      <MemoryRouter>
+        <CreateLienDialog
+          open
+          onOpenChange={vi.fn()}
+          accountId="acct-001"
+          instrumentCode="kWh"
+          accountType="current"
+        />
+      </MemoryRouter>,
+      { initialToken: tenantToken },
+    )
+
+    await userEvent.type(screen.getByLabelText(/amount/i), '1.5')
+    await userEvent.type(screen.getByLabelText(/reason/i), 'energy-ref-002')
+    await userEvent.click(screen.getByRole('button', { name: /create lien/i }))
+
+    await waitFor(() => {
+      expect(capturedBody).toMatchObject({
+        amount: { amount: '1500' },
+      })
+    })
+  })
 })
 
 describe('CreateLienDialog - cancel', () => {

--- a/frontend/src/features/accounts/pages/create-lien-dialog.tsx
+++ b/frontend/src/features/accounts/pages/create-lien-dialog.tsx
@@ -13,6 +13,7 @@ import { Input } from '@/components/ui/input'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
 import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch'
+import { getInstrumentPrecision } from '@/shared/instrument-precision'
 import { amountToBigInt } from './account-form-utils'
 
 export interface CreateLienDialogProps {
@@ -21,6 +22,7 @@ export interface CreateLienDialogProps {
   accountId: string
   instrumentCode: string
   accountType: 'current' | 'internal'
+  /** Optional override; defaults to the instrument's display precision. */
   decimalPlaces?: number
 }
 
@@ -68,11 +70,14 @@ export function CreateLienDialog({
   accountId,
   instrumentCode,
   accountType,
-  decimalPlaces = 2,
+  decimalPlaces,
 }: CreateLienDialogProps) {
   const { tenantSlug } = useTenantContext()
   const authFetch = useAuthenticatedFetch()
   const queryClient = useQueryClient()
+  // Derive entry precision from the account instrument (same source as
+  // money-display) so entered values round-trip; an explicit prop still wins.
+  const resolvedDecimalPlaces = decimalPlaces ?? getInstrumentPrecision(instrumentCode)
 
   const [amount, setAmount] = React.useState('')
   const [reason, setReason] = React.useState('')
@@ -98,7 +103,7 @@ export function CreateLienDialog({
 
   const mutation = useMutation({
     mutationFn: async () => {
-      const minorUnits = amountToBigInt(amount, decimalPlaces).toString()
+      const minorUnits = amountToBigInt(amount, resolvedDecimalPlaces).toString()
       const expiresAtSeconds = expiry
         ? Math.floor(parseDatetimeLocalAsUtc(expiry).getTime() / 1000).toString()
         : undefined
@@ -148,7 +153,7 @@ export function CreateLienDialog({
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
 
-    const amtErr = validateAmount(amount, decimalPlaces)
+    const amtErr = validateAmount(amount, resolvedDecimalPlaces)
     const rsnErr = validateReason(reason)
     const expErr = validateExpiry(expiry)
 

--- a/frontend/src/features/accounts/pages/deposit-dialog.test.tsx
+++ b/frontend/src/features/accounts/pages/deposit-dialog.test.tsx
@@ -126,6 +126,39 @@ describe('DepositDialog - submission', () => {
     })
   })
 
+  it.each([
+    { currency: 'kWh', input: '1.5', expected: '1500' }, // 3 dp
+    { currency: 'GPU_HOUR', input: '1.234567', expected: '1234567' }, // 6 dp
+    { currency: 'TONNE_CO2E', input: '2.5', expected: '25000' }, // 4 dp
+    { currency: 'JPY', input: '1000', expected: '1000' }, // 0 dp
+    { currency: 'KWD', input: '1.234', expected: '1234' }, // 3 dp
+  ])(
+    'scales amount to instrument precision for $currency',
+    async ({ currency, input, expected }) => {
+      let capturedBody: unknown
+      server.use(
+        http.post(
+          '*/meridian.current_account.v1.CurrentAccountService/DepositFunds',
+          async ({ request }) => {
+            capturedBody = await request.json()
+            return HttpResponse.json({})
+          },
+        ),
+      )
+
+      renderDepositDialog({ currency })
+      await userEvent.type(screen.getByLabelText(/amount/i), input)
+      await userEvent.click(screen.getByRole('button', { name: /deposit/i }))
+
+      await waitFor(() => {
+        expect(capturedBody).toMatchObject({
+          accountId: 'acct-001',
+          amount: { amount: expected },
+        })
+      })
+    },
+  )
+
   it('closes dialog on success', async () => {
     const onOpenChange = vi.fn()
     renderDepositDialog({ onOpenChange })

--- a/frontend/src/features/accounts/pages/deposit-dialog.tsx
+++ b/frontend/src/features/accounts/pages/deposit-dialog.tsx
@@ -13,6 +13,7 @@ import { Input } from '@/components/ui/input'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
 import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch'
+import { getInstrumentPrecision } from '@/shared/instrument-precision'
 import { amountToBigInt } from './account-form-utils'
 
 interface DepositDialogProps {
@@ -22,11 +23,11 @@ interface DepositDialogProps {
   currency: string
 }
 
-function validateAmount(value: string): string | null {
+function validateAmount(value: string, decimalPlaces: number): string | null {
   const trimmed = value.trim()
   if (!trimmed) return 'Amount is required'
   try {
-    const minorUnits = amountToBigInt(trimmed)
+    const minorUnits = amountToBigInt(trimmed, decimalPlaces)
     if (minorUnits <= 0n) return 'Amount must be greater than zero'
   } catch (err) {
     // amountToBigInt throws 'Amount must be positive' for negative values
@@ -41,6 +42,9 @@ export function DepositDialog({ open, onOpenChange, accountId, currency }: Depos
   const { tenantSlug } = useTenantContext()
   const authFetch = useAuthenticatedFetch()
   const queryClient = useQueryClient()
+  // Derive entry precision from the account instrument so it matches how the
+  // amount is displayed (see money-display / getInstrumentPrecision).
+  const decimalPlaces = getInstrumentPrecision(currency)
   const [amount, setAmount] = React.useState('')
   const [amountError, setAmountError] = React.useState<string | null>(null)
   const [serverError, setServerError] = React.useState<string | null>(null)
@@ -55,7 +59,7 @@ export function DepositDialog({ open, onOpenChange, accountId, currency }: Depos
 
   const mutation = useMutation({
     mutationFn: async () => {
-      const minorUnits = amountToBigInt(amount).toString()
+      const minorUnits = amountToBigInt(amount, decimalPlaces).toString()
       const response = await authFetch(
         `/meridian.current_account.v1.CurrentAccountService/DepositFunds`,
         {
@@ -81,7 +85,7 @@ export function DepositDialog({ open, onOpenChange, accountId, currency }: Depos
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
-    const error = validateAmount(amount)
+    const error = validateAmount(amount, decimalPlaces)
     if (error) {
       setAmountError(error)
       return

--- a/frontend/src/features/accounts/pages/withdraw-dialog.tsx
+++ b/frontend/src/features/accounts/pages/withdraw-dialog.tsx
@@ -13,6 +13,7 @@ import { Input } from '@/components/ui/input'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
 import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch'
+import { getInstrumentPrecision } from '@/shared/instrument-precision'
 import { amountToBigInt } from './account-form-utils'
 
 interface WithdrawDialogProps {
@@ -24,11 +25,11 @@ interface WithdrawDialogProps {
 
 type Step = 'initiate' | 'confirm'
 
-function validateAmount(value: string): string | null {
+function validateAmount(value: string, decimalPlaces: number): string | null {
   const trimmed = value.trim()
   if (!trimmed) return 'Amount is required'
   try {
-    const minorUnits = amountToBigInt(trimmed)
+    const minorUnits = amountToBigInt(trimmed, decimalPlaces)
     if (minorUnits <= 0n) return 'Amount must be greater than zero'
   } catch (err) {
     // amountToBigInt throws 'Amount must be positive' for negative values
@@ -43,6 +44,9 @@ export function WithdrawDialog({ open, onOpenChange, accountId, currency }: With
   const { tenantSlug } = useTenantContext()
   const authFetch = useAuthenticatedFetch()
   const queryClient = useQueryClient()
+  // Derive entry precision from the account instrument so it matches how the
+  // amount is displayed (see money-display / getInstrumentPrecision).
+  const decimalPlaces = getInstrumentPrecision(currency)
   const isOpenRef = React.useRef(open)
   const [step, setStep] = React.useState<Step>('initiate')
   const [amount, setAmount] = React.useState('')
@@ -63,7 +67,7 @@ export function WithdrawDialog({ open, onOpenChange, accountId, currency }: With
 
   const initiateMutation = useMutation({
     mutationFn: async () => {
-      const minorUnits = amountToBigInt(amount).toString()
+      const minorUnits = amountToBigInt(amount, decimalPlaces).toString()
       const response = await authFetch(
         `/meridian.current_account.v1.CurrentAccountService/InitiateWithdrawal`,
         { method: 'POST', body: JSON.stringify({ accountId, amount: { amount: minorUnits } }) },
@@ -112,7 +116,7 @@ export function WithdrawDialog({ open, onOpenChange, accountId, currency }: With
 
   function handleInitiate(e: React.FormEvent) {
     e.preventDefault()
-    const error = validateAmount(amount)
+    const error = validateAmount(amount, decimalPlaces)
     if (error) {
       setAmountError(error)
       return

--- a/frontend/src/hooks/use-event-stream.test.tsx
+++ b/frontend/src/hooks/use-event-stream.test.tsx
@@ -2,7 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
-import { EVENT_QUERY_MAP, type DomainEvent, type UseEventStreamOptions } from './use-event-stream'
+import {
+  EVENT_QUERY_MAP,
+  normalizeTenantIdentifier,
+  type DomainEvent,
+  type UseEventStreamOptions,
+} from './use-event-stream'
 
 // --- Mocks ---
 
@@ -104,6 +109,22 @@ afterEach(() => {
 })
 
 // --- Tests ---
+
+describe('normalizeTenantIdentifier', () => {
+  it('unifies underscores and hyphens', () => {
+    expect(normalizeTenantIdentifier('acme_bank')).toBe('acme-bank')
+    expect(normalizeTenantIdentifier('acme-bank')).toBe('acme-bank')
+  })
+
+  it('lower-cases the identifier', () => {
+    expect(normalizeTenantIdentifier('Acme_Bank')).toBe('acme-bank')
+  })
+
+  it('treats null and undefined as empty string', () => {
+    expect(normalizeTenantIdentifier(null)).toBe('')
+    expect(normalizeTenantIdentifier(undefined)).toBe('')
+  })
+})
 
 describe('EVENT_QUERY_MAP', () => {
   it('maps AccountStatusChanged to account query keys', () => {
@@ -248,6 +269,60 @@ describe('useEventStream', () => {
     })
 
     expect(onEvent).not.toHaveBeenCalled()
+  })
+
+  it('matches events when gateway uses underscore tenant_id and context uses a hyphen slug', () => {
+    // Gateway wire format uses underscores (acme_bank); the frontend context
+    // slug is the URL-safe hyphenated form (acme-bank). They must still match.
+    mockTenantSlug.mockReturnValue('acme-bank')
+    const onEvent = vi.fn()
+
+    renderHook(() => useEventStream({ onEvent }), { wrapper: createWrapper() })
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+      mockWsInstances[0].simulateMessage(makeServerEvent({ tenantSlug: 'acme_bank' }))
+    })
+
+    expect(onEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('matches events regardless of tenant identifier case', () => {
+    mockTenantSlug.mockReturnValue('Acme')
+    const onEvent = vi.fn()
+
+    renderHook(() => useEventStream({ onEvent }), { wrapper: createWrapper() })
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+      mockWsInstances[0].simulateMessage(makeServerEvent({ tenantSlug: 'acme' }))
+    })
+
+    expect(onEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('invalidates queries using the context slug when identifier formats differ', () => {
+    // Context slug is hyphenated; gateway event carries the underscore form.
+    // Invalidation keys must use the context slug so they hit existing caches.
+    mockTenantSlug.mockReturnValue('acme-bank')
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    })
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    renderHook(() => useEventStream(), { wrapper: createWrapper(queryClient) })
+
+    act(() => {
+      mockWsInstances[0].simulateOpen()
+      mockWsInstances[0].simulateMessage(makeServerEvent({ tenantSlug: 'acme_bank' }))
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['tenants', 'acme-bank', 'accounts'],
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['tenants', 'acme-bank', 'accounts', 'acc-1'],
+    })
   })
 
   it('invalidates React Query cache when autoInvalidate is true (default)', () => {

--- a/frontend/src/hooks/use-event-stream.ts
+++ b/frontend/src/hooks/use-event-stream.ts
@@ -80,6 +80,20 @@ const MAX_RECONNECT_ATTEMPTS = 5
 const BASE_RECONNECT_DELAY_MS = 1000
 
 /**
+ * Normalizes a tenant identifier for comparison.
+ *
+ * The gateway wire format carries the tenant on `event.tenant_id`, which uses
+ * underscores (e.g. `acme_bank`), while the frontend tenant context may hold a
+ * URL-safe subdomain slug that uses hyphens (e.g. `acme-bank`). Without
+ * normalization the two never compare equal and every event is silently dropped
+ * by the tenant-isolation guard. Lower-casing and unifying the separator makes
+ * the comparison format-agnostic.
+ */
+export function normalizeTenantIdentifier(id: string | null | undefined): string {
+  return (id ?? '').replace(/_/g, '-').toLowerCase()
+}
+
+/**
  * React hook for consuming real-time domain events via WebSocket.
  *
  * Connects to the gateway's /ws/events endpoint and delivers events to
@@ -111,8 +125,10 @@ export function useEventStream(options: UseEventStreamOptions = {}) {
    */
   const handleEvent = useCallback(
     (event: DomainEvent) => {
-      // Enforce tenant isolation - ignore events from other tenants
-      if (event.tenantSlug !== tenantSlug) {
+      // Enforce tenant isolation - ignore events from other tenants.
+      // Compare on a normalized form so a gateway underscore identifier
+      // (acme_bank) still matches a hyphenated context slug (acme-bank).
+      if (normalizeTenantIdentifier(event.tenantSlug) !== normalizeTenantIdentifier(tenantSlug)) {
         return
       }
 
@@ -127,9 +143,13 @@ export function useEventStream(options: UseEventStreamOptions = {}) {
       // Fire user callback if provided
       onEvent?.(event)
 
-      // Auto-invalidate queries based on event type
+      // Auto-invalidate queries based on event type. Build keys from the local
+      // context tenantSlug (the canonical identifier the app's queries are keyed
+      // by) rather than the event's raw tenant field, so invalidation targets
+      // existing caches even when the two identifier formats differ.
       if (autoInvalidate) {
-        const keys = EVENT_QUERY_MAP[event.eventType]?.(event) ?? []
+        const keyEvent = tenantSlug ? { ...event, tenantSlug } : event
+        const keys = EVENT_QUERY_MAP[event.eventType]?.(keyEvent) ?? []
         keys.forEach((key) => {
           queryClient.invalidateQueries({ queryKey: key })
         })

--- a/frontend/src/shared/instrument-precision.test.ts
+++ b/frontend/src/shared/instrument-precision.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getInstrumentPrecision,
+  DEFAULT_DECIMAL_PLACES,
+  NON_FIAT_UNITS,
+} from './instrument-precision'
+
+describe('getInstrumentPrecision', () => {
+  it('returns non-fiat instrument precision', () => {
+    expect(getInstrumentPrecision('kWh')).toBe(3)
+    expect(getInstrumentPrecision('GPU_HOUR')).toBe(6)
+    expect(getInstrumentPrecision('TONNE_CO2E')).toBe(4)
+  })
+
+  it('returns fiat currency overrides', () => {
+    expect(getInstrumentPrecision('JPY')).toBe(0)
+    expect(getInstrumentPrecision('KRW')).toBe(0)
+    expect(getInstrumentPrecision('KWD')).toBe(3)
+    expect(getInstrumentPrecision('BHD')).toBe(3)
+  })
+
+  it('defaults to 2 for standard currencies', () => {
+    expect(getInstrumentPrecision('GBP')).toBe(DEFAULT_DECIMAL_PLACES)
+    expect(getInstrumentPrecision('USD')).toBe(2)
+    expect(getInstrumentPrecision('EUR')).toBe(2)
+  })
+
+  it('defaults to 2 for unknown instrument codes', () => {
+    expect(getInstrumentPrecision('UNKNOWN')).toBe(2)
+    expect(getInstrumentPrecision('')).toBe(2)
+  })
+
+  it('keeps NON_FIAT_UNITS precision aligned with getInstrumentPrecision', () => {
+    for (const [code, config] of Object.entries(NON_FIAT_UNITS)) {
+      expect(getInstrumentPrecision(code)).toBe(config.precision)
+    }
+  })
+})

--- a/frontend/src/shared/instrument-precision.ts
+++ b/frontend/src/shared/instrument-precision.ts
@@ -1,0 +1,50 @@
+/**
+ * Single source of truth for instrument display/entry precision.
+ *
+ * Amounts are stored and transmitted as integer minor units. The number of
+ * decimal places an instrument uses determines how a decimal input string is
+ * scaled to minor units (and back for display). Currencies default to 2 decimal
+ * places; several fiat currencies and all non-fiat instruments differ.
+ *
+ * This module is consumed by both money-display (formatting) and the account
+ * action dialogs (deposit / withdraw / lien amount entry) so entry precision
+ * always matches display precision.
+ */
+
+/** Default decimal places for standard currencies without an explicit override. */
+export const DEFAULT_DECIMAL_PLACES = 2
+
+/** Currencies with non-standard decimal places (ISO 4217). */
+const CURRENCY_PRECISION: Record<string, number> = {
+  JPY: 0,
+  KRW: 0,
+  VND: 0,
+  BHD: 3,
+  KWD: 3,
+  OMR: 3,
+}
+
+/** Non-fiat instrument types with display configuration (precision + unit suffix). */
+export const NON_FIAT_UNITS: Record<string, { precision: number; suffix: string }> = {
+  kWh: { precision: 3, suffix: ' kWh' },
+  GPU_HOUR: { precision: 6, suffix: ' GPU-hrs' },
+  TONNE_CO2E: { precision: 4, suffix: ' tCO2e' },
+}
+
+/**
+ * Returns the number of decimal places used by the given instrument code.
+ *
+ * Resolution order: non-fiat instrument → fiat currency override → default (2).
+ *
+ * @example getInstrumentPrecision('kWh')      // 3
+ * @example getInstrumentPrecision('GPU_HOUR') // 6
+ * @example getInstrumentPrecision('JPY')      // 0
+ * @example getInstrumentPrecision('GBP')      // 2 (default)
+ */
+export function getInstrumentPrecision(instrumentCode: string): number {
+  return (
+    NON_FIAT_UNITS[instrumentCode]?.precision ??
+    CURRENCY_PRECISION[instrumentCode] ??
+    DEFAULT_DECIMAL_PLACES
+  )
+}

--- a/frontend/src/shared/money-display.tsx
+++ b/frontend/src/shared/money-display.tsx
@@ -1,21 +1,5 @@
 import { useMemo } from 'react'
-
-// Currencies with non-standard decimal places (ISO 4217)
-const CURRENCY_PRECISION: Record<string, number> = {
-  JPY: 0,
-  KRW: 0,
-  VND: 0,
-  BHD: 3,
-  KWD: 3,
-  OMR: 3,
-}
-
-// Non-fiat instrument types with display configuration
-const NON_FIAT_UNITS: Record<string, { precision: number; suffix: string }> = {
-  kWh: { precision: 3, suffix: ' kWh' },
-  GPU_HOUR: { precision: 6, suffix: ' GPU-hrs' },
-  TONNE_CO2E: { precision: 4, suffix: ' tCO2e' },
-}
+import { NON_FIAT_UNITS, getInstrumentPrecision } from './instrument-precision'
 
 export interface FormatMoneyOptions {
   precision?: number
@@ -38,11 +22,7 @@ export function formatMoney(
   const isNegative = bigAmount < 0n
   const absAmount = isNegative ? -bigAmount : bigAmount
 
-  const prec =
-    options.precision ??
-    NON_FIAT_UNITS[currency]?.precision ??
-    CURRENCY_PRECISION[currency] ??
-    2
+  const prec = options.precision ?? getInstrumentPrecision(currency)
   const divisor = BigInt(10 ** prec)
 
   const intPart = absAmount / divisor


### PR DESCRIPTION
## Summary

Fixes two frontend bugs from the 2026-07-07 bug sweep:

- **FE-1 (task 17)**: Amount inputs hardcoded 2 decimal places when converting to minor units, corrupting any instrument whose precision is not 2 (kWh=3, GPU_HOUR=6, TONNE_CO2E=4, JPY=0, KWD=3, etc.). Depositing `1.5 kWh` was sent as `150` minor units instead of `1500`.
- **LOW-12 (task 38)**: The event-stream tenant-isolation guard compared the gateway `tenant_id` (underscore form, e.g. `acme_bank`) against the frontend context slug (URL-safe hyphenated form, e.g. `acme-bank`), so a format mismatch silently dropped every real-time event.

## Changes Made

**FE-1**
- Extracted the instrument-precision map that `money-display.tsx` already used into a shared single source: `frontend/src/shared/instrument-precision.ts` (`getInstrumentPrecision`, `NON_FIAT_UNITS`, `DEFAULT_DECIMAL_PLACES`).
- `money-display.tsx` now consumes that module (removed the duplicate maps).
- `deposit-dialog.tsx` and `withdraw-dialog.tsx` derive `decimalPlaces` from the account instrument (`getInstrumentPrecision(currency)`) and pass it to `amountToBigInt` / validation.
- `create-lien-dialog.tsx` derives precision from its existing `instrumentCode` prop when no explicit `decimalPlaces` override is supplied. All three amount dialogs now derive precision from their instrument the same way.

**LOW-12**
- Added `normalizeTenantIdentifier` (lower-case + unify `_`/`-`) and compare normalized identifiers in the isolation guard.
- Auto-invalidation query keys are now built from the canonical context `tenantSlug` (the identifier the rest of the app keys queries by) rather than the event's raw tenant field, so invalidation hits existing caches even when the two identifier formats differ.

## Technical Details

- Confirmed the gateway wire format: `services/api-gateway/eventstream/protocol.go` sends `tenant_id`; backend tenant identifiers use underscores (e.g. `acme_bank`), whereas subdomain-derived slugs use hyphens - the root of the mismatch.
- `[accountId].tsx` was intentionally left unchanged: it is an already-oversized file governed by a strict "never increase" size ratchet, so deriving precision inside `CreateLienDialog` (from the `instrumentCode` it already receives) is both cleaner and consistent with the deposit/withdraw dialogs. The task's step 3 goal - lien amounts using instrument precision - is met.

## Testing

- New unit tests: `instrument-precision.test.ts`; parametrised round-trip conversion tests for deposit (kWh/GPU_HOUR/TONNE_CO2E/JPY/KWD); create-lien deriving precision from instrument with no override; event-stream underscore↔hyphen and case-insensitive tenant matching plus canonical-slug invalidation keys.
- Full frontend suite: 2895 passed. `npm run typecheck` clean, `npm run lint` 0 errors, ts-prune gate at baseline (233).

## Risk Assessment

Low. Frontend-only. No API or wire-format changes. Behaviour for standard 2dp currencies is unchanged.
