### PR TITLE
fix: Scope mcp-server rate limiter per tenant/session (CTL-4)

### DIFF
--- a/services/mcp-server/cmd/main.go
+++ b/services/mcp-server/cmd/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	mcpauth "github.com/meridianhub/meridian/services/mcp-server/internal/auth"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/tools"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
 	"github.com/meridianhub/meridian/shared/platform/env"
 )
@@ -63,7 +64,10 @@ func run(logger *slog.Logger) error {
 
 	// Wire tools, resources, and prompts onto the server.
 	// cookbookFS is nil until the cookbook directory is embedded at build time.
-	cleanup, err := wireServer(srv, logger, nil)
+	// rateLimiter scopes limits per tenant/session (see session.Manager) and
+	// must be attached to the transport's context via tools.WithRateLimiter
+	// so addTool enforces it on every tool call.
+	cleanup, rateLimiter, err := wireServer(srv, logger, nil)
 	if err != nil {
 		return fmt.Errorf("wire server: %w", err)
 	}
@@ -73,20 +77,21 @@ func run(logger *slog.Logger) error {
 
 	switch transportMode {
 	case "stdio":
-		return runStdio(logger, srv)
+		return runStdio(logger, srv, rateLimiter)
 	case "http":
-		return runHTTP(logger, srv)
+		return runHTTP(logger, srv, rateLimiter)
 	default:
 		return bootstrap.Permanent(fmt.Errorf("%w: %s (expected stdio or http)", errUnknownTransport, transportMode))
 	}
 }
 
-func runStdio(logger *slog.Logger, srv *mcp.Server) error {
+func runStdio(logger *slog.Logger, srv *mcp.Server, rateLimiter tools.RateLimiter) error {
 	logger.Info("using stdio transport")
 
 	// For stdio, we run until stdin closes or we receive a signal.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	ctx = tools.WithRateLimiter(ctx, rateLimiter)
 
 	sigChan, signalCleanup := bootstrap.SignalHandler()
 	defer signalCleanup()
@@ -175,16 +180,25 @@ func (p *passthroughIssuer) Issue(claims map[string]any) (string, error) {
 	return fmt.Sprintf("mcp-issued-%v", claims["client_id"]), nil
 }
 
-func runHTTP(logger *slog.Logger, srv *mcp.Server) error {
+// withRateLimiter attaches rl to each request's context before it reaches
+// next, so that addTool can enforce per-tenant/session limits on tool calls
+// handled by the streamable HTTP transport (see tools.WithRateLimiter).
+func withRateLimiter(rl tools.RateLimiter, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r.WithContext(tools.WithRateLimiter(r.Context(), rl)))
+	})
+}
+
+func runHTTP(logger *slog.Logger, srv *mcp.Server, rateLimiter tools.RateLimiter) error {
 	port := env.GetEnvOrDefault("MCP_PORT", "8090")
 	addr := fmt.Sprintf(":%s", port)
 
 	logger.Info("using streamable HTTP transport", "address", addr)
 
 	// The SDK's StreamableHTTPHandler creates sessions and transports internally.
-	streamableHandler := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
+	streamableHandler := withRateLimiter(rateLimiter, mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
 		return srv
-	}, nil)
+	}, nil))
 
 	mux := http.NewServeMux()
 

