### PR TITLE
fix: Isolate JWKS auto-refresh from request context and validate JWT aud/iss

### DIFF
--- a/shared/platform/auth/jwks.go
+++ b/shared/platform/auth/jwks.go
@@ -66,11 +66,15 @@ type JWKSProvider struct {
 	cacheTTL   time.Duration
 	refreshTTL time.Duration
 
-	mu              sync.RWMutex
-	keys            map[string]*rsa.PublicKey
-	lastFetch       time.Time
-	stopRefresh     chan struct{}
-	closeOnce       sync.Once
+	mu        sync.RWMutex
+	keys      map[string]*rsa.PublicKey
+	lastFetch time.Time
+
+	// refreshCtx is a dedicated background context for the auto-refresh goroutine.
+	// It is independent of any request context so the goroutine survives past the
+	// request that triggered the first fetch. refreshCancel stops it on Close.
+	refreshCtx      context.Context
+	refreshCancel   context.CancelFunc
 	autoRefreshOnce sync.Once
 }
 
@@ -99,13 +103,20 @@ func NewJWKSProvider(_ context.Context, cfg *JWKSProviderConfig) (*JWKSProvider,
 		cfg.RefreshTTL = cfg.CacheTTL / 2
 	}
 
+	// Dedicated background context for the auto-refresh goroutine, independent of
+	// any request context. context.Background() (not the passed-in ctx) ensures the
+	// refresh loop is not tied to the lifecycle of the request that constructs the
+	// provider or triggers the first fetch.
+	refreshCtx, refreshCancel := context.WithCancel(context.Background())
+
 	provider := &JWKSProvider{
-		url:         cfg.URL,
-		client:      cfg.Client,
-		cacheTTL:    cfg.CacheTTL,
-		refreshTTL:  cfg.RefreshTTL,
-		keys:        make(map[string]*rsa.PublicKey),
-		stopRefresh: make(chan struct{}),
+		url:           cfg.URL,
+		client:        cfg.Client,
+		cacheTTL:      cfg.CacheTTL,
+		refreshTTL:    cfg.RefreshTTL,
+		keys:          make(map[string]*rsa.PublicKey),
+		refreshCtx:    refreshCtx,
+		refreshCancel: refreshCancel,
 	}
 
 	// No initial fetch — keys are fetched lazily on first GetKey call.
@@ -137,11 +148,12 @@ func (p *JWKSProvider) GetKey(ctx context.Context, kid string) (*rsa.PublicKey, 
 		return nil, fmt.Errorf("failed to refresh JWKS: %w", err)
 	}
 
-	// Start auto-refresh goroutine after first successful fetch
+	// Start auto-refresh goroutine after first successful fetch.
+	// It runs on the provider's dedicated background context, NOT the request
+	// context, so it survives after the triggering request completes.
 	if p.refreshTTL > 0 {
-		refreshCtx := ctx
 		p.autoRefreshOnce.Do(func() {
-			go p.autoRefresh(refreshCtx)
+			go p.autoRefresh(p.refreshCtx)
 		})
 	}
 
@@ -214,25 +226,22 @@ func (p *JWKSProvider) autoRefresh(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			// Use context derived from parent to maintain proper cancellation chain
+			// Derive a per-refresh timeout from the background context.
 			refreshCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 			// Ignore errors during automatic refresh - the cache will continue to serve old keys
 			_ = p.refresh(refreshCtx)
 			cancel()
-		case <-p.stopRefresh:
-			return
 		case <-ctx.Done():
+			// Provider closed - stop refreshing.
 			return
 		}
 	}
 }
 
-// Close stops the automatic refresh goroutine.
-// This method is idempotent and safe to call multiple times.
+// Close stops the automatic refresh goroutine by cancelling its background context.
+// This method is idempotent and safe to call multiple times (context.CancelFunc is a no-op after the first call).
 func (p *JWKSProvider) Close() error {
-	p.closeOnce.Do(func() {
-		close(p.stopRefresh)
-	})
+	p.refreshCancel()
 	return nil
 }
 
