### PR TITLE
fix: Apply pool session settings to every pooled connection (PLT-2)

### DIFF
--- a/shared/platform/db/integration_test.go
+++ b/shared/platform/db/integration_test.go
@@ -948,3 +948,79 @@ func TestPostgresPool_Integration_MultiplePools(t *testing.T) {
 	}
 	assert.Error(t, err, "service_a should not see service_b's tables")
 }
+
+// TestPostgresPool_Integration_SessionSettingsAppliedToAllConnections verifies
+// that session settings (isolation level, statement timeout) reach every
+// connection in the pool - not just the connection that happened to serve the
+// initial setup Exec calls in NewPostgresPool. It forces database/sql to open
+// several distinct physical connections concurrently (each held open briefly
+// via pg_sleep) and checks the settings on each one individually.
+func TestPostgresPool_Integration_SessionSettingsAppliedToAllConnections(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	ctx := context.Background()
+	pool, cleanup := setupPostgresContainer(ctx, t)
+	defer cleanup()
+
+	require.NoError(t, pool.Ping(ctx), "database should be ready")
+
+	const concurrency = 6
+
+	type connSettings struct {
+		pid              int
+		isolation        string
+		statementTimeout string
+	}
+
+	results := make(chan connSettings, concurrency)
+	errs := make(chan error, concurrency)
+
+	var wg sync.WaitGroup
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			// pg_sleep holds this goroutine's connection open long enough
+			// that database/sql must open multiple distinct physical
+			// connections to serve all goroutines concurrently, exercising
+			// pool growth beyond the initial connection.
+			var pid int
+			var isolation, statementTimeout string
+			err := pool.QueryRowContext(ctx,
+				`SELECT pg_backend_pid(), current_setting('default_transaction_isolation'), current_setting('statement_timeout')
+				 FROM pg_sleep(0.3)`,
+			).Scan(&pid, &isolation, &statementTimeout)
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- connSettings{pid: pid, isolation: isolation, statementTimeout: statementTimeout}
+		}()
+	}
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err, "session settings query should succeed on every connection")
+	}
+
+	seenPIDs := make(map[int]bool)
+	count := 0
+	for r := range results {
+		count++
+		seenPIDs[r.pid] = true
+
+		assert.Equal(t, "serializable", r.isolation,
+			"connection (pid %d) should have serializable isolation applied", r.pid)
+		assert.NotEqual(t, "0", r.statementTimeout,
+			"connection (pid %d) should have a non-default statement timeout applied", r.pid)
+	}
+
+	require.Equal(t, concurrency, count, "expected a result from every goroutine")
+	require.Greater(t, len(seenPIDs), 1,
+		"expected multiple distinct pooled connections to be exercised, got %d unique pid(s)", len(seenPIDs))
+}

--- a/shared/platform/db/pool.go
+++ b/shared/platform/db/pool.go
@@ -7,7 +7,8 @@ import (
 	"fmt"
 	"time"
 
-	_ "github.com/jackc/pgx/v5/stdlib" // Register pgx driver
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/stdlib"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -39,14 +40,17 @@ func NewPostgresPool(ctx context.Context, cfg *Config) (*PostgresPool, error) {
 		return nil, fmt.Errorf("failed to create pool: %w", ErrConnectionStringEmpty)
 	}
 
-	// Build connection string with CockroachDB-specific parameters
-	connStr := cfg.ConnectionString
-
-	// Open connection using pgx driver
-	db, err := sql.Open("pgx", connStr)
+	// Parse the connection string into a pgx config so we can attach an
+	// AfterConnect hook. database/sql grows and replaces pooled connections
+	// over time (pool growth, reconnects after network blips, idle eviction),
+	// so session settings must be applied per-connection rather than once
+	// against whichever connection happened to serve the initial Exec calls.
+	connConfig, err := pgx.ParseConfig(cfg.ConnectionString)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open database connection: %w", err)
+		return nil, fmt.Errorf("failed to parse connection string: %w", err)
 	}
+
+	db := stdlib.OpenDB(*connConfig, stdlib.OptionAfterConnect(sessionSettingsAfterConnect(cfg)))
 
 	// Configure connection pool
 	db.SetMaxOpenConns(cfg.MaxConnections)