--- a/services/mcp-server/cmd/wire.go
+++ b/services/mcp-server/cmd/wire.go
@@ -36,9 +36,19 @@ import (
 //
 // cookbookFS provides the cookbook registry filesystem (may be nil to skip cookbook tools).
 //
-// Returns a cleanup function to close the gRPC connection (nil when no
-// connection was established).
-func wireServer(srv *mcp.Server, logger *slog.Logger, cookbookFS fs.FS) (func(), error) {
+// Returns a cleanup function (always non-nil — stops the rate limiter's
+// background eviction goroutine, and additionally closes the gRPC connection
+// once one has been established) and a RateLimiter that the caller must
+// attach to the transport's context via tools.WithRateLimiter so that
+// addTool enforces it on every tool call.
+func wireServer(srv *mcp.Server, logger *slog.Logger, cookbookFS fs.FS) (func(), tools.RateLimiter, error) {
+	// The rate limiter is scoped per tenant/session (see session.Manager) so
+	// that one caller's traffic can never exhaust another caller's quota. It
+	// is created once here, for the life of the process, and enforced by
+	// addTool for every tool registered below — local or gRPC-backed alike.
+	rateLimiter := session.NewManager(session.DefaultLimits())
+	cleanup := func() { rateLimiter.Close() }
+
 	// Prompts are always available (no external deps).
 	prompts.RegisterPrompts(srv)
 
@@ -72,14 +82,12 @@ func wireServer(srv *mcp.Server, logger *slog.Logger, cookbookFS fs.FS) (func(),
 	resources.RegisterEmbeddedDocs(srv)
 
 	// Try to connect to the Meridian backend for remote tools.
-	var cleanup func()
-
 	authCfg, err := mcpauth.LoadFromEnv()
 	if err != nil {
 		logger.Warn("Meridian backend not configured — only local tools available", "error", err)
 		// Register manifest resource with nil client (placeholder).
 		resources.RegisterManifestResource(srv, nil)
-		return nil, nil //nolint:nilnil // partial availability is intentional
+		return cleanup, rateLimiter, nil
 	}
 
 	mc, err := clients.New(authCfg)
@@ -87,9 +95,9 @@ func wireServer(srv *mcp.Server, logger *slog.Logger, cookbookFS fs.FS) (func(),
 		logger.Warn("failed to create gRPC clients — only local tools available", "error", err)
 		// Register manifest resource with nil client (placeholder).
 		resources.RegisterManifestResource(srv, nil)
-		return nil, nil //nolint:nilnil // partial availability is intentional
+		return cleanup, rateLimiter, nil
 	}
-	cleanup = func() { _ = mc.Close() }
+	cleanup = func() { _ = mc.Close(); rateLimiter.Close() }
 
 	logger.Info("gRPC clients connected", "target", authCfg.APIUrl)
 
@@ -119,6 +127,9 @@ func wireServer(srv *mcp.Server, logger *slog.Logger, cookbookFS fs.FS) (func(),
 	})
 
 	// -- Economy tools (manifest plan/apply/history) --
+	// sess gates the plan-before-apply workflow only (StorePlan/ValidatePlan);
+	// rate limiting is handled separately by the per-tenant/session
+	// rateLimiter created above, not by sess's own (unused) embedded limiter.
 	sess := session.NewDefault()
 	tools.RegisterEconomyTools(srv, sess, tools.EconomyDeps{
 		Applier:   applyManifestAdapter{c: mc.ApplyManifest},
@@ -141,7 +152,7 @@ func wireServer(srv *mcp.Server, logger *slog.Logger, cookbookFS fs.FS) (func(),
 		InstructionWriter:  gatewayInstructionAdapter{c: mc.OperationalGateway},
 	})
 
-	return cleanup, nil
+	return cleanup, rateLimiter, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/services/mcp-server/internal/session/manager.go
+++ b/services/mcp-server/internal/session/manager.go
@@ -1,0 +1,99 @@
+package session
+
+import (
+	"sync"
+	"time"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/tools"
+)
+
+const (
+	// managerEvictInterval is how often Manager sweeps idle per-key limiters.
+	managerEvictInterval = 10 * time.Minute
+	// managerIdleTTL is how long a key's limiter survives without activity
+	// before eviction, bounding memory growth over a long-running server's
+	// lifetime as distinct tenants/sessions come and go.
+	managerIdleTTL = 30 * time.Minute
+)
+
+// keyedLimiter pairs a RateLimiter with its last-used time so evictIdle can
+// reclaim limiters for tenants/sessions that have gone quiet.
+type keyedLimiter struct {
+	limiter    *RateLimiter
+	lastUsedAt time.Time
+}
+
+// Manager scopes rate limiting per key — typically an authenticated tenant
+// ID or an MCP session ID — so that one caller's traffic can never exhaust
+// another caller's quota. Each key gets its own independent RateLimiter,
+// created lazily on first use with the same configured limits. Satisfies
+// tools.RateLimiter. Safe for concurrent use.
+type Manager struct {
+	mu        sync.Mutex
+	limits    map[tools.ToolCategory]CategoryLimit
+	limiters  map[string]*keyedLimiter
+	stop      chan struct{}
+	closeOnce sync.Once
+}
+
+// NewManager returns a Manager that enforces limits independently per key,
+// and starts a background goroutine that evicts idle keys. Call Close when
+// the manager is no longer needed to stop that goroutine.
+func NewManager(limits map[tools.ToolCategory]CategoryLimit) *Manager {
+	copiedLimits := make(map[tools.ToolCategory]CategoryLimit, len(limits))
+	for cat, limit := range limits {
+		copiedLimits[cat] = limit
+	}
+	m := &Manager{
+		limits:   copiedLimits,
+		limiters: make(map[string]*keyedLimiter),
+		stop:     make(chan struct{}),
+	}
+	go m.evictLoop()
+	return m
+}
+
+// Close stops the background eviction goroutine. Safe to call more than once.
+func (m *Manager) Close() {
+	m.closeOnce.Do(func() { close(m.stop) })
+}
+
+// Allow reports whether the caller scoped to key has capacity remaining for
+// category, consulting (and lazily creating) that key's own RateLimiter.
+// Keys are fully independent: exhausting one key's limit never affects any
+// other key.
+func (m *Manager) Allow(key string, category tools.ToolCategory) bool {
+	m.mu.Lock()
+	kl, ok := m.limiters[key]
+	if !ok {
+		kl = &keyedLimiter{limiter: NewRateLimiter(m.limits)}
+		m.limiters[key] = kl
+	}
+	kl.lastUsedAt = time.Now()
+	m.mu.Unlock()
+
+	return kl.limiter.Allow(category)
+}
+
+func (m *Manager) evictLoop() {
+	ticker := time.NewTicker(managerEvictInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			m.evictIdle()
+		case <-m.stop:
+			return
+		}
+	}
+}
+
+func (m *Manager) evictIdle() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for key, kl := range m.limiters {
+		if time.Since(kl.lastUsedAt) > managerIdleTTL {
+			delete(m.limiters, key)
+		}
+	}
+}

--- a/services/mcp-server/internal/session/manager_test.go
+++ b/services/mcp-server/internal/session/manager_test.go
@@ -1,0 +1,95 @@
+package session_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/session"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/tools"
+)
+
+func TestManager_KeysAreIndependent(t *testing.T) {
+	limits := map[tools.ToolCategory]session.CategoryLimit{
+		tools.CategoryWrite: {MaxRequests: 1, Window: time.Minute},
+	}
+	m := session.NewManager(limits)
+	defer m.Close()
+
+	// Exhaust tenant-a's quota.
+	if !m.Allow("tenant-a", tools.CategoryWrite) {
+		t.Fatal("expected tenant-a's first call to be allowed")
+	}
+	if m.Allow("tenant-a", tools.CategoryWrite) {
+		t.Fatal("expected tenant-a's second call to be blocked")
+	}
+
+	// tenant-b must be unaffected by tenant-a exhausting its limit — this is
+	// the exact scenario CTL-4 fixes: one tenant's traffic must never
+	// throttle a different tenant.
+	if !m.Allow("tenant-b", tools.CategoryWrite) {
+		t.Error("expected tenant-b to be unaffected by tenant-a's exhausted limit")
+	}
+
+	// tenant-a should remain blocked; tenant-b now exhausted on its own quota.
+	if m.Allow("tenant-a", tools.CategoryWrite) {
+		t.Error("expected tenant-a to remain blocked")
+	}
+	if m.Allow("tenant-b", tools.CategoryWrite) {
+		t.Error("expected tenant-b's own limit to now be exhausted")
+	}
+}
+
+func TestManager_SameKeySharesState(t *testing.T) {
+	limits := map[tools.ToolCategory]session.CategoryLimit{
+		tools.CategoryRead: {MaxRequests: 2, Window: time.Minute},
+	}
+	m := session.NewManager(limits)
+	defer m.Close()
+
+	if !m.Allow("tenant-a", tools.CategoryRead) {
+		t.Fatal("expected first call to be allowed")
+	}
+	if !m.Allow("tenant-a", tools.CategoryRead) {
+		t.Fatal("expected second call to be allowed")
+	}
+	if m.Allow("tenant-a", tools.CategoryRead) {
+		t.Error("expected third call for the same key to be blocked")
+	}
+}
+
+func TestManager_UnconfiguredCategoryAlwaysAllowed(t *testing.T) {
+	m := session.NewManager(map[tools.ToolCategory]session.CategoryLimit{})
+	defer m.Close()
+
+	for i := 0; i < 50; i++ {
+		if !m.Allow("any-key", tools.CategoryWrite) {
+			t.Fatalf("unconfigured category should always be allowed (call %d)", i+1)
+		}
+	}
+}
+
+func TestManager_CloseIsIdempotent(_ *testing.T) {
+	m := session.NewManager(session.DefaultLimits())
+	m.Close()
+	m.Close() // must not panic
+}
+
+func TestManager_ManyKeysDoNotInterfere(t *testing.T) {
+	limits := map[tools.ToolCategory]session.CategoryLimit{
+		tools.CategoryWrite: {MaxRequests: 1, Window: time.Minute},
+	}
+	m := session.NewManager(limits)
+	defer m.Close()
+
+	keys := []string{"tenant-a", "tenant-b", "tenant-c", "session-1", "session-2"}
+	for _, k := range keys {
+		if !m.Allow(k, tools.CategoryWrite) {
+			t.Fatalf("expected first call for key %q to be allowed", k)
+		}
+	}
+	for _, k := range keys {
+		if m.Allow(k, tools.CategoryWrite) {
+			t.Fatalf("expected second call for key %q to be blocked", k)
+		}
+	}
+}

--- a/services/mcp-server/internal/session/session.go
+++ b/services/mcp-server/internal/session/session.go
@@ -16,6 +16,13 @@ type Config struct {
 
 // Session combines plan caching and rate limiting for a single MCP session.
 // It is safe for concurrent use.
+//
+// The wired server (cmd/wire.go) uses Session only for its plan cache — the
+// plan-before-apply gate is intentionally shared across a single manifest
+// workflow. Request-level rate limiting is enforced separately by Manager,
+// which scopes an independent RateLimiter per tenant/session key so that one
+// caller's traffic can never exhaust another's quota; a single shared
+// Session's embedded limiter would not provide that isolation.
 type Session struct {
 	cache   *PlanCache
 	limiter *RateLimiter

--- a/services/mcp-server/internal/tools/ratelimit.go
+++ b/services/mcp-server/internal/tools/ratelimit.go
@@ -1,0 +1,63 @@
+package tools
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// RateLimiter abstracts per-key, per-category request throttling. It lives in
+// the tools package — rather than session, which already imports tools for
+// ToolCategory — purely to avoid an import cycle. session.Manager satisfies
+// this interface.
+type RateLimiter interface {
+	// Allow reports whether the caller scoped to key has remaining capacity
+	// for category. Each key (tenant or session) gets an independent quota,
+	// so one caller's traffic can never exhaust another caller's limit.
+	Allow(key string, category ToolCategory) bool
+}
+
+// rateLimiterCtxKey is the context key under which a RateLimiter is stored.
+type rateLimiterCtxKey struct{}
+
+// WithRateLimiter returns a context carrying rl. addTool consults it (via
+// rateLimiterFromContext) to enforce per-tenant/session limits on every
+// registered tool call, without threading rl through each Register*
+// function's signature. A context with no RateLimiter attached — or a nil
+// rl — disables enforcement.
+func WithRateLimiter(ctx context.Context, rl RateLimiter) context.Context {
+	return context.WithValue(ctx, rateLimiterCtxKey{}, rl)
+}
+
+// rateLimiterFromContext returns the RateLimiter attached to ctx, or nil if
+// none was attached.
+func rateLimiterFromContext(ctx context.Context) RateLimiter {
+	rl, _ := ctx.Value(rateLimiterCtxKey{}).(RateLimiter)
+	return rl
+}
+
+// rateLimitKey derives the scope a rate limit check is keyed on:
+//   - the authenticated tenant, when present — injected into ctx by
+//     auth.BearerMiddleware via tenant.WithTenant on the HTTP/OAuth
+//     transport (see resolveTenantID for the equivalent pattern used by
+//     tenant-scoped tools);
+//   - otherwise the MCP session ID (stdio / API-key transport, or HTTP
+//     without OAuth), so distinct client connections never share a quota;
+//   - a shared fallback key only when neither is available.
+//
+// Keying on tenant first (rather than session) means multiple sessions
+// authenticated for the same tenant correctly share one quota, while
+// sessions for different tenants never interfere with each other.
+func rateLimitKey(ctx context.Context, sess *mcp.ServerSession) string {
+	if t, ok := tenant.FromContext(ctx); ok && !t.IsEmpty() {
+		return "tenant:" + string(t)
+	}
+	if sess != nil {
+		if id := sess.ID(); id != "" {
+			return "session:" + id
+		}
+	}
+	return "default"
+}

--- a/services/mcp-server/internal/tools/ratelimit_integration_test.go
+++ b/services/mcp-server/internal/tools/ratelimit_integration_test.go
@@ -1,0 +1,91 @@
+// Package tools_test exercises addTool's rate-limit enforcement together
+// with the real session.Manager. It lives in a separate (external) test
+// package because session imports tools for ToolCategory — an internal
+// (package tools) test could not import session without creating a cycle.
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/session"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/tools"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// TestManager_EnforcesIsolatedLimitsAcrossTenants is the CTL-4 regression
+// test end-to-end: a single session.Manager (as wired once per process in
+// cmd/wire.go) backs every tool call, routed through the real addTool
+// wrapper via tools.RegisterValidationTools — no synthetic test-only tool.
+// A tenant that exhausts its quota must never throttle a different tenant
+// sharing that same Manager.
+func TestManager_EnforcesIsolatedLimitsAcrossTenants(t *testing.T) {
+	limits := map[tools.ToolCategory]session.CategoryLimit{
+		tools.CategorySimulate: {MaxRequests: 1, Window: time.Minute},
+	}
+	manager := session.NewManager(limits)
+	defer manager.Close()
+
+	srv := mcp.NewServer(&mcp.Implementation{Name: "ratelimit-integration-test", Version: "v0.0.1"}, nil)
+	// meridian_cel_validate is CategorySimulate and needs no gRPC backend,
+	// so it exercises the real addTool wrapper without extra fixtures.
+	tools.RegisterValidationTools(srv)
+
+	params := celValidateParams(t)
+
+	sessionA := connectTenant(t, srv, manager, "tenant-a")
+	sessionB := connectTenant(t, srv, manager, "tenant-b")
+
+	resultA1, err := sessionA.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "meridian_cel_validate", Arguments: params,
+	})
+	require.NoError(t, err)
+	assert.False(t, resultA1.IsError, "tenant-a's first call should succeed")
+
+	resultA2, err := sessionA.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "meridian_cel_validate", Arguments: params,
+	})
+	require.NoError(t, err)
+	assert.True(t, resultA2.IsError, "tenant-a's second call should be rate limited")
+
+	resultB1, err := sessionB.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "meridian_cel_validate", Arguments: params,
+	})
+	require.NoError(t, err)
+	assert.False(t, resultB1.IsError, "tenant-b must have its own independent quota")
+}
+
+// connectTenant connects a fresh in-memory client/server session pair to
+// srv, attaching rl and tenantID to the server-side context the same way
+// auth.BearerMiddleware attaches an authenticated tenant to each HTTP
+// request's context in production (see tenant.WithTenant).
+func connectTenant(t *testing.T, srv *mcp.Server, rl tools.RateLimiter, tenantID string) *mcp.ClientSession {
+	t.Helper()
+	ctx := tools.WithRateLimiter(context.Background(), rl)
+	ctx = tenant.WithTenant(ctx, tenant.TenantID(tenantID))
+
+	ct, st := mcp.NewInMemoryTransports()
+	ss, err := srv.Connect(ctx, st, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { ss.Close() })
+
+	c := mcp.NewClient(&mcp.Implementation{Name: "ratelimit-integration-test-client", Version: "v0.0.1"}, nil)
+	cs, err := c.Connect(context.Background(), ct, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { cs.Close() })
+	return cs
+}
+
+func celValidateParams(t *testing.T) map[string]any {
+	t.Helper()
+	var m map[string]any
+	raw := json.RawMessage(`{"expression": "1 == 1", "environment": "validation"}`)
+	require.NoError(t, json.Unmarshal(raw, &m))
+	return m
+}