@@ -272,16 +281,19 @@ func parseRSAPublicKey(jwk JWK) (*rsa.PublicKey, error) {
 // JWTValidatorWithJWKS extends JWTValidator to support JWKS-based key rotation
 type JWTValidatorWithJWKS struct {
 	provider *JWKSProvider
+	opts     []ValidatorOption
 }
 
-// NewJWTValidatorWithJWKS creates a JWT validator that uses JWKS for public key retrieval
-func NewJWTValidatorWithJWKS(provider *JWKSProvider) (*JWTValidatorWithJWKS, error) {
+// NewJWTValidatorWithJWKS creates a JWT validator that uses JWKS for public key retrieval.
+// Optional ValidatorOptions (WithAudience, WithIssuer) are applied to every token validation.
+func NewJWTValidatorWithJWKS(provider *JWKSProvider, opts ...ValidatorOption) (*JWTValidatorWithJWKS, error) {
 	if provider == nil {
 		return nil, fmt.Errorf("failed to create validator: %w", ErrJWKSProviderNil)
 	}
 
 	return &JWTValidatorWithJWKS{
 		provider: provider,
+		opts:     opts,
 	}, nil
 }
 
@@ -312,7 +324,7 @@ func (v *JWTValidatorWithJWKS) ValidateToken(ctx context.Context, tokenString st
 	}
 
 	// Create validator with the retrieved public key
-	validator, err := NewJWTValidator(publicKey)
+	validator, err := NewJWTValidator(publicKey, v.opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create validator: %w", err)
 	}

--- a/shared/platform/auth/jwks_test.go
+++ b/shared/platform/auth/jwks_test.go
@@ -7,10 +7,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/meridianhub/meridian/shared/platform/await"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -468,6 +470,63 @@ func TestNewJWTValidatorWithJWKS(t *testing.T) {
 		assert.ErrorIs(t, err, ErrJWKSProviderNil)
 		assert.Nil(t, validator)
 	})
