### PR TITLE
fix: Preserve decimal precision in valuation and bound saga CEL cost (bug-sweep 36+37)

### DIFF
--- a/shared/pkg/saga/cel_evaluator.go
+++ b/shared/pkg/saga/cel_evaluator.go
@@ -5,7 +5,16 @@ import (
 	"fmt"
 
 	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/interpreter"
 )
+
+// DefaultCELCostLimit bounds the runtime cost of a single saga CEL expression.
+// CEL cost is an abstract metric of the number and expense of operations performed
+// during evaluation (indicative of CPU usage). Enforcing a limit upholds Meridian's
+// bounded-execution guarantee: a tenant expression cannot run unboundedly expensive
+// computation. The value mirrors the per-call budget Kubernetes uses for its CEL
+// admission rules, which keeps well-formed pricing/validation expressions sub-millisecond.
+const DefaultCELCostLimit uint64 = 1_000_000
 
 // CEL evaluation errors.
 var (
@@ -14,20 +23,33 @@ var (
 
 	// ErrCELEvaluationFailed is returned when CEL expression evaluation fails.
 	ErrCELEvaluationFailed = errors.New("CEL evaluation failed")
+
+	// ErrCELCostLimitExceeded is returned when evaluation is cancelled because the
+	// expression exceeded the configured runtime cost limit.
+	ErrCELCostLimitExceeded = errors.New("CEL cost limit exceeded")
 )
 
 // CELEvaluator provides CEL expression evaluation for saga scripts.
 // It maintains a CEL environment with saga-specific variables and provides
 // methods to compile and evaluate CEL expressions within the saga context.
 type CELEvaluator struct {
-	env *cel.Env
+	env       *cel.Env
+	costLimit uint64
 }
 
-// NewCELEvaluator creates a CEL evaluator with saga-specific environment.
+// NewCELEvaluator creates a CEL evaluator with saga-specific environment and the
+// default runtime cost limit (DefaultCELCostLimit).
 // The environment includes the following variables:
 //   - input: map[string]any - saga input parameters
 //   - ctx: map[string]string - saga context metadata (saga_execution_id, correlation_id)
 func NewCELEvaluator() (*CELEvaluator, error) {
+	return newCELEvaluator(DefaultCELCostLimit)
+}
+
+// newCELEvaluator builds a CEL evaluator bounded by the given runtime cost limit.
+// A zero limit disables cost tracking (unbounded); callers should pass a positive
+// value. It exists to let tests exercise the cost-limit boundary with small limits.
+func newCELEvaluator(costLimit uint64) (*CELEvaluator, error) {
 	env, err := cel.NewEnv(
 		cel.Variable("input", cel.DynType),
 		cel.Variable("ctx", cel.MapType(cel.StringType, cel.DynType)),
@@ -35,7 +57,7 @@ func NewCELEvaluator() (*CELEvaluator, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
 	}
-	return &CELEvaluator{env: env}, nil
+	return &CELEvaluator{env: env, costLimit: costLimit}, nil
 }
 
 // Eval compiles and evaluates a CEL expression with the given variables.
@@ -48,8 +70,13 @@ func (e *CELEvaluator) Eval(expression string, variables map[string]interface{})
 		return nil, fmt.Errorf("%w: %w", ErrCELCompilationFailed, issues.Err())
 	}
 
-	// Create program
-	prg, err := e.env.Program(ast)
+	// Create program with a bounded runtime cost limit so a tenant expression
+	// cannot run unboundedly expensive computation (bounded-execution guarantee).
+	programOpts := make([]cel.ProgramOption, 0, 1)
+	if e.costLimit > 0 {
+		programOpts = append(programOpts, cel.CostLimit(e.costLimit))
+	}
+	prg, err := e.env.Program(ast, programOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CEL program: %w", err)
 	}
@@ -57,9 +84,19 @@ func (e *CELEvaluator) Eval(expression string, variables map[string]interface{})
 	// Evaluate
 	result, _, err := prg.Eval(variables)
 	if err != nil {
+		if isCostLimitExceeded(err) {
+			return nil, fmt.Errorf("%w: cost exceeded limit of %d", ErrCELCostLimitExceeded, e.costLimit)
+		}
 		return nil, fmt.Errorf("%w: %w", ErrCELEvaluationFailed, err)
 	}
 
 	// Convert CEL result to Go value
 	return result.Value(), nil
+}
+
+// isCostLimitExceeded reports whether a CEL evaluation error was raised because
+// the expression exceeded its configured runtime cost limit.
+func isCostLimitExceeded(err error) bool {
+	var cancelled interpreter.EvalCancelledError
+	return errors.As(err, &cancelled) && cancelled.Cause == interpreter.CostLimitExceeded
 }