--- a/services/mcp-server/internal/tools/ratelimit_test.go
+++ b/services/mcp-server/internal/tools/ratelimit_test.go
@@ -1,0 +1,158 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// --- rateLimitKey ---
+
+func TestRateLimitKey_TenantPresent_ReturnsTenantScopedKey(t *testing.T) {
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("acme"))
+	assert.Equal(t, "tenant:acme", rateLimitKey(ctx, nil))
+}
+
+func TestRateLimitKey_NoTenantNoSession_ReturnsDefault(t *testing.T) {
+	assert.Equal(t, "default", rateLimitKey(context.Background(), nil))
+}
+
+func TestRateLimitKey_NoTenantEmptySessionID_ReturnsDefault(t *testing.T) {
+	// A ServerSession with no underlying connection has an empty ID, and
+	// should fall back to the shared default key rather than an empty string.
+	assert.Equal(t, "default", rateLimitKey(context.Background(), &mcp.ServerSession{}))
+}
+
+func TestRateLimitKey_TenantTakesPrecedenceOverSession(t *testing.T) {
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("acme"))
+	// Even with a (non-resolving) session present, an authenticated tenant wins.
+	assert.Equal(t, "tenant:acme", rateLimitKey(ctx, &mcp.ServerSession{}))
+}
+
+// --- addTool rate limit enforcement ---
+
+// fakeRateLimiter is a minimal per-key counter used to verify that addTool
+// enforces whatever RateLimiter is attached to the request context. It
+// deliberately avoids depending on the session package (which imports tools,
+// so tools cannot import session back) — session.Manager is exercised
+// end-to-end in ratelimit_integration_test.go instead.
+type fakeRateLimiter struct {
+	mu     sync.Mutex
+	counts map[string]int
+	max    int
+}
+
+func newFakeRateLimiter(maxRequests int) *fakeRateLimiter {
+	return &fakeRateLimiter{counts: make(map[string]int), max: maxRequests}
+}
+
+func (f *fakeRateLimiter) Allow(key string, _ ToolCategory) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.counts[key]++
+	return f.counts[key] <= f.max
+}
+
+// connectSession connects a fresh in-memory client/server session pair to
+// srv, with rl (and optionally a tenant) attached to the server-side context
+// so addTool can enforce it. tenantID may be empty to omit tenant scoping.
+//
+// The in-memory transport's connection always reports an empty session ID
+// (see mcp.ioConn.SessionID — only the streamable HTTP transport's connection
+// assigns real ones), so rateLimitKey's session-ID fallback cannot be
+// exercised through this harness; tenant scoping is used instead to prove
+// per-caller isolation. This mirrors the documented limitation in
+// tenant_enforcement_test.go.
+func connectSession(t *testing.T, srv *mcp.Server, rl RateLimiter, tenantID string) *mcp.ClientSession {
+	t.Helper()
+	ctx := context.Background()
+	if rl != nil {
+		ctx = WithRateLimiter(ctx, rl)
+	}
+	if tenantID != "" {
+		ctx = tenant.WithTenant(ctx, tenant.TenantID(tenantID))
+	}
+
+	ct, st := mcp.NewInMemoryTransports()
+	ss, err := srv.Connect(ctx, st, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { ss.Close() })
+
+	c := mcp.NewClient(&mcp.Implementation{Name: "ratelimit-test-client", Version: "v0.0.1"}, nil)
+	cs, err := c.Connect(context.Background(), ct, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { cs.Close() })
+	return cs
+}
+
+func registerLimitedTool(srv *mcp.Server, name string) {
+	addTool(srv, Tool{
+		Name:        name,
+		Description: "A rate-limited tool",
+		InputSchema: emptySchema,
+		Category:    CategoryWrite,
+		Handler: func(_ context.Context, _ json.RawMessage) (interface{}, error) {
+			return "ok", nil
+		},
+	})
+}
+
+func TestAddTool_NoRateLimiterInContext_NeverBlocks(t *testing.T) {
+	srv := mcp.NewServer(&mcp.Implementation{Name: "ratelimit-test", Version: "v0.0.1"}, nil)
+	registerLimitedTool(srv, "limited")
+	cs := connectSession(t, srv, nil, "")
+
+	for i := 0; i < 10; i++ {
+		result, err := cs.CallTool(context.Background(), &mcp.CallToolParams{Name: "limited"})
+		require.NoError(t, err)
+		assert.False(t, result.IsError, "call %d should not be rate limited when no limiter is attached", i+1)
+	}
+}
+
+func TestAddTool_RateLimiterInContext_BlocksAfterLimit(t *testing.T) {
+	srv := mcp.NewServer(&mcp.Implementation{Name: "ratelimit-test", Version: "v0.0.1"}, nil)
+	registerLimitedTool(srv, "limited")
+	rl := newFakeRateLimiter(1)
+	cs := connectSession(t, srv, rl, "")
+
+	result1, err := cs.CallTool(context.Background(), &mcp.CallToolParams{Name: "limited"})
+	require.NoError(t, err)
+	assert.False(t, result1.IsError, "first call should succeed")
+
+	result2, err := cs.CallTool(context.Background(), &mcp.CallToolParams{Name: "limited"})
+	require.NoError(t, err)
+	assert.True(t, result2.IsError, "second call should be rate limited")
+}
+
+// TestAddTool_RateLimiting_IsolatesPerTenant is the CTL-4 regression test:
+// two callers share the same RateLimiter instance (as they would in the real
+// server, where one Manager backs every connection), but because
+// rateLimitKey scopes on the authenticated tenant, one tenant exhausting its
+// quota must never throttle a different tenant.
+func TestAddTool_RateLimiting_IsolatesPerTenant(t *testing.T) {
+	srv := mcp.NewServer(&mcp.Implementation{Name: "ratelimit-test", Version: "v0.0.1"}, nil)
+	registerLimitedTool(srv, "limited")
+	rl := newFakeRateLimiter(1)
+
+	sessionA := connectSession(t, srv, rl, "tenant-a")
+	sessionB := connectSession(t, srv, rl, "tenant-b")
+
+	resultA1, err := sessionA.CallTool(context.Background(), &mcp.CallToolParams{Name: "limited"})
+	require.NoError(t, err)
+	assert.False(t, resultA1.IsError, "session A's first call should succeed")
+
+	resultA2, err := sessionA.CallTool(context.Background(), &mcp.CallToolParams{Name: "limited"})
+	require.NoError(t, err)
+	assert.True(t, resultA2.IsError, "tenant-a's second call should be rate limited")
+
+	resultB1, err := sessionB.CallTool(context.Background(), &mcp.CallToolParams{Name: "limited"})
+	require.NoError(t, err)
+	assert.False(t, resultB1.IsError, "tenant-b must be unaffected by tenant-a's exhausted limit")
+}