+}
+
+func TestJWKSProvider_AutoRefreshSurvivesRequestContext(t *testing.T) {
+	// Regression test: the auto-refresh goroutine must NOT be tied to the
+	// request context that triggered the first fetch. Previously the goroutine
+	// captured the request-scoped ctx and died when that request ended.
+	jwks, _ := createTestJWKS(t)
+
+	var mu sync.Mutex
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		requestCount++
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(jwks))
+	}))
+	defer server.Close()
+
+	count := func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return requestCount
+	}
+
+	// CacheTTL is kept small so RefreshTTL is not clamped to CacheTTL/2, letting
+	// the auto-refresh ticker fire within the test window.
+	cfg := &JWKSProviderConfig{
+		URL:        server.URL,
+		Client:     server.Client(),
+		CacheTTL:   100 * time.Millisecond,
+		RefreshTTL: 50 * time.Millisecond,
+	}
+
+	provider, err := NewJWKSProvider(context.Background(), cfg)
+	require.NoError(t, err)
+	defer func() { _ = provider.Close() }()
+
+	// Trigger the first fetch (which starts the auto-refresh goroutine) with a
+	// request-scoped context, then cancel it as though the request had ended.
+	reqCtx, cancel := context.WithCancel(context.Background())
+	_, err = provider.GetKey(reqCtx, "test-key-1")
+	require.NoError(t, err)
+	cancel()
+
+	countAtCancel := count()
+
+	// The background goroutine must keep refreshing despite the cancelled
+	// request context. With the old request-scoped context, the count would
+	// never advance past countAtCancel.
+	err = await.New().
+		AtMost(2 * time.Second).
+		PollInterval(20 * time.Millisecond).
+		Until(func() bool {
+			return count() > countAtCancel
+		})
+	require.NoError(t, err, "auto-refresh goroutine stopped after request context was cancelled")
 }
 
 func TestJWKSProvider_Close(t *testing.T) {

--- a/shared/platform/auth/jwt.go
+++ b/shared/platform/auth/jwt.go
@@ -23,6 +23,10 @@ var (
 	ErrTokenStringEmpty = errors.New("token string cannot be empty")
 	// ErrTenantClaimMissing is returned when the tenant ID claim is missing from the token
 	ErrTenantClaimMissing = errors.New("x-tenant-id claim missing")
+	// ErrInvalidAudience is returned when the token audience does not match the expected value
+	ErrInvalidAudience = errors.New("invalid audience")
+	// ErrInvalidIssuer is returned when the token issuer does not match the expected value
+	ErrInvalidIssuer = errors.New("invalid issuer")
 )
 
 // Claims represents the JWT claims extracted from a validated token.
@@ -48,19 +52,43 @@ type Claims struct {
 // JWTValidator validates JWT tokens using RS256 algorithm.
 // It provides thread-safe token validation and claims extraction.
 type JWTValidator struct {
-	publicKey *rsa.PublicKey
+	publicKey     *rsa.PublicKey
+	parserOptions []jwt.ParserOption
+}
+
+// ValidatorOption configures optional JWT validation behavior.
+type ValidatorOption func(*JWTValidator)
+
+// WithAudience rejects tokens whose "aud" claim does not contain the expected
+// audience. Passing multiple audiences accepts a token matching any one of them.
+func WithAudience(audience ...string) ValidatorOption {
+	return func(v *JWTValidator) {
+		v.parserOptions = append(v.parserOptions, jwt.WithAudience(audience...))
+	}
+}
+
+// WithIssuer rejects tokens whose "iss" claim does not match the expected issuer.
+func WithIssuer(issuer string) ValidatorOption {
+	return func(v *JWTValidator) {
+		v.parserOptions = append(v.parserOptions, jwt.WithIssuer(issuer))
+	}
 }
 
 // NewJWTValidator creates a new JWT validator with the specified RSA public key.
 // The public key is used to verify token signatures using RS256 algorithm.
-func NewJWTValidator(publicKey *rsa.PublicKey) (*JWTValidator, error) {
+// Optional ValidatorOptions (WithAudience, WithIssuer) add claim validation.
+func NewJWTValidator(publicKey *rsa.PublicKey, opts ...ValidatorOption) (*JWTValidator, error) {
 	if publicKey == nil {
 		return nil, fmt.Errorf("failed to create JWT validator: %w", ErrPublicKeyNil)
 	}
 
-	return &JWTValidator{
+	v := &JWTValidator{
 		publicKey: publicKey,
-	}, nil
+	}
+	for _, opt := range opts {
+		opt(v)
+	}
+	return v, nil
 }
 
 // ValidateToken validates a JWT token string and returns the extracted claims.
@@ -78,13 +106,19 @@ func (v *JWTValidator) ValidateToken(tokenString string) (*Claims, error) {
 			return nil, fmt.Errorf("unexpected signing method: %v: %w", token.Header["alg"], ErrInvalidSignature)
 		}
 		return v.publicKey, nil
-	})
+	}, v.parserOptions...)
 	if err != nil {
 		if errors.Is(err, jwt.ErrTokenExpired) {
 			return nil, fmt.Errorf("failed to validate token: %w", ErrTokenExpired)
 		}
 		if errors.Is(err, jwt.ErrSignatureInvalid) {
 			return nil, fmt.Errorf("failed to validate token: %w", ErrInvalidSignature)
+		}
+		if errors.Is(err, jwt.ErrTokenInvalidAudience) {
+			return nil, fmt.Errorf("failed to validate token: %w", ErrInvalidAudience)
+		}
+		if errors.Is(err, jwt.ErrTokenInvalidIssuer) {
+			return nil, fmt.Errorf("failed to validate token: %w", ErrInvalidIssuer)
 		}
 		return nil, fmt.Errorf("failed to parse token: %w: %w", err, ErrInvalidToken)
 	}

--- a/shared/platform/auth/jwt_test.go
+++ b/shared/platform/auth/jwt_test.go
@@ -619,3 +619,146 @@ func TestValidateToken_WithOrganizationClaim(t *testing.T) {
 		assert.ErrorIs(t, err, ErrTenantClaimMissing)
 	})
 }
