### PR TITLE
fix: Reject webhooks with missing or zero timestamp

### DIFF
--- a/services/party/adapters/http/verification_webhook.go
+++ b/services/party/adapters/http/verification_webhook.go
@@ -31,6 +31,7 @@ var (
 	ErrEmptyHMACSecret           = errors.New("HMAC secret cannot be empty")
 	ErrVerificationAlreadyDone   = errors.New("verification already in terminal state")
 	ErrEmptyProviderSecret       = errors.New("HMAC secret for provider cannot be empty")
+	ErrMissingTimestamp          = errors.New("webhook timestamp is required")
 )
 
 // WebhookSignatureHeader is the HTTP header containing the HMAC signature.
@@ -233,10 +234,14 @@ func (h *VerificationWebhookHandler) parseAndValidatePayload(w http.ResponseWrit
 }
 
 // checkTimestampFreshness validates the webhook timestamp to prevent replay attacks.
-// Returns true if the timestamp is valid or zero, false if it should be rejected.
+// Returns true if the timestamp is present and valid, false if it should be rejected.
+// A missing (zero-value) timestamp is rejected, since it would otherwise bypass
+// the freshness and clock-drift checks below.
 func (h *VerificationWebhookHandler) checkTimestampFreshness(w http.ResponseWriter, webhookReq *VerificationWebhookRequest, provider string) bool {
 	if webhookReq.Timestamp.IsZero() {
-		return true
+		h.logger.Warn("missing webhook timestamp", "provider", provider)
+		h.writeErrorResponse(w, http.StatusBadRequest, ErrMissingTimestamp.Error())
+		return false
 	}
 
 	now := time.Now()

--- a/services/party/adapters/http/verification_webhook.go
+++ b/services/party/adapters/http/verification_webhook.go
@@ -271,11 +271,10 @@ func (h *VerificationWebhookHandler) checkTimestampFreshness(w http.ResponseWrit
 }
 
 // processVerificationUpdate builds the update request and calls the verification service.
+// webhookReq.Timestamp is guaranteed non-zero here: checkTimestampFreshness rejects a
+// missing timestamp before this method is called.
 func (h *VerificationWebhookHandler) processVerificationUpdate(ctx context.Context, w http.ResponseWriter, provider string, webhookReq *VerificationWebhookRequest, status verification.Status) {
 	completedAt := webhookReq.Timestamp
-	if completedAt.IsZero() {
-		completedAt = time.Now()
-	}
 
 	var reason *string
 	if webhookReq.Reason != "" {

--- a/services/party/adapters/http/verification_webhook_test.go
+++ b/services/party/adapters/http/verification_webhook_test.go
@@ -474,6 +474,42 @@ func TestVerificationWebhookHandler_HandleWebhook_ProviderFromHeader(t *testing.
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
+func TestVerificationWebhookHandler_HandleWebhook_ZeroTimestamp(t *testing.T) {
+	// A webhook with a missing/zero timestamp must be rejected - it would
+	// otherwise bypass replay-protection (freshness and clock-drift checks).
+	secret := []byte("test-secret")
+	handler, err := NewVerificationWebhookHandler(VerificationWebhookHandlerConfig{
+		VerificationService: &mockVerificationService{},
+		HMACSecrets:         map[string][]byte{"default": secret},
+	})
+	require.NoError(t, err)
+
+	webhookReq := VerificationWebhookRequest{
+		VerificationID: "verify-123",
+		Status:         "APPROVED",
+		// Timestamp is zero value
+	}
+	body, err := json.Marshal(webhookReq)
+	require.NoError(t, err)
+
+	signature := GenerateWebhookSignature(body, secret)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/verification/default", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(WebhookSignatureHeader, signature)
+
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	var resp VerificationWebhookResponse
+	err = json.NewDecoder(rr.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.False(t, resp.Acknowledged)
+	assert.Equal(t, ErrMissingTimestamp.Error(), resp.Error)
+}
+
 func TestVerificationWebhookHandler_HandleWebhook_ExpiredTimestamp(t *testing.T) {
 	secret := []byte("test-secret")
 	handler, err := NewVerificationWebhookHandler(VerificationWebhookHandlerConfig{

--- a/services/payment-order/adapters/http/webhook_handler.go
+++ b/services/payment-order/adapters/http/webhook_handler.go
@@ -28,6 +28,7 @@ var (
 	ErrInvalidGatewayStatus   = errors.New("invalid gateway_status")
 	ErrTimestampExpired       = errors.New("webhook timestamp expired")
 	ErrTimestampFuture        = errors.New("webhook timestamp is in the future")
+	ErrMissingTimestamp       = errors.New("webhook timestamp is required")
 	ErrPaymentOrderService    = errors.New("payment order service error")
 	ErrNilPaymentOrderService = errors.New("payment order service cannot be nil")
 	ErrEmptyHMACSecret        = errors.New("HMAC secret cannot be empty")
@@ -185,9 +186,13 @@ func (h *WebhookHandler) parseAndValidateWebhookRequest(w http.ResponseWriter, b
 }
 
 // validateWebhookTimestamp validates timestamp freshness to prevent replay attacks.
+// A missing (zero-value) timestamp is rejected, since it would otherwise bypass
+// the freshness and clock-drift checks below.
 func (h *WebhookHandler) validateWebhookTimestamp(w http.ResponseWriter, timestamp time.Time) error {
 	if timestamp.IsZero() {
-		return nil
+		h.logger.Warn("missing webhook timestamp")
+		h.writeErrorResponse(w, http.StatusBadRequest, ErrMissingTimestamp.Error())
+		return ErrMissingTimestamp
 	}
 	age := time.Since(timestamp)
 	if age > DefaultWebhookMaxAge {

--- a/services/payment-order/adapters/http/webhook_handler_coverage_test.go
+++ b/services/payment-order/adapters/http/webhook_handler_coverage_test.go
@@ -116,7 +116,8 @@ func TestWebhookHandler_HandleWebhook_PaymentOrderIDOnly(t *testing.T) {
 }
 
 func TestWebhookHandler_HandleWebhook_ZeroTimestamp(t *testing.T) {
-	// Test that a webhook with zero timestamp skips freshness check
+	// A webhook with a missing/zero timestamp must be rejected - it would
+	// otherwise bypass replay-protection (freshness and clock-drift checks).
 	secret := []byte("test-secret")
 	handler, err := NewWebhookHandler(WebhookHandlerConfig{
 		PaymentOrderService: &mockPaymentOrderService{},
@@ -141,7 +142,13 @@ func TestWebhookHandler_HandleWebhook_ZeroTimestamp(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.HandleWebhook(rr, req)
 
-	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	var resp WebhookResponse
+	err = json.NewDecoder(rr.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.False(t, resp.Acknowledged)
+	assert.Equal(t, ErrMissingTimestamp.Error(), resp.Error)
 }
 
 func TestValidateSignature_InvalidHex(t *testing.T) {


### PR DESCRIPTION
## Summary
- Payment-order and party (KYC/AML verification) webhook handlers treated a missing/zero timestamp as a signal to skip the replay-protection freshness and clock-drift checks, rather than rejecting it.
- A webhook sender could bypass replay protection entirely by simply omitting the `timestamp` field.

## Changes Made
- `services/payment-order/adapters/http/webhook_handler.go`: `validateWebhookTimestamp` now rejects a zero-value timestamp with `400` and the new `ErrMissingTimestamp`, instead of returning `nil` (pass).
- `services/party/adapters/http/verification_webhook.go`: `checkTimestampFreshness` now rejects a zero-value timestamp with `400` and the new `ErrMissingTimestamp`, instead of returning `true` (pass).

## Technical Details
- Both handlers already enforce a 5-minute max age and 30-second clock-drift tolerance once a timestamp is present; the zero-value short-circuit made that enforcement optional.
- The Stripe-specific verification webhook path (`stripe_webhook_adapter.go`) is unaffected — it validates the timestamp as part of the Stripe signature scheme and already rejects a missing timestamp there.

## Testing
- Updated `TestWebhookHandler_HandleWebhook_ZeroTimestamp` (payment-order) to assert `400`/`ErrMissingTimestamp` instead of `200`.
- Added `TestVerificationWebhookHandler_HandleWebhook_ZeroTimestamp` (party) asserting the same rejection.
- `go test ./services/payment-order/adapters/http/... ./services/party/adapters/http/...` passes.

## Risk Assessment
- Low risk, additive validation only. Any legitimate webhook sender omitting a timestamp was already relying on undefined/insecure behavior; this closes a replay-protection bypass.