--- a/shared/pkg/saga/cel_evaluator_test.go
+++ b/shared/pkg/saga/cel_evaluator_test.go
@@ -104,6 +104,40 @@ func TestCELEvaluator_Eval_CompilationErrors(t *testing.T) {
 	}
 }
 
+func TestCELEvaluator_Eval_CostLimitExceeded(t *testing.T) {
+	// A tiny cost limit must reject an expression that would otherwise run
+	// unbounded work, upholding the bounded-execution guarantee.
+	evaluator, err := newCELEvaluator(1)
+	require.NoError(t, err)
+
+	// A comprehension over a large range is cheap to write but expensive to run,
+	// so its accumulated cost blows past the 1-unit budget.
+	_, err = evaluator.Eval(
+		"[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(x, x * x).size()",
+		map[string]interface{}{},
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCELCostLimitExceeded)
+	assert.NotErrorIs(t, err, ErrCELEvaluationFailed)
+}
+
+func TestCELEvaluator_Eval_WithinCostLimitPasses(t *testing.T) {
+	// The default limit is generous enough for ordinary pricing/validation logic.
+	evaluator, err := NewCELEvaluator()
+	require.NoError(t, err)
+
+	result, err := evaluator.Eval("input.amount * 2", map[string]interface{}{
+		"input": map[string]interface{}{"amount": int64(21)},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), result)
+}
+
+func TestDefaultCELCostLimit_IsPositive(t *testing.T) {
+	// A zero default would silently disable cost tracking.
+	assert.Positive(t, DefaultCELCostLimit)
+}
+
 func TestCELEvaluator_Eval_EvaluationErrors(t *testing.T) {
 	evaluator, err := NewCELEvaluator()
 	require.NoError(t, err)

--- a/shared/pkg/valuation/starlark_runtime.go
+++ b/shared/pkg/valuation/starlark_runtime.go
@@ -214,9 +214,14 @@ func (r *defaultStarlarkRuntime) buildScriptContext(req *Request) map[string]int
 	ctx["party_id"] = req.PartyID.String()
 	ctx["knowledge_at"] = req.KnowledgeAt.Format(time.RFC3339)
 
-	// Add input quantity
+	// Add input quantity.
+	// Amount is exposed as its exact decimal string, never a float64: monetary math
+	// must stay decimal end-to-end. Round-tripping through float64 loses precision,
+	// and parseResult reconstructs the decimal exactly via decimal.NewFromString.
+	// Scripts delegate arithmetic to CEL via run_policy (see the Decimal/quantity
+	// builtins, which also represent amounts as strings).
 	ctx["input_quantity"] = map[string]interface{}{
-		"amount":     req.Quantity.Amount.InexactFloat64(),
+		"amount":     req.Quantity.Amount.String(),
 		"instrument": req.Quantity.InstrumentCode,
 		"attributes": req.Quantity.Attributes,
 	}

--- a/shared/pkg/valuation/starlark_runtime_test.go
+++ b/shared/pkg/valuation/starlark_runtime_test.go
@@ -69,6 +69,47 @@ result = valuate(ctx)
 	assert.Equal(t, decimal.NewFromFloat(35.0), resp.ValuedAmount.Amount)
 }
 