+
+func TestJWTValidator_AudienceValidation(t *testing.T) {
+	privateKey, publicKey, err := generateTestRSAKeys()
+	require.NoError(t, err)
+
+	makeToken := func(aud jwt.ClaimStrings) string {
+		claims := &Claims{
+			UserID: "user-123",
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+				IssuedAt:  jwt.NewNumericDate(time.Now()),
+				Audience:  aud,
+			},
+		}
+		tokenString, tokenErr := createTestToken(privateKey, claims)
+		require.NoError(t, tokenErr)
+		return tokenString
+	}
+
+	t.Run("accepts token with matching audience", func(t *testing.T) {
+		validator, vErr := NewJWTValidator(publicKey, WithAudience("meridian-api"))
+		require.NoError(t, vErr)
+
+		claims, valErr := validator.ValidateToken(makeToken(jwt.ClaimStrings{"meridian-api"}))
+		require.NoError(t, valErr)
+		assert.Equal(t, "user-123", claims.UserID)
+	})
+
+	t.Run("accepts token when any expected audience matches", func(t *testing.T) {
+		validator, vErr := NewJWTValidator(publicKey, WithAudience("other", "meridian-api"))
+		require.NoError(t, vErr)
+
+		claims, valErr := validator.ValidateToken(makeToken(jwt.ClaimStrings{"meridian-api"}))
+		require.NoError(t, valErr)
+		assert.Equal(t, "user-123", claims.UserID)
+	})
+
+	t.Run("rejects token with wrong audience", func(t *testing.T) {
+		validator, vErr := NewJWTValidator(publicKey, WithAudience("meridian-api"))
+		require.NoError(t, vErr)
+
+		claims, valErr := validator.ValidateToken(makeToken(jwt.ClaimStrings{"other-service"}))
+		require.Error(t, valErr)
+		assert.ErrorIs(t, valErr, ErrInvalidAudience)
+		assert.Nil(t, claims)
+	})
+
+	t.Run("rejects token missing audience when audience expected", func(t *testing.T) {
+		validator, vErr := NewJWTValidator(publicKey, WithAudience("meridian-api"))
+		require.NoError(t, vErr)
+
+		claims, valErr := validator.ValidateToken(makeToken(nil))
+		require.Error(t, valErr)
+		assert.Nil(t, claims)
+	})
+
+	t.Run("accepts any audience when no audience option is set", func(t *testing.T) {
+		validator, vErr := NewJWTValidator(publicKey)
+		require.NoError(t, vErr)
+
+		claims, valErr := validator.ValidateToken(makeToken(jwt.ClaimStrings{"anything"}))
+		require.NoError(t, valErr)
+		assert.Equal(t, "user-123", claims.UserID)
+	})
+}
+
+func TestJWTValidator_IssuerValidation(t *testing.T) {
+	privateKey, publicKey, err := generateTestRSAKeys()
+	require.NoError(t, err)
+
+	makeToken := func(issuer string) string {
+		claims := &Claims{
+			UserID: "user-123",
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+				IssuedAt:  jwt.NewNumericDate(time.Now()),
+				Issuer:    issuer,
+			},
+		}
+		tokenString, tokenErr := createTestToken(privateKey, claims)
+		require.NoError(t, tokenErr)
+		return tokenString
+	}
+
+	t.Run("accepts token with matching issuer", func(t *testing.T) {
+		validator, vErr := NewJWTValidator(publicKey, WithIssuer("meridian"))
+		require.NoError(t, vErr)
+
+		claims, valErr := validator.ValidateToken(makeToken("meridian"))
+		require.NoError(t, valErr)
+		assert.Equal(t, "user-123", claims.UserID)
+	})
+
+	t.Run("rejects token with wrong issuer", func(t *testing.T) {
+		validator, vErr := NewJWTValidator(publicKey, WithIssuer("meridian"))
+		require.NoError(t, vErr)
+
+		claims, valErr := validator.ValidateToken(makeToken("evil-issuer"))
+		require.Error(t, valErr)
+		assert.ErrorIs(t, valErr, ErrInvalidIssuer)
+		assert.Nil(t, claims)
+	})
+
+	t.Run("rejects token missing issuer when issuer expected", func(t *testing.T) {
+		validator, vErr := NewJWTValidator(publicKey, WithIssuer("meridian"))
+		require.NoError(t, vErr)
+
+		claims, valErr := validator.ValidateToken(makeToken(""))
+		require.Error(t, valErr)
+		assert.Nil(t, claims)
+	})
+
+	t.Run("accepts any issuer when no issuer option is set", func(t *testing.T) {
+		validator, vErr := NewJWTValidator(publicKey)
+		require.NoError(t, vErr)
+
+		claims, valErr := validator.ValidateToken(makeToken("anyone"))
+		require.NoError(t, valErr)
+		assert.Equal(t, "user-123", claims.UserID)
+	})
+
+	t.Run("rejects token when both audience and issuer are enforced and issuer is wrong", func(t *testing.T) {
+		validator, vErr := NewJWTValidator(publicKey, WithAudience("meridian-api"), WithIssuer("meridian"))
+		require.NoError(t, vErr)
+
+		claims := &Claims{
+			UserID: "user-123",
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+				IssuedAt:  jwt.NewNumericDate(time.Now()),
+				Audience:  jwt.ClaimStrings{"meridian-api"},
+				Issuer:    "evil-issuer",
+			},
+		}
+		tokenString, tokenErr := createTestToken(privateKey, claims)
+		require.NoError(t, tokenErr)
+
+		extracted, valErr := validator.ValidateToken(tokenString)
+		require.Error(t, valErr)
+		assert.ErrorIs(t, valErr, ErrInvalidIssuer)
+		assert.Nil(t, extracted)
+	})
+}


