### PR TITLE
fix: Make reconciliation outbox writes atomic with domain changes (DAT-8)

### DIFF
--- a/services/reconciliation/adapters/messaging/kafka_publisher.go
+++ b/services/reconciliation/adapters/messaging/kafka_publisher.go
@@ -12,6 +12,7 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/events/topics"
 	"github.com/meridianhub/meridian/shared/platform/kafka"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"gorm.io/gorm"
 )
 
 // Topic aliases for reconciliation domain events.
@@ -149,6 +150,14 @@ func (p *KafkaPublisher) publishToTopic(ctx context.Context, topic string, event
 	return nil
 }
 
+// PublishTx publishes directly to Kafka, ignoring the transaction. This publisher
+// does not use the transactional outbox, so it cannot make delivery atomic with
+// the domain write; it is retained for the legacy direct-Kafka path. Prefer
+// OutboxEventPublisher for atomic delivery.
+func (p *KafkaPublisher) PublishTx(ctx context.Context, _ *gorm.DB, topic string, event interface{}) error {
+	return p.Publish(ctx, topic, event)
+}
+
 // Close flushes pending messages and closes the producer.
 func (p *KafkaPublisher) Close() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -215,4 +224,10 @@ func (p *NoopPublisher) Publish(_ context.Context, topic string, _ interface{}) 
 		"topic", topic,
 	)
 	return nil
+}
+
+// PublishTx logs the event instead of publishing to Kafka. The transaction is
+// ignored because the no-op publisher performs no persistence.
+func (p *NoopPublisher) PublishTx(ctx context.Context, _ *gorm.DB, topic string, event interface{}) error {
+	return p.Publish(ctx, topic, event)
 }

--- a/services/reconciliation/adapters/messaging/outbox_event_publisher.go
+++ b/services/reconciliation/adapters/messaging/outbox_event_publisher.go
@@ -39,20 +39,29 @@ func NewOutboxEventPublisher(db *gorm.DB, publisher *events.OutboxPublisher) *Ou
 }
 
 // Publish implements the service.EventPublisher interface.
-// It maps the topic and event to a protobuf message and writes it to the outbox.
+// It maps the topic and event to a protobuf message and writes it to the outbox
+// in its own transaction. Prefer PublishTx when the caller already holds a
+// transaction, so the outbox row is atomic with the domain write.
 func (p *OutboxEventPublisher) Publish(ctx context.Context, topic string, event interface{}) error {
 	return p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		switch topic {
-		case TopicDisputeCreated:
-			return p.publishDisputeCreated(ctx, tx, event)
-		case TopicDisputeResolved:
-			return p.publishDisputeResolved(ctx, tx, event)
-		case TopicPositionLockRequested:
-			return p.publishPositionLockRequested(ctx, tx, event)
-		default:
-			return fmt.Errorf("%w: %s", errUnsupportedTopic, topic)
-		}
+		return p.PublishTx(ctx, tx, topic, event)
 	})
+}
+
+// PublishTx maps the topic and event to a protobuf message and writes it to the
+// outbox within the provided transaction. This makes the outbox row atomic with
+// the domain mutation performed on the same transaction.
+func (p *OutboxEventPublisher) PublishTx(ctx context.Context, tx *gorm.DB, topic string, event interface{}) error {
+	switch topic {
+	case TopicDisputeCreated:
+		return p.publishDisputeCreated(ctx, tx, event)
+	case TopicDisputeResolved:
+		return p.publishDisputeResolved(ctx, tx, event)
+	case TopicPositionLockRequested:
+		return p.publishPositionLockRequested(ctx, tx, event)
+	default:
+		return fmt.Errorf("%w: %s", errUnsupportedTopic, topic)
+	}
 }
 
 // Close is a no-op for the outbox publisher (the outbox worker handles Kafka lifecycle).

--- a/services/reconciliation/adapters/persistence/dispute_repository.go
+++ b/services/reconciliation/adapters/persistence/dispute_repository.go
@@ -47,9 +47,21 @@ func (r *DisputeRepository) isInTransaction() bool {
 
 // Create persists a new Dispute.
 func (r *DisputeRepository) Create(ctx context.Context, dispute *domain.Dispute) error {
+	return r.CreateWithOutbox(ctx, dispute, nil)
+}
+
+// CreateWithOutbox persists a new Dispute and runs postFn within the same
+// transaction, ensuring the domain write and any outbox row are atomic.
+func (r *DisputeRepository) CreateWithOutbox(ctx context.Context, dispute *domain.Dispute, postFn func(tx *gorm.DB) error) error {
 	entity := toDisputeEntity(dispute)
 	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
-		return tx.Create(entity).Error
+		if err := tx.Create(entity).Error; err != nil {
+			return err
+		}
+		if postFn != nil {
+			return postFn(tx)
+		}
+		return nil
 	})
 }
 
