### PR TITLE
fix: Correct tenant provisioning retry classification and status read source

### DIFF
--- a/services/tenant/service/grpc_provisioning_endpoints.go
+++ b/services/tenant/service/grpc_provisioning_endpoints.go
@@ -6,12 +6,11 @@ import (
 
 	pb "github.com/meridianhub/meridian/api/proto/meridian/tenant/v1"
 	"github.com/meridianhub/meridian/services/tenant/adapters/persistence"
-	"github.com/meridianhub/meridian/services/tenant/domain"
+	"github.com/meridianhub/meridian/services/tenant/provisioner"
 	"github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // ReconcileMigrations applies new migrations to existing tenant schemas.
@@ -136,7 +135,7 @@ func (s *Service) GetTenantProvisioningStatus(ctx context.Context, req *pb.GetTe
 	}
 
 	// Build per-service status response
-	serviceStatuses, err := s.buildServiceProvisioningStatuses(ctx, req.TenantId)
+	serviceStatuses, err := s.buildServiceProvisioningStatuses(ctx, tenantID)
 	if err != nil {
 		return nil, err
 	}
@@ -181,38 +180,33 @@ func (s *Service) authorizeProvisioningStatusQuery(ctx context.Context, requeste
 	return nil
 }
 
-// buildServiceProvisioningStatuses queries and maps per-service provisioning records to proto.
-func (s *Service) buildServiceProvisioningStatuses(ctx context.Context, tenantID string) ([]*pb.ServiceProvisioningStatus, error) {
-	provisioningStatuses, err := s.repo.FindProvisioningStatusByTenantID(ctx, tenantID)
+// buildServiceProvisioningStatuses returns per-service provisioning status sourced
+// from the provisioner's persisted state (the tenant_provisioning.service_schemas
+// JSONB blob written by the provisioner during provisioning). Reading from the
+// provisioner's own store - rather than the normalized tenant_provisioning_status
+// table - ensures the status the worker actually recorded is what callers observe.
+//
+// Returns an empty slice (not an error) when schema provisioning is disabled
+// (no provisioner) or no provisioning record exists yet for the tenant.
+func (s *Service) buildServiceProvisioningStatuses(ctx context.Context, tenantID tenant.TenantID) ([]*pb.ServiceProvisioningStatus, error) {
+	if s.provisioner == nil {
+		return []*pb.ServiceProvisioningStatus{}, nil
+	}
+
+	provStatus, err := s.provisioner.GetProvisioningStatus(ctx, tenantID)
 	if err != nil {
+		if errors.Is(err, provisioner.ErrProvisioningStatusNotFound) {
+			return []*pb.ServiceProvisioningStatus{}, nil
+		}
 		s.logger.Error("failed to retrieve provisioning status records",
-			"tenant_id", tenantID,
+			"tenant_id", tenantID.String(),
 			"error", err)
 		return nil, status.Errorf(codes.Internal, "failed to retrieve provisioning status")
 	}
 
-	serviceStatuses := make([]*pb.ServiceProvisioningStatus, 0, len(provisioningStatuses))
-	for _, ps := range provisioningStatuses {
-		serviceStatuses = append(serviceStatuses, s.mapProvisioningStatusToProto(ps))
+	serviceStatuses := make([]*pb.ServiceProvisioningStatus, 0, len(provStatus.Services))
+	for _, svc := range provStatus.Services {
+		serviceStatuses = append(serviceStatuses, s.mapServiceSchemaStatusToProto(svc))
 	}
 	return serviceStatuses, nil
-}
-
-// mapProvisioningStatusToProto converts a domain provisioning status to its proto representation.
-func (s *Service) mapProvisioningStatusToProto(ps domain.ProvisioningStatus) *pb.ServiceProvisioningStatus {
-	sps := &pb.ServiceProvisioningStatus{
-		ServiceName:      ps.ServiceName,
-		Status:           s.toProtoServiceStatus(ps.Status),
-		MigrationVersion: ps.MigrationVersion,
-	}
-	if ps.ErrorMessage != nil {
-		sps.ErrorMessage = *ps.ErrorMessage
-	}
-	if ps.StartedAt != nil {
-		sps.StartedAt = timestamppb.New(*ps.StartedAt)
-	}
-	if ps.CompletedAt != nil {
-		sps.CompletedAt = timestamppb.New(*ps.CompletedAt)
-	}
-	return sps
 }

--- a/services/tenant/service/grpc_service_test.go
+++ b/services/tenant/service/grpc_service_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strconv"
 	"testing"
-	"time"
 
 	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/tenant/v1"
@@ -1214,7 +1213,15 @@ func TestProvisioningHintFromStatus(t *testing.T) {
 // Tests for GetTenantProvisioningStatus
 
 func TestService_GetTenantProvisioningStatus_Success(t *testing.T) {
-	svc, db, cleanup := setupTest(t)
+	// Use a real provisioner-backed service so per-service status is sourced from
+	// the provisioner's persisted state (the tenant_provisioning.service_schemas
+	// JSONB blob), which is where the provisioner actually records progress.
+	mockProv := provisioner.NewMockProvisioner([]provisioner.ServiceConfig{
+		{Name: "party", MigrationPath: "/migrations/party"},
+		{Name: "account", MigrationPath: "/migrations/account"},
+		{Name: "transaction", MigrationPath: "/migrations/transaction"},
+	})
+	svc, _, cleanup := setupTestWithProvisioner(t, mockProv)
 	defer cleanup()
 
 	// Create context with platform-admin claims for cross-tenant access
@@ -1224,49 +1231,31 @@ func TestService_GetTenantProvisioningStatus_Success(t *testing.T) {
 	}
 	ctx := context.WithValue(context.Background(), auth.ClaimsContextKey, claims)
 
-	// Create tenant with provisioning status
+	// Create tenant (provisioner present -> starts PROVISIONING_PENDING)
 	createReq := &pb.InitiateTenantRequest{
 		TenantId:        "provisioning_status_test",
 		DisplayName:     "Provisioning Status Test",
 		SettlementAsset: "GBP",
 	}
-	_, err := svc.InitiateTenant(ctx, createReq)
+	createResp, err := svc.InitiateTenant(ctx, createReq)
 	require.NoError(t, err)
 
-	// Auto-migrate the provisioning status table
-	err = db.AutoMigrate(&persistence.ProvisioningStatusEntity{})
+	tenantID, err := tenant.NewTenantID(createResp.Tenant.TenantId)
 	require.NoError(t, err)
 
-	// Insert test provisioning status records directly via GORM
-	partyStarted := time.Now().Add(-5 * time.Minute)
-	partyCompleted := time.Now().Add(-3 * time.Minute)
-	accountStarted := time.Now().Add(-2 * time.Minute)
-
-	err = db.Create(&persistence.ProvisioningStatusEntity{
-		TenantID:         "provisioning_status_test",
-		ServiceName:      "party",
-		Status:           string(domain.ServiceStatusCompleted),
-		MigrationVersion: stringPtr("20240115_001"),
-		StartedAt:        &partyStarted,
-		CompletedAt:      &partyCompleted,
-	}).Error
+	// Mark the tenant active and record per-service progress in the provisioner's
+	// own store - exactly as the worker does during real provisioning.
+	_, err = svc.repo.UpdateStatus(ctx, tenantID, domain.StatusActive, int(createResp.Tenant.Version))
 	require.NoError(t, err)
-
-	err = db.Create(&persistence.ProvisioningStatusEntity{
-		TenantID:         "provisioning_status_test",
-		ServiceName:      "account",
-		Status:           string(domain.ServiceStatusInProgress),
-		MigrationVersion: stringPtr("20240120_002"),
-		StartedAt:        &accountStarted,
-	}).Error
-	require.NoError(t, err)
-
-	err = db.Create(&persistence.ProvisioningStatusEntity{
-		TenantID:    "provisioning_status_test",
-		ServiceName: "transaction",
-		Status:      string(domain.ServiceStatusPending),
-	}).Error
-	require.NoError(t, err)
+	mockProv.SetStatus(&provisioner.ProvisioningStatus{
+		TenantID: tenantID,
+		State:    provisioner.StateActive,
+		Services: []provisioner.ServiceSchemaStatus{
+			{ServiceName: "party", State: provisioner.ServiceStateMigrated, MigrationVersion: "20240115_001"},
+			{ServiceName: "account", State: provisioner.ServiceStateCreated, MigrationVersion: "20240120_002"},
+			{ServiceName: "transaction", State: provisioner.ServiceStatePending},
+		},
+	})
 
 	// Get provisioning status
 	req := &pb.GetTenantProvisioningStatusRequest{
@@ -1279,26 +1268,20 @@ func TestService_GetTenantProvisioningStatus_Success(t *testing.T) {
 	// Verify response structure
 	assert.Equal(t, "provisioning_status_test", resp.TenantId)
 	assert.Equal(t, pb.TenantStatus_TENANT_STATUS_ACTIVE, resp.OverallStatus)
-	assert.Len(t, resp.Services, 3)
+	require.Len(t, resp.Services, 3)
 
-	// Verify service statuses are returned in alphabetical order
-	assert.Equal(t, "account", resp.Services[0].ServiceName)
-	assert.Equal(t, pb.ServiceProvisioningStatus_STATUS_IN_PROGRESS, resp.Services[0].Status)
-	assert.Equal(t, "20240120_002", resp.Services[0].MigrationVersion)
-	assert.NotNil(t, resp.Services[0].StartedAt)
-	assert.Nil(t, resp.Services[0].CompletedAt)
+	// Services are returned in the provisioner's stored (provisioning-sequence) order.
+	assert.Equal(t, "party", resp.Services[0].ServiceName)
+	assert.Equal(t, pb.ServiceProvisioningStatus_STATUS_COMPLETED, resp.Services[0].Status)
+	assert.Equal(t, "20240115_001", resp.Services[0].MigrationVersion)
 
-	assert.Equal(t, "party", resp.Services[1].ServiceName)
-	assert.Equal(t, pb.ServiceProvisioningStatus_STATUS_COMPLETED, resp.Services[1].Status)
-	assert.Equal(t, "20240115_001", resp.Services[1].MigrationVersion)
-	assert.NotNil(t, resp.Services[1].StartedAt)
-	assert.NotNil(t, resp.Services[1].CompletedAt)
+	assert.Equal(t, "account", resp.Services[1].ServiceName)
+	assert.Equal(t, pb.ServiceProvisioningStatus_STATUS_IN_PROGRESS, resp.Services[1].Status)
+	assert.Equal(t, "20240120_002", resp.Services[1].MigrationVersion)
 
 	assert.Equal(t, "transaction", resp.Services[2].ServiceName)
 	assert.Equal(t, pb.ServiceProvisioningStatus_STATUS_PENDING, resp.Services[2].Status)
 	assert.Empty(t, resp.Services[2].MigrationVersion)
-	assert.Nil(t, resp.Services[2].StartedAt)
-	assert.Nil(t, resp.Services[2].CompletedAt)
 }
 
 func TestService_GetTenantProvisioningStatus_TenantNotFound(t *testing.T) {
@@ -1326,7 +1309,9 @@ func TestService_GetTenantProvisioningStatus_TenantNotFound(t *testing.T) {
 }
 
 func TestService_GetTenantProvisioningStatus_EmptyServicesList(t *testing.T) {
-	svc, db, cleanup := setupTest(t)
+	// No provisioner configured (schema provisioning disabled): the endpoint must
+	// return an empty services list rather than erroring.
+	svc, _, cleanup := setupTest(t)
 	defer cleanup()
 
 	ctx := context.Background()
@@ -1347,10 +1332,6 @@ func TestService_GetTenantProvisioningStatus_EmptyServicesList(t *testing.T) {
 	}
 	authCtx := context.WithValue(context.Background(), auth.ClaimsContextKey, claims)
 
-	// Auto-migrate the provisioning status table but don't insert any records
-	err = db.AutoMigrate(&persistence.ProvisioningStatusEntity{})
-	require.NoError(t, err)
-
 	// Get provisioning status using authenticated context
 	req := &pb.GetTenantProvisioningStatusRequest{
 		TenantId: "empty_services_test",
@@ -1367,7 +1348,10 @@ func TestService_GetTenantProvisioningStatus_EmptyServicesList(t *testing.T) {
 }
 
 func TestService_GetTenantProvisioningStatus_WithFailedService(t *testing.T) {
-	svc, db, cleanup := setupTest(t)
+	mockProv := provisioner.NewMockProvisioner([]provisioner.ServiceConfig{
+		{Name: "party", MigrationPath: "/migrations/party"},
+	})
+	svc, _, cleanup := setupTestWithProvisioner(t, mockProv)
 	defer cleanup()
 
 	ctx := context.Background()
@@ -1394,22 +1378,19 @@ func TestService_GetTenantProvisioningStatus_WithFailedService(t *testing.T) {
 	_, err = svc.repo.UpdateStatusWithError(ctx, tenantID, domain.StatusProvisioningFailed, "Database connection timeout", int(createResp.Tenant.Version))
 	require.NoError(t, err)
 
-	// Auto-migrate provisioning status table
-	err = db.AutoMigrate(&persistence.ProvisioningStatusEntity{})
-	require.NoError(t, err)
-
-	// Insert failed service status via GORM
-	failedStarted := time.Now().Add(-5 * time.Minute)
-	failedCompleted := time.Now()
-	err = db.Create(&persistence.ProvisioningStatusEntity{
-		TenantID:     "failed_provisioning_test",
-		ServiceName:  "party",
-		Status:       string(domain.ServiceStatusFailed),
-		ErrorMessage: stringPtr("Migration 003 failed: constraint violation"),
-		StartedAt:    &failedStarted,
-		CompletedAt:  &failedCompleted,
-	}).Error
-	require.NoError(t, err)
+	// Record the failed per-service status in the provisioner's own store.
+	mockProv.SetStatus(&provisioner.ProvisioningStatus{
+		TenantID:     tenantID,
+		State:        provisioner.StateFailed,
+		ErrorMessage: "Database connection timeout",
+		Services: []provisioner.ServiceSchemaStatus{
+			{
+				ServiceName:  "party",
+				State:        provisioner.ServiceStateFailed,
+				ErrorMessage: "Migration 003 failed: constraint violation",
+			},
+		},
+	})
 
 	// Get provisioning status using authenticated context
 	req := &pb.GetTenantProvisioningStatusRequest{
@@ -1429,8 +1410,6 @@ func TestService_GetTenantProvisioningStatus_WithFailedService(t *testing.T) {
 	assert.Equal(t, "party", resp.Services[0].ServiceName)
 	assert.Equal(t, pb.ServiceProvisioningStatus_STATUS_FAILED, resp.Services[0].Status)
 	assert.Equal(t, "Migration 003 failed: constraint violation", resp.Services[0].ErrorMessage)
-	assert.NotNil(t, resp.Services[0].StartedAt)
-	assert.NotNil(t, resp.Services[0].CompletedAt)
 }
 
 func TestService_GetTenantProvisioningStatus_InvalidTenantID(t *testing.T) {
@@ -1782,11 +1761,6 @@ func TestService_InitiateTenant_SlugRepositoryError(t *testing.T) {
 	//
 	// Then verify that the error is properly handled and returns codes.Internal
 	t.Skip("Requires mock repository - covered by integration tests")
-}
-
-// stringPtr is a helper function to create a pointer to a string.
-func stringPtr(s string) *string {
-	return &s
 }
 
 // ctxWithClaims returns a context with the given auth claims injected.

--- a/services/tenant/service/mappers.go
+++ b/services/tenant/service/mappers.go
@@ -3,6 +3,7 @@ package service
 import (
 	pb "github.com/meridianhub/meridian/api/proto/meridian/tenant/v1"
 	"github.com/meridianhub/meridian/services/tenant/domain"
+	"github.com/meridianhub/meridian/services/tenant/provisioner"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -74,6 +75,37 @@ func (s *Service) toDomainStatus(status pb.TenantStatus) (domain.Status, error) 
 		return "", ErrUnknownStatus
 	default:
 		return "", ErrUnknownStatus
+	}
+}
+
+// mapServiceSchemaStatusToProto converts a provisioner per-service schema status
+// (as persisted in the tenant_provisioning.service_schemas JSONB blob) to its
+// proto representation. The blob does not track per-service started/completed
+// timestamps, so those proto fields are left unset.
+func (s *Service) mapServiceSchemaStatusToProto(svc provisioner.ServiceSchemaStatus) *pb.ServiceProvisioningStatus {
+	return &pb.ServiceProvisioningStatus{
+		ServiceName:      svc.ServiceName,
+		Status:           toProtoServiceSchemaState(svc.State),
+		MigrationVersion: svc.MigrationVersion,
+		ErrorMessage:     svc.ErrorMessage,
+	}
+}
+
+// toProtoServiceSchemaState maps a provisioner ServiceProvisioningState to the
+// proto service status enum. A tripped circuit breaker (circuit_open) is reported
+// as FAILED since the service did not complete provisioning; the worker retries it.
+func toProtoServiceSchemaState(state provisioner.ServiceProvisioningState) pb.ServiceProvisioningStatus_Status {
+	switch state {
+	case provisioner.ServiceStatePending:
+		return pb.ServiceProvisioningStatus_STATUS_PENDING
+	case provisioner.ServiceStateCreated:
+		return pb.ServiceProvisioningStatus_STATUS_IN_PROGRESS
+	case provisioner.ServiceStateMigrated:
+		return pb.ServiceProvisioningStatus_STATUS_COMPLETED
+	case provisioner.ServiceStateFailed, provisioner.ServiceStateCircuitOpen:
+		return pb.ServiceProvisioningStatus_STATUS_FAILED
+	default:
+		return pb.ServiceProvisioningStatus_STATUS_UNSPECIFIED
 	}
 }
 

--- a/services/tenant/worker/provisioning_worker_retry.go
+++ b/services/tenant/worker/provisioning_worker_retry.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/meridianhub/meridian/services/tenant/domain"
 	"github.com/meridianhub/meridian/services/tenant/observability"
+	"github.com/meridianhub/meridian/services/tenant/provisioner"
 	"github.com/meridianhub/meridian/shared/platform/defaults"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
@@ -223,6 +224,24 @@ func (w *ProvisioningWorker) calculateBackoffDelay(attempt int) time.Duration {
 	return delay
 }
 
+// retryableErrors are typed provisioning errors that are always transient and
+// should be retried regardless of their message text. Typed classification runs
+// before substring matching (see isRetryableError) so that an error whose message
+// happens to contain a permanent pattern is still classified by its type, not its
+// wording. For example, ErrSchemaVerificationFailed's message contains "not found"
+// which would otherwise match permanentPatterns and be misclassified as permanent.
+var retryableErrors = []error{
+	// ErrCircuitBreakerOpen: a tripped circuit breaker is transient - the service is
+	// skipped until the breaker transitions to half-open, then provisioning succeeds.
+	provisioner.ErrCircuitBreakerOpen,
+	// ErrCircuitBreakerTooManyRequests: half-open throttle rejecting requests; retry
+	// once the in-flight test requests complete.
+	provisioner.ErrCircuitBreakerTooManyRequests,
+	// ErrSchemaVerificationFailed: post-migration table verification can fail
+	// transiently while migrations are still settling; retrying re-verifies.
+	provisioner.ErrSchemaVerificationFailed,
+}
+
 // retryablePatterns are substrings in error messages that indicate transient errors
 // that are worth retrying. These typically include:
 //   - Lock contention: Atlas migration locks, database row locks, etc.
@@ -269,9 +288,11 @@ var permanentPatterns = []string{
 // Classification rules:
 //  1. Nil errors are never retryable (no error to retry)
 //  2. Context errors (Canceled, DeadlineExceeded) are never retryable
-//  3. Errors matching permanent patterns are never retryable
-//  4. Errors matching retryable patterns are retryable
-//  5. Unknown errors default to non-retryable (fail-safe behavior)
+//  3. Errors matching a typed retryableErrors entry are retryable (authoritative,
+//     checked before substring matching so message wording cannot misclassify them)
+//  4. Errors matching permanent patterns are never retryable
+//  5. Errors matching retryable patterns are retryable
+//  6. Unknown errors default to non-retryable (fail-safe behavior)
 //
 // The function uses case-insensitive substring matching on error messages.
 // For structured errors, it checks the full error chain via Error() string.
@@ -296,6 +317,15 @@ func isRetryableError(err error) bool {
 	// or the deadline was exceeded. Retrying won't help.
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return false
+	}
+
+	// Typed-error classification takes precedence over substring matching.
+	// These errors are authoritative about their own retryability regardless of
+	// message text (e.g. a wrapped ErrCircuitBreakerOpen or ErrSchemaVerificationFailed).
+	for _, retryable := range retryableErrors {
+		if errors.Is(err, retryable) {
+			return true
+		}
 	}
 
 	// Convert error to lowercase string for case-insensitive matching.

--- a/services/tenant/worker/provisioning_worker_test.go
+++ b/services/tenant/worker/provisioning_worker_test.go
@@ -1300,6 +1300,59 @@ func TestIsRetryableError_PermanentTakesPrecedence(t *testing.T) {
 	}
 }
 
+// TestIsRetryableError_CircuitBreakerOpenIsRetryable verifies that a tripped
+// circuit breaker (CTL-1) is classified as retryable via its typed error, even
+// when wrapped with additional context as the provisioner does in production.
+func TestIsRetryableError_CircuitBreakerOpenIsRetryable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"bare circuit breaker open", provisioner.ErrCircuitBreakerOpen},
+		{
+			"wrapped as provisioner returns it",
+			fmt.Errorf("%w: %s", provisioner.ErrCircuitBreakerOpen, "party, current-account"),
+		},
+		{"circuit breaker too many requests", provisioner.ErrCircuitBreakerTooManyRequests},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.True(t, isRetryableError(tt.err),
+				"a tripped circuit breaker is transient and should be retried")
+		})
+	}
+}
+
+// TestIsRetryableError_SchemaVerificationFailedIsRetryable verifies that a
+// schema-verification failure (LOW-3) is classified by its typed error rather
+// than its message text. Its message contains "not found", which matches the
+// permanent substring patterns; typed classification must win so the error is
+// treated as the transient failure it is.
+func TestIsRetryableError_SchemaVerificationFailedIsRetryable(t *testing.T) {
+	// Guard: the message really does contain a permanent pattern, so this test
+	// proves typed classification beats substring matching.
+	require.Contains(t, provisioner.ErrSchemaVerificationFailed.Error(), "not found")
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"bare schema verification failed", provisioner.ErrSchemaVerificationFailed},
+		{
+			"wrapped with tenant context",
+			fmt.Errorf("tenant %s: %w", "acme_bank", provisioner.ErrSchemaVerificationFailed),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.True(t, isRetryableError(tt.err),
+				"schema verification failure is transient and must not be misclassified as permanent")
+		})
+	}
+}
+
 // TestIsRetryableError_AtlasSpecificErrors verifies classification of
 // Atlas migration-specific error messages.
 func TestIsRetryableError_AtlasSpecificErrors(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes three tenant-provisioning defects from bug-sweep-2026-07-07 (tasks 21, 22, 29). All changes are contained to `services/tenant`.

## Changes Made

### CTL-1 (#21): Circuit-breaker-open provisioning now retries
`postgres_provisioner.go` returns `ErrCircuitBreakerOpen` when services are skipped because their circuit breaker is tripped. A tripped breaker is transient - the service is skipped only until the breaker transitions to half-open - so provisioning must retry, not fail permanently. `isRetryableError` previously classified it as non-retryable (default fail-safe), permanently failing the tenant.

### LOW-3 (#29): Schema-verification failure classified by type, not message
`ErrSchemaVerificationFailed`'s message is `"schema provisioning verification failed: expected tables not found"`. The substring `not found` matched `permanentPatterns`, so a transient verification failure was misclassified as permanent. `isRetryableError` now performs typed-error classification (`errors.Is` against a `retryableErrors` list) **before** substring matching, so an error's type is authoritative over its wording.

### CTL-2 (#22): GetTenantProvisioningStatus reads the correct source
`GetTenantProvisioningStatus` read per-service status from the normalized `tenant_provisioning_status` table, but the provisioner records status into the `tenant_provisioning.service_schemas` JSONB blob. The two never met, so the response's `Services` was always empty. `buildServiceProvisioningStatuses` now sources status from the provisioner's own persisted state via `GetProvisioningStatus` (Option B), returning an empty slice when provisioning is disabled or no record exists yet.

## Technical Details

- `provisioning_worker_retry.go`: added `retryableErrors` typed list (`ErrCircuitBreakerOpen`, `ErrCircuitBreakerTooManyRequests`, `ErrSchemaVerificationFailed`) checked via `errors.Is` ahead of substring matching.
- `grpc_provisioning_endpoints.go`: `buildServiceProvisioningStatuses` now takes a `tenant.TenantID` and reads the JSONB-backed status; removed the now-unused normalized-table mapping path.
- `mappers.go`: added `mapServiceSchemaStatusToProto` / `toProtoServiceSchemaState` (circuit_open reported as FAILED; the worker retries it).

## Testing

- `TestIsRetryableError_CircuitBreakerOpenIsRetryable` - proves the wrapped `ErrCircuitBreakerOpen` (as the provisioner returns it) is retryable.
- `TestIsRetryableError_SchemaVerificationFailedIsRetryable` - guards that the message contains `not found`, then proves typed classification wins.
- `GetTenantProvisioningStatus` tests reworked to seed status through the provisioner's store and assert it is returned (previously seeded the wrong table).
- Full packages pass: `services/tenant/{worker,service,provisioner}` (CockroachDB testcontainers).

## Risk Assessment

Low. Retry-classification change only widens what is retried (to genuinely transient errors); the status-read change corrects an always-empty response. No schema/migration changes.