### PR DESCRIPTION
## Summary

Two fixes in the shared `shared/platform/auth` package (bug-sweep tasks #18 and #27), both scoped to auth infrastructure used across all services.

## Changes Made

### #18 (PLT-1): JWKS auto-refresh tied to request context
The JWKS auto-refresh goroutine captured the request-scoped `context.Context` from the first `GetKey` call. When that request ended, the context was cancelled and the background refresh goroutine exited - so key rotation silently stopped after the first request that warmed the cache.

- `JWKSProvider` now creates a dedicated background context (`context.WithCancel(context.Background())`) at construction. The auto-refresh goroutine runs on this context, independent of any request.
- `Close()` cancels that context to stop the goroutine. Shutdown is consolidated onto context cancellation - the redundant `stopRefresh` channel and `closeOnce` are removed (`context.CancelFunc` is already idempotent, so `Close()` remains safe to call multiple times).

### #27 (LOW-1): No audience/issuer validation on JWTs
`ValidateToken` verified signature and expiry but never checked `aud`/`iss`, so a validly-signed token minted for a different audience or issuer was accepted.

- Added `WithAudience(...string)` and `WithIssuer(string)` functional options.
- Options thread through both `NewJWTValidator` and `NewJWTValidatorWithJWKS`.
- New sentinel errors `ErrInvalidAudience` / `ErrInvalidIssuer` are returned when a present claim mismatches. A missing-but-expected claim is rejected as `ErrInvalidToken` (golang-jwt returns `ErrTokenRequiredClaimMissing`, which is claim-agnostic).

## Technical Details

- Both constructors take the options as variadic parameters, so all existing callers (`NewJWTValidator(publicKey)`, `NewJWTValidatorWithJWKS(provider)`) compile and behave unchanged. Audience/issuer enforcement is opt-in.
- Uses golang-jwt/v5 `jwt.WithAudience` / `jwt.WithIssuer` parser options under the hood.

## Testing

- `TestJWKSProvider_AutoRefreshSurvivesRequestContext`: starts the refresh via a request-scoped context, cancels it, and asserts (via `shared/platform/await`, no `time.Sleep`) that the endpoint keeps being polled. Verified this test fails on the pre-fix code and passes after - a genuine regression guard. Passes under `-race`.
- `TestJWTValidator_AudienceValidation` / `TestJWTValidator_IssuerValidation`: matching aud/iss passes; wrong aud/iss rejected with the sentinel errors; missing-but-expected claim rejected; no-option validators accept any aud/iss (backward compatibility).
- Full `shared/platform/auth` suite, `go vet`, `go build ./...`, function-size ratchet (`tests/architecture`), and `golangci-lint --new-from-rev origin/develop` (0 new issues) all green.

## Risk Assessment

Low. Behavior-preserving for existing callers (opt-in options; identical default behavior). The JWKS change fixes silent key-rotation failure. No wiring in services is changed by this PR - enabling aud/iss enforcement in production is a follow-up wiring decision at the call sites.