--- a/services/mcp-server/internal/tools/sdk.go
+++ b/services/mcp-server/internal/tools/sdk.go
@@ -70,6 +70,7 @@ func compileSchema(schema map[string]interface{}) (*jsonschema.Schema, error) {
 // Input is validated against the tool's JSON Schema before the handler is called.
 func addTool(srv *mcp.Server, t Tool) {
 	handler := t.Handler // capture for closure
+	name, category := t.Name, t.Category
 	validator, err := compileSchema(t.InputSchema)
 	if err != nil {
 		panic(fmt.Sprintf("compile schema for tool %q: %v", t.Name, err))
@@ -79,6 +80,16 @@ func addTool(srv *mcp.Server, t Tool) {
 		Description: t.Description,
 		InputSchema: t.InputSchema,
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		// Enforce per-tenant/session rate limits before doing any work. The
+		// limiter is attached to ctx by the transport layer (see
+		// tools.WithRateLimiter); a request with none attached is unlimited.
+		if rl := rateLimiterFromContext(ctx); rl != nil {
+			key := rateLimitKey(ctx, req.Session)
+			if !rl.Allow(key, category) {
+				return mcputil.ErrorResult(fmt.Sprintf("rate limit exceeded for tool %q; try again shortly", name)), nil
+			}
+		}
+
 		// Validate input against JSON Schema.
 		args := req.Params.Arguments
 		if len(args) == 0 {


### PR DESCRIPTION
## Summary

- `cmd/wire.go:122` created a single `session.Session` (with one embedded `RateLimiter`) for the whole mcp-server process. Every tenant/session sharing that process would have shared the same request counters, so one tenant's traffic could exhaust the quota for every other tenant. The limiter was also never actually consulted by any tool call — limits were not enforced at all.
- Adds `session.Manager`, which lazily creates an independent `RateLimiter` per key (authenticated tenant ID when present, else the MCP session ID) and evicts idle keys in the background (`Close()` stops the eviction goroutine, mirroring the existing eviction pattern in `internal/auth`).
- Wires enforcement into `addTool` (the single funnel every registered tool passes through) via a context value, `tools.WithRateLimiter`/`tools.RateLimiter`, mirroring the existing `tenant.WithTenant`/`tenant.FromContext` pattern already used for tenant scoping in this service. This avoids threading a limiter parameter through every `Register*` tool-registration function.
- `cmd/main.go` attaches the shared `session.Manager` to the request context for both transports: once at the top of the stdio connection, and per-HTTP-request for the streamable HTTP transport (so a per-request authenticated tenant is available the same way it already is for `resolveTenantID`).
- The pre-existing `session.Session` (used only for the plan-before-apply cache) is unchanged; its own embedded `RateLimiter` was already dead code and remains so — a doc comment now says why.

## Technical Details

- `rateLimitKey` scopes on tenant first (so multiple sessions for the same tenant correctly share one quota), falling back to the MCP session ID, then a shared "default" key if neither is available (relevant only to single-tenant stdio/dev deployments).
- Verified via the SDK's jsonrpc2 internals that `context.WithValue` attached to the ctx passed to `Server.Connect`/`Server.Run` propagates to every subsequent request handler for that connection (each request context is derived via `context.WithCancel`, which preserves `Value()` lookups) — this is what makes the context-based wiring reliable for stdio/in-memory transports, in addition to the already-proven per-HTTP-request propagation used by tenant enforcement.

## Testing

- `session/manager_test.go`: unit tests proving per-key isolation (exhausting one key never affects another), same-key state sharing, unconfigured categories always allowed, idempotent `Close`.
- `tools/ratelimit_test.go`: white-box tests for `rateLimitKey`'s precedence rules, plus black-box tests (real in-memory MCP transport) proving `addTool` enforces a limiter attached to context, and that two tenants sharing one limiter instance are isolated.
- `tools/ratelimit_integration_test.go`: external-package end-to-end test driving the real `session.Manager` through the real `addTool` wrapper via `tools.RegisterValidationTools`, confirming one tenant exhausting its quota does not throttle a different tenant.
- `go build ./...`, `go test ./services/mcp-server/... -race`, and `golangci-lint run ./services/mcp-server/...` all pass; pre-existing `goconst` findings in untouched files are unrelated to this change.

## Risk Assessment

- Enforcement is newly wired for the first time (it was previously dead code), so tool calls now receive per-tenant/session quotas by default (`DefaultLimits`: Read 60/min, Simulate 30/min, Write 5/min). No behavioral change for stdio single-tenant usage beyond that new default enforcement.
- `wireServer`'s return signature changed (`(func(), error)` → `(func(), tools.RateLimiter, error)`); its only call site (`cmd/main.go`) is updated in this PR.