@@ -94,6 +106,13 @@ func (r *DisputeRepository) FindByVarianceID(ctx context.Context, varianceID uui
 
 // Update updates an existing Dispute.
 func (r *DisputeRepository) Update(ctx context.Context, dispute *domain.Dispute) error {
+	return r.UpdateWithOutbox(ctx, dispute, nil)
+}
+
+// UpdateWithOutbox updates an existing Dispute and runs postFn within the same
+// transaction, ensuring the domain write and any outbox row are atomic.
+// postFn is only invoked when the update affects a row (the dispute exists).
+func (r *DisputeRepository) UpdateWithOutbox(ctx context.Context, dispute *domain.Dispute, postFn func(tx *gorm.DB) error) error {
 	entity := toDisputeEntity(dispute)
 	var rowsAffected int64
 
@@ -111,6 +130,12 @@ func (r *DisputeRepository) Update(ctx context.Context, dispute *domain.Dispute)
 			return result.Error
 		}
 		rowsAffected = result.RowsAffected
+		if rowsAffected == 0 {
+			return nil
+		}
+		if postFn != nil {
+			return postFn(tx)
+		}
 		return nil
 	})
 	if err != nil {

--- a/services/reconciliation/adapters/persistence/main_test.go
+++ b/services/reconciliation/adapters/persistence/main_test.go
@@ -20,6 +20,7 @@ var sharedDB *gorm.DB
 
 // allTables lists every table created in the tenant schema, in deletion order (children first).
 var allTables = []string{
+	"event_outbox",
 	"imbalance_trend",
 	"dispute",
 	"variance",
@@ -216,6 +217,27 @@ func runMigrations(db *gorm.DB) error {
 		);
 		CREATE UNIQUE INDEX IF NOT EXISTS "idx_it_trend_id" ON "imbalance_trend" ("trend_id");
 		CREATE UNIQUE INDEX IF NOT EXISTS "idx_it_instrument_code" ON "imbalance_trend" ("instrument_code");
+
+		CREATE TABLE IF NOT EXISTS "event_outbox" (
+			"id" uuid NOT NULL DEFAULT gen_random_uuid(),
+			"event_type" character varying(200) NOT NULL,
+			"aggregate_id" character varying(100) NOT NULL,
+			"aggregate_type" character varying(100) NOT NULL,
+			"event_payload" bytea NOT NULL,
+			"correlation_id" character varying(100) NULL,
+			"causation_id" character varying(100) NULL,
+			"status" character varying(20) NOT NULL DEFAULT 'pending',
+			"topic" character varying(200) NOT NULL,
+			"partition_key" character varying(200) NULL,
+			"created_at" timestamptz NOT NULL DEFAULT now(),
+			"processed_at" timestamptz NULL,
+			"retry_count" integer NOT NULL DEFAULT 0,
+			"last_error" text NULL,
+			"service_name" character varying(100) NOT NULL,
+			"tenant_id" character varying(100) NOT NULL,
+			PRIMARY KEY ("id")
+		);
+		CREATE INDEX IF NOT EXISTS "idx_event_outbox_polling" ON "event_outbox" ("status", "service_name", "created_at");
 
 		SET search_path TO public;
 	`

--- a/services/reconciliation/adapters/persistence/outbox_atomicity_test.go
+++ b/services/reconciliation/adapters/persistence/outbox_atomicity_test.go
@@ -1,0 +1,159 @@
+package persistence_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/adapters/persistence"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// errOutboxBoom simulates a failure that occurs after the outbox row has been
+// written but before the surrounding transaction commits.
+var errOutboxBoom = errors.New("simulated failure after outbox write")
+
+// countOutboxRows returns the number of event_outbox rows for a given aggregate.
+func countOutboxRows(t *testing.T, db *gorm.DB, aggregateID string) int64 {
+	t.Helper()
+	tid := tenant.TenantID("test-tenant-01")
+	quoted := fmt.Sprintf("%q", tid.SchemaName())
+	var count int64
+	err := db.WithContext(tenantCtx()).
+		Raw(fmt.Sprintf(`SELECT COUNT(*) FROM %s."event_outbox" WHERE aggregate_id = ?`, quoted), aggregateID).
+		Scan(&count).Error
+	require.NoError(t, err)
+	return count
+}
+
+// insertOutboxRow writes an outbox entry using the shared events repository on
+// the provided transaction, exactly as the production publishers do.
+func insertOutboxRow(ctx context.Context, tx *gorm.DB, aggregateID string) error {
+	outboxRepo := events.NewPostgresOutboxRepository(tx)
+	entry := events.NewEventOutbox(
+		"reconciliation.dispute_created.v1",
+		aggregateID,
+		"Dispute",
+		[]byte("payload"),
+		"reconciliation.dispute.created",
+		"reconciliation",
+		aggregateID,
+		"test-tenant-01",
+	)
+	return outboxRepo.Insert(ctx, tx, entry)
+}
+
+func TestDisputeRepository_CreateWithOutbox_CommitsBoth(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewDisputeRepository(db)
+	ctx := tenantCtx()
+
+	runID, snapshotID, varianceID := uuid.New(), uuid.New(), uuid.New()
+	seedRunAndVariance(t, db, runID, snapshotID, varianceID)
+
+	dispute, err := domain.NewDispute(varianceID, runID, "ACC-001", "Amount mismatch", "user-1")
+	require.NoError(t, err)
+	aggregateID := dispute.DisputeID.String()
+
+	err = repo.CreateWithOutbox(ctx, dispute, func(tx *gorm.DB) error {
+		return insertOutboxRow(ctx, tx, aggregateID)
+	})
+	require.NoError(t, err)
+
+	// Both the domain row and the outbox row are persisted.
+	persisted, err := repo.FindByID(ctx, dispute.DisputeID)
+	require.NoError(t, err)
+	assert.Equal(t, dispute.DisputeID, persisted.DisputeID)
+	assert.Equal(t, int64(1), countOutboxRows(t, db, aggregateID))
+}
+
+func TestDisputeRepository_CreateWithOutbox_RollsBackBoth(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewDisputeRepository(db)
+	ctx := tenantCtx()
+
+	runID, snapshotID, varianceID := uuid.New(), uuid.New(), uuid.New()
+	seedRunAndVariance(t, db, runID, snapshotID, varianceID)
+
+	dispute, err := domain.NewDispute(varianceID, runID, "ACC-001", "Amount mismatch", "user-1")
+	require.NoError(t, err)
+	aggregateID := dispute.DisputeID.String()
+
+	// The callback writes the outbox row and then fails, forcing a rollback of
+	// the whole transaction after both writes have been staged.
+	err = repo.CreateWithOutbox(ctx, dispute, func(tx *gorm.DB) error {
+		if insErr := insertOutboxRow(ctx, tx, aggregateID); insErr != nil {
+			return insErr
+		}
+		return errOutboxBoom
+	})
+	require.ErrorIs(t, err, errOutboxBoom)
+
+	// Neither the dispute nor the outbox row survives: all-or-nothing.
+	_, err = repo.FindByID(ctx, dispute.DisputeID)
+	assert.ErrorIs(t, err, domain.ErrNotFound)
+	assert.Equal(t, int64(0), countOutboxRows(t, db, aggregateID))
+}
+
+func TestSettlementRunRepository_UpdateWithOutbox_CommitsBoth(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewSettlementRunRepository(db)
+	ctx := tenantCtx()
+
+	run := newTestSettlementRun(t)
+	require.NoError(t, repo.Create(ctx, run))
+	require.NoError(t, run.Start())
+	aggregateID := run.RunID.String()
+
+	err := repo.UpdateWithOutbox(ctx, run, func(tx *gorm.DB) error {
+		return insertOutboxRow(ctx, tx, aggregateID)
+	})
+	require.NoError(t, err)
+
+	found, err := repo.FindByID(ctx, run.RunID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.RunStatusRunning, found.Status)
+	assert.Equal(t, int64(2), found.Version)
+	assert.Equal(t, int64(1), countOutboxRows(t, db, aggregateID))
+}
+
+func TestSettlementRunRepository_UpdateWithOutbox_RollsBackBoth(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewSettlementRunRepository(db)
+	ctx := tenantCtx()
+
+	run := newTestSettlementRun(t)
+	require.NoError(t, repo.Create(ctx, run))
+	require.NoError(t, run.Start()) // in-memory transition to RUNNING, version 2
+	aggregateID := run.RunID.String()
+
+	err := repo.UpdateWithOutbox(ctx, run, func(tx *gorm.DB) error {
+		if insErr := insertOutboxRow(ctx, tx, aggregateID); insErr != nil {
+			return insErr
+		}
+		return errOutboxBoom
+	})
+	require.ErrorIs(t, err, errOutboxBoom)
+
+	// The persisted run remains in its pre-update state and no event was written.
+	found, err := repo.FindByID(ctx, run.RunID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.RunStatusPending, found.Status)
+	assert.Equal(t, int64(1), found.Version)
+	assert.Equal(t, int64(0), countOutboxRows(t, db, aggregateID))
+}

--- a/services/reconciliation/adapters/persistence/settlement_run_repository.go
+++ b/services/reconciliation/adapters/persistence/settlement_run_repository.go
@@ -107,6 +107,14 @@ func (r *SettlementRunRepository) FindByID(ctx context.Context, runID uuid.UUID)
 
 // Update updates an existing SettlementRun using optimistic locking.
 func (r *SettlementRunRepository) Update(ctx context.Context, run *domain.SettlementRun) error {
+	return r.UpdateWithOutbox(ctx, run, nil)
+}
+
+// UpdateWithOutbox updates an existing SettlementRun using optimistic locking and
+// runs postFn within the same transaction, ensuring the domain write and any
+// outbox row are atomic. postFn is only invoked when the update affects a row
+// (the run exists and the version matches).
+func (r *SettlementRunRepository) UpdateWithOutbox(ctx context.Context, run *domain.SettlementRun, postFn func(tx *gorm.DB) error) error {
 	entity := toSettlementRunEntity(run)
 	var rowsAffected int64
 
@@ -127,6 +135,12 @@ func (r *SettlementRunRepository) Update(ctx context.Context, run *domain.Settle
 			return result.Error
 		}
 		rowsAffected = result.RowsAffected
+		if rowsAffected == 0 {
+			return nil
+		}
+		if postFn != nil {
+			return postFn(tx)
+		}
 		return nil
 	})
 	if err != nil {

--- a/services/reconciliation/adapters/stripe/settlement_ingestor_test.go
+++ b/services/reconciliation/adapters/stripe/settlement_ingestor_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	stripego "github.com/stripe/stripe-go/v82"
+	"gorm.io/gorm"
 )
 
 // mockRunRepo implements domain.SettlementRunRepository for testing.
@@ -57,6 +58,16 @@ func (m *mockRunRepo) Update(_ context.Context, run *domain.SettlementRun) error
 	}
 	m.updated = append(m.updated, run)
 	m.runs[run.RunID] = run
+	return nil
+}
+
+func (m *mockRunRepo) UpdateWithOutbox(ctx context.Context, run *domain.SettlementRun, postFn func(tx *gorm.DB) error) error {
+	if err := m.Update(ctx, run); err != nil {
+		return err
+	}
+	if postFn != nil {
+		return postFn(nil)
+	}
 	return nil
 }
 

--- a/services/reconciliation/domain/repository.go
+++ b/services/reconciliation/domain/repository.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 )
 
 // SettlementRunRepository defines the contract for persisting and retrieving settlement runs.
@@ -21,6 +22,12 @@ type SettlementRunRepository interface {
 	// Returns ErrNotFound if the run doesn't exist.
 	// Returns ErrOptimisticLock if the version doesn't match.
 	Update(ctx context.Context, run *SettlementRun) error
+
+	// UpdateWithOutbox updates an existing SettlementRun and runs postFn within
+	// the same database transaction as the update, enabling atomic transactional
+	// outbox writes. If postFn returns an error, both the update and any outbox
+	// row it wrote are rolled back. A nil postFn behaves like Update.
+	UpdateWithOutbox(ctx context.Context, run *SettlementRun, postFn func(tx *gorm.DB) error) error
 
 	// List retrieves settlement runs matching the given filter with pagination.
 	List(ctx context.Context, filter RunFilter) ([]*SettlementRun, error)
@@ -104,6 +111,12 @@ type DisputeRepository interface {
 	// Create persists a new Dispute.
 	Create(ctx context.Context, dispute *Dispute) error
 
+	// CreateWithOutbox persists a new Dispute and runs postFn within the same
+	// database transaction as the insert, enabling atomic transactional outbox
+	// writes. If postFn returns an error, both the insert and any outbox row it
+	// wrote are rolled back. A nil postFn behaves like Create.
+	CreateWithOutbox(ctx context.Context, dispute *Dispute, postFn func(tx *gorm.DB) error) error
+
 	// FindByID retrieves a Dispute by its DisputeID.
 	// Returns ErrNotFound if the dispute doesn't exist.
 	FindByID(ctx context.Context, disputeID uuid.UUID) (*Dispute, error)
@@ -114,6 +127,12 @@ type DisputeRepository interface {
 	// Update updates an existing Dispute.
 	// Returns ErrNotFound if the dispute doesn't exist.
 	Update(ctx context.Context, dispute *Dispute) error
+
+	// UpdateWithOutbox updates an existing Dispute and runs postFn within the same
+	// database transaction as the update, enabling atomic transactional outbox
+	// writes. If postFn returns an error, both the update and any outbox row it
+	// wrote are rolled back. A nil postFn behaves like Update.
+	UpdateWithOutbox(ctx context.Context, dispute *Dispute, postFn func(tx *gorm.DB) error) error
 
 	// List retrieves disputes matching the given filter.
 	List(ctx context.Context, filter DisputeFilter) ([]*Dispute, error)

--- a/services/reconciliation/service/finalizer.go
+++ b/services/reconciliation/service/finalizer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/auth"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
 )
 
 const (
@@ -159,8 +160,6 @@ func (f *SettlementFinalizer) FinalizeSettlement(ctx context.Context, runID uuid
 		return err
 	}
 
-	f.publishLockEvent(ctx, run)
-
 	observability.SettlementFinalityTotal.WithLabelValues("SUCCESS").Inc()
 
 	f.logger.InfoContext(ctx, "settlement finalization completed",
@@ -224,17 +223,21 @@ func (f *SettlementFinalizer) markFinalized(ctx context.Context, run *domain.Set
 	if err := run.Finalize(); err != nil {
 		return fmt.Errorf("transitioning run %s to FINALIZED: %w", run.RunID, err)
 	}
-	if err := f.runRepo.Update(ctx, run); err != nil {
+	if err := f.runRepo.UpdateWithOutbox(ctx, run, f.lockEventOutboxFn(ctx, run)); err != nil {
 		return fmt.Errorf("persisting FINALIZED state for run %s: %w", run.RunID, err)
 	}
 
 	return nil
 }
 
-// publishLockEvent publishes a PositionLockRequestedEvent after successful finalization.
-func (f *SettlementFinalizer) publishLockEvent(ctx context.Context, run *domain.SettlementRun) {
+// lockEventOutboxFn returns a transaction callback that writes a
+// PositionLockRequestedEvent to the outbox within the run's FINALIZED update
+// transaction, making event delivery atomic with the domain write. Returns nil
+// when no event publisher is configured, in which case the update runs without
+// an outbox write.
+func (f *SettlementFinalizer) lockEventOutboxFn(ctx context.Context, run *domain.SettlementRun) func(tx *gorm.DB) error {
 	if f.publisher == nil {
-		return
+		return nil
 	}
 	event := PositionLockRequestedEvent{
 		RunID:       run.RunID.String(),
@@ -244,9 +247,8 @@ func (f *SettlementFinalizer) publishLockEvent(ctx context.Context, run *domain.
 		PeriodEnd:   run.PeriodEnd.Format(time.RFC3339),
 		Status:      "LOCKED",
 	}
-	if pubErr := f.publisher.Publish(ctx, messaging.TopicPositionLockRequested, event); pubErr != nil {
-		f.logger.WarnContext(ctx, "failed to publish PositionLockRequestedEvent",
-			"run_id", run.RunID, "error", pubErr)
+	return func(tx *gorm.DB) error {
+		return f.publisher.PublishTx(ctx, tx, messaging.TopicPositionLockRequested, event)
 	}
 }
 

--- a/services/reconciliation/service/finalizer_test.go
+++ b/services/reconciliation/service/finalizer_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
 )
 
 // --- Mock PositionLockClient ---
@@ -85,6 +86,10 @@ func (m *mockFinalityPublisher) Publish(_ context.Context, topic string, event i
 	}
 	m.events = append(m.events, finalityEvent{topic: topic, event: event})
 	return nil
+}
+
+func (m *mockFinalityPublisher) PublishTx(ctx context.Context, _ *gorm.DB, topic string, event interface{}) error {
+	return m.Publish(ctx, topic, event)
 }
 
 func (m *mockFinalityPublisher) eventCount() int {
@@ -414,22 +419,24 @@ func TestFinalizeSettlement_SnapshotMarkFailureBlocksFinalization(t *testing.T) 
 	assert.NotEqual(t, domain.RunStatusFinalized, unchangedRun.Status)
 }
 
-func TestFinalizeSettlement_PublisherFailureNonFatal(t *testing.T) {
+func TestFinalizeSettlement_PublisherFailureRollsBack(t *testing.T) {
 	runRepo := newMockRunRepo()
 	snapRepo := &mockFinalSnapshotRepo{}
-	publisher := &mockFinalityPublisher{err: errors.New("kafka unavailable")}
+	publisher := &mockFinalityPublisher{err: errors.New("outbox write failed")}
 
 	run := newCompletedFinalRun(t)
 	_ = runRepo.Create(context.Background(), run)
 
 	finalizer := NewSettlementFinalizer(runRepo, snapRepo, nil, publisher, nil)
 	err := finalizer.FinalizeSettlement(serviceCtx(), run.RunID)
-	// Should succeed even if event publishing fails (non-fatal)
-	require.NoError(t, err)
-
-	// Run should still be FINALIZED
-	finalizedRun, _ := runRepo.FindByID(context.Background(), run.RunID)
-	assert.Equal(t, domain.RunStatusFinalized, finalizedRun.Status)
+	// The outbox write is atomic with the FINALIZED transition: if the event
+	// cannot be written, the whole update rolls back and finalization fails.
+	// (DB-level rollback of the persisted row is covered by the integration
+	// test; this mock shares the run pointer so its status field is not a
+	// reliable rollback signal.)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "persisting FINALIZED state")
+	assert.Equal(t, 0, publisher.eventCount())
 }
 
 func TestFinalizeSettlement_RunUpdateFailure(t *testing.T) {

--- a/services/reconciliation/service/grpc_dispute_endpoints.go
+++ b/services/reconciliation/service/grpc_dispute_endpoints.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"gorm.io/gorm"
 )
 
 // SagaRuntime defines the contract for invoking Starlark sagas.
@@ -22,7 +23,12 @@ type SagaRuntime interface {
 
 // EventPublisher defines the contract for publishing domain events.
 type EventPublisher interface {
+	// Publish writes the event to the outbox in its own transaction.
 	Publish(ctx context.Context, topic string, event interface{}) error
+
+	// PublishTx writes the event to the outbox within the provided transaction,
+	// making the outbox row atomic with the domain write on the same transaction.
+	PublishTx(ctx context.Context, tx *gorm.DB, topic string, event interface{}) error
 }
 
 // VarianceFinder retrieves variances for dispute validation.
@@ -129,13 +135,12 @@ func (s *AccountReconciliationService) InitiateDispute(
 		dispute.Attributes = req.GetAttributes()
 	}
 
-	if err := s.disputeRepo.Create(ctx, dispute); err != nil {
+	if err := s.disputeRepo.CreateWithOutbox(ctx, dispute, s.disputeCreatedOutboxFn(ctx, dispute)); err != nil {
 		slog.ErrorContext(ctx, "failed to create dispute", "error", err)
 		return nil, status.Errorf(codes.Internal, "failed to create dispute: %v", err)
 	}
 
 	s.markVarianceDisputed(ctx, varianceID)
-	s.publishDisputeCreatedEvent(ctx, dispute)
 
 	return &reconciliationv1.InitiateDisputeResponse{
 		Dispute: toDisputeDetailProto(dispute),
@@ -168,10 +173,13 @@ func (s *AccountReconciliationService) markVarianceDisputed(ctx context.Context,
 	}
 }
 
-// publishDisputeCreatedEvent publishes a DisputeCreatedEvent to the outbox.
-func (s *AccountReconciliationService) publishDisputeCreatedEvent(ctx context.Context, dispute *domain.Dispute) {
+// disputeCreatedOutboxFn returns a transaction callback that writes a
+// DisputeCreatedEvent to the outbox within the dispute's insert transaction,
+// making event delivery atomic with the domain write. Returns nil when no
+// event publisher is configured (the insert then runs without an outbox write).
+func (s *AccountReconciliationService) disputeCreatedOutboxFn(ctx context.Context, dispute *domain.Dispute) func(tx *gorm.DB) error {
 	if s.eventPublisher == nil {
-		return
+		return nil
 	}
 	event := DisputeCreatedEvent{
 		DisputeID:  dispute.DisputeID.String(),
@@ -181,9 +189,8 @@ func (s *AccountReconciliationService) publishDisputeCreatedEvent(ctx context.Co
 		Reason:     dispute.Reason,
 		RaisedBy:   dispute.RaisedBy,
 	}
-	if err := s.eventPublisher.Publish(ctx, messaging.TopicDisputeCreated, event); err != nil {
-		slog.WarnContext(ctx, "failed to publish DisputeCreatedEvent",
-			"dispute_id", dispute.DisputeID, "error", err)
+	return func(tx *gorm.DB) error {
+		return s.eventPublisher.PublishTx(ctx, tx, messaging.TopicDisputeCreated, event)
 	}
 }
 
@@ -214,12 +221,10 @@ func (s *AccountReconciliationService) ControlDispute(
 		return nil, err
 	}
 
-	if err := s.disputeRepo.Update(ctx, dispute); err != nil {
+	if err := s.disputeRepo.UpdateWithOutbox(ctx, dispute, s.disputeResolvedOutboxFn(ctx, dispute, action.String())); err != nil {
 		slog.ErrorContext(ctx, "failed to update dispute", "error", err)
 		return nil, status.Errorf(codes.Internal, "failed to update dispute: %v", err)
 	}
-
-	s.publishDisputeResolvedEvent(ctx, dispute, action)
 
 	return &reconciliationv1.ControlDisputeResponse{
 		Dispute: toDisputeDetailProto(dispute),
@@ -281,16 +286,14 @@ func (s *AccountReconciliationService) invokeReconciliationAdjustment(ctx contex
 	}
 }
 
-// publishDisputeResolvedEvent publishes a DisputeResolvedEvent for terminal states.
-func (s *AccountReconciliationService) publishDisputeResolvedEvent(ctx context.Context, dispute *domain.Dispute, action reconciliationv1.DisputeControlAction) {
-	s.publishDisputeResolvedEventWithAction(ctx, dispute, action.String())
-}
-
-// publishDisputeResolvedEventWithAction publishes a DisputeResolvedEvent for terminal states
-// using the provided action string.
-func (s *AccountReconciliationService) publishDisputeResolvedEventWithAction(ctx context.Context, dispute *domain.Dispute, actionStr string) {
+// disputeResolvedOutboxFn returns a transaction callback that writes a
+// DisputeResolvedEvent to the outbox within the dispute's update transaction,
+// making event delivery atomic with the domain write. Returns nil when the
+// dispute is not in a final state or no event publisher is configured, in which
+// case the update runs without an outbox write.
+func (s *AccountReconciliationService) disputeResolvedOutboxFn(ctx context.Context, dispute *domain.Dispute, actionStr string) func(tx *gorm.DB) error {
 	if !dispute.Status.IsFinal() || s.eventPublisher == nil {
-		return
+		return nil
 	}
 	event := DisputeResolvedEvent{
 		DisputeID:  dispute.DisputeID.String(),
@@ -301,9 +304,8 @@ func (s *AccountReconciliationService) publishDisputeResolvedEventWithAction(ctx
 		Resolution: dispute.Resolution,
 		ResolvedBy: dispute.ResolvedBy,
 	}
-	if err := s.eventPublisher.Publish(ctx, messaging.TopicDisputeResolved, event); err != nil {
-		slog.WarnContext(ctx, "failed to publish DisputeResolvedEvent",
-			"dispute_id", dispute.DisputeID, "error", err)
+	return func(tx *gorm.DB) error {
+		return s.eventPublisher.PublishTx(ctx, tx, messaging.TopicDisputeResolved, event)
 	}
 }
 

--- a/services/reconciliation/service/grpc_dispute_endpoints_test.go
+++ b/services/reconciliation/service/grpc_dispute_endpoints_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
 )
 
 // mockDisputeRepo implements domain.DisputeRepository for testing.
@@ -26,6 +27,16 @@ func newMockDisputeRepo() *mockDisputeRepo {
 
 func (m *mockDisputeRepo) Create(_ context.Context, d *domain.Dispute) error {
 	m.disputes[d.DisputeID] = d
+	return nil
+}
+
+func (m *mockDisputeRepo) CreateWithOutbox(ctx context.Context, d *domain.Dispute, postFn func(tx *gorm.DB) error) error {
+	if err := m.Create(ctx, d); err != nil {
+		return err
+	}
+	if postFn != nil {
+		return postFn(nil)
+	}
 	return nil
 }
 
@@ -53,6 +64,16 @@ func (m *mockDisputeRepo) Update(_ context.Context, d *domain.Dispute) error {
 		return domain.ErrNotFound
 	}
 	m.disputes[d.DisputeID] = d
+	return nil
+}
+
+func (m *mockDisputeRepo) UpdateWithOutbox(ctx context.Context, d *domain.Dispute, postFn func(tx *gorm.DB) error) error {
+	if err := m.Update(ctx, d); err != nil {
+		return err
+	}
+	if postFn != nil {
+		return postFn(nil)
+	}
 	return nil
 }
 
@@ -102,6 +123,11 @@ type mockEventPublisher struct {
 }
 
 func (m *mockEventPublisher) Publish(_ context.Context, _ string, event interface{}) error {
+	m.events = append(m.events, event)
+	return nil
+}
+
+func (m *mockEventPublisher) PublishTx(_ context.Context, _ *gorm.DB, _ string, event interface{}) error {
 	m.events = append(m.events, event)
 	return nil
 }

--- a/services/reconciliation/service/grpc_list_endpoints.go
+++ b/services/reconciliation/service/grpc_list_endpoints.go
@@ -128,15 +128,13 @@ func (s *AccountReconciliationService) UpdateDispute(
 		return nil, err
 	}
 
-	if err := s.disputeRepo.Update(ctx, dispute); err != nil {
+	if err := s.disputeRepo.UpdateWithOutbox(ctx, dispute, s.disputeResolvedOutboxFn(ctx, dispute, newStatus.String())); err != nil {
 		return nil, status.Error(codes.Internal, "failed to update dispute")
 	}
 
 	if newStatus == reconciliationv1.DisputeStatus_DISPUTE_STATUS_RESOLVED {
 		s.invokeReconciliationAdjustment(ctx, dispute)
 	}
-
-	s.publishDisputeResolvedEventWithAction(ctx, dispute, newStatus.String())
 
 	return &reconciliationv1.UpdateDisputeResponse{
 		Dispute: toDisputeDetailProto(dispute),

--- a/services/reconciliation/service/runrepo_outbox_blackbox_test.go
+++ b/services/reconciliation/service/runrepo_outbox_blackbox_test.go
@@ -1,0 +1,73 @@
+package service_test
+
+import (
+	"context"
+
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"gorm.io/gorm"
+)
+
+// UpdateWithOutbox test shims delegate to each mock's Update and then run the
+// outbox callback in the same (mock) transaction, mirroring the production
+// transactional-outbox contract. Defining them centrally keeps the individual
+// mock definitions focused on their primary behavior.
+
+func (m *updateFailRepo) UpdateWithOutbox(ctx context.Context, run *domain.SettlementRun, postFn func(tx *gorm.DB) error) error {
+	if err := m.Update(ctx, run); err != nil {
+		return err
+	}
+	if postFn != nil {
+		return postFn(nil)
+	}
+	return nil
+}
+
+func (m *findCountRepo) UpdateWithOutbox(ctx context.Context, run *domain.SettlementRun, postFn func(tx *gorm.DB) error) error {
+	if err := m.Update(ctx, run); err != nil {
+		return err
+	}
+	if postFn != nil {
+		return postFn(nil)
+	}
+	return nil
+}
+
+func (m *updateAfterRunningRepo) UpdateWithOutbox(ctx context.Context, run *domain.SettlementRun, postFn func(tx *gorm.DB) error) error {
+	if err := m.Update(ctx, run); err != nil {
+		return err
+	}
+	if postFn != nil {
+		return postFn(nil)
+	}
+	return nil
+}
+
+func (m *listRunRepo) UpdateWithOutbox(ctx context.Context, run *domain.SettlementRun, postFn func(tx *gorm.DB) error) error {
+	if err := m.Update(ctx, run); err != nil {
+		return err
+	}
+	if postFn != nil {
+		return postFn(nil)
+	}
+	return nil
+}
+
+func (m *testRunRepo) UpdateWithOutbox(ctx context.Context, run *domain.SettlementRun, postFn func(tx *gorm.DB) error) error {
+	if err := m.Update(ctx, run); err != nil {
+		return err
+	}
+	if postFn != nil {
+		return postFn(nil)
+	}
+	return nil
+}
+
+func (m *mockSettlementRunRepo) UpdateWithOutbox(ctx context.Context, run *domain.SettlementRun, postFn func(tx *gorm.DB) error) error {
+	if err := m.Update(ctx, run); err != nil {
+		return err
+	}
+	if postFn != nil {
+		return postFn(nil)
+	}
+	return nil
+}

--- a/services/reconciliation/service/runrepo_outbox_whitebox_test.go
+++ b/services/reconciliation/service/runrepo_outbox_whitebox_test.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"context"
+
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"gorm.io/gorm"
+)
+
+// UpdateWithOutbox test shims delegate to each mock's Update and then run the
+// outbox callback in the same (mock) transaction, mirroring the production
+// transactional-outbox contract. Defining them centrally keeps the individual
+// mock definitions focused on their primary behavior.
+
+func (m *vdRunRepo) UpdateWithOutbox(ctx context.Context, run *domain.SettlementRun, postFn func(tx *gorm.DB) error) error {
+	if err := m.Update(ctx, run); err != nil {
+		return err
+	}
+	if postFn != nil {
+		return postFn(nil)
+	}
+	return nil
+}
+
+func (r *gormRunRepo) UpdateWithOutbox(ctx context.Context, run *domain.SettlementRun, postFn func(tx *gorm.DB) error) error {
+	if err := r.Update(ctx, run); err != nil {
+		return err
+	}
+	if postFn != nil {
+		return postFn(nil)
+	}
+	return nil
+}

--- a/services/reconciliation/service/server_options_test.go
+++ b/services/reconciliation/service/server_options_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/services/reconciliation/domain"
 	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
 )
 
 // Minimal stubs for option tests.
@@ -41,6 +42,10 @@ func (stubSagaRuntime) InvokeSaga(_ context.Context, _ string, _ map[string]inte
 type stubEventPublisher struct{}
 
 func (stubEventPublisher) Publish(_ context.Context, _ string, _ interface{}) error { return nil }
+
+func (stubEventPublisher) PublishTx(_ context.Context, _ *gorm.DB, _ string, _ interface{}) error {
+	return nil
+}
 
 func TestWithDisputeRepository(t *testing.T) {
 	repo := stubDisputeRepo{}

--- a/services/reconciliation/service/service_test.go
+++ b/services/reconciliation/service/service_test.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"gorm.io/gorm"
 )
 
 // mockVarianceLister implements VarianceLister for testing.
@@ -364,6 +365,16 @@ func (m *initiateRunRepoMock) Update(_ context.Context, run *domain.SettlementRu
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.runs[run.RunID] = run
+	return nil
+}
+
+func (m *initiateRunRepoMock) UpdateWithOutbox(ctx context.Context, run *domain.SettlementRun, postFn func(tx *gorm.DB) error) error {
+	if err := m.Update(ctx, run); err != nil {
+		return err
+	}
+	if postFn != nil {
+		return postFn(nil)
+	}
 	return nil
 }
 

--- a/services/reconciliation/service/snapshot_capturer_test.go
+++ b/services/reconciliation/service/snapshot_capturer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 // --- Mock PositionDataProvider ---
@@ -73,6 +74,24 @@ func (m *mockRunRepo) Update(_ context.Context, run *domain.SettlementRun) error
 	defer m.mu.Unlock()
 	if m.updateErr != nil {
 		return m.updateErr
+	}
+	m.runs[run.RunID] = run
+	return nil
+}
+
+// UpdateWithOutbox models a transactional outbox write: the run is only
+// persisted if the outbox callback succeeds, mirroring the all-or-nothing
+// guarantee of the real GORM repository.
+func (m *mockRunRepo) UpdateWithOutbox(_ context.Context, run *domain.SettlementRun, postFn func(tx *gorm.DB) error) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	if postFn != nil {
+		if err := postFn(nil); err != nil {
+			return err
+		}
 	}
 	m.runs[run.RunID] = run
 	return nil

--- a/tests/reconciliation-e2e/infra_test.go
+++ b/tests/reconciliation-e2e/infra_test.go
@@ -617,6 +617,13 @@ func (m *mockEventPublisher) Publish(_ context.Context, topic string, event inte
 	return m.err
 }
 
+func (m *mockEventPublisher) PublishTx(_ context.Context, _ *gorm.DB, topic string, event interface{}) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, publishedEvent{Topic: topic, Event: event})
+	return m.err
+}
+
 func (m *mockEventPublisher) PublishBalanceImbalanceDetected(_ context.Context, event *domain.BalanceImbalanceDetectedEvent) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/tests/reconciliation-e2e/repositories_test.go
+++ b/tests/reconciliation-e2e/repositories_test.go
@@ -89,6 +89,33 @@ func (r *gormRunRepository) Update(_ context.Context, run *domain.SettlementRun)
 	return nil
 }
 
+func (r *gormRunRepository) UpdateWithOutbox(_ context.Context, run *domain.SettlementRun, postFn func(tx *gorm.DB) error) error {
+	entity := toRunEntity(run)
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		result := tx.Model(&settlementRunEntity{}).
+			Where("run_id = ? AND version = ?", entity.RunID, entity.Version-1).
+			Updates(map[string]interface{}{
+				"status":               entity.Status,
+				"completed_at":         entity.CompletedAt,
+				"variance_count":       entity.VarianceCount,
+				"failure_reason":       entity.FailureReason,
+				"last_completed_phase": entity.LastCompletedPhase,
+				"version":              entity.Version,
+				"updated_at":           time.Now().UTC(),
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return domain.ErrOptimisticLock
+		}
+		if postFn != nil {
+			return postFn(tx)
+		}
+		return nil
+	})
+}
+
 func (r *gormRunRepository) List(_ context.Context, filter domain.RunFilter) ([]*domain.SettlementRun, error) {
 	query := r.db.Model(&settlementRunEntity{})
 


### PR DESCRIPTION
## Summary

Fixes DAT-8 (bug-sweep-2026-07-07 task 26): outbox event writes were performed in a separate database transaction from the domain mutation. A crash between the domain write and the outbox write could lose the event (missed downstream delivery) or double-publish it.

This PR makes the reconciliation service's outbox writes atomic with the domain change using the transactional-outbox pattern already established in `position-keeping` (`CreateWithOutbox`/`UpdateWithOutbox` + a `postFn` run inside the same transaction).

## Changes Made

- **`domain.DisputeRepository`**: added `CreateWithOutbox` / `UpdateWithOutbox`; `Create`/`Update` now delegate with a nil callback (no behavior change).
- **`domain.SettlementRunRepository`**: added `UpdateWithOutbox`; `Update` delegates.
- **Persistence impls** run the domain write and the outbox callback inside one `withTenantTransaction`, so both commit or neither does.
- **`messaging.OutboxEventPublisher`**: added `PublishTx(ctx, tx, topic, event)` that writes the outbox row on a caller-supplied transaction; `Publish` now wraps it in its own transaction (unchanged external behavior). `KafkaPublisher`/`NoopPublisher` gained `PublishTx` for interface completeness.
- **Service wiring**: `InitiateDispute`, `ControlDispute`, `UpdateDispute`, and `SettlementFinalizer.markFinalized` now write the domain change and the event atomically via the `*WithOutbox` methods.

## Technical Details

The reconciliation domain and outbox both persist via GORM, so a single GORM transaction spans the domain row and the `event_outbox` row. The `postFn` runs after a successful domain write; if it fails, the transaction rolls back both rows.

**Behavior change (intended):** event publishing is no longer best-effort. If the outbox row cannot be written, the operation now fails and the domain change rolls back (all-or-nothing), rather than logging a warning and returning success with a lost event.

## Testing

- New DB-level integration tests (CockroachDB testcontainer) prove atomicity for both new repo methods: `TestDisputeRepository_CreateWithOutbox_{CommitsBoth,RollsBackBoth}` and `TestSettlementRunRepository_UpdateWithOutbox_{CommitsBoth,RollsBackBoth}` — a failure after the domain write but before commit rolls back BOTH rows; a successful commit persists both. The test migration now provisions `event_outbox` in the tenant schema.
- Updated finalizer unit test (`TestFinalizeSettlement_PublisherFailureRollsBack`) to assert the new atomic contract.
- Full `./services/reconciliation/...` suite passes with `INTEGRATION_TEST=1`.

## Risk Assessment

Scoped to the reconciliation service. Interface additions are backward compatible (`Create`/`Update` preserved). The one behavioral change (publish failure now fails the operation) is the intended correctness fix.

## Scope Note

The task also listed the **market-information** spot (`outbox_event_publisher.go:42`). That service persists domain data via pgx while its outbox uses a separate GORM connection targeting a fixed schema, and it has no `event_outbox` migration of its own. Making it atomic requires moving the outbox write into the pgx observation transaction, adding an `event_outbox` migration in the observation schema, and reconciling the non-tenant-scoped outbox worker's read schema — a materially larger, higher-risk change that also overlaps market-information write internals under active work in other PRs. Recommend tracking it as a separate task.