+func TestStarlarkRuntime_Execute_InputAmountRetainsDecimalPrecision(t *testing.T) {
+	// A value with more significant digits than float64 can represent (~15-17):
+	// round-tripping the input amount through float64 would corrupt it. The identity
+	// script passes ctx["input_quantity"]["amount"] straight to valued_amount, so the
+	// output must equal the input exactly.
+	highPrecision := decimal.RequireFromString("12345678901234.12345678901234567")
+
+	runtime := valuation.NewStarlarkRuntime(valuation.StarlarkRuntimeConfig{
+		Timeout: 5 * time.Second,
+	})
+
+	script := `
+input = ctx["input_quantity"]
+result = {
+    "valued_amount": input["amount"],
+    "instrument": input["instrument"],
+}
+`
+
+	req := &valuation.Request{
+		RequestID: uuid.New(),
+		MethodID:  uuid.New(),
+		Quantity: valuation.Quantity{
+			Amount:         highPrecision,
+			InstrumentCode: "GBP",
+		},
+		AccountID:   uuid.New(),
+		PartyID:     uuid.New(),
+		KnowledgeAt: time.Now(),
+	}
+
+	resp, err := runtime.Execute(context.Background(), script, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.True(t, resp.ValuedAmount.Amount.Equal(highPrecision),
+		"expected exact %s, got %s (precision lost)", highPrecision, resp.ValuedAmount.Amount)
+	// Guard against a float64 round-trip specifically: the inexact float value must differ.
+	assert.False(t, resp.ValuedAmount.Amount.Equal(decimal.NewFromFloat(highPrecision.InexactFloat64())),
+		"amount matches the float64 approximation, precision was lost")
+}
+
 func TestStarlarkRuntime_Execute_Timeout(t *testing.T) {
 	t.Skip("Starlark timeout enforcement requires thread interruption hooks - deferred for future implementation")
 	// Starlark execution is atomic (no built-in cancellation points)


### PR DESCRIPTION
## Summary

Two shared-package numeric/execution-safety fixes from the 2026-07-07 bug sweep.

- **#36 (LOW-10)** - Valuation exposed the input quantity amount to Starlark via `decimal.InexactFloat64()`, round-tripping money through `float64` and losing precision.
- **#37 (LOW-11)** - The saga `cel_eval` builtin created CEL programs with no cost limit, so a tenant expression could run unboundedly expensive computation, violating the bounded-execution guarantee.

## Changes Made

**Valuation (`shared/pkg/valuation/starlark_runtime.go`)**
- `buildScriptContext` now exposes `input_quantity.amount` as the exact decimal string (`Amount.String()`) instead of `InexactFloat64()`. `parseResult` already reconstructs the decimal exactly via `decimal.NewFromString`, so precision is preserved end-to-end. This is consistent with the `Decimal()`/`quantity()` builtins, which also represent amounts as strings.

**Saga CEL (`shared/pkg/saga/cel_evaluator.go`)**
- `CELEvaluator` gained a `costLimit` field. `NewCELEvaluator()` uses `DefaultCELCostLimit` (1,000,000 - mirrors the per-call budget Kubernetes uses for its CEL admission rules; keeps well-formed pricing/validation expressions sub-millisecond).
- `Eval` builds the program with `cel.CostLimit(...)`. Cost-limit cancellations are detected and surfaced as a distinct `ErrCELCostLimitExceeded`, separate from `ErrCELEvaluationFailed`.
- Internal `newCELEvaluator(costLimit)` constructor lets tests exercise the boundary with small limits.

## Technical Details

CEL cost is an abstract metric of the number and expense of operations performed during evaluation (indicative of CPU usage, not memory). `cel.CostLimit` enables cost tracking and exits early once the budget is exceeded; the `interpreter.EvalCancelledError` with cause `CostLimitExceeded` is mapped to the sentinel error.

## Testing

- `#36` - `TestStarlarkRuntime_Execute_InputAmountRetainsDecimalPrecision`: an amount with more significant digits than `float64` can hold survives an identity valuation exactly, and is asserted to differ from its `float64` approximation.
- `#37` - `TestCELEvaluator_Eval_CostLimitExceeded` (a comprehension over a 1-unit budget is rejected with `ErrCELCostLimitExceeded`), `TestCELEvaluator_Eval_WithinCostLimitPasses` (ordinary expression passes under the default limit), `TestDefaultCELCostLimit_IsPositive`.
- Full `shared/pkg/valuation/...` and `shared/pkg/saga/...` suites pass. No `time.Sleep`. No other `input_quantity` consumers (only the pass-through identity script).

## Risk Assessment

Low. Shared packages, but the only consumer of `input_quantity.amount` is the pass-through identity script; no `.star` scripts perform raw Starlark arithmetic on it (arithmetic is delegated to CEL via `run_policy`). The CEL cost limit is generous enough that existing saga expressions are unaffected.

## Deployment Notes

None - no schema or migration changes.