### PR TITLE
fix: Add row locking to audit outbox worker

### DIFF
--- a/shared/platform/audit/worker.go
+++ b/shared/platform/audit/worker.go
@@ -7,8 +7,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/meridianhub/meridian/shared/platform/defaults"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // Errors are defined in errors.go for centralized error management.
@@ -325,18 +328,13 @@ func (w *Worker) processBatchWithCount(ctx context.Context) (int, error) {
 		RecordProcessingDuration(time.Since(start).Seconds())
 	}()
 
-	var entries []AuditOutbox
-
-	// Fetch pending entries, ordered by creation time for FIFO processing
-	result := w.db.WithContext(ctx).
-		Table(w.outboxTable()).
-		Where("status = ?", StatusPending).
-		Order("created_at ASC").
-		Limit(w.batchSize).
-		Find(&entries)
-
-	if result.Error != nil {
-		return 0, fmt.Errorf("failed to fetch pending entries: %w", result.Error)
+	// Fetch and claim pending entries, ordered by creation time for FIFO processing.
+	// FOR UPDATE SKIP LOCKED lets concurrent worker instances (multiple replicas
+	// polling the same outbox table) claim disjoint sets of rows without blocking
+	// on each other, preventing the same entry from being double-published.
+	entries, err := w.claimPendingEntries(ctx)
+	if err != nil {
+		return 0, err
 	}
 
 	// Record batch size and outbox depth metrics
@@ -389,6 +387,52 @@ func (w *Worker) processBatchWithCount(ctx context.Context) (int, error) {
 	}
 
 	return processedCount, nil
+}
+
+// claimPendingEntries selects up to batchSize pending entries, ordered by creation
+// time for FIFO processing, and immediately claims them by setting their status to
+// 'processing' within the same transaction.
+//
+// The SELECT uses FOR UPDATE SKIP LOCKED: rows already locked by another worker's
+// concurrent claim are skipped rather than blocking this query, and skipped rows are
+// simply left for that other worker (or a later poll) to handle. Combined with the
+// in-transaction status update, this guarantees no two worker instances can ever
+// claim the same outbox entry, eliminating double-publishing under horizontal scaling.
+func (w *Worker) claimPendingEntries(ctx context.Context) ([]AuditOutbox, error) {
+	var entries []AuditOutbox
+
+	err := w.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE", Options: "SKIP LOCKED"}).
+			Table(w.outboxTable()).
+			Where("status = ?", StatusPending).
+			Order("created_at ASC").
+			Limit(w.batchSize).
+			Find(&entries).Error; err != nil {
+			return fmt.Errorf("failed to fetch pending entries: %w", err)
+		}
+
+		if len(entries) == 0 {
+			return nil
+		}
+
+		ids := make([]uuid.UUID, len(entries))
+		for i, entry := range entries {
+			ids[i] = entry.ID
+		}
+
+		if err := tx.Table(w.outboxTable()).
+			Where("id IN ?", ids).
+			Update("status", StatusProcessing).Error; err != nil {
+			return fmt.Errorf("failed to claim pending entries: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return entries, nil
 }
 
 // processEntry processes a single audit outbox entry.

--- a/shared/platform/audit/worker_locking_test.go
+++ b/shared/platform/audit/worker_locking_test.go
@@ -1,0 +1,152 @@
+package audit
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+)
+
+// createPendingOutboxEntries inserts count pending audit_outbox rows for locking tests.
+func createPendingOutboxEntries(t *testing.T, db *gorm.DB, count int) {
+	t.Helper()
+
+	for i := 0; i < count; i++ {
+		entry := &AuditOutbox{
+			ID:        uuid.New(),
+			Table:     "customer",
+			Operation: "INSERT",
+			RecordID:  uuid.New().String(),
+			NewValues: `{"id": "123", "name": "Test Customer"}`,
+			Status:    StatusPending,
+			CreatedAt: time.Now(),
+		}
+		require.NoError(t, db.Create(entry).Error, "failed to create pending outbox entry")
+	}
+}
+
+// TestAuditWorker_ClaimPendingEntries_ConcurrentWorkersClaimDisjointRows verifies that
+// two worker instances polling the same outbox table concurrently never claim the same
+// row, and that neither blocks waiting on the other's lock (FOR UPDATE SKIP LOCKED).
+//
+// Because SELECT ... FOR UPDATE SKIP LOCKED combined with ORDER BY/LIMIT picks its
+// candidate rows before checking locks, a worker that loses the race for the same
+// candidate window can legitimately claim zero rows in a single round rather than
+// falling back to the next unlocked rows - this is documented Postgres/CockroachDB
+// behavior, not a bug. What must hold is: no entry is ever claimed twice, no worker
+// blocks, and nothing is lost - unclaimed entries stay pending for the next poll.
+func TestAuditWorker_ClaimPendingEntries_ConcurrentWorkersClaimDisjointRows(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+	defer cleanup()
+	testdb.CreateAuditTables(t, db)
+
+	const totalEntries = 40
+	createPendingOutboxEntries(t, db, totalEntries)
+
+	workerA := NewAuditWorker(db, "", nil)
+	workerA.batchSize = totalEntries / 2
+	workerB := NewAuditWorker(db, "", nil)
+	workerB.batchSize = totalEntries / 2
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	results := make([][]AuditOutbox, 2)
+	errs := make([]error, 2)
+	durations := make([]time.Duration, 2)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		begin := time.Now()
+		results[0], errs[0] = workerA.claimPendingEntries(context.Background())
+		durations[0] = time.Since(begin)
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		begin := time.Now()
+		results[1], errs[1] = workerB.claimPendingEntries(context.Background())
+		durations[1] = time.Since(begin)
+	}()
+	close(start)
+	wg.Wait()
+
+	require.NoError(t, errs[0])
+	require.NoError(t, errs[1])
+
+	// SKIP LOCKED must never block: both claims should complete quickly even though
+	// they raced to lock the same candidate rows.
+	assert.Less(t, durations[0], 5*time.Second, "worker A's claim should not block on worker B's lock")
+	assert.Less(t, durations[1], 5*time.Second, "worker B's claim should not block on worker A's lock")
+
+	// No two workers may ever claim the same row.
+	seen := make(map[uuid.UUID]bool, totalEntries)
+	for _, batch := range results {
+		for _, entry := range batch {
+			assert.False(t, seen[entry.ID], "entry %s claimed by more than one worker", entry.ID)
+			seen[entry.ID] = true
+		}
+	}
+	require.NotEmpty(t, seen, "at least one worker should have claimed entries in the initial race")
+
+	var processingCount int64
+	require.NoError(t, db.Model(&AuditOutbox{}).Where("status = ?", StatusProcessing).Count(&processingCount).Error)
+	assert.Equal(t, int64(len(seen)), processingCount, "only entries actually claimed should be marked processing")
+
+	// Anything not claimed in the concurrent round is still pending, not lost. Simulate
+	// subsequent polls (sequentially, standing in for the ticker's next tick) until every
+	// entry has been claimed exactly once, proving SKIP LOCKED never drops work.
+	for len(seen) < totalEntries {
+		more, err := workerA.claimPendingEntries(context.Background())
+		require.NoError(t, err)
+		require.NotEmpty(t, more, "remaining pending entries must eventually be claimable")
+
+		for _, entry := range more {
+			assert.False(t, seen[entry.ID], "entry %s claimed by more than one worker across polls", entry.ID)
+			seen[entry.ID] = true
+		}
+	}
+
+	assert.Len(t, seen, totalEntries, "every entry should eventually be claimed exactly once")
+
+	var pendingCount int64
+	require.NoError(t, db.Model(&AuditOutbox{}).Where("status = ?", StatusPending).Count(&pendingCount).Error)
+	assert.Equal(t, int64(0), pendingCount, "no pending entries should remain once all rounds complete")
+}
+
+// TestAuditWorker_ClaimPendingEntries_RespectsBatchSize verifies that claiming stops at
+// batchSize even when more pending entries exist, leaving the remainder for the next poll.
+func TestAuditWorker_ClaimPendingEntries_RespectsBatchSize(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+	defer cleanup()
+	testdb.CreateAuditTables(t, db)
+
+	createPendingOutboxEntries(t, db, 15)
+
+	worker := NewAuditWorker(db, "", nil)
+	worker.batchSize = 10
+
+	entries, err := worker.claimPendingEntries(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, entries, 10)
+
+	var pendingCount int64
+	require.NoError(t, db.Model(&AuditOutbox{}).Where("status = ?", StatusPending).Count(&pendingCount).Error)
+	assert.Equal(t, int64(5), pendingCount, "unclaimed entries should remain pending")
+}