@@ -54,36 +58,42 @@ func NewPostgresPool(ctx context.Context, cfg *Config) (*PostgresPool, error) {
 	db.SetConnMaxLifetime(cfg.MaxConnectionLifetime)
 	db.SetConnMaxIdleTime(cfg.MaxConnectionIdleTime)
 
-	// Verify initial connection
+	// Verify initial connection. This also exercises the AfterConnect hook,
+	// so a misconfigured session setting fails fast at startup.
 	if err := db.PingContext(ctx); err != nil {
 		// Ignore close error during cleanup - ping failure is the real issue
 		_ = db.Close()
 		return nil, fmt.Errorf("failed to ping database: %w", err)
 	}
 
-	// Set session-level defaults
-	// Use serializable isolation for CockroachDB best practices
-	_, err = db.ExecContext(ctx, "SET default_transaction_isolation = 'serializable'")
-	if err != nil {
-		// Ignore close error during cleanup - isolation setting failure is the real issue
-		_ = db.Close()
-		return nil, fmt.Errorf("failed to set default transaction isolation: %w", err)
-	}
-
-	// Set statement timeout if configured
-	if cfg.StatementTimeout > 0 {
-		timeoutMs := cfg.StatementTimeout.Milliseconds()
-		_, err = db.ExecContext(ctx, fmt.Sprintf("SET statement_timeout = '%dms'", timeoutMs))
-		if err != nil {
-			// Ignore close error during cleanup - timeout setting failure is the real issue
-			_ = db.Close()
-			return nil, fmt.Errorf("failed to set statement timeout: %w", err)
-		}
-	}
-
 	return &PostgresPool{
 		db: db,
 	}, nil
+}
+
+// sessionSettingsAfterConnect returns a pgx AfterConnect hook that applies
+// the pool's session-level defaults (isolation level, statement timeout) to
+// every physical connection as it is established. Wiring this through
+// stdlib.OptionAfterConnect - rather than running SET once against the pool
+// after open - guarantees connections created later (pool growth beyond the
+// initial size, reconnects, idle eviction and replacement) also receive the
+// settings, not just the connection that served the first Exec call.
+func sessionSettingsAfterConnect(cfg *Config) func(ctx context.Context, conn *pgx.Conn) error {
+	return func(ctx context.Context, conn *pgx.Conn) error {
+		// Use serializable isolation for CockroachDB best practices
+		if _, err := conn.Exec(ctx, "SET default_transaction_isolation = 'serializable'"); err != nil {
+			return fmt.Errorf("failed to set default transaction isolation: %w", err)
+		}
+
+		if cfg.StatementTimeout > 0 {
+			timeoutMs := cfg.StatementTimeout.Milliseconds()
+			if _, err := conn.Exec(ctx, fmt.Sprintf("SET statement_timeout = '%dms'", timeoutMs)); err != nil {
+				return fmt.Errorf("failed to set statement timeout: %w", err)
+			}
+		}
+
+		return nil
+	}
 }
 
 // QueryContext executes a query that returns rows with context support.


### PR DESCRIPTION
## Summary
- `NewPostgresPool` (shared/platform/db/pool.go) previously ran `SET default_transaction_isolation` and `SET statement_timeout` once, right after opening the pool, so only whichever single connection served those two `Exec` calls actually received the settings.
- Every other connection the pool later opens - growth beyond the initial size, reconnects after a network blip, idle eviction and replacement - silently ran with database defaults (read committed isolation, no statement timeout) instead of the configured CockroachDB-safe values.
- Fixed by switching to `stdlib.OpenDB` with a pgx `AfterConnect` hook, so the session settings are applied as each physical connection is established, guaranteeing every connection in the pool gets them regardless of when it is created.

## Changes Made
- `shared/platform/db/pool.go`: parse the connection string with `pgx.ParseConfig`, open the pool via `stdlib.OpenDB` with `stdlib.OptionAfterConnect`, and move the isolation/statement-timeout `SET` commands into that hook.
- `shared/platform/db/integration_test.go`: added `TestPostgresPool_Integration_SessionSettingsAppliedToAllConnections`, which forces `database/sql` to open several concurrent physical connections (via `pg_sleep`) and asserts the isolation level and statement timeout on each one individually, keyed by distinct backend pid.

## Technical Details
`database/sql` manages the physical connection pool internally and can open new connections at any time (pool growth, reconnect after a dropped connection, idle-timeout replacement). Running `SET ...` once via `db.ExecContext` after `sql.Open` only guarantees the setting reaches the one connection that call happened to acquire - it says nothing about connections opened afterward. `pgx/v5/stdlib`'s `AfterConnect` hook runs on every `Connect()` call the driver makes, which is the correct integration point for connection-scoped session state.

No other callers were affected: `services/api-gateway/cmd/main.go` is the only consumer of `NewPostgresPool` and its call signature is unchanged.

## Testing
- `go build ./...` - full repo builds.
- `golangci-lint run ./shared/platform/db/...` - 0 issues.
- `go test ./shared/platform/db/...` (testcontainers, ~4.5 min) - all tests pass, including the new session-settings test.
- Verified the new test actually catches the regression: reverted `pool.go` locally and re-ran the new test - it failed with `read committed` instead of `serializable` and a `0` (disabled) statement timeout on connections beyond the first. Restored the fix and it passes.

## Risk Assessment
Low risk, isolated to shared DB pool construction. Behavior for the single-connection case (the common local/test case) is unchanged; the fix only changes what happens as the pool grows past one connection, which is exactly the previously-broken path.