### PR TITLE
fix: Unify manifest version persistence + enable concurrency control (CTL-3)

### DIFF
--- a/cmd/meridian/wire_grpc.go
+++ b/cmd/meridian/wire_grpc.go
@@ -434,6 +434,7 @@ func wireControlPlane(ctx context.Context, server *grpc.Server, pool *pgxpool.Po
 
 	if err := controlplaneservice.RegisterApplyManifestService(server, controlplaneservice.ApplyManifestServiceConfig{
 		Pool:        pool,
+		GormDB:      db,
 		Logger:      logger,
 		HandlerDeps: deps,
 		GRPCConn:    loopback.rawConn,

--- a/services/control-plane/internal/applier/grpc_handler.go
+++ b/services/control-plane/internal/applier/grpc_handler.go
@@ -259,8 +259,11 @@ func (h *ApplyManifestHandler) recordAndFinalize(
 		response.SequenceNumber = snapshot.SequenceNumber
 	}
 
-	// Save to version store for future diffs
-	if h.versionStore != nil {
+	// Persist to the legacy version store only when no history service is wired.
+	// When the history service is present it is the single source of truth
+	// (versioned, sequence-assigned via recordHistory above), so writing here too
+	// would produce a duplicate, unsequenced (sequence-0) row for the same apply.
+	if h.historyService == nil && h.versionStore != nil {
 		if err := h.versionStore.Save(ctx, req.GetManifest(), req.GetAppliedBy()); err != nil {
 			logger.Error("failed to save manifest version to differ store", "error", err)
 		}

--- a/services/control-plane/internal/applier/grpc_handler_history_integration_test.go
+++ b/services/control-plane/internal/applier/grpc_handler_history_integration_test.go
@@ -1,0 +1,183 @@
+package applier
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/services/control-plane/internal/differ"
+	"github.com/meridianhub/meridian/services/control-plane/internal/differ/persistence"
+	"github.com/meridianhub/meridian/services/control-plane/internal/manifest"
+	"github.com/meridianhub/meridian/services/control-plane/internal/planner"
+	"github.com/meridianhub/meridian/services/control-plane/internal/validator"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	gormpostgres "gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// newHistoryBackedHandler builds an ApplyManifestHandler wired to a real
+// DB-backed executor, the pgx version store, AND the versioned GORM-backed
+// HistoryService, all sharing a single Postgres testcontainer. This mirrors the
+// production wiring (RegisterApplyManifestService with a GormDB) so the full
+// validate -> diff -> plan -> execute -> recordHistory path exercises sequence
+// assignment and optimistic concurrency control. Returns the handler, a
+// tenant-scoped context, the pool, and the tenant ID for row assertions.
+func newHistoryBackedHandler(t *testing.T, tenantID string) (*ApplyManifestHandler, context.Context, *pgxpool.Pool, string) {
+	t.Helper()
+
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool := testdb.NewTestPool(t, testdb.WithMigrations("control-plane"))
+	ctx, cleanup := testdb.SetupTenantSchemaForPgx(t, pool, tenantID, "control-plane")
+	t.Cleanup(cleanup)
+
+	script, version, err := loadEmbeddedApplyManifest()
+	require.NoError(t, err)
+	insertPlatformSaga(t, pool, version, script)
+
+	deps := &HandlerDependencies{
+		ReferenceData:      &noopReferenceData{},
+		InternalAccount:    &noopInternalAccount{},
+		MarketInformation:  &noopMarketInformation{},
+		Party:              &noopParty{},
+		OperationalGateway: &noopOperationalGateway{},
+	}
+	executor := newExecutorWithRunner(t, pool, deps)
+
+	// Open a GORM handle over the SAME container so the history service and the
+	// executor/version store observe one database and tenant schema.
+	gormDB, err := gorm.Open(gormpostgres.Open(pool.Config().ConnString()), &gorm.Config{})
+	require.NoError(t, err)
+	repo, err := manifest.NewRepository(gormDB)
+	require.NoError(t, err)
+	historySvc, err := manifest.NewHistoryService(repo)
+	require.NoError(t, err)
+
+	v, err := validator.New()
+	require.NoError(t, err)
+
+	handler, err := NewApplyManifestHandler(ApplyManifestHandlerConfig{
+		Validator:      v,
+		Differ:         differ.New(nil, nil, nil),
+		Planner:        planner.NewManifestPlanner(),
+		Executor:       executor,
+		VersionStore:   persistence.NewPostgresManifestVersionStore(pool),
+		HistoryService: historySvc,
+	})
+	require.NoError(t, err)
+	return handler, ctx, pool, tenantID
+}
+
+// seqTestManifest builds a manifest whose instrument set grows with each version
+// so successive applies always produce a real (non-empty) CREATE diff.
+func seqTestManifest(version string, instrumentCodes ...string) *controlplanev1.Manifest {
+	m := &controlplanev1.Manifest{
+		Version: version,
+		Metadata: &controlplanev1.ManifestMetadata{
+			Name:     "Sequence Test Manifest",
+			Industry: "testing",
+		},
+	}
+	for _, code := range instrumentCodes {
+		m.Instruments = append(m.Instruments, &controlplanev1.InstrumentDefinition{
+			Code: code,
+			Name: code,
+			Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+			Dimensions: &controlplanev1.InstrumentDimensions{
+				Unit:      code,
+				Precision: 2,
+			},
+		})
+	}
+	return m
+}
+
+// countManifestVersionRows returns the number of manifest_version rows in the
+// tenant's schema, used to prove a single apply persists exactly one row.
+func countManifestVersionRows(t *testing.T, pool *pgxpool.Pool, tenantID string) int {
+	t.Helper()
+	schema := pgx.Identifier{tenant.TenantID(tenantID).SchemaName()}.Sanitize()
+	var count int
+	err := pool.QueryRow(
+		context.Background(),
+		fmt.Sprintf("SELECT count(*) FROM %s.manifest_version", schema),
+	).Scan(&count)
+	require.NoError(t, err)
+	return count
+}
+
+// TestApplyManifest_HistoryWiring_SequenceIncrements verifies that when the
+// history service is wired into the handler, sequential applies through the full
+// gRPC pipeline receive monotonically increasing sequence numbers (1, 2, 3) and
+// that each apply persists exactly one manifest_version row (no duplicate
+// sequence-0 rows from a second, unsequenced write).
+func TestApplyManifest_HistoryWiring_SequenceIncrements(t *testing.T) {
+	handler, ctx, pool, tenantID := newHistoryBackedHandler(t, "seqinc")
+
+	applies := []*controlplanev1.Manifest{
+		seqTestManifest("1.1", "GBP"),
+		seqTestManifest("1.2", "GBP", "USD"),
+		seqTestManifest("1.3", "GBP", "USD", "EUR"),
+	}
+
+	for i, m := range applies {
+		resp, err := handler.ApplyManifest(ctx, &controlplanev1.ApplyManifestRequest{
+			Manifest:  m,
+			AppliedBy: "tester",
+		})
+		require.NoError(t, err)
+		require.Equal(t, controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_APPLIED, resp.Status,
+			"apply %d should succeed", i+1)
+		require.NotNil(t, resp.Snapshot, "history service must attach a version snapshot")
+		assert.Equal(t, int64(i+1), resp.SequenceNumber, "sequence number must increment per apply")
+		assert.Equal(t, int64(i+1), resp.Snapshot.SequenceNumber, "snapshot sequence must match response")
+	}
+
+	// Exactly one row per apply: proves the legacy version store no longer writes
+	// a duplicate, unsequenced row alongside the history service.
+	assert.Equal(t, len(applies), countManifestVersionRows(t, pool, tenantID))
+}
+
+// TestApplyManifest_HistoryWiring_StaleSequenceAborted verifies that an apply
+// carrying a stale expected_sequence_number is rejected with codes.Aborted via
+// the optimistic concurrency check, so concurrent applies cannot clobber the
+// version history by landing on the same sequence.
+func TestApplyManifest_HistoryWiring_StaleSequenceAborted(t *testing.T) {
+	handler, ctx, _, _ := newHistoryBackedHandler(t, "seqconflict")
+
+	// First apply -> sequence 1.
+	resp1, err := handler.ApplyManifest(ctx, &controlplanev1.ApplyManifestRequest{
+		Manifest:  seqTestManifest("1.1", "GBP"),
+		AppliedBy: "tester",
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), resp1.SequenceNumber)
+
+	// Second apply -> sequence 2.
+	resp2, err := handler.ApplyManifest(ctx, &controlplanev1.ApplyManifestRequest{
+		Manifest:  seqTestManifest("1.2", "GBP", "USD"),
+		AppliedBy: "tester",
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), resp2.SequenceNumber)
+
+	// Third apply supplies a stale expected sequence (1, but current is 2).
+	// The optimistic-concurrency check must reject it with codes.Aborted.
+	_, err = handler.ApplyManifest(ctx, &controlplanev1.ApplyManifestRequest{
+		Manifest:               seqTestManifest("1.3", "GBP", "USD", "EUR"),
+		AppliedBy:              "tester",
+		ExpectedSequenceNumber: 1,
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.Aborted, status.Code(err), "stale expected sequence must be Aborted")
+}

--- a/services/control-plane/internal/differ/persistence/manifest_version_store.go
+++ b/services/control-plane/internal/differ/persistence/manifest_version_store.go
@@ -36,10 +36,14 @@ func NewPostgresManifestVersionStore(pool *pgxpool.Pool) *PostgresManifestVersio
 func (s *PostgresManifestVersionStore) GetLatestApplied(ctx context.Context) (*differ.ManifestVersion, error) {
 	var result *differ.ManifestVersion
 	err := s.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		// Restrict to successfully applied versions and order by sequence number so
+		// the diff baseline is the latest good manifest. The history service records
+		// FAILED/PARTIAL rows in this same table; those must never become a baseline.
 		row := tx.QueryRow(ctx, `
 			SELECT id, version, manifest_json, applied_at, applied_by
 			FROM manifest_version
-			ORDER BY applied_at DESC
+			WHERE apply_status = 'APPLIED'
+			ORDER BY sequence_number DESC, applied_at DESC
 			LIMIT 1
 		`)
 

--- a/services/control-plane/service/apply_manifest.go
+++ b/services/control-plane/service/apply_manifest.go
@@ -67,19 +67,11 @@ func RegisterApplyManifestService(server *grpc.Server, cfg ApplyManifestServiceC
 
 	versionStore := persistence.NewPostgresManifestVersionStore(cfg.Pool)
 
-	// Wire the versioned history service when a GORM handle is available. This is
-	// the single source of truth for manifest persistence: it assigns sequence
-	// numbers atomically and enforces optimistic-concurrency checks, so concurrent
-	// applies cannot clobber each other or produce duplicate sequence-0 rows.
 	var historyService *manifest.HistoryService
 	if cfg.GormDB != nil {
-		repo, repoErr := manifest.NewRepository(cfg.GormDB)
-		if repoErr != nil {
-			return fmt.Errorf("manifest repository: %w", repoErr)
-		}
-		historyService, err = manifest.NewHistoryService(repo)
+		historyService, err = buildManifestHistoryService(cfg.GormDB)
 		if err != nil {
-			return fmt.Errorf("manifest history service: %w", err)
+			return err
 		}
 	}
 
@@ -121,6 +113,23 @@ func RegisterApplyManifestService(server *grpc.Server, cfg ApplyManifestServiceC
 
 	controlplanev1.RegisterApplyManifestServiceServer(server, handler)
 	return nil
+}
+
+// buildManifestHistoryService wires the versioned history service when a GORM
+// handle is available. It is the single source of truth for manifest
+// persistence: sequence numbers are assigned atomically and optimistic-
+// concurrency checks prevent concurrent applies from clobbering each other or
+// producing duplicate sequence-0 rows. Callers guard on a non-nil gormDB.
+func buildManifestHistoryService(gormDB *gorm.DB) (*manifest.HistoryService, error) {
+	repo, err := manifest.NewRepository(gormDB)
+	if err != nil {
+		return nil, fmt.Errorf("manifest repository: %w", err)
+	}
+	historyService, err := manifest.NewHistoryService(repo)
+	if err != nil {
+		return nil, fmt.Errorf("manifest history service: %w", err)
+	}
+	return historyService, nil
 }
 
 // NewHandlerDeps builds HandlerDependencies from a raw gRPC connection that can

--- a/services/control-plane/service/apply_manifest.go
+++ b/services/control-plane/service/apply_manifest.go
@@ -12,15 +12,25 @@ import (
 	"github.com/meridianhub/meridian/services/control-plane/internal/applier"
 	"github.com/meridianhub/meridian/services/control-plane/internal/differ"
 	"github.com/meridianhub/meridian/services/control-plane/internal/differ/persistence"
+	"github.com/meridianhub/meridian/services/control-plane/internal/manifest"
 	"github.com/meridianhub/meridian/services/control-plane/internal/planner"
 	"github.com/meridianhub/meridian/services/control-plane/internal/validator"
 	"google.golang.org/grpc"
+	"gorm.io/gorm"
 )
 
 // ApplyManifestServiceConfig holds the configuration for RegisterApplyManifestService.
 type ApplyManifestServiceConfig struct {
 	// Pool is the database connection pool (required).
 	Pool *pgxpool.Pool
+
+	// GormDB is the GORM handle for the control-plane database. When provided,
+	// manifest history is recorded through the versioned HistoryService, giving
+	// each apply a monotonically increasing sequence number with optimistic
+	// concurrency control. When nil, history recording is disabled (suitable for
+	// validate/dry-run-only deployments) and the legacy version store is used
+	// as the single persistence path.
+	GormDB *gorm.DB
 
 	// Logger is the structured logger. Defaults to slog.Default() if nil.
 	Logger *slog.Logger
@@ -57,6 +67,22 @@ func RegisterApplyManifestService(server *grpc.Server, cfg ApplyManifestServiceC
 
 	versionStore := persistence.NewPostgresManifestVersionStore(cfg.Pool)
 
+	// Wire the versioned history service when a GORM handle is available. This is
+	// the single source of truth for manifest persistence: it assigns sequence
+	// numbers atomically and enforces optimistic-concurrency checks, so concurrent
+	// applies cannot clobber each other or produce duplicate sequence-0 rows.
+	var historyService *manifest.HistoryService
+	if cfg.GormDB != nil {
+		repo, repoErr := manifest.NewRepository(cfg.GormDB)
+		if repoErr != nil {
+			return fmt.Errorf("manifest repository: %w", repoErr)
+		}
+		historyService, err = manifest.NewHistoryService(repo)
+		if err != nil {
+			return fmt.Errorf("manifest history service: %w", err)
+		}
+	}
+
 	var liveState differ.LiveStateProvider
 	if cfg.GRPCConn != nil {
 		var lsErr error
@@ -81,12 +107,13 @@ func RegisterApplyManifestService(server *grpc.Server, cfg ApplyManifestServiceC
 	}
 
 	handler, err := applier.NewApplyManifestHandler(applier.ApplyManifestHandlerConfig{
-		Validator:    v,
-		Differ:       d,
-		Planner:      p,
-		Executor:     executor,
-		VersionStore: versionStore,
-		Logger:       cfg.Logger,
+		Validator:      v,
+		Differ:         d,
+		Planner:        p,
+		Executor:       executor,
+		VersionStore:   versionStore,
+		HistoryService: historyService,
+		Logger:         cfg.Logger,
 	})
 	if err != nil {
 		return fmt.Errorf("apply manifest handler: %w", err)


### PR DESCRIPTION
## Summary

The `ApplyManifest` handler persisted applied manifests through two independent paths:

1. **`HistoryService`** (GORM `Repository`) - versioned, assigns a monotonic `sequence_number` atomically, enforces optimistic-concurrency via `expected_sequence_number`.
2. **`PostgresManifestVersionStore`** (pgx) - unconditional `INSERT`, `sequence_number` defaulting to `0`.

`RegisterApplyManifestService` never wired a `HistoryService` into the handler, so `historyService` was always `nil`. The entire optimistic-concurrency path (`recordHistory` → `Repository.Store`) was dead code in production, and every successful apply wrote only an unsequenced, duplicate-prone `sequence-0` row via the legacy store. Concurrent `ApplyManifest` calls could not detect conflicts and produced duplicate `sequence 0` records.

## Changes Made

- **`service/apply_manifest.go`**: Added an optional `GormDB` to `ApplyManifestServiceConfig`. When provided, `RegisterApplyManifestService` builds the `manifest.Repository` + `HistoryService` and wires it into the handler - making the history service the single source of truth for manifest persistence.
- **`cmd/meridian/wire_grpc.go`**: Pass the control-plane `*gorm.DB` into `RegisterApplyManifestService` (the unified binary already had it in scope).
- **`internal/applier/grpc_handler.go`**: Skip the legacy `versionStore.Save` when a history service is wired, so an apply no longer writes a duplicate `sequence-0` row alongside the sequenced history record.
- **`internal/differ/persistence/manifest_version_store.go`**: `GetLatestApplied` now filters `apply_status = 'APPLIED'` and orders by `sequence_number DESC`. The history service records `FAILED`/`PARTIAL` rows in the same table, so those must never become a diff baseline.

## Technical Details

The concurrency control itself already existed and is well-tested in `Repository.Store` (atomic `MAX(sequence_number)` + `expected_sequence_number` check → `ErrSequenceConflict`), and the handler already mapped `ErrSequenceConflict` → `codes.Aborted`. The defect was purely that this path was never connected. The standalone control-plane binary (validate/dry-run only, no `GormDB`) is unaffected: `historyService` stays `nil` and the legacy store remains the fallback.

## Testing

New integration test `grpc_handler_history_integration_test.go` drives the full `ApplyManifest` pipeline (validate → diff → plan → execute → recordHistory) with the history service wired over a shared Postgres testcontainer:

- **`TestApplyManifest_HistoryWiring_SequenceIncrements`**: three sequential applies receive sequence numbers 1, 2, 3, and exactly one `manifest_version` row is persisted per apply (no duplicate `sequence-0` rows).
- **`TestApplyManifest_HistoryWiring_StaleSequenceAborted`**: an apply carrying a stale `expected_sequence_number` is rejected with `codes.Aborted`.

Verified green locally: `service`, `internal/applier`, `internal/differ/persistence`, and the relevant `internal/manifest` sequence/conflict tests.

## Risk Assessment

Low. The wiring is additive and gated on `GormDB != nil`; deployments without a GORM handle keep prior behavior. The `GetLatestApplied` read change aligns the pgx store's baseline semantics with the GORM `Repository.GetLatestApplied` (which already filtered `apply_status = 'APPLIED'`).

## Deployment Notes

No migration required; `sequence_number`, `apply_status`, `checksum` columns already exist on `manifest_version`.