### PR DESCRIPTION
## Summary
- The audit outbox worker's batch fetch (`shared/platform/audit/worker.go`) selected pending rows with a plain `SELECT`, with no row locking. Multiple worker instances polling the same schema's outbox table could select and process the same pending rows concurrently, double-publishing audit entries.
- Adds `claimPendingEntries`, which selects candidate rows with `FOR UPDATE SKIP LOCKED` inside a transaction and immediately flips their status to `processing` before committing, so a claimed row is never visible as `pending` to another worker's concurrent query.

## Technical Details
- `SKIP LOCKED` means a worker that races for the same candidate window never blocks waiting on another worker's lock - it just returns fewer rows for that poll cycle. Nothing is lost: unclaimed pending rows remain `pending` and get picked up on the worker's next tick.
- The claim step reuses the existing GORM `Transaction` helper; `processBatchWithCount` is otherwise unchanged (it still calls `processEntry` per claimed row, whose own `processing` status update becomes a no-op re-write - harmless and left as-is to keep the diff minimal).

## Testing
- `TestAuditWorker_ClaimPendingEntries_ConcurrentWorkersClaimDisjointRows` (new, CockroachDB testcontainer): two workers race to claim from a shared 40-row outbox; asserts no entry is ever claimed by both, neither call blocks, and every entry is eventually claimed across polls with none lost or duplicated.
- `TestAuditWorker_ClaimPendingEntries_RespectsBatchSize` (new): confirms claiming still respects `batchSize`, leaving the remainder pending.
- Full existing `shared/platform/audit` suite passes unchanged.

## Risk Assessment
Change is scoped to the outbox fetch path in one file; no schema/migration changes required (`FOR UPDATE SKIP LOCKED` is supported by CockroachDB). Existing single-worker behavior (batch size limits, retry/failure handling) is